### PR TITLE
canvas: ensure there is a subpath in `PathBuilderRef`

### DIFF
--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -708,7 +708,7 @@ impl GenericPathBuilder<RaqoteBackend> for PathBuilder {
             PathOp::MoveTo(point) | PathOp::LineTo(point) => Some(Point2D::new(point.x, point.y)),
             PathOp::CubicTo(_, _, point) => Some(Point2D::new(point.x, point.y)),
             PathOp::QuadTo(_, point) => Some(Point2D::new(point.x, point.y)),
-            PathOp::Close => None,
+            PathOp::Close => path.ops.first().and_then(get_first_point),
         })
     }
 
@@ -728,6 +728,15 @@ impl GenericPathBuilder<RaqoteBackend> for PathBuilder {
     }
     fn finish(&mut self) -> raqote::Path {
         self.0.take().unwrap().finish()
+    }
+}
+
+fn get_first_point(op: &PathOp) -> Option<euclid::Point2D<f32, euclid::UnknownUnit>> {
+    match op {
+        PathOp::MoveTo(point) | PathOp::LineTo(point) => Some(Point2D::new(point.x, point.y)),
+        PathOp::CubicTo(point, _, _) => Some(Point2D::new(point.x, point.y)),
+        PathOp::QuadTo(point, _) => Some(Point2D::new(point.x, point.y)),
+        PathOp::Close => None,
     }
 }
 

--- a/tests/wpt/meta/css/css-borders/tentative/corner-shape/corner-shape-render-precise.html.ini
+++ b/tests/wpt/meta/css/css-borders/tentative/corner-shape/corner-shape-render-precise.html.ini
@@ -37,9 +37,6 @@
 [corner-shape-render-precise.html?corner-top-left-shape=bevel&border-width=10px&border-color=black]
   expected: FAIL
 
-[corner-shape-render-precise.html?corner-bottom-right-shape=bevel&corner-bottom-left-shape=bevel]
-  expected: FAIL
-
 [corner-shape-render-precise.html?corner-shape=superellipse(8)&border-radius=10px&box-shadow=10px 10px 0 10px black]
   expected: FAIL
 
@@ -91,11 +88,5 @@
 [corner-shape-render-precise.html?corner-shape=superellipse(-2)&border-top-left-radius=40%&border-width=20px]
   expected: FAIL
 
-[corner-shape-render-precise.html?corner-top-left-shape=bevel&border-width=10px]
-  expected: FAIL
-
 [corner-shape-render-precise.html?corner-shape=notch&border-radius=30px&border-width=30px]
-  expected: FAIL
-
-[corner-shape-render-precise.html?corner-top-right-shape=bevel&border-width=10px]
   expected: FAIL


### PR DESCRIPTION
This is also required by spec: https://html.spec.whatwg.org/multipage/canvas.html#ensure-there-is-a-subpath 
and if we not ensure it vello will trigger debug asserts. Enforcing this at `PathBuilderRef` is the lowest possible level that avoids misuse (and avoids IPC messages if we were to do this in content process) while still keeping it from backend.

Testing: There are tests in WPT
Split of https://github.com/servo/servo/pull/36821
try run: https://github.com/sagudev/servo/actions/runs/15449044694