### PR TITLE
Layout: Impl Gecko's Pseudo Element Matching 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6607,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.28.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#9eb5efa885bdcb019e54b8d558c6724ea929bb2a"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#9eb5efa885bdcb019e54b8d558c6724ea929bb2a"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7363,7 +7363,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#9eb5efa885bdcb019e54b8d558c6724ea929bb2a"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7421,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#9eb5efa885bdcb019e54b8d558c6724ea929bb2a"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7430,12 +7430,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#9eb5efa885bdcb019e54b8d558c6724ea929bb2a"
 
 [[package]]
 name = "stylo_derive"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#9eb5efa885bdcb019e54b8d558c6724ea929bb2a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7447,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#9eb5efa885bdcb019e54b8d558c6724ea929bb2a"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -7456,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#9eb5efa885bdcb019e54b8d558c6724ea929bb2a"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7473,12 +7473,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#9eb5efa885bdcb019e54b8d558c6724ea929bb2a"
 
 [[package]]
 name = "stylo_traits"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#9eb5efa885bdcb019e54b8d558c6724ea929bb2a"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -7887,7 +7887,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#9eb5efa885bdcb019e54b8d558c6724ea929bb2a"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#9eb5efa885bdcb019e54b8d558c6724ea929bb2a"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6607,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.28.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7363,7 +7363,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7421,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7430,12 +7430,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
 
 [[package]]
 name = "stylo_derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7447,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -7456,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7473,12 +7473,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
 
 [[package]]
 name = "stylo_traits"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -7887,7 +7887,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#945b70e9a1984cd44ee56b7a674c302b19a4f620"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6607,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.28.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7363,7 +7363,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7421,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7430,12 +7430,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
 
 [[package]]
 name = "stylo_derive"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7447,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -7456,7 +7456,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7473,12 +7473,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
 
 [[package]]
 name = "stylo_traits"
 version = "0.3.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -7887,7 +7887,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#b0123d478e727125f8f6862e7afb5cf8ebf8ba17"
+source = "git+https://github.com/stevennovaryo/stylo?branch=input-text-internal-pseudo-selector#ae8a6e376ce4838a9d08ac5905d4c25a9aa5659a"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ rustls-pemfile = "2.0"
 rustls-pki-types = "1.12"
 script_layout_interface = { path = "components/shared/script_layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
+selectors = { git = "https://github.com/stevennovaryo/stylo", branch = "input-text-internal-pseudo-selector" }
 serde = "1.0.219"
 serde_bytes = "0.11"
 serde_json = "1.0"
@@ -127,7 +127,7 @@ servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
+servo_arc = { git = "https://github.com/stevennovaryo/stylo", branch = "input-text-internal-pseudo-selector" }
 smallbitvec = "2.6.0"
 smallvec = "1.15"
 snapshot = { path = "./components/shared/snapshot" }
@@ -136,12 +136,12 @@ string_cache = "0.8"
 string_cache_codegen = "0.5"
 strum = "0.26"
 strum_macros = "0.26"
-stylo = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
-stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-05-01" }
+stylo = { git = "https://github.com/stevennovaryo/stylo", branch = "input-text-internal-pseudo-selector" }
+stylo_atoms = { git = "https://github.com/stevennovaryo/stylo", branch = "input-text-internal-pseudo-selector" }
+stylo_config = { git = "https://github.com/stevennovaryo/stylo", branch = "input-text-internal-pseudo-selector" }
+stylo_dom = { git = "https://github.com/stevennovaryo/stylo", branch = "input-text-internal-pseudo-selector" }
+stylo_malloc_size_of = { git = "https://github.com/stevennovaryo/stylo", branch = "input-text-internal-pseudo-selector" }
+stylo_traits = { git = "https://github.com/stevennovaryo/stylo", branch = "input-text-internal-pseudo-selector" }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
@@ -233,7 +233,7 @@ codegen-units = 1
 # stylo_dom = { path = "../stylo/stylo_dom" }
 # stylo_malloc_size_of = { path = "../stylo/malloc_size_of" }
 # stylo_traits = { path = "../stylo/style_traits" }
-#
+# #
 # Or for WebRender:
 #
 # [patch."https://github.com/servo/webrender"]

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -88,7 +88,20 @@ impl<'dom> NodeAndStyleInfo<'dom> {
     }
 
     pub(crate) fn get_selected_style(&self) -> ServoArc<ComputedValues> {
-        self.node.to_threadsafe().selected_style()
+        // The Selection of an inner editor of a `<input>` should follow its
+        // Shadow Host's selection style.
+        if self.node.is_text_control_inner_editor() {
+            self.node
+                .as_element()
+                .expect("Inner editor should be an element")
+                .containing_shadow_host()
+                .expect("Unassociated inner editor")
+                .as_node()
+                .to_threadsafe()
+                .selected_style()
+        } else {
+            self.node.to_threadsafe().selected_style()
+        }
     }
 
     pub(crate) fn get_selection_range(&self) -> Option<Range<ByteIndex>> {

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -19,26 +19,26 @@ textarea {
   font-size: 0.8333em;
 }
 
-::-servo-text-control-inner-editor {
+input::-servo-text-control-inner-editor {
   overflow-wrap: normal;
   pointer-events: auto;
 }
 
-::-servo-text-control-inner-container {
+input::-servo-text-control-inner-container {
   position: relative;
   height: 100%;
   pointer-events: none;
   display: flex;
 }
 
-::-servo-text-control-inner-editor, ::-servo-text-control-placeholder {
+input::-servo-text-control-inner-editor, input::-servo-text-control-placeholder {
   white-space: pre;
   margin-block: auto !important;
   inset-block: 0 !important;
   block-size: fit-content !important;
 }
 
-::-servo-text-control-placeholder {
+input::-servo-text-control-placeholder {
   overflow: hidden !important;
   position: absolute !important;
   color: grey !important;

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -19,6 +19,32 @@ textarea {
   font-size: 0.8333em;
 }
 
+::-servo-text-control-inner-editor {
+  overflow-wrap: normal;
+  pointer-events: auto;
+}
+
+::-servo-text-control-inner-container {
+  position: relative;
+  height: 100%;
+  pointer-events: none;
+  display: flex;
+}
+
+::-servo-text-control-inner-editor, ::-servo-text-control-placeholder {
+  white-space: pre;
+  margin-block: auto !important;
+  inset-block: 0 !important;
+  block-size: fit-content !important;
+}
+
+::-servo-text-control-placeholder {
+  overflow: hidden !important;
+  position: absolute !important;
+  color: grey !important;
+  pointer-events: none !important;
+}
+
 input::selection,
 textarea::selection {
   background: rgba(176, 214, 255, 1.0);

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -49,6 +49,15 @@ input::-servo-text-control-placeholder {
   pointer-events: none !important;
 }
 
+input::-servo-input-color-swatch {
+  width: 100%;
+  height: 100%;
+  display: inline-block;
+  box-sizing: border-box;
+  border: 1px solid gray;
+  border-radius: 2px;
+}
+
 input::selection,
 textarea::selection {
   background: rgba(176, 214, 255, 1.0);

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -31,6 +31,10 @@ input::-servo-text-control-inner-container {
   display: flex;
 }
 
+input:not(:placeholder-shown)::-servo-text-control-placeholder {
+  visibility: hidden !important
+}
+
 input::-servo-text-control-inner-editor, input::-servo-text-control-placeholder {
   white-space: pre;
   margin-block: auto !important;

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -703,10 +703,8 @@ impl Element {
             )
             .expect("Attaching UA shadow root failed");
 
-        if use_ua_widget_styling {
-            root.upcast::<Node>().set_in_ua_widget();
-        }
-
+        root.upcast::<Node>()
+            .set_in_ua_widget(use_ua_widget_styling);
         root
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -666,6 +666,10 @@ impl Element {
             .upcast::<Node>()
             .set_containing_shadow_root(Some(&shadow_root));
 
+        if is_ua_widget == IsUserAgentWidget::Yes {
+            shadow_root.upcast::<Node>().set_in_ua_widget();
+        }
+
         let bind_context = BindContext {
             tree_connected: self.upcast::<Node>().is_connected(),
             tree_is_in_a_document_tree: self.upcast::<Node>().is_in_a_document_tree(),

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -666,10 +666,6 @@ impl Element {
             .upcast::<Node>()
             .set_containing_shadow_root(Some(&shadow_root));
 
-        if is_ua_widget == IsUserAgentWidget::Yes {
-            shadow_root.upcast::<Node>().set_in_ua_widget();
-        }
-
         let bind_context = BindContext {
             tree_connected: self.upcast::<Node>().is_connected(),
             tree_is_in_a_document_tree: self.upcast::<Node>().is_in_a_document_tree(),
@@ -682,6 +678,36 @@ impl Element {
         node.rev_version();
 
         Ok(shadow_root)
+    }
+
+    /// Attach a UA widget shadow root with its default parameters.
+    /// Additionally mark ShadowRoot to use styling configuration for a UA widget.
+    ///
+    /// TODO: Ideally, all of the UA shadow root should use UA widget styling, but
+    ///       some of the UA widget implemented prior to the implementation of Gecko's
+    ///       UA widget matching, might need some tweaking.
+    pub(crate) fn attach_ua_shadow_root(
+        &self,
+        use_ua_widget_styling: bool,
+        can_gc: CanGc,
+    ) -> DomRoot<ShadowRoot> {
+        let root = self
+            .attach_shadow(
+                IsUserAgentWidget::Yes,
+                ShadowRootMode::Closed,
+                false,
+                false,
+                true,
+                SlotAssignmentMode::Manual,
+                can_gc,
+            )
+            .expect("Attaching UA shadow root failed");
+
+        if use_ua_widget_styling {
+            root.upcast::<Node>().set_in_ua_widget();
+        }
+
+        root
     }
 
     pub(crate) fn detach_shadow(&self, can_gc: CanGc) {

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -103,18 +103,10 @@ impl HTMLDetailsElement {
 
     fn create_shadow_tree(&self, can_gc: CanGc) {
         let document = self.owner_document();
+        // TODO(stevennovaryo): Reimplement details styling.
         let root = self
             .upcast::<Element>()
-            .attach_shadow(
-                IsUserAgentWidget::Yes,
-                ShadowRootMode::Closed,
-                false,
-                false,
-                false,
-                SlotAssignmentMode::Manual,
-                can_gc,
-            )
-            .expect("Attaching UA shadow root failed");
+            .attach_ua_shadow_root(false, can_gc);
 
         let summary = HTMLSlotElement::new(local_name!("slot"), None, &document, None, can_gc);
         root.upcast::<Node>()

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -13,9 +13,6 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLDetailsElementBinding::HTMLDetailsElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLSlotElementBinding::HTMLSlotElement_Binding::HTMLSlotElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
-use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::{
-    ShadowRootMode, SlotAssignmentMode,
-};
 use crate::dom::bindings::codegen::UnionTypes::ElementOrText;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
@@ -26,7 +23,6 @@ use crate::dom::eventtarget::EventTarget;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlslotelement::HTMLSlotElement;
 use crate::dom::node::{BindContext, ChildrenMutation, Node, NodeDamage, NodeTraits};
-use crate::dom::shadowroot::IsUserAgentWidget;
 use crate::dom::text::Text;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -1090,17 +1090,9 @@ impl HTMLInputElement {
     /// or create one if none exists.
     fn shadow_root(&self, can_gc: CanGc) -> DomRoot<ShadowRoot> {
         self.upcast::<Element>().shadow_root().unwrap_or_else(|| {
+            // TODO(stevennovaryo): adjust type=color's styling.
             self.upcast::<Element>()
-                .attach_shadow(
-                    IsUserAgentWidget::Yes,
-                    ShadowRootMode::Closed,
-                    false,
-                    false,
-                    true,
-                    SlotAssignmentMode::Manual,
-                    can_gc,
-                )
-                .expect("Attaching UA shadow root failed")
+                .attach_ua_shadow_root(self.input_type() == InputType::Text, can_gc)
         })
     }
 
@@ -1269,7 +1261,7 @@ impl HTMLInputElement {
                 } else {
                     value = DOMString::from("#000000");
                 }
-                let style = format!("background-color: {value}");
+                let style = format!("background-color: {value} !important; z-index: 10000");
                 color_shadow_tree
                     .color_value
                     .upcast::<Element>()

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2197,17 +2197,10 @@ impl HTMLInputElement {
             return;
         }
 
-        // Ideally we are not supposed to handle visibility of the placeholder.
-        // But we are doing so because UA stylesheet does not support `:host` selector yet.
-        let placeholder_text = match self.upcast::<Element>().placeholder_shown_state() {
-            true => self.placeholder.borrow().clone(),
-            false => "".into(),
-        };
-
         self.text_shadow_tree(can_gc)
             .placeholder_container
             .upcast::<Node>()
-            .SetTextContent(Some(placeholder_text), can_gc);
+            .SetTextContent(Some(self.placeholder.borrow().clone()), can_gc);
     }
 
     // https://html.spec.whatwg.org/multipage/#file-upload-state-(type=file)
@@ -3048,7 +3041,6 @@ impl VirtualMethods for HTMLInputElement {
                         }
                         self.value_dirty.set(true);
                         self.update_placeholder_shown_state();
-                        self.update_text_shadow_tree_placeholder(can_gc);
                         self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
                         event.mark_as_handled();
                     },

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -57,9 +57,6 @@ use crate::dom::bindings::codegen::Bindings::MediaErrorBinding::MediaErrorConsta
 use crate::dom::bindings::codegen::Bindings::MediaErrorBinding::MediaErrorMethods;
 use crate::dom::bindings::codegen::Bindings::NavigatorBinding::Navigator_Binding::NavigatorMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
-use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::{
-    ShadowRootMode, SlotAssignmentMode,
-};
 use crate::dom::bindings::codegen::Bindings::TextTrackBinding::{TextTrackKind, TextTrackMode};
 use crate::dom::bindings::codegen::Bindings::URLBinding::URLMethods;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
@@ -93,7 +90,6 @@ use crate::dom::mediastream::MediaStream;
 use crate::dom::node::{Node, NodeDamage, NodeTraits, UnbindContext};
 use crate::dom::performanceresourcetiming::InitiatorType;
 use crate::dom::promise::Promise;
-use crate::dom::shadowroot::IsUserAgentWidget;
 use crate::dom::texttrack::TextTrack;
 use crate::dom::texttracklist::TextTrackList;
 use crate::dom::timeranges::{TimeRanges, TimeRangesContainer};

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1996,17 +1996,10 @@ impl HTMLMediaElement {
             // if we are already showing the controls.
             return;
         }
-        let shadow_root = element
-            .attach_shadow(
-                IsUserAgentWidget::Yes,
-                ShadowRootMode::Closed,
-                false,
-                false,
-                false,
-                SlotAssignmentMode::Manual,
-                can_gc,
-            )
-            .unwrap();
+        // FIXME: Recheck styling for media element
+        let shadow_root = self
+            .upcast::<Element>()
+            .attach_ua_shadow_root(false, can_gc);
         let document = self.owner_document();
         let script = HTMLScriptElement::new(
             local_name!("script"),

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -14,9 +14,6 @@ use crate::dom::attr::Attr;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::HTMLMeterElementBinding::HTMLMeterElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
-use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::{
-    ShadowRootMode, SlotAssignmentMode,
-};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
@@ -27,7 +24,6 @@ use crate::dom::htmldivelement::HTMLDivElement;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{BindContext, ChildrenMutation, Node, NodeTraits};
 use crate::dom::nodelist::NodeList;
-use crate::dom::shadowroot::IsUserAgentWidget;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -79,18 +79,8 @@ impl HTMLMeterElement {
 
     fn create_shadow_tree(&self, can_gc: CanGc) {
         let document = self.owner_document();
-        let root = self
-            .upcast::<Element>()
-            .attach_shadow(
-                IsUserAgentWidget::Yes,
-                ShadowRootMode::Closed,
-                false,
-                false,
-                false,
-                SlotAssignmentMode::Manual,
-                can_gc,
-            )
-            .expect("Attaching UA shadow root failed");
+        // FIXME: Add servo specific appearence reftest
+        let root = self.upcast::<Element>().attach_ua_shadow_root(true, can_gc);
 
         let meter_value = HTMLDivElement::new(local_name!("div"), None, &document, None, can_gc);
         root.upcast::<Node>()

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -13,9 +13,6 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::Element_Binding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLProgressElementBinding::HTMLProgressElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::Node_Binding::NodeMethods;
-use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::{
-    ShadowRootMode, SlotAssignmentMode,
-};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
@@ -26,7 +23,6 @@ use crate::dom::htmldivelement::HTMLDivElement;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{BindContext, Node, NodeTraits};
 use crate::dom::nodelist::NodeList;
-use crate::dom::shadowroot::IsUserAgentWidget;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -77,18 +77,8 @@ impl HTMLProgressElement {
 
     fn create_shadow_tree(&self, can_gc: CanGc) {
         let document = self.owner_document();
-        let root = self
-            .upcast::<Element>()
-            .attach_shadow(
-                IsUserAgentWidget::Yes,
-                ShadowRootMode::Closed,
-                false,
-                false,
-                false,
-                SlotAssignmentMode::Manual,
-                can_gc,
-            )
-            .expect("Attaching UA shadow root failed");
+        // FIXME: Add servo specific appearence reftest
+        let root = self.upcast::<Element>().attach_ua_shadow_root(true, can_gc);
 
         let progress_bar = HTMLDivElement::new(local_name!("div"), None, &document, None, can_gc);
         // FIXME: This should use ::-moz-progress-bar

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -258,18 +258,8 @@ impl HTMLSelectElement {
 
     fn create_shadow_tree(&self, can_gc: CanGc) {
         let document = self.owner_document();
-        let root = self
-            .upcast::<Element>()
-            .attach_shadow(
-                IsUserAgentWidget::Yes,
-                ShadowRootMode::Closed,
-                false,
-                false,
-                false,
-                SlotAssignmentMode::Manual,
-                can_gc,
-            )
-            .expect("Attaching UA shadow root failed");
+        // TODO: Adjust <select> element styling considering
+        let root = self.upcast::<Element>().attach_ua_shadow_root(true, can_gc);
 
         let select_box = HTMLDivElement::new(local_name!("div"), None, &document, None, can_gc);
         select_box.upcast::<Element>().set_string_attribute(

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -26,9 +26,6 @@ use crate::dom::bindings::codegen::Bindings::HTMLOptionElementBinding::HTMLOptio
 use crate::dom::bindings::codegen::Bindings::HTMLOptionsCollectionBinding::HTMLOptionsCollectionMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLSelectElementBinding::HTMLSelectElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
-use crate::dom::bindings::codegen::Bindings::ShadowRootBinding::{
-    ShadowRootMode, SlotAssignmentMode,
-};
 use crate::dom::bindings::codegen::GenericBindings::CharacterDataBinding::CharacterData_Binding::CharacterDataMethods;
 use crate::dom::bindings::codegen::UnionTypes::{
     HTMLElementOrLong, HTMLOptionElementOrHTMLOptGroupElement,
@@ -52,7 +49,6 @@ use crate::dom::htmloptionelement::HTMLOptionElement;
 use crate::dom::htmloptionscollection::HTMLOptionsCollection;
 use crate::dom::node::{BindContext, ChildrenMutation, Node, NodeTraits, UnbindContext};
 use crate::dom::nodelist::NodeList;
-use crate::dom::shadowroot::IsUserAgentWidget;
 use crate::dom::text::Text;
 use crate::dom::validation::{Validatable, is_barred_by_datalist_ancestor};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -716,8 +716,8 @@ impl Node {
             .contains(NodeFlags::IS_TEXT_CONTROL_INNER_EDITOR)
     }
 
-    pub(crate) fn set_in_ua_widget(&self) {
-        self.set_flag(NodeFlags::IS_IN_UA_WIDGET, true)
+    pub(crate) fn set_in_ua_widget(&self, in_ua_widget: bool) {
+        self.set_flag(NodeFlags::IS_IN_UA_WIDGET, in_ua_widget)
     }
 
     pub(crate) fn in_ua_widget(&self) -> bool {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -295,7 +295,7 @@ impl Node {
         let parent_is_in_a_document_tree = self.is_in_a_document_tree();
         let parent_in_shadow_tree = self.is_in_a_shadow_tree();
         let parent_is_connected = self.is_connected();
-        let parent_is_in_ua_widget = self.in_ua_widget();
+        let parent_is_in_ua_widget = self.is_in_ua_widget();
 
         for node in new_child.traverse_preorder(ShadowIncluding::No) {
             if parent_in_shadow_tree {
@@ -720,7 +720,7 @@ impl Node {
         self.set_flag(NodeFlags::IS_IN_UA_WIDGET, in_ua_widget)
     }
 
-    pub(crate) fn in_ua_widget(&self) -> bool {
+    pub(crate) fn is_in_ua_widget(&self) -> bool {
         self.flags.get().contains(NodeFlags::IS_IN_UA_WIDGET)
     }
 
@@ -1677,7 +1677,7 @@ pub(crate) trait LayoutNodeHelpers<'dom> {
     fn iframe_pipeline_id(self) -> Option<PipelineId>;
     fn opaque(self) -> OpaqueNode;
     fn pseudo_element(&self) -> Option<PseudoElement>;
-    fn in_ua_widget(&self) -> bool;
+    fn is_in_ua_widget(&self) -> bool;
 }
 
 impl<'dom> LayoutDom<'dom, Node> {
@@ -1958,8 +1958,8 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
             .and_then(|data| data.pseudo_element)
     }
 
-    fn in_ua_widget(&self) -> bool {
-        self.unsafe_get().in_ua_widget()
+    fn is_in_ua_widget(&self) -> bool {
+        self.unsafe_get().is_in_ua_widget()
     }
 }
 

--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -5,6 +5,7 @@
 use std::rc::Rc;
 
 use euclid::default::Rect;
+use style::selector_parser::PseudoElement;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::root::{Dom, MutNullableDom};
@@ -46,6 +47,10 @@ pub(crate) struct NodeRareData {
 
     /// The live list of children return by .childNodes.
     pub(crate) child_list: MutNullableDom<NodeList>,
+
+    /// Internal Pseudo Element type
+    #[no_trace]
+    pub(crate) pseudo_element: Option<PseudoElement>,
 }
 
 #[derive(Default, JSTraceable, MallocSizeOf)]

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -47,7 +47,7 @@ use crate::script_runtime::CanGc;
 use crate::stylesheet_set::StylesheetSetRef;
 
 /// Whether a shadow root hosts an User Agent widget.
-#[derive(JSTraceable, MallocSizeOf, PartialEq)]
+#[derive(JSTraceable, MallocSizeOf, PartialEq, Clone, Copy)]
 pub(crate) enum IsUserAgentWidget {
     No,
     Yes,

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -244,10 +244,7 @@ pub struct ServoThreadSafeLayoutNode<'dom> {
 impl<'dom> ServoThreadSafeLayoutNode<'dom> {
     /// Creates a new `ServoThreadSafeLayoutNode` from the given `ServoLayoutNode`.
     pub fn new(node: ServoLayoutNode<'dom>) -> Self {
-        ServoThreadSafeLayoutNode {
-            node,
-            pseudo: node.node.pseudo_element(),
-        }
+        ServoThreadSafeLayoutNode { node, pseudo: None }
     }
 
     /// Returns the interior of this node as a `LayoutDom`. This is highly unsafe for layout to
@@ -443,7 +440,6 @@ pub struct ServoThreadSafeLayoutNodeChildrenIterator<'dom> {
 }
 
 impl<'dom> ServoThreadSafeLayoutNodeChildrenIterator<'dom> {
-    // MYNOTES: This seems to be unused anywhere.
     pub fn new(parent: ServoThreadSafeLayoutNode<'dom>) -> Self {
         let first_child = match parent.pseudo_element() {
             None => parent

--- a/tests/wpt/meta/content-security-policy/form-action/form-action-src-default-ignored.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/form-action/form-action-src-default-ignored.sub.html.ini
@@ -1,3 +1,0 @@
-[form-action-src-default-ignored.sub.html]
-  [Expecting logs: ["PASS","TEST COMPLETE"\]]
-    expected: FAIL


### PR DESCRIPTION
This is a demonstration of a possible solution to handle the pseudo element selector matching. Implemented for input `type=text` element. 

In the changes, `Node` is passing a `PseudoElement` attribute as a `NodeRareData`. This is akin to how Firefox and Chrome are handling pseudo element, which use property table of a `Document` and HTML attribute respectively. Additionally, the changes introduces a new `NodeFlag` for marking nodes that resides within a UA shadow DOM.

Furthermore, the changes would implement the matching traits for a pseudo element by utilizing the aforementioned traits. Implementing pseudo element specific functions for `style::dom::TElement` and `style::dom::Element`. In that manner, we could handle non-internal pseudo element selector as well, such as `::details-content` and `::placeholder`.

Note that, due to the previous commit's handling of placeholder with shadow scoped selector `:host`, which are incompatible with UA stylesheet, the changes will address placeholder manually.

Testing: *Describe how this pull request is tested or why it doesn't require tests*
Fixes: *Link to an issue this pull requests fixes or remove this line if there is no issue*
