### PR TITLE
Add support for subsuite to servo(driver)

### DIFF
--- a/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servo.py
@@ -37,7 +37,8 @@ def check_args(**kwargs):
     require_arg(kwargs, "binary")
 
 
-def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
+def browser_kwargs(logger, test_type, run_info_data, config, subsuite, **kwargs):
+    kwargs["binary_args"].extend(subsuite.config.get("binary_args", []))
     return {
         "binary": kwargs["binary"],
         "debug_info": kwargs["debug_info"],
@@ -68,7 +69,7 @@ def env_options():
 
 
 def update_properties():
-    return ["debug", "os", "processor"], {"os": ["version"], "processor": ["bits"]}
+    return ["debug", "os", "processor", "subsuite"], {"os": ["version"], "processor": ["bits"]}
 
 
 class ServoBrowser(NullBrowser):

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -39,7 +39,8 @@ def check_args(**kwargs):
     require_arg(kwargs, "binary")
 
 
-def browser_kwargs(logger, test_type, run_info_data, config, **kwargs):
+def browser_kwargs(logger, test_type, run_info_data, config, subsuite, **kwargs):
+    kwargs["binary_args"].extend(subsuite.config.get("binary_args", []))
     return {
         "binary": kwargs["binary"],
         "binary_args": kwargs["binary_args"],
@@ -67,7 +68,7 @@ def env_options():
 
 
 def update_properties():
-    return (["debug", "os", "processor"], {"os": ["version"], "processor": ["bits"]})
+    return (["debug", "os", "processor", "subsuite"], {"os": ["version"], "processor": ["bits"]})
 
 
 def write_hosts_file(config):


### PR DESCRIPTION
based on firefox code https://github.com/web-platform-tests/wpt/blob/2e547483d48c482395a801e2a82fdae5a60983e3/tools/wptrunner/wptrunner/browsers/firefox.py#L139
and https://github.com/web-platform-tests/wpt/commit/9cc314e8042e9637b1eeb1836e462b19fe7730d3

Testing: These are for testing
Split of #36821
