### PR TITLE
script: Enrich `DocumentOrShadowRoot::get_active_element`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -5319,6 +5319,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     // https://html.spec.whatwg.org/multipage/#dom-document-activeelement
     fn GetActiveElement(&self) -> Option<DomRoot<Element>> {
         self.document_or_shadow_root.get_active_element(
+            self.upcast(),
             self.get_focused_element(),
             self.GetBody(),
             self.GetDocumentElement(),

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -315,8 +315,12 @@ impl ShadowRoot {
 impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     // https://html.spec.whatwg.org/multipage/#dom-document-activeelement
     fn GetActiveElement(&self) -> Option<DomRoot<Element>> {
-        self.document_or_shadow_root
-            .get_active_element(self.get_focused_element(), None, None)
+        self.document_or_shadow_root.get_active_element(
+            self.upcast(),
+            self.get_focused_element(),
+            None,
+            None,
+        )
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint


### PR DESCRIPTION
[Spec](https://html.spec.whatwg.org/multipage/#dom-document-activeelement)

Testing: [Action run](https://github.com/yezhizhen/servo/actions/runs/15626846822/job/44024150306). A lot fails because of another bug: focus element is always empty when browsing context just created. See #36330 from Josh earlier.

Partly fixes: #37420 