### PR TITLE
Fix mistakes in webdriver element send keys

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1633,7 +1633,7 @@ impl Handler {
         // TODO: distinguish the not found and not focusable cases
         // File input and non-typeable form control should have
         // been handled in `webdriver_handler.rs`.
-        if wait_for_script_response(receiver)?.map_err(|error| WebDriverError::new(error, ""))? {
+        if !wait_for_script_response(receiver)?.map_err(|error| WebDriverError::new(error, ""))? {
             return Ok(WebDriverResponse::Void);
         }
 

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/form_controls.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/form_controls.py.ini
@@ -4,3 +4,6 @@
 
   [test_textarea_append]
     expected: FAIL
+
+  [test_date]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/send_keys.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/send_keys.py.ini
@@ -7,6 +7,3 @@
 
   [test_no_such_element_from_other_window_handle[closed\]]
     expected: FAIL
-
-  [test_surrogates]
-    expected: FAIL


### PR DESCRIPTION
Fix mistakes from https://github.com/servo/servo/pull/37224. We should return in the middle of send keys if the element is either file input or non typeable form control.

Fixes: https://github.com/servo/servo/pull/37224#pullrequestreview-2903871157