### PR TITLE
Hitrace-bench will now report simple memory results to bencher.dev.

### DIFF
--- a/support/hitrace-bencher/runs.json
+++ b/support/hitrace-bencher/runs.json
@@ -25,6 +25,28 @@
                 "start_fn_partial": "on_surface_created_cb",
                 "end_fn_partial": "PageLoadEndedPrompt"
             }
+        ],
+        "point_filters": [
+            {
+                "name": "Explicit",
+                "match_str": "explicit"
+            },
+            {
+                "name": "Resident",
+                "match_str": "resident"
+            },
+            {
+                "name": "LayoutThread",
+                "match_str": "layout-thread"
+            },
+            {
+                "name": "image-cache",
+                "match_str": "image-cache"
+            },
+            {
+                "name": "JS",
+                "match_str": "js"
+            }
         ]
     },
     {
@@ -39,7 +61,28 @@
                 "start_fn_partial": "on_surface_created_cb",
                 "end_fn_partial": "PageLoadEndedPrompt"
             }
+        ],
+        "point_filters": [
+            {
+                "name": "Explicit",
+                "match_str": "explicit"
+            },
+            {
+                "name": "Resident",
+                "match_str": "resident"
+            },
+            {
+                "name": "LayoutThread",
+                "match_str": "layout-thread"
+            },
+            {
+                "name": "image-cache",
+                "match_str": "image-cache"
+            },
+            {
+                "name": "JS",
+                "match_str": "js"
+            }
         ]
     }
 ]
-


### PR DESCRIPTION
Hitrace-bench will now report simple memory information. This includes LayoutThread memory, JS memory, image-cache. The CI needs update to hitrace-bench 0.5.0 which will have happened when t his PR is marked ready.


- Action Run: https://github.com/Narfinger/servo/actions/runs/15387749215
- Bencher output: https://bencher.dev/perf/servo-ci?branches=e50d3058-235a-4437-9bd1-84b850cf7bcc&heads=e3e709a5-0309-416d-a5f1-283f3e401d0a&testbeds=62fa0d12-4dc9-4063-b445-aad7c4ed08b3&benchmarks=6bc5e3f4-8610-4fb4-bac6-652a110d7125&measures=80b345a8-20ec-4866-b12a-20fbf690adf8&start_time=1746261995000&end_time=1748853995000&report=ec3e632c-9c00-4b69-908a-457894cc7d40&key=true&reports_per_page=4&branches_per_page=8&testbeds_per_page=8&benchmarks_per_page=8&plots_per_page=8&reports_page=1&branches_page=1&testbeds_page=1&benchmarks_page=1&plots_page=1


Testing: CI does not have test but tested on own ci.
