### PR TITLE
compositor: Wait for both Script and the Constellation when shutting down Pipelines

### DIFF
--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -58,7 +58,7 @@ impl MixedMessage {
                 ScriptThreadMessage::ThemeChange(id, ..) => Some(*id),
                 ScriptThreadMessage::ResizeInactive(id, ..) => Some(*id),
                 ScriptThreadMessage::UnloadDocument(id) => Some(*id),
-                ScriptThreadMessage::ExitPipeline(id, ..) => Some(*id),
+                ScriptThreadMessage::ExitPipeline(_webview_id, id, ..) => Some(*id),
                 ScriptThreadMessage::ExitScriptThread => None,
                 ScriptThreadMessage::SendInputEvent(id, ..) => Some(*id),
                 ScriptThreadMessage::Viewport(id, ..) => Some(*id),

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -28,6 +28,7 @@ pub mod viewport_description;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+use bitflags::bitflags;
 use display_list::CompositorDisplayListInfo;
 use embedder_traits::{CompositorHitTestResult, ScreenGeometry};
 use euclid::default::Size2D as UntypedSize2D;
@@ -96,12 +97,11 @@ pub enum CompositorMsg {
     /// the frame is ready. It contains a bool to indicate if it needs to composite and the
     /// `DocumentId` of the new frame.
     NewWebRenderFrameReady(DocumentId, bool),
-    /// A pipeline was shut down.
-    // This message acts as a synchronization point between the constellation,
-    // when it shuts down a pipeline, to the compositor; when the compositor
-    // sends a reply on the IpcSender, the constellation knows it's safe to
-    // tear down the other threads associated with this pipeline.
-    PipelineExited(WebViewId, PipelineId, IpcSender<()>),
+    /// Script or the Constellation is notifying the renderer that a Pipeline has finished
+    /// shutting down. The renderer will not discard the Pipeline until both report that
+    /// they have fully shut it down, to avoid recreating it due to any subsequent
+    /// messages.
+    PipelineExited(WebViewId, PipelineId, PipelineExitSource),
     /// The load of a page has completed
     LoadComplete(WebViewId),
     /// WebDriver mouse button event
@@ -561,4 +561,16 @@ pub trait WebViewTrait {
     fn id(&self) -> WebViewId;
     fn screen_geometry(&self) -> Option<ScreenGeometry>;
     fn set_animating(&self, new_value: bool);
+}
+
+/// What entity is reporting that a `Pipeline` has exited. Only when all have
+/// done this will the renderer discard its details.
+#[derive(Clone, Copy, Default, Deserialize, PartialEq, Serialize)]
+pub struct PipelineExitSource(u8);
+
+bitflags! {
+    impl PipelineExitSource: u8 {
+        const Script = 1 << 0;
+        const Constellation = 1 << 1;
+    }
 }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -140,7 +140,7 @@ pub enum ScriptThreadMessage {
     /// Notifies the script that the document associated with this pipeline should 'unload'.
     UnloadDocument(PipelineId),
     /// Notifies the script that a pipeline should be closed.
-    ExitPipeline(PipelineId, DiscardBrowsingContext),
+    ExitPipeline(WebViewId, PipelineId, DiscardBrowsingContext),
     /// Notifies the script that the whole thread should be closed.
     ExitScriptThread,
     /// Sends a DOM event.


### PR DESCRIPTION
Previously, the Constellation would immediately ask the Compositor to
shut down a pipeline, even before the ScriptThread finished shutting it
down. This meant that the Compositor might remove a Pipeline and then
re-add it if the ScriptThread sent a Pipeline-related message (such as a
new display list) in the meantime.

This change makes it so that the Compositor waits for both the
Constellation and the ScriptThread to finish shutting down a Pipeline
before removing its data. In addition, the Constellation no longer
synchronously waits on the Compositor when shutting down Pipelines. This
was important when the Compositor would talk to the ScriptThread
directly, but isn't necessary any longer.

Testing: This is very hard to test, because it depends on the creation
and destruction of many iframes and the particular timing of of all
the messaging between Servo bits. That said, this was tested manually
by observing the completion of Speedometer 2.1.
Fixes: #37458.
