### PR TITLE
[#26488] Makes RTCPeerConnection weak referenceable thorugh Binding.conf

### DIFF
--- a/components/script/dom/rtcpeerconnection.rs
+++ b/components/script/dom/rtcpeerconnection.rs
@@ -8,7 +8,6 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
-use script_bindings::weakref::WeakReferenceable;
 use servo_media::ServoMedia;
 use servo_media::streams::MediaStreamType;
 use servo_media::streams::registry::MediaStreamId;
@@ -790,8 +789,6 @@ impl RTCPeerConnectionMethods<crate::DomTypeHolder> for RTCPeerConnection {
         RTCRtpTransceiver::new(&self.global(), init.direction, CanGc::note())
     }
 }
-
-impl WeakReferenceable for RTCPeerConnection {}
 
 impl Convert<RTCSessionDescriptionInit> for SessionDescription {
     fn convert(self) -> RTCSessionDescriptionInit {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -559,13 +559,10 @@ DOMInterfaces = {
     'canGc': ['Error', 'Redirect', 'Clone', 'CreateFromJson', 'Text', 'Blob', 'FormData', 'Json', 'ArrayBuffer', 'Headers', 'Bytes'],
 },
 
-'RTCDataChannel': {
-    'weakReferenceable': True, 
-},
-
 'RTCPeerConnection': {
     'inRealms': ['AddIceCandidate', 'CreateAnswer', 'CreateOffer', 'SetLocalDescription', 'SetRemoteDescription'],
     'canGc': ['Close', 'AddIceCandidate', 'CreateAnswer', 'CreateOffer', 'SetLocalDescription', 'SetRemoteDescription'],
+    'weakReferenceable': True,
 },
 
 'RTCRtpSender': {


### PR DESCRIPTION
This PR fixes some mistakes introduced in https://github.com/servo/servo/pull/37332. Where Binding.conf and WeakReferenceable trait were used badly

Testing: No test introduces
Fixes: It fixes mistake introduced in the incrementally implementation of #26488 
