### PR TITLE
CI: WebDriver test on try

### DIFF
--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -109,6 +109,22 @@ def handle_preset(s: str) -> Optional[JobConfig]:
             profile="production",  # WebGPU works to slow with debug assert
             unit_tests=False,
         )  # production profile does not work with unit-tests
+    elif any(word in s for word in ["webdriver", "wd"]):
+        return JobConfig(
+            "WebDriver",
+            Workflow.LINUX,
+            wpt=True,
+            wpt_args=" ".join(
+                [
+                    "./tests/wpt/tests/webdriver/tests/classic/",
+                    "--pref=dom_testing_html_input_element_select_files_enabled",
+                    "--product servodriver",
+                    "--headless",
+                ]
+            ),
+            unit_tests=False,
+            number_of_wpt_chunks=1,
+        )
     elif any(word in s for word in ["lint", "tidy"]):
         return JobConfig("Lint", Workflow.LINT)
     else:


### PR DESCRIPTION
Add webdriver test on the workflow with `--product servodriver`. This will make tracking progression/regression in webdriver development easier.

However, since webdriver test is still unstable, the webdriver test is only enabled on try.

To run try: `./mach try wd`, `./mach try webdriver`

Testing: This PR add webdriver test on try