### PR TITLE
layout: Floor free space by 0 in solve_inline_margins_avoiding_floats()

### DIFF
--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -2032,8 +2032,10 @@ fn solve_inline_margins_avoiding_floats(
     placement_rect: LogicalRect<Au>,
     justify_self: AlignFlags,
 ) -> ((Au, Au), Au) {
-    let free_space = placement_rect.size.inline - inline_size;
-    debug_assert!(free_space >= Au::zero());
+    // PlacementAmongFloats should guarantee that the inline size of the placement rect
+    // is at least as big as `inline_size`. However, that may fail when dealing with
+    // huge sizes that need to be saturated to MAX_AU, so floor by zero. See #37312.
+    let free_space = Au::zero().max(placement_rect.size.inline - inline_size);
     let cb_info = &sequential_layout_state.floats.containing_block_info;
     let start_adjustment = placement_rect.start_corner.inline - cb_info.inline_start;
     let end_adjustment = cb_info.inline_end - placement_rect.max_inline_position();

--- a/tests/wpt/tests/css/CSS2/floats/crashtests/huge-width-after-float.html
+++ b/tests/wpt/tests/css/CSS2/floats/crashtests/huge-width-after-float.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/37312">
+
+<div style="float: left"></div>
+<div style="width: 10000000000px; overflow: scroll"></div>


### PR DESCRIPTION
`PlacementAmongFloats` should guarantee that the inline size of the placement rect is at least as big as the inline size of the box, resulting in a non-negative free space.

However, that may fail when dealing with huge sizes that need to be saturated to MAX_AU, so this floors the free space by zero.

Testing: New crashtest
Fixes: #37312
