### PR TITLE
Do not mutate kwargs["binary_args"]

### DIFF
--- a/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servo.py
@@ -38,11 +38,10 @@ def check_args(**kwargs):
 
 
 def browser_kwargs(logger, test_type, run_info_data, config, subsuite, **kwargs):
-    kwargs["binary_args"].extend(subsuite.config.get("binary_args", []))
     return {
         "binary": kwargs["binary"],
         "debug_info": kwargs["debug_info"],
-        "binary_args": kwargs["binary_args"],
+        "binary_args": kwargs["binary_args"] + subsuite.config.get("binary_args", []),
         "user_stylesheets": kwargs.get("user_stylesheets"),
         "ca_certificate_path": config.ssl_config["ca_cert_path"],
     }

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -40,10 +40,9 @@ def check_args(**kwargs):
 
 
 def browser_kwargs(logger, test_type, run_info_data, config, subsuite, **kwargs):
-    kwargs["binary_args"].extend(subsuite.config.get("binary_args", []))
     return {
         "binary": kwargs["binary"],
-        "binary_args": kwargs["binary_args"],
+        "binary_args": kwargs["binary_args"] + subsuite.config.get("binary_args", []),
         "debug_info": kwargs["debug_info"],
         "server_config": config,
         "user_stylesheets": kwargs.get("user_stylesheets"),


### PR DESCRIPTION
Fixup of #37255, we should not modify existing `kwargs["binary_args"]` or else subsuite's `binary_args` will apply in non subsuite runs.

Testing: I verified fix in my personal fork run with vello (where I actually use subsuite).
