### PR TITLE
Remove `Snapshot::from_shared_memory` to avoid double allocation

### DIFF
--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -17,7 +17,7 @@ use cssparser::color::clamp_unit_f32;
 use cssparser::{Parser, ParserInput};
 use euclid::default::{Point2D, Rect, Size2D, Transform2D};
 use euclid::vec2;
-use ipc_channel::ipc::{self, IpcSender, IpcSharedMemory};
+use ipc_channel::ipc::{self, IpcSender};
 use net_traits::image_cache::{ImageCache, ImageResponse};
 use net_traits::request::CorsSettings;
 use pixels::PixelFormat;
@@ -358,11 +358,11 @@ impl CanvasState {
             premultiplied: false,
         };
 
-        Some(snapshot::Snapshot::from_shared_memory(
+        Some(snapshot::Snapshot::from_vec(
             size.cast(),
             format,
             alpha_mode,
-            IpcSharedMemory::from_bytes(img.first_frame().bytes),
+            img.first_frame().bytes.to_vec(),
         ))
     }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -32,7 +32,7 @@ use embedder_traits::EmbedderMsg;
 use euclid::default::Size2D;
 use http::HeaderMap;
 use hyper_serde::Serde;
-use ipc_channel::ipc::{self, IpcSender, IpcSharedMemory};
+use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use js::glue::{IsWrapper, UnwrapObjectDynamic};
 use js::jsapi::{
@@ -3069,11 +3069,11 @@ impl GlobalScope {
                     premultiplied: false,
                 };
 
-                let snapshot = Snapshot::from_shared_memory(
+                let snapshot = Snapshot::from_vec(
                     size.cast(),
                     format,
                     alpha_mode,
-                    IpcSharedMemory::from_bytes(img.first_frame().bytes),
+                    img.first_frame().bytes.to_vec(),
                 );
 
                 // Step 6.3. Set imageBitmap's bitmap data to a copy of image's media data,
@@ -3244,11 +3244,11 @@ impl GlobalScope {
                     premultiplied: false,
                 };
 
-                let snapshot = Snapshot::from_shared_memory(
+                let snapshot = Snapshot::from_vec(
                     image_data.get_size().cast(),
                     snapshot::PixelFormat::RGBA,
                     alpha_mode,
-                    image_data.to_shared_memory(),
+                    image_data.to_vec(),
                 );
 
                 // Step 6.3. Set imageBitmap's bitmap data to image's image data,

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -183,6 +183,12 @@ impl ImageData {
         let ptr: *const [u8] = internal_data.as_slice() as *const _;
         &*ptr
     }
+
+    #[allow(unsafe_code)]
+    pub(crate) fn to_vec(&self) -> Vec<u8> {
+        // This is safe because we copy the slice content
+        unsafe { self.as_slice() }.to_vec()
+    }
 }
 
 impl ImageDataMethods<crate::DomTypeHolder> for ImageData {

--- a/components/shared/snapshot/lib.rs
+++ b/components/shared/snapshot/lib.rs
@@ -156,20 +156,6 @@ impl Snapshot<Data> {
         }
     }
 
-    pub fn from_shared_memory(
-        size: Size2D<u32>,
-        format: PixelFormat,
-        alpha_mode: AlphaMode,
-        ism: IpcSharedMemory,
-    ) -> Self {
-        Self {
-            size,
-            data: Data::Owned(ism.to_vec()),
-            format,
-            alpha_mode,
-        }
-    }
-
     // TODO: https://github.com/servo/servo/issues/36594
     /*
     /// # Safety


### PR DESCRIPTION
It was always misused, causing extra allocations all over the place. Discovered in https://github.com/servo/servo/pull/37560#discussion_r2157222917

Testing: WPT tests
