### PR TITLE
fix(xpath): pass in correct context node for // and / in predicates

### DIFF
--- a/tests/wpt/meta/domxpath/predicates.html.ini
+++ b/tests/wpt/meta/domxpath/predicates.html.ini
@@ -1,3 +1,0 @@
-[predicates.html]
-  [An expression in a predicate should not change the context node]
-    expected: FAIL

--- a/tests/wpt/meta/domxpath/text-html-attributes.html.ini
+++ b/tests/wpt/meta/domxpath/text-html-attributes.html.ini
@@ -23,8 +23,5 @@
   [Select SVG element with non-ascii attribute 2]
     expected: FAIL
 
-  [xmlns attribute]
-    expected: FAIL
-
   [svg element with XLink attribute]
     expected: FAIL


### PR DESCRIPTION
For example `div[count(//p)]` should count all `<p>` elements in the document, not just the ones underneath the `<div>`.

Testing: WPT tests cover this, the fix makes two more test pass.
