### PR TITLE
[WebDriver: handle_get_shadow_root] Fix Serialization problem

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1347,17 +1347,12 @@ impl Handler {
         self.browsing_context_script_command(cmd)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => {
-                if value.is_none() {
-                    return Err(WebDriverError::new(
-                        ErrorStatus::NoSuchShadowRoot,
-                        "No shadow root found for the element",
-                    ));
-                }
-                let value_resp = serde_json::to_value(
-                    value.map(|x| serde_json::to_value(WebElement(x)).unwrap()),
-                )?;
-                let shadow_root_value = json!({ SHADOW_ROOT_IDENTIFIER: value_resp });
-                Ok(WebDriverResponse::Generic(ValueResponse(shadow_root_value)))
+                let Some(value) = value else {
+                    return Err(WebDriverError::new(ErrorStatus::NoSuchShadowRoot, ""));
+                };
+                Ok(WebDriverResponse::Generic(ValueResponse(
+                    json!({ SHADOW_ROOT_IDENTIFIER: value }),
+                )))
             },
             Err(error) => Err(WebDriverError::new(error, "")),
         }

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -55,7 +55,7 @@ use webdriver::command::{
     SwitchToFrameParameters, SwitchToWindowParameters, TimeoutsParameters, WebDriverCommand,
     WebDriverExtensionCommand, WebDriverMessage, WindowRectParameters,
 };
-use webdriver::common::{Cookie, Date, LocatorStrategy, Parameters, WebElement};
+use webdriver::common::{Cookie, Date, LocatorStrategy, Parameters, ShadowRoot, WebElement};
 use webdriver::error::{ErrorStatus, WebDriverError, WebDriverResult};
 use webdriver::httpapi::WebDriverExtensionRoute;
 use webdriver::response::{
@@ -1351,7 +1351,7 @@ impl Handler {
                     return Err(WebDriverError::new(ErrorStatus::NoSuchShadowRoot, ""));
                 };
                 Ok(WebDriverResponse::Generic(ValueResponse(
-                    json!({ SHADOW_ROOT_IDENTIFIER: value }),
+                    serde_json::to_value(ShadowRoot(value))?,
                 )))
             },
             Err(error) => Err(WebDriverError::new(error, "")),


### PR DESCRIPTION
1. Correctly Serialize the ShadowRoot. Previously, it contains a nested element identifier "element-6066-11e4-a52e-4f735466cecf"
2. Improve coding style with what I learnt from Josh today

Testing: Passing way more "Find Elements from Shadow Root" test locally now
Fixes: #37559 
