### PR TITLE
Use DOMString for internal data of Trusted Types

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3783,7 +3783,9 @@ impl Document {
                 containing_class,
                 field,
                 can_gc,
-            )?;
+            )?
+            .as_ref()
+            .to_owned();
         }
         // Step 5: If lineFeed is true, append U+000A LINE FEED to string.
         if line_feed {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3272,13 +3272,13 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 1. Let compliantHTML be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, html, "Element setHTMLUnsafe", and "script".
-        let html = DOMString::from(TrustedHTML::get_trusted_script_compliant_string(
+        let html = TrustedHTML::get_trusted_script_compliant_string(
             &self.owner_global(),
             html,
             "Element",
             "setHTMLUnsafe",
             can_gc,
-        )?);
+        )?;
         // Step 2. Let target be this's template contents if this is a template element; otherwise this.
         let target = if let Some(template) = self.downcast::<HTMLTemplateElement>() {
             DomRoot::upcast(template.Content(can_gc))
@@ -3329,13 +3329,13 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 1: Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, the given value, "Element innerHTML", and "script".
-        let value = DOMString::from(TrustedHTML::get_trusted_script_compliant_string(
+        let value = TrustedHTML::get_trusted_script_compliant_string(
             &self.owner_global(),
             value.convert(),
             "Element",
             "innerHTML",
             can_gc,
-        )?);
+        )?;
         // https://github.com/w3c/DOM-Parsing/issues/1
         let target = if let Some(template) = self.downcast::<HTMLTemplateElement>() {
             // Step 4: If context is a template element, then set context to
@@ -3387,13 +3387,13 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 1: Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, the given value, "Element outerHTML", and "script".
-        let value = DOMString::from(TrustedHTML::get_trusted_script_compliant_string(
+        let value = TrustedHTML::get_trusted_script_compliant_string(
             &self.owner_global(),
             value.convert(),
             "Element",
             "outerHTML",
             can_gc,
-        )?);
+        )?;
         let context_document = self.owner_document();
         let context_node = self.upcast::<Node>();
         // Step 2: Let parent be this's parent.
@@ -3603,13 +3603,13 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         // Step 1: Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, string, "Element insertAdjacentHTML", and "script".
-        let text = DOMString::from(TrustedHTML::get_trusted_script_compliant_string(
+        let text = TrustedHTML::get_trusted_script_compliant_string(
             &self.owner_global(),
             text,
             "Element",
             "insertAdjacentHTML",
             can_gc,
-        )?);
+        )?;
         let position = position.parse::<AdjacentPosition>()?;
 
         // Step 2: Let context be null.

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -622,7 +622,11 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
             can_gc,
         )?;
         // Step 2: Set an attribute value given this, srcdoc's local name, and compliantString.
-        element.set_attribute(local_name, AttrValue::String(value), can_gc);
+        element.set_attribute(
+            local_name,
+            AttrValue::String(value.as_ref().to_owned()),
+            can_gc,
+        );
         Ok(())
     }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -672,8 +672,7 @@ impl HTMLScriptElement {
                 "HTMLScriptElement",
                 "text",
                 can_gc,
-            )?
-            .into();
+            )?;
         }
 
         Ok(())
@@ -1436,7 +1435,11 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
             local_name,
             can_gc,
         )?;
-        element.set_attribute(local_name, AttrValue::String(value), can_gc);
+        element.set_attribute(
+            local_name,
+            AttrValue::String(value.as_ref().to_owned()),
+            can_gc,
+        );
         Ok(())
     }
 
@@ -1524,7 +1527,6 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
             "innerText",
             can_gc,
         )?;
-        let value = DOMString::from(value);
         *self.script_text.borrow_mut() = value.clone();
         // Step 3: Run set the inner text steps with this and value.
         self.upcast::<HTMLElement>().set_inner_text(value, can_gc);
@@ -1548,7 +1550,6 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
             can_gc,
         )?;
         // Step 2: Set this's script text value to the given value.
-        let value = DOMString::from(value);
         *self.script_text.borrow_mut() = value.clone();
         // Step 3: String replace all with the given value within this.
         Node::string_replace_all(value, self.upcast::<Node>(), can_gc);
@@ -1575,7 +1576,6 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
             can_gc,
         )?;
         // Step 2: Set this's script text value to value.
-        let value = DOMString::from(value);
         *self.script_text.borrow_mut() = value.clone();
         // Step 3: Run set text content with this and value.
         self.upcast::<Node>().SetTextContent(Some(value), can_gc);

--- a/components/script/dom/trustedhtml.rs
+++ b/components/script/dom/trustedhtml.rs
@@ -24,11 +24,11 @@ use crate::script_runtime::CanGc;
 pub struct TrustedHTML {
     reflector_: Reflector,
 
-    data: String,
+    data: DOMString,
 }
 
 impl TrustedHTML {
-    fn new_inherited(data: String) -> Self {
+    fn new_inherited(data: DOMString) -> Self {
         Self {
             reflector_: Reflector::new(),
             data,
@@ -36,7 +36,7 @@ impl TrustedHTML {
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn new(data: String, global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
+    pub(crate) fn new(data: DOMString, global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
         reflect_dom_object(Box::new(Self::new_inherited(data)), global, can_gc)
     }
 
@@ -46,21 +46,21 @@ impl TrustedHTML {
         containing_class: &str,
         field: &str,
         can_gc: CanGc,
-    ) -> Fallible<String> {
+    ) -> Fallible<DOMString> {
         match value {
             TrustedHTMLOrString::String(value) => {
                 let sink = format!("{} {}", containing_class, field);
                 TrustedTypePolicyFactory::get_trusted_type_compliant_string(
                     TrustedType::TrustedHTML,
                     global,
-                    value.as_ref().to_owned(),
+                    value,
                     &sink,
                     "'script'",
                     can_gc,
                 )
             },
 
-            TrustedHTMLOrString::TrustedHTML(trusted_html) => Ok(trusted_html.to_string()),
+            TrustedHTMLOrString::TrustedHTML(trusted_html) => Ok(trusted_html.data.clone()),
         }
     }
 }
@@ -75,12 +75,12 @@ impl fmt::Display for TrustedHTML {
 impl TrustedHTMLMethods<crate::DomTypeHolder> for TrustedHTML {
     /// <https://www.w3.org/TR/trusted-types/#trustedhtml-stringification-behavior>
     fn Stringifier(&self) -> DOMString {
-        DOMString::from(&*self.data)
+        self.data.clone()
     }
 
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedhtml-tojson>
     fn ToJSON(&self) -> DOMString {
-        DOMString::from(&*self.data)
+        self.data.clone()
     }
 }
 

--- a/components/script/dom/trustedscript.rs
+++ b/components/script/dom/trustedscript.rs
@@ -20,11 +20,11 @@ use crate::script_runtime::CanGc;
 pub struct TrustedScript {
     reflector_: Reflector,
 
-    data: String,
+    data: DOMString,
 }
 
 impl TrustedScript {
-    fn new_inherited(data: String) -> Self {
+    fn new_inherited(data: DOMString) -> Self {
         Self {
             reflector_: Reflector::new(),
             data,
@@ -32,7 +32,7 @@ impl TrustedScript {
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn new(data: String, global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
+    pub(crate) fn new(data: DOMString, global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
         reflect_dom_object(Box::new(Self::new_inherited(data)), global, can_gc)
     }
 
@@ -42,21 +42,21 @@ impl TrustedScript {
         containing_class: &str,
         field: &str,
         can_gc: CanGc,
-    ) -> Fallible<String> {
+    ) -> Fallible<DOMString> {
         match value {
             TrustedScriptOrString::String(value) => {
                 let sink = format!("{} {}", containing_class, field);
                 TrustedTypePolicyFactory::get_trusted_type_compliant_string(
                     TrustedType::TrustedScript,
                     global,
-                    value.as_ref().to_owned(),
+                    value,
                     &sink,
                     "'script'",
                     can_gc,
                 )
             },
 
-            TrustedScriptOrString::TrustedScript(trusted_script) => Ok(trusted_script.to_string()),
+            TrustedScriptOrString::TrustedScript(trusted_script) => Ok(trusted_script.data.clone()),
         }
     }
 }
@@ -71,11 +71,11 @@ impl fmt::Display for TrustedScript {
 impl TrustedScriptMethods<crate::DomTypeHolder> for TrustedScript {
     /// <https://www.w3.org/TR/trusted-types/#trustedscript-stringification-behavior>
     fn Stringifier(&self) -> DOMString {
-        DOMString::from(&*self.data)
+        self.data.clone()
     }
 
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedscript-tojson>
     fn ToJSON(&self) -> DOMString {
-        DOMString::from(&*self.data)
+        self.data.clone()
     }
 }

--- a/components/script/dom/trustedscripturl.rs
+++ b/components/script/dom/trustedscripturl.rs
@@ -21,11 +21,11 @@ use crate::script_runtime::CanGc;
 pub struct TrustedScriptURL {
     reflector_: Reflector,
 
-    data: String,
+    data: DOMString,
 }
 
 impl TrustedScriptURL {
-    fn new_inherited(data: String) -> Self {
+    fn new_inherited(data: DOMString) -> Self {
         Self {
             reflector_: Reflector::new(),
             data,
@@ -33,7 +33,7 @@ impl TrustedScriptURL {
     }
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
-    pub(crate) fn new(data: String, global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
+    pub(crate) fn new(data: DOMString, global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
         reflect_dom_object(Box::new(Self::new_inherited(data)), global, can_gc)
     }
 
@@ -43,21 +43,21 @@ impl TrustedScriptURL {
         containing_class: &str,
         field: &str,
         can_gc: CanGc,
-    ) -> Fallible<String> {
+    ) -> Fallible<DOMString> {
         match value {
             TrustedScriptURLOrUSVString::USVString(value) => {
                 let sink = format!("{} {}", containing_class, field);
                 TrustedTypePolicyFactory::get_trusted_type_compliant_string(
                     TrustedType::TrustedScriptURL,
                     global,
-                    value.as_ref().to_owned(),
+                    value.as_ref().into(),
                     &sink,
                     "'script'",
                     can_gc,
                 )
             },
             TrustedScriptURLOrUSVString::TrustedScriptURL(trusted_script_url) => {
-                Ok(trusted_script_url.to_string())
+                Ok(trusted_script_url.data.clone())
             },
         }
     }
@@ -73,11 +73,11 @@ impl fmt::Display for TrustedScriptURL {
 impl TrustedScriptURLMethods<crate::DomTypeHolder> for TrustedScriptURL {
     /// <https://www.w3.org/TR/trusted-types/#trustedscripturl-stringification-behavior>
     fn Stringifier(&self) -> DOMString {
-        DOMString::from(&*self.data)
+        self.data.clone()
     }
 
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedscripturl-tojson>
     fn ToJSON(&self) -> DOMString {
-        DOMString::from(&*self.data)
+        self.data.clone()
     }
 }

--- a/components/script/dom/trustedtypepolicy.rs
+++ b/components/script/dom/trustedtypepolicy.rs
@@ -68,7 +68,7 @@ impl TrustedTypePolicy {
     }
 
     /// <https://w3c.github.io/trusted-types/dist/spec/#get-trusted-type-policy-value-algorithm>
-    fn check_callback_if_missing(throw_if_missing: bool) -> Fallible<Option<String>> {
+    fn check_callback_if_missing(throw_if_missing: bool) -> Fallible<Option<DOMString>> {
         // Step 3.1: If throwIfMissing throw a TypeError.
         if throw_if_missing {
             Err(Type("Cannot find type".to_owned()))
@@ -87,7 +87,7 @@ impl TrustedTypePolicy {
         arguments: Vec<HandleValue>,
         throw_if_missing: bool,
         can_gc: CanGc,
-    ) -> Fallible<Option<String>> {
+    ) -> Fallible<Option<DOMString>> {
         rooted!(in(*cx) let this_object: *mut JSObject);
         // Step 1: Let functionName be a function name for the given trustedTypeName, based on the following table:
         match expected_type {
@@ -99,15 +99,13 @@ impl TrustedTypePolicy {
                     // Step 4: Let policyValue be the result of invoking function with value as a first argument,
                     // items of arguments as subsequent arguments, and callback **this** value set to null,
                     // rethrowing any exceptions.
-                    callback
-                        .Call_(
-                            &this_object.handle(),
-                            input,
-                            arguments,
-                            ExceptionHandling::Rethrow,
-                            can_gc,
-                        )
-                        .map(|result| result.map(|str| str.as_ref().to_owned()))
+                    callback.Call_(
+                        &this_object.handle(),
+                        input,
+                        arguments,
+                        ExceptionHandling::Rethrow,
+                        can_gc,
+                    )
                 },
             },
             TrustedType::TrustedScript => match &self.create_script {
@@ -118,15 +116,13 @@ impl TrustedTypePolicy {
                     // Step 4: Let policyValue be the result of invoking function with value as a first argument,
                     // items of arguments as subsequent arguments, and callback **this** value set to null,
                     // rethrowing any exceptions.
-                    callback
-                        .Call_(
-                            &this_object.handle(),
-                            input,
-                            arguments,
-                            ExceptionHandling::Rethrow,
-                            can_gc,
-                        )
-                        .map(|result| result.map(|str| str.as_ref().to_owned()))
+                    callback.Call_(
+                        &this_object.handle(),
+                        input,
+                        arguments,
+                        ExceptionHandling::Rethrow,
+                        can_gc,
+                    )
                 },
             },
             TrustedType::TrustedScriptURL => match &self.create_script_url {
@@ -145,7 +141,7 @@ impl TrustedTypePolicy {
                             ExceptionHandling::Rethrow,
                             can_gc,
                         )
-                        .map(|result| result.map(|str| str.as_ref().to_owned()))
+                        .map(|result| result.map(|str| DOMString::from(str.as_ref())))
                 },
             },
         }
@@ -173,7 +169,7 @@ impl TrustedTypePolicy {
     ) -> Fallible<DomRoot<R>>
     where
         R: DomObject,
-        TrustedTypeCallback: FnOnce(String) -> DomRoot<R>,
+        TrustedTypeCallback: FnOnce(DOMString) -> DomRoot<R>,
     {
         // Step 1: Let policyValue be the result of executing Get Trusted Type policy value
         // with the same arguments as this algorithm and additionally true as throwIfMissing.
@@ -187,7 +183,7 @@ impl TrustedTypePolicy {
                 let data_string = match policy_value {
                     Some(value) => value,
                     // Step 4: If policyValue is null or undefined, set dataString to the empty string.
-                    None => "".to_owned(),
+                    None => DOMString::new(),
                 };
                 // Step 5: Return a new instance of an interface with a type name trustedTypeName,
                 // with its associated data value set to dataString.

--- a/components/script/dom/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypepolicyfactory.rs
@@ -144,10 +144,10 @@ impl TrustedTypePolicyFactory {
     pub(crate) fn process_value_with_default_policy(
         expected_type: TrustedType,
         global: &GlobalScope,
-        input: String,
+        input: DOMString,
         sink: &str,
         can_gc: CanGc,
-    ) -> Fallible<Option<String>> {
+    ) -> Fallible<Option<DOMString>> {
         // Step 1: Let defaultPolicy be the value of global’s trusted type policy factory's default policy.
         let global_policy_factory = global.trusted_types(can_gc);
         let default_policy = match global_policy_factory.default_policy.get() {
@@ -172,7 +172,7 @@ impl TrustedTypePolicyFactory {
         let policy_value = default_policy.get_trusted_type_policy_value(
             expected_type,
             cx,
-            DOMString::from(input.to_owned()),
+            input,
             arguments,
             false,
             can_gc,
@@ -194,11 +194,11 @@ impl TrustedTypePolicyFactory {
     pub(crate) fn get_trusted_type_compliant_string(
         expected_type: TrustedType,
         global: &GlobalScope,
-        input: String,
+        input: DOMString,
         sink: &str,
         sink_group: &str,
         can_gc: CanGc,
-    ) -> Fallible<String> {
+    ) -> Fallible<DOMString> {
         let csp_list = match global.get_csp_list() {
             None => return Ok(input),
             Some(csp_list) => csp_list,
@@ -288,11 +288,11 @@ impl TrustedTypePolicyFactoryMethods<crate::DomTypeHolder> for TrustedTypePolicy
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-emptyhtml>
     fn EmptyHTML(&self, can_gc: CanGc) -> DomRoot<TrustedHTML> {
-        TrustedHTML::new("".to_string(), &self.global(), can_gc)
+        TrustedHTML::new(DOMString::new(), &self.global(), can_gc)
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-emptyscript>
     fn EmptyScript(&self, can_gc: CanGc) -> DomRoot<TrustedScript> {
-        TrustedScript::new("".to_string(), &self.global(), can_gc)
+        TrustedScript::new(DOMString::new(), &self.global(), can_gc)
     }
     /// <https://www.w3.org/TR/trusted-types/#dom-trustedtypepolicyfactory-getattributetype>
     fn GetAttributeType(


### PR DESCRIPTION
This avoids various conversions back and forth between DOMString and String. By using DOMString consistently, we avoid these double-conversions. The only caveat are the USVString which are initially passed into
TrustedScriptURL.

Part of #36258
