### PR TITLE
servoshell: Do not focus and raise new auxiliary WebDriver-created `WebView`s 

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -81,6 +81,8 @@ fn find_node_by_unique_id(
     match documents.find_document(pipeline) {
         Some(doc) => find_node_by_unique_id_in_document(&doc, node_id),
         None => {
+            // FIXME: This is unreacheable!! Because we already early return in Constellation
+            // To be Fixed soon
             if ScriptThread::has_node_id(pipeline, &node_id) {
                 Err(ErrorStatus::StaleElementReference)
             } else {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -981,7 +981,6 @@ impl Handler {
 
         let _ = self.wait_for_load();
 
-        // We can't create a new OS-level window, so the type would always be "tab"
         Ok(WebDriverResponse::NewWindow(NewWindowResponse {
             handle,
             typ: "tab".to_string(),

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -949,6 +949,7 @@ impl Handler {
         )))
     }
 
+    /// <https://w3c.github.io/webdriver/#new-window>
     fn handle_new_window(
         &mut self,
         _parameters: &NewWindowParameters,
@@ -956,11 +957,16 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
 
         let session = self.session().unwrap();
+        // Step 2. (TODO) If session's current top-level browsing context is no longer open,
+        // return error with error code no such window.
+
         let cmd_msg = WebDriverCommandMsg::NewWebView(
             session.webview_id,
             sender,
             self.load_status_sender.clone(),
         );
+        // Step 5. Create a new top-level browsing context by running the window open steps.
+        // This MUST be done without invoking the focusing steps.
         self.constellation_chan
             .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();
@@ -968,8 +974,6 @@ impl Handler {
         let mut handle = self.session.as_ref().unwrap().id.to_string();
         if let Ok(new_webview_id) = receiver.recv() {
             let session = self.session_mut().unwrap();
-            session.webview_id = new_webview_id;
-            session.browsing_context_id = BrowsingContextId::from(new_webview_id);
             let new_handle = Uuid::new_v4().to_string();
             handle = new_handle.clone();
             session.window_handles.insert(new_webview_id, new_handle);
@@ -977,6 +981,7 @@ impl Handler {
 
         let _ = self.wait_for_load();
 
+        // We can't create a new OS-level window, so the type would always be "tab"
         Ok(WebDriverResponse::NewWindow(NewWindowResponse {
             handle,
             typ: "tab".to_string(),

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -467,6 +467,9 @@ impl WebViewDelegate for RunningAppState {
         );
     }
 
+    // We open the auxiliary webview without focusing
+    // DO NOT change this behaviour because it is required by webdriver
+    // This behaviour is consistent with egl/app_state.rs
     fn request_open_auxiliary_webview(
         &self,
         parent_webview: servo::WebView,
@@ -477,9 +480,6 @@ impl WebViewDelegate for RunningAppState {
             .build();
 
         webview.notify_theme_change(self.inner().window.theme());
-        webview.focus();
-        webview.raise_to_top(true);
-
         self.add(webview.clone());
         Some(webview)
     }

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -237,6 +237,8 @@ impl WebViewDelegate for RunningAppState {
         }
     }
 
+    // We open the auxiliary webview without focusing
+    // This behaviour is consistent with desktop/app_state.rs
     fn request_open_auxiliary_webview(&self, parent_webview: WebView) -> Option<WebView> {
         let webview = WebViewBuilder::new_auxiliary(&self.servo)
             .delegate(parent_webview.delegate())

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -237,8 +237,6 @@ impl WebViewDelegate for RunningAppState {
         }
     }
 
-    // We open the auxiliary webview without focusing
-    // This behaviour is consistent with desktop/app_state.rs
     fn request_open_auxiliary_webview(&self, parent_webview: WebView) -> Option<WebView> {
         let webview = WebViewBuilder::new_auxiliary(&self.servo)
             .delegate(parent_webview.delegate())

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/click.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/click.py.ini
@@ -4,6 +4,3 @@
 
   [test_no_such_element_with_shadow_root]
     expected: FAIL
-
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/shadow_dom.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/shadow_dom.py.ini
@@ -1,9 +1,0 @@
-[shadow_dom.py]
-  [test_shadow_element_click[host_element\]]
-    expected: FAIL
-
-  [test_nested_shadow_element_click[outer_element\]]
-    expected: FAIL
-
-  [test_nested_shadow_element_click[inner_element\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/interactability.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/interactability.py.ini
@@ -5,9 +5,6 @@
   [test_iframe_is_interactable]
     expected: FAIL
 
-  [test_readonly_element]
-    expected: FAIL
-
   [test_not_a_focusable_element]
     expected: FAIL
 
@@ -21,4 +18,10 @@
     expected: FAIL
 
   [test_disabled]
+    expected: FAIL
+
+  [test_transparent_element]
+    expected: FAIL
+
+  [test_readonly_element]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/send_keys.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/send_keys.py.ini
@@ -5,5 +5,5 @@
   [test_no_such_element_with_shadow_root]
     expected: FAIL
 
-  [test_no_such_element_from_other_window_handle[closed\]]
+  [test_surrogates]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/find_element_from_element/find.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/find_element_from_element/find.py.ini
@@ -1,7 +1,6 @@
 [find.py]
-  expected: TIMEOUT
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_no_such_element_with_shadow_root]
     expected: FAIL
@@ -15,31 +14,10 @@
   [test_no_such_element_with_unknown_selector[existent-inside-shadow-root\]]
     expected: FAIL
 
-  [test_no_such_element_with_startnode_from_other_window_handle]
-    expected: FAIL
-
   [test_no_such_element_with_startnode_from_other_frame]
     expected: FAIL
 
-  [test_stale_element_reference[top_context\]]
-    expected: FAIL
-
-  [test_stale_element_reference[child_context\]]
-    expected: FAIL
-
   [test_find_element[xpath-//a\]]
-    expected: FAIL
-
-  [test_xhtml_namespace[css selector-#linkText\]]
-    expected: FAIL
-
-  [test_xhtml_namespace[link text-full link text\]]
-    expected: FAIL
-
-  [test_xhtml_namespace[partial link text-link text\]]
-    expected: FAIL
-
-  [test_xhtml_namespace[tag name-a\]]
     expected: FAIL
 
   [test_xhtml_namespace[xpath-//*[name()='a'\]\]]

--- a/tests/wpt/meta/webdriver/tests/classic/get_computed_role/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_computed_role/get.py.ini
@@ -5,8 +5,5 @@
   [test_no_such_element_with_shadow_root]
     expected: FAIL
 
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL
-
   [test_computed_roles[<article>foo</article>-article-article\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_attribute/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_attribute/get.py.ini
@@ -5,9 +5,6 @@
   [test_no_such_element_with_shadow_root]
     expected: FAIL
 
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL
-
   [test_boolean_attribute[audio-attrs0\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_css_value/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_css_value/get.py.ini
@@ -4,6 +4,3 @@
 
   [test_no_such_element_with_shadow_root]
     expected: FAIL
-
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_property/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_property/get.py.ini
@@ -5,8 +5,5 @@
   [test_no_such_element_with_shadow_root]
     expected: FAIL
 
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL
-
   [test_web_reference[shadowRoot-ShadowRoot\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_rect/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_rect/get.py.ini
@@ -5,8 +5,5 @@
   [test_no_such_element_with_shadow_root]
     expected: FAIL
 
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL
-
   [test_basic]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_shadow_root/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_shadow_root/get.py.ini
@@ -1,33 +1,3 @@
 [get.py]
-  [test_no_top_browsing_context]
-    expected: FAIL
-
   [test_no_browsing_context]
-    expected: FAIL
-
-  [test_no_such_element_with_invalid_value]
-    expected: FAIL
-
-  [test_no_such_element_from_other_window_handle[open\]]
-    expected: FAIL
-
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL
-
-  [test_no_such_element_from_other_frame[open\]]
-    expected: FAIL
-
-  [test_no_such_element_from_other_frame[closed\]]
-    expected: FAIL
-
-  [test_stale_element_reference[top_context\]]
-    expected: FAIL
-
-  [test_stale_element_reference[child_context\]]
-    expected: FAIL
-
-  [test_get_shadow_root]
-    expected: FAIL
-
-  [test_no_shadow_root]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_tag_name/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_tag_name/get.py.ini
@@ -5,8 +5,5 @@
   [test_no_such_element_with_shadow_root]
     expected: FAIL
 
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL
-
   [test_get_element_tag_name]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_text/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_text/get.py.ini
@@ -5,9 +5,6 @@
   [test_no_such_element_with_shadow_root]
     expected: FAIL
 
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL
-
   [test_transform_capitalize[space\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/is_element_enabled/enabled.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/is_element_enabled/enabled.py.ini
@@ -5,9 +5,6 @@
   [test_no_such_element_with_shadow_root]
     expected: FAIL
 
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL
-
   [test_stale_element_reference[child_context\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/is_element_selected/selected.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/is_element_selected/selected.py.ini
@@ -5,8 +5,5 @@
   [test_no_such_element_with_shadow_root]
     expected: FAIL
 
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL
-
   [test_stale_element_reference[child_context\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/new_window/new.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/new_window/new.py.ini
@@ -1,6 +1,3 @@
 [new.py]
   [test_no_top_browsing_context]
     expected: FAIL
-
-  [test_no_browsing_context]
-    expected: ERROR

--- a/tests/wpt/meta/webdriver/tests/classic/new_window/new_tab.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/new_window/new_tab.py.ini
@@ -1,9 +1,3 @@
 [new_tab.py]
-  [test_keeps_current_window_handle]
-    expected: FAIL
-
-  [test_opens_about_blank_in_new_tab]
-    expected: FAIL
-
   [test_initial_selection_for_contenteditable]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/new_window/new_window.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/new_window/new_window.py.ini
@@ -2,11 +2,5 @@
   [test_payload]
     expected: FAIL
 
-  [test_keeps_current_window_handle]
-    expected: FAIL
-
-  [test_opens_about_blank_in_new_window]
-    expected: FAIL
-
   [test_initial_selection_for_contenteditable]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/key.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/key.py.ini
@@ -9,19 +9,16 @@
     expected: FAIL
 
   [test_backspace_erases_keys]
-    expected: ERROR
+    expected: FAIL
 
   [test_element_in_shadow_tree[outer-open\]]
-    expected: ERROR
+    expected: FAIL
 
   [test_element_in_shadow_tree[outer-closed\]]
-    expected: ERROR
+    expected: FAIL
 
   [test_element_in_shadow_tree[inner-open\]]
-    expected: ERROR
+    expected: FAIL
 
   [test_element_in_shadow_tree[inner-closed\]]
-    expected: ERROR
-
-  [test_element_not_focused]
-    expected: ERROR
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_origin.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_origin.py.ini
@@ -1,10 +1,4 @@
 [pointer_origin.py]
-  [test_viewport_inside]
-    expected: FAIL
-
-  [test_pointer_inside]
-    expected: FAIL
-
   [test_element_center_point]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/switch_to_frame/switch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/switch_to_frame/switch.py.ini
@@ -13,6 +13,3 @@
 
   [test_no_browsing_context_when_already_top_level]
     expected: FAIL
-
-  [test_frame_id_shadow_root]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/take_screenshot/iframe.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/take_screenshot/iframe.py.ini
@@ -1,9 +1,0 @@
-[iframe.py]
-  [test_always_captures_top_browsing_context]
-    expected: FAIL
-
-  [test_source_origin[same_origin\]]
-    expected: FAIL
-
-  [test_source_origin[cross_origin\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/take_screenshot/iframe.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/take_screenshot/iframe.py.ini
@@ -1,0 +1,9 @@
+[iframe.py]
+  [test_always_captures_top_browsing_context]
+    expected: FAIL
+
+  [test_source_origin[same_origin\]]
+    expected: FAIL
+
+  [test_source_origin[cross_origin\]]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/take_screenshot/screenshot.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/take_screenshot/screenshot.py.ini
@@ -4,6 +4,3 @@
 
   [test_no_browsing_context]
     expected: FAIL
-
-  [test_format_and_dimensions]
-    expected: FAIL


### PR DESCRIPTION
For Desktop port of `request_open_auxiliary_webview`, stay on the original WebView if the request originates WebDriver. 

This is to make sure `webdriver_server::handle_new_window` does not focus the new window, according to spec. See https://github.com/servo/servo/blob/c7eba2dbbac24e8571d12ce686173a11b287c5ca/tests/wpt/tests/webdriver/tests/classic/new_window/new_window.py#L31-L37 

**To clarify**: this won't change the behaviour when user interacts, but only affects WebDriver [New Window](https://w3c.github.io/webdriver/#new-window).

Testing: `./mach test-wpt -r --log-raw "D:/servo log/all.txt" ./tests/wpt/tests/webdriver/tests/classic --product servodriver` based on 96b097303783ff12d4a1a7986260ad3c19a31837
