### PR TITLE
script: Remove unused `Window::page_clip_rect`

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2451,7 +2451,7 @@ impl ScriptThread {
     fn handle_viewport(&self, id: PipelineId, rect: Rect<f32>) {
         let document = self.documents.borrow().find_document(id);
         if let Some(document) = document {
-            document.window().set_page_clip_rect_with_new_viewport(rect);
+            document.window().set_viewport(rect);
             return;
         }
         let loads = self.incomplete_loads.borrow();

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -382,13 +382,6 @@ impl ReflowGoal {
     }
 }
 
-/// Information needed for a reflow.
-#[derive(Debug)]
-pub struct Reflow {
-    ///  A clipping rectangle for the page, an enlarged rectangle containing the viewport.
-    pub page_clip_rect: Rect<Au>,
-}
-
 #[derive(Clone, Debug, MallocSizeOf)]
 pub struct IFrameSize {
     pub browsing_context_id: BrowsingContextId,
@@ -416,8 +409,6 @@ pub struct ReflowResult {
 /// Information needed for a script-initiated reflow.
 #[derive(Debug)]
 pub struct ReflowRequest {
-    /// General reflow data.
-    pub reflow_info: Reflow,
     /// The document node.
     pub document: TrustedNodeAddress,
     /// The dirty root from which to restyle.


### PR DESCRIPTION
This value was used when rendering was not done by WebRender. Nowadays,
we do not need this page clip rect concept and it is completely
unused.

Testing: This just remove dead code, so should be covered by existing tests.
