### PR TITLE
imagebitmap: Resolve promise with ImageBitmap on bitmap task source

### DIFF
--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -132,6 +132,7 @@ impl TaskManager {
             .cancel_pending_tasks_for_source(task_source_name);
     }
 
+    task_source_functions!(self, bitmap_task_source, Bitmap);
     task_source_functions!(self, canvas_blob_task_source, Canvas);
     task_source_functions!(self, clipboard_task_source, Clipboard);
     task_source_functions!(self, dom_manipulation_task_source, DOMManipulation);

--- a/components/script/task_source.rs
+++ b/components/script/task_source.rs
@@ -22,6 +22,8 @@ use crate::task_manager::TaskManager;
 /// doesn't implement TaskSource.
 #[derive(Clone, Copy, Debug, Eq, Hash, JSTraceable, MallocSizeOf, PartialEq, VariantArray)]
 pub(crate) enum TaskSourceName {
+    /// <https://html.spec.whatwg.org/multipage/#bitmap-task-source>
+    Bitmap,
     Canvas,
     Clipboard,
     DOMManipulation,
@@ -48,6 +50,7 @@ pub(crate) enum TaskSourceName {
 impl From<TaskSourceName> for ScriptThreadEventCategory {
     fn from(value: TaskSourceName) -> Self {
         match value {
+            TaskSourceName::Bitmap => ScriptThreadEventCategory::ScriptEvent,
             TaskSourceName::Canvas => ScriptThreadEventCategory::ScriptEvent,
             TaskSourceName::Clipboard => ScriptThreadEventCategory::ScriptEvent,
             TaskSourceName::DOMManipulation => ScriptThreadEventCategory::ScriptEvent,

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js.ini
@@ -1,14 +1,8 @@
 [createImageBitmap-resolves-in-task.any.html]
-  [createImageBitmap with an HTMLCanvasElement source should resolve async]
-    expected: FAIL
-
   [createImageBitmap with an HTMLVideoElement source should resolve async]
     expected: FAIL
 
   [createImageBitmap with an HTMLVideoElement from a data URL source should resolve async]
-    expected: FAIL
-
-  [createImageBitmap with a bitmap HTMLImageElement source should resolve async]
     expected: FAIL
 
   [createImageBitmap with a vector HTMLImageElement source should resolve async]
@@ -32,28 +26,10 @@
   [createImageBitmap with a vector SVGImageElement source should resolve async]
     expected: FAIL
 
-  [createImageBitmap with an OffscreenCanvas source should resolve async]
-    expected: FAIL
-
-  [createImageBitmap with an ImageData source should resolve async]
-    expected: FAIL
-
-  [createImageBitmap with an ImageBitmap source should resolve async]
-    expected: FAIL
-
   [createImageBitmap with a Blob source should resolve async]
     expected: FAIL
 
 
 [createImageBitmap-resolves-in-task.any.worker.html]
-  [createImageBitmap with an OffscreenCanvas source should resolve async]
-    expected: FAIL
-
-  [createImageBitmap with an ImageData source should resolve async]
-    expected: FAIL
-
-  [createImageBitmap with an ImageBitmap source should resolve async]
-    expected: FAIL
-
   [createImageBitmap with a Blob source should resolve async]
     expected: FAIL


### PR DESCRIPTION
Follow the ImageBitmap specification and use the global scope bitmap task source
to fulfill resolved promise (asynchronously). 
https://html.spec.whatwg.org/multipage/#bitmap-task-source

Any promise rejection must be done synchronously.

Testing: Improvements in the following WPT test
- html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js

Fixes (partially): #34112