### PR TITLE
Support exporting shadow parts with the `exportparts` attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6654,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.28.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#3a3663a3199282cb06889e48a427db76f320ddc3"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -6949,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#3a3663a3199282cb06889e48a427db76f320ddc3"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7410,7 +7410,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#3a3663a3199282cb06889e48a427db76f320ddc3"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7467,7 +7467,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#3a3663a3199282cb06889e48a427db76f320ddc3"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7476,12 +7476,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#3a3663a3199282cb06889e48a427db76f320ddc3"
 
 [[package]]
 name = "stylo_derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#3a3663a3199282cb06889e48a427db76f320ddc3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7493,7 +7493,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#3a3663a3199282cb06889e48a427db76f320ddc3"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -7502,7 +7502,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#3a3663a3199282cb06889e48a427db76f320ddc3"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7519,12 +7519,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#3a3663a3199282cb06889e48a427db76f320ddc3"
 
 [[package]]
 name = "stylo_traits"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#3a3663a3199282cb06889e48a427db76f320ddc3"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -7933,7 +7933,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#3a3663a3199282cb06889e48a427db76f320ddc3"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7946,7 +7946,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-05-01#15596275d9bdfcbfc584bdb6618fa2006ac38f29"
+source = "git+https://github.com/servo/stylo?branch=2025-05-01#3a3663a3199282cb06889e48a427db76f320ddc3"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,14 +225,14 @@ codegen-units = 1
 # Or for Stylo:
 #
 # [patch."https://github.com/servo/stylo"]
-# selectors = { path = "../stylo/selectors" }
-# servo_arc = { path = "../stylo/servo_arc" }
-# stylo = { path = "../stylo/style" }
-# stylo_atoms = { path = "../stylo/stylo_atoms" }
-# stylo_config = { path = "../stylo/stylo_config" }
-# stylo_dom = { path = "../stylo/stylo_dom" }
-# stylo_malloc_size_of = { path = "../stylo/malloc_size_of" }
-# stylo_traits = { path = "../stylo/style_traits" }
+# selectors = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
+# servo_arc = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
+# stylo = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
+# stylo_atoms = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
+# stylo_config = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
+# stylo_dom = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
+# stylo_malloc_size_of = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
+# stylo_traits = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
 #
 # Or for WebRender:
 #

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4226,6 +4226,7 @@ impl VirtualMethods for Element {
             local_name!("class") | local_name!("part") => {
                 AttrValue::from_serialized_tokenlist(value.into())
             },
+            local_name!("exportparts") => AttrValue::from_shadow_parts(value.into()),
             _ => self
                 .super_type()
                 .unwrap()

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -307,6 +307,21 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
         }
     }
 
+    fn each_exported_part<F>(&self, name: &AtomIdent, callback: F)
+    where
+        F: FnMut(&AtomIdent),
+    {
+        let Some(exported_parts) = self
+            .element
+            .get_attr_for_layout(&ns!(), &local_name!("exportparts"))
+        else {
+            return;
+        };
+        exported_parts
+            .as_shadow_parts()
+            .for_each_exported_part(AtomIdent::cast(name), callback);
+    }
+
     fn has_dirty_descendants(&self) -> bool {
         unsafe {
             self.as_node()
@@ -751,8 +766,12 @@ impl<'dom> ::selectors::Element for ServoLayoutElement<'dom> {
         )
     }
 
-    fn imported_part(&self, _: &AtomIdent) -> Option<AtomIdent> {
-        None
+    fn imported_part(&self, name: &AtomIdent) -> Option<AtomIdent> {
+        self.element
+            .get_attr_for_layout(&ns!(), &local_name!("exportparts"))?
+            .as_shadow_parts()
+            .imported_part(name)
+            .map(|import| AtomIdent::new(import.clone()))
     }
 
     #[inline]

--- a/tests/wpt/meta/css/css-shadow-parts/both-part-and-exportparts.html.ini
+++ b/tests/wpt/meta/css/css-shadow-parts/both-part-and-exportparts.html.ini
@@ -1,3 +1,0 @@
-[both-part-and-exportparts.html]
-  [::part() rules match elements having both @part and @exportparts]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-shadow-parts/double-forward.html.ini
+++ b/tests/wpt/meta/css/css-shadow-parts/double-forward.html.ini
@@ -1,3 +1,0 @@
-[double-forward.html]
-  [Part in inner host is forwarded through the middle host for styling by document style sheet]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-shadow-parts/exportparts-different-scope.html.ini
+++ b/tests/wpt/meta/css/css-shadow-parts/exportparts-different-scope.html.ini
@@ -1,2 +1,0 @@
-[exportparts-different-scope.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-shadow-parts/exportparts-multiple.html.ini
+++ b/tests/wpt/meta/css/css-shadow-parts/exportparts-multiple.html.ini
@@ -1,3 +1,0 @@
-[exportparts-multiple.html]
-  [Forwarding part under multiple names should work]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-shadow-parts/invalidation-complex-selector-forward.html.ini
+++ b/tests/wpt/meta/css/css-shadow-parts/invalidation-complex-selector-forward.html.ini
@@ -1,3 +1,0 @@
-[invalidation-complex-selector-forward.html]
-  [Part in selected host changed color]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-shadow-parts/precedence-part-vs-part.html.ini
+++ b/tests/wpt/meta/css/css-shadow-parts/precedence-part-vs-part.html.ini
@@ -1,3 +1,0 @@
-[precedence-part-vs-part.html]
-  [Style from document overrides style from outer CE]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-shadow-parts/simple-forward-shorthand.html.ini
+++ b/tests/wpt/meta/css/css-shadow-parts/simple-forward-shorthand.html.ini
@@ -1,3 +1,0 @@
-[simple-forward-shorthand.html]
-  [Part in inner host is forwarded, under the same name, for styling by document style sheet]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-shadow-parts/simple-forward.html.ini
+++ b/tests/wpt/meta/css/css-shadow-parts/simple-forward.html.ini
@@ -1,3 +1,0 @@
-[simple-forward.html]
-  [Part in inner host is forwarded for styling by document style sheet]
-    expected: FAIL


### PR DESCRIPTION
The attribute is implemented as a new `AttrValue` variant containing the mappings of exported part names (https://github.com/servo/stylo/pull/197).

Take a look at the [MDN page](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/exportparts) for more information about the attribute.


Testing: Covered by WPT
Fixes: https://github.com/servo/servo/issues/35349
