### PR TITLE
canvas: Don't do operations on paths with uninvertible transforms

### DIFF
--- a/tests/wpt/tests/html/canvas/element/manual/drawing-paths-to-the-canvas/fill-path-with-uninvertible-transform-crash.html
+++ b/tests/wpt/tests/html/canvas/element/manual/drawing-paths-to-the-canvas/fill-path-with-uninvertible-transform-crash.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<script>
+  let context = document.createElement("canvas").getContext("2d");
+  context.moveTo(0, 0);
+  context.setTransform(4, 2, 6, 3, 0, 0); // non-invertible (4 * 3 - 6 * 2 = 0)
+  context.fill("nonzero");
+</script>


### PR DESCRIPTION
When the path is created with an uninvertible transform, don't do any
path-based operations. Now `ensure_path()` returns a `Path` object and
this change adds early returns which prevent trying to use it.

Testing: This change adds a WPT crash test.
Fixes #36995.
