### PR TITLE
layout: Split overflow calculation after fragment tree construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6613,7 +6613,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.28.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#610fcfb48987d75b7d1d53887882fcdb244d74ee"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -6908,7 +6908,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#610fcfb48987d75b7d1d53887882fcdb244d74ee"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7369,7 +7369,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#610fcfb48987d75b7d1d53887882fcdb244d74ee"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7427,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#610fcfb48987d75b7d1d53887882fcdb244d74ee"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7436,12 +7436,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#610fcfb48987d75b7d1d53887882fcdb244d74ee"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
 
 [[package]]
 name = "stylo_derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#610fcfb48987d75b7d1d53887882fcdb244d74ee"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7453,7 +7453,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#610fcfb48987d75b7d1d53887882fcdb244d74ee"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -7462,7 +7462,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#610fcfb48987d75b7d1d53887882fcdb244d74ee"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7479,12 +7479,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#610fcfb48987d75b7d1d53887882fcdb244d74ee"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
 
 [[package]]
 name = "stylo_traits"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#610fcfb48987d75b7d1d53887882fcdb244d74ee"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -7893,7 +7893,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#610fcfb48987d75b7d1d53887882fcdb244d74ee"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7906,7 +7906,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#610fcfb48987d75b7d1d53887882fcdb244d74ee"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -618,7 +618,7 @@ impl StackingContext {
         // If it’s larger, we also want to paint areas reachable after scrolling.
         let painting_area = fragment_tree
             .initial_containing_block
-            .union(&fragment_tree.scrollable_overflow)
+            .union(&fragment_tree.scrollable_overflow())
             .to_webrender();
 
         let background_color =
@@ -1346,7 +1346,7 @@ impl BoxFragment {
         let position = self.style.get_box().position;
         // https://drafts.csswg.org/css2/#clipping
         // The clip property applies only to absolutely positioned elements
-        if position != ComputedPosition::Absolute && position != ComputedPosition::Fixed {
+        if !position.is_absolutely_positioned() {
             return None;
         }
 

--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -29,7 +29,7 @@ use crate::flow::inline::InlineItem;
 use crate::flow::{BlockContainer, BlockFormattingContext, BlockLevelBox};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::FragmentTree;
-use crate::geom::{LogicalVec2, PhysicalRect, PhysicalSize};
+use crate::geom::{LogicalVec2, PhysicalSize};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
 use crate::replaced::ReplacedContents;
 use crate::style_ext::{Display, DisplayGeneratingBox, DisplayInside};
@@ -392,31 +392,9 @@ impl BoxTree {
             &mut root_fragments,
         );
 
-        let scrollable_overflow = root_fragments
-            .iter()
-            .fold(PhysicalRect::zero(), |acc, child| {
-                let child_overflow = child.scrollable_overflow_for_parent();
-
-                // https://drafts.csswg.org/css-overflow/#scrolling-direction
-                // We want to clip scrollable overflow on box-start and inline-start
-                // sides of the scroll container.
-                //
-                // FIXME(mrobinson, bug 25564): This should take into account writing
-                // mode.
-                let child_overflow = PhysicalRect::new(
-                    euclid::Point2D::zero(),
-                    euclid::Size2D::new(
-                        child_overflow.size.width + child_overflow.origin.x,
-                        child_overflow.size.height + child_overflow.origin.y,
-                    ),
-                );
-                acc.union(&child_overflow)
-            });
-
         FragmentTree::new(
             layout_context,
             root_fragments,
-            scrollable_overflow,
             physical_containing_block,
             self.viewport_scroll_sensitivity,
         )

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -183,16 +183,33 @@ impl Fragment {
         }
     }
 
-    pub fn scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
+    pub(crate) fn scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
         match self {
             Fragment::Box(fragment) | Fragment::Float(fragment) => {
-                fragment.borrow().scrollable_overflow_for_parent()
+                return fragment.borrow().scrollable_overflow_for_parent();
             },
             Fragment::AbsoluteOrFixedPositioned(_) => PhysicalRect::zero(),
-            Fragment::Positioning(fragment) => fragment.borrow().scrollable_overflow,
+            Fragment::Positioning(fragment) => fragment.borrow().scrollable_overflow_for_parent(),
             Fragment::Text(fragment) => fragment.borrow().rect,
             Fragment::Image(fragment) => fragment.borrow().rect,
             Fragment::IFrame(fragment) => fragment.borrow().rect,
+        }
+    }
+
+    pub(crate) fn calculate_scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
+        self.calculate_scrollable_overflow();
+        self.scrollable_overflow_for_parent()
+    }
+
+    pub(crate) fn calculate_scrollable_overflow(&self) {
+        match self {
+            Fragment::Box(fragment) | Fragment::Float(fragment) => {
+                fragment.borrow_mut().calculate_scrollable_overflow()
+            },
+            Fragment::Positioning(fragment) => {
+                fragment.borrow_mut().calculate_scrollable_overflow()
+            },
+            _ => {},
         }
     }
 

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::Cell;
+
 use app_units::Au;
 use base::print_tree::PrintTree;
 use compositing_traits::display_list::AxesScrollSensitivity;
-use euclid::default::Size2D;
 use fxhash::FxHashSet;
 use malloc_size_of_derive::MallocSizeOf;
 use style::animation::AnimationSetKey;
-use webrender_api::units;
 
 use super::{BoxFragment, ContainingBlockManager, Fragment};
 use crate::ArcRefCell;
@@ -30,7 +30,7 @@ pub struct FragmentTree {
 
     /// The scrollable overflow rectangle for the entire tree
     /// <https://drafts.csswg.org/css-overflow/#scrollable>
-    pub(crate) scrollable_overflow: PhysicalRect<Au>,
+    scrollable_overflow: Cell<Option<PhysicalRect<Au>>>,
 
     /// The containing block used in the layout of this fragment tree.
     pub(crate) initial_containing_block: PhysicalRect<Au>,
@@ -43,13 +43,12 @@ impl FragmentTree {
     pub(crate) fn new(
         layout_context: &LayoutContext,
         root_fragments: Vec<Fragment>,
-        scrollable_overflow: PhysicalRect<Au>,
         initial_containing_block: PhysicalRect<Au>,
         viewport_scroll_sensitivity: AxesScrollSensitivity,
     ) -> Self {
         let fragment_tree = Self {
             root_fragments,
-            scrollable_overflow,
+            scrollable_overflow: Cell::default(),
             initial_containing_block,
             viewport_scroll_sensitivity,
         };
@@ -97,11 +96,35 @@ impl FragmentTree {
         }
     }
 
-    pub fn scrollable_overflow(&self) -> units::LayoutSize {
-        units::LayoutSize::from_untyped(Size2D::new(
-            self.scrollable_overflow.size.width.to_f32_px(),
-            self.scrollable_overflow.size.height.to_f32_px(),
-        ))
+    pub(crate) fn scrollable_overflow(&self) -> PhysicalRect<Au> {
+        self.scrollable_overflow
+            .get()
+            .expect("Should only call `scrollable_overflow()` after calculating overflow")
+    }
+
+    pub(crate) fn calculate_scrollable_overflow(&self) {
+        self.scrollable_overflow
+            .set(Some(self.root_fragments.iter().fold(
+                PhysicalRect::zero(),
+                |acc, child| {
+                    let child_overflow = child.calculate_scrollable_overflow_for_parent();
+
+                    // https://drafts.csswg.org/css-overflow/#scrolling-direction
+                    // We want to clip scrollable overflow on box-start and inline-start
+                    // sides of the scroll container.
+                    //
+                    // FIXME(mrobinson, bug 25564): This should take into account writing
+                    // mode.
+                    let child_overflow = PhysicalRect::new(
+                        euclid::Point2D::zero(),
+                        euclid::Size2D::new(
+                            child_overflow.size.width + child_overflow.origin.x,
+                            child_overflow.size.height + child_overflow.origin.y,
+                        ),
+                    );
+                    acc.union(&child_overflow)
+                },
+            )));
     }
 
     pub(crate) fn find<T>(

--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -305,10 +305,7 @@ impl PositioningContext {
     }
 
     pub(crate) fn push(&mut self, hoisted_box: HoistedAbsolutelyPositionedBox) {
-        debug_assert!(matches!(
-            hoisted_box.position(),
-            Position::Absolute | Position::Fixed
-        ));
+        debug_assert!(hoisted_box.position().is_absolutely_positioned());
         self.absolutes.push(hoisted_box);
     }
 
@@ -380,7 +377,7 @@ impl HoistedAbsolutelyPositionedBox {
             .context
             .style()
             .clone_position();
-        assert!(position == Position::Fixed || position == Position::Absolute);
+        assert!(position.is_absolutely_positioned());
         position
     }
 

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 //! Utilities for querying the layout, as needed by layout.
-use std::sync::Arc;
+use std::rc::Rc;
 
 use app_units::Au;
 use euclid::default::{Point2D, Rect};
@@ -80,7 +80,7 @@ pub fn process_client_rect_request(node: ServoLayoutNode<'_>) -> Rect<i32> {
 /// <https://drafts.csswg.org/cssom-view/#scrolling-area>
 pub fn process_node_scroll_area_request(
     requested_node: Option<ServoLayoutNode<'_>>,
-    fragment_tree: Option<Arc<FragmentTree>>,
+    fragment_tree: Option<Rc<FragmentTree>>,
 ) -> Rect<i32> {
     let Some(tree) = fragment_tree else {
         return Rect::zero();

--- a/tests/wpt/meta/css/css-masking/clip-path/clip-path-fixed-scroll.html.ini
+++ b/tests/wpt/meta/css/css-masking/clip-path/clip-path-fixed-scroll.html.ini
@@ -1,2 +1,0 @@
-[clip-path-fixed-scroll.html]
-  expected: FAIL


### PR DESCRIPTION
Instead of computing scrollable overflow while constructing the fragment tree, we will now do it later. In the future this will also allow to only recalculate the overflow without rebuilding the tree when transform properties change, but that's left for a follow-up.

Stylo PR: https://github.com/servo/stylo/pull/194

Testing: One test is now passing (more investigation is needed), but otherwise this isn't expected to have any effect.
