### PR TITLE
OHOS: servoshell: forward special alerts to hitrace

### DIFF
--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -869,6 +869,17 @@ impl HostTrait for HostCallbacks {
                 response_sender,
             } => {
                 debug!("SimpleDialog::Alert");
+
+                // forward it to tracing
+                #[cfg(feature = "tracing-hitrace")]
+                {
+                    if message.contains("TESTCASE_PROFILING") {
+                        if let Some((tag, number)) = message.rsplit_once(":") {
+                            hitrace::trace_metric_str(tag, number.parse::<i64>().unwrap_or(-1));
+                        }
+                    }
+                }
+
                 // TODO: Indicate that this message is untrusted, and what origin it came from.
                 self.show_alert(message);
                 response_sender.send(AlertResponse::Ok)


### PR DESCRIPTION
We want to have special files with testcases running javascript and
reporting their timing via alert(). This pushes these messages to
hitrace.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Does not change functionality and will only add messages to hitrace.
