### PR TITLE
fonts: Start using `fontations` to read font tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,6 +2176,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "font-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a596f5713680923a2080d86de50fe472fb290693cf0f701187a1c8b36996b7"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "fontconfig-parser"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,6 +2238,7 @@ dependencies = [
  "parking_lot",
  "profile_traits",
  "range",
+ "read-fonts",
  "serde",
  "servo_allocator",
  "servo_arc",
@@ -6162,6 +6172,16 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04ca636dac446b5664bd16c069c00a9621806895b8bb02c2dc68542b23b8f25d"
+dependencies = [
+ "bytemuck",
+ "font-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ rand_core = "0.6"
 rand_isaac = "0.3"
 raw-window-handle = "0.6"
 rayon = "1"
+read-fonts = "0.29.2"
 regex = "1.11"
 resvg = "0.45.0"
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -39,6 +39,7 @@ net_traits = { workspace = true }
 num-traits = { workspace = true }
 parking_lot = { workspace = true }
 profile_traits = { workspace = true }
+read-fonts = { workspace = true }
 range = { path = "../range" }
 serde = { workspace = true }
 servo_arc = { workspace = true }

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -143,7 +143,7 @@ pub trait FontTableMethods {
     fn buffer(&self) -> &[u8];
 }
 
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub struct FontMetrics {
     pub underline_size: Au,
     pub underline_offset: Au,


### PR DESCRIPTION
Use `read-fonts` to read font tables for FreeType fonts. This is the
first step to using fontations throughout Servo. The main benefit here
is that we no longer need to provide our own table data structures and
we can read tables from these fonts without making copies of the table
contents.

Testing: This should not change observable behavior and is covered by
existing WPT tests. I have run some manual microbenchmarks and have not
noticed any changes in performance that are larger than the general noise.
This adds a new memory map of the font file for local fonts, but this
should be very cheap as FreeType is already doing this internally and
subsequent maps should just reuuse the existing memory-mapped file.
