### PR TITLE
htmlmediaelement: Support seek requests for non seekable fetch context

### DIFF
--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-colorSpaceConversion.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-colorSpaceConversion.html.ini
@@ -1,5 +1,4 @@
 [createImageBitmap-colorSpaceConversion.html]
-  expected: ERROR
   [createImageBitmap from a bitmap HTMLImageElement, and drawImage on the created ImageBitmap with colorSpaceConversion: none]
     expected: FAIL
 

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage.html.ini
@@ -1,5 +1,4 @@
 [createImageBitmap-drawImage.html]
-  expected: ERROR
   [createImageBitmap from an OffscreenCanvas resized, and drawImage on the created ImageBitmap]
     expected: FAIL
 

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY.html.ini
@@ -1,5 +1,4 @@
 [createImageBitmap-flipY.html]
-  expected: ERROR
   [createImageBitmap from a vector SVGImageElement imageOrientation: "none", and drawImage on the created ImageBitmap]
     expected: NOTRUN
 

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-invalid-args.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-invalid-args.html.ini
@@ -1,5 +1,4 @@
 [createImageBitmap-invalid-args.html]
-  expected: ERROR
   [createImageBitmap with a vector HTMLImageElement source and sw set to 0]
     expected: FAIL
 
@@ -138,16 +137,10 @@
   [createImageBitmap with a vector SVGImageElement source and a value between 0 and 1 in resizeHeight]
     expected: FAIL
 
-  [createImageBitmap with an HTMLVideoElement from a data URL source and a value between 0 and 1 in resizeWidth]
-    expected: FAIL
-
   [createImageBitmap with a vector SVGImageElement source and a value of 0 in resizeHeight]
     expected: FAIL
 
   [createImageBitmap with a bitmap SVGImageElement source and a value between 0 and 1 in resizeHeight]
-    expected: FAIL
-
-  [createImageBitmap with an HTMLVideoElement from a data URL source and a value of 0 in resizeHeight]
     expected: FAIL
 
   [createImageBitmap with an ImageBitmap source and a value of 0 in resizeHeight]
@@ -160,12 +153,6 @@
     expected: FAIL
 
   [createImageBitmap with a bitmap SVGImageElement source and a value of 0 int resizeWidth]
-    expected: FAIL
-
-  [createImageBitmap with an HTMLVideoElement from a data URL source and a value of 0 int resizeWidth]
-    expected: FAIL
-
-  [createImageBitmap with an HTMLVideoElement from a data URL source and a value between 0 and 1 in resizeHeight]
     expected: FAIL
 
   [createImageBitmap with a vector SVGImageElement source and a value between 0 and 1 in resizeWidth]

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-premultiplyAlpha.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-premultiplyAlpha.html.ini
@@ -1,5 +1,4 @@
 [createImageBitmap-premultiplyAlpha.html]
-  expected: ERROR
   [createImageBitmap: from ImageData, unpremultiplied, drawn to canvas]
     expected: FAIL
 

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer.html.ini
@@ -1,5 +1,4 @@
 [createImageBitmap-transfer.html]
-  expected: ERROR
   [Transfer ImageBitmap created from a vector HTMLImageElement]
     expected: FAIL
 

--- a/tests/wpt/meta/mixed-content/gen/top.http-rp/opt-in/video-tag.https.html.ini
+++ b/tests/wpt/meta/mixed-content/gen/top.http-rp/opt-in/video-tag.https.html.ini
@@ -1,13 +1,7 @@
 [video-tag.https.html]
   expected: TIMEOUT
-  [Mixed-Content: Expects allowed for video-tag to same-https origin and keep-scheme redirection from https context.]
-    expected: TIMEOUT
-
-  [Mixed-Content: Expects allowed for video-tag to same-https origin and no-redirect redirection from https context.]
-    expected: NOTRUN
-
   [Mixed-Content: Expects blocked for video-tag to cross-http origin and keep-scheme redirection from https context.]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [Mixed-Content: Expects blocked for video-tag to cross-http origin and no-redirect redirection from https context.]
     expected: NOTRUN

--- a/tests/wpt/meta/mixed-content/gen/top.meta/opt-in/video-tag.https.html.ini
+++ b/tests/wpt/meta/mixed-content/gen/top.meta/opt-in/video-tag.https.html.ini
@@ -1,10 +1,7 @@
 [video-tag.https.html]
   expected: TIMEOUT
-  [Mixed-Content: Expects allowed for video-tag to same-https origin and no-redirect redirection from https context.]
-    expected: TIMEOUT
-
   [Mixed-Content: Expects blocked for video-tag to cross-http origin and no-redirect redirection from https context.]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [Mixed-Content: Expects blocked for video-tag to same-http origin and no-redirect redirection from https context.]
     expected: NOTRUN

--- a/tests/wpt/webgl/meta/conformance/textures/misc/texture-srgb-upload.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/misc/texture-srgb-upload.html.ini
@@ -1,4 +1,4 @@
 [texture-srgb-upload.html]
-  expected: TIMEOUT
+  expected: ERROR
   [Overall test]
     expected: NOTRUN


### PR DESCRIPTION
According to specification the data:// URL protocol doesn't support range request
so be able make any seek request to required content position let's allow
for non seekable fetch context discard fetched content bytes until seek offset.
https://fetch.spec.whatwg.org/#scheme-fetch

Some scheme URLs (like data:// URL) doesn't expose "Content-Length" header in response
so the total expected size of the stream is unknown and it causes some additional
seek request (SeekData) from the media player. Try to post configure stream size
after we reached fetch EOS response.

Related source code which breaks WPT tests:
[tests/wpt/tests/html/canvas/element/manual/imagebitmap/common.sub.js#L56-L78](https://github.com/servo/servo/tree/main/tests/wpt/tests/html/canvas/element/manual/imagebitmap/common.sub.js#L56-L78)

Testing: Improvements in the following tests:
 - html/canvas/element/manual/imagebitmap/createImageBitmap*

Fixes: https://github.com/servo/servo/issues/32645
Fixes: https://github.com/servo/servo/issues/32745
Fixes: https://github.com/servo/servo/issues/34119
Fixes: https://github.com/servo/servo/issues/34120
Fixes: https://github.com/servo/servo/issues/34151