### PR TITLE
Add top-level creation URL for global scope

### DIFF
--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -60,6 +60,7 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.script_to_constellation_chan().clone(),
                 global_to_clone_from.resource_threads().clone(),
                 global_to_clone_from.origin().clone(),
+                global_to_clone_from.creation_url().clone(),
                 global_to_clone_from.top_level_creation_url().clone(),
                 // FIXME(nox): The microtask queue is probably not important
                 // here, but this whole DOM interface is a hack anyway.

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -60,7 +60,7 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.script_to_constellation_chan().clone(),
                 global_to_clone_from.resource_threads().clone(),
                 global_to_clone_from.origin().clone(),
-                global_to_clone_from.creation_url().clone(),
+                global_to_clone_from.top_level_creation_url().clone(),
                 // FIXME(nox): The microtask queue is probably not important
                 // here, but this whole DOM interface is a hack anyway.
                 global_to_clone_from.microtask_queue().clone(),

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -279,6 +279,10 @@ pub(crate) struct GlobalScope {
     #[no_trace]
     origin: MutableOrigin,
 
+    /// <https://html.spec.whatwg.org/multipage/#concept-environment-creation-url>
+    #[no_trace]
+    creation_url: ServoUrl,
+
     /// <https://html.spec.whatwg.org/multipage/#concept-environment-top-level-creation-url>
     #[no_trace]
     top_level_creation_url: Option<ServoUrl>,
@@ -732,6 +736,7 @@ impl GlobalScope {
         script_to_constellation_chan: ScriptToConstellationChan,
         resource_threads: ResourceThreads,
         origin: MutableOrigin,
+        creation_url: ServoUrl,
         top_level_creation_url: Option<ServoUrl>,
         microtask_queue: Rc<MicrotaskQueue>,
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
@@ -760,6 +765,7 @@ impl GlobalScope {
             resource_threads,
             timers: OnceCell::default(),
             origin,
+            creation_url,
             top_level_creation_url,
             permission_state_invocation_results: Default::default(),
             microtask_queue,
@@ -2462,6 +2468,11 @@ impl GlobalScope {
     /// Get the origin for this global scope
     pub(crate) fn origin(&self) -> &MutableOrigin {
         &self.origin
+    }
+
+    /// Get the creation_url for this global scope
+    pub(crate) fn creation_url(&self) -> &ServoUrl {
+        &self.creation_url
     }
 
     /// Get the top_level_creation_url for this global scope

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -279,9 +279,9 @@ pub(crate) struct GlobalScope {
     #[no_trace]
     origin: MutableOrigin,
 
-    /// <https://html.spec.whatwg.org/multipage/#concept-environment-creation-url>
+    /// <https://html.spec.whatwg.org/multipage/#concept-environment-top-level-creation-url>
     #[no_trace]
-    creation_url: Option<ServoUrl>,
+    top_level_creation_url: Option<ServoUrl>,
 
     /// A map for storing the previous permission state read results.
     permission_state_invocation_results: DomRefCell<HashMap<PermissionName, PermissionState>>,
@@ -732,7 +732,7 @@ impl GlobalScope {
         script_to_constellation_chan: ScriptToConstellationChan,
         resource_threads: ResourceThreads,
         origin: MutableOrigin,
-        creation_url: Option<ServoUrl>,
+        top_level_creation_url: Option<ServoUrl>,
         microtask_queue: Rc<MicrotaskQueue>,
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
         inherited_secure_context: Option<bool>,
@@ -760,7 +760,7 @@ impl GlobalScope {
             resource_threads,
             timers: OnceCell::default(),
             origin,
-            creation_url,
+            top_level_creation_url,
             permission_state_invocation_results: Default::default(),
             microtask_queue,
             list_auto_close_worker: Default::default(),
@@ -2464,9 +2464,9 @@ impl GlobalScope {
         &self.origin
     }
 
-    /// Get the creation_url for this global scope
-    pub(crate) fn creation_url(&self) -> &Option<ServoUrl> {
-        &self.creation_url
+    /// Get the top_level_creation_url for this global scope
+    pub(crate) fn top_level_creation_url(&self) -> &Option<ServoUrl> {
+        &self.top_level_creation_url
     }
 
     pub(crate) fn image_cache(&self) -> Arc<dyn ImageCache> {
@@ -3420,11 +3420,13 @@ impl GlobalScope {
         if Some(false) == self.inherited_secure_context {
             return false;
         }
-        if let Some(creation_url) = self.creation_url() {
-            if creation_url.scheme() == "blob" && Some(true) == self.inherited_secure_context {
+        if let Some(top_level_creation_url) = self.top_level_creation_url() {
+            if top_level_creation_url.scheme() == "blob" &&
+                Some(true) == self.inherited_secure_context
+            {
                 return true;
             }
-            return creation_url.is_potentially_trustworthy();
+            return top_level_creation_url.is_potentially_trustworthy();
         }
         false
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3047,7 +3047,7 @@ impl Window {
         parent_info: Option<PipelineId>,
         viewport_details: ViewportDetails,
         origin: MutableOrigin,
-        creator_url: ServoUrl,
+        top_level_creation_url: ServoUrl,
         navigation_start: CrossProcessInstant,
         webgl_chan: Option<WebGLChan>,
         #[cfg(feature = "webxr")] webxr_registry: Option<webxr_api::Registry>,
@@ -3083,7 +3083,7 @@ impl Window {
                 constellation_chan,
                 resource_threads,
                 origin,
-                Some(creator_url),
+                Some(top_level_creation_url),
                 microtask_queue,
                 #[cfg(feature = "webgpu")]
                 gpu_id_hub,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3047,6 +3047,7 @@ impl Window {
         parent_info: Option<PipelineId>,
         viewport_details: ViewportDetails,
         origin: MutableOrigin,
+        creation_url: ServoUrl,
         top_level_creation_url: ServoUrl,
         navigation_start: CrossProcessInstant,
         webgl_chan: Option<WebGLChan>,
@@ -3083,6 +3084,7 @@ impl Window {
                 constellation_chan,
                 resource_threads,
                 origin,
+                creation_url,
                 Some(top_level_creation_url),
                 microtask_queue,
                 #[cfg(feature = "webgpu")]

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -84,6 +84,7 @@ pub(crate) fn prepare_workerscope_init(
         worker_id: worker_id.unwrap_or_else(|| WorkerId(Uuid::new_v4())),
         pipeline_id: global.pipeline_id(),
         origin: global.origin().immutable().clone(),
+        creation_url: global.creation_url().clone(),
         inherited_secure_context: Some(global.is_secure_context()),
     };
 
@@ -167,6 +168,7 @@ impl WorkerGlobalScope {
                 init.script_to_constellation_chan,
                 init.resource_threads,
                 MutableOrigin::new(init.origin),
+                init.creation_url,
                 None,
                 runtime.microtask_queue.clone(),
                 #[cfg(feature = "webgpu")]

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -84,7 +84,6 @@ pub(crate) fn prepare_workerscope_init(
         worker_id: worker_id.unwrap_or_else(|| WorkerId(Uuid::new_v4())),
         pipeline_id: global.pipeline_id(),
         origin: global.origin().immutable().clone(),
-        creation_url: global.creation_url().clone(),
         inherited_secure_context: Some(global.is_secure_context()),
     };
 
@@ -168,7 +167,7 @@ impl WorkerGlobalScope {
                 init.script_to_constellation_chan,
                 init.resource_threads,
                 MutableOrigin::new(init.origin),
-                init.creation_url,
+                None,
                 runtime.microtask_queue.clone(),
                 #[cfg(feature = "webgpu")]
                 gpu_id_hub,

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -104,6 +104,7 @@ impl WorkletGlobalScope {
                 script_to_constellation_chan,
                 init.resource_threads.clone(),
                 MutableOrigin::new(ImmutableOrigin::new_opaque()),
+                base_url.clone(),
                 None,
                 Default::default(),
                 #[cfg(feature = "webgpu")]

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3353,6 +3353,10 @@ impl ScriptThread {
             incomplete.parent_info,
             incomplete.viewport_details,
             origin.clone(),
+            // TODO(37417): Set correct top-level URL here. Currently, we only specify the
+            // url of the current window. However, in case this is an iframe, we should
+            // pass in the URL from the frame that includes the iframe (which potentially
+            // is another nested iframe in a frame).
             final_url.clone(),
             incomplete.navigation_start,
             self.webgl_chan.as_ref().map(|chan| chan.channel()),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3353,6 +3353,7 @@ impl ScriptThread {
             incomplete.parent_info,
             incomplete.viewport_details,
             origin.clone(),
+            final_url.clone(),
             // TODO(37417): Set correct top-level URL here. Currently, we only specify the
             // url of the current window. However, in case this is an iframe, we should
             // pass in the URL from the frame that includes the iframe (which potentially

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -442,6 +442,8 @@ pub struct WorkerGlobalScopeInit {
     pub pipeline_id: PipelineId,
     /// The origin
     pub origin: ImmutableOrigin,
+    /// The creation URL
+    pub creation_url: ServoUrl,
     /// True if secure context
     pub inherited_secure_context: Option<bool>,
 }

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -442,8 +442,6 @@ pub struct WorkerGlobalScopeInit {
     pub pipeline_id: PipelineId,
     /// The origin
     pub origin: ImmutableOrigin,
-    /// The creation URL
-    pub creation_url: Option<ServoUrl>,
     /// True if secure context
     pub inherited_secure_context: Option<bool>,
 }


### PR DESCRIPTION
Global scopes have two creation URLs: one for itself and one for the "top-level" scope. It's not immediately obvious what is considered top-level here (it is not strictly defined in the specification).

In any case, reports need the creation URL of the scope itself, not the top-level version. Therefore, propagate this information from all scopes, where the worker and worklets remain to pass in `None` for their top-level scope.

Part of #37328