### PR TITLE
Move `to_bidi_level` method from Stylo to Servo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6653,7 +6653,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.28.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -6948,7 +6948,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7409,7 +7409,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7457,7 +7457,6 @@ dependencies = [
  "to_shmem",
  "to_shmem_derive",
  "uluru",
- "unicode-bidi",
  "url",
  "void",
  "walkdir",
@@ -7467,7 +7466,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7476,12 +7475,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
 
 [[package]]
 name = "stylo_derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7493,7 +7492,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -7502,7 +7501,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7519,12 +7518,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
 
 [[package]]
 name = "stylo_traits"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -7933,7 +7932,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7946,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#47c2a67d4cf4441d46274b8298915ad745099168"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -21,7 +21,7 @@ use crate::formatting_contexts::{
     IndependentNonReplacedContents,
 };
 use crate::layout_box_base::LayoutBoxBase;
-use crate::style_ext::DisplayGeneratingBox;
+use crate::style_ext::{ComputedValuesExt, DisplayGeneratingBox};
 
 /// A builder used for both flex and grid containers.
 pub(crate) struct ModernContainerBuilder<'a, 'dom> {
@@ -152,7 +152,7 @@ impl<'a, 'dom> ModernContainerBuilder<'a, 'dom> {
                         self.context,
                         true,  /* has_first_formatted_line */
                         false, /* is_single_line_text_box */
-                        self.info.style.writing_mode.to_bidi_level(),
+                        self.info.style.to_bidi_level(),
                     )?;
 
                     let block_formatting_context = BlockFormattingContext::from_block_container(

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -230,7 +230,7 @@ impl<'dom, 'style> BlockContainerBuilder<'dom, 'style> {
             self.context,
             !self.have_already_seen_first_line_for_text_indent,
             self.info.is_single_line_text_input(),
-            self.info.style.writing_mode.to_bidi_level(),
+            self.info.style.to_bidi_level(),
         )
     }
 
@@ -539,7 +539,7 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
                 builder.split_around_block_and_finish(
                     self.context,
                     !self.have_already_seen_first_line_for_text_indent,
-                    self.info.style.writing_mode.to_bidi_level(),
+                    self.info.style.to_bidi_level(),
                 )
             })
         {

--- a/components/layout/style_ext.rs
+++ b/components/layout/style_ext.rs
@@ -28,6 +28,7 @@ use style::values::generics::position::{GenericAspectRatio, PreferredRatio};
 use style::values::generics::transform::{GenericRotate, GenericScale, GenericTranslate};
 use style::values::specified::align::AlignFlags;
 use style::values::specified::{Overflow, WillChangeBits, box_ as stylo};
+use unicode_bidi::Level;
 use webrender_api as wr;
 use webrender_api::units::LayoutTransform;
 
@@ -365,6 +366,7 @@ pub(crate) trait ComputedValuesExt {
     ) -> bool;
     fn is_inline_box(&self, fragment_flags: FragmentFlags) -> bool;
     fn overflow_direction(&self) -> OverflowDirection;
+    fn to_bidi_level(&self) -> Level;
 }
 
 impl ComputedValuesExt for ComputedValues {
@@ -1015,6 +1017,17 @@ impl ComputedValuesExt for ComputedValues {
         OverflowDirection {
             rightward,
             downward,
+        }
+    }
+
+    /// The default bidirectional embedding level for the writing mode of this style.
+    ///
+    /// Returns bidi level 0 if the mode is LTR, or 1 otherwise.
+    fn to_bidi_level(&self) -> Level {
+        if self.writing_mode.is_bidi_ltr() {
+            Level::ltr()
+        } else {
+            Level::rtl()
         }
     }
 }


### PR DESCRIPTION
This method is only used in Servo and is the only reason that `stylo` depends on `unicode-bidi`.

Stylo PR: https://github.com/servo/stylo/pull/196