### PR TITLE
libservo: Allow embedders to signal when the cursor has left the `WebView`

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -385,8 +385,13 @@ impl WebViewRenderer {
             InputEvent::Touch(ref mut touch_event) => {
                 touch_event.init_sequence_id(self.touch_handler.current_sequence_id);
             },
-            InputEvent::MouseButton(_) | InputEvent::MouseMove(_) | InputEvent::Wheel(_) => {
-                self.global.borrow_mut().update_cursor(point, &result);
+            InputEvent::MouseButton(_) |
+            InputEvent::MouseLeave(_) |
+            InputEvent::MouseMove(_) |
+            InputEvent::Wheel(_) => {
+                self.global
+                    .borrow_mut()
+                    .update_cursor_from_hittest(point, &result);
             },
             _ => unreachable!("Unexpected input event type: {event:?}"),
         }
@@ -428,7 +433,9 @@ impl WebViewRenderer {
                     touch_event.init_sequence_id(self.touch_handler.current_sequence_id);
                 },
                 InputEvent::MouseButton(_) | InputEvent::MouseMove(_) | InputEvent::Wheel(_) => {
-                    self.global.borrow_mut().update_cursor(point, &result);
+                    self.global
+                        .borrow_mut()
+                        .update_cursor_from_hittest(point, &result);
                 },
                 _ => unreachable!("Unexpected input event type: {event:?}"),
             }

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -97,6 +97,7 @@ mod from_compositor {
                 InputEvent::Keyboard(..) => target_variant!("Keyboard"),
                 InputEvent::MouseButton(..) => target_variant!("MouseButton"),
                 InputEvent::MouseMove(..) => target_variant!("MouseMove"),
+                InputEvent::MouseLeave(..) => target_variant!("MouseLeave"),
                 InputEvent::Touch(..) => target_variant!("Touch"),
                 InputEvent::Wheel(..) => target_variant!("Wheel"),
                 InputEvent::Scroll(..) => target_variant!("Scroll"),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1127,6 +1127,14 @@ impl ScriptThread {
                         can_gc,
                     );
                 },
+                InputEvent::MouseLeave(_) => {
+                    self.topmost_mouse_over_target.take();
+                    document.handle_mouse_leave_event(
+                        event.hit_test_result,
+                        event.pressed_mouse_buttons,
+                        can_gc,
+                    );
+                },
                 InputEvent::Touch(touch_event) => {
                     let touch_result =
                         document.handle_touch_event(touch_event, event.hit_test_result, can_gc);

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -20,6 +20,7 @@ pub enum InputEvent {
     Keyboard(KeyboardEvent),
     MouseButton(MouseButtonEvent),
     MouseMove(MouseMoveEvent),
+    MouseLeave(MouseLeaveEvent),
     Touch(TouchEvent),
     Wheel(WheelEvent),
     Scroll(ScrollEvent),
@@ -42,6 +43,7 @@ impl InputEvent {
             InputEvent::Keyboard(..) => None,
             InputEvent::MouseButton(event) => Some(event.point),
             InputEvent::MouseMove(event) => Some(event.point),
+            InputEvent::MouseLeave(event) => Some(event.point),
             InputEvent::Touch(event) => Some(event.point),
             InputEvent::Wheel(event) => Some(event.point),
             InputEvent::Scroll(..) => None,
@@ -56,6 +58,7 @@ impl InputEvent {
             InputEvent::Keyboard(..) => None,
             InputEvent::MouseButton(event) => event.webdriver_id,
             InputEvent::MouseMove(event) => event.webdriver_id,
+            InputEvent::MouseLeave(..) => None,
             InputEvent::Touch(..) => None,
             InputEvent::Wheel(event) => event.webdriver_id,
             InputEvent::Scroll(..) => None,
@@ -74,6 +77,7 @@ impl InputEvent {
             InputEvent::MouseMove(ref mut event) => {
                 event.webdriver_id = webdriver_id;
             },
+            InputEvent::MouseLeave(..) => {},
             InputEvent::Touch(..) => {},
             InputEvent::Wheel(ref mut event) => {
                 event.webdriver_id = webdriver_id;
@@ -164,6 +168,17 @@ impl MouseMoveEvent {
             point,
             webdriver_id: None,
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct MouseLeaveEvent {
+    pub point: DevicePoint,
+}
+
+impl MouseLeaveEvent {
+    pub fn new(point: DevicePoint) -> Self {
+        Self { point }
     }
 }
 

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -20,9 +20,10 @@ use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize, DevicePixel};
 use servo::{
     Cursor, ImeEvent, InputEvent, Key, KeyState, KeyboardEvent, MouseButton as ServoMouseButton,
-    MouseButtonAction, MouseButtonEvent, MouseMoveEvent, OffscreenRenderingContext,
-    RenderingContext, ScreenGeometry, Theme, TouchEvent, TouchEventType, TouchId,
-    WebRenderDebugOption, WebView, WheelDelta, WheelEvent, WheelMode, WindowRenderingContext,
+    MouseButtonAction, MouseButtonEvent, MouseLeaveEvent, MouseMoveEvent,
+    OffscreenRenderingContext, RenderingContext, ScreenGeometry, Theme, TouchEvent, TouchEventType,
+    TouchId, WebRenderDebugOption, WebView, WheelDelta, WheelEvent, WheelMode,
+    WindowRenderingContext,
 };
 use surfman::{Context, Device};
 use url::Url;
@@ -566,8 +567,22 @@ impl WindowPortsMethods for Window {
                 let mut point = winit_position_to_euclid_point(position).to_f32();
                 point.y -= (self.toolbar_height() * self.hidpi_scale_factor()).0;
 
+                let previous_point = self.webview_relative_mouse_point.get();
+                if webview.rect().contains(point) {
+                    webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point)));
+                } else if webview.rect().contains(previous_point) {
+                    webview.notify_input_event(InputEvent::MouseLeave(MouseLeaveEvent::new(
+                        previous_point,
+                    )));
+                }
+
                 self.webview_relative_mouse_point.set(point);
-                webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point)));
+            },
+            WindowEvent::CursorLeft { .. } => {
+                let point = self.webview_relative_mouse_point.get();
+                if webview.rect().contains(point) {
+                    webview.notify_input_event(InputEvent::MouseLeave(MouseLeaveEvent::new(point)));
+                }
             },
             WindowEvent::MouseWheel { delta, phase, .. } => {
                 let (mut dx, mut dy, mode) = match delta {
@@ -588,8 +603,7 @@ impl WindowPortsMethods for Window {
                     z: 0.0,
                     mode,
                 };
-                let pos = self.webview_relative_mouse_point.get();
-                let point = Point2D::new(pos.x, pos.y);
+                let point = self.webview_relative_mouse_point.get();
 
                 // Scroll events snap to the major axis of movement, with vertical
                 // preferred over horizontal.
@@ -604,11 +618,7 @@ impl WindowPortsMethods for Window {
 
                 // Send events
                 webview.notify_input_event(InputEvent::Wheel(WheelEvent::new(delta, point)));
-                webview.notify_scroll_event(
-                    scroll_location,
-                    self.webview_relative_mouse_point.get().to_i32(),
-                    phase,
-                );
+                webview.notify_scroll_event(scroll_location, point.to_i32(), phase);
             },
             WindowEvent::Touch(touch) => {
                 webview.notify_input_event(InputEvent::Touch(TouchEvent::new(


### PR DESCRIPTION
Currently, the hover state will stay when the mouse moves out of the webview, this PR fixes it

Testing: Hover on the `About` on servo.org, and then move the mouse up to the browser UI, see the hover state resets
