### PR TITLE
devtools: Fix inspector on Firefox 139

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -82,6 +82,13 @@ struct BrowsingContextTraits {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+enum TargetType {
+    Frame,
+    // Other target types not implemented yet.
+}
+
+#[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BrowsingContextActorMsg {
     actor: String,
@@ -104,6 +111,7 @@ pub struct BrowsingContextActorMsg {
     reflow_actor: String,
     style_sheets_actor: String,
     thread_actor: String,
+    target_type: TargetType,
     // Part of the official protocol, but not yet implemented.
     // animations_actor: String,
     // changes_actor: String,
@@ -302,6 +310,7 @@ impl BrowsingContextActor {
             reflow_actor: self.reflow.clone(),
             style_sheets_actor: self.style_sheets.clone(),
             thread_actor: self.thread.clone(),
+            target_type: TargetType::Frame,
         }
     }
 


### PR DESCRIPTION
Added a `target_type` field so that Firefox 139 is happy with showing the inspector. In the future, this should probably include other `TARGET_TYPES` like watcher and process.

Testing: Manually tested the inspector in Firefox 139 (not sure if we have automatic devtools tests now).
Fixes: #37242