### PR TITLE
layout: Unify scrollable overflow calculation and include `position: absolute`

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1100,12 +1100,7 @@ impl<'a> BuilderForBoxFragment<'a> {
 
     fn build(&mut self, builder: &mut DisplayListBuilder, section: StackingContextSection) {
         if self.is_hit_test_for_scrollable_overflow {
-            self.build_hit_test(
-                builder,
-                self.fragment
-                    .reachable_scrollable_overflow_region()
-                    .to_webrender(),
-            );
+            self.build_hit_test(builder, self.fragment.scrollable_overflow().to_webrender());
             return;
         }
 

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -1472,12 +1472,10 @@ impl BoxFragment {
             y: overflow.y.into(),
         };
 
-        let content_rect = self.reachable_scrollable_overflow_region().to_webrender();
-
         let scroll_tree_node_id = stacking_context_tree.define_scroll_frame(
             parent_scroll_node_id,
             external_id,
-            content_rect,
+            self.scrollable_overflow().to_webrender(),
             scroll_frame_rect,
             sensitivity,
         );

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -162,22 +162,11 @@ impl Fragment {
         }
     }
 
-    pub fn unclipped_scrolling_area(&self) -> PhysicalRect<Au> {
+    pub(crate) fn scrolling_area(&self) -> PhysicalRect<Au> {
         match self {
             Fragment::Box(fragment) | Fragment::Float(fragment) => {
                 let fragment = fragment.borrow();
                 fragment.offset_by_containing_block(&fragment.scrollable_overflow())
-            },
-            _ => self.scrollable_overflow_for_parent(),
-        }
-    }
-
-    pub fn scrolling_area(&self) -> PhysicalRect<Au> {
-        match self {
-            Fragment::Box(fragment) | Fragment::Float(fragment) => {
-                let fragment = fragment.borrow();
-                fragment
-                    .offset_by_containing_block(&fragment.reachable_scrollable_overflow_region())
             },
             _ => self.scrollable_overflow_for_parent(),
         }

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -92,7 +92,7 @@ pub fn process_node_scroll_area_request(
             .first()
             .map(Fragment::scrolling_area)
             .unwrap_or_default(),
-        None => tree.get_scrolling_area_for_viewport(),
+        None => tree.scrollable_overflow(),
     };
 
     Rect::new(

--- a/tests/wpt/meta/css/css-flexbox/negative-overflow.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/negative-overflow.html.ini
@@ -5,9 +5,6 @@
   [.flexbox 11]
     expected: FAIL
 
-  [.flexbox 2]
-    expected: FAIL
-
   [.flexbox 8]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-masking/clip-path/clip-path-fixed-scroll.html.ini
+++ b/tests/wpt/meta/css/css-masking/clip-path/clip-path-fixed-scroll.html.ini
@@ -1,0 +1,2 @@
+[clip-path-fixed-scroll.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-overflow/overflow-outside-padding.html.ini
+++ b/tests/wpt/meta/css/css-overflow/overflow-outside-padding.html.ini
@@ -1,0 +1,3 @@
+[overflow-outside-padding.html]
+  [#target did not trigger scroll overflow]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-overflow/scrollable-overflow-transform-005.tentative.html.ini
+++ b/tests/wpt/meta/css/css-overflow/scrollable-overflow-transform-005.tentative.html.ini
@@ -1,3 +1,0 @@
-[scrollable-overflow-transform-005.tentative.html]
-  [.container 6]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-overflow/scrollable-overflow-transform-009.html.ini
+++ b/tests/wpt/meta/css/css-overflow/scrollable-overflow-transform-009.html.ini
@@ -1,6 +1,0 @@
-[scrollable-overflow-transform-009.html]
-  [.container 2]
-    expected: FAIL
-
-  [.container 3]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-position/position-absolute-under-non-containing-stacking-context.html.ini
+++ b/tests/wpt/meta/css/css-position/position-absolute-under-non-containing-stacking-context.html.ini
@@ -1,2 +1,0 @@
-[position-absolute-under-non-containing-stacking-context.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/positon-absolute-scrollable-overflow-001.html.ini
+++ b/tests/wpt/meta/css/css-position/positon-absolute-scrollable-overflow-001.html.ini
@@ -11,9 +11,6 @@
   [.containing-block 4]
     expected: FAIL
 
-  [.containing-block 7]
-    expected: FAIL
-
   [.containing-block 8]
     expected: FAIL
 
@@ -24,7 +21,4 @@
     expected: FAIL
 
   [.containing-block 11]
-    expected: FAIL
-
-  [.containing-block 14]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/scrollTo-zoom.html.ini
+++ b/tests/wpt/meta/css/cssom-view/scrollTo-zoom.html.ini
@@ -1,2 +1,0 @@
-[scrollTo-zoom.html]
-  expected: FAIL


### PR DESCRIPTION
Previously, layout was handling scrollable overflow and srolling area
calculation separately, only excluding the "unreachable scrollable
overflow region" at the last step. In addition, `position: absolute` was
not included in scrollable overflow calculation.

This change combines the two concepts into a single scrollable overflow
calculation and starts taking into account `position: absolute`.
Finally, `BoxFragment::scrollable_overflow_for_parent` is converted to
use early returns which reduces the amount of indentation.

Fixes #35928.
Fixes #37204.
Testing: This causes some WPT test to pass, but also two to start failing:
 - `/css/css-masking/clip-path/clip-path-fixed-scroll.html`: This seems to fail
   because script is scrolling past the boundaries of the document. This is a
   failure that was uncovered by the fixed element now being added to the
   page's scroll area.
 - `/css/css-overflow/overflow-outside-padding.html`: One test has started to fail
   here because now the absolutely positioned element is included in the scroll area,
   and I think there is an issue with how we are placing RTL items with negative margins.
