### PR TITLE
script: Make webdriver's Get Element Text operation return visible text

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2461,7 +2461,7 @@ impl ScriptThread {
                 )
             },
             WebDriverScriptCommand::GetElementText(node_id, reply) => {
-                webdriver_handlers::handle_get_text(&documents, pipeline_id, node_id, reply)
+                webdriver_handlers::handle_get_text(&documents, pipeline_id, node_id, reply, can_gc)
             },
             WebDriverScriptCommand::GetElementInViewCenterPoint(node_id, reply) => {
                 webdriver_handlers::handle_get_element_in_view_center_point(

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1318,6 +1318,7 @@ impl Handler {
         }
     }
 
+    /// <https://w3c.github.io/webdriver/#dfn-get-element-text>
     fn handle_element_text(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetElementText(element.to_string(), sender);


### PR DESCRIPTION
Fix `WebDriverScriptCommand::GetElementText` similar to https://github.com/servo/servo/pull/37452#discussion_r2146350739, by correctly retrieving rendered text.

Testing: `./mach test-wpt -r --log-raw "D:\servo test log\gt_ele_txt.txt" webdriver/tests/classic/get_element_text --product servodriver`
