### PR TITLE
servoshell: Fallback to light theme when initializing `egui`

### DIFF
--- a/ports/servoshell/desktop/egui_glue.rs
+++ b/ports/servoshell/desktop/egui_glue.rs
@@ -39,6 +39,7 @@ pub use egui_winit;
 pub use egui_winit::EventResponse;
 use egui_winit::winit;
 use winit::event_loop::ActiveEventLoop;
+use winit::window::Theme;
 
 /// Use [`egui`] from a [`glow`] app based on [`winit`].
 pub struct EguiGlow {
@@ -63,6 +64,7 @@ impl EguiGlow {
             })
             .unwrap();
 
+        let theme = event_loop.system_theme().unwrap_or(Theme::Light);
         let egui_ctx = egui::Context::default();
         Self {
             egui_winit: egui_winit::State::new(
@@ -70,7 +72,7 @@ impl EguiGlow {
                 ViewportId::ROOT,
                 event_loop,
                 None,
-                event_loop.system_theme(),
+                Some(theme),
                 None,
             ),
             egui_ctx,


### PR DESCRIPTION
Not all winit platforms support getting the system theme properly. In
some places we fall back to the light theme, but it seems that the
default for `egui` is dark. This change makes it so that we fall back to
the light theme more consistently, meaning that servoshell on Wayland
will properly use the light theme.

Testing: This is difficult to test because we have no servoshell display tests.
