### PR TITLE
Use own ViewportDescription to clamp() initial_scale

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -1048,9 +1048,8 @@ impl WebViewRenderer {
     pub fn set_viewport_description(&mut self, viewport_description: ViewportDescription) {
         self.pending_scroll_zoom_events
             .push(ScrollZoomEvent::ViewportZoom(
-                self.viewport_description
+                viewport_description
                     .clone()
-                    .unwrap_or_default()
                     .clamp_zoom(viewport_description.initial_scale.get()),
             ));
         self.viewport_description = Some(viewport_description);


### PR DESCRIPTION
Use own `ViewportDescription` to `clamp()` initial_scale.

If use `self` it will use current module `ViewportDescription`, which is old one because new `ViewportDescription` is not set yet.

Testing: Tested Locally
Fixes: #37338 