### PR TITLE
[WebDriver] Improve get active element

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1323,15 +1323,26 @@ impl Handler {
         }
     }
 
+    ///<https://w3c.github.io/webdriver/#get-active-element>
     fn handle_active_element(&self) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetActiveElement(sender);
         self.browsing_context_script_command(cmd)?;
         let value = wait_for_script_response(receiver)?
             .map(|x| serde_json::to_value(WebElement(x)).unwrap());
-        Ok(WebDriverResponse::Generic(ValueResponse(
-            serde_json::to_value(value)?,
-        )))
+        // Step 4. If active element is a non-null element, return success
+        // with data set to web element reference object for session and active element.
+        // Otherwise, return error with error code no such element.
+        if value.is_some() {
+            Ok(WebDriverResponse::Generic(ValueResponse(
+                serde_json::to_value(value)?,
+            )))
+        } else {
+            Err(WebDriverError::new(
+                ErrorStatus::NoSuchElement,
+                "No active element found",
+            ))
+        }
     }
 
     fn handle_computed_role(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {


### PR DESCRIPTION
Report `NoSuchElement` if the active element is null, according to spec.

Testing: `./mach test-wpt -r --log-raw "D:\servo test log\all.txt" .\tests\wpt\tests\webdriver\tests\classic\get_active_element --product servodriver`
Partly fixes: #37420. We can pass `get_active_element` test once #37424 is done.
