### PR TITLE
[webdriver] Implement get shadow root

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2280,6 +2280,14 @@ impl ScriptThread {
                     can_gc,
                 )
             },
+            WebDriverScriptCommand::GetElementShadowRoot(element_id, reply) => {
+                webdriver_handlers::handle_get_element_shadow_root(
+                    &documents,
+                    pipeline_id,
+                    element_id,
+                    reply,
+                )
+            },
             WebDriverScriptCommand::ElementClick(element_id, reply) => {
                 webdriver_handlers::handle_element_click(
                     &documents,

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -843,6 +843,27 @@ pub(crate) fn handle_find_element_elements_tag_name(
         .unwrap();
 }
 
+/// <https://www.w3.org/TR/webdriver2/#dfn-get-element-shadow-root>
+pub(crate) fn handle_get_element_shadow_root(
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    element_id: String,
+    reply: IpcSender<Result<Option<String>, ErrorStatus>>,
+) {
+    reply
+        .send(
+            find_node_by_unique_id(documents, pipeline, element_id).and_then(|node| match node
+                .downcast::<Element>(
+            ) {
+                Some(element) => Ok(element
+                    .GetShadowRoot()
+                    .map(|x| x.upcast::<Node>().unique_id(pipeline))),
+                None => Err(ErrorStatus::NoSuchElement),
+            }),
+        )
+        .unwrap();
+}
+
 pub(crate) fn handle_will_send_keys(
     documents: &DocumentCollection,
     pipeline: PipelineId,

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -130,6 +130,7 @@ pub enum WebDriverScriptCommand {
         IpcSender<Result<Vec<String>, ErrorStatus>>,
     ),
     FindElementElementsTagName(String, String, IpcSender<Result<Vec<String>, ErrorStatus>>),
+    GetElementShadowRoot(String, IpcSender<Result<Option<String>, ErrorStatus>>),
     ElementClick(String, IpcSender<Result<Option<String>, ErrorStatus>>),
     GetActiveElement(IpcSender<Option<String>>),
     GetComputedRole(String, IpcSender<Result<Option<String>, ErrorStatus>>),


### PR DESCRIPTION
Implement Get Element Shadow Root
https://www.w3.org/TR/webdriver2/#dfn-get-element-shadow-root

cc: @xiaochengh, @yezhizhen, @PotatoCP 

Testing: `\tests\wpt\tests\webdriver\tests\classic\get_element_shadow_root\get.py`
is blocked by `no_browsing_context` and `closed_window`
pass for other sub-tests.