### PR TITLE
servoshell: Fix reversed logic for WebDriver open window and `window.open` from #37284

### DIFF
--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -480,7 +480,7 @@ impl WebViewDelegate for RunningAppState {
         // When WebDriver is enabled, do not focus and raise the WebView to the top,
         // as that is what the specification expects. Otherwise, we would like `window.open()`
         // to create a new foreground tab
-        if opts::get().webdriver_port.is_some() {
+        if opts::get().webdriver_port.is_none() {
             webview.focus();
             webview.raise_to_top(true);
         }


### PR DESCRIPTION
The logic was opposite to intended in #37284. We ended up staying in same tab for `window.open` but focus new tab for WebDriver.

Testing: This modifies whether or not tabs are activated in servoshell and WebDriver. WebDriver is currently not tested and neither is servoshell.