### PR TITLE
DevTools: sources for HTML files should be the whole HTML file

### DIFF
--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -146,11 +146,12 @@ impl Actor for SourceActor {
                 let reply = SourceContentReply {
                     from: self.name(),
                     content_type: self.content_type.clone(),
-                    // TODO: is this correct? Do we instead want to defer response until content is available?
+                    // TODO: do we want to wait instead of giving up immediately, in cases where the content could
+                    // become available later (e.g. after a fetch)?
                     source: self
                         .content
                         .as_deref()
-                        .unwrap_or("<!-- not available -->")
+                        .unwrap_or("<!-- not available; please reload! -->")
                         .to_owned(),
                 };
                 let _ = stream.write_json_packet(&reply);

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -51,7 +51,7 @@ pub struct SourceActor {
     /// <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#black-boxing-sources>
     pub is_black_boxed: bool,
 
-    pub content: String,
+    pub content: Option<String>,
     pub content_type: String,
 }
 
@@ -86,7 +86,12 @@ impl SourceManager {
 }
 
 impl SourceActor {
-    pub fn new(name: String, url: ServoUrl, content: String, content_type: String) -> SourceActor {
+    pub fn new(
+        name: String,
+        url: ServoUrl,
+        content: Option<String>,
+        content_type: String,
+    ) -> SourceActor {
         SourceActor {
             name,
             url,
@@ -99,7 +104,7 @@ impl SourceActor {
     pub fn new_registered(
         actors: &mut ActorRegistry,
         url: ServoUrl,
-        content: String,
+        content: Option<String>,
         content_type: String,
     ) -> &SourceActor {
         let source_actor_name = actors.new_name("source");
@@ -138,7 +143,12 @@ impl Actor for SourceActor {
                 let reply = SourceContentReply {
                     from: self.name(),
                     content_type: self.content_type.clone(),
-                    source: self.content.clone(),
+                    // TODO: is this correct? Do we instead want to defer response until content is available?
+                    source: self
+                        .content
+                        .as_deref()
+                        .unwrap_or("<!-- not available -->")
+                        .to_owned(),
                 };
                 let _ = stream.write_json_packet(&reply);
                 ActorMessageStatus::Processed

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 use std::collections::BTreeSet;
 use std::net::TcpStream;
 
+use base::id::PipelineId;
 use serde::Serialize;
 use serde_json::{Map, Value};
 use servo_url::ServoUrl;
@@ -103,6 +104,7 @@ impl SourceActor {
 
     pub fn new_registered(
         actors: &mut ActorRegistry,
+        pipeline_id: PipelineId,
         url: ServoUrl,
         content: Option<String>,
         content_type: String,
@@ -111,6 +113,7 @@ impl SourceActor {
 
         let source_actor = SourceActor::new(source_actor_name.clone(), url, content, content_type);
         actors.register(Box::new(source_actor));
+        actors.register_source_actor(pipeline_id, &source_actor_name);
 
         actors.find(&source_actor_name)
     }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -28,7 +28,7 @@ use devtools_traits::{
 };
 use embedder_traits::{AllowOrDeny, EmbedderMsg, EmbedderProxy};
 use ipc_channel::ipc::{self, IpcSender};
-use log::{trace, warn};
+use log::trace;
 use resource::ResourceAvailable;
 use serde::Serialize;
 use servo_rand::RngCore;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -521,7 +521,7 @@ impl DevtoolsInstance {
         let source_actor = SourceActor::new_registered(
             &mut actors,
             source_info.url,
-            source_info.content.clone(),
+            source_info.content,
             source_info.content_type.unwrap(),
         );
         let source_actor_name = source_actor.name.clone();

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -519,7 +519,6 @@ impl DevtoolsInstance {
     }
 
     fn handle_create_source_actor(&mut self, pipeline_id: PipelineId, source_info: SourceInfo) {
-        warn!("CreateSourceActor pipeline_id={pipeline_id} source_info={source_info:?}");
         let mut actors = self.actors.lock().unwrap();
 
         let source_actor = SourceActor::new_registered(
@@ -574,7 +573,6 @@ impl DevtoolsInstance {
     }
 
     fn handle_update_source_content(&mut self, pipeline_id: PipelineId, source_content: String) {
-        warn!("UpdateSourceContent pipeline_id={pipeline_id} source_content={source_content:?}");
         let mut actors = self.actors.lock().unwrap();
 
         for actor_name in actors.source_actor_names_for_pipeline(pipeline_id) {

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -491,7 +491,7 @@ impl DedicatedWorkerGlobalScope {
                         content: Some(source.to_string()),
                         content_type: metadata.content_type.map(|c_type| c_type.0.to_string()),
                     };
-                    let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
+                    let _ = chan.send(ScriptToDevtoolsControlMsg::CreateSourceActor(
                         pipeline_id,
                         source_info,
                     ));

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -488,7 +488,7 @@ impl DedicatedWorkerGlobalScope {
                         url: metadata.final_url,
                         external: true, // Worker scripts are always external.
                         worker_id: Some(global.upcast::<WorkerGlobalScope>().get_worker_id()),
-                        content: source.to_string(),
+                        content: Some(source.to_string()),
                         content_type: metadata.content_type.map(|c_type| c_type.0.to_string()),
                     };
                     let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1109,7 +1109,7 @@ impl HTMLScriptElement {
                 content,
                 content_type: Some(content_type.to_string()),
             };
-            let _ = chan.send(ScriptToDevtoolsControlMsg::ScriptSourceLoaded(
+            let _ = chan.send(ScriptToDevtoolsControlMsg::CreateSourceActor(
                 pipeline_id,
                 source_info,
             ));

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1091,32 +1091,15 @@ impl HTMLScriptElement {
                 };
 
                 // content_type: https://html.spec.whatwg.org/multipage/#scriptingLanguages
-                (script.url.clone(), content, "text/javascript", true)
+                (script.url.clone(), Some(content), "text/javascript", true)
             } else {
-                // TODO: make the request the same way as in the original request.
-                // TODO: make the request in devtools, only when needed by a devtools client.
-                let request = RequestBuilder::new(
-                    Some(doc.webview_id()),
-                    doc.url(),
-                    self.global().get_referrer(),
-                );
-                let (metadata, content) = load_whole_resource(
-                    request,
-                    &self.global().resource_threads().sender(),
-                    &self.global(),
-                    can_gc,
-                )
-                .expect("FIXME: devtools page request failed");
-
-                // TODO: handle encodings the same way as in HTML, taking <meta charset> into account.
-                let encoding = metadata
-                    .charset
-                    .and_then(|encoding| Encoding::for_label(encoding.as_bytes()))
-                    .expect("FIXME: no character encoding");
-                let (content, _, _) = encoding.decode(&content);
+                // TODO: if needed, fetch the page again, in the same way as in the original request.
+                // Fetch it from cache, even if the original request was non-idempotent (e.g. POST).
+                // If we can’t fetch it from cache, we should probably give up, because with a real
+                // fetch, the server could return a different response.
 
                 // TODO: handle cases where Content-Type is not text/html.
-                (doc.url(), content.into_owned(), "text/html", false)
+                (doc.url(), None, "text/html", false)
             };
 
             let source_info = SourceInfo {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -701,13 +701,15 @@ impl ServoParser {
 
         // Send the source contents to devtools, if needed.
         if let Some(chan) = self.document.global().devtools_chan() {
-            // FIXME: this seems to run for innerHTML assignments too
-            let content_for_devtools = self.content_for_devtools.take();
-            let pipeline_id = self.document.global().pipeline_id();
-            let _ = chan.send(ScriptToDevtoolsControlMsg::UpdateSourceContent(
-                pipeline_id,
-                content_for_devtools,
-            ));
+            // Only send the HTML for page load parsing, not things like innerHTML
+            if self.document.has_browsing_context() {
+                let content_for_devtools = self.content_for_devtools.take();
+                let pipeline_id = self.document.global().pipeline_id();
+                let _ = chan.send(ScriptToDevtoolsControlMsg::UpdateSourceContent(
+                    pipeline_id,
+                    content_for_devtools,
+                ));
+            }
         }
     }
 }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -105,7 +105,9 @@ pub enum ScriptToDevtoolsControlMsg {
     TitleChanged(PipelineId, String),
 
     /// Get source information from script
-    ScriptSourceLoaded(PipelineId, SourceInfo),
+    CreateSourceActor(PipelineId, SourceInfo),
+
+    UpdateSourceContent(PipelineId, String),
 }
 
 /// Serialized JS return values

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -563,6 +563,6 @@ pub struct SourceInfo {
     pub url: ServoUrl,
     pub external: bool,
     pub worker_id: Option<WorkerId>,
-    pub content: String,
+    pub content: Option<String>,
     pub content_type: Option<String>,
 }

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -96,9 +96,9 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         self.assert_sources_list(1, set([tuple(["data:text/html,<script type=module>;</script>"])]))
 
     def test_source_content_inline_script(self):
-        script_content = "console.log('Hello, world!');"
-        self.run_servoshell(url=f"data:text/html,<script>{script_content}</script>")
-        self.assert_source_content("data:text/html,<script>console.log('Hello, world!');</script>", script_content)
+        script_tag = "<script>console.log('Hello, world!')</script>"
+        self.run_servoshell(url=f"data:text/html,{script_tag}")
+        self.assert_source_content(f"data:text/html,{script_tag}", script_tag)
 
     def test_source_content_external_script(self):
         self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -106,6 +106,12 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         expected_content = 'console.log("external classic");\n'
         self.assert_source_content(f"{self.base_url}/classic.js", expected_content)
 
+    def test_source_content_html_file(self):
+        self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))
+        self.run_servoshell()
+        expected_content = '<!doctype html><meta charset=utf-8>\n<script src="classic.js"></script>\n<script>\n    console.log("inline classic");\n    new Worker("worker.js");\n</script>\n<script type="module">\n    import module from "./module.js";\n    console.log("inline module");\n</script>\n<script src="https://servo.org/js/load-table.js"></script>\n'
+        self.assert_source_content(f"{self.base_url}/test.html", expected_content)
+
     # Sets `base_url` and `web_server` and `web_server_thread`.
     def start_web_server(self, *, test_dir=None):
         if test_dir is None:

--- a/python/servo/devtools_tests/sources_content_with_responsexml/empty.html
+++ b/python/servo/devtools_tests/sources_content_with_responsexml/empty.html
@@ -1,0 +1,1 @@
+<!doctype html><meta charset=utf-8>

--- a/python/servo/devtools_tests/sources_content_with_responsexml/test.html
+++ b/python/servo/devtools_tests/sources_content_with_responsexml/test.html
@@ -1,0 +1,11 @@
+<!doctype html><meta charset=utf-8>
+<script>
+    const req = new XMLHttpRequest;
+    req.responseType = "document";
+    req.open("GET", "empty.html");
+    req.send(null);
+    req.onreadystatechange = () => {
+        if (req.readyState == 4)
+            console.log(req.responseXML);
+    };
+</script>

--- a/python/servo/devtools_tests/sources_content_with_responsexml/test.html
+++ b/python/servo/devtools_tests/sources_content_with_responsexml/test.html
@@ -5,7 +5,7 @@
     req.open("GET", "empty.html");
     req.send(null);
     req.onreadystatechange = () => {
-        if (req.readyState == 4)
+        if (req.readyState == XMLHttpRequest.DONE)
             console.log(req.responseXML);
     };
 </script>


### PR DESCRIPTION
To show the contents of inline scripts in the Sources panel, we need to send the whole HTML file from script to devtools, not just the script code. This is trickier than the external script case, but we can look to [how Firefox does it](https://servo.zulipchat.com/#narrow/channel/263398-general/topic/Getting.20the.20original.20page.20HTML.20from.20script/near/524392861) for some inspiration. The process is as follows:

- when we execute a script
  - notify devtools to create the source actor
  - if it’s an external script, send the script code to the devtools server
  - if it’s an inline script, don’t send any source contents yet
  - devtools stores the contents in the source actor
- while loading a new document
  - buffer the markup, so we can send it to devtools
- when we finish loading a new document
  - send the buffered markup to the devtools server
  - devtools stores the contents in any source actors with no contents yet
- when a source actor gets a `source` request
  - if we have the contents, send those contents to the client
  - if we don’t have the contents (inline script that loaded while devtools was closed)
    - FUTURE: try to fetch the markup out of cache
    - otherwise send `<!-- not available; please reload! -->`

Testing: Several tests added to test the changes, also updates an existing test with correct assertion
Fixes: https://github.com/servo/servo/issues/36874