### PR TITLE
script::webdriver_handlers: Replace `find_node_by_unique_id` with `get_known_element`

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -533,8 +533,8 @@ pub(crate) fn handle_get_browsing_context_id(
                 Err(ErrorStatus::UnsupportedOperation)
             },
             WebDriverFrameId::Element(element_id) => {
-                get_known_element(documents, pipeline, element_id).and_then(|node| {
-                    node.downcast::<HTMLIFrameElement>()
+                get_known_element(documents, pipeline, element_id).and_then(|ele| {
+                    ele.downcast::<HTMLIFrameElement>()
                         .and_then(|element| element.browsing_context_id())
                         .ok_or(ErrorStatus::NoSuchFrame)
                 })
@@ -595,8 +595,8 @@ pub(crate) fn handle_get_element_in_view_center_point(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).map(|node| {
-                get_element_in_view_center_point(&node, can_gc).map(|point| (point.x, point.y))
+            get_known_element(documents, pipeline, element_id).map(|ele| {
+                get_element_in_view_center_point(&ele, can_gc).map(|point| (point.x, point.y))
             }),
         )
         .unwrap();
@@ -633,7 +633,7 @@ pub(crate) fn handle_find_element_css(
                 document
                     .QuerySelector(DOMString::from(selector))
                     .map_err(|_| ErrorStatus::InvalidSelector)
-                    .map(|node| node.map(|x| x.upcast::<Node>().unique_id(pipeline))),
+                    .map(|ele| ele.map(|x| x.upcast::<Node>().unique_id(pipeline))),
             )
             .unwrap(),
         Err(error) => reply.send(Err(error)).unwrap(),
@@ -674,7 +674,7 @@ pub(crate) fn handle_find_element_tag_name(
                 .GetElementsByTagName(DOMString::from(selector), can_gc)
                 .elements_iter()
                 .next()
-                .map(|node| node.upcast::<Node>().unique_id(pipeline))))
+                .map(|ele| ele.upcast::<Node>().unique_id(pipeline))))
             .unwrap(),
         Err(error) => reply.send(Err(error)).unwrap(),
     }
@@ -753,11 +753,11 @@ pub(crate) fn handle_find_element_element_css(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).and_then(|node| {
-                node.upcast::<Node>()
+            get_known_element(documents, pipeline, element_id).and_then(|ele| {
+                ele.upcast::<Node>()
                     .query_selector(DOMString::from(selector))
                     .map_err(|_| ErrorStatus::InvalidSelector)
-                    .map(|node| node.map(|x| x.upcast::<Node>().unique_id(pipeline)))
+                    .map(|ele| ele.map(|x| x.upcast::<Node>().unique_id(pipeline)))
             }),
         )
         .unwrap();
@@ -774,8 +774,8 @@ pub(crate) fn handle_find_element_element_link_text(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).and_then(|node| {
-                first_matching_link(node.upcast::<Node>(), selector.clone(), partial, can_gc)
+            get_known_element(documents, pipeline, element_id).and_then(|ele| {
+                first_matching_link(ele.upcast::<Node>(), selector.clone(), partial, can_gc)
             }),
         )
         .unwrap();
@@ -791,8 +791,8 @@ pub(crate) fn handle_find_element_element_tag_name(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).map(|node| {
-                node.GetElementsByTagName(DOMString::from(selector), can_gc)
+            get_known_element(documents, pipeline, element_id).map(|ele| {
+                ele.GetElementsByTagName(DOMString::from(selector), can_gc)
                     .elements_iter()
                     .next()
                     .map(|x| x.upcast::<Node>().unique_id(pipeline))
@@ -810,8 +810,8 @@ pub(crate) fn handle_find_element_elements_css(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).and_then(|node| {
-                node.upcast::<Node>()
+            get_known_element(documents, pipeline, element_id).and_then(|ele| {
+                ele.upcast::<Node>()
                     .query_selector_all(DOMString::from(selector))
                     .map_err(|_| ErrorStatus::InvalidSelector)
                     .map(|nodes| {
@@ -836,8 +836,8 @@ pub(crate) fn handle_find_element_elements_link_text(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).and_then(|node| {
-                all_matching_links(node.upcast::<Node>(), selector.clone(), partial, can_gc)
+            get_known_element(documents, pipeline, element_id).and_then(|ele| {
+                all_matching_links(ele.upcast::<Node>(), selector.clone(), partial, can_gc)
             }),
         )
         .unwrap();
@@ -853,8 +853,8 @@ pub(crate) fn handle_find_element_elements_tag_name(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).map(|node| {
-                node.GetElementsByTagName(DOMString::from(selector), can_gc)
+            get_known_element(documents, pipeline, element_id).map(|ele| {
+                ele.GetElementsByTagName(DOMString::from(selector), can_gc)
                     .elements_iter()
                     .map(|x| x.upcast::<Node>().unique_id(pipeline))
                     .collect::<Vec<String>>()
@@ -872,8 +872,8 @@ pub(crate) fn handle_get_element_shadow_root(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).map(|node| {
-                node.GetShadowRoot()
+            get_known_element(documents, pipeline, element_id).map(|ele| {
+                ele.GetShadowRoot()
                     .map(|x| x.upcast::<Node>().unique_id(pipeline))
             }),
         )
@@ -891,16 +891,16 @@ pub(crate) fn handle_will_send_keys(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).and_then(|node| {
+            get_known_element(documents, pipeline, element_id).and_then(|ele| {
                 // Step 6: Let file be true if element is input element
                 // in the file upload state, or false otherwise
-                let file_input = node
+                let file_input = ele
                     .downcast::<HTMLInputElement>()
                     .filter(|&input_element| input_element.input_type() == InputType::File);
 
                 // Step 7: If file is false or the session's strict file interactability
                 if file_input.is_none() || strict_file_interactability {
-                    match node.downcast::<HTMLElement>() {
+                    match ele.downcast::<HTMLElement>() {
                         Some(element) => {
                             // Need a way to find if this actually succeeded
                             element.Focus(can_gc);
@@ -969,7 +969,7 @@ pub(crate) fn handle_get_computed_role(
     reply
         .send(
             get_known_element(documents, pipeline, node_id)
-                .map(|node| node.GetRole().map(String::from)),
+                .map(|ele| ele.GetRole().map(String::from)),
         )
         .unwrap();
 }
@@ -1175,9 +1175,9 @@ pub(crate) fn handle_get_rect(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).and_then(|node| {
+            get_known_element(documents, pipeline, element_id).and_then(|ele| {
                 // https://w3c.github.io/webdriver/webdriver-spec.html#dfn-calculate-the-absolute-position
-                match node.downcast::<HTMLElement>() {
+                match ele.downcast::<HTMLElement>() {
                     Some(html_element) => {
                         // Step 1
                         let mut x = 0;
@@ -1221,8 +1221,8 @@ pub(crate) fn handle_get_bounding_client_rect(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).map(|node| {
-                let rect = node.GetBoundingClientRect(can_gc);
+            get_known_element(documents, pipeline, element_id).map(|ele| {
+                let rect = ele.GetBoundingClientRect(can_gc);
                 Rect::new(
                     Point2D::new(rect.X() as f32, rect.Y() as f32),
                     Size2D::new(rect.Width() as f32, rect.Height() as f32),
@@ -1241,11 +1241,11 @@ pub(crate) fn handle_get_text(
     can_gc: CanGc,
 ) {
     reply
-        .send(get_known_element(documents, pipeline, node_id).map(|node| {
-            node.downcast::<HTMLElement>()
+        .send(get_known_element(documents, pipeline, node_id).map(|ele| {
+            ele.downcast::<HTMLElement>()
                 .map(|element| element.InnerText(can_gc).to_string())
                 .unwrap_or_else(|| {
-                    node.upcast::<Node>()
+                    ele.upcast::<Node>()
                         .GetTextContent()
                         .map_or("".to_owned(), String::from)
                 })
@@ -1261,8 +1261,7 @@ pub(crate) fn handle_get_name(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, node_id)
-                .map(|node| String::from(node.TagName())),
+            get_known_element(documents, pipeline, node_id).map(|ele| String::from(ele.TagName())),
         )
         .unwrap();
 }
@@ -1277,7 +1276,7 @@ pub(crate) fn handle_get_attribute(
     reply
         .send(
             get_known_element(documents, pipeline, node_id)
-                .map(|node| node.GetAttribute(DOMString::from(name)).map(String::from)),
+                .map(|ele| ele.GetAttribute(DOMString::from(name)).map(String::from)),
         )
         .unwrap();
 }
@@ -1292,7 +1291,7 @@ pub(crate) fn handle_get_property(
     can_gc: CanGc,
 ) {
     reply
-        .send(get_known_element(documents, pipeline, node_id).map(|node| {
+        .send(get_known_element(documents, pipeline, node_id).map(|ele| {
             let document = documents.find_document(pipeline).unwrap();
             let realm = enter_realm(&*document);
             let cx = document.window().get_cx();
@@ -1301,7 +1300,7 @@ pub(crate) fn handle_get_property(
             match unsafe {
                 get_property_jsval(
                     *cx,
-                    node.reflector().get_jsobject(),
+                    ele.reflector().get_jsobject(),
                     &name,
                     property.handle_mut(),
                 )
@@ -1309,7 +1308,7 @@ pub(crate) fn handle_get_property(
                 Ok(_) => {
                     match jsval_to_webdriver(
                         cx,
-                        &node.global(),
+                        &ele.global(),
                         property.handle(),
                         InRealm::entered(&realm),
                         can_gc,
@@ -1319,7 +1318,7 @@ pub(crate) fn handle_get_property(
                     }
                 },
                 Err(error) => {
-                    throw_dom_exception(cx, &node.global(), error, can_gc);
+                    throw_dom_exception(cx, &ele.global(), error, can_gc);
                     WebDriverJSValue::Undefined
                 },
             }
@@ -1336,11 +1335,11 @@ pub(crate) fn handle_get_css(
     can_gc: CanGc,
 ) {
     reply
-        .send(get_known_element(documents, pipeline, node_id).map(|node| {
-            let window = node.owner_window();
+        .send(get_known_element(documents, pipeline, node_id).map(|ele| {
+            let window = ele.owner_window();
             String::from(
                 window
-                    .GetComputedStyle(&node, None)
+                    .GetComputedStyle(&ele, None)
                     .GetPropertyValue(DOMString::from(name), can_gc),
             )
         }))
@@ -1404,15 +1403,15 @@ pub(crate) fn handle_element_click(
     reply
         .send(
             // Step 3
-            get_known_element(documents, pipeline, element_id).and_then(|node| {
+            get_known_element(documents, pipeline, element_id).and_then(|ele| {
                 // Step 4
-                if let Some(input_element) = node.downcast::<HTMLInputElement>() {
+                if let Some(input_element) = ele.downcast::<HTMLInputElement>() {
                     if input_element.input_type() == InputType::File {
                         return Err(ErrorStatus::InvalidArgument);
                     }
                 }
 
-                let Some(container) = get_container(node.upcast::<Node>()) else {
+                let Some(container) = get_container(ele.upcast::<Node>()) else {
                     return Err(ErrorStatus::UnknownError);
                 };
 
@@ -1426,7 +1425,7 @@ pub(crate) fn handle_element_click(
                 // TODO: return error if obscured
 
                 // Step 8
-                match node.downcast::<HTMLOptionElement>() {
+                match ele.downcast::<HTMLOptionElement>() {
                     Some(option_element) => {
                         // Steps 8.2 - 8.4
                         let event_target = container.upcast::<EventTarget>();
@@ -1470,7 +1469,7 @@ pub(crate) fn handle_element_click(
 
                         Ok(None)
                     },
-                    None => Ok(Some(node.upcast::<Node>().unique_id(pipeline))),
+                    None => Ok(Some(ele.upcast::<Node>().unique_id(pipeline))),
                 }
             }),
         )
@@ -1484,7 +1483,7 @@ pub(crate) fn handle_is_enabled(
     reply: IpcSender<Result<bool, ErrorStatus>>,
 ) {
     reply
-        .send(get_known_element(documents, pipeline, element_id).map(|node| node.enabled_state()))
+        .send(get_known_element(documents, pipeline, element_id).map(|ele| ele.enabled_state()))
         .unwrap();
 }
 
@@ -1496,12 +1495,12 @@ pub(crate) fn handle_is_selected(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).and_then(|node| {
-                if let Some(input_element) = node.downcast::<HTMLInputElement>() {
+            get_known_element(documents, pipeline, element_id).and_then(|ele| {
+                if let Some(input_element) = ele.downcast::<HTMLInputElement>() {
                     Ok(input_element.Checked())
-                } else if let Some(option_element) = node.downcast::<HTMLOptionElement>() {
+                } else if let Some(option_element) = ele.downcast::<HTMLOptionElement>() {
                     Ok(option_element.Selected())
-                } else if node.is::<HTMLElement>() {
+                } else if ele.is::<HTMLElement>() {
                     Ok(false) // regular elements are not selectable
                 } else {
                     Err(ErrorStatus::UnknownError)


### PR DESCRIPTION
Implement previously missing step 3 of [get a known element](https://w3c.github.io/webdriver/#dfn-get-a-known-element): "If node is not null and node does not implement Element, return error with error code no such element"

Testing: All webdriver conformance test