### PR TITLE
imagebitmap: Add support of Blob as ImageBitmapSource

### DIFF
--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.clear.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.clear.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.clear.html]
-  [Canvas test: 2d.composite.canvas.clear]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.copy.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.copy.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.copy.html]
-  [Canvas test: 2d.composite.canvas.copy]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.destination-atop.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.destination-atop.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.destination-atop.html]
-  [Canvas test: 2d.composite.canvas.destination-atop]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.destination-in.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.destination-in.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.destination-in.html]
-  [Canvas test: 2d.composite.canvas.destination-in]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.destination-out.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.destination-out.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.destination-out.html]
-  [Canvas test: 2d.composite.canvas.destination-out]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.destination-over.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.destination-over.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.destination-over.html]
-  [Canvas test: 2d.composite.canvas.destination-over]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.lighter.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.lighter.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.lighter.html]
-  [Canvas test: 2d.composite.canvas.lighter]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.source-atop.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.source-atop.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.source-atop.html]
-  [Canvas test: 2d.composite.canvas.source-atop]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.source-in.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.source-in.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.source-in.html]
-  [Canvas test: 2d.composite.canvas.source-in]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.source-out.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.source-out.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.source-out.html]
-  [Canvas test: 2d.composite.canvas.source-out]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.source-over.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.source-over.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.source-over.html]
-  [Canvas test: 2d.composite.canvas.source-over]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.xor.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.canvas.xor.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.xor.html]
-  [Canvas test: 2d.composite.canvas.xor]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.globalAlpha.image.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.globalAlpha.image.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.globalAlpha.image.html]
-  [Canvas test: 2d.composite.globalAlpha.image]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.globalAlpha.imagepattern.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.globalAlpha.imagepattern.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.globalAlpha.imagepattern.html]
-  [Canvas test: 2d.composite.globalAlpha.imagepattern]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.clear.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.clear.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.clear.html]
-  [Canvas test: 2d.composite.image.clear]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.copy.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.copy.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.copy.html]
-  [Canvas test: 2d.composite.image.copy]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.destination-atop.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.destination-atop.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.destination-atop.html]
-  [Canvas test: 2d.composite.image.destination-atop]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.destination-in.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.destination-in.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.destination-in.html]
-  [Canvas test: 2d.composite.image.destination-in]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.destination-out.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.destination-out.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.destination-out.html]
-  [Canvas test: 2d.composite.image.destination-out]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.destination-over.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.destination-over.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.destination-over.html]
-  [Canvas test: 2d.composite.image.destination-over]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.lighter.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.lighter.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.lighter.html]
-  [Canvas test: 2d.composite.image.lighter]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.source-atop.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.source-atop.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.source-atop.html]
-  [Canvas test: 2d.composite.image.source-atop]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.source-in.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.source-in.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.source-in.html]
-  [Canvas test: 2d.composite.image.source-in]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.source-out.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.source-out.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.source-out.html]
-  [Canvas test: 2d.composite.image.source-out]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.source-over.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.source-over.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.source-over.html]
-  [Canvas test: 2d.composite.image.source-over]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.xor.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.image.xor.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.xor.html]
-  [Canvas test: 2d.composite.image.xor]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.image.copy.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.image.copy.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.uncovered.image.copy.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.image.destination-atop.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.image.destination-atop.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.uncovered.image.destination-atop.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.image.destination-in.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.image.destination-in.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.uncovered.image.destination-in.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.image.source-in.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.image.source-in.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.uncovered.image.source-in.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.image.source-out.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.image.source-out.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.uncovered.image.source-out.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.pattern.copy.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.pattern.copy.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.uncovered.pattern.copy.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.pattern.destination-atop.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.pattern.destination-atop.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.uncovered.pattern.destination-atop.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.pattern.destination-in.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.pattern.destination-in.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.uncovered.pattern.destination-in.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.pattern.source-in.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.pattern.source-in.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.uncovered.pattern.source-in.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.pattern.source-out.html.ini
+++ b/tests/wpt/meta/html/canvas/element/compositing/2d.composite.uncovered.pattern.source-out.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.uncovered.pattern.source-out.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.3arg.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.3arg.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.3arg.html]
-  [Canvas test: 2d.drawImage.3arg]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.5arg.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.5arg.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.5arg.html]
-  [Canvas test: 2d.drawImage.5arg]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.9arg.basic.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.9arg.basic.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.9arg.basic.html]
-  [Canvas test: 2d.drawImage.9arg.basic]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.9arg.destpos.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.9arg.destpos.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.9arg.destpos.html]
-  [Canvas test: 2d.drawImage.9arg.destpos]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.9arg.destsize.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.9arg.destsize.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.9arg.destsize.html]
-  [Canvas test: 2d.drawImage.9arg.destsize]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.9arg.sourcepos.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.9arg.sourcepos.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.9arg.sourcepos.html]
-  [Canvas test: 2d.drawImage.9arg.sourcepos]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.9arg.sourcesize.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.9arg.sourcesize.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.9arg.sourcesize.html]
-  [Canvas test: 2d.drawImage.9arg.sourcesize]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.alpha.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.alpha.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.alpha.html]
-  [Canvas test: 2d.drawImage.alpha]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.clip.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.clip.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.clip.html]
-  [Canvas test: 2d.drawImage.clip]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.composite.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.composite.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.composite.html]
-  [Canvas test: 2d.drawImage.composite]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.floatsource.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.floatsource.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.floatsource.html]
-  [Canvas test: 2d.drawImage.floatsource]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.negativedest.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.negativedest.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.negativedest.html]
-  [Negative destination width/height represents the correct rectangle]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.negativedir.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.negativedir.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.negativedir.html]
-  [Negative dimensions do not affect the direction of the image]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.negativesource.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.negativesource.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.negativesource.html]
-  [Negative source width/height represents the correct rectangle]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.nonfinite.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.nonfinite.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.nonfinite.html]
-  [drawImage() with Infinity/NaN is ignored]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.nowrap.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.nowrap.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.nowrap.html]
-  [Stretched images do not get pixels wrapping around the edges]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.path.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.path.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.path.html]
-  [Canvas test: 2d.drawImage.path]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.transform.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.transform.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.transform.html]
-  [Canvas test: 2d.drawImage.transform]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.zerosource.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.zerosource.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.zerosource.html]
-  [drawImage with zero-sized source rectangle draws nothing without exception]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/drawing-images-to-the-canvas/image-orientation/drawImage-from-blob.tentative.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/drawing-images-to-the-canvas/image-orientation/drawImage-from-blob.tentative.html.ini
@@ -1,2 +1,2 @@
 [drawImage-from-blob.tentative.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/canvas-createImageBitmap-resize.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/canvas-createImageBitmap-resize.html.ini
@@ -1,6 +1,3 @@
 [canvas-createImageBitmap-resize.html]
-  [createImageBitmap from a Blob with resize option.]
-    expected: FAIL
-
   [createImageBitmap from a HTMLImageElement of svg with no specified size with resize option.]
     expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-blob-invalidtype.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-blob-invalidtype.html.ini
@@ -1,4 +1,0 @@
-[createImageBitmap-blob-invalidtype.html]
-  [createImageBitmap: blob with wrong mime type]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-colorSpaceConversion.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-colorSpaceConversion.html.ini
@@ -1,3 +1,0 @@
-[createImageBitmap-colorSpaceConversion.html]
-  [createImageBitmap from a Blob, and drawImage on the created ImageBitmap with colorSpaceConversion: none]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-drawImage.html.ini
@@ -38,9 +38,6 @@
   [createImageBitmap from a vector HTMLImageElement, and drawImage on the created ImageBitmap]
     expected: FAIL
 
-  [createImageBitmap from a Blob scaled down, and drawImage on the created ImageBitmap]
-    expected: FAIL
-
   [createImageBitmap from a vector HTMLImageElement scaled down, and drawImage on the created ImageBitmap]
     expected: FAIL
 
@@ -50,16 +47,10 @@
   [createImageBitmap from a vector SVGImageElement scaled up, and drawImage on the created ImageBitmap]
     expected: FAIL
 
-  [createImageBitmap from a Blob scaled up, and drawImage on the created ImageBitmap]
-    expected: FAIL
-
   [createImageBitmap from a bitmap SVGImageElement scaled down, and drawImage on the created ImageBitmap]
     expected: FAIL
 
   [createImageBitmap from an HTMLVideoElement scaled up, and drawImage on the created ImageBitmap]
-    expected: FAIL
-
-  [createImageBitmap from a Blob, and drawImage on the created ImageBitmap]
     expected: FAIL
 
   [createImageBitmap from an HTMLVideoElement resized, and drawImage on the created ImageBitmap]
@@ -68,13 +59,7 @@
   [createImageBitmap from an HTMLVideoElement from a data URL scaled up, and drawImage on the created ImageBitmap]
     expected: FAIL
 
-  [createImageBitmap from a Blob with negative sw/sh, and drawImage on the created ImageBitmap]
-    expected: FAIL
-
   [createImageBitmap from a bitmap SVGImageElement with negative sw/sh, and drawImage on the created ImageBitmap]
-    expected: FAIL
-
-  [createImageBitmap from a Blob resized, and drawImage on the created ImageBitmap]
     expected: FAIL
 
   [createImageBitmap from an HTMLVideoElement from a data URL, and drawImage on the created ImageBitmap]

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-flipY.html.ini
@@ -11,9 +11,6 @@
   [createImageBitmap from an HTMLVideoElement imageOrientation: "flipY", and drawImage on the created ImageBitmap]
     expected: FAIL
 
-  [createImageBitmap from a Blob imageOrientation: "flipY", and drawImage on the created ImageBitmap]
-    expected: FAIL
-
   [createImageBitmap from a bitmap SVGImageElement imageOrientation: "flipY", and drawImage on the created ImageBitmap]
     expected: FAIL
 
@@ -30,7 +27,4 @@
     expected: FAIL
 
   [createImageBitmap from a vector SVGImageElement imageOrientation: "from-image", and drawImage on the created ImageBitmap]
-    expected: FAIL
-
-  [createImageBitmap from a Blob imageOrientation: "from-image", and drawImage on the created ImageBitmap]
     expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-in-worker-transfer.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-in-worker-transfer.html.ini
@@ -1,4 +1,0 @@
-[createImageBitmap-in-worker-transfer.html]
-  expected: TIMEOUT
-  [Transfer ImageBitmap created in worker]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-resolves-in-task.any.js.ini
@@ -20,10 +20,5 @@
   [createImageBitmap with a vector SVGImageElement source should resolve async]
     expected: FAIL
 
-  [createImageBitmap with a Blob source should resolve async]
-    expected: FAIL
-
 
 [createImageBitmap-resolves-in-task.any.worker.html]
-  [createImageBitmap with a Blob source should resolve async]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-serializable.html.ini
@@ -5,8 +5,5 @@
   [Serialize ImageBitmap created from a vector HTMLImageElement]
     expected: FAIL
 
-  [Serialize ImageBitmap created from a Blob]
-    expected: FAIL
-
   [Serialize ImageBitmap created from a bitmap SVGImageElement]
     expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer.html.ini
@@ -5,8 +5,5 @@
   [Transfer ImageBitmap created from a vector SVGImageElement]
     expected: FAIL
 
-  [Transfer ImageBitmap created from a Blob]
-    expected: FAIL
-
   [Transfer ImageBitmap created from a bitmap SVGImageElement]
     expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-Blob.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-Blob.html.ini
@@ -1,625 +1,408 @@
 [canvas-display-p3-drawImage-ImageBitmap-Blob.html]
-  expected: ERROR
-  [sRGB-FF0000FF.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-FF0000FF.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
-
   [sRGB-FF0000FF.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FF0000FF.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-FF0000FF.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-FF0000FF.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FF0000FF.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FF0000FF.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-FF0000CC.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-FF0000CC.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FF0000CC.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FF0000CC.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-FF0000CC.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-FF0000CC.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FF0000CC.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FF0000CC.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-BB0000FF.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-BB0000FF.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BB0000FF.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BB0000FF.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-BB0000FF.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-BB0000FF.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BB0000FF.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BB0000FF.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-BB0000CC.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-BB0000CC.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BB0000CC.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BB0000CC.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-BB0000CC.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-BB0000CC.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BB0000CC.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BB0000CC.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-FF0000FF.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-FF0000FF.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-FF0000FF.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-FF0000FF.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-FF0000FF.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-FF0000FF.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-FF0000FF.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-FF0000FF.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-FF0000CC.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-FF0000CC.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-FF0000CC.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-FF0000CC.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-FF0000CC.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-FF0000CC.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-FF0000CC.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-FF0000CC.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BB0000FF.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BB0000FF.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BB0000FF.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BB0000FF.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BB0000FF.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BB0000FF.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-BB0000FF.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-BB0000FF.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BB0000CC.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BB0000CC.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BB0000CC.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BB0000CC.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BB0000CC.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BB0000CC.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-BB0000CC.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-BB0000CC.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [Adobe-RGB-FF0000FF.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [Adobe-RGB-FF0000FF.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FF0000FF.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FF0000FF.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FF0000FF.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FF0000FF.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FF0000FF.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FF0000FF.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [Adobe-RGB-FF0000CC.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [Adobe-RGB-FF0000CC.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FF0000CC.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FF0000CC.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FF0000CC.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FF0000CC.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FF0000CC.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FF0000CC.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000FF.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000FF.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000FF.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000FF.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000FF.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000FF.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000FF.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000FF.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000CC.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000CC.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000CC.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000CC.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000CC.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000CC.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000CC.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BB0000CC.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-FF000000.jpg, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-FF000000.jpg, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-FF000000.jpg, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-FF000000.jpg, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-FF000000.jpg, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-FF000000.jpg, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-FF000000.jpg, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-FF000000.jpg, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-BE000000.jpg, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-BE000000.jpg, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-BE000000.jpg, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-BE000000.jpg, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-BE000000.jpg, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-BE000000.jpg, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-BE000000.jpg, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Generic-CMYK-BE000000.jpg, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-FFFF00000000FFFF.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-FFFF00000000FFFF.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FFFF00000000FFFF.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FFFF00000000FFFF.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-FFFF00000000FFFF.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-FFFF00000000FFFF.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FFFF00000000FFFF.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FFFF00000000FFFF.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-FFFF00000000CCCC.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-FFFF00000000CCCC.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FFFF00000000CCCC.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FFFF00000000CCCC.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-FFFF00000000CCCC.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-FFFF00000000CCCC.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FFFF00000000CCCC.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-FFFF00000000CCCC.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-BBBC00000000FFFF.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-BBBC00000000FFFF.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BBBC00000000FFFF.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BBBC00000000FFFF.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-BBBC00000000FFFF.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-BBBC00000000FFFF.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BBBC00000000FFFF.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BBBC00000000FFFF.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-BBBC00000000CCCC.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-BBBC00000000CCCC.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BBBC00000000CCCC.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BBBC00000000CCCC.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [sRGB-BBBC00000000CCCC.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [sRGB-BBBC00000000CCCC.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BBBC00000000CCCC.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [sRGB-BBBC00000000CCCC.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-FFFF00000000FFFF.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-FFFF00000000FFFF.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-FFFF00000000FFFF.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-FFFF00000000FFFF.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-FFFF00000000FFFF.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-FFFF00000000FFFF.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-FFFF00000000FFFF.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-FFFF00000000FFFF.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-FFFF00000000CCCC.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-FFFF00000000CCCC.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-FFFF00000000CCCC.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-FFFF00000000CCCC.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-FFFF00000000CCCC.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-FFFF00000000CCCC.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-FFFF00000000CCCC.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-FFFF00000000CCCC.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BBBC00000000FFFF.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BBBC00000000FFFF.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BBBC00000000FFFF.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BBBC00000000FFFF.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BBBC00000000FFFF.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BBBC00000000FFFF.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-BBBC00000000FFFF.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-BBBC00000000FFFF.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BBBC00000000CCCC.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BBBC00000000CCCC.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BBBC00000000CCCC.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BBBC00000000CCCC.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BBBC00000000CCCC.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Display-P3-BBBC00000000CCCC.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
-
-  [Display-P3-BBBC00000000CCCC.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
-
-  [Display-P3-BBBC00000000CCCC.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [Adobe-RGB-FFFF00000000FFFF.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [Adobe-RGB-FFFF00000000FFFF.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FFFF00000000FFFF.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FFFF00000000FFFF.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FFFF00000000FFFF.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FFFF00000000FFFF.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FFFF00000000FFFF.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FFFF00000000FFFF.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
-
-  [Adobe-RGB-FFFF00000000CCCC.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
-
-  [Adobe-RGB-FFFF00000000CCCC.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FFFF00000000CCCC.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FFFF00000000CCCC.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FFFF00000000CCCC.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FFFF00000000CCCC.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FFFF00000000CCCC.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-FFFF00000000CCCC.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000FFFF.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000FFFF.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000FFFF.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000FFFF.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000FFFF.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000FFFF.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000FFFF.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000FFFF.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000CCCC.png, Context srgb, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000CCCC.png, Context srgb, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000CCCC.png, Context srgb, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000CCCC.png, Context srgb, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000CCCC.png, Context display-p3, ImageData srgb, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000CCCC.png, Context display-p3, ImageData srgb, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000CCCC.png, Context display-p3, ImageData display-p3, cropSource=false]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Adobe-RGB-BBBC00000000CCCC.png, Context display-p3, ImageData display-p3, cropSource=true]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.clear.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.clear.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.clear.html]
-  [OffscreenCanvas test: 2d.composite.canvas.clear]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.clear.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.clear.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.composite.canvas.clear.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.copy.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.copy.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.copy.html]
-  [OffscreenCanvas test: 2d.composite.canvas.copy]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.copy.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.copy.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.copy.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-atop.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-atop.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.destination-atop.html]
-  [OffscreenCanvas test: 2d.composite.canvas.destination-atop]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-atop.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-atop.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.destination-atop.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-in.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-in.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.destination-in.html]
-  [OffscreenCanvas test: 2d.composite.canvas.destination-in]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-in.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-in.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.destination-in.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-out.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-out.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.destination-out.html]
-  [OffscreenCanvas test: 2d.composite.canvas.destination-out]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-out.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-out.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.destination-out.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-over.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-over.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.destination-over.html]
-  [OffscreenCanvas test: 2d.composite.canvas.destination-over]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-over.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.destination-over.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.destination-over.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.lighter.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.lighter.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.lighter.html]
-  [OffscreenCanvas test: 2d.composite.canvas.lighter]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.lighter.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.lighter.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.lighter.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-atop.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-atop.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.source-atop.html]
-  [OffscreenCanvas test: 2d.composite.canvas.source-atop]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-atop.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-atop.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.source-atop.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-in.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-in.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.source-in.html]
-  [OffscreenCanvas test: 2d.composite.canvas.source-in]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-in.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-in.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.source-in.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-out.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-out.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.source-out.html]
-  [OffscreenCanvas test: 2d.composite.canvas.source-out]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-out.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-out.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.source-out.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-over.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-over.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.source-over.html]
-  [OffscreenCanvas test: 2d.composite.canvas.source-over]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-over.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.source-over.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.source-over.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.xor.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.xor.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.xor.html]
-  [OffscreenCanvas test: 2d.composite.canvas.xor]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.xor.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.canvas.xor.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.canvas.xor.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.globalAlpha.image.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.globalAlpha.image.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.globalAlpha.image.html]
-  [OffscreenCanvas test: 2d.composite.globalAlpha.image]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.globalAlpha.image.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.globalAlpha.image.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.composite.globalAlpha.image.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.globalAlpha.imagepattern.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.globalAlpha.imagepattern.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.globalAlpha.imagepattern.html]
-  [OffscreenCanvas test: 2d.composite.globalAlpha.imagepattern]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.globalAlpha.imagepattern.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.globalAlpha.imagepattern.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.composite.globalAlpha.imagepattern.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.clear.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.clear.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.clear.html]
-  [OffscreenCanvas test: 2d.composite.image.clear]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.clear.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.clear.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.clear.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.copy.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.copy.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.copy.html]
-  [OffscreenCanvas test: 2d.composite.image.copy]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.copy.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.copy.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.copy.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-atop.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-atop.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.destination-atop.html]
-  [OffscreenCanvas test: 2d.composite.image.destination-atop]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-atop.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-atop.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.destination-atop.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-in.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-in.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.destination-in.html]
-  [OffscreenCanvas test: 2d.composite.image.destination-in]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-in.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-in.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.destination-in.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-out.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-out.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.destination-out.html]
-  [OffscreenCanvas test: 2d.composite.image.destination-out]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-out.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-out.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.destination-out.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-over.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-over.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.destination-over.html]
-  [OffscreenCanvas test: 2d.composite.image.destination-over]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-over.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.destination-over.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.destination-over.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.lighter.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.lighter.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.lighter.html]
-  [OffscreenCanvas test: 2d.composite.image.lighter]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.lighter.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.lighter.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.lighter.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-atop.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-atop.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.source-atop.html]
-  [OffscreenCanvas test: 2d.composite.image.source-atop]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-atop.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-atop.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.source-atop.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-in.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-in.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.source-in.html]
-  [OffscreenCanvas test: 2d.composite.image.source-in]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-in.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-in.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.source-in.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-out.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-out.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.source-out.html]
-  [OffscreenCanvas test: 2d.composite.image.source-out]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-out.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-out.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.source-out.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-over.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-over.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.source-over.html]
-  [OffscreenCanvas test: 2d.composite.image.source-over]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-over.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.source-over.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.source-over.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.xor.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.xor.html.ini
@@ -1,3 +1,0 @@
-[2d.composite.image.xor.html]
-  [OffscreenCanvas test: 2d.composite.image.xor]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.xor.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.image.xor.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.image.xor.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.copy.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.copy.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.image.copy.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.copy.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.copy.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.image.copy.worker.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-atop.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-atop.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.image.destination-atop.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-atop.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-atop.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.image.destination-atop.worker.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-in.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-in.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.image.destination-in.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-in.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.destination-in.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.image.destination-in.worker.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-in.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-in.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.image.source-in.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-in.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-in.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.image.source-in.worker.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-out.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-out.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.image.source-out.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-out.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.image.source-out.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.image.source-out.worker.html]
-  [drawImage() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.pattern.copy.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.copy.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.pattern.copy.worker.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.pattern.destination-atop.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-atop.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.pattern.destination-atop.worker.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.pattern.destination-in.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.destination-in.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.pattern.destination-in.worker.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.pattern.source-in.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-in.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.pattern.source-in.worker.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.html.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.pattern.source-out.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/compositing/2d.composite.uncovered.pattern.source-out.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.composite.uncovered.pattern.source-out.worker.html]
-  [Pattern fill() draws pixels not covered by the source object as (0,0,0,0), and does not leave the pixels unchanged.]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.3arg.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.3arg.html.ini
@@ -1,4 +1,0 @@
-[2d.drawImage.3arg.html]
-  [OffscreenCanvas test: 2d.drawImage.3arg]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.3arg.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.3arg.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.drawImage.3arg.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.5arg.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.5arg.html.ini
@@ -1,4 +1,0 @@
-[2d.drawImage.5arg.html]
-  [OffscreenCanvas test: 2d.drawImage.5arg]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.5arg.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.5arg.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.drawImage.5arg.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.basic.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.basic.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.9arg.basic.html]
-  [OffscreenCanvas test: 2d.drawImage.9arg.basic]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.basic.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.basic.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.9arg.basic.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.destpos.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.destpos.html.ini
@@ -1,4 +1,0 @@
-[2d.drawImage.9arg.destpos.html]
-  [OffscreenCanvas test: 2d.drawImage.9arg.destpos]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.destpos.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.destpos.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.drawImage.9arg.destpos.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.destsize.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.destsize.html.ini
@@ -1,4 +1,0 @@
-[2d.drawImage.9arg.destsize.html]
-  [OffscreenCanvas test: 2d.drawImage.9arg.destsize]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.destsize.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.destsize.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.drawImage.9arg.destsize.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.sourcepos.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.sourcepos.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.9arg.sourcepos.html]
-  [OffscreenCanvas test: 2d.drawImage.9arg.sourcepos]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.sourcepos.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.sourcepos.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.9arg.sourcepos.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.sourcesize.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.sourcesize.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.9arg.sourcesize.html]
-  [OffscreenCanvas test: 2d.drawImage.9arg.sourcesize]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.sourcesize.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.9arg.sourcesize.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.9arg.sourcesize.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.alpha.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.alpha.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.alpha.html]
-  [OffscreenCanvas test: 2d.drawImage.alpha]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.alpha.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.alpha.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.alpha.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.clip.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.clip.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.clip.html]
-  [OffscreenCanvas test: 2d.drawImage.clip]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.clip.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.clip.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.clip.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.composite.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.composite.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.composite.html]
-  [OffscreenCanvas test: 2d.drawImage.composite]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.composite.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.composite.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.composite.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.floatsource.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.floatsource.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.floatsource.html]
-  [OffscreenCanvas test: 2d.drawImage.floatsource]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.floatsource.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.floatsource.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.floatsource.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.negativedest.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.negativedest.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.negativedest.html]
-  [Negative destination width/height represents the correct rectangle]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.negativedest.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.negativedest.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.negativedest.worker.html]
-  [Negative destination width/height represents the correct rectangle]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.negativedir.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.negativedir.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.negativedir.html]
-  [Negative dimensions do not affect the direction of the image]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.negativedir.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.negativedir.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.negativedir.worker.html]
-  [Negative dimensions do not affect the direction of the image]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.negativesource.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.negativesource.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.negativesource.html]
-  [Negative source width/height represents the correct rectangle]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.negativesource.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.negativesource.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.negativesource.worker.html]
-  [Negative source width/height represents the correct rectangle]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.nonfinite.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.nonfinite.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.nonfinite.html]
-  [drawImage() with Infinity/NaN is ignored]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.nonfinite.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.nonfinite.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.nonfinite.worker.html]
-  [drawImage() with Infinity/NaN is ignored]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.nowrap.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.nowrap.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.nowrap.html]
-  [Stretched images do not get pixels wrapping around the edges]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.nowrap.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.nowrap.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.nowrap.worker.html]
-  [Stretched images do not get pixels wrapping around the edges]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.path.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.path.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.path.html]
-  [OffscreenCanvas test: 2d.drawImage.path]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.path.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.path.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.path.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.transform.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.transform.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.transform.html]
-  [OffscreenCanvas test: 2d.drawImage.transform]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.transform.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.transform.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.transform.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.zerosource.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.zerosource.html.ini
@@ -1,6 +1,3 @@
 [2d.drawImage.zerosource.html]
   [drawImage with zero-sized source rectangle throws INDEX_SIZE_ERR]
     expected: FAIL
-
-  [drawImage with zero-sized source rectangle draws nothing without exception]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.zerosource.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage.zerosource.worker.js.ini
@@ -1,6 +1,3 @@
 [2d.drawImage.zerosource.worker.html]
   [drawImage with zero-sized source rectangle throws INDEX_SIZE_ERR]
     expected: FAIL
-
-  [drawImage with zero-sized source rectangle draws nothing without exception]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.basic.image.html]
-  [OffscreenCanvas test: 2d.pattern.basic.image]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.image.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.basic.image.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.type.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.type.html.ini
@@ -1,3 +1,0 @@
-[2d.pattern.basic.type.html]
-  [OffscreenCanvas test: 2d.pattern.basic.type]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.type.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.basic.type.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.pattern.basic.type.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.crosscanvas.html]
-  [OffscreenCanvas test: 2d.pattern.crosscanvas]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.crosscanvas.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.crosscanvas.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.norepeat.basic.html]
-  [OffscreenCanvas test: 2d.pattern.paint.norepeat.basic]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.basic.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.norepeat.basic.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.norepeat.coord1.html]
-  [OffscreenCanvas test: 2d.pattern.paint.norepeat.coord1]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord1.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.norepeat.coord1.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.norepeat.coord2.html]
-  [OffscreenCanvas test: 2d.pattern.paint.norepeat.coord2]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord2.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.norepeat.coord2.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.norepeat.coord3.html]
-  [OffscreenCanvas test: 2d.pattern.paint.norepeat.coord3]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.coord3.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.norepeat.coord3.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.norepeat.outside.html]
-  [OffscreenCanvas test: 2d.pattern.paint.norepeat.outside]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.norepeat.outside.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.norepeat.outside.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.orientation.image.html]
-  [Image patterns do not get flipped when painted]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.orientation.image.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.orientation.image.worker.html]
-  [Image patterns do not get flipped when painted]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeat.basic.html]
-  [OffscreenCanvas test: 2d.pattern.paint.repeat.basic]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.basic.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeat.basic.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeat.coord1.html]
-  [OffscreenCanvas test: 2d.pattern.paint.repeat.coord1]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord1.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeat.coord1.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeat.coord2.html]
-  [OffscreenCanvas test: 2d.pattern.paint.repeat.coord2]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord2.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeat.coord2.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeat.coord3.html]
-  [OffscreenCanvas test: 2d.pattern.paint.repeat.coord3]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.coord3.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeat.coord3.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeat.outside.html]
-  [OffscreenCanvas test: 2d.pattern.paint.repeat.outside]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeat.outside.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeat.outside.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeatx.basic.html]
-  [OffscreenCanvas test: 2d.pattern.paint.repeatx.basic]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.basic.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeatx.basic.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeatx.coord1.html]
-  [OffscreenCanvas test: 2d.pattern.paint.repeatx.coord1]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.coord1.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeatx.coord1.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeatx.outside.html]
-  [OffscreenCanvas test: 2d.pattern.paint.repeatx.outside]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeatx.outside.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeatx.outside.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeaty.basic.html]
-  [OffscreenCanvas test: 2d.pattern.paint.repeaty.basic]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.basic.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeaty.basic.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeaty.coord1.html]
-  [OffscreenCanvas test: 2d.pattern.paint.repeaty.coord1]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.coord1.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeaty.coord1.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeaty.outside.html]
-  [OffscreenCanvas test: 2d.pattern.paint.repeaty.outside]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.paint.repeaty.outside.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.paint.repeaty.outside.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.html.ini
@@ -1,4 +1,0 @@
-[2d.pattern.repeat.empty.html]
-  [OffscreenCanvas test: 2d.pattern.repeat.empty]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/fill-and-stroke-styles/2d.pattern.repeat.empty.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.pattern.repeat.empty.worker.html]
-  [2d]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/shadows/2d.shadow.image.section.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/shadows/2d.shadow.image.section.html.ini
@@ -1,4 +1,0 @@
-[2d.shadow.image.section.html]
-  [Shadows are not drawn for areas outside image source rectangles]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/shadows/2d.shadow.image.section.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/shadows/2d.shadow.image.section.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.shadow.image.section.worker.html]
-  [Shadows are not drawn for areas outside image source rectangles]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/shadows/2d.shadow.image.transparent.1.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/shadows/2d.shadow.image.transparent.1.html.ini
@@ -1,4 +1,0 @@
-[2d.shadow.image.transparent.1.html]
-  [Shadows are not drawn for transparent images]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/shadows/2d.shadow.image.transparent.1.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/shadows/2d.shadow.image.transparent.1.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.shadow.image.transparent.1.worker.html]
-  [Shadows are not drawn for transparent images]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1.html.ini
@@ -1,4 +1,0 @@
-[2d.shadow.pattern.transparent.1.html]
-  [Shadows are not drawn for transparent fill patterns]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/shadows/2d.shadow.pattern.transparent.1.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.shadow.pattern.transparent.1.worker.html]
-  [Shadows are not drawn for transparent fill patterns]
-    expected: FAIL
-

--- a/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-alpha-alpha-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-alpha-alpha-unsigned_byte.html.ini
@@ -1,6 +1,0 @@
-[tex-2d-alpha-alpha-unsigned_byte.html]
-  [WebGL test #1]
-    expected: FAIL
-
-  [WebGL test #3]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-luminance-luminance-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-luminance-luminance-unsigned_byte.html.ini
@@ -1,6 +1,0 @@
-[tex-2d-luminance-luminance-unsigned_byte.html]
-  [WebGL test #1]
-    expected: FAIL
-
-  [WebGL test #3]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html.ini
@@ -1,6 +1,0 @@
-[tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html]
-  [WebGL test #1]
-    expected: FAIL
-
-  [WebGL test #3]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-rgb-rgb-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-rgb-rgb-unsigned_byte.html.ini
@@ -1,6 +1,0 @@
-[tex-2d-rgb-rgb-unsigned_byte.html]
-  [WebGL test #1]
-    expected: FAIL
-
-  [WebGL test #3]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-rgb-rgb-unsigned_short_5_6_5.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-rgb-rgb-unsigned_short_5_6_5.html.ini
@@ -1,6 +1,0 @@
-[tex-2d-rgb-rgb-unsigned_short_5_6_5.html]
-  [WebGL test #1]
-    expected: FAIL
-
-  [WebGL test #3]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-rgba-rgba-unsigned_byte.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-rgba-rgba-unsigned_byte.html.ini
@@ -1,6 +1,0 @@
-[tex-2d-rgba-rgba-unsigned_byte.html]
-  [WebGL test #1]
-    expected: FAIL
-
-  [WebGL test #3]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html.ini
@@ -1,6 +1,0 @@
-[tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html]
-  [WebGL test #1]
-    expected: FAIL
-
-  [WebGL test #3]
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/image_bitmap_from_blob/tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html.ini
@@ -1,6 +1,0 @@
-[tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html]
-  [WebGL test #1]
-    expected: FAIL
-
-  [WebGL test #3]
-    expected: FAIL


### PR DESCRIPTION
Follow to the HTML specification and support of Blob as ImageBitmapSource
to able use it as intermediate instance in "fetch() -> Blob -> ImageBitmap" execution sequence. https://html.spec.whatwg.org/multipage/#imagebitmapsource

The specification says what these steps must run in parallel
(outside the createImageBitmap task), but currently loading bytes from Blob
and later image decoding happen in synchronous order while
promise is fullfilled or rejected on bitmap task source.
https://html.spec.whatwg.org/multipage/#the-imagebitmap-interface:blob-4

Testing: Improvements in the following WPT tests
- html/canvas/element/compositing/2d.composite*
- html/canvas/element/drawing-images-to-the-canvas/2d.drawImage*
- html/canvas/element/manual/imagebitmap/createImageBitmap*
- html/canvas/offscreen/compositing/2d.composite
- html/canvas/offscreen/drawing-images-to-the-canvas/2d.drawImage
- webgl/tests/conformance/textures/image_bitmap_from_blob/*

Fixes (partially): #34112