### PR TITLE
layout: Do not add empty border images to the display list

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1509,6 +1509,13 @@ impl<'a> BuilderForBoxFragment<'a> {
         };
 
         let size = euclid::Size2D::new(width as i32, height as i32);
+
+        // If the size of the border is zero or the size of the border image is zero, just
+        // don't render anything. Zero-sized gradients cause problems in WebRender.
+        if size.is_empty() || border_image_size.is_empty() {
+            return true;
+        }
+
         let details = BorderDetails::NinePatch(NinePatchBorder {
             source,
             width: size.width,

--- a/tests/wpt/tests/css/css-borders/border-image-gradient-zero-size-transform-crash.html
+++ b/tests/wpt/tests/css/css-borders/border-image-gradient-zero-size-transform-crash.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+  #container {
+      border-style: dotted hidden;
+      border-image: repeating-linear-gradient(to left top, blue, red);
+      width: 0;
+      transition: all 0.5s;
+  }
+</style>
+
+<div id="container"></div>
+
+<script>
+    addEventListener("load", () => {
+        container.style.padding = "1px";
+    });
+</script>
+</body>


### PR DESCRIPTION
Zero-sized gradient border images cause WebRender to panic, so simply
don't add them to the display list.

Testing: This change adds a WPT crash test.
Fixes: #37432
