### PR TITLE
HTMLScriptElement: add `ScriptType::ImportMap`

### DIFF
--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -824,7 +824,9 @@ impl HTMLScriptElement {
             // Step 31. If el has a src content attribute, then:
 
             // Step 31.1. If el's type is "importmap".
-            if let ScriptType::ImportMap = script_type {
+            if script_type == ScriptType::ImportMap {
+                // then queue an element task on the DOM manipulation task source
+                // given el to fire an event named error at el, and return.
                 self.queue_error_event();
                 return;
             }
@@ -1068,7 +1070,6 @@ impl HTMLScriptElement {
             },
             ScriptType::Module => {
                 document.set_current_script(None);
-                assert!(document.GetCurrentScript().is_none());
                 self.run_a_module_script(&script, false, can_gc);
             },
             ScriptType::ImportMap => {

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -823,7 +823,11 @@ impl HTMLScriptElement {
         if let Some(src) = element.get_attribute(&ns!(), &local_name!("src")) {
             // Step 31. If el has a src content attribute, then:
 
-            // TODO: Step 31.1. If el's type is "importmap".
+            // Step 31.1. If el's type is "importmap".
+            if let ScriptType::ImportMap = script_type {
+                self.queue_error_event();
+                return;
+            }
 
             // Step 31.2. Let src be the value of el's src attribute.
             let src = src.value();
@@ -960,7 +964,8 @@ impl HTMLScriptElement {
                     );
                 },
                 ScriptType::ImportMap => {
-                    // TODO: Let result be the result of creating an import map parse result given source text and base URL.
+                    // TODO: Let result be the result of creating an import map
+                    // parse result given source text and base URL.
                 },
             }
         }
@@ -1067,7 +1072,8 @@ impl HTMLScriptElement {
                 self.run_a_module_script(&script, false, can_gc);
             },
             ScriptType::ImportMap => {
-                // TODO: Register an import map given el's relevant global object and el's result.
+                // TODO: Register an import map given el's relevant
+                // global object and el's result.
             },
         }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -275,6 +275,7 @@ pub(crate) static SCRIPT_JS_MIMES: StaticStringVec = &[
 pub(crate) enum ScriptType {
     Classic,
     Module,
+    ImportMap,
 }
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -770,14 +771,15 @@ impl HTMLScriptElement {
         // Step 23. Module script credentials mode.
         let module_credentials_mode = match script_type {
             ScriptType::Classic => CredentialsMode::CredentialsSameOrigin,
-            ScriptType::Module => reflect_cross_origin_attribute(element).map_or(
-                CredentialsMode::CredentialsSameOrigin,
-                |attr| match &*attr {
-                    "use-credentials" => CredentialsMode::Include,
-                    "anonymous" => CredentialsMode::CredentialsSameOrigin,
-                    _ => CredentialsMode::CredentialsSameOrigin,
-                },
-            ),
+            ScriptType::Module | ScriptType::ImportMap => reflect_cross_origin_attribute(element)
+                .map_or(
+                    CredentialsMode::CredentialsSameOrigin,
+                    |attr| match &*attr {
+                        "use-credentials" => CredentialsMode::Include,
+                        "anonymous" => CredentialsMode::CredentialsSameOrigin,
+                        _ => CredentialsMode::CredentialsSameOrigin,
+                    },
+                ),
         };
 
         // Step 24. Let cryptographic nonce be el's [[CryptographicNonce]] internal slot's value.
@@ -904,7 +906,7 @@ impl HTMLScriptElement {
                         doc.add_asap_script(self);
                     };
                 },
-                // TODO: Case "importmap"
+                ScriptType::ImportMap => (),
             }
         } else {
             // Step 32. If el does not have a src content attribute:
@@ -913,18 +915,17 @@ impl HTMLScriptElement {
 
             let text_rc = Rc::new(text);
 
-            // TODO: Fix step number or match spec text. Is this step 32.1?
-            let result = Ok(ScriptOrigin::internal(
-                Rc::clone(&text_rc),
-                base_url.clone(),
-                options.clone(),
-                script_type,
-                self.global().unminified_js_dir(),
-            ));
-
-            // TODO: Fix step number or match spec text. Is this step 32.2?
+            // Step 32.2: Switch on el's type:
             match script_type {
                 ScriptType::Classic => {
+                    let result = Ok(ScriptOrigin::internal(
+                        Rc::clone(&text_rc),
+                        base_url.clone(),
+                        options.clone(),
+                        script_type,
+                        self.global().unminified_js_dir(),
+                    ));
+
                     if was_parser_inserted &&
                         doc.get_current_parser()
                             .is_some_and(|parser| parser.script_nesting_level() <= 1) &&
@@ -957,6 +958,9 @@ impl HTMLScriptElement {
                         options,
                         can_gc,
                     );
+                },
+                ScriptType::ImportMap => {
+                    // TODO: Let result be the result of creating an import map parse result given source text and base URL.
                 },
             }
         }
@@ -1054,18 +1058,16 @@ impl HTMLScriptElement {
                 } else {
                     document.set_current_script(Some(self))
                 }
-            },
-            ScriptType::Module => document.set_current_script(None),
-        }
-
-        match script.type_ {
-            ScriptType::Classic => {
                 self.run_a_classic_script(&script, can_gc);
                 document.set_current_script(old_script.as_deref());
             },
             ScriptType::Module => {
+                document.set_current_script(None);
                 assert!(document.GetCurrentScript().is_none());
                 self.run_a_module_script(&script, false, can_gc);
+            },
+            ScriptType::ImportMap => {
+                // TODO: Register an import map given el's relevant global object and el's result.
             },
         }
 


### PR DESCRIPTION
HTMLScriptElement: add `ScriptType::ImportMap`

Part of #37262
This covers most steps that are related to import map.

Testing: Existing WPT on HTMLScriptElement should remain the same.

