### PR TITLE
Keep `winit::Window` alive until all rendering contexts are destroyed

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -42,13 +42,17 @@ pub struct App {
     preferences: Preferences,
     servoshell_preferences: ServoShellPreferences,
     suspended: Cell<bool>,
-    windows: HashMap<WindowId, Rc<dyn WindowPortsMethods>>,
     minibrowser: Option<Minibrowser>,
     waker: Box<dyn EventLoopWaker>,
     initial_url: ServoUrl,
     t_start: Instant,
     t: Instant,
     state: AppState,
+
+    // This is the last field of the struct to ensure that windows are dropped *after* all other
+    // references to the relevant rendering contexts have been destroyed.
+    // (https://github.com/servo/servo/issues/36711)
+    windows: HashMap<WindowId, Rc<dyn WindowPortsMethods>>,
 }
 
 /// Action to be taken by the caller of [`App::handle_events`].

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -49,7 +49,6 @@ use crate::desktop::keyutils::CMD_OR_CONTROL;
 use crate::prefs::ServoShellPreferences;
 
 pub struct Window {
-    winit_window: winit::window::Window,
     screen_size: Size2D<u32, DeviceIndependentPixel>,
     inner_size: Cell<PhysicalSize<u32>>,
     toolbar_height: Cell<Length<f32, DeviceIndependentPixel>>,
@@ -72,6 +71,11 @@ pub struct Window {
     /// The `RenderingContext` of Servo itself. This is used to render Servo results
     /// temporarily until they can be blitted into the egui scene.
     rendering_context: Rc<OffscreenRenderingContext>,
+
+    // Keep this as the last field of the struct to ensure that the rendering context is
+    // dropped first.
+    // (https://github.com/servo/servo/issues/36711)
+    winit_window: winit::window::Window,
 }
 
 impl Window {


### PR DESCRIPTION
Dropping the window while the rendering contexts are still around causes a segmentation fault during shutdown. This is a very fragile change. I added comments to hopes of making regressions less likely.

Testing: I don't think we have a way to write tests for this change since it requires a wayland system ):
Fixes: https://github.com/servo/servo/issues/36711
