### PR TITLE
[webdriver] Add synchronization for wheel action

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -673,7 +673,7 @@ impl IOCompositor {
                 let point = dppx.transform_point(Point2D::new(x, y));
                 webview_renderer.dispatch_point_input_event(
                     InputEvent::MouseButton(MouseButtonEvent::new(action, button, point))
-                        .with_webdriver_message_id(Some(message_id)),
+                        .with_webdriver_message_id(message_id),
                 );
             },
 
@@ -686,11 +686,18 @@ impl IOCompositor {
                 let point = dppx.transform_point(Point2D::new(x, y));
                 webview_renderer.dispatch_point_input_event(
                     InputEvent::MouseMove(MouseMoveEvent::new(point))
-                        .with_webdriver_message_id(Some(message_id)),
+                        .with_webdriver_message_id(message_id),
                 );
             },
 
-            CompositorMsg::WebDriverWheelScrollEvent(webview_id, x, y, delta_x, delta_y) => {
+            CompositorMsg::WebDriverWheelScrollEvent(
+                webview_id,
+                x,
+                y,
+                delta_x,
+                delta_y,
+                message_id,
+            ) => {
                 let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
                     warn!("Handling input event for unknown webview: {webview_id}");
                     return;
@@ -705,8 +712,10 @@ impl IOCompositor {
                 let point = dppx.transform_point(Point2D::new(x, y));
                 let scroll_delta =
                     dppx.transform_vector(Vector2D::new(delta_x as f32, delta_y as f32));
-                webview_renderer
-                    .dispatch_point_input_event(InputEvent::Wheel(WheelEvent { delta, point }));
+                webview_renderer.dispatch_point_input_event(
+                    InputEvent::Wheel(WheelEvent::new(delta, point))
+                        .with_webdriver_message_id(message_id),
+                );
                 webview_renderer.on_webdriver_wheel_action(scroll_delta, point);
             },
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4899,10 +4899,20 @@ where
                         webview_id, x, y, msg_id,
                     ));
             },
-            WebDriverCommandMsg::WheelScrollAction(webview, x, y, delta_x, delta_y) => {
+            WebDriverCommandMsg::WheelScrollAction(
+                webview_id,
+                x,
+                y,
+                delta_x,
+                delta_y,
+                msg_id,
+                response_sender,
+            ) => {
+                self.webdriver.input_command_response_sender = Some(response_sender);
+
                 self.compositor_proxy
                     .send(CompositorMsg::WebDriverWheelScrollEvent(
-                        webview, x, y, delta_x, delta_y,
+                        webview_id, x, y, delta_x, delta_y, msg_id,
                     ));
             },
             WebDriverCommandMsg::TakeScreenshot(webview_id, rect, response_sender) => {

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -111,12 +111,12 @@ pub enum CompositorMsg {
         MouseButton,
         f32,
         f32,
-        WebDriverMessageId,
+        Option<WebDriverMessageId>,
     ),
     /// WebDriver mouse move event
-    WebDriverMouseMoveEvent(WebViewId, f32, f32, WebDriverMessageId),
+    WebDriverMouseMoveEvent(WebViewId, f32, f32, Option<WebDriverMessageId>),
     // Webdriver wheel scroll event
-    WebDriverWheelScrollEvent(WebViewId, f32, f32, f64, f64),
+    WebDriverWheelScrollEvent(WebViewId, f32, f32, f64, f64, Option<WebDriverMessageId>),
 
     /// Inform WebRender of the existence of this pipeline.
     SendInitialTransaction(WebRenderPipelineId),

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -54,7 +54,7 @@ impl InputEvent {
             InputEvent::MouseButton(event) => event.webdriver_id,
             InputEvent::MouseMove(event) => event.webdriver_id,
             InputEvent::Touch(..) => None,
-            InputEvent::Wheel(..) => None,
+            InputEvent::Wheel(event) => event.webdriver_id,
         }
     }
 
@@ -71,7 +71,9 @@ impl InputEvent {
                 event.webdriver_id = webdriver_id;
             },
             InputEvent::Touch(..) => {},
-            InputEvent::Wheel(..) => {},
+            InputEvent::Wheel(ref mut event) => {
+                event.webdriver_id = webdriver_id;
+            },
         };
 
         self
@@ -275,6 +277,17 @@ pub struct WheelDelta {
 pub struct WheelEvent {
     pub delta: WheelDelta,
     pub point: DevicePoint,
+    webdriver_id: Option<WebDriverMessageId>,
+}
+
+impl WheelEvent {
+    pub fn new(delta: WheelDelta, point: DevicePoint) -> Self {
+        WheelEvent {
+            delta,
+            point,
+            webdriver_id: None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -50,7 +50,7 @@ pub enum WebDriverCommandMsg {
         MouseButton,
         f32,
         f32,
-        WebDriverMessageId,
+        Option<WebDriverMessageId>,
         IpcSender<WebDriverCommandResponse>,
     ),
     /// Act as if the mouse was moved in the browsing context with the given ID.
@@ -58,11 +58,19 @@ pub enum WebDriverCommandMsg {
         WebViewId,
         f32,
         f32,
-        WebDriverMessageId,
+        Option<WebDriverMessageId>,
         IpcSender<WebDriverCommandResponse>,
     ),
     /// Act as if the mouse wheel is scrolled in the browsing context given the given ID.
-    WheelScrollAction(WebViewId, f32, f32, f64, f64),
+    WheelScrollAction(
+        WebViewId,
+        f32,
+        f32,
+        f64,
+        f64,
+        Option<WebDriverMessageId>,
+        IpcSender<WebDriverCommandResponse>,
+    ),
     /// Set the window size.
     SetWindowSize(WebViewId, DeviceIntSize, IpcSender<Size2D<f32, CSSPixel>>),
     /// Take a screenshot of the window.

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -50,6 +50,7 @@ pub enum WebDriverCommandMsg {
         MouseButton,
         f32,
         f32,
+        // Should never be None.
         Option<WebDriverMessageId>,
         IpcSender<WebDriverCommandResponse>,
     ),
@@ -58,6 +59,8 @@ pub enum WebDriverCommandMsg {
         WebViewId,
         f32,
         f32,
+        // None if it's not the last `perform_pointer_move` since we only
+        // expect one response from constellation for each tick actions.
         Option<WebDriverMessageId>,
         IpcSender<WebDriverCommandResponse>,
     ),
@@ -68,6 +71,8 @@ pub enum WebDriverCommandMsg {
         f32,
         f64,
         f64,
+        // None if it's not the last `perform_wheel_scroll` since we only
+        // expect one response from constellation for each tick actions.
         Option<WebDriverMessageId>,
         IpcSender<WebDriverCommandResponse>,
     ),

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -603,7 +603,7 @@ impl WindowPortsMethods for Window {
                 let phase = winit_phase_to_touch_event_type(phase);
 
                 // Send events
-                webview.notify_input_event(InputEvent::Wheel(WheelEvent { delta, point }));
+                webview.notify_input_event(InputEvent::Wheel(WheelEvent::new(delta, point)));
                 webview.notify_scroll_event(
                     scroll_location,
                     self.webview_relative_mouse_point.get().to_i32(),

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/wheel.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/wheel.py.ini
@@ -1,13 +1,4 @@
 [wheel.py]
-  [test_scroll_not_scrollable]
-    expected: FAIL
-
-  [test_scroll_scrollable_overflow]
-    expected: FAIL
-
-  [test_scroll_iframe]
-    expected: FAIL
-
   [test_scroll_shadow_tree[outer-open\]]
     expected: FAIL
 


### PR DESCRIPTION
Implement action synchronization for wheel event. Previously only done for pointer here https://github.com/servo/servo/pull/36932.

Testing: `tests/wpt/meta/webdriver/tests/classic/perform_actions/wheel.py`
