### PR TITLE
script::webdriver_handler: Fully implement `get_known_element`

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1439,14 +1439,11 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     fn WebdriverElement(&self, id: DOMString) -> Option<DomRoot<Element>> {
-        find_node_by_unique_id_in_document(&self.Document(), id.into())
-            .ok()
-            .and_then(Root::downcast)
+        find_node_by_unique_id_in_document(&self.Document(), id.into()).and_then(Root::downcast)
     }
 
     fn WebdriverFrame(&self, id: DOMString) -> Option<DomRoot<Element>> {
         find_node_by_unique_id_in_document(&self.Document(), id.into())
-            .ok()
             .and_then(Root::downcast::<HTMLIFrameElement>)
             .map(Root::upcast::<Element>)
     }
@@ -1457,9 +1454,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     fn WebdriverShadowRoot(&self, id: DOMString) -> Option<DomRoot<ShadowRoot>> {
-        find_node_by_unique_id_in_document(&self.Document(), id.into())
-            .ok()
-            .and_then(Root::downcast)
+        find_node_by_unique_id_in_document(&self.Document(), id.into()).and_then(Root::downcast)
     }
 
     // https://drafts.csswg.org/cssom/#dom-window-getcomputedstyle


### PR DESCRIPTION
1. `get_known_element`: Refactor to follow same step of spec (which reduces unnecessary search) and implement previously missing step 4.2: If node is stale return error with error code stale element reference. An element is stale if its node document is not the active document or if it is not connected.

2. Refactor `find_node_by_unique_id_in_document` to make it not check error and really return a `Option<DomRoot<Node>>` as the name suggests. This will greatly reduce duplication when implement [get a known shadow root](https://w3c.github.io/webdriver/#dfn-get-a-known-shadow-root) soon

Testing: All WebDriver Conformance test after removing two problematic commits in #37520 
