### PR TITLE
Layout: Add Debug Print for The Scroll Tree

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -110,6 +110,9 @@ pub struct DebugOptions {
     /// Print the stacking context tree after each layout.
     pub dump_stacking_context_tree: bool,
 
+    /// Print the scroll tree after each layout.
+    pub dump_scroll_tree: bool,
+
     /// Print the display list after each layout.
     pub dump_display_list: bool,
 
@@ -156,6 +159,7 @@ impl DebugOptions {
                 "dump-flow-tree" => self.dump_flow_tree = true,
                 "dump-rule-tree" => self.dump_rule_tree = true,
                 "dump-style-tree" => self.dump_style_tree = true,
+                "dump-scroll-tree" => self.dump_scroll_tree = true,
                 "gc-profile" => self.gc_profile = true,
                 "profile-script-events" => self.profile_script_events = true,
                 "relayout-event" => self.relayout_event = true,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -691,6 +691,20 @@ impl LayoutThread {
             self.set_scroll_offset_from_script(external_scroll_id, offset);
         }
 
+        if self.debug.dump_scroll_tree {
+            // Print the [ScrollTree], this is done after display list build so we have
+            // the information about webrender id. Whether a scroll tree is initialized
+            // or not depends on the reflow goal.
+            if let Some(tree) = self.stacking_context_tree.borrow().as_ref() {
+                tree.compositor_info.scroll_tree.debug_print();
+            } else {
+                println!(
+                    "Scroll Tree -- reflow {:?}: scroll tree is not initialized yet.",
+                    reflow_request.reflow_goal
+                );
+            }
+        }
+
         let pending_images = std::mem::take(&mut *layout_context.pending_images.lock());
         let pending_rasterization_images =
             std::mem::take(&mut *layout_context.pending_rasterization_images.lock());


### PR DESCRIPTION
Add debug option `dump-scroll-tree` to print the scroll tree that had been stored after each reflow, or log that the scoll tree is not initialized yet..

To reduce the coupling, the debug print operation will process the scroll tree node list that have been constructed in the stacking context tree. It will generate a adjacency list and do preorder traversal. The order of the tree then will depends on the order of the node in the node list that has been constructed. Which, in turn, correspond to the declaration order of the nodes.

This would help with the analysis and development of post composite queries and its caching.

cc: @xiaochengh 