### PR TITLE
script: Upgrade `node_ids` to `pipeline_to_node_ids` to track the owner pipeline of the node

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -132,7 +132,7 @@ fn find_node_by_unique_id(
         document
             .upcast::<Node>()
             .traverse_preorder(ShadowIncluding::Yes)
-            .find(|candidate| candidate.unique_id() == node_id)
+            .find(|candidate| candidate.unique_id(pipeline) == node_id)
     })
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -827,7 +827,7 @@ impl ScriptThread {
                 .pipeline_to_node_ids
                 .borrow_mut()
                 .entry(pipeline)
-                .or_insert_with(HashSet::new)
+                .or_default()
                 .insert(node_id);
         })
     }

--- a/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/iframe.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/iframe.py.ini
@@ -1,9 +1,3 @@
 [iframe.py]
   [test_frame_element]
     expected: FAIL
-
-  [test_source_origin[same_origin\]]
-    expected: FAIL
-
-  [test_source_origin[cross_origin\]]
-    expected: FAIL


### PR DESCRIPTION
Upgrade `ScriptThread::node_ids` to `pipeline_to_node_ids` to track the owner pipeline of the node
This will enable webdriver to know if it is requesting element from other origins and properly distinguish "stale element reference" from "no such element".

Testing: [Action run](https://github.com/yezhizhen/servo/actions/runs/15385994907), no regression. We can now pass WebDriver "cross origin" tests. 

Fixes: #35749 