### PR TITLE
Allow usage of the mimalloc allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,6 +1489,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4312,6 +4318,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
+dependencies = [
+ "cc",
+ "cty",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4620,6 +4637,15 @@ dependencies = [
  "servo_config",
  "servo_malloc_size_of",
  "servo_url",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -6894,6 +6920,8 @@ name = "servo_allocator"
 version = "0.0.1"
 dependencies = [
  "libc",
+ "libmimalloc-sys",
+ "mimalloc",
  "tikv-jemalloc-sys",
  "tikv-jemallocator",
  "windows-sys 0.59.0",

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -12,6 +12,7 @@ path = "lib.rs"
 
 [features]
 use-system-allocator = ["libc"]
+use-mimalloc = ["mimalloc", "libmimalloc-sys"]
 
 [target.'cfg(not(any(windows, target_env = "ohos")))'.dependencies]
 libc = { workspace = true, optional = true }
@@ -23,3 +24,7 @@ windows-sys = { workspace = true, features = ["Win32_System_Memory"] }
 
 [target.'cfg(target_env = "ohos")'.dependencies]
 libc = { workspace = true }
+
+[dependencies]
+mimalloc = { version = "0.1", features = ["extended"], optional = true }
+libmimalloc-sys = { version = "0.1", optional = true }

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -9,7 +9,12 @@ static ALLOC: Allocator = Allocator;
 
 pub use crate::platform::*;
 
-#[cfg(not(any(windows, feature = "use-system-allocator", feature = "use-mimalloc", target_env = "ohos")))]
+#[cfg(not(any(
+    windows,
+    feature = "use-system-allocator",
+    feature = "use-mimalloc",
+    target_env = "ohos"
+)))]
 mod platform {
     use std::os::raw::c_void;
 
@@ -104,6 +109,6 @@ mod platform {
 
     /// Memory allocation APIs compatible with libc
     pub mod libc_compat {
-        pub use libmimalloc_sys::{ mi_free as free, mi_malloc as malloc, mi_realloc as realloc };
+        pub use libmimalloc_sys::{mi_free as free, mi_malloc as malloc, mi_realloc as realloc};
     }
 }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -52,6 +52,7 @@ webdriver = ["libservo/webdriver"]
 webgl_backtrace = ["libservo/webgl_backtrace"]
 webgpu = ["libservo/webgpu"]
 webxr = ["libservo/webxr"]
+use-mimalloc = ["servo_allocator/use-mimalloc"]
 
 [dependencies]
 cfg-if = { workspace = true }


### PR DESCRIPTION
This adds a `use-mimalloc` feature to the allocator crate. Ideally it should be exclusive with the `use-system-allocator` feature, but currently setting both with just fail to compile.

On Linux testing with https://github.com/servo/servo/issues/37223 doesn't show much difference in speed. I did not check memory usage.

Fixes: Maybe https://github.com/servo/servo/issues/37223 but I don't have a windows machine to verify.
