### PR TITLE
[WebDriver] Properly report error for `find_element` & `find_elements`; Get correct visible text when matching links

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2278,6 +2278,7 @@ impl ScriptThread {
                     selector,
                     partial,
                     reply,
+                    can_gc,
                 )
             },
             WebDriverScriptCommand::FindElementTagName(selector, reply) => {
@@ -2304,6 +2305,7 @@ impl ScriptThread {
                     selector,
                     partial,
                     reply,
+                    can_gc,
                 )
             },
             WebDriverScriptCommand::FindElementsTagName(selector, reply) => {
@@ -2336,6 +2338,7 @@ impl ScriptThread {
                 selector,
                 partial,
                 reply,
+                can_gc,
             ),
             WebDriverScriptCommand::FindElementElementTagName(selector, element_id, reply) => {
                 webdriver_handlers::handle_find_element_element_tag_name(
@@ -2368,6 +2371,7 @@ impl ScriptThread {
                 selector,
                 partial,
                 reply,
+                can_gc,
             ),
             WebDriverScriptCommand::FindElementElementsTagName(selector, element_id, reply) => {
                 webdriver_handlers::handle_find_element_elements_tag_name(

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -133,6 +133,7 @@ fn all_matching_links(
     link_text: String,
     partial: bool,
 ) -> Result<Vec<String>, ErrorStatus> {
+    /// <https://w3c.github.io/webdriver/#dfn-find>
     // Step 7.2. If a DOMException, SyntaxError, XPathException, or other error occurs
     // during the execution of the element location strategy, return error invalid selector.
     root_node
@@ -146,6 +147,7 @@ fn first_matching_link(
     link_text: String,
     partial: bool,
 ) -> Result<Option<String>, ErrorStatus> {
+    /// <https://w3c.github.io/webdriver/#dfn-find>
     // Step 7.2. If a DOMException, SyntaxError, XPathException, or other error occurs
     // during the execution of the element location strategy, return error invalid selector.
     root_node
@@ -594,6 +596,8 @@ fn retrieve_document_and_check_root_existence(
     let document = documents
         .find_document(pipeline)
         .expect("script:webdriver_handlers::Document should exists because we checked");
+    /// <https://w3c.github.io/webdriver/#find-element>
+    /// <https://w3c.github.io/webdriver/#find-elements>
     // Step 7 - 8. If current browsing context's document element is null,
     // return error with error code no such element.
     if document.GetDocumentElement().is_none() {

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -133,7 +133,7 @@ fn all_matching_links(
     link_text: String,
     partial: bool,
 ) -> Result<Vec<String>, ErrorStatus> {
-    /// <https://w3c.github.io/webdriver/#dfn-find>
+    // <https://w3c.github.io/webdriver/#dfn-find>
     // Step 7.2. If a DOMException, SyntaxError, XPathException, or other error occurs
     // during the execution of the element location strategy, return error invalid selector.
     root_node
@@ -147,7 +147,7 @@ fn first_matching_link(
     link_text: String,
     partial: bool,
 ) -> Result<Option<String>, ErrorStatus> {
-    /// <https://w3c.github.io/webdriver/#dfn-find>
+    // <https://w3c.github.io/webdriver/#dfn-find>
     // Step 7.2. If a DOMException, SyntaxError, XPathException, or other error occurs
     // during the execution of the element location strategy, return error invalid selector.
     root_node
@@ -596,8 +596,8 @@ fn retrieve_document_and_check_root_existence(
     let document = documents
         .find_document(pipeline)
         .expect("script:webdriver_handlers::Document should exists because we checked");
-    /// <https://w3c.github.io/webdriver/#find-element>
-    /// <https://w3c.github.io/webdriver/#find-elements>
+    // <https://w3c.github.io/webdriver/#find-element>
+    // <https://w3c.github.io/webdriver/#find-elements>
     // Step 7 - 8. If current browsing context's document element is null,
     // return error with error code no such element.
     if document.GetDocumentElement().is_none() {

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -601,7 +601,8 @@ fn retrieve_document_and_check_root_existence(
 ) -> Result<DomRoot<Document>, ErrorStatus> {
     let document = documents
         .find_document(pipeline)
-        .expect("script:webdriver_handlers::Document should exists because we checked");
+        .ok_or(ErrorStatus::NoSuchWindow)?;
+
     // <https://w3c.github.io/webdriver/#find-element>
     // <https://w3c.github.io/webdriver/#find-elements>
     // Step 7 - 8. If current browsing context's document element is null,

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -103,6 +103,7 @@ pub(crate) fn find_node_by_unique_id_in_document(
     }
 }
 
+/// <https://w3c.github.io/webdriver/#dfn-link-text-selector>
 fn matching_links(
     links: &NodeList,
     link_text: String,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1167,8 +1167,7 @@ impl Handler {
 
         match wait_for_script_response(receiver)? {
             Ok(value) => {
-                let resp_value: Vec<WebElement> =
-                    value.into_iter().map(|x| WebElement(x)).collect();
+                let resp_value: Vec<WebElement> = value.into_iter().map(WebElement).collect();
                 Ok(WebDriverResponse::Generic(ValueResponse(
                     serde_json::to_value(resp_value)?,
                 )))

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -929,10 +929,15 @@ impl Handler {
         )))
     }
 
+    /// <https://w3c.github.io/webdriver/#find-element>
     fn handle_find_element(
         &self,
         parameters: &LocatorParameters,
     ) -> WebDriverResult<WebDriverResponse> {
+        // Step 4. If selector is undefined, return error with error code invalid argument.
+        if parameters.value.is_empty() {
+            return Err(WebDriverError::new(ErrorStatus::InvalidArgument, ""));
+        }
         let (sender, receiver) = ipc::channel().unwrap();
 
         match parameters.using {
@@ -961,12 +966,15 @@ impl Handler {
             },
         }
 
+        // Step 10. If result is empty, return error with error code no such element.
+        // Otherwise, return the first element of result.
         match wait_for_script_response(receiver)? {
-            Ok(value) => {
-                let value_resp = serde_json::to_value(
-                    value.map(|x| serde_json::to_value(WebElement(x)).unwrap()),
-                )?;
-                Ok(WebDriverResponse::Generic(ValueResponse(value_resp)))
+            Ok(value) => match value {
+                Some(value) => {
+                    let value_resp = serde_json::to_value(WebElement(value)).unwrap();
+                    Ok(WebDriverResponse::Generic(ValueResponse(value_resp)))
+                },
+                None => Err(WebDriverError::new(ErrorStatus::NoSuchElement, "")),
             },
             Err(error) => Err(WebDriverError::new(error, "")),
         }
@@ -1121,13 +1129,16 @@ impl Handler {
         }
     }
 
-    // https://w3c.github.io/webdriver/#find-elements
+    /// <https://w3c.github.io/webdriver/#find-elements>
     fn handle_find_elements(
         &self,
         parameters: &LocatorParameters,
     ) -> WebDriverResult<WebDriverResponse> {
+        // Step 4. If selector is undefined, return error with error code invalid argument.
+        if parameters.value.is_empty() {
+            return Err(WebDriverError::new(ErrorStatus::InvalidArgument, ""));
+        }
         let (sender, receiver) = ipc::channel().unwrap();
-
         match parameters.using {
             LocatorStrategy::CSSSelector => {
                 let cmd = WebDriverScriptCommand::FindElementsCSS(parameters.value.clone(), sender);
@@ -1156,10 +1167,8 @@ impl Handler {
 
         match wait_for_script_response(receiver)? {
             Ok(value) => {
-                let resp_value: Vec<Value> = value
-                    .into_iter()
-                    .map(|x| serde_json::to_value(WebElement(x)).unwrap())
-                    .collect();
+                let resp_value: Vec<WebElement> =
+                    value.into_iter().map(|x| WebElement(x)).collect();
                 Ok(WebDriverResponse::Generic(ValueResponse(
                     serde_json::to_value(resp_value)?,
                 )))

--- a/tests/wpt/meta/webdriver/tests/classic/find_element/find.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/find_element/find.py.ini
@@ -2,15 +2,6 @@
   [test_no_browsing_context]
     expected: FAIL
 
-  [test_no_such_element_with_unknown_selector[not-existent\]]
-    expected: FAIL
-
-  [test_no_such_element_with_unknown_selector[existent-other-frame\]]
-    expected: FAIL
-
-  [test_no_such_element_with_unknown_selector[existent-inside-shadow-root\]]
-    expected: FAIL
-
   [test_find_element[xpath-//a\]]
     expected: FAIL
 
@@ -18,4 +9,16 @@
     expected: FAIL
 
   [test_htmldocument[xpath-/html\]]
+    expected: FAIL
+
+  [test_find_element_link_text[<a href=#>link<br>text</a>-link\\ntext\]]
+    expected: FAIL
+
+  [test_find_element_link_text[<a href=# style='text-transform: uppercase'>link text</a>-LINK TEXT\]]
+    expected: FAIL
+
+  [test_find_element_partial_link_text[<a href=#>partial link<br>text</a>-k\\nt\]]
+    expected: FAIL
+
+  [test_find_element_partial_link_text[<a href=# style='text-transform: uppercase'>partial link text</a>-LINK\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/find_element/find.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/find_element/find.py.ini
@@ -10,15 +10,3 @@
 
   [test_htmldocument[xpath-/html\]]
     expected: FAIL
-
-  [test_find_element_link_text[<a href=#>link<br>text</a>-link\\ntext\]]
-    expected: FAIL
-
-  [test_find_element_link_text[<a href=# style='text-transform: uppercase'>link text</a>-LINK TEXT\]]
-    expected: FAIL
-
-  [test_find_element_partial_link_text[<a href=#>partial link<br>text</a>-k\\nt\]]
-    expected: FAIL
-
-  [test_find_element_partial_link_text[<a href=# style='text-transform: uppercase'>partial link text</a>-LINK\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/find_elements/find.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/find_elements/find.py.ini
@@ -5,18 +5,6 @@
   [test_find_elements[xpath-//a\]]
     expected: FAIL
 
-  [test_find_elements_link_text[<a href=#>link<br>text</a>-link\\ntext\]]
-    expected: FAIL
-
-  [test_find_elements_link_text[<a href=# style='text-transform: uppercase'>link text</a>-LINK TEXT\]]
-    expected: FAIL
-
-  [test_find_elements_partial_link_text[<a href=#>partial link<br>text</a>-k\\nt\]]
-    expected: FAIL
-
-  [test_find_elements_partial_link_text[<a href=# style='text-transform: uppercase'>partial link text</a>-LINK\]]
-    expected: FAIL
-
   [test_xhtml_namespace[xpath-//*[name()='a'\]\]]
     expected: FAIL
 


### PR DESCRIPTION
1. Properly report new types of errors for `find_element` and `find_elements`. Previously never reported.
1.1. `InvalidSelector`
1.2. `NoSuchElement`
1.3. `InvalidArgument`

2. Get the visible text for `<a>` correctly in `script::webdriver_handler` so that matching would work.

Testing: `./mach test-wpt -r --log-raw "D:\servo test log\all.txt" webdriver/tests/classic/find_element/find.py webdriver/tests/classic/find_elements/find.py --product servodriver`