### PR TITLE
Fix the native-bluetooth feature on macOS

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -150,7 +150,7 @@ jobs:
           brew install gnu-tar
       - name: Build (${{ inputs.profile }})
         run: |
-          ./mach build --use-crown --locked --${{ inputs.profile }}  ${{ inputs.build-args }}
+          ./mach build --features native-bluetooth --use-crown --locked --${{ inputs.profile }}  ${{ inputs.build-args }}
           cp -r target/cargo-timings target/cargo-timings-macos
       - name: Smoketest
         uses: nick-fields/retry@v3

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -150,7 +150,7 @@ jobs:
           brew install gnu-tar
       - name: Build (${{ inputs.profile }})
         run: |
-          ./mach build --features native-bluetooth --use-crown --locked --${{ inputs.profile }}  ${{ inputs.build-args }}
+          ./mach build --use-crown --locked --${{ inputs.profile }}  ${{ inputs.build-args }}
           cp -r target/cargo-timings target/cargo-timings-macos
       - name: Smoketest
         uses: nick-fields/retry@v3

--- a/third_party/blurmac/src/adapter.rs
+++ b/third_party/blurmac/src/adapter.rs
@@ -8,10 +8,11 @@
 use std::error::Error;
 use std::os::raw::c_int;
 
-use delegate::bm;
-use framework::{cb, io, ns};
 use objc::runtime::{Object, YES};
-use utils::{NOT_SUPPORTED_ERROR, nsx};
+
+use crate::delegate::bm;
+use crate::framework::{cb, io, ns};
+use crate::utils::{NOT_SUPPORTED_ERROR, nsx};
 
 #[derive(Clone, Debug)]
 pub struct BluetoothAdapter {

--- a/third_party/blurmac/src/delegate.rs
+++ b/third_party/blurmac/src/delegate.rs
@@ -8,10 +8,11 @@
 use std::error::Error;
 use std::sync::Once;
 
-use framework::{cb, nil, ns};
 use objc::declare::ClassDecl;
 use objc::runtime::{Class, Object, Protocol, Sel};
-use utils::{NO_PERIPHERAL_FOUND, cbx, nsx, wait};
+
+use crate::framework::{cb, nil, ns};
+use crate::utils::{NO_PERIPHERAL_FOUND, cbx, nsx, wait};
 
 pub mod bm {
     use super::*;

--- a/third_party/blurmac/src/device.rs
+++ b/third_party/blurmac/src/device.rs
@@ -9,11 +9,12 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::sync::Arc;
 
-use adapter::BluetoothAdapter;
-use delegate::{bm, bmx};
-use framework::{cb, nil, ns};
 use objc::runtime::Object;
-use utils::{NO_PERIPHERAL_FOUND, NOT_SUPPORTED_ERROR, cbx, nsx, wait};
+
+use crate::adapter::BluetoothAdapter;
+use crate::delegate::{bm, bmx};
+use crate::framework::{cb, nil, ns};
+use crate::utils::{NO_PERIPHERAL_FOUND, NOT_SUPPORTED_ERROR, cbx, nsx, wait};
 
 #[derive(Clone, Debug)]
 pub struct BluetoothDevice {

--- a/third_party/blurmac/src/discovery_session.rs
+++ b/third_party/blurmac/src/discovery_session.rs
@@ -8,7 +8,7 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use adapter::BluetoothAdapter;
+use crate::adapter::BluetoothAdapter;
 
 #[derive(Clone, Debug)]
 pub struct BluetoothDiscoverySession {

--- a/third_party/blurmac/src/gatt_characteristic.rs
+++ b/third_party/blurmac/src/gatt_characteristic.rs
@@ -10,11 +10,12 @@ use std::os::raw::c_uint;
 use std::slice;
 use std::sync::Arc;
 
-use delegate::bmx;
-use framework::{cb, nil, ns};
-use gatt_service::BluetoothGATTService;
 use objc::runtime::{NO, Object, YES};
-use utils::{NO_CHARACTERISTIC_FOUND, NOT_SUPPORTED_ERROR, cbx, wait};
+
+use crate::delegate::bmx;
+use crate::framework::{cb, nil, ns};
+use crate::gatt_service::BluetoothGATTService;
+use crate::utils::{NO_CHARACTERISTIC_FOUND, NOT_SUPPORTED_ERROR, cbx, wait};
 
 #[derive(Clone, Debug)]
 pub struct BluetoothGATTCharacteristic {

--- a/third_party/blurmac/src/gatt_descriptor.rs
+++ b/third_party/blurmac/src/gatt_descriptor.rs
@@ -7,7 +7,7 @@
 
 use std::error::Error;
 
-use utils::NOT_SUPPORTED_ERROR;
+use crate::utils::NOT_SUPPORTED_ERROR;
 
 #[derive(Clone, Debug)]
 pub struct BluetoothGATTDescriptor {}

--- a/third_party/blurmac/src/gatt_service.rs
+++ b/third_party/blurmac/src/gatt_service.rs
@@ -8,11 +8,12 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use delegate::bmx;
-use device::BluetoothDevice;
-use framework::{cb, nil, ns};
 use objc::runtime::Object;
-use utils::{NO_SERVICE_FOUND, cbx, wait};
+
+use crate::delegate::bmx;
+use crate::device::BluetoothDevice;
+use crate::framework::{cb, nil, ns};
+use crate::utils::{NO_SERVICE_FOUND, cbx, wait};
 
 #[derive(Clone, Debug)]
 pub struct BluetoothGATTService {

--- a/third_party/blurmac/src/utils.rs
+++ b/third_party/blurmac/src/utils.rs
@@ -10,8 +10,9 @@ use std::ffi::{CStr, CString};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{thread, time};
 
-use framework::{cb, nil, ns};
 use objc::runtime::Object;
+
+use crate::framework::{cb, nil, ns};
 
 pub const NOT_SUPPORTED_ERROR: &str = "Error! Not supported by blurmac!";
 pub const NO_PERIPHERAL_FOUND: &str = "Error! No peripheral found!";


### PR DESCRIPTION
Fix the native-bluetooth feature on macOS builds. Enable the native-bluetooth by default.

Testing: Added --features native-bluetooth to GH actions so the build will fail if something is wrong. Don't know why it was not enabled previously, please let me know if it is ok to leave the feature enabled.
Fixes: https://github.com/servo/servo/issues/37454

As for the numerous such warnings
```
warning: unexpected `cfg` condition value: `cargo-clippy`
   --> third_party/blurmac/src/framework.rs:480:43
    |
480 |             let uuidstring: *mut Object = msg_send![cbuuid, UUIDString];
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: no expected values for `feature`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `sel_impl` crate for guidance on how handle this unexpected cfg
    = help: the macro `sel_impl` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `sel_impl` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
```

that macOS builds generates (mentioned [here](https://github.com/servo/servo/pull/37439)) I found this: https://github.com/SSheldon/rust-objc/issues/125. Also, in general the `objc` crate seems to be stale and people are forking it, so maybe I should start a Zulip conversation about migrating to something like this https://github.com/madsmtm/objc2?
