### PR TITLE
Hot fix panic in webdriver

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1086,6 +1086,9 @@ impl Handler {
             session.browsing_context_id = BrowsingContextId::from(webview_id);
 
             let msg = EmbedderToConstellationMessage::FocusWebView(webview_id);
+            // Wait for the webview to be focused.
+            // TODO: We will implement the proper synchronization after moving webdriver to embedder.
+            thread::sleep(Duration::from_millis(250));
             self.constellation_chan.send(msg).unwrap();
             Ok(WebDriverResponse::Void)
         } else {


### PR DESCRIPTION
Webdriver send `FocusWebview` command without waiting for the result.
If a `CloseWindow` command comes next, it may close the webview before `FocusWebview` is handled, causes a panic when setting focused webview.

Note: The proper fix requires webdriver can communicate with embedder, so should be done after https://github.com/servo/servo/pull/36714
This fix helps us continue to use webdriver CI. Because both `FocusWebview` and  `CloseWindow` are used in all tests of Webdriver, this panic affect all tests.

Testing: `./tests/wpt/tests/webdriver/tests/classic/new_window/new_tab.py`
Fixes: https://github.com/servo/servo/issues/37520

cc: @xiaochengh @yezhizhen 