### PR TITLE
WPT: Handle flake detection in `ServoHandler`

### DIFF
--- a/python/wpt/grouping_formatter.py
+++ b/python/wpt/grouping_formatter.py
@@ -159,7 +159,7 @@ class ServoHandler(mozlog.reader.LogHandler):
         return any(not unexpected.flaky for unexpected in self.unexpected_results)
 
     def suite_start(self, data):
-        if self.flakes_detection:
+        if self.detect_flakes:
             self.reset_statistics()
         else:
             self.reset_state()

--- a/python/wpt/grouping_formatter.py
+++ b/python/wpt/grouping_formatter.py
@@ -112,12 +112,12 @@ class ServoHandler(mozlog.reader.LogHandler):
     """LogHandler designed to collect unexpected results for use by
     script or by the ServoFormatter output formatter."""
 
-    def __init__(self, flakes_detection=False):
+    def __init__(self, detect_flakes=False):
         """
         Flake detection assumes first suite is actual run
         and rest of the suites are retry-unexpected for flakes detection.
         """
-        self.flakes_detection = flakes_detection
+        self.detect_flakes = detect_flakes
         self.reset_state()
 
     def reset_state(self):

--- a/python/wpt/grouping_formatter.py
+++ b/python/wpt/grouping_formatter.py
@@ -121,7 +121,7 @@ class ServoHandler(mozlog.reader.LogHandler):
         self.reset_state()
 
     def reset_state(self):
-        self.reset_stats()
+        self.reset_statistics()
         self.suite_count = 0
         self.test_output = collections.defaultdict(str)
         self.subtest_failures = collections.defaultdict(list)
@@ -149,7 +149,7 @@ class ServoHandler(mozlog.reader.LogHandler):
             "PRECONDITION_FAILED": [],
         }
 
-    def reset_stats(self):
+    def reset_statistics(self):
         self.number_of_tests = 0
         self.completed_tests = 0
         self.need_to_erase_last_line = False
@@ -160,7 +160,7 @@ class ServoHandler(mozlog.reader.LogHandler):
 
     def suite_start(self, data):
         if self.flakes_detection:
-            self.reset_stats()
+            self.reset_statistics()
         else:
             self.reset_state()
         self.suite_count += 1

--- a/python/wpt/grouping_formatter.py
+++ b/python/wpt/grouping_formatter.py
@@ -112,7 +112,12 @@ class ServoHandler(mozlog.reader.LogHandler):
     """LogHandler designed to collect unexpected results for use by
     script or by the ServoFormatter output formatter."""
 
-    def __init__(self):
+    def __init__(self, flakes_detection=False):
+        """
+        Flake detection assumes first suite is actual run
+        and rest of the suites are retry-unexpected for flakes detection.
+        """
+        self.flakes_detection = flakes_detection
         self.reset_state()
 
     def reset_state(self):
@@ -154,7 +159,10 @@ class ServoHandler(mozlog.reader.LogHandler):
         return any(not unexpected.flaky for unexpected in self.unexpected_results)
 
     def suite_start(self, data):
-        self.reset_stats()
+        if self.flakes_detection:
+            self.reset_stats()
+        else:
+            self.reset_state()
         self.suite_count += 1
         self.number_of_tests = sum(len(tests) for tests in itervalues(data["tests"]))
         self.suite_start_time = data["time"]

--- a/python/wpt/grouping_formatter.py
+++ b/python/wpt/grouping_formatter.py
@@ -118,6 +118,7 @@ class ServoHandler(mozlog.reader.LogHandler):
         and rest of the suites are retry-unexpected for flakes detection.
         """
         self.detect_flakes = detect_flakes
+        self.currently_detecting_flakes = False
         self.reset_state()
 
     def reset_state(self):
@@ -163,6 +164,7 @@ class ServoHandler(mozlog.reader.LogHandler):
         # TODO: Support running more than a single suite at once.
         if self.unexpected_results:
             self.currently_detecting_flakes = True
+        self.reset_state()
 
         self.number_of_tests = sum(len(tests) for tests in itervalues(data["tests"]))
         self.suite_start_time = data["time"]

--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -114,7 +114,7 @@ def run_tests(default_binary_path: str, **kwargs):
     else:
         logger = wptrunner.setup_logging(kwargs, {"servo": sys.stdout})
 
-    handler = ServoHandler()
+    handler = ServoHandler(flakes_detection=kwargs["retry_unexpected"] >= 1)
     logger.add_handler(handler)
 
     wptrunner.run_tests(**kwargs)

--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -114,7 +114,7 @@ def run_tests(default_binary_path: str, **kwargs):
     else:
         logger = wptrunner.setup_logging(kwargs, {"servo": sys.stdout})
 
-    handler = ServoHandler(flakes_detection=kwargs["retry_unexpected"] >= 1)
+    handler = ServoHandler(detect_flakes=kwargs["retry_unexpected"] >= 1)
     logger.add_handler(handler)
 
     wptrunner.run_tests(**kwargs)


### PR DESCRIPTION
With this PR ServoHandler will store state of first suite and deal with subsequent suites as they were run from `--retry-unexpected`, so it will use results to mark unexpected from first run as flaky. Stats that are used to display current running tests are still reset per suite. This allows us to use `--retry-unexpected=1` for flake detection instead of manual rerunning, which will help with proper subsuites support.

Testing: Manual CI run to ensure end results are still the same: https://github.com/sagudev/servo/actions/runs/15886712204
Fixes: #37319 