### PR TITLE
Verify `webview` still open in webdriver switch frame command

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1029,6 +1029,8 @@ impl Handler {
         &mut self,
         parameters: &SwitchToFrameParameters,
     ) -> WebDriverResult<WebDriverResponse> {
+        self.verify_top_level_browsing_context_is_open(self.session()?.webview_id)?;
+
         use webdriver::common::FrameId;
         let frame_id = match parameters.id {
             FrameId::Top => {
@@ -1044,6 +1046,11 @@ impl Handler {
     }
 
     fn handle_switch_to_parent_frame(&mut self) -> WebDriverResult<WebDriverResponse> {
+        let webview_id = self.session()?.webview_id;
+        self.verify_top_level_browsing_context_is_open(webview_id)?;
+        if self.session()?.browsing_context_id == webview_id {
+            return Ok(WebDriverResponse::Void);
+        }
         self.switch_to_frame(WebDriverFrameId::Parent)
     }
 

--- a/tests/wpt/meta/webdriver/tests/classic/switch_to_frame/switch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/switch_to_frame/switch.py.ini
@@ -1,15 +1,6 @@
 [switch.py]
-  [test_no_top_browsing_context[None\]]
-    expected: FAIL
-
-  [test_no_top_browsing_context[0\]]
-    expected: FAIL
-
   [test_no_browsing_context[0\]]
     expected: FAIL
 
   [test_no_browsing_context[id2\]]
-    expected: FAIL
-
-  [test_no_browsing_context_when_already_top_level]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/switch_to_parent_frame/switch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/switch_to_parent_frame/switch.py.ini
@@ -1,3 +1,0 @@
-[switch.py]
-  [test_switch_from_top_level]
-    expected: FAIL


### PR DESCRIPTION
SwitchToParentFrame webdriver commands do not handle the case where the current top-level browsing context has been closed.

Tests:
`./tests/wpt/tests/webdriver/tests/classic/switch_to_parent_frame/switch.py`
`./tests/wpt/tests/webdriver/tests/classic/switch_to_frame/switch.py`