### PR TITLE
Fix potential clippy warning for NodeDamage enum variant

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -96,7 +96,7 @@ impl Animations {
             .keys()
             .filter_map(|key| rooted_nodes.get(&NoTrace(key.node)))
         {
-            node.dirty(NodeDamage::NodeStyleDamaged);
+            node.dirty(NodeDamage::Style);
         }
 
         true

--- a/components/script/canvas_context.rs
+++ b/components/script/canvas_context.rs
@@ -54,7 +54,7 @@ pub(crate) trait CanvasContext {
 
     fn mark_as_dirty(&self) {
         if let HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) = &self.canvas() {
-            canvas.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            canvas.upcast::<Node>().dirty(NodeDamage::Other);
         }
     }
 

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -170,7 +170,7 @@ impl CanvasContext for CanvasRenderingContext2D {
 
     fn mark_as_dirty(&self) {
         if let Some(canvas) = self.canvas.canvas() {
-            canvas.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            canvas.upcast::<Node>().dirty(NodeDamage::Other);
             canvas.owner_document().add_dirty_2d_canvas(self);
         }
     }

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -86,7 +86,7 @@ impl CharacterData {
 
     fn content_changed(&self) {
         let node = self.upcast::<Node>();
-        node.dirty(NodeDamage::OtherNodeDamage);
+        node.dirty(NodeDamage::Other);
 
         // If this is a Text node, we might need to re-parse (say, if our parent
         // is a <style> element.) We don't need to if this is a Comment or

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -940,7 +940,7 @@ impl Document {
 
         // FIXME(emilio): This is very inefficient, ideally the flag above would
         // be enough and incremental layout could figure out from there.
-        node.dirty(NodeDamage::OtherNodeDamage);
+        node.dirty(NodeDamage::Other);
     }
 
     /// Remove any existing association between the provided id and any elements in this document.
@@ -1516,7 +1516,7 @@ impl Document {
             .upcast::<Node>()
             .traverse_preorder(ShadowIncluding::Yes)
         {
-            node.dirty(NodeDamage::OtherNodeDamage)
+            node.dirty(NodeDamage::Other)
         }
     }
 
@@ -2550,7 +2550,7 @@ impl Document {
         //
         // FIXME(emilio): Use the DocumentStylesheetSet invalidation stuff.
         if let Some(element) = self.GetDocumentElement() {
-            element.upcast::<Node>().dirty(NodeDamage::NodeStyleDamaged);
+            element.upcast::<Node>().dirty(NodeDamage::Style);
         }
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -360,7 +360,7 @@ impl Element {
         // NodeStyleDamaged, but I'm preserving existing behavior.
         restyle.hint.insert(RestyleHint::RESTYLE_SELF);
 
-        if damage == NodeDamage::OtherNodeDamage {
+        if damage == NodeDamage::Other {
             doc.note_node_with_dirty_descendants(self.upcast());
             restyle.damage = RestyleDamage::reconstruct();
         }
@@ -674,7 +674,7 @@ impl Element {
         shadow_root.bind_to_tree(&bind_context, can_gc);
 
         let node = self.upcast::<Node>();
-        node.dirty(NodeDamage::OtherNodeDamage);
+        node.dirty(NodeDamage::Other);
         node.rev_version();
 
         Ok(shadow_root)
@@ -4208,7 +4208,7 @@ impl VirtualMethods for Element {
                 // FIXME(emilio): This is pretty dubious, and should be done in
                 // the relevant super-classes.
                 if attr.namespace() == &ns!() && attr.local_name() == &local_name!("src") {
-                    node.dirty(NodeDamage::OtherNodeDamage);
+                    node.dirty(NodeDamage::Other);
                 }
             },
         };
@@ -4321,20 +4321,20 @@ impl VirtualMethods for Element {
         let flags = self.selector_flags.get();
         if flags.intersects(ElementSelectorFlags::HAS_SLOW_SELECTOR) {
             // All children of this node need to be restyled when any child changes.
-            self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            self.upcast::<Node>().dirty(NodeDamage::Other);
         } else {
             if flags.intersects(ElementSelectorFlags::HAS_SLOW_SELECTOR_LATER_SIBLINGS) {
                 if let Some(next_child) = mutation.next_child() {
                     for child in next_child.inclusively_following_siblings() {
                         if child.is::<Element>() {
-                            child.dirty(NodeDamage::OtherNodeDamage);
+                            child.dirty(NodeDamage::Other);
                         }
                     }
                 }
             }
             if flags.intersects(ElementSelectorFlags::HAS_EDGE_CHILD_SELECTOR) {
                 if let Some(child) = mutation.modified_edge_element() {
-                    child.dirty(NodeDamage::OtherNodeDamage);
+                    child.dirty(NodeDamage::Other);
                 }
             }
         }
@@ -4916,7 +4916,7 @@ impl Element {
 
     pub(crate) fn set_focus_state(&self, value: bool) {
         self.set_state(ElementState::FOCUS, value);
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        self.upcast::<Node>().dirty(NodeDamage::Other);
     }
 
     pub(crate) fn hover_state(&self) -> bool {
@@ -4958,7 +4958,7 @@ impl Element {
     pub(crate) fn set_placeholder_shown_state(&self, value: bool) {
         if self.placeholder_shown_state() != value {
             self.set_state(ElementState::PLACEHOLDER_SHOWN, value);
-            self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            self.upcast::<Node>().dirty(NodeDamage::Other);
         }
     }
 

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -718,7 +718,7 @@ impl VirtualMethods for HTMLCanvasElement {
         match attr.local_name() {
             &local_name!("width") | &local_name!("height") => {
                 self.recreate_contexts_after_resize();
-                self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                self.upcast::<Node>().dirty(NodeDamage::Other);
             },
             _ => {},
         };

--- a/components/script/dom/htmldetailselement.rs
+++ b/components/script/dom/htmldetailselement.rs
@@ -142,7 +142,7 @@ impl HTMLDetailsElement {
             implicit_summary: fallback_summary.as_traced(),
         });
         self.upcast::<Node>()
-            .dirty(crate::dom::node::NodeDamage::OtherNodeDamage);
+            .dirty(crate::dom::node::NodeDamage::Other);
     }
 
     pub(crate) fn find_corresponding_summary_element(&self) -> Option<DomRoot<HTMLElement>> {
@@ -249,7 +249,7 @@ impl VirtualMethods for HTMLDetailsElement {
                         this.upcast::<EventTarget>().fire_event(atom!("toggle"), CanGc::note());
                     }
                 }));
-            self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            self.upcast::<Node>().dirty(NodeDamage::Other);
         }
     }
 

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -473,7 +473,7 @@ impl HTMLIFrameElement {
             LoadBlocker::terminate(blocker, can_gc);
         }
 
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        self.upcast::<Node>().dirty(NodeDamage::Other);
     }
 
     fn new_inherited(

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -456,7 +456,7 @@ impl HTMLImageElement {
         self.current_request.borrow_mut().state = State::CompletelyAvailable;
         LoadBlocker::terminate(&self.current_request.borrow().blocker, can_gc);
         // Mark the node dirty
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        self.upcast::<Node>().dirty(NodeDamage::Other);
         self.resolve_image_decode_promises(can_gc);
     }
 
@@ -522,7 +522,7 @@ impl HTMLImageElement {
                 .fire_event(atom!("loadend"), can_gc);
         }
 
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        self.upcast::<Node>().dirty(NodeDamage::Other);
     }
 
     fn process_image_response_for_environment_change(
@@ -1229,7 +1229,7 @@ impl HTMLImageElement {
                 this.abort_request(State::Unavailable, ImageRequestPhase::Pending, CanGc::note());
 
                 // Step 15.6
-                this.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                this.upcast::<Node>().dirty(NodeDamage::Other);
 
                 // Step 15.7
                 this.upcast::<EventTarget>().fire_event(atom!("load"), CanGc::note());

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -520,7 +520,7 @@ impl HTMLInputElement {
         let mut value = textinput.single_line_content().clone();
         self.sanitize_value(&mut value);
         textinput.set_content(value);
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        self.upcast::<Node>().dirty(NodeDamage::Other);
     }
 
     fn does_minmaxlength_apply(&self) -> bool {
@@ -1498,7 +1498,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
         }
 
         self.value_changed(can_gc);
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        self.upcast::<Node>().dirty(NodeDamage::Other);
         Ok(())
     }
 
@@ -2025,7 +2025,7 @@ impl HTMLInputElement {
             broadcast_radio_checked(self, self.radio_group_name().as_ref());
         }
 
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        self.upcast::<Node>().dirty(NodeDamage::Other);
     }
 
     // https://html.spec.whatwg.org/multipage/#concept-fe-mutable
@@ -2048,7 +2048,7 @@ impl HTMLInputElement {
         }
         self.textinput.borrow_mut().set_content(self.DefaultValue());
         self.value_dirty.set(false);
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        self.upcast::<Node>().dirty(NodeDamage::Other);
     }
 
     fn update_placeholder_shown_state(&self) {
@@ -2669,7 +2669,7 @@ impl VirtualMethods for HTMLInputElement {
                         let mut value = textinput.single_line_content().clone();
                         self.sanitize_value(&mut value);
                         textinput.set_content(value);
-                        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                        self.upcast::<Node>().dirty(NodeDamage::Other);
 
                         // Steps 7-9
                         if !previously_selectable && self.selection_api_applies() {
@@ -2698,7 +2698,7 @@ impl VirtualMethods for HTMLInputElement {
                 self.textinput.borrow_mut().set_content(value);
                 self.update_placeholder_shown_state();
 
-                self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                self.upcast::<Node>().dirty(NodeDamage::Other);
             },
             local_name!("name") if self.input_type() == InputType::Radio => {
                 self.radio_group_updated(
@@ -2865,7 +2865,7 @@ impl VirtualMethods for HTMLInputElement {
                             .borrow_mut()
                             .set_edit_point_index(edit_point_index);
                         // trigger redraw
-                        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                        self.upcast::<Node>().dirty(NodeDamage::Other);
                         event.PreventDefault();
                     }
                 }
@@ -2896,11 +2896,11 @@ impl VirtualMethods for HTMLInputElement {
                         }
                         self.value_dirty.set(true);
                         self.update_placeholder_shown_state();
-                        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                        self.upcast::<Node>().dirty(NodeDamage::Other);
                         event.mark_as_handled();
                     },
                     RedrawSelection => {
-                        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                        self.upcast::<Node>().dirty(NodeDamage::Other);
                         event.mark_as_handled();
                     },
                     Nothing => (),
@@ -2924,13 +2924,13 @@ impl VirtualMethods for HTMLInputElement {
                         .textinput
                         .borrow_mut()
                         .handle_compositionend(compositionevent);
-                    self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                    self.upcast::<Node>().dirty(NodeDamage::Other);
                 } else if event.type_() == atom!("compositionupdate") {
                     let _ = self
                         .textinput
                         .borrow_mut()
                         .handle_compositionupdate(compositionevent);
-                    self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                    self.upcast::<Node>().dirty(NodeDamage::Other);
                 }
                 event.mark_as_handled();
             }

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -2088,7 +2088,7 @@ impl HTMLMediaElement {
             warn!("Could not render media controls {:?}", e);
         }
 
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        self.upcast::<Node>().dirty(NodeDamage::Other);
     }
 
     fn remove_controls(&self, can_gc: CanGc) {
@@ -2118,7 +2118,7 @@ impl HTMLMediaElement {
     fn handle_resize(&self, width: Option<u32>, height: Option<u32>) {
         if let Some(video_elem) = self.downcast::<HTMLVideoElement>() {
             video_elem.resize(width, height);
-            self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            self.upcast::<Node>().dirty(NodeDamage::Other);
         }
     }
 

--- a/components/script/dom/htmlmeterelement.rs
+++ b/components/script/dom/htmlmeterelement.rs
@@ -101,7 +101,7 @@ impl HTMLMeterElement {
             meter_value: meter_value.as_traced(),
         });
         self.upcast::<Node>()
-            .dirty(crate::dom::node::NodeDamage::OtherNodeDamage);
+            .dirty(crate::dom::node::NodeDamage::Other);
     }
 
     fn shadow_tree(&self, can_gc: CanGc) -> Ref<'_, ShadowTree> {

--- a/components/script/dom/htmlprogresselement.rs
+++ b/components/script/dom/htmlprogresselement.rs
@@ -103,7 +103,7 @@ impl HTMLProgressElement {
             progress_bar: progress_bar.as_traced(),
         });
         self.upcast::<Node>()
-            .dirty(crate::dom::node::NodeDamage::OtherNodeDamage);
+            .dirty(crate::dom::node::NodeDamage::Other);
     }
 
     fn shadow_tree(&self, can_gc: CanGc) -> Ref<'_, ShadowTree> {

--- a/components/script/dom/htmlslotelement.rs
+++ b/components/script/dom/htmlslotelement.rs
@@ -346,7 +346,7 @@ impl HTMLSlotElement {
 
     /// <https://dom.spec.whatwg.org/#signal-a-slot-change>
     pub(crate) fn signal_a_slot_change(&self) {
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        self.upcast::<Node>().dirty(NodeDamage::Other);
 
         if self.is_in_agents_signal_slots.get() {
             return;

--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -183,10 +183,10 @@ impl VirtualMethods for HTMLTableCellElement {
         }
 
         if matches!(*attr.local_name(), local_name!("colspan")) {
-            self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            self.upcast::<Node>().dirty(NodeDamage::Other);
         }
         if matches!(*attr.local_name(), local_name!("rowspan")) {
-            self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            self.upcast::<Node>().dirty(NodeDamage::Other);
         }
     }
 

--- a/components/script/dom/htmltablecolelement.rs
+++ b/components/script/dom/htmltablecolelement.rs
@@ -101,7 +101,7 @@ impl VirtualMethods for HTMLTableColElement {
         }
 
         if matches!(*attr.local_name(), local_name!("span")) {
-            self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+            self.upcast::<Node>().dirty(NodeDamage::Other);
         }
     }
 

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -348,7 +348,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
 
         self.validity_state()
             .perform_validation_and_update(ValidationFlags::all(), CanGc::note());
-        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+        self.upcast::<Node>().dirty(NodeDamage::Other);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-textlength
@@ -656,11 +656,11 @@ impl VirtualMethods for HTMLTextAreaElement {
                         }
                         self.value_dirty.set(true);
                         self.update_placeholder_shown_state();
-                        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                        self.upcast::<Node>().dirty(NodeDamage::Other);
                         event.mark_as_handled();
                     },
                     KeyReaction::RedrawSelection => {
-                        self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                        self.upcast::<Node>().dirty(NodeDamage::Other);
                         event.mark_as_handled();
                     },
                     KeyReaction::Nothing => (),
@@ -680,13 +680,13 @@ impl VirtualMethods for HTMLTextAreaElement {
                         .textinput
                         .borrow_mut()
                         .handle_compositionend(compositionevent);
-                    self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                    self.upcast::<Node>().dirty(NodeDamage::Other);
                 } else if event.type_() == atom!("compositionupdate") {
                     let _ = self
                         .textinput
                         .borrow_mut()
                         .handle_compositionupdate(compositionevent);
-                    self.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                    self.upcast::<Node>().dirty(NodeDamage::Other);
                 }
                 event.mark_as_handled();
             }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3912,9 +3912,9 @@ impl VirtualMethods for Node {
 #[derive(Clone, Copy, MallocSizeOf, PartialEq)]
 pub(crate) enum NodeDamage {
     /// The node's `style` attribute changed.
-    NodeStyleDamaged,
+    Style,
     /// Other parts of a node changed; attributes, text content, etc.
-    OtherNodeDamage,
+    Other,
 }
 
 pub(crate) enum ChildrenMutation<'a> {

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -215,7 +215,7 @@ impl ShadowRoot {
         self.author_styles.borrow_mut().stylesheets.force_dirty();
         // Mark the host element dirty so a reflow will be performed.
         if let Some(host) = self.host.get() {
-            host.upcast::<Node>().dirty(NodeDamage::NodeStyleDamaged);
+            host.upcast::<Node>().dirty(NodeDamage::Style);
         }
     }
 

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -316,8 +316,6 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
                 );
         }
 
-        self.element
-            .upcast::<Node>()
-            .dirty(NodeDamage::OtherNodeDamage);
+        self.element.upcast::<Node>().dirty(NodeDamage::Other);
     }
 }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -2016,7 +2016,7 @@ impl CanvasContext for WebGLRenderingContext {
 
         match self.canvas {
             HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) => {
-                canvas.upcast::<Node>().dirty(NodeDamage::OtherNodeDamage);
+                canvas.upcast::<Node>().dirty(NodeDamage::Other);
                 canvas.owner_document().add_dirty_webgl_canvas(self);
             },
             HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(_) => {},

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -594,7 +594,7 @@ impl Window {
             Entry::Vacant(_) => return,
         };
         for node in nodes.get() {
-            node.dirty(NodeDamage::OtherNodeDamage);
+            node.dirty(NodeDamage::Other);
         }
         match response.response {
             ImageResponse::MetadataLoaded(_) => {},
@@ -617,7 +617,7 @@ impl Window {
             Entry::Vacant(_) => return,
         };
         for node in nodes.get() {
-            node.dirty(NodeDamage::OtherNodeDamage);
+            node.dirty(NodeDamage::Other);
         }
         nodes.remove();
     }

--- a/components/script/image_animation.rs
+++ b/components/script/image_animation.rs
@@ -71,7 +71,7 @@ impl ImageAnimationManager {
                         .expect("active_frame should within range of frames");
 
                     if let Some(node) = rooted_nodes.get(&NoTrace(*node)) {
-                        node.dirty(crate::dom::node::NodeDamage::OtherNodeDamage);
+                        node.dirty(crate::dom::node::NodeDamage::Other);
                     }
                     Some(ImageUpdate::UpdateImage(
                         image.id.unwrap(),


### PR DESCRIPTION
The default of `enum-variant-name-threshold` is 3, so adding any new variants will lead to the lint being triggered, reference:
[enum_variant_names](https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names). This PR fix this potential clippy lint warning for facilitate the addition of new variant in following PR about incremental box tree update.

Testing: No logic changed, just covered by existing WPT tests
Fixes: None
