### PR TITLE
Stop DedicatedWorker from handling remaining messages after closed

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -618,6 +618,9 @@ impl DedicatedWorkerGlobalScope {
     }
 
     fn handle_mixed_message(&self, msg: MixedMessage, can_gc: CanGc) -> bool {
+        if self.upcast::<WorkerGlobalScope>().is_closing() {
+            return false;
+        }
         // FIXME(#26324): `self.worker` is None in devtools messages.
         match msg {
             MixedMessage::Devtools(msg) => match msg {

--- a/tests/wpt/meta/workers/WorkerGlobalScope-close.html.ini
+++ b/tests/wpt/meta/workers/WorkerGlobalScope-close.html.ini
@@ -1,3 +1,0 @@
-[WorkerGlobalScope-close.html]
-  [Test sending a message after closing.]
-    expected: FAIL


### PR DESCRIPTION
Stop DedicatedWorker from handling remaining messages after closed

Testing: WPT workers/WorkerGlobalScope-close.html

