### PR TITLE
Don't allocate in `Dom::trace` even when debug assertions are enabled

### DIFF
--- a/components/script_bindings/root.rs
+++ b/components/script_bindings/root.rs
@@ -229,15 +229,15 @@ impl<T: DomObject> Deref for Dom<T> {
 }
 
 unsafe impl<T: DomObject> JSTraceable for Dom<T> {
-    unsafe fn trace(&self, trc: *mut JSTracer) {
-        let trace_string;
+    unsafe fn trace(&self, tracer: *mut JSTracer) {
         let trace_info = if cfg!(debug_assertions) {
-            trace_string = format!("for {} on heap", ::std::any::type_name::<T>());
-            &trace_string[..]
+            std::any::type_name::<T>()
         } else {
-            "for DOM object on heap"
+            "DOM object on heap"
         };
-        trace_reflector(trc, trace_info, (*self.ptr.as_ptr()).reflector());
+        unsafe {
+            trace_reflector(tracer, trace_info, (*self.ptr.as_ptr()).reflector());
+        }
     }
 }
 


### PR DESCRIPTION
`Dom::trace` currently allocates a new string when debug assertions are enabled:
https://github.com/servo/servo/blob/0f61361e27e6904c51431f96c9550fab9048d220/components/script_bindings/root.rs#L232-L241

This allocation is very heavy in profiles (~14% of runtime). While it doesn't affect production builds, these few characters are not providing enough value to justify the cost.

This changes the method to instead only use `std::any::type_name`, without `format!`. With this change, all the string-format related methods vanish from the profile.