### PR TITLE
Use unified mozjs build.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4692,7 +4692,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#728acdf3d4ce0604e9f75dd1d539dc6f291ccec7"
+source = "git+https://github.com/redfire75369/mozjs?branch=build%2Funified#c195b8a1fa4b1b2dcecab2c9fc605469e5f181c0"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -4703,8 +4703,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.9-2"
-source = "git+https://github.com/servo/mozjs#728acdf3d4ce0604e9f75dd1d539dc6f291ccec7"
+version = "0.128.9-3"
+source = "git+https://github.com/redfire75369/mozjs?branch=build%2Funified#c195b8a1fa4b1b2dcecab2c9fc605469e5f181c0"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,6 +210,10 @@ debug = true
 lto = "thin"
 codegen-units = 1
 
+[patch."https://github.com/servo/mozjs"]
+mozjs = { git = "https://github.com/redfire75369/mozjs", branch = "build/unified" }
+mozjs_sys = { git = "https://github.com/redfire75369/mozjs", branch = "build/unified" }
+
 [patch.crates-io]
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:


### PR DESCRIPTION
Verifying that https://github.com/servo/mozjs/pull/553 works correctly in Servo's build.