### PR TITLE
[WebDriver: Dispatch Action] Check if browsing context still open for each tick action

### DIFF
--- a/tests/wpt/meta/webdriver/tests/classic/refresh/refresh.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/refresh/refresh.py.ini
@@ -1,7 +1,4 @@
 [refresh.py]
-  [test_no_top_browsing_context]
-    expected: FAIL
-
   [test_no_browsing_context]
     expected: FAIL
 


### PR DESCRIPTION
As titled. This is what [spec](https://w3c.github.io/webdriver/#dfn-dispatch-actions-inner) requires. The motivation is that the previous action might have changed the browsing context.

Testing: `./mach test-wpt -r --log-raw "D:\servo test log\all.txt" .\tests\wpt\tests\webdriver\tests\classic\ --product servodriver`