### PR TITLE
script: Get scroll offsets from layout

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -472,6 +472,14 @@ impl Layout for LayoutThread {
             .scroll_tree
             .set_all_scroll_offsets(scroll_states);
     }
+
+    fn scroll_offset(&self, id: ExternalScrollId) -> Option<LayoutVector2D> {
+        self.stacking_context_tree
+            .borrow_mut()
+            .as_mut()
+            .and_then(|tree| tree.compositor_info.scroll_tree.scroll_offset(id))
+            .map(|scroll_offset| -scroll_offset)
+    }
 }
 
 impl LayoutThread {
@@ -996,7 +1004,7 @@ impl LayoutThread {
             .scroll_tree
             .set_scroll_offset_for_node_with_external_scroll_id(
                 external_scroll_id,
-                offset,
+                -offset,
                 ScrollType::Script,
             )
         {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3080,7 +3080,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 9
-        let point = node.scroll_offset();
+        let point = win.scroll_offset_query(node, can_gc);
         point.y.abs() as f64
     }
 
@@ -3179,7 +3179,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 9
-        let point = node.scroll_offset();
+        let point = win.scroll_offset_query(node, can_gc);
         point.x.abs() as f64
     }
 

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -9,6 +9,7 @@ use dom_struct::dom_struct;
 use embedder_traits::CompositorHitTestResult;
 use euclid::default::Point2D;
 use js::rust::HandleObject;
+use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use servo_config::pref;
 
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
@@ -373,9 +374,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
         if self.upcast::<Event>().dispatching() {
             self.page_x.get()
         } else {
-            let global = self.global();
-            let window = global.as_window();
-            window.current_viewport().origin.x.to_px() + self.client_x.get()
+            self.global().as_window().ScrollX() + self.client_x.get()
         }
     }
 
@@ -384,9 +383,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
         if self.upcast::<Event>().dispatching() {
             self.page_y.get()
         } else {
-            let global = self.global();
-            let window = global.as_window();
-            window.current_viewport().origin.y.to_px() + self.client_y.get()
+            self.global().as_window().ScrollY() + self.client_y.get()
         }
     }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -18,7 +18,7 @@ use bitflags::bitflags;
 use devtools_traits::NodeInfo;
 use dom_struct::dom_struct;
 use embedder_traits::UntrustedNodeAddress;
-use euclid::default::{Rect, Size2D, Vector2D};
+use euclid::default::{Rect, Size2D};
 use html5ever::serialize::HtmlSerializer;
 use html5ever::{Namespace, Prefix, QualName, ns, serialize as html_serialize};
 use js::jsapi::JSObject;
@@ -978,12 +978,6 @@ impl Node {
         // these steps."
         // "7. Return the width of the element’s scrolling area."
         window.scrolling_area_query(Some(self), can_gc)
-    }
-
-    pub(crate) fn scroll_offset(&self) -> Vector2D<f32> {
-        let document = self.owner_doc();
-        let window = document.window();
-        window.scroll_offset_query(self).to_untyped()
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-before>

--- a/components/shared/compositing/display_list.rs
+++ b/components/shared/compositing/display_list.rs
@@ -424,6 +424,15 @@ impl ScrollTree {
             _ => None,
         }))
     }
+
+    /// Get the scroll offset for the given [`ExternalScrollId`] or `None` if that node cannot
+    /// be found in the tree.
+    pub fn scroll_offset(&self, id: ExternalScrollId) -> Option<LayoutVector2D> {
+        self.nodes.iter().find_map(|node| match node.info {
+            SpatialTreeNodeInfo::Scroll(ref info) if info.external_id == id => Some(info.offset),
+            _ => None,
+        })
+    }
 }
 
 /// In order to pretty print the [ScrollTree] structure, we are converting

--- a/components/shared/script_layout/lib.rs
+++ b/components/shared/script_layout/lib.rs
@@ -251,6 +251,10 @@ pub trait Layout {
         scroll_states: &HashMap<ExternalScrollId, LayoutVector2D>,
     );
 
+    /// Get the scroll offset of the given scroll node with id of [`ExternalScrollId`] or `None` if it does
+    /// not exist in the tree.
+    fn scroll_offset(&self, id: ExternalScrollId) -> Option<LayoutVector2D>;
+
     fn query_content_box(&self, node: TrustedNodeAddress) -> Option<Rect<Au>>;
     fn query_content_boxes(&self, node: TrustedNodeAddress) -> Vec<Rect<Au>>;
     fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32>;
@@ -309,7 +313,7 @@ pub enum QueryMsg {
     ContentBox,
     ContentBoxes,
     ClientRectQuery,
-    ScrollingAreaQuery,
+    ScrollingAreaOrOffsetQuery,
     OffsetParentQuery,
     TextIndexQuery,
     NodesFromPointQuery,
@@ -351,13 +355,13 @@ impl ReflowGoal {
                 QueryMsg::InnerWindowDimensionsQuery |
                 QueryMsg::NodesFromPointQuery |
                 QueryMsg::ResolvedStyleQuery |
+                QueryMsg::ScrollingAreaOrOffsetQuery |
                 QueryMsg::TextIndexQuery => true,
                 QueryMsg::ClientRectQuery |
                 QueryMsg::ContentBox |
                 QueryMsg::ContentBoxes |
                 QueryMsg::OffsetParentQuery |
                 QueryMsg::ResolvedFontStyleQuery |
-                QueryMsg::ScrollingAreaQuery |
                 QueryMsg::StyleQuery => false,
             },
         }
@@ -375,7 +379,7 @@ impl ReflowGoal {
                 QueryMsg::ContentBox |
                 QueryMsg::ContentBoxes |
                 QueryMsg::ClientRectQuery |
-                QueryMsg::ScrollingAreaQuery |
+                QueryMsg::ScrollingAreaOrOffsetQuery |
                 QueryMsg::ResolvedStyleQuery |
                 QueryMsg::ResolvedFontStyleQuery |
                 QueryMsg::OffsetParentQuery |

--- a/tests/wpt/meta/css/CSS2/positioning/relpos-percentage-top-in-scrollable.html.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/relpos-percentage-top-in-scrollable.html.ini
@@ -1,3 +1,0 @@
-[relpos-percentage-top-in-scrollable.html]
-  [Top percentage resolved correctly for overflow contribution]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-overflow/incremental-scroll-002.html.ini
+++ b/tests/wpt/meta/css/css-overflow/incremental-scroll-002.html.ini
@@ -1,2 +1,0 @@
-[incremental-scroll-002.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/cssom-view/elementScroll.html.ini
+++ b/tests/wpt/meta/css/cssom-view/elementScroll.html.ini
@@ -1,3 +1,0 @@
-[elementScroll.html]
-  [Element scroll maximum test]
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/scrollLeftTop.html.ini
+++ b/tests/wpt/meta/css/cssom-view/scrollLeftTop.html.ini
@@ -1,7 +1,4 @@
 [scrollLeftTop.html]
-  [writing-mode:vertical-lr; direction:ltr]
-    expected: FAIL
-
   [writing-mode:vertical-rl; direction:rtl]
     expected: FAIL
 
@@ -11,9 +8,5 @@
   [writing-mode:vertical-rl; direction:ltr]
     expected: FAIL
 
-  [writing-mode:horizontal-tb; direction:ltr]
-    expected: FAIL
-
   [writing-mode:horizontal-tb; direction:rtl]
     expected: FAIL
-

--- a/tests/wpt/meta/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
+++ b/tests/wpt/meta/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
@@ -8,15 +8,6 @@
   [scrollWidth/scrollHeight on the HTML body element in quirks mode]
     expected: FAIL
 
-  [scroll() on the HTML body element in non-quirks mode]
-    expected: FAIL
-
-  [scrollBy() on the HTML body element in non-quirks mode]
-    expected: FAIL
-
-  [scrollLeft/scrollTop on the HTML body element in non-quirks mode]
-    expected: FAIL
-
   [scroll() on the root element in non-quirks mode]
     expected: FAIL
 

--- a/tests/wpt/meta/shadow-dom/scroll-to-the-fragment-in-shadow-tree.html.ini
+++ b/tests/wpt/meta/shadow-dom/scroll-to-the-fragment-in-shadow-tree.html.ini
@@ -1,0 +1,27 @@
+[scroll-to-the-fragment-in-shadow-tree.html]
+  [The user agent scroll to the fragment when there is an anchor element with a name attribute exactly equal to the decoded fragid]
+    expected: FAIL
+
+  [The user agent should not scroll to an element with an ID exactly equal to the decoded fragid in an open shadow tree]
+    expected: FAIL
+
+  [The user agent should not scroll to an element with an ID exactly equal to the decoded fragid in a closed shadow tree]
+    expected: FAIL
+
+  [The user agent should not scroll to an anchor element with a name attribute exactly equal to the decoded fragid in an open shadow tree]
+    expected: FAIL
+
+  [The user agent should not scroll to an anchor element with a name attribute exactly equal to the decoded fragid in a closed shadow tree]
+    expected: FAIL
+
+  [The user agent should scroll to an element with an ID exactly equal to the decoded fragid in the document tree even if there was another element with the same ID inside an open shadow tree earlier in tree order]
+    expected: FAIL
+
+  [The user agent should scroll to an element with an ID exactly equal to the decoded fragid in the document tree even if there was another element with the same ID inside a closed shadow tree earlier in tree order]
+    expected: FAIL
+
+  [The user agent should scroll to an anchor element with a name attribute exactly equal to the decoded fragid in the document tree even if there was another element with the same ID inside an open shadow tree earlier in tree order]
+    expected: FAIL
+
+  [The user agent should scroll to an anchor element with a name attribute exactly equal to the decoded fragid in the document tree even if there was another element with the same ID inside a closed shadow tree earlier in tree order]
+    expected: FAIL


### PR DESCRIPTION
No longer store scroll offsets for elements in the DOM. Instead
consistently get and set these in layout's `ScrollTree`. This more
consistently requires layout to run when querying scroll offsets, which
ensures that they are up-to-date and properly bounded by scrollable
overflow area.

Testing: This causes several WPT tests to start passing, and one to start
failing. In the case of
`/shadow-dom/scroll-to-the-fragment-in-shadow-tree.html`, I believe the issue
is that we don't properly handle scrolling and shadow DOM elements. Before, the
faulty scrolling was hiding this issue.
