### PR TITLE
OHOS: Use native API to get most of the information needed for starting servoshell.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5392,6 +5392,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ohos-abilitykit-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff6fba3cf019d0dcabc3ee41396a7180b9b6fd64bee904a27144224a9be81c7"
+dependencies = [
+ "ohos-sys-opaque-types",
+]
+
+[[package]]
+name = "ohos-deviceinfo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e75dc6477dd4a8bafe2e7b1feb9cf10e882d3b15903e51f320a80015a59d93"
+dependencies = [
+ "ohos-deviceinfo-sys",
+]
+
+[[package]]
+name = "ohos-deviceinfo-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847d268f96c5ad9d03fd6bd303f9529ab3a83019497fa1c1a585aac50c378ec"
+
+[[package]]
 name = "ohos-drawing-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5436,6 +5460,15 @@ name = "ohos-vsync-sys"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93e60dacb893ed4eb57e8fd9eff81b8ad0153842661b3093927bdfd861506652"
+
+[[package]]
+name = "ohos-window-manager-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0b36f3adea9bae4251f2c215e5569330a59b1a150d73af3182fe92fb490570"
+dependencies = [
+ "ohos-sys-opaque-types",
+]
 
 [[package]]
 name = "once_cell"
@@ -7086,9 +7119,12 @@ dependencies = [
  "nix",
  "objc2-app-kit 0.3.1",
  "objc2-foundation 0.3.1",
+ "ohos-abilitykit-sys",
+ "ohos-deviceinfo",
  "ohos-ime",
  "ohos-ime-sys",
  "ohos-vsync",
+ "ohos-window-manager-sys",
  "raw-window-handle",
  "rustls",
  "serde_json",

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -85,8 +85,7 @@ backtrace = { workspace = true }
 env_filter = "0.1.3"
 euclid = { workspace = true }
 hilog = "0.2.0"
-# force inprocess for now.
-# https://github.com/rust-lang/libc/commit/9e248e212c5602cb4e98676e4c21ea0382663a12
+# force inprocess until we add multi-process support for ohos
 ipc-channel = { workspace = true, features = ["force-inprocess"] }
 napi-derive-ohos = "1.0.4"
 napi-ohos = "1.0.4"

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -85,15 +85,18 @@ backtrace = { workspace = true }
 env_filter = "0.1.3"
 euclid = { workspace = true }
 hilog = "0.2.0"
-# force inprocess, until libc-rs 0.2.156 is released containing
+# force inprocess for now.
 # https://github.com/rust-lang/libc/commit/9e248e212c5602cb4e98676e4c21ea0382663a12
 ipc-channel = { workspace = true, features = ["force-inprocess"] }
 napi-derive-ohos = "1.0.4"
 napi-ohos = "1.0.4"
 ohos-ime = "0.4.0"
 ohos-ime-sys = "0.2.0"
+ohos-deviceinfo = "0.1.0"
+ohos-abilitykit-sys = { version = "0.1.0", features = ["api-14"] }
 ohos-vsync = "0.1.3"
-xcomponent-sys = { version = "0.3.1", features = ["api-12", "keyboard-types"] }
+ohos-window-manager-sys = { version = "0.1", features = ["api-14"] }
+xcomponent-sys = { version = "0.3.1", features = ["api-14", "keyboard-types"] }
 
 [target.'cfg(any(target_os = "android", target_env = "ohos"))'.dependencies]
 nix = { workspace = true, features = ["fs"] }

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -50,8 +50,6 @@ pub struct InitOpts {
     pub commandline_args: String,
 }
 
-/// display_density:
-
 #[derive(Debug)]
 enum CallError {
     ChannelNotInitialized,

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -45,14 +45,12 @@ mod simpleservo;
 #[derive(Debug)]
 pub struct InitOpts {
     pub url: String,
-    pub device_type: String,
-    pub os_full_name: String,
     /// Path to application data bundled with the servo app, e.g. web-pages.
     pub resource_dir: String,
-    pub cache_dir: String,
-    pub display_density: f64,
     pub commandline_args: String,
 }
+
+/// display_density:
 
 #[derive(Debug)]
 enum CallError {
@@ -626,10 +624,6 @@ pub fn register_prompt_toast_callback(callback: Function<String, ()>) -> napi_oh
 #[napi]
 pub fn init_servo(init_opts: InitOpts) -> napi_ohos::Result<()> {
     info!("Servo is being initialised with the following Options: ");
-    info!(
-        "Device Type: {}, DisplayDensity: {}",
-        init_opts.device_type, init_opts.display_density
-    );
     info!("Initial URL: {}", init_opts.url);
     let channel = if let Some(channel) = SERVO_CHANNEL.get() {
         channel

--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -293,8 +293,8 @@ class OpenHarmonyTarget(CrossBuildTarget):
                 meta = json.load(meta_file)
             ohos_api_version = int(meta["apiVersion"])
             ohos_sdk_version = parse_version(meta["version"])
-            if ohos_sdk_version < parse_version("5.0") or ohos_api_version < 12:
-                raise RuntimeError("Building servo for OpenHarmony requires SDK version 5.0 (API-12) or newer.")
+            if ohos_sdk_version < parse_version("5.0") or ohos_api_version < 14:
+                raise RuntimeError("Building servo for OpenHarmony requires SDK version 5.0.2 (API-14) or newer.")
             print(f"Info: The OpenHarmony SDK {ohos_sdk_version} is targeting API-level {ohos_api_version}")
         except (OSError, json.JSONDecodeError) as e:
             print(f"Failed to read metadata information from {package_info}")

--- a/support/openharmony/entry/src/main/ets/pages/Index.ets
+++ b/support/openharmony/entry/src/main/ets/pages/Index.ets
@@ -15,33 +15,8 @@ interface ServoXComponentInterface {
 
 interface InitOpts {
   url: string;
-  deviceType: string,
-  osFullName: string,
   resourceDir: string,
-  cacheDir: string,
-  displayDensity: number,
   commandlineArgs: string,
-}
-
-function get_density(): number {
-    try {
-      let displayClass = display.getDefaultDisplaySync();
-      console.info('Test densityDPI:' + JSON.stringify(displayClass.densityDPI));
-      return displayClass.densityDPI / 160;
-  } catch (exception) {
-      console.error('Failed to obtain the default display object. Code: ' + JSON.stringify(exception));
-      return 3;
-  }
-}
-
-function get_device_type(): string {
-  let device_type: string = deviceInfo.deviceType;
-  if (device_type == "") {
-      console.error("deviceInfo.deviceType is empty string!")
-  } else {
-    console.info("Device type is " + device_type)
-  }
-  return device_type;
 }
 
 function prompt_toast(msg: string) {
@@ -114,16 +89,10 @@ struct Index {
         .onLoad((xComponentContext) => {
           this.xComponentContext = xComponentContext as ServoXComponentInterface;
           let resource_dir: string = this.context.resourceDir;
-          let cache_dir: string = this.context.cacheDir;
           console.debug("resourceDir: ", resource_dir);
-          console.debug("cacheDir: ", cache_dir);
           let init_options: InitOpts = {
             url: this.urlToLoad,
-            deviceType: get_device_type(),
-            osFullName: deviceInfo.osFullName,
-            displayDensity: get_density(),
             resourceDir: resource_dir,
-            cacheDir: cache_dir,
             commandlineArgs: this.CommandlineArgs
           }
           this.xComponentContext.initServo(init_options)


### PR DESCRIPTION
Uses the native ohos-api crates to get the required information for starting servoshell.
This increases the minimum API version requirement to API-14.

Testing: Tested on device.
