### PR TITLE
Fix skipping CSP checks for styles when cloning nodes

### DIFF
--- a/tests/wpt/meta/content-security-policy/style-src/inline-style-allowed-while-cloning-objects.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/style-src/inline-style-allowed-while-cloning-objects.sub.html.ini
@@ -2,35 +2,8 @@
   [non-HTML namespace]
     expected: FAIL
 
-  [inline-style-allowed-while-cloning-objects 1]
-    expected: FAIL
-
-  [inline-style-allowed-while-cloning-objects 3]
-    expected: FAIL
-
-  [inline-style-allowed-while-cloning-objects 5]
-    expected: FAIL
-
-  [inline-style-allowed-while-cloning-objects 7]
-    expected: FAIL
-
-  [inline-style-allowed-while-cloning-objects 8]
-    expected: FAIL
-
-  [inline-style-allowed-while-cloning-objects 9]
-    expected: FAIL
-
-  [inline-style-allowed-while-cloning-objects 10]
-    expected: FAIL
-
-  [inline-style-allowed-while-cloning-objects 11]
-    expected: FAIL
-
-  [inline-style-allowed-while-cloning-objects 17]
-    expected: FAIL
-
-  [inline-style-allowed-while-cloning-objects 18]
-    expected: FAIL
-
   [inline-style-allowed-while-cloning-objects 19]
+    expected: FAIL
+
+  [inline-style-allowed-while-cloning-objects 20]
     expected: FAIL

--- a/tests/wpt/tests/content-security-policy/style-src/inline-style-allowed-while-cloning-objects.sub.html
+++ b/tests/wpt/tests/content-security-policy/style-src/inline-style-allowed-while-cloning-objects.sub.html
@@ -81,6 +81,9 @@
               assert_equals(clonedOps.style.background, "")
           });
           test(function() {
+              assert_equals(clonedOps.style.color, "red")
+          });
+          test(function() {
               assert_equals(violetOps.style.background.match(/rgb\(238, 130, 238\)/)[0], "rgb(238, 130, 238)")
           });
           test(function() {


### PR DESCRIPTION
Cloned nodes were re-parsing already-parsed style attributes. As such, they were also checking CSP, which shouldn't happen as the original node already was checked for it.

Testing: The existing WPT test now mostly passes. It had two cases which were passing in no browsers.
Fixes: Part of #4577
