### PR TITLE
layout: Remove two arguments from `StackingContextTree::new()`

### DIFF
--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -121,19 +121,23 @@ impl StackingContextTree {
     pub fn new(
         fragment_tree: &FragmentTree,
         viewport_size: LayoutSize,
-        content_size: LayoutSize,
         pipeline_id: wr::PipelineId,
-        viewport_scroll_sensitivity: AxesScrollSensitivity,
         first_reflow: bool,
         debug: &DebugOptions,
     ) -> Self {
+        let scrollable_overflow = fragment_tree.scrollable_overflow();
+        let scrollable_overflow = LayoutSize::from_untyped(Size2D::new(
+            scrollable_overflow.size.width.to_f32_px(),
+            scrollable_overflow.size.height.to_f32_px(),
+        ));
+
         let compositor_info = CompositorDisplayListInfo::new(
             viewport_size,
-            content_size,
+            scrollable_overflow,
             pipeline_id,
             // This epoch is set when the WebRender display list is built. For now use a dummy value.
             wr::Epoch(0),
-            viewport_scroll_sensitivity,
+            fragment_tree.viewport_scroll_sensitivity,
             first_reflow,
         );
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -872,21 +872,13 @@ impl LayoutThread {
             viewport_size.height.to_f32_px(),
         );
 
-        let scrollable_overflow = fragment_tree.scrollable_overflow();
-        let scrollable_overflow = LayoutSize::from_untyped(Size2D::new(
-            scrollable_overflow.size.width.to_f32_px(),
-            scrollable_overflow.size.height.to_f32_px(),
-        ));
-
         // Build the StackingContextTree. This turns the `FragmentTree` into a
         // tree of fragments in CSS painting order and also creates all
         // applicable spatial and clip nodes.
         *self.stacking_context_tree.borrow_mut() = Some(StackingContextTree::new(
             fragment_tree,
             viewport_size,
-            scrollable_overflow,
             self.id.into(),
-            fragment_tree.viewport_scroll_sensitivity,
             self.first_reflow.get(),
             &self.debug,
         ));


### PR DESCRIPTION
This is a minor cleanup that simplifies the construction of
`StackingContextTree`. The two arguments removed are derived from the
`FragmentTree` which is already passed as an argument.

Testing: This should not change behavior and is thus covered by existing tests.
