### PR TITLE
Fix ReadableStream cancel error message

### DIFF
--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -1926,7 +1926,7 @@ impl ReadableStreamMethods<crate::DomTypeHolder> for ReadableStream {
             // If ! IsReadableStreamLocked(this) is true,
             // return a promise rejected with a TypeError exception.
             let promise = Promise::new(&global, can_gc);
-            promise.reject_error(Error::Type("stream is not locked".to_owned()), can_gc);
+            promise.reject_error(Error::Type("stream is locked".to_owned()), can_gc);
             promise
         } else {
             // Return ! ReadableStreamCancel(this, reason).


### PR DESCRIPTION
Align error message with WHATWG Streams spec by changing:  
- `'stream is not locked'` to `'stream is locked'` 

This will match the step 2 of the readablestream cancel method that requires the correct TypeError when the stream is locked.
