### PR TITLE
Fix network event update Message

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -30,7 +30,7 @@ use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::object::ObjectActor;
 use crate::actors::worker::WorkerActor;
 use crate::protocol::JsonPacketStream;
-use crate::resource::ResourceAvailable;
+use crate::resource::{ResourceArrayType, ResourceAvailable};
 use crate::{StreamId, UniqueId};
 
 trait EncodableConsoleMessage {
@@ -261,13 +261,12 @@ impl ConsoleActor {
             .push(CachedConsoleMessage::PageError(page_error.clone()));
         if id == self.current_unique_id(registry) {
             if let Root::BrowsingContext(bc) = &self.root {
-                registry
-                    .find::<BrowsingContextActor>(bc)
-                    .resource_available(
-                        PageErrorWrapper { page_error },
-                        "error-message".into(),
-                        stream,
-                    )
+                registry.find::<BrowsingContextActor>(bc).resource_array(
+                    PageErrorWrapper { page_error },
+                    "error-message".into(),
+                    ResourceArrayType::Available,
+                    stream,
+                )
             };
         }
     }
@@ -287,9 +286,12 @@ impl ConsoleActor {
             .push(CachedConsoleMessage::ConsoleLog(log_message.clone()));
         if id == self.current_unique_id(registry) {
             if let Root::BrowsingContext(bc) = &self.root {
-                registry
-                    .find::<BrowsingContextActor>(bc)
-                    .resource_available(log_message, "console-message".into(), stream)
+                registry.find::<BrowsingContextActor>(bc).resource_array(
+                    log_message,
+                    "console-message".into(),
+                    ResourceArrayType::Available,
+                    stream,
+                )
             };
         }
     }

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -47,6 +47,15 @@ pub struct NetworkEventActor {
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct NetworkEventResource {
+    pub resource_id: u64,
+    pub resource_updates: Map<String, Value>,
+    pub browsing_context_id: u64,
+    pub inner_window_id: u64,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct EventActor {
     pub actor: String,
     pub url: String,
@@ -62,6 +71,7 @@ pub struct EventActor {
 #[derive(Serialize)]
 pub struct ResponseCookiesMsg {
     pub cookies: usize,
+    pub response_cookies_available: bool,
 }
 
 #[derive(Serialize)]
@@ -74,6 +84,7 @@ pub struct ResponseStartMsg {
     pub status_text: String,
     pub headers_size: usize,
     pub discard_response_body: bool,
+    pub response_start_available: bool,
 }
 
 #[derive(Serialize)]
@@ -83,6 +94,7 @@ pub struct ResponseContentMsg {
     pub content_size: u32,
     pub transferred_size: u32,
     pub discard_response_body: bool,
+    pub response_content_available: bool,
 }
 
 #[derive(Serialize)]
@@ -90,11 +102,13 @@ pub struct ResponseContentMsg {
 pub struct ResponseHeadersMsg {
     pub headers: usize,
     pub headers_size: usize,
+    pub response_headers_available: bool,
 }
 
 #[derive(Serialize)]
 pub struct RequestCookiesMsg {
     pub cookies: usize,
+    pub request_cookies_available: bool,
 }
 
 #[derive(Serialize)]
@@ -102,6 +116,7 @@ pub struct RequestCookiesMsg {
 pub struct RequestHeadersMsg {
     headers: usize,
     headers_size: usize,
+    request_headers_available: bool,
 }
 
 #[derive(Serialize)]
@@ -431,6 +446,7 @@ impl NetworkEventActor {
             status_text: String::from_utf8_lossy(status.message()).to_string(),
             headers_size: h_size,
             discard_response_body: false,
+            response_start_available: true,
         }
     }
 
@@ -448,6 +464,7 @@ impl NetworkEventActor {
             content_size: 0,
             transferred_size: 0,
             discard_response_body: true,
+            response_content_available: false,
         }
     }
 
@@ -461,6 +478,7 @@ impl NetworkEventActor {
         }
         ResponseCookiesMsg {
             cookies: cookies_size,
+            response_cookies_available: false,
         }
     }
 
@@ -476,6 +494,7 @@ impl NetworkEventActor {
         ResponseHeadersMsg {
             headers: headers_size,
             headers_size: headers_byte_count,
+            response_headers_available: true,
         }
     }
 
@@ -486,6 +505,7 @@ impl NetworkEventActor {
         RequestHeadersMsg {
             headers: self.request.headers.len(),
             headers_size: size,
+            request_headers_available: true,
         }
     }
 
@@ -496,10 +516,136 @@ impl NetworkEventActor {
         };
         RequestCookiesMsg {
             cookies: cookies_size,
+            request_cookies_available: true,
         }
     }
 
     pub fn total_time(&self) -> Duration {
         self.request.connect_time + self.request.send_time
+    }
+
+    pub fn resource_updates(&self) -> NetworkEventResource {
+        let mut resource_updates = Map::new();
+        resource_updates.insert(
+            "requestCookiesAvailable".to_owned(),
+            serde_json::to_value(self.request_cookies()).unwrap(),
+        ); //check for boolean
+
+        resource_updates.insert(
+            "requestHeadersAvailable".to_owned(),
+            serde_json::to_value(self.request_cookies()).unwrap(),
+        ); //check for boolean
+
+        resource_updates.insert(
+            "httpVersion".to_owned(),
+            serde_json::to_value(self.request_headers()).unwrap(),
+        ); //http version
+
+        resource_updates.insert(
+            "status".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); //http status
+
+        resource_updates.insert(
+            "statusText".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); //http status text
+
+        resource_updates.insert(
+            "earlyHintsStatus".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); //hmm
+
+        resource_updates.insert(
+            "remoteAddress".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        );
+
+        resource_updates.insert(
+            "remotePort".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        );
+
+        resource_updates.insert(
+            "mimeType".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); //mime type
+
+        resource_updates.insert(
+            "waitingTime".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); // waiting time
+
+        resource_updates.insert(
+            "isResolvedByTRR".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); // is resolved by TRR
+
+        resource_updates.insert(
+            "responseHeadersAvailable".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); // check for boolean
+
+        resource_updates.insert(
+            "responseCookiesAvailable".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); // check for boolean
+
+        resource_updates.insert(
+            "responseStartAvailable".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); // check for boolean
+
+        resource_updates.insert(
+            "totalTime".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); // total time
+
+        resource_updates.insert(
+            "eventTimingsAvailable".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); // check for boolean
+
+        resource_updates.insert(
+            "securityState".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); // security state
+
+        resource_updates.insert(
+            "isRacing".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); // is racing
+
+        resource_updates.insert(
+            "securityInfoAvailable".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); // check for boolean
+
+        resource_updates.insert(
+            "contentSize".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); // content size
+
+        resource_updates.insert(
+            "transferredSize".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); // transferred size
+
+        resource_updates.insert(
+            "blockedReason".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); //  blocked reason
+
+        resource_updates.insert(
+            "responseContentAvailable".to_owned(),
+            serde_json::to_value(self.response_start()).unwrap(),
+        ); //  check for boolean
+
+        NetworkEventResource {
+            resource_id: 0, // Set to a valid ID if available
+            resource_updates,
+            browsing_context_id: 0, // Set to a valid ID if available
+            inner_window_id: 0,     // Set to a valid ID if available
+        }
     }
 }

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -53,7 +53,7 @@ pub struct NetworkEventActor {
     pub request_headers: Option<RequestHeadersMsg>,
     pub total_time: Duration,
     pub security_state: String,
-    pub event_timing: Option<GetEventTimingsReply>,
+    pub event_timing: Option<Timings>,
 }
 
 #[derive(Clone, Serialize)]
@@ -122,11 +122,6 @@ pub struct RequestCookiesMsg {
 pub struct RequestHeadersMsg {
     headers: usize,
     headers_size: usize,
-}
-
-#[derive(Serialize)]
-struct SecurityInfoUpdateMsg {
-    security_state: String,
 }
 
 #[derive(Serialize)]

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -32,7 +32,7 @@ use crate::actors::watcher::thread_configuration::{
     ThreadConfigurationActor, ThreadConfigurationActorMsg,
 };
 use crate::protocol::JsonPacketStream;
-use crate::resource::ResourceAvailable;
+use crate::resource::{ResourceArrayType, ResourceAvailable};
 use crate::{EmptyReplyMsg, StreamId, WorkerActor};
 
 pub mod network_parent;
@@ -292,15 +292,21 @@ impl Actor for WatcherActor {
                                     title: Some(target.title.borrow().clone()),
                                     url: Some(target.url.borrow().clone()),
                                 };
-                                target.resource_available(event, "document-event".into(), stream);
+                                target.resource_array(
+                                    event,
+                                    "document-event".into(),
+                                    ResourceArrayType::Available,
+                                    stream,
+                                );
                             }
                         },
                         "source" => {
                             let thread_actor = registry.find::<ThreadActor>(&target.thread);
                             let sources = thread_actor.source_manager.sources();
-                            target.resources_available(
+                            target.resources_array(
                                 sources.iter().collect(),
                                 "source".into(),
+                                ResourceArrayType::Available,
                                 stream,
                             );
 
@@ -309,9 +315,10 @@ impl Actor for WatcherActor {
                                 let thread = registry.find::<ThreadActor>(&worker.thread);
                                 let worker_sources = thread.source_manager.sources();
 
-                                worker.resources_available(
+                                worker.resources_array(
                                     worker_sources.iter().collect(),
                                     "source".into(),
+                                    ResourceArrayType::Available,
                                     stream,
                                 );
                             }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -29,7 +29,7 @@ use devtools_traits::{
 use embedder_traits::{AllowOrDeny, EmbedderMsg, EmbedderProxy};
 use ipc_channel::ipc::{self, IpcSender};
 use log::trace;
-use resource::ResourceAvailable;
+use resource::{ResourceArrayType, ResourceAvailable};
 use serde::Serialize;
 use servo_rand::RngCore;
 
@@ -548,7 +548,12 @@ impl DevtoolsInstance {
             let worker_actor = actors.find::<WorkerActor>(worker_actor_name);
 
             for stream in self.connections.values_mut() {
-                worker_actor.resource_available(&source, "source".into(), stream);
+                worker_actor.resource_array(
+                    &source,
+                    "source".into(),
+                    ResourceArrayType::Available,
+                    stream,
+                );
             }
         } else {
             let Some(browsing_context_id) = self.pipelines.get(&pipeline_id) else {
@@ -582,7 +587,12 @@ impl DevtoolsInstance {
             let browsing_context = actors.find::<BrowsingContextActor>(actor_name);
 
             for stream in self.connections.values_mut() {
-                browsing_context.resource_available(&source, "source".into(), stream);
+                browsing_context.resource_array(
+                    &source,
+                    "source".into(),
+                    ResourceArrayType::Available,
+                    stream,
+                );
             }
         }
     }

--- a/components/devtools/network_handler.rs
+++ b/components/devtools/network_handler.rs
@@ -11,29 +11,19 @@ use serde::Serialize;
 use crate::actor::ActorRegistry;
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::network_event::NetworkEventActor;
-use crate::resource::ResourceAvailable;
-
-#[derive(Clone, Serialize)]
-struct ResourcesUpdatedArray {
-    updates: Vec<UpdateEntry>,
-}
-
-#[derive(Clone, Serialize)]
-struct UpdateEntry {
-    #[serde(rename = "updateType")]
-    update_type: String,
-    data: serde_json::Value,
-}
+use crate::resource::{ResourceArrayType, ResourceAvailable};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct EventTimingsUpdateMsg {
     total_time: u64,
+    event_timings_available: bool,
 }
 
 #[derive(Serialize)]
 struct SecurityInfoUpdateMsg {
-    state: String,
+    security_state: String,
+    security_info_available: bool,
 }
 #[derive(Clone, Serialize)]
 pub struct Cause {
@@ -63,9 +53,10 @@ pub(crate) fn handle_network_event(
             let browsing_context_actor =
                 actors.find::<BrowsingContextActor>(&browsing_context_actor_name);
             for stream in &mut connections {
-                browsing_context_actor.resource_available(
+                browsing_context_actor.resource_array(
                     event_actor.clone(),
                     "network-event".to_string(),
+                    ResourceArrayType::Available,
                     stream,
                 );
             }
@@ -76,56 +67,16 @@ pub(crate) fn handle_network_event(
                 let actor = actors.find_mut::<NetworkEventActor>(&netevent_actor_name);
                 // Store the response information in the actor
                 actor.add_response(httpresponse);
-                ResourcesUpdatedArray {
-                    updates: vec![
-                        UpdateEntry {
-                            update_type: "requestHeaders".to_owned(),
-                            data: serde_json::to_value(actor.request_headers()).unwrap(),
-                        },
-                        UpdateEntry {
-                            update_type: "requestCookies".to_owned(),
-                            data: serde_json::to_value(actor.request_cookies()).unwrap(),
-                        },
-                        UpdateEntry {
-                            update_type: "responseStart".to_owned(),
-                            data: serde_json::to_value(actor.response_start()).unwrap(),
-                        },
-                        UpdateEntry {
-                            update_type: "eventTimings".to_owned(),
-                            data: serde_json::to_value(EventTimingsUpdateMsg {
-                                total_time: actor.total_time().as_millis() as u64,
-                            })
-                            .unwrap(),
-                        },
-                        UpdateEntry {
-                            update_type: "securityInfo".to_owned(),
-                            data: serde_json::to_value(SecurityInfoUpdateMsg {
-                                state: "insecure".to_owned(),
-                            })
-                            .unwrap(),
-                        },
-                        UpdateEntry {
-                            update_type: "responseContent".to_owned(),
-                            data: serde_json::to_value(actor.response_content()).unwrap(),
-                        },
-                        UpdateEntry {
-                            update_type: "responseCookies".to_owned(),
-                            data: serde_json::to_value(actor.response_cookies()).unwrap(),
-                        },
-                        UpdateEntry {
-                            update_type: "responseHeaders".to_owned(),
-                            data: serde_json::to_value(actor.response_headers()).unwrap(),
-                        },
-                    ],
-                }
+                actor.resource_updates()
             };
 
             let browsing_context_actor =
                 actors.find::<BrowsingContextActor>(&browsing_context_actor_name);
             for stream in &mut connections {
-                browsing_context_actor.resource_available(
+                browsing_context_actor.resource_array(
                     resource.clone(),
-                    "resources-updated".to_string(),
+                    "network-event".to_string(),
+                    ResourceArrayType::Updated,
                     stream,
                 );
             }

--- a/components/devtools/network_handler.rs
+++ b/components/devtools/network_handler.rs
@@ -13,18 +13,6 @@ use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::network_event::NetworkEventActor;
 use crate::resource::{ResourceArrayType, ResourceAvailable};
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct EventTimingsUpdateMsg {
-    total_time: u64,
-    event_timings_available: bool,
-}
-
-#[derive(Serialize)]
-struct SecurityInfoUpdateMsg {
-    security_state: String,
-    security_info_available: bool,
-}
 #[derive(Clone, Serialize)]
 pub struct Cause {
     #[serde(rename = "type")]

--- a/components/devtools/resource.rs
+++ b/components/devtools/resource.rs
@@ -8,6 +8,11 @@ use serde::Serialize;
 
 use crate::protocol::JsonPacketStream;
 
+pub enum ResourceArrayType {
+    Available,
+    Updated,
+}
+
 #[derive(Serialize)]
 pub(crate) struct ResourceAvailableReply<T: Serialize> {
     pub from: String,
@@ -19,24 +24,29 @@ pub(crate) struct ResourceAvailableReply<T: Serialize> {
 pub(crate) trait ResourceAvailable {
     fn actor_name(&self) -> String;
 
-    fn resource_available<T: Serialize>(
+    fn resource_array<T: Serialize>(
         &self,
         resource: T,
         resource_type: String,
+        array_type: ResourceArrayType,
         stream: &mut TcpStream,
     ) {
-        self.resources_available(vec![resource], resource_type, stream);
+        self.resources_array(vec![resource], resource_type, array_type, stream);
     }
 
-    fn resources_available<T: Serialize>(
+    fn resources_array<T: Serialize>(
         &self,
         resources: Vec<T>,
         resource_type: String,
+        array_type: ResourceArrayType,
         stream: &mut TcpStream,
     ) {
         let msg = ResourceAvailableReply::<T> {
             from: self.actor_name(),
-            type_: "resources-available-array".into(),
+            type_: match array_type {
+                ResourceArrayType::Available => "resources-available-array".to_string(),
+                ResourceArrayType::Updated => "resources-updated-array".to_string(),
+            },
             array: vec![(resource_type, resources)],
         };
 


### PR DESCRIPTION
- Add `ResourceArrayType` with `Available` and `Updated` variants
- Rename `resources-available` and `resource-available` to `resources-array` ,`resource-array`
- Add `ResourceArrayType` as an argument to decide the type of resources
- Add `Option<ResponseContentMsg>`,`Option<ResponseStartMsg>`, `Option<ResponseCookiesMsg>`, `Option<ResponseHeadersMsg>`,`Option<RequestCookiesMsg>`, `Option<RequestHeadersMsg>`, `total_time`, `security_state` to `NetworkEventActor` struct , and serialize the data in each to `resource_updates` , flattening the nested arrays into a single JSON
- Refactor the following methods `request_headers`,`response_start` , `response_content`,`response_cookies`,`response_headers`, `request_cookies`,`total_time` to associated functions passing `HttpRequest` and `HttpResponse` as parameters . 

Testing: Ran servo with devtools flag to see the logs corresponding to the changes
Fixes: https://github.com/servo/servo/issues/37479
