### PR TITLE
Don't count <img> elements with both name and id twice in document's named getter

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6129,17 +6129,17 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         self.set_body_attribute(&local_name!("text"), value, can_gc)
     }
 
-    #[allow(unsafe_code)]
     /// <https://html.spec.whatwg.org/multipage/#dom-tree-accessors:dom-document-nameditem-filter>
-    fn NamedGetter(&self, name: DOMString) -> Option<NamedPropertyValue> {
+    fn NamedGetter(&self, name: DOMString, can_gc: CanGc) -> Option<NamedPropertyValue> {
         if name.is_empty() {
             return None;
         }
         let name = Atom::from(name);
 
-        // Step 1.
+        // Step 1. Let elements be the list of named elements with the name name that are in a document tree
+        // with the Document as their root.
         let elements_with_name = self.get_elements_with_name(&name);
-        let name_iter = elements_with_name
+        let mut name_iter = elements_with_name
             .iter()
             .filter(|elem| is_named_element_with_name_attribute(elem));
         let elements_with_id = self.get_elements_with_id(&name);
@@ -6148,10 +6148,15 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             .filter(|elem| is_named_element_with_id_attribute(elem));
         let mut elements = name_iter.chain(id_iter);
 
-        let first = elements.next()?;
 
-        if elements.next().is_none() {
-            // Step 2.
+        // Step 2. If elements has only one element, and that element is an iframe element,
+        // and that iframe element's content navigable is not null, then return the active
+        // WindowProxy of the element's content navigable.
+
+        // NOTE: We have to check if the second element (if present) is different from the first,
+        // since the same elements may appear in both lists
+        let first = elements.next()?;
+        if elements.next().is_none_or(|second| first == second) {
             if let Some(nested_window_proxy) = first
                 .downcast::<HTMLIFrameElement>()
                 .and_then(|iframe| iframe.GetContentWindow())
@@ -6159,11 +6164,12 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 return Some(NamedPropertyValue::WindowProxy(nested_window_proxy));
             }
 
-            // Step 3.
+            // Step 3. Otherwise, if elements has only one element, return that element.
             return Some(NamedPropertyValue::Element(DomRoot::from_ref(first)));
         }
 
-        // Step 4.
+        // Step 4. Otherwise, return an HTMLCollection rooted at the Document node,
+        // whose filter matches only named elements with the name name.
         #[derive(JSTraceable, MallocSizeOf)]
         struct DocumentNamedGetter {
             #[no_trace]
@@ -6194,7 +6200,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             self.window(),
             self.upcast(),
             Box::new(DocumentNamedGetter { name }),
-            CanGc::note(),
+            can_gc,
         );
         Some(NamedPropertyValue::HTMLCollection(collection))
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6139,7 +6139,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         // Step 1. Let elements be the list of named elements with the name name that are in a document tree
         // with the Document as their root.
         let elements_with_name = self.get_elements_with_name(&name);
-        let mut name_iter = elements_with_name
+        let name_iter = elements_with_name
             .iter()
             .filter(|elem| is_named_element_with_name_attribute(elem));
         let elements_with_id = self.get_elements_with_id(&name);
@@ -6148,15 +6148,14 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
             .filter(|elem| is_named_element_with_id_attribute(elem));
         let mut elements = name_iter.chain(id_iter);
 
-
         // Step 2. If elements has only one element, and that element is an iframe element,
         // and that iframe element's content navigable is not null, then return the active
         // WindowProxy of the element's content navigable.
 
-        // NOTE: We have to check if the second element (if present) is different from the first,
-        // since the same elements may appear in both lists
+        // NOTE: We have to check if all remaining elements are equal to the first, since
+        // the same element may appear in both lists.
         let first = elements.next()?;
-        if elements.next().is_none_or(|second| first == second) {
+        if elements.all(|other| first == other) {
             if let Some(nested_window_proxy) = first
                 .downcast::<HTMLIFrameElement>()
                 .and_then(|iframe| iframe.GetContentWindow())

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -122,7 +122,7 @@ impl XMLDocumentMethods<crate::DomTypeHolder> for XMLDocument {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-tree-accessors:dom-document-nameditem-filter
-    fn NamedGetter(&self, name: DOMString) -> Option<NamedPropertyValue> {
-        self.upcast::<Document>().NamedGetter(name)
+    fn NamedGetter(&self, name: DOMString, can_gc: CanGc) -> Option<NamedPropertyValue> {
+        self.upcast::<Document>().NamedGetter(name, can_gc)
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -167,7 +167,7 @@ DOMInterfaces = {
 
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
-    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'GetScrollingElement', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection'],
+    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'GetScrollingElement', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter'],
 },
 
 'DissimilarOriginWindow': {
@@ -669,6 +669,10 @@ DOMInterfaces = {
 'Worklet': {
     'inRealms': ['AddModule'],
     'canGc': ['AddModule'],
+},
+
+'XMLDocument': {
+    'canGc': ['NamedGetter'],
 },
 
 'XMLHttpRequest': {

--- a/tests/wpt/meta/html/dom/documents/dom-tree-accessors/nameditem-01.html.ini
+++ b/tests/wpt/meta/html/dom/documents/dom-tree-accessors/nameditem-01.html.ini
@@ -1,9 +1,0 @@
-[nameditem-01.html]
-  [img elements that have a name and id attribute with same value.]
-    expected: FAIL
-
-  [Dynamically updating the name attribute from img elements, should be accessible by values.]
-    expected: FAIL
-
-  [Dynamically updating the id attribute from img elements, should be accessible by values.]
-    expected: FAIL


### PR DESCRIPTION
A document's named getter collects elements with either matching name or id's (varies per element type) and returns them .

We implement this the following way:
* Create an iterator with elements whose `name` attribute matches
* Create an iterator with elements whose `id` attribute matches
* Concatenate both

The spec then asks us if there is more than one element in the list, which we implement by checking whether the iterator returns `None` after we get the first element. However, the same element can appear in both iterators if it is a `img` element and both it's name and id attribute match. Therefore, we need to check if there are more elements *which are not equal to the first one*.

Testing: New web platform tests pass

