### PR TITLE
OHOS: update ci to use api-14 and newer action

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -67,9 +67,9 @@ jobs:
         run: sudo apt update && ./mach bootstrap --skip-lints
       - name: Setup OpenHarmony SDK
         id: setup_sdk
-        uses: openharmony-rs/setup-ohos-sdk@v0.1
+        uses: openharmony-rs/setup-ohos-sdk@v0.2.1
         with:
-          version: "5.0.0"
+          version: "5.0.2"
           fixup-path: true
       - name: Install node for hvigor
         uses: actions/setup-node@v4

--- a/support/openharmony/build-profile.json5
+++ b/support/openharmony/build-profile.json5
@@ -4,16 +4,16 @@
       {
         "name": "default",
         "signingConfig": "default",
-        "compileSdkVersion": 12,
-        "compatibleSdkVersion": 12,
-        "targetSdkVersion": 12,
+        "compileSdkVersion": 14,
+        "compatibleSdkVersion": 14,
+        "targetSdkVersion": 14,
         "runtimeOS": "OpenHarmony"
       },
       {
         "name": "harmonyos",
         "signingConfig": "hos",
-        "compatibleSdkVersion": "5.0.0(12)",
-        "targetSdkVersion": "5.0.0(12)",
+        "compatibleSdkVersion": "5.0.2(14)",
+        "targetSdkVersion": "5.0.2(14)",
         "runtimeOS": "HarmonyOS"
       }
     ],


### PR DESCRIPTION
Update the CI to use api version 14 and 5.0.2 sdk. Additionally, update the action. This is required because of https://github.com/servo/servo/pull/37392.

Testing: CI does not have tests.
