### PR TITLE
Unify Scroll Offsets Caching of Script and Layout Thread

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -257,7 +257,7 @@ impl PipelineDetails {
         }
     }
 
-    // MYNOTES: move this to display list
+    // MYNOTES: we also do this in the display list now
     fn install_new_scroll_tree(&mut self, new_scroll_tree: ScrollTree) {
         let old_scroll_offsets: FnvHashMap<ExternalScrollId, LayoutVector2D> = self
             .scroll_tree
@@ -731,7 +731,10 @@ impl IOCompositor {
 
                 if !pipeline_details
                     .scroll_tree
-                    .set_scroll_offsets_for_node_with_external_scroll_id(&external_scroll_id, offset)
+                    .set_scroll_offsets_for_node_with_external_scroll_id(
+                        &external_scroll_id,
+                        offset,
+                    )
                 {
                     warn!("Could not scroll not with id: {external_scroll_id:?}");
                     return;

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -257,6 +257,7 @@ impl PipelineDetails {
         }
     }
 
+    // MYNOTES: move this to display list
     fn install_new_scroll_tree(&mut self, new_scroll_tree: ScrollTree) {
         let old_scroll_offsets: FnvHashMap<ExternalScrollId, LayoutVector2D> = self
             .scroll_tree
@@ -717,7 +718,7 @@ impl IOCompositor {
                 self.global.borrow_mut().send_transaction(txn);
             },
 
-            CompositorMsg::SendScrollNode(webview_id, pipeline_id, point, external_scroll_id) => {
+            CompositorMsg::SendScrollNode(webview_id, pipeline_id, offset, external_scroll_id) => {
                 let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
                     return;
                 };
@@ -728,13 +729,9 @@ impl IOCompositor {
                     return;
                 };
 
-                let offset = LayoutVector2D::new(point.x, point.y);
                 if !pipeline_details
                     .scroll_tree
-                    .set_scroll_offsets_for_node_with_external_scroll_id(
-                        external_scroll_id,
-                        -offset,
-                    )
+                    .set_scroll_offsets_for_node_with_external_scroll_id(&external_scroll_id, offset)
                 {
                     warn!("Could not scroll not with id: {external_scroll_id:?}");
                     return;

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -257,7 +257,7 @@ impl PipelineDetails {
         }
     }
 
-    // MYNOTES: we also do this in the display list now
+    /// Install a new scroll tree, but maintaining the scroll offsets it has from the old ones.
     fn install_new_scroll_tree(&mut self, new_scroll_tree: ScrollTree) {
         let old_scroll_offsets: FnvHashMap<ExternalScrollId, LayoutVector2D> = self
             .scroll_tree
@@ -744,7 +744,7 @@ impl IOCompositor {
                 txn.set_scroll_offsets(
                     external_scroll_id,
                     vec![SampledScrollOffset {
-                        offset,
+                        offset: -offset,
                         generation: 0,
                     }],
                 );

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -183,7 +183,6 @@ impl WebViewRenderer {
         self.pipelines.remove(&pipeline_id);
     }
 
-    // MYNOTES: I suppose this is not needed now? If changing composition's frame tree does trigger reflow?
     pub(crate) fn set_frame_tree(&mut self, frame_tree: &SendableFrameTree) {
         let pipeline_id = frame_tree.pipeline.id;
         let old_pipeline_id = std::mem::replace(&mut self.root_pipeline_id, Some(pipeline_id));
@@ -876,6 +875,8 @@ impl WebViewRenderer {
                 combined_event.scroll_location,
             )
         });
+        // If something is scrolled, we are sending the scroll information to layout in
+        // order to sync the scroll offsets for queries and scripts.
         if let Some(scroll_result) = scroll_result {
             self.send_scroll_result_to_layout(scroll_result);
         }
@@ -894,7 +895,6 @@ impl WebViewRenderer {
     /// scrolling to the applicable scroll node under that point. If a scroll was
     /// performed, returns the [`PipelineId`] of the node scrolled, the id, and the final
     /// scroll delta.
-    // MYNOTES: this could be changed to we only store the diff
     fn scroll_node_at_device_point(
         &mut self,
         cursor: DevicePoint,

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -862,9 +862,10 @@ impl WebViewRenderer {
                 combined_event.scroll_location,
             )
         });
-        if let Some(scroll_result) = scroll_result {
-            self.send_scroll_positions_to_layout_for_pipeline(scroll_result.pipeline_id);
-        }
+        // MYNOTES: change this to single update
+        // if let Some(scroll_result) = scroll_result {
+        //     self.send_scroll_positions_to_layout_for_pipeline(scroll_result.pipeline_id);
+        // }
 
         let pinch_zoom_result = match self
             .set_pinch_zoom_level(self.pinch_zoom_level().get() * combined_magnification)

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -220,6 +220,20 @@ impl WebViewRenderer {
         );
     }
 
+    pub(crate) fn send_scroll_result_to_layout(&self, scroll_result: ScrollResult) {
+        let scroll_state = ScrollState {
+            scroll_id: scroll_result.external_scroll_id,
+            scroll_offset: scroll_result.offset,
+        };
+
+        let _ = self.global.borrow().constellation_sender.send(
+            EmbedderToConstellationMessage::UpdateScrollState(
+                scroll_result.pipeline_id,
+                scroll_state,
+            ),
+        );
+    }
+
     pub(crate) fn set_frame_tree_on_pipeline_details(
         &mut self,
         frame_tree: &SendableFrameTree,
@@ -862,10 +876,9 @@ impl WebViewRenderer {
                 combined_event.scroll_location,
             )
         });
-        // MYNOTES: change this to single update
-        // if let Some(scroll_result) = scroll_result {
-        //     self.send_scroll_positions_to_layout_for_pipeline(scroll_result.pipeline_id);
-        // }
+        if let Some(scroll_result) = scroll_result {
+            self.send_scroll_result_to_layout(scroll_result);
+        }
 
         let pinch_zoom_result = match self
             .set_pinch_zoom_level(self.pinch_zoom_level().get() * combined_magnification)

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -183,6 +183,7 @@ impl WebViewRenderer {
         self.pipelines.remove(&pipeline_id);
     }
 
+    // MYNOTES: I suppose this is not needed now? If changing composition's frame tree does trigger reflow?
     pub(crate) fn set_frame_tree(&mut self, frame_tree: &SendableFrameTree) {
         let pipeline_id = frame_tree.pipeline.id;
         let old_pipeline_id = std::mem::replace(&mut self.root_pipeline_id, Some(pipeline_id));
@@ -879,6 +880,7 @@ impl WebViewRenderer {
     /// scrolling to the applicable scroll node under that point. If a scroll was
     /// performed, returns the [`PipelineId`] of the node scrolled, the id, and the final
     /// scroll delta.
+    // MYNOTES: this could be changed to we only store the diff
     fn scroll_node_at_device_point(
         &mut self,
         cursor: DevicePoint,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -6019,6 +6019,7 @@ where
         }
     }
 
+    // MYNOTES: this shouldn't be necessary anymore since, we have scroll offsets tree at layout impl
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -6022,14 +6022,13 @@ where
         }
     }
 
-    // MYNOTES: this shouldn't be necessary anymore since, we have scroll offsets tree at layout impl
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
     )]
     fn handle_set_scroll_states(&self, pipeline_id: PipelineId, scroll_states: Vec<ScrollState>) {
         let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
-            warn!("Discarding scroll offset update for unknown pipeline");
+            warn!("Discarding scroll offsets update for unknown pipeline");
             return;
         };
         if let Err(error) = pipeline
@@ -6049,7 +6048,7 @@ where
     )]
     fn handle_update_scroll_state(&self, pipeline_id: PipelineId, scroll_state: ScrollState) {
         let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
-            warn!("Discarding scroll offset update for unknown pipeline");
+            warn!("Discarding a scroll result update for unknown pipeline");
             return;
         };
         if let Err(error) = pipeline
@@ -6059,7 +6058,7 @@ where
                 scroll_state,
             ))
         {
-            warn!("Could not send scroll offsets to pipeline: {pipeline_id:?}: {error:?}");
+            warn!("Could not send scroll result update to pipeline: {pipeline_id:?}: {error:?}");
         }
     }
 

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -76,6 +76,7 @@ mod from_compositor {
                 Self::MediaSessionAction(_) => target!("MediaSessionAction"),
                 Self::SetWebViewThrottled(_, _) => target!("SetWebViewThrottled"),
                 Self::SetScrollStates(..) => target!("SetScrollStates"),
+                Self::UpdateScrollState(..) => target!("UpdateScrollState"),
                 Self::PaintMetric(..) => target!("PaintMetric"),
                 Self::EvaluateJavaScript(..) => target!("EvaluateJavaScript"),
                 Self::CreateMemoryReport(..) => target!("CreateMemoryReport"),

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -118,7 +118,7 @@ pub(crate) struct StackingContextTree {
 impl StackingContextTree {
     /// Create a new [DisplayList] given the dimensions of the layout and the WebRender
     /// pipeline id.
-    // MYNOTES: fix this
+    // FIXME(stevennovaryo): refactor the stacking context parameters
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         fragment_tree: &FragmentTree,
@@ -979,6 +979,8 @@ impl BoxFragment {
         StackingContextSection::DescendantBackgroundsAndBorders
     }
 
+    // FIXME(stevennovaryo): refactor the stacking context parameters
+    #[allow(clippy::too_many_arguments)]
     fn build_stacking_context_tree(
         &self,
         fragment: Fragment,
@@ -1000,6 +1002,8 @@ impl BoxFragment {
         );
     }
 
+    // FIXME(stevennovaryo): refactor the stacking context parameters
+    #[allow(clippy::too_many_arguments)]
     fn build_stacking_context_tree_maybe_creating_reference_frame(
         &self,
         fragment: Fragment,
@@ -1076,7 +1080,7 @@ impl BoxFragment {
         );
     }
 
-    // MYNOTES: fix this
+    // FIXME(stevennovaryo): refactor the stacking context parameters
     #[allow(clippy::too_many_arguments)]
     fn build_stacking_context_tree_maybe_creating_stacking_context(
         &self,
@@ -1172,7 +1176,7 @@ impl BoxFragment {
             .append(&mut stolen_children);
     }
 
-    // MYNOTES: fix this
+    // FIXME(stevennovaryo): refactor the stacking context parameters
     #[allow(clippy::too_many_arguments)]
     fn build_stacking_context_tree_for_children(
         &self,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -412,27 +412,6 @@ impl Layout for LayoutThread {
             .unwrap_or_default()
     }
 
-    /// Step 1-4 of <https://drafts.csswg.org/cssom-view/#element-scrolling-members>
-    /// Additionally, we are updating the scroll states to be processed by
-    fn process_scroll_an_element_position(
-        &self,
-        node: OpaqueNode,
-        scroll_offset: LayoutVector2D,
-    ) -> LayoutVector2D {
-        // TODO(stevennovaryo): handle step 1-4 properly here
-        let scroll_id = ExternalScrollId(
-            combine_id_with_fragment_type(node.id(), FragmentType::FragmentBody),
-            self.id.into(),
-        );
-        let scroll_state = ScrollState {
-            scroll_id,
-            scroll_offset,
-        };
-        self.update_scroll_node_state(&scroll_state);
-
-        scroll_offset
-    }
-
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
@@ -526,6 +505,14 @@ impl Layout for LayoutThread {
             {
                 tree.set_scroll_offsets_for_node_with_external_scroll_id(scroll_id, *scroll_offset);
             }
+        }
+    }
+
+    //
+    fn update_scroll_offset(&self, scroll_id: ExternalScrollId, scroll_offset: LayoutVector2D) {
+        if let Some(mut scroll_tree) = self.cached_scroll_tree_mut() {
+            scroll_tree
+                .set_scroll_offsets_for_node_with_external_scroll_id(&scroll_id, scroll_offset);
         }
     }
 }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -496,6 +496,9 @@ impl Layout for LayoutThread {
     ) {
     }
 
+    /// Sets the scroll offsets of the cached [`ScrollTree`] based on the scroll states.
+    ///
+    /// This is done whenever the embedder ask layout to do so.
     fn set_scroll_offsets(&mut self, scroll_states: &[ScrollState]) {
         if let Some(mut tree) = self.cached_scroll_tree_mut() {
             for ScrollState {
@@ -508,7 +511,9 @@ impl Layout for LayoutThread {
         }
     }
 
-    //
+    /// Update a node's scroll offsets in the cached [`ScrollTree`].
+    ///
+    /// This is done whenever the embedder ask layout to do so.
     fn update_scroll_offset(&self, scroll_id: ExternalScrollId, scroll_offset: LayoutVector2D) {
         if let Some(mut scroll_tree) = self.cached_scroll_tree_mut() {
             scroll_tree
@@ -773,10 +778,10 @@ impl LayoutThread {
             .flush(guards, Some(root_element), Some(snapshot_map));
     }
 
-    // #[cfg_attr(
-    //     feature = "tracing",
-    //     tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
-    // )]
+    #[cfg_attr(
+        feature = "tracing",
+        tracing::instrument(skip_all, fields(servo_profiling = true), level = "trace")
+    )]
     fn restyle_and_build_trees(
         &self,
         reflow_request: &ReflowRequest,
@@ -848,7 +853,8 @@ impl LayoutThread {
         *self.fragment_tree.borrow_mut() = Some(fragment_tree);
 
         // The FragmentTree has been updated, so any existing StackingContext tree that layout
-        // had is now out of date and should be rebuilt.
+        // had is now out of date and should be rebuilt. We could still uses some information
+        // from the previous StackingContext tree though.
         let old_stacking_context_tree = self.stacking_context_tree.borrow_mut().take();
 
         if self.debug.dump_style_tree {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2541,22 +2541,23 @@ impl Window {
         behavior: ScrollBehavior,
         can_gc: CanGc,
     ) {
-        // The scroll offsets are immediatly updated since later calls
-        // to topScroll and others may access the properties before
-        // webrender has a chance to update the offsets.
-        let x = x_.to_f32().unwrap_or(0.0f32);
-        let y = y_.to_f32().unwrap_or(0.0f32);
+        // TODO(stevennovaryo): Impl step 1-5
         let scroll_id = ExternalScrollId(
             combine_id_with_fragment_type(node.to_opaque().id(), FragmentType::FragmentBody),
             self.pipeline_id().into(),
         );
-        self.layout()
-            .update_scroll_offset(scroll_id, Vector2D::new(-x, -y));
 
         // Step 6
         // > Perform a scroll of box to position, element as the associated
         // > element and behavior as the scroll behavior.
-        self.perform_a_scroll(x, y, scroll_id, behavior, None, can_gc);
+        self.perform_a_scroll(
+            x_.to_f32().unwrap_or(0.0f32),
+            y_.to_f32().unwrap_or(0.0f32),
+            scroll_id,
+            behavior,
+            None,
+            can_gc,
+        );
     }
 
     pub(crate) fn resolved_style_query(

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -77,7 +77,6 @@ use servo_arc::Arc as ServoArc;
 use servo_config::{opts, pref};
 use servo_geometry::{DeviceIndependentIntRect, MaxRect, f32_rect_to_au_rect};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
-use style::dom::OpaqueNode;
 use style::error_reporting::{ContextualParseError, ParseErrorReporter};
 use style::properties::PropertyId;
 use style::properties::style_structs::Font;
@@ -2552,7 +2551,7 @@ impl Window {
             self.pipeline_id().into(),
         );
         self.layout()
-            .update_scroll_offset(scroll_id, Vector2D::new(x, y));
+            .update_scroll_offset(scroll_id, Vector2D::new(-x, -y));
 
         // Step 6
         // > Perform a scroll of box to position, element as the associated

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2547,13 +2547,12 @@ impl Window {
         // webrender has a chance to update the offsets.
         let x = x_.to_f32().unwrap_or(0.0f32);
         let y = y_.to_f32().unwrap_or(0.0f32);
-        self.layout()
-            .process_scroll_an_element_position(node.to_opaque(), Vector2D::new(x, y));
-
         let scroll_id = ExternalScrollId(
             combine_id_with_fragment_type(node.to_opaque().id(), FragmentType::FragmentBody),
             self.pipeline_id().into(),
         );
+        self.layout()
+            .update_scroll_offset(scroll_id, Vector2D::new(x, y));
 
         // Step 6
         // > Perform a scroll of box to position, element as the associated

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -91,6 +91,7 @@ impl MixedMessage {
                 #[cfg(feature = "webgpu")]
                 ScriptThreadMessage::SetWebGPUPort(..) => None,
                 ScriptThreadMessage::SetScrollStates(id, ..) => Some(*id),
+                ScriptThreadMessage::UpdateScrollState(id, ..) => Some(*id),
                 ScriptThreadMessage::EvaluateJavaScript(id, _, _) => Some(*id),
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1930,7 +1930,10 @@ impl ScriptThread {
 
                 for scroll_state in scroll_states.into_iter() {
                     if scroll_state.scroll_id.is_root() {
-                        window.update_viewport_for_scroll(-scroll_state.scroll_offset.x, -scroll_state.scroll_offset.y);
+                        window.update_viewport_for_scroll(
+                            -scroll_state.scroll_offset.x,
+                            -scroll_state.scroll_offset.y,
+                        );
                     }
                 }
             },

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1909,6 +1909,9 @@ impl ScriptThread {
             ScriptThreadMessage::SetScrollStates(pipeline_id, scroll_states) => {
                 self.handle_set_scroll_states(pipeline_id, scroll_states)
             },
+            ScriptThreadMessage::UpdateScrollState(pipeline_id, scroll_state) => {
+                self.handle_update_scroll_state(pipeline_id, scroll_state)
+            },
             ScriptThreadMessage::EvaluateJavaScript(pipeline_id, evaluation_id, script) => {
                 self.handle_evaluate_javascript(pipeline_id, evaluation_id, script, can_gc);
             },
@@ -1938,6 +1941,15 @@ impl ScriptThread {
                 }
             },
         )
+    }
+
+    fn handle_update_scroll_state(&self, pipeline_id: PipelineId, scroll_state: ScrollState) {
+        let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
+            warn!("Received scroll states for closed pipeline {pipeline_id}");
+            return;
+        };
+
+        window.layout_mut().update_scroll_offset(scroll_state.scroll_id, scroll_state.scroll_offset);
     }
 
     #[cfg(feature = "webgpu")]

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1925,20 +1925,14 @@ impl ScriptThread {
             ScriptThreadEventCategory::SetScrollState,
             Some(pipeline_id),
             || {
+                // MYNOTES: FIXME
                 window.layout_mut().set_scroll_offsets(&scroll_states);
 
-                let mut scroll_offsets = HashMap::new();
                 for scroll_state in scroll_states.into_iter() {
-                    let scroll_offset = scroll_state.scroll_offset;
                     if scroll_state.scroll_id.is_root() {
-                        window.update_viewport_for_scroll(-scroll_offset.x, -scroll_offset.y);
-                    } else if let Some(node_id) =
-                        node_id_from_scroll_id(scroll_state.scroll_id.0 as usize)
-                    {
-                        scroll_offsets.insert(OpaqueNode(node_id), -scroll_offset);
+                        window.update_viewport_for_scroll(-scroll_state.scroll_offset.x, -scroll_state.scroll_offset.y);
                     }
                 }
-                window.set_scroll_offsets(scroll_offsets)
             },
         )
     }

--- a/components/shared/compositing/display_list.rs
+++ b/components/shared/compositing/display_list.rs
@@ -264,11 +264,12 @@ impl ScrollTree {
         parent: Option<&ScrollTreeNodeId>,
         info: SpatialTreeNodeInfo,
     ) -> ScrollTreeNodeId {
-        let new_scroll_id =         ScrollTreeNodeId {
+        let new_scroll_id = ScrollTreeNodeId {
             index: self.nodes.len(),
         };
         if let SpatialTreeNodeInfo::Scroll(spatial_scroll_node) = &info {
-            self.external_scroll_id_to_node_id.insert(spatial_scroll_node.external_id, new_scroll_id);
+            self.external_scroll_id_to_node_id
+                .insert(spatial_scroll_node.external_id, new_scroll_id);
         }
 
         self.nodes.push(ScrollTreeNode {
@@ -370,6 +371,9 @@ impl ScrollTree {
         }
         false
     }
+
+    // Update this stacking context
+    pub fn persevere_old_stacking_context_tree_scroll() {}
 }
 
 /// A data structure which stores compositor-side information about

--- a/components/shared/compositing/display_list.rs
+++ b/components/shared/compositing/display_list.rs
@@ -157,7 +157,7 @@ impl ScrollTreeNode {
 
     /// Set the offset for this node, returns false if this was a
     /// non-scrolling node for which you cannot set the offset.
-    // MYNOTES: should i make this &mut so it will modify the new_offset
+    // TODO(stevennovaryo): We should consider writing mode as well.
     pub fn set_offset(&mut self, new_offset: LayoutVector2D) -> bool {
         match self.info {
             SpatialTreeNodeInfo::Scroll(ref mut info) => {
@@ -361,12 +361,11 @@ impl ScrollTree {
     ) -> bool {
         if let Some(node) = self.get_node_by_external_scroll_id_mut(external_scroll_id) {
             node.set_offset(offset);
+            true
+        } else {
+            false
         }
-        false
     }
-
-    // Update this stacking context
-    pub fn persevere_old_stacking_context_tree_scroll() {}
 }
 
 /// A data structure which stores compositor-side information about

--- a/components/shared/compositing/display_list.rs
+++ b/components/shared/compositing/display_list.rs
@@ -157,6 +157,7 @@ impl ScrollTreeNode {
 
     /// Set the offset for this node, returns false if this was a
     /// non-scrolling node for which you cannot set the offset.
+    // MYNOTES: should i make this &mut so it will modify the new_offset
     pub fn set_offset(&mut self, new_offset: LayoutVector2D) -> bool {
         match self.info {
             SpatialTreeNodeInfo::Scroll(ref mut info) => {
@@ -359,15 +360,7 @@ impl ScrollTree {
         offset: LayoutVector2D,
     ) -> bool {
         if let Some(node) = self.get_node_by_external_scroll_id_mut(external_scroll_id) {
-            match node.info {
-                SpatialTreeNodeInfo::Scroll(ref mut scroll_info)
-                    if &scroll_info.external_id == external_scroll_id =>
-                {
-                    scroll_info.offset = offset;
-                    return true;
-                },
-                _ => {},
-            }
+            node.set_offset(offset);
         }
         false
     }

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -34,7 +34,7 @@ use ipc_channel::ipc::{self, IpcSharedMemory};
 use profile_traits::mem::{OpaqueSender, ReportsChan};
 use serde::{Deserialize, Serialize};
 use servo_geometry::{DeviceIndependentIntRect, DeviceIndependentIntSize};
-use webrender_api::units::{DevicePoint, LayoutPoint, TexelRect};
+use webrender_api::units::{DevicePoint, LayoutVector2D, TexelRect};
 use webrender_api::{
     BuiltDisplayList, BuiltDisplayListDescriptor, ExternalImage, ExternalImageData,
     ExternalImageHandler, ExternalImageId, ExternalImageSource, ExternalScrollId,
@@ -121,7 +121,7 @@ pub enum CompositorMsg {
     SendScrollNode(
         WebViewId,
         WebRenderPipelineId,
-        LayoutPoint,
+        LayoutVector2D,
         ExternalScrollId,
     ),
     /// Inform WebRender of a new display list for the given pipeline.
@@ -227,13 +227,13 @@ impl CrossProcessCompositorApi {
         &self,
         webview_id: WebViewId,
         pipeline_id: WebRenderPipelineId,
-        point: LayoutPoint,
+        offset: LayoutVector2D,
         scroll_id: ExternalScrollId,
     ) {
         if let Err(e) = self.0.send(CompositorMsg::SendScrollNode(
             webview_id,
             pipeline_id,
-            point,
+            offset,
             scroll_id,
         )) {
             warn!("Error sending scroll node: {}", e);

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -90,7 +90,11 @@ pub enum EmbedderToConstellationMessage {
     SetWebViewThrottled(WebViewId, bool),
     /// The Servo renderer scrolled and is updating the scroll states of the nodes in the
     /// given pipeline via the constellation.
+    // MYNOTES: Do we still need this?
     SetScrollStates(PipelineId, Vec<ScrollState>),
+    /// The Servo renderer scrolled and is updating the scroll states of the nodes in the
+    /// given pipeline via the constellation.
+    UpdateScrollState(PipelineId, ScrollState),
     /// Notify the constellation that a particular paint metric event has happened for the given pipeline.
     PaintMetric(PipelineId, PaintMetricEvent),
     /// Evaluate a JavaScript string in the context of a `WebView`. When execution is complete or an

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -90,7 +90,6 @@ pub enum EmbedderToConstellationMessage {
     SetWebViewThrottled(WebViewId, bool),
     /// The Servo renderer scrolled and is updating the scroll states of the nodes in the
     /// given pipeline via the constellation.
-    // MYNOTES: Do we still need this?
     SetScrollStates(PipelineId, Vec<ScrollState>),
     /// The Servo renderer scrolled and is updating the scroll states of the nodes in the
     /// given pipeline via the constellation.

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -247,6 +247,9 @@ pub enum ScriptThreadMessage {
     /// The compositor scrolled and is updating the scroll states of the nodes in the given
     /// pipeline via the Constellation.
     SetScrollStates(PipelineId, Vec<ScrollState>),
+    /// The compositor scrolled and is updating the scroll state of a node in the given
+    /// pipeline via the Constellation.
+    UpdateScrollState(PipelineId, ScrollState),
     /// Evaluate the given JavaScript and return a result via a corresponding message
     /// to the Constellation.
     EvaluateJavaScript(PipelineId, JavaScriptEvaluationId, String),

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -48,7 +48,7 @@ use style::properties::PropertyId;
 use style::properties::style_structs::Font;
 use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
 use style::stylesheets::Stylesheet;
-use webrender_api::ImageKey;
+use webrender_api::{ExternalScrollId, ImageKey};
 use webrender_api::units::{DeviceIntSize, LayoutVector2D};
 
 pub trait GenericLayoutDataTrait: Any + MallocSizeOfTrait {
@@ -250,13 +250,7 @@ pub trait Layout {
     /// Query scroll offset for any scroll offset query through the layout.
     fn query_scroll_offset(&self, node: OpaqueNode) -> LayoutVector2D;
 
-    /// Process the step 1-4 of scroll an element algorithm.
-    /// <https://drafts.csswg.org/cssom-view/#scroll-an-element>
-    fn process_scroll_an_element_position(
-        &self,
-        node: OpaqueNode,
-        scroll_offset: LayoutVector2D,
-    ) -> LayoutVector2D;
+    fn update_scroll_offset(&self, scroll_id: ExternalScrollId, scroll_offset: LayoutVector2D);
 
     fn query_content_box(&self, node: TrustedNodeAddress) -> Option<Rect<Au>>;
     fn query_content_boxes(&self, node: TrustedNodeAddress) -> Vec<Rect<Au>>;

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -48,8 +48,8 @@ use style::properties::PropertyId;
 use style::properties::style_structs::Font;
 use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
 use style::stylesheets::Stylesheet;
-use webrender_api::{ExternalScrollId, ImageKey};
 use webrender_api::units::{DeviceIntSize, LayoutVector2D};
+use webrender_api::{ExternalScrollId, ImageKey};
 
 pub trait GenericLayoutDataTrait: Any + MallocSizeOfTrait {
     fn as_any(&self) -> &dyn Any;

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -49,7 +49,7 @@ use style::properties::style_structs::Font;
 use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
 use style::stylesheets::Stylesheet;
 use webrender_api::ImageKey;
-use webrender_api::units::DeviceIntSize;
+use webrender_api::units::{DeviceIntSize, LayoutVector2D};
 
 pub trait GenericLayoutDataTrait: Any + MallocSizeOfTrait {
     fn as_any(&self) -> &dyn Any;
@@ -246,6 +246,17 @@ pub trait Layout {
 
     /// Set the scroll states of this layout after a compositor scroll.
     fn set_scroll_offsets(&mut self, scroll_states: &[ScrollState]);
+
+    /// Query scroll offset for any scroll offset query through the layout.
+    fn query_scroll_offset(&self, node: OpaqueNode) -> LayoutVector2D;
+
+    /// Process the step 1-4 of scroll an element algorithm.
+    /// <https://drafts.csswg.org/cssom-view/#scroll-an-element>
+    fn process_scroll_an_element_position(
+        &self,
+        node: OpaqueNode,
+        scroll_offset: LayoutVector2D,
+    ) -> LayoutVector2D;
 
     fn query_content_box(&self, node: TrustedNodeAddress) -> Option<Rect<Au>>;
     fn query_content_boxes(&self, node: TrustedNodeAddress) -> Vec<Rect<Au>>;


### PR DESCRIPTION
Following the recent caching of `StackingContextTree`, now it is possible to use the cached tree for layout queries and script computation. 

This changes remove the old scroll offsets sync between composition and layout, which uses `scroll_offsets` HashMap. These `scroll_offsets` HashMap is previously maintained by having a IPC message `EmbedderToConstellationMessage::SetScrollStates` that sends a whole `ScrollNode`, this will causes mouse scrolling to be very janky and slow when a website is quite enormous. The changes introduces a new messages `EmbedderToConstellationMessage::UpdateScrollState` that sends a single `ScrollResult` to updates a single node, rather than a whole `ScrollTree`. 

Furthermore, the old `StackingContextTree` (specifically the `ScrollTree`) will be included in the `StackingContextTree`'s computation, for persisting the scroll offsets. In the near future, the old `StackingContextTree` could be used to handle the invalidation of lazy/caching of transform queries. Or, to reduce the payload of `CompositorMsg::SendDisplayList` by sending modification list instead of a full `ScrollTree`.

This changes also drive `Window` to use the information from cached `StackingContextTree`. This should be a bit slower for accessing and setting `offset`.  

The big picture of how a scroll lives in Servo and the the changes introduced by this PR is shown by the following diagram. With the pat that could be optimized shown by the red background, and the new changes is marked with the green ones.
![Scrolling drawio](https://github.com/user-attachments/assets/7a0ab47e-c4c9-4626-a43b-039cb2a01686)

Testing: At least no regression of WPT.
Fixes: #35019 and part of #36879
