### PR TITLE
Devtools: refactor source actor state

### DIFF
--- a/components/devtools/actors/thread.rs
+++ b/components/devtools/actors/thread.rs
@@ -7,7 +7,7 @@ use std::net::TcpStream;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use super::source::{SourceData, SourceManager, SourcesReply};
+use super::source::{SourceManager, SourcesReply};
 use crate::actor::{Actor, ActorMessageStatus, ActorRegistry};
 use crate::protocol::JsonPacketStream;
 use crate::{EmptyReplyMsg, StreamId};
@@ -124,17 +124,9 @@ impl Actor for ThreadActor {
             // Client has attached to the thread and wants to load script sources.
             // <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#loading-script-sources>
             "sources" => {
-                let sources: Vec<SourceData> = self
-                    .source_manager
-                    .source_urls
-                    .borrow()
-                    .iter()
-                    .cloned()
-                    .collect();
-
                 let msg = SourcesReply {
                     from: self.name(),
-                    sources,
+                    sources: self.source_manager.source_forms(registry),
                 };
                 let _ = stream.write_json_packet(&msg);
                 ActorMessageStatus::Processed

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -297,9 +297,8 @@ impl Actor for WatcherActor {
                         },
                         "source" => {
                             let thread_actor = registry.find::<ThreadActor>(&target.thread);
-                            let sources = thread_actor.source_manager.sources();
                             target.resources_available(
-                                sources.iter().collect(),
+                                thread_actor.source_manager.source_forms(registry),
                                 "source".into(),
                                 stream,
                             );
@@ -307,10 +306,9 @@ impl Actor for WatcherActor {
                             for worker_name in &root.workers {
                                 let worker = registry.find::<WorkerActor>(worker_name);
                                 let thread = registry.find::<ThreadActor>(&worker.thread);
-                                let worker_sources = thread.source_manager.sources();
 
                                 worker.resources_available(
-                                    worker_sources.iter().collect(),
+                                    thread.source_manager.source_forms(registry),
                                     "source".into(),
                                     stream,
                                 );


### PR DESCRIPTION
We currently store the source contents in both the SourceActor and the ThreadActor’s SourceManager, which is redundant. We also currently send the source contents in thread `sources` responses and watcher `resources-available-array` messages, but in both cases this is unnecessary (and ignored by the client).

This patch merges SourceData into SourceActor, making the latter the single source of truth for source-related state. We also create a SourceForm type, which represents the subset of source-related state that gets sent in thread `sources` responses (and for now, watcher `resources-available-array` messages).

Finally we rename `source_urls` → `source_actor_names` and `new_source` → `new_registered` for clarity.

Testing: no changes to client-facing behaviour, and this is covered by tests