### PR TITLE
Fix Rust-analyzer errors and warnings in `blurmac`

### DIFF
--- a/third_party/blurmac/src/lib.rs
+++ b/third_party/blurmac/src/lib.rs
@@ -4,6 +4,7 @@
 // <LICENSE.md or https://opensource.org/licenses/BSD-3-Clause>.
 // This file may not be copied, modified, or distributed except
 // according to those terms.
+#![cfg(target_os = "macos")]
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
I got 22 errors and 63 warnings when I opened the Servo project in Visual Studio Code with the Rust-analyzer extension on Linux. The `blurmac` package, which is vendored in the source tree, only needs to be be compiled on macOS.

With this change I get zero errors and 2 unrelated warnings.

Testing: I don't have a mac and cannot test it there. I only tested it building on Linux. I also did not test test the Bluetooth feature. I think the change is pretty straightforward and unlikely to cause a major regression.