### PR TITLE
layout: Force outside ::marker to establish a BFC

### DIFF
--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -744,9 +744,14 @@ impl BlockLevelJob<'_> {
                     self.propagated_data,
                     false, /* is_list_item */
                 );
+                // An outside ::marker must establish a BFC, and can't contain floats.
+                let block_formatting_context = BlockFormattingContext {
+                    contents: block_container,
+                    contains_floats: false,
+                };
                 ArcRefCell::new(BlockLevelBox::OutsideMarker(OutsideMarker {
                     base: LayoutBoxBase::new(info.into(), info.style.clone()),
-                    block_container,
+                    block_formatting_context,
                     list_item_style,
                 }))
             },

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -308,7 +308,7 @@ pub(crate) struct CollapsibleWithParentStartMargin(bool);
 pub(crate) struct OutsideMarker {
     pub list_item_style: Arc<ComputedValues>,
     pub base: LayoutBoxBase,
-    pub block_container: BlockContainer,
+    pub block_formatting_context: BlockFormattingContext,
 }
 
 impl OutsideMarker {
@@ -317,8 +317,11 @@ impl OutsideMarker {
         layout_context: &LayoutContext,
         constraint_space: &ConstraintSpace,
     ) -> InlineContentSizesResult {
-        self.base
-            .inline_content_sizes(layout_context, constraint_space, &self.block_container)
+        self.base.inline_content_sizes(
+            layout_context,
+            constraint_space,
+            &self.block_formatting_context.contents,
+        )
     }
 
     fn layout(
@@ -326,8 +329,6 @@ impl OutsideMarker {
         layout_context: &LayoutContext<'_>,
         containing_block: &ContainingBlock<'_>,
         positioning_context: &mut PositioningContext,
-        sequential_layout_state: Option<&mut SequentialLayoutState>,
-        collapsible_with_parent_start_margin: Option<CollapsibleWithParentStartMargin>,
     ) -> Fragment {
         let constraint_space = ConstraintSpace::new_for_style_and_ratio(
             &self.base.style,
@@ -342,17 +343,11 @@ impl OutsideMarker {
             style: &self.base.style,
         };
 
-        // A ::marker can't have a stretch size (must be auto), so this doesn't matter.
-        // https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing
-        let ignore_block_margins_for_stretch = LogicalSides1D::new(false, false);
-
-        let flow_layout = self.block_container.layout(
+        let flow_layout = self.block_formatting_context.layout(
             layout_context,
             positioning_context,
             &containing_block_for_children,
-            sequential_layout_state,
-            collapsible_with_parent_start_margin.unwrap_or(CollapsibleWithParentStartMargin(false)),
-            ignore_block_margins_for_stretch,
+            false, /* depends_on_block_constraints */
         );
 
         let max_inline_size =
@@ -900,13 +895,9 @@ impl BlockLevelBox {
             BlockLevelBox::OutOfFlowFloatBox(float_box) => Fragment::Float(ArcRefCell::new(
                 float_box.layout(layout_context, positioning_context, containing_block),
             )),
-            BlockLevelBox::OutsideMarker(outside_marker) => outside_marker.layout(
-                layout_context,
-                containing_block,
-                positioning_context,
-                sequential_layout_state,
-                collapsible_with_parent_start_margin,
-            ),
+            BlockLevelBox::OutsideMarker(outside_marker) => {
+                outside_marker.layout(layout_context, containing_block, positioning_context)
+            },
         };
 
         self.with_base(|base| base.set_fragment(fragment.clone()));

--- a/tests/wpt/meta/css/CSS2/lists/list-style-applies-to-017.html.ini
+++ b/tests/wpt/meta/css/CSS2/lists/list-style-applies-to-017.html.ini
@@ -1,0 +1,2 @@
+[list-style-applies-to-017.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/lists/list-style-image-applies-to-017.html.ini
+++ b/tests/wpt/meta/css/CSS2/lists/list-style-image-applies-to-017.html.ini
@@ -1,0 +1,2 @@
+[list-style-image-applies-to-017.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/lists/list-style-type-applies-to-017.html.ini
+++ b/tests/wpt/meta/css/CSS2/lists/list-style-type-applies-to-017.html.ini
@@ -1,0 +1,2 @@
+[list-style-type-applies-to-017.html]
+  expected: FAIL

--- a/tests/wpt/tests/css/CSS2/lists/list-style-applies-to-016.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-applies-to-016.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#propdef-list-style">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="../../reference/single_square_list_marker.xht">
+<meta name="assert" content="The 'list-style' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a single square below.</p>
+<div style="margin-left: 1in">
+  <div style="float: left"></div>
+  <div style="display: list-item; list-style: square"></div>
+</div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-applies-to-017.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-applies-to-017.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#propdef-list-style">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="../../reference/single_square_list_marker.xht">
+<meta name="assert" content="The 'list-style' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a single square below.</p>
+<div style="float: left; width: 1in; height: 1in"></div>
+<div style="display: list-item; list-style: square"></div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-001.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-001.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-row-group'." />
         <style type="text/css">
             #test

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-002.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-002.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-header-group'." />
         <style type="text/css">
             #test

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-003.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-003.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-footer-group'." />
         <style type="text/css">
             #test

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-004.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-004.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-row'." />
         <style type="text/css">
             #table

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-005.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-005.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-2.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-column-group'." />
         <style type="text/css">
             #test

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-006.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-006.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-2.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-column'." />
         <style type="text/css">
             #test

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-007.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-007.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-cell'." />
         <style type="text/css">
             #table

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-008.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-008.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'inline'." />
         <style type="text/css">
             div

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-009.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-009.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'block'." />
         <style type="text/css">
             span

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-010.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-010.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'list-item'." />
         <style type="text/css">
             div

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-012.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-012.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'inline-block'." />
         <style type="text/css">
             div

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-013.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-013.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table'." />
         <style type="text/css">
             #table

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-014.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-014.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'inline-table'." />
         <style type="text/css">
             #table

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-015.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-015.xht
@@ -6,6 +6,7 @@
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-image" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
         <meta name="flags" content="image" />
+        <link rel="match" href="list-style-image-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-image' property applies to elements with 'display' set to 'table-caption'." />
         <style type="text/css">
             #test

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-016.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-016.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style-image">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="list-style-image-applies-to-ref-1.html">
+<meta name="assert" content="The 'list-style-image' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a single blue square below.</p>
+<div style="margin-left: 1in">
+  <div style="float: left"></div>
+  <div style="display: list-item; list-style-image: url('support/blue15x15.png')"></div>
+</div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-017.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-017.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style-image">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="list-style-image-applies-to-ref-1.html">
+<meta name="assert" content="The 'list-style-image' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a single blue square below.</p>
+<div style="float: left; width: 1in; height: 1in"></div>
+<div style="display: list-item; list-style-image: url('support/blue15x15.png')"></div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-ref-1.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-ref-1.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  display: list-item;
+  list-style-image: url('support/blue15x15.png');
+  margin-left: 96px;
+}
+</style>
+
+<p>Test passes if there is a single blue square below.</p>
+<div>&nbsp;</div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-ref-2.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-image-applies-to-ref-2.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  display: list-item;
+  margin-left: 96px;
+}
+</style>
+
+<p>Test passes if there is a single round dot below.</p>
+<div>&nbsp;</div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-001.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-001.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-row-group'." />
         <style type="text/css">
             #test

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-002.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-002.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-header-group'." />
         <style type="text/css">
             #test

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-003.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-003.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-footer-group'." />
         <style type="text/css">
             #test

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-004.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-004.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-row'." />
         <style type="text/css">
             #table

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-005.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-005.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-2.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-column-group'." />
         <style type="text/css">
             #test

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-006.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-006.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-2.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-column'." />
         <style type="text/css">
             #test

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-007.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-007.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-cell'." />
         <style type="text/css">
             #table

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-008.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-008.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-3.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'inline'." />
         <style type="text/css">
             div

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-009.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-009.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-3.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'block'." />
         <style type="text/css">
             span

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-010.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-010.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-3.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'list-item'." />
         <style type="text/css">
             div

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-012.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-012.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'inline-block'." />
         <style type="text/css">
             div

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-013.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-013.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table'." />
         <style type="text/css">
             #table

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-014.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-014.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-1.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'inline-table'." />
         <style type="text/css">
             #table

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-015.xht
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-015.xht
@@ -5,6 +5,7 @@
         <link rel="author" title="Microsoft" href="http://www.microsoft.com/" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#propdef-list-style-position" />
         <link rel="help" href="http://www.w3.org/TR/CSS21/generate.html#list-style" />
+        <link rel="match" href="list-style-position-applies-to-ref-4.html" />
         <meta name="assert" content="The 'list-style-position' property applies to elements with 'display' set to 'table-caption'." />
         <style type="text/css">
             #test

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-016.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-016.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style-position">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="list-style-position-applies-to-ref-3.html">
+<meta name="assert" content="The 'list-style-position' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a black dot inside an orange box below.</p>
+<div style="margin-left: 1in">
+  <div style="float: left"></div>
+  <div style="display: list-item; list-style-position: inside; background: orange"></div>
+</div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-017.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-017.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS2/generate.html#propdef-list-style-position">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="list-style-position-applies-to-ref-5.html">
+<meta name="assert" content="The 'list-style-position' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a black dot inside an orange box below.</p>
+<div style="float: left; width: 1in; height: 1in"></div>
+<div style="display: list-item; list-style-position: inside; background: orange"></div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-ref-1.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-ref-1.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  display: inline-block;
+}
+span {
+  background: orange;
+  display: list-item;
+  list-style-position: inside;
+  margin-left: 1in;
+}
+</style>
+
+<p>Test passes if there is a black dot inside an orange box below.</p>
+<div><span></span></div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-ref-2.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-ref-2.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  display: list-item;
+  margin-left: 1in;
+}
+</style>
+
+<p>Test passes if there is a black dot on a white background below.</p>
+<div></div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-ref-3.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-ref-3.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  background: orange;
+  display: list-item;
+  list-style-position: inside;
+  margin-left: 1in;
+}
+</style>
+
+<p>Test passes if there is a black dot inside an orange box below.</p>
+<div></div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-ref-4.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-ref-4.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  background: orange;
+  display: list-item;
+  list-style-position: inside;
+  margin-left: 1in;
+  width: 5em;
+}
+</style>
+
+<p>Test passes if there is a black dot inside an orange box below.</p>
+<div></div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-ref-5.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-position-applies-to-ref-5.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>CSS Reference</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+div {
+  background: orange;
+  display: list-item;
+  list-style-position: inside;
+  padding-left: 1in;
+}
+</style>
+
+<p>Test passes if there is a black dot inside an orange box below.</p>
+<div></div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-type-applies-to-016.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-type-applies-to-016.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="../../reference/single_square_list_marker.xht">
+<meta name="assert" content="The 'list-style-type' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a single square below.</p>
+<div style="margin-left: 1in">
+  <div style="float: left"></div>
+  <div style="display: list-item; list-style-type: square"></div>
+</div>

--- a/tests/wpt/tests/css/CSS2/lists/list-style-type-applies-to-017.html
+++ b/tests/wpt/tests/css/CSS2/lists/list-style-type-applies-to-017.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#propdef-list-style-type">
+<link rel="help" href="https://www.w3.org/TR/CSS21/generate.html#list-style">
+<link rel="help" href="https://github.com/servo/servo/issues/37222">
+<link rel="match" href="../../reference/single_square_list_marker.xht">
+<meta name="assert" content="The 'list-style-type' property applies to a list item which is a sibling of a float.">
+
+<p>Test passes if there is a single square below.</p>
+<div style="float: left; width: 1in; height: 1in"></div>
+<div style="display: list-item; list-style-type: square"></div>


### PR DESCRIPTION
Even though we were continuing the parent BFC, we weren't updating the SequentialLayoutState to have the correct containing block info. That caused problem in the presence of floats.

This patch establishes an independent BFC, which avoids the problem. This seems reasonable since outside markers are out-of-flow-ish, and it matches Firefox. Blink implements them as inline-blocks, so they should also establish a BFC.

Testing: Adding new tests. Some still fail because of a different issue. Also, adding an expectation for several existing tests that were missing it.
Fixes: #37222
