### PR TITLE
Fix `window.open` focus back to opener issue

### DIFF
--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -318,6 +318,7 @@ impl WindowProxy {
         };
         let constellation_msg = ScriptToConstellationMessage::CreateAuxiliaryWebView(load_info);
         window.send_to_constellation(constellation_msg);
+        document.get_skip_sending_to_constellation().set(true);
 
         let response = response_receiver.recv().unwrap()?;
         let new_browsing_context_id = BrowsingContextId::from(response.new_webview_id);


### PR DESCRIPTION
`create_auxiliary_browsing_context` is triggered by either `window.open` or `href` attribute along with certain `target`. Previously, it would focus on the new webview but immediately switch back to opener webview, because `document::handle_mouse_button_event` delayed by ScriptThread would commit focus on the clicked element from opener, and notify Constellation afterwards.

This PR adds a flag to `Document` to implement same behaviour as other browsers
1. We focus the new window.
2. We still focus the element which triggers `create_auxiliary_browsing_context` in the opener webview, but do NOT focus the webview itself in embedder/constellation. So that if we later focus opener, we still see button to be `document.activeElement`


Testing: [Action run](https://github.com/yezhizhen/servo/actions/runs/15556767153) and WebDriver test locally: `./mach test-wpt -r --log-raw "D:/servo log/all.txt" ./tests/wpt/tests/webdriver/tests/classic --product servodriver`
Fixes: #37364 
