### PR TITLE
build(deps): bump ohos-ime from 0.3.0 to 0.4.0, bump ohos-ime-sys from 0.1.4 to 0.2.0,

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5390,9 +5390,9 @@ dependencies = [
 
 [[package]]
 name = "ohos-ime"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ea454e31a3372cd9c4ed903db4fae861e92f57cf51852a3cd80f9d3945dcd"
+checksum = "c28c803dbc0fa52e888c62c0a3573ea7559e5283ac10d1d3a75f064dba032575"
 dependencies = [
  "log",
  "ohos-ime-sys",
@@ -5400,9 +5400,9 @@ dependencies = [
 
 [[package]]
 name = "ohos-ime-sys"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f68e03eb5b698781a69dc4918a17fe040a30be87de7014c12e4a2a3cb8a00f"
+checksum = "89d326ae2b2e71f95ca756b7d418c0adcb0018889e73f7eabed59671cb179608"
 
 [[package]]
 name = "ohos-sys-opaque-types"

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -90,8 +90,8 @@ hilog = "0.2.0"
 ipc-channel = { workspace = true, features = ["force-inprocess"] }
 napi-derive-ohos = "1.0.4"
 napi-ohos = "1.0.4"
-ohos-ime = "0.3.0"
-ohos-ime-sys = "0.1.4"
+ohos-ime = "0.4.0"
+ohos-ime-sys = "0.2.0"
 ohos-vsync = "0.1.3"
 xcomponent-sys = { version = "0.3.1", features = ["api-12", "keyboard-types"] }
 

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -867,14 +867,14 @@ impl HostTrait for HostCallbacks {
         let mut ime_proxy = self.ime_proxy.borrow_mut();
         let ime = ime_proxy.get_or_insert_with(|| {
             let attach_options = AttachOptions::new(true);
-            let configbuilder = ohos_ime::TextConfigBuilder::new();
             let options = convert_ime_options(input_type, multiline);
-            let text_config = configbuilder
+            let text_config = ohos_ime::TextConfigBuilder::new()
                 .input_type(options.input_type)
                 .enterkey_type(options.enterkey_type)
                 .build();
-            let editor = RawTextEditorProxy::new(Box::new(ServoIme { text_config }));
-            ImeProxy::new(editor, attach_options)
+            let editor = RawTextEditorProxy::new(Box::new(ServoIme { text_config }))
+                .expect("Failed to create RawTextEditorProxy");
+            ImeProxy::new(editor, attach_options).expect("Failed to create IME proxy")
         });
         match ime.show_keyboard() {
             Ok(()) => debug!("IME show keyboard - success"),


### PR DESCRIPTION
This patch updates following crates
ohos-ime: v0.3.0 to v0.4.0
ohos-ime-sys: v0.1.4 to v0.2.0,

Testing: N/A
Fixes: N/A