### PR TITLE
script: Reverse wheel event delta sign to match specification-defined behavior

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2202,9 +2202,13 @@ impl Document {
             EventCancelable::Cancelable,
             Some(&self.window),
             0i32,
-            Finite::wrap(event.delta.x),
-            Finite::wrap(event.delta.y),
-            Finite::wrap(event.delta.z),
+            // winit defines positive wheel delta values as revealing more content left/up.
+            // https://docs.rs/winit-gtk/latest/winit/event/enum.MouseScrollDelta.html
+            // This is the opposite of wheel delta in uievents
+            // https://w3c.github.io/uievents/#dom-wheeleventinit-deltaz
+            Finite::wrap(-event.delta.x),
+            Finite::wrap(-event.delta.y),
+            Finite::wrap(-event.delta.z),
             event.delta.mode as u32,
             can_gc,
         );


### PR DESCRIPTION
Fix wheel event, either dispatched from window or webdriver:
- Positive deltaY means scrolling down, negative deltaY means scrolling up
- Positive deltaX means scrolling right, negative deltaX means scrolling left

Tests: Many scrolling interaction test will depend on this.