### PR TITLE
improvement: body element check

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2490,12 +2490,11 @@ impl Document {
     }
 
     pub(crate) fn get_body_attribute(&self, local_name: &LocalName) -> DOMString {
-        match self
-            .GetBody()
-            .and_then(DomRoot::downcast::<HTMLBodyElement>)
-        {
-            Some(ref body) => body.upcast::<Element>().get_string_attribute(local_name),
-            None => DOMString::new(),
+        match self.GetBody() {
+            Some(ref body) if body.is_body_element() => {
+                body.upcast::<Element>().get_string_attribute(local_name)
+            },
+            _ => DOMString::new(),
         }
     }
 
@@ -2505,10 +2504,7 @@ impl Document {
         value: DOMString,
         can_gc: CanGc,
     ) {
-        if let Some(ref body) = self
-            .GetBody()
-            .and_then(DomRoot::downcast::<HTMLBodyElement>)
-        {
+        if let Some(ref body) = self.GetBody().filter(|elem| elem.is_body_element()) {
             let body = body.upcast::<Element>();
             let value = body.parse_attribute(&ns!(), local_name, value);
             body.set_attribute(local_name, value, can_gc);

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -145,7 +145,6 @@ use crate::dom::hashchangeevent::HashChangeEvent;
 use crate::dom::htmlanchorelement::HTMLAnchorElement;
 use crate::dom::htmlareaelement::HTMLAreaElement;
 use crate::dom::htmlbaseelement::HTMLBaseElement;
-use crate::dom::htmlbodyelement::HTMLBodyElement;
 use crate::dom::htmlcollection::{CollectionFilter, HTMLCollection};
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmlembedelement::HTMLEmbedElement;

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -55,17 +55,6 @@ impl HTMLBodyElement {
             can_gc,
         )
     }
-
-    /// <https://drafts.csswg.org/cssom-view/#the-html-body-element>
-    pub(crate) fn is_the_html_body_element(&self) -> bool {
-        let self_node = self.upcast::<Node>();
-        let root_elem = self.upcast::<Element>().root_element();
-        let root_node = root_elem.upcast::<Node>();
-        root_node.is_parent_of(self_node) &&
-            self_node
-                .preceding_siblings()
-                .all(|n| !n.is::<HTMLBodyElement>())
-    }
 }
 
 impl HTMLBodyElementMethods<crate::DomTypeHolder> for HTMLBodyElement {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -817,6 +817,17 @@ impl HTMLElement {
         }
     }
 
+    /// <https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2>
+    pub(crate) fn is_body_element(&self) -> bool {
+        let self_node = self.upcast::<Node>();
+        self_node.GetParentNode().is_some_and(|parent| {
+            let parent_node = parent.upcast::<Node>();
+            self_node.is::<HTMLBodyElement>()
+             && parent_node.is::<HTMLHtmlElement>()
+              && self_node.preceding_siblings().all(|n| !n.is::<HTMLBodyElement>())
+        })
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#category-submit>
     pub(crate) fn is_submittable_element(&self) -> bool {
         match self.upcast::<Node>().type_id() {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -822,9 +822,11 @@ impl HTMLElement {
         let self_node = self.upcast::<Node>();
         self_node.GetParentNode().is_some_and(|parent| {
             let parent_node = parent.upcast::<Node>();
-            self_node.is::<HTMLBodyElement>()
-             && parent_node.is::<HTMLHtmlElement>()
-              && self_node.preceding_siblings().all(|n| !n.is::<HTMLBodyElement>())
+            self_node.is::<HTMLBodyElement>() &&
+                parent_node.is::<HTMLHtmlElement>() &&
+                self_node
+                    .preceding_siblings()
+                    .all(|n| !n.is::<HTMLBodyElement>())
         })
     }
 

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -439,7 +439,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
 
     /// <https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent>
     fn GetOffsetParent(&self, can_gc: CanGc) -> Option<DomRoot<Element>> {
-        if self.is::<HTMLBodyElement>() || self.is::<HTMLHtmlElement>() {
+        if self.is_body_element() || self.is::<HTMLHtmlElement>() {
             return None;
         }
 
@@ -452,7 +452,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsettop
     fn OffsetTop(&self, can_gc: CanGc) -> i32 {
-        if self.is::<HTMLBodyElement>() {
+        if self.is_body_element() {
             return 0;
         }
 
@@ -465,7 +465,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetleft
     fn OffsetLeft(&self, can_gc: CanGc) -> i32 {
-        if self.is::<HTMLBodyElement>() {
+        if self.is_body_element() {
             return 0;
         }
 

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -822,11 +822,11 @@ impl HTMLElement {
         let self_node = self.upcast::<Node>();
         self_node.GetParentNode().is_some_and(|parent| {
             let parent_node = parent.upcast::<Node>();
-            self_node.is::<HTMLBodyElement>() &&
+            (self_node.is::<HTMLBodyElement>() || self_node.is::<HTMLFrameSetElement>()) &&
                 parent_node.is::<HTMLHtmlElement>() &&
                 self_node
                     .preceding_siblings()
-                    .all(|n| !n.is::<HTMLBodyElement>())
+                    .all(|n| !n.is::<HTMLBodyElement>() && !n.is::<HTMLFrameSetElement>())
         })
     }
 

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -817,7 +817,7 @@ impl HTMLElement {
         }
     }
 
-    /// <https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2>
+    /// <https://html.spec.whatwg.org/multipage/#the-body-element-2>
     pub(crate) fn is_body_element(&self) -> bool {
         let self_node = self.upcast::<Node>();
         self_node.GetParentNode().is_some_and(|parent| {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -92,7 +92,6 @@ use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator, Se
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::htmlbodyelement::HTMLBodyElement;
 use crate::dom::htmlcanvaselement::{HTMLCanvasElement, LayoutHTMLCanvasElementHelpers};
 use crate::dom::htmlcollection::HTMLCollection;
 use crate::dom::htmlelement::HTMLElement;
@@ -958,8 +957,8 @@ impl Node {
         let in_quirks_mode = document.quirks_mode() == QuirksMode::Quirks;
         let is_root = self.downcast::<Element>().is_some_and(|e| e.is_root());
         let is_body_element = self
-            .downcast::<HTMLBodyElement>()
-            .is_some_and(|e| e.is_the_html_body_element());
+            .downcast::<HTMLElement>()
+            .is_some_and(|e| e.is_body_element());
 
         // "4. If the element is the root element and document is not in quirks mode
         // return max(viewport scrolling area width/height, viewport width/height)."


### PR DESCRIPTION
Created a new method `HTMLElement::is_body_element` that replaces `HTMLBodyElement::is_the_html_body_element`.

Testing: Existing WPT tests should pass.
Fixes: https://github.com/servo/servo/issues/37429
