### PR TITLE
Remove @command in executorservodriver.py

### DIFF
--- a/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -20,17 +20,14 @@ def do_delayed_imports():
         def __init__(self, session):
             self.session = session
 
-        @webdriver.client.command
         def get_prefs(self, *prefs):
             body = {"prefs": list(prefs)}
             return self.session.send_session_command("POST", "servo/prefs/get", body)
 
-        @webdriver.client.command
         def set_prefs(self, prefs):
             body = {"prefs": prefs}
             return self.session.send_session_command("POST", "servo/prefs/set", body)
 
-        @webdriver.client.command
         def reset_prefs(self, *prefs):
             body = {"prefs": list(prefs)}
             return self.session.send_session_command("POST", "servo/prefs/reset", body)


### PR DESCRIPTION
The `@webdriver.client.command` function is removed in the [recent upstream sync](https://github.com/servo/servo/commit/bd6639aadbbda905a82bfe911caf033cd33cfde1#diff-f09302464a433395dfc4a01c84c093fdf14aaeb0a9fd39845e2c945610655c22L12-L29).

Change that removes the function:
[[Commit]](https://github.com/web-platform-tests/wpt/commit/8ccc161a1fe7bfea16a5d0e34f2a5ff4b953155f) | [[Issue]](https://github.com/web-platform-tests/wpt/issues/51845)

Testing: `./mach test-wpt -r --product servodriver tests/wpt/tests/infrastucture/testdriver/actions`
