### PR TITLE
renderer: Have the viewport meta element establish the initial zoom of new pages

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -46,8 +46,8 @@ struct ScrollEvent {
 enum ScrollZoomEvent {
     /// A pinch zoom event that magnifies the view by the given factor.
     PinchZoom(f32),
-    /// A zoom event that magnifies the view by the factor parsed from meta tag.
-    ViewportZoom(f32),
+    /// A zoom event that establishes the initial zoom from the viewport meta tag.
+    InitialViewportZoom(f32),
     /// A scroll event that scrolls the scroll node at the given location by the
     /// given amount.
     Scroll(ScrollEvent),
@@ -810,9 +810,11 @@ impl WebViewRenderer {
         let mut combined_magnification = self.pinch_zoom_level().get();
         for scroll_event in self.pending_scroll_zoom_events.drain(..) {
             match scroll_event {
-                ScrollZoomEvent::PinchZoom(magnification) |
-                ScrollZoomEvent::ViewportZoom(magnification) => {
+                ScrollZoomEvent::PinchZoom(magnification) => {
                     combined_magnification *= magnification
+                },
+                ScrollZoomEvent::InitialViewportZoom(magnification) => {
+                    combined_magnification = magnification
                 },
                 ScrollZoomEvent::Scroll(scroll_event_info) => {
                     let combined_event = match combined_scroll_event.as_mut() {
@@ -1065,7 +1067,7 @@ impl WebViewRenderer {
 
     pub fn set_viewport_description(&mut self, viewport_description: ViewportDescription) {
         self.pending_scroll_zoom_events
-            .push(ScrollZoomEvent::ViewportZoom(
+            .push(ScrollZoomEvent::InitialViewportZoom(
                 viewport_description
                     .clone()
                     .clamp_zoom(viewport_description.initial_scale.get()),

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -807,7 +807,7 @@ impl WebViewRenderer {
 
         // Batch up all scroll events into one, or else we'll do way too much painting.
         let mut combined_scroll_event: Option<ScrollEvent> = None;
-        let mut combined_magnification = 1.0;
+        let mut combined_magnification = self.pinch_zoom_level().get();
         for scroll_event in self.pending_scroll_zoom_events.drain(..) {
             match scroll_event {
                 ScrollZoomEvent::PinchZoom(magnification) |
@@ -870,9 +870,7 @@ impl WebViewRenderer {
             );
         }
 
-        let pinch_zoom_result = match self
-            .set_pinch_zoom_level(self.pinch_zoom_level().get() * combined_magnification)
-        {
+        let pinch_zoom_result = match self.set_pinch_zoom_level(combined_magnification) {
             true => PinchZoomResult::DidPinchZoom,
             false => PinchZoomResult::DidNotPinchZoom,
         };

--- a/tests/wpt/tests/visual-viewport/resource/viewport-apply-initial-scale-after-navigation-inner.html
+++ b/tests/wpt/tests/visual-viewport/resource/viewport-apply-initial-scale-after-navigation-inner.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+    <head>
+        <title>Viewport: Apply initial-scale after Navigation</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <script src="/common/reftest-wait.js"></script>
+        <script>
+            onload = takeScreenshot;
+        </script>
+    </head>
+    <body>
+        <h1>Viewport: Apply initial-scale after Navigation</h1>
+        <p>Test passes if page opens with own initial-scale of 1.0</p>
+    </body>
+</html>

--- a/tests/wpt/tests/visual-viewport/viewport-apply-initial-scale-after-navigation-ref.html
+++ b/tests/wpt/tests/visual-viewport/viewport-apply-initial-scale-after-navigation-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Viewport: Apply initial-scale after Navigation</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    </head>
+    <body>
+        <h1>Viewport: Apply initial-scale after Navigation</h1>
+        <p>Test passes if page opens with own initial-scale of 1.0</p>
+    </body>
+</html>

--- a/tests/wpt/tests/visual-viewport/viewport-apply-initial-scale-after-navigation.html
+++ b/tests/wpt/tests/visual-viewport/viewport-apply-initial-scale-after-navigation.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+    <title>Viewport: Apply initial-scale after Navigation</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=2.0">
+    <link rel="match" href="viewport-apply-initial-scale-after-navigation-ref.html">
+    <script src="/common/reftest-wait.js"></script>
+    <script>
+        function runTest() {
+            const url = "resource/viewport-apply-initial-scale-after-navigation-inner.html";
+            window.location.replace(new URL(url, window.location));
+        }
+        onload = () => runTest();
+    </script>
+</head>
+</html>


### PR DESCRIPTION
This patch contains 2 components: 

1. Instead of passing `self.pinch_zoom_level().get()` while checking `zoom_result`, initialize it in `combined_magnification`. Ideally, this part shouldn't have any effect on behavior.

2. Separates the logic for PinchZoom and ViewportZoom. So, when a new page is opened, it will start with its own viewport zoom scale (rather than the previous scale multiples).
i.e `self.pinch_zoom_level().get() * 1.0 * magnification`
```rust
        let mut combined_magnification = 1.0;
        ... 
                ScrollZoomEvent::ViewportZoom(magnification) => {
                    combined_magnification *= magnification
                },
        ...        
        let pinch_zoom_result = match self.set_pinch_zoom_level(self.pinch_zoom_level().get() * combined_magnification)
``` 





Testing: This change adds a new WPT test.
Fixes: #37314 
