### PR TITLE
Cleanup Cargo.toml `[patch]` section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,18 +221,19 @@ codegen-units = 1
 # html5ever = { path = "../html5ever/html5ever" }
 # markup5ever = { path = "../html5ever/markup5ever" }
 # xml5ever = { path = "../html5ever/xml5ever" }
+# web_atoms = { path = "../html5ever/web_atoms" }
 #
 # Or for Stylo:
 #
 # [patch."https://github.com/servo/stylo"]
-# selectors = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
-# servo_arc = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
-# stylo = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
-# stylo_atoms = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
-# stylo_config = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
-# stylo_dom = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
-# stylo_malloc_size_of = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
-# stylo_traits = { git = "https://github.com/simonwuelker/stylo", branch = "shadow-parts-exportparts" }
+# selectors = { path = "../stylo/selectors" }
+# servo_arc = { path = "../stylo/servo_arc" }
+# stylo = { path = "../stylo/style" }
+# stylo_atoms = { path = "../stylo/stylo_atoms" }
+# stylo_config = { path = "../stylo/stylo_config" }
+# stylo_dom = { path = "../stylo/stylo_dom" }
+# stylo_malloc_size_of = { path = "../stylo/malloc_size_of" }
+# stylo_traits = { path = "../stylo/style_traits" }
 #
 # Or for WebRender:
 #
@@ -248,4 +249,3 @@ codegen-units = 1
 #
 # [patch."https://github.com/servo/rust-content-security-policy"]
 # content-security-policy = { path = "../rust-content-security-policy/" }
-# content-security-policy = { git = "https://github.com/timvdlippe/rust-content-security-policy/", branch = "fix-report-checks", features = ["serde"] }


### PR DESCRIPTION

* Removes a reference to my stylo fork i accidentally added in https://github.com/servo/servo/pull/37345
* Removes a similar reference for rust-content-security-policy 
* Adds `web_atoms` to the `html5ever` patch list. This crate lives in the html5ever repo since https://github.com/servo/html5ever/pull/599 and you'll need to patch it when you're patching htmlever 

Testing: These are comments, no tests needed