### PR TITLE
CI: Limit concurency of WPT Export

### DIFF
--- a/.github/workflows/pull-request-wpt-export.yml
+++ b/.github/workflows/pull-request-wpt-export.yml
@@ -4,6 +4,10 @@ on:
     types: ['opened', 'synchronize', 'reopened', 'edited', 'closed']
     branches: ['main']
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: false
+
 jobs:
   upstream:
     # Run job only on servo/servo


### PR DESCRIPTION
In https://github.com/servo/servo/pull/37255 I discovered that editing PR title to soon will not take into affect until I manually rerun WPT export (because first run that actually created PR hasn't done yet). We can somehow resolve this by  forbidding concurrent runs of WPT Export for same PR and hope that first queued run is also firstly run.

docs: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs

Testing: This is CI
