### PR TITLE
Draft: CI: Fast MSRV linting using prebuilt docker image

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,0 +1,95 @@
+# Dockerfile to build servo in CI with the Rust MSRV
+# We use multi-stage builds to reduce the size of the final image and
+# allow parallel building of independant layers
+
+FROM ubuntu:22.04 AS base_fetcher
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+    ca-certificates unzip curl git jq \
+    && apt-get clean
+
+
+FROM base_fetcher AS base_with_cc
+# We need a c-compiler to `cargo install` some of our dependencies
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+    build-essential ccache clang cmake python3 \
+    && apt-get clean
+
+FROM base_with_cc AS base
+# Install the remaining dependencies in a new stage, so that `cargo install` can run in parallel
+# For our MSRV CI builds we need less dependencies, and smaller images mean faster builds.
+# If servo fails to build, check ./mach bootstrap and investigate which additional dependency needs to be
+# installed. The smaller the subset we install here, the smaller the resulting image -> faster image pulls
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends \
+        libdbus-1-dev libfreetype6-dev libgl1-mesa-dri libgles2-mesa-dev \
+        libglib2.0-dev  libges-1.0-dev \
+        libharfbuzz-dev liblzma-dev libudev-dev libunwind-dev \
+        libvulkan1 libx11-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxmu-dev \
+        libxmu6 libegl1-mesa-dev llvm-dev m4 xorg-dev libxkbcommon0 libxkbcommon-x11-0 \
+        xvfb sudo
+
+RUN mkdir -p /data/servo/servo
+
+##### FETCH SERVO ####################################################################
+FROM base_fetcher AS servo_fetcher
+
+
+RUN mkdir -p /data/servo/servo
+
+RUN cd /data/servo && git clone https://github.com/servo/servo.git
+WORKDIR /data/servo/servo
+# Incrementally update checked out version
+ARG SERVO_COMMIT_HASH
+RUN git fetch origin main && git checkout "${SERVO_COMMIT_HASH}"
+
+##### END FETCH SERVO #################################################################
+
+
+FROM base_with_cc AS rust_toolchain
+# Should match the Rust MSRV!
+ARG RUST_VERSION=1.85.0
+ENV CARGO_HOME=/data/.cargo
+ENV RUSTUP_HOME=/data/.rustup
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain ${RUST_VERSION} \
+        --profile=default
+
+
+FROM base_fetcher AS uv
+
+ARG UV_VERSION=0.8.5
+RUN mkdir -p "$HOME/.local/bin" \
+    && curl --proto '=https' --tlsv1.2  --fail \
+        -LsSf https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-installer.sh | sh
+
+FROM base AS servo_base
+COPY --from=rust_toolchain /data/.cargo /data/.cargo
+COPY --from=rust_toolchain /data/.rustup /data/.rustup
+ENV CARGO_HOME=/data/.cargo
+ENV RUSTUP_HOME=/data/.rustup
+ENV PATH="/data/.cargo/bin:${PATH}"
+COPY --from=uv /root/.local/bin/uv /root/.local/bin/uvx /data/.cargo/bin/
+
+##### Pre-run cargo check ####################################################################
+FROM servo_base AS servo_check_cook
+
+COPY --from=servo_fetcher /data/servo/servo /data/servo/servo
+WORKDIR /data/servo/servo
+ARG RUST_VERSION=1.85.0
+RUN cargo +${RUST_VERSION} fetch --target x86_64-unknown-linux-gnu
+# Run cargo check twice, so we can use incremental cargo check in CI.
+# Note: twice is necessary to avoid rebuilding due to generated files
+RUN mkdir -p /data/servo/target \
+    && cargo +${RUST_VERSION} check --locked -p libservo --target-dir /data/servo/target \
+    && cargo +${RUST_VERSION} check --locked -p libservo --target-dir /data/servo/target
+
+
+#FROM servo_base AS final
+## Add the target directory to the image, so we can do incremental checks in CI.
+## Trade-off image size (longer image download) for faster / incremental cargo check in CI
+#COPY --from=servo_check_cook /data/servo/target /data/servo/target

--- a/.github/docker/build.sh
+++ b/.github/docker/build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null || exit 1
+
+#docker build \
+# --label "org.opencontainers.image.source=https://github.com/servo/servo" \
+# --label "org.opencontainers.image.description=Docker image for servo CI" \
+# --target servo_cooked_dev-crown-default_features \
+# --tag ghcr.io/jschwe/servo_ci_testing_dev-crown-default_features:latest \
+# .
+
+# update servo if the repo changed
+SERVO_COMMIT_HASH=$(git rev-parse main)
+
+docker build \
+ --platform linux/amd64 \
+ --label "org.opencontainers.image.source=https://github.com/servo/servo" \
+ --label "org.opencontainers.image.description=Docker image for servo CI" \
+ --build-arg "SERVO_COMMIT_HASH=${SERVO_COMMIT_HASH}" \
+ --tag ghcr.io/jschwe/servo_msrv_ci:latest \
+ --tag ghcr.io/jschwe/servo_msrv_ci:0.1 \
+ .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,3 +48,52 @@ jobs:
           ./mach clippy --use-crown --locked --github-annotations -- -- --deny warnings
       - name: Tidy
         run: ./mach test-tidy --no-progress --all --github-annotations
+
+  msrv_check:
+    name: Minimum supported Rust version check
+    runs-on: ubuntu-22.04
+    container:
+      image: 'ghcr.io/jschwe/servo_msrv_ci:latest'
+      env:
+        # This version should be kept in sync with the `rust-version` in our
+        # workspace Cargo.toml. Changes should be discussed on zulip.
+        MINIMUM_SUPPORTED_RUST_VERSION: "1.85.0"
+        CARGO_HOME: "/data/.cargo"
+        CARGO_INCREMENTAL: 1
+    env:
+      # This version should be kept in sync with the `rust-version` in our
+      # workspace Cargo.toml. Changes should be discussed on zulip.
+      MINIMUM_SUPPORTED_RUST_VERSION: "1.85.0"
+      CARGO_HOME: "/data/.cargo"
+      CARGO_INCREMENTAL: 1
+    steps:
+      # Set the remote-url when run in a fork.
+      - if: ${{ github.repository != 'servo/servo' && github.event_name != 'pull_request_target' }}
+        run: git remote set-url origin ${{ github.server_url}}/${{ github.repository }}
+        working-directory: /data/servo/servo
+
+      - if: ${{ github.event_name != 'pull_request_target' }}
+        run: git fetch --depth=1 origin $GITHUB_SHA
+        working-directory: /data/servo/servo
+      - if: ${{ github.event_name == 'pull_request_target' }}
+        run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
+        working-directory: /data/servo/servo
+      - name: Show diff
+        run: git diff FETCH_HEAD
+        working-directory: /data/servo/servo
+      - run: |
+          git switch --detach FETCH_HEAD
+          git reset --hard FETCH_HEAD
+        working-directory: /data/servo/servo
+      # Prevent downloading of components specified in our rust-toolchain.toml
+      - run: rustup set profile minimal
+        working-directory: /data/servo/servo
+      - run: rustup toolchain list
+        working-directory: /data/servo/servo
+      - name: Compile libservo with MSRV
+        # /data/servo/target is part of the image, meaning we can do an incremental check here in CI
+        # if we re-use the image.
+        working-directory: /data/servo/servo
+        run: |
+          CARGO_LOG=cargo::core::compiler::fingerprint=info \
+            cargo +${{ env.MINIMUM_SUPPORTED_RUST_VERSION }} check -p libservo --locked --target-dir /data/servo/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,6 +221,11 @@ debug = true
 lto = "thin"
 codegen-units = 1
 
+# A custom profile for building libservo in CI, while minimizing target dir.
+[profile.ci_dev]
+inherits = "dev"
+debug = false
+
 [patch.crates-io]
 # If you need to temporarily test Servo with a local fork of some upstream
 # crate, add that here. Use the form:


### PR DESCRIPTION
Use a docker image with prebuilt target directory containing `cargo check` results to allow incremental checking in CI.
This allows much faster cargo check runs in CI.
Downloading a large prebaked image does take around 2 minutes, but the speed improvement for incremental check should offset that.

Todo: 

- [ ] (re-)build the image in CI automatically (on every commit for main or daily? Perhaps a combination with one daily build and another image which adds an incremental layer on every merged commit?)
- [ ] embedder_traits is always being rebuilt, even without any changes. Investigate the build-script, maybe we need to add a rerun-if-changed line?
- [ ] Perhaps clippy could also take advantage of this? 

Testing: this is a CI job.
