### PR TITLE
Fix network event update Message

### DIFF
--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -30,7 +30,7 @@ use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::object::ObjectActor;
 use crate::actors::worker::WorkerActor;
 use crate::protocol::JsonPacketStream;
-use crate::resource::ResourceAvailable;
+use crate::resource::{ResourceArrayType, ResourceAvailable};
 use crate::{StreamId, UniqueId};
 
 trait EncodableConsoleMessage {
@@ -261,13 +261,12 @@ impl ConsoleActor {
             .push(CachedConsoleMessage::PageError(page_error.clone()));
         if id == self.current_unique_id(registry) {
             if let Root::BrowsingContext(bc) = &self.root {
-                registry
-                    .find::<BrowsingContextActor>(bc)
-                    .resource_available(
-                        PageErrorWrapper { page_error },
-                        "error-message".into(),
-                        stream,
-                    )
+                registry.find::<BrowsingContextActor>(bc).resource_array(
+                    PageErrorWrapper { page_error },
+                    "error-message".into(),
+                    ResourceArrayType::Available,
+                    stream,
+                )
             };
         }
     }
@@ -287,9 +286,12 @@ impl ConsoleActor {
             .push(CachedConsoleMessage::ConsoleLog(log_message.clone()));
         if id == self.current_unique_id(registry) {
             if let Root::BrowsingContext(bc) = &self.root {
-                registry
-                    .find::<BrowsingContextActor>(bc)
-                    .resource_available(log_message, "console-message".into(), stream)
+                registry.find::<BrowsingContextActor>(bc).resource_array(
+                    log_message,
+                    "console-message".into(),
+                    ResourceArrayType::Available,
+                    stream,
+                )
             };
         }
     }

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -22,7 +22,7 @@ use crate::network_handler::Cause;
 use crate::protocol::JsonPacketStream;
 
 #[derive(Clone)]
-struct HttpRequest {
+pub struct HttpRequest {
     url: String,
     method: Method,
     headers: HeaderMap,
@@ -34,7 +34,7 @@ struct HttpRequest {
 }
 
 #[derive(Clone)]
-struct HttpResponse {
+pub struct HttpResponse {
     headers: Option<HeaderMap>,
     status: HttpStatus,
     body: Option<Vec<u8>>,
@@ -177,7 +177,7 @@ struct GetResponseCookiesReply {
 }
 
 #[derive(Serialize)]
-struct Timings {
+pub struct Timings {
     blocked: u32,
     dns: u32,
     connect: u64,

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -32,7 +32,7 @@ use crate::actors::watcher::thread_configuration::{
     ThreadConfigurationActor, ThreadConfigurationActorMsg,
 };
 use crate::protocol::JsonPacketStream;
-use crate::resource::ResourceAvailable;
+use crate::resource::{ResourceArrayType, ResourceAvailable};
 use crate::{EmptyReplyMsg, StreamId, WorkerActor};
 
 pub mod network_parent;
@@ -292,14 +292,20 @@ impl Actor for WatcherActor {
                                     title: Some(target.title.borrow().clone()),
                                     url: Some(target.url.borrow().clone()),
                                 };
-                                target.resource_available(event, "document-event".into(), stream);
+                                target.resource_array(
+                                    event,
+                                    "document-event".into(),
+                                    ResourceArrayType::Available,
+                                    stream,
+                                );
                             }
                         },
                         "source" => {
                             let thread_actor = registry.find::<ThreadActor>(&target.thread);
-                            target.resources_available(
+                            target.resources_array(
                                 thread_actor.source_manager.source_forms(registry),
                                 "source".into(),
+                                ResourceArrayType::Available,
                                 stream,
                             );
 
@@ -307,9 +313,10 @@ impl Actor for WatcherActor {
                                 let worker = registry.find::<WorkerActor>(worker_name);
                                 let thread = registry.find::<ThreadActor>(&worker.thread);
 
-                                worker.resources_available(
+                                worker.resources_array(
                                     thread.source_manager.source_forms(registry),
                                     "source".into(),
+                                    ResourceArrayType::Available,
                                     stream,
                                 );
                             }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -29,7 +29,7 @@ use devtools_traits::{
 use embedder_traits::{AllowOrDeny, EmbedderMsg, EmbedderProxy};
 use ipc_channel::ipc::{self, IpcSender};
 use log::trace;
-use resource::ResourceAvailable;
+use resource::{ResourceArrayType, ResourceAvailable};
 use serde::Serialize;
 use servo_rand::RngCore;
 
@@ -540,7 +540,12 @@ impl DevtoolsInstance {
             let worker_actor = actors.find::<WorkerActor>(worker_actor_name);
 
             for stream in self.connections.values_mut() {
-                worker_actor.resource_available(&source_form, "source".into(), stream);
+                worker_actor.resource_array(
+                    &source_form,
+                    "source".into(),
+                    ResourceArrayType::Available,
+                    stream,
+                );
             }
         } else {
             let Some(browsing_context_id) = self.pipelines.get(&pipeline_id) else {
@@ -563,7 +568,12 @@ impl DevtoolsInstance {
             let browsing_context = actors.find::<BrowsingContextActor>(actor_name);
 
             for stream in self.connections.values_mut() {
-                browsing_context.resource_available(&source_form, "source".into(), stream);
+                browsing_context.resource_array(
+                    &source_form,
+                    "source".into(),
+                    ResourceArrayType::Available,
+                    stream,
+                );
             }
         }
     }

--- a/components/devtools/resource.rs
+++ b/components/devtools/resource.rs
@@ -8,6 +8,11 @@ use serde::Serialize;
 
 use crate::protocol::JsonPacketStream;
 
+pub enum ResourceArrayType {
+    Available,
+    Updated,
+}
+
 #[derive(Serialize)]
 pub(crate) struct ResourceAvailableReply<T: Serialize> {
     pub from: String,
@@ -19,24 +24,29 @@ pub(crate) struct ResourceAvailableReply<T: Serialize> {
 pub(crate) trait ResourceAvailable {
     fn actor_name(&self) -> String;
 
-    fn resource_available<T: Serialize>(
+    fn resource_array<T: Serialize>(
         &self,
         resource: T,
         resource_type: String,
+        array_type: ResourceArrayType,
         stream: &mut TcpStream,
     ) {
-        self.resources_available(vec![resource], resource_type, stream);
+        self.resources_array(vec![resource], resource_type, array_type, stream);
     }
 
-    fn resources_available<T: Serialize>(
+    fn resources_array<T: Serialize>(
         &self,
         resources: Vec<T>,
         resource_type: String,
+        array_type: ResourceArrayType,
         stream: &mut TcpStream,
     ) {
         let msg = ResourceAvailableReply::<T> {
             from: self.actor_name(),
-            type_: "resources-available-array".into(),
+            type_: match array_type {
+                ResourceArrayType::Available => "resources-available-array".to_string(),
+                ResourceArrayType::Updated => "resources-updated-array".to_string(),
+            },
             array: vec![(resource_type, resources)],
         };
 


### PR DESCRIPTION

- Add `ResourceArrayType` with `Available` and `Updated` variants
- Rename `resources-available` and `resource-available` to `resources-array` ,`resource-array`
- Add `ResourceArrayType` as an argument to decide the type of resources
- Add `Option<ResponseContentMsg>`,`Option<ResponseStartMsg>`, `Option<ResponseCookiesMsg>`, `Option<ResponseHeadersMsg>`,`Option<RequestCookiesMsg>`, `Option<RequestHeadersMsg>`, `total_time`, `security_state` to `NetworkEventActor` struct , and serialize the data in each to `resource_updates` , flattening the nested arrays into a single JSON
- Refactor the following methods `request_headers`,`response_start` , `response_content`,`response_cookies`,`response_headers`, `request_cookies`,`total_time` to associated functions passing `HttpRequest` and `HttpResponse` as parameters . 

Testing: Ran servo with devtools flag to see the logs corresponding to the changes
Fixes: https://github.com/servo/servo/issues/37479

This PR Builds on https://github.com/servo/servo/pull/37517 and was opened due to merge conflicts and branch issues
