### PR TITLE
Implement wb element send keys for file input

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2266,15 +2266,6 @@ impl ScriptThread {
                     can_gc,
                 )
             },
-            WebDriverScriptCommand::FocusElement(element_id, reply) => {
-                webdriver_handlers::handle_focus_element(
-                    &documents,
-                    pipeline_id,
-                    element_id,
-                    reply,
-                    can_gc,
-                )
-            },
             WebDriverScriptCommand::ElementClick(element_id, reply) => {
                 webdriver_handlers::handle_element_click(
                     &documents,
@@ -2380,6 +2371,20 @@ impl ScriptThread {
             WebDriverScriptCommand::GetTitle(reply) => {
                 webdriver_handlers::handle_get_title(&documents, pipeline_id, reply)
             },
+            WebDriverScriptCommand::WillSendKeys(
+                element_id,
+                text,
+                strict_file_interactability,
+                reply,
+            ) => webdriver_handlers::handle_will_send_keys(
+                &documents,
+                pipeline_id,
+                element_id,
+                text,
+                strict_file_interactability,
+                reply,
+                can_gc,
+            ),
             _ => (),
         }
     }

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -130,7 +130,6 @@ pub enum WebDriverScriptCommand {
         IpcSender<Result<Vec<String>, ErrorStatus>>,
     ),
     FindElementElementsTagName(String, String, IpcSender<Result<Vec<String>, ErrorStatus>>),
-    FocusElement(String, IpcSender<Result<(), ErrorStatus>>),
     ElementClick(String, IpcSender<Result<Option<String>, ErrorStatus>>),
     GetActiveElement(IpcSender<Option<String>>),
     GetComputedRole(String, IpcSender<Result<Option<String>, ErrorStatus>>),
@@ -161,6 +160,8 @@ pub enum WebDriverScriptCommand {
     IsEnabled(String, IpcSender<Result<bool, ErrorStatus>>),
     IsSelected(String, IpcSender<Result<bool, ErrorStatus>>),
     GetTitle(IpcSender<String>),
+    /// Match the element type before sending the event for webdriver `element send keys`.
+    WillSendKeys(String, String, bool, IpcSender<Result<bool, ErrorStatus>>),
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1617,14 +1617,23 @@ impl Handler {
 
         let (sender, receiver) = ipc::channel().unwrap();
 
-        let cmd = WebDriverScriptCommand::FocusElement(element.to_string(), sender);
+        let cmd = WebDriverScriptCommand::WillSendKeys(
+            element.to_string(),
+            keys.text.to_string(),
+            self.session()?.strict_file_interactability,
+            sender,
+        );
         let cmd_msg = WebDriverCommandMsg::ScriptCommand(browsing_context_id, cmd);
         self.constellation_chan
             .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
 
         // TODO: distinguish the not found and not focusable cases
-        wait_for_script_response(receiver)?.map_err(|error| WebDriverError::new(error, ""))?;
+        // File input and non-typeable form control should have
+        // been handled in `webdriver_handler.rs`.
+        if wait_for_script_response(receiver)?.map_err(|error| WebDriverError::new(error, ""))? {
+            return Ok(WebDriverResponse::Void);
+        }
 
         let input_events = send_keys(&keys.text);
 

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/events.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/events.py.ini
@@ -1,7 +1,4 @@
 [events.py]
-  [test_file_upload]
-    expected: FAIL
-
   [test_form_control_send_text[input\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/file_upload.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/file_upload.py.ini
@@ -1,15 +1,8 @@
 [file_upload.py]
-  expected: TIMEOUT
   [test_empty_text]
     expected: FAIL
 
-  [test_multiple_files]
-    expected: FAIL
-
   [test_multiple_files_last_path_not_found]
-    expected: FAIL
-
-  [test_multiple_files_without_multiple_attribute]
     expected: FAIL
 
   [test_multiple_files_send_twice]
@@ -18,31 +11,7 @@
   [test_multiple_files_reset_with_element_clear]
     expected: FAIL
 
-  [test_single_file]
-    expected: FAIL
-
-  [test_single_file_replaces_without_multiple_attribute]
-    expected: FAIL
-
   [test_single_file_appends_with_multiple_attribute]
-    expected: FAIL
-
-  [test_transparent]
-    expected: FAIL
-
-  [test_obscured]
-    expected: FAIL
-
-  [test_outside_viewport]
-    expected: FAIL
-
-  [test_hidden]
-    expected: FAIL
-
-  [test_display_none]
-    expected: FAIL
-
-  [test_not_focused]
     expected: FAIL
 
   [test_focused]


### PR DESCRIPTION
We can now send keys to file input, which results in uploading file with given filename. Needs `pref=dom_testing_html_input_element_select_files_enabled` flag to work.

https://w3c.github.io/webdriver/#element-send-keys

Testing: `tests/wpt/meta/webdriver/tests/classic/element_send_keys/{events, file_upload}.py.`
