### PR TITLE
script: Fix check for document root when targeting CSP events

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -120,7 +120,7 @@ use crate::dom::htmlscriptelement::{ScriptId, SourceCode};
 use crate::dom::imagebitmap::ImageBitmap;
 use crate::dom::messageevent::MessageEvent;
 use crate::dom::messageport::MessagePort;
-use crate::dom::node::Node;
+use crate::dom::node::{Node, NodeTraits};
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
 use crate::dom::performance::Performance;
 use crate::dom::performanceobserver::VALID_ENTRY_TYPES;
@@ -3626,11 +3626,10 @@ impl GlobalScope {
                 // Step 3.1: If target is not null, and global is a Window,
                 // and target’s shadow-including root is not global’s associated Document, set target to null.
                 if let Some(window) = self.downcast::<Window>() {
-                    if !window
-                        .Document()
-                        .upcast::<Node>()
-                        .is_shadow_including_inclusive_ancestor_of(event_target.upcast())
-                    {
+                    // If a node is connected, its owner document is always the shadow-including root.
+                    // If it isn't connected, then it also doesn't have a corresponding document, hence
+                    // it can't be this document.
+                    if event_target.upcast::<Node>().owner_document() != window.Document() {
                         return None;
                     }
                 }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2933,7 +2933,11 @@ impl GlobalScope {
         is_js_evaluation_allowed == CheckResult::Allowed
     }
 
-    pub(crate) fn should_navigation_request_be_blocked(&self, load_data: &LoadData) -> bool {
+    pub(crate) fn should_navigation_request_be_blocked(
+        &self,
+        load_data: &LoadData,
+        element: Option<&Element>,
+    ) -> bool {
         let Some(csp_list) = self.get_csp_list() else {
             return false;
         };
@@ -2955,7 +2959,7 @@ impl GlobalScope {
         let (result, violations) =
             csp_list.should_navigation_request_be_blocked(&request, NavigationCheckType::Other);
 
-        self.report_csp_violations(violations, None);
+        self.report_csp_violations(violations, element);
 
         result == CheckResult::Blocked
     }

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -168,7 +168,7 @@ impl HTMLIFrameElement {
             if let Some(window_proxy) = window_proxy {
                 if document
                     .global()
-                    .should_navigation_request_be_blocked(&load_data)
+                    .should_navigation_request_be_blocked(&load_data, Some(self.upcast()))
                 {
                     return;
                 }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -627,7 +627,7 @@ impl ScriptThread {
                     if let Some(window) = trusted_global.root().downcast::<Window>() {
                         // Step 5: If the result of should navigation request of type be blocked by
                         // Content Security Policy? given request and cspNavigationType is "Blocked", then return. [CSP]
-                        if trusted_global.root().should_navigation_request_be_blocked(&load_data) {
+                        if trusted_global.root().should_navigation_request_be_blocked(&load_data, None) {
                             return;
                         }
                         if ScriptThread::check_load_origin(&load_data.load_origin, &window.get_url().origin()) {

--- a/components/script/security_manager.rs
+++ b/components/script/security_manager.rs
@@ -198,7 +198,7 @@ impl CSPViolationReportTask {
             &self.global.root(),
             Atom::from("securitypolicyviolation"),
             EventBubbles::Bubbles,
-            EventCancelable::Cancelable,
+            EventCancelable::NotCancelable,
             EventComposed::Composed,
             &self.violation_report.clone().convert(),
             can_gc,

--- a/tests/wpt/meta/content-security-policy/securitypolicyviolation/script-sample-no-opt-in.html.ini
+++ b/tests/wpt/meta/content-security-policy/securitypolicyviolation/script-sample-no-opt-in.html.ini
@@ -1,4 +1,0 @@
-[script-sample-no-opt-in.html]
-  expected: TIMEOUT
-  [JavaScript URLs in iframes should not have a sample.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/securitypolicyviolation/script-sample-no-opt-in.html.ini
+++ b/tests/wpt/meta/content-security-policy/securitypolicyviolation/script-sample-no-opt-in.html.ini
@@ -2,6 +2,3 @@
   expected: TIMEOUT
   [JavaScript URLs in iframes should not have a sample.]
     expected: TIMEOUT
-
-  [Inline event handlers should not have a sample.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/securitypolicyviolation/script-sample.html.ini
+++ b/tests/wpt/meta/content-security-policy/securitypolicyviolation/script-sample.html.ini
@@ -1,4 +1,3 @@
 [script-sample.html]
-  expected: TIMEOUT
   [JavaScript URLs in iframes should have a sample.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/securitypolicyviolation/script-sample.html.ini
+++ b/tests/wpt/meta/content-security-policy/securitypolicyviolation/script-sample.html.ini
@@ -2,6 +2,3 @@
   expected: TIMEOUT
   [JavaScript URLs in iframes should have a sample.]
     expected: TIMEOUT
-
-  [Inline event handlers should have a sample.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/securitypolicyviolation/style-sample-no-opt-in.html.ini
+++ b/tests/wpt/meta/content-security-policy/securitypolicyviolation/style-sample-no-opt-in.html.ini
@@ -1,4 +1,0 @@
-[style-sample-no-opt-in.html]
-  expected: TIMEOUT
-  [Inline style attributes should not have a sample.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/securitypolicyviolation/style-sample.html.ini
+++ b/tests/wpt/meta/content-security-policy/securitypolicyviolation/style-sample.html.ini
@@ -1,4 +1,0 @@
-[style-sample.html]
-  expected: TIMEOUT
-  [Inline style attributes should have a sample.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/securitypolicyviolation/targeting.html.ini
+++ b/tests/wpt/meta/content-security-policy/securitypolicyviolation/targeting.html.ini
@@ -8,6 +8,3 @@
 
   [Correct targeting inside shadow tree (inline handler).]
     expected: TIMEOUT
-
-  [Elements created in this document, but pushed into a same-origin frame trigger on that frame's document, not on this frame's document.]
-    expected: TIMEOUT


### PR DESCRIPTION
The check was incorrect, where it was never matching and always discarding the element. Instead, we should check the owner document, which is the shadow-including root of the node.

Part of #4577
