### PR TITLE
script Exclude `CDATASection` nodes from `Node::normalize()`

### DIFF
--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1260,7 +1260,7 @@ impl WeakRangeVec {
             .extend(ranges.drain(..));
     }
 
-    /// Used for steps 7.1-2. when normalizing a node.
+    /// Used for steps 6.1-2. when normalizing a node.
     /// <https://dom.spec.whatwg.org/#dom-node-normalize>
     pub(crate) fn drain_to_preceding_text_sibling(&self, node: &Node, sibling: &Node, length: u32) {
         if self.is_empty() {
@@ -1287,7 +1287,7 @@ impl WeakRangeVec {
         sibling.ranges().cell.borrow_mut().extend(ranges.drain(..));
     }
 
-    /// Used for steps 7.3-4. when normalizing a node.
+    /// Used for steps 6.3-4. when normalizing a node.
     /// <https://dom.spec.whatwg.org/#dom-node-normalize>
     pub(crate) fn move_to_text_child_at(
         &self,

--- a/tests/wpt/meta/dom/nodes/Node-normalize.html.ini
+++ b/tests/wpt/meta/dom/nodes/Node-normalize.html.ini
@@ -1,3 +1,0 @@
-[Node-normalize.html]
-  [Non-text nodes with empty textContent values.]
-    expected: FAIL


### PR DESCRIPTION
Exclude CDATASection nodes from Node::normalize. I made it under the assumption that CDATAs can't have children so we don't need to go into the `else node.Normalize()` branch on line 3485 with them, hope this is correct.

Testing: covered by `dom/nodes/Node-normalize.html`
Fixes: https://github.com/servo/servo/issues/37006
