### PR TITLE
script: Support creating a DOMStringList for any global.

### DIFF
--- a/components/script/dom/domstringlist.rs
+++ b/components/script/dom/domstringlist.rs
@@ -8,7 +8,7 @@ use crate::dom::bindings::codegen::Bindings::DOMStringListBinding::DOMStringList
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::window::Window;
+use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -18,7 +18,6 @@ pub(crate) struct DOMStringList {
 }
 
 impl DOMStringList {
-    #[allow(unused)]
     pub(crate) fn new_inherited(strings: Vec<DOMString>) -> DOMStringList {
         DOMStringList {
             reflector_: Reflector::new(),
@@ -26,15 +25,14 @@ impl DOMStringList {
         }
     }
 
-    #[allow(unused)]
     pub(crate) fn new(
-        window: &Window,
+        global: &GlobalScope,
         strings: Vec<DOMString>,
         can_gc: CanGc,
     ) -> DomRoot<DOMStringList> {
         reflect_dom_object(
             Box::new(DOMStringList::new_inherited(strings)),
-            window,
+            global,
             can_gc,
         )
     }

--- a/components/script/dom/idbdatabase.rs
+++ b/components/script/dom/idbdatabase.rs
@@ -85,7 +85,7 @@ impl IDBDatabase {
 
     pub fn object_stores(&self) -> DomRoot<DOMStringList> {
         DOMStringList::new(
-            self.global().as_window(),
+            &self.global(),
             self.object_store_names.borrow().clone(),
             CanGc::note(),
         )
@@ -161,7 +161,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
                 &self.global(),
                 self,
                 mode,
-                &DOMStringList::new(self.global().as_window(), vec![name], CanGc::note()),
+                &DOMStringList::new(&self.global(), vec![name], CanGc::note()),
                 CanGc::note(),
             ),
             StringOrStringSequence::StringSequence(sequence) => {
@@ -171,7 +171,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
                     &self.global(),
                     self,
                     mode,
-                    &DOMStringList::new(self.global().as_window(), sequence, CanGc::note()),
+                    &DOMStringList::new(&self.global(), sequence, CanGc::note()),
                     CanGc::note(),
                 )
             },
@@ -343,7 +343,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
     fn ObjectStoreNames(&self) -> DomRoot<DOMStringList> {
         // FIXME: (arihant2math) Sort the list of names, as per spec
         DOMStringList::new(
-            self.global().as_window(),
+            &self.global(),
             self.object_store_names.borrow().clone(),
             CanGc::note(),
         )

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -79,7 +79,7 @@ impl IDBObjectStore {
             name: DomRefCell::new(name),
             key_path,
 
-            index_names: DOMStringList::new(global.as_window(), Vec::new(), can_gc),
+            index_names: DOMStringList::new(global, Vec::new(), can_gc),
             transaction: Default::default(),
             // FIXME:(arihant2math)
             auto_increment: false,

--- a/tests/wpt/meta/indexeddb/close-in-upgradeneeded.any.js.ini
+++ b/tests/wpt/meta/indexeddb/close-in-upgradeneeded.any.js.ini
@@ -7,7 +7,9 @@
 
 
 [close-in-upgradeneeded.any.worker.html]
-  expected: CRASH
+  [When db.close() is called in onupgradeneeded, the db is cleaned up on refresh]
+    expected: FAIL
+
 
 [close-in-upgradeneeded.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/cursor-overloads.any.js.ini
+++ b/tests/wpt/meta/indexeddb/cursor-overloads.any.js.ini
@@ -7,7 +7,9 @@
 
 
 [cursor-overloads.any.worker.html]
-  expected: CRASH
+  [Validate the overloads of IDBObjectStore.openCursor(), IDBIndex.openCursor() and IDBIndex.openKeyCursor()]
+    expected: FAIL
+
 
 [cursor-overloads.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbcursor-advance-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor-advance-exception-order.any.js.ini
@@ -2,11 +2,12 @@
   expected: ERROR
 
 [idbcursor-advance-exception-order.any.worker.html]
+  expected: TIMEOUT
   [IDBCursor.advance exception order: TypeError vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBCursor.advance exception order: TransactionInactiveError vs. InvalidStateError #1]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBCursor.advance exception order: TransactionInactiveError vs. InvalidStateError #2]
     expected: FAIL
@@ -16,11 +17,12 @@
   expected: ERROR
 
 [idbcursor-advance-exception-order.any.html]
+  expected: TIMEOUT
   [IDBCursor.advance exception order: TypeError vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBCursor.advance exception order: TransactionInactiveError vs. InvalidStateError #1]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBCursor.advance exception order: TransactionInactiveError vs. InvalidStateError #2]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbcursor-continuePrimaryKey-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor-continuePrimaryKey-exception-order.any.js.ini
@@ -5,82 +5,84 @@
   expected: ERROR
 
 [idbcursor-continuePrimaryKey-exception-order.any.html]
+  expected: TIMEOUT
   [TransactionInactiveError v.s. InvalidStateError(deleted index)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidStateError(deleted source) v.s. InvalidAccessError(incorrect source)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidStateError(deleted source) v.s. InvalidAccessError(incorrect direction)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidAccessError(incorrect direction) v.s. InvalidStateError(iteration complete)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidAccessError(incorrect direction) v.s. InvalidStateError(iteration ongoing)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidAccessError(incorrect source) v.s. InvalidStateError(iteration ongoing)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidAccessError(incorrect source) v.s. InvalidStateError(iteration complete)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidStateError(iteration ongoing) v.s. DataError(unset key)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidStateError(iteration complete) v.s. DataError(unset key)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [DataError(unset key)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [DataError(unset primary key)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [DataError(keys are lower then current one) in 'next' direction]
-    expected: FAIL
+    expected: TIMEOUT
 
   [DataError(keys are larger then current one) in 'prev' direction]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [idbcursor-continuePrimaryKey-exception-order.any.worker.html]
+  expected: TIMEOUT
   [TransactionInactiveError v.s. InvalidStateError(deleted index)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidStateError(deleted source) v.s. InvalidAccessError(incorrect source)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidStateError(deleted source) v.s. InvalidAccessError(incorrect direction)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidAccessError(incorrect direction) v.s. InvalidStateError(iteration complete)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidAccessError(incorrect direction) v.s. InvalidStateError(iteration ongoing)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidAccessError(incorrect source) v.s. InvalidStateError(iteration ongoing)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidAccessError(incorrect source) v.s. InvalidStateError(iteration complete)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidStateError(iteration ongoing) v.s. DataError(unset key)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [InvalidStateError(iteration complete) v.s. DataError(unset key)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [DataError(unset key)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [DataError(unset primary key)]
-    expected: FAIL
+    expected: TIMEOUT
 
   [DataError(keys are lower then current one) in 'next' direction]
-    expected: FAIL
+    expected: TIMEOUT
 
   [DataError(keys are larger then current one) in 'prev' direction]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/indexeddb/idbcursor-continuePrimaryKey-exceptions.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor-continuePrimaryKey-exceptions.any.js.ini
@@ -2,9 +2,19 @@
   expected: ERROR
 
 [idbcursor-continuePrimaryKey-exceptions.any.worker.html]
-  expected: CRASH
+  expected: ERROR
+  [IDBCursor continuePrimaryKey() on object store cursor]
+    expected: FAIL
+
+  [IDBCursor continuePrimaryKey() on "nextunique" cursor]
+    expected: TIMEOUT
+
+  [IDBCursor continuePrimaryKey() on "prevunique" cursor]
+    expected: TIMEOUT
+
 
 [idbcursor-continuePrimaryKey-exceptions.any.html]
+  expected: ERROR
   [IDBCursor continuePrimaryKey() on object store cursor]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbcursor-direction.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor-direction.any.js.ini
@@ -2,7 +2,22 @@
   expected: ERROR
 
 [idbcursor-direction.any.worker.html]
-  expected: CRASH
+  expected: ERROR
+  [IDBCursor.direction - undefined]
+    expected: FAIL
+
+  [IDBCursor.direction - next]
+    expected: NOTRUN
+
+  [IDBCursor.direction - prev]
+    expected: NOTRUN
+
+  [IDBCursor.direction - nextunique]
+    expected: NOTRUN
+
+  [IDBCursor.direction - prevunique]
+    expected: NOTRUN
+
 
 [idbcursor-direction.any.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbcursor-key.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor-key.any.js.ini
@@ -5,7 +5,15 @@
   expected: ERROR
 
 [idbcursor-key.any.worker.html]
-  expected: CRASH
+  [IDBCursor.key]
+    expected: FAIL
+
+  [IDBCursor.key 1]
+    expected: FAIL
+
+  [IDBCursor.key 2]
+    expected: FAIL
+
 
 [idbcursor-key.any.html]
   [IDBCursor.key]

--- a/tests/wpt/meta/indexeddb/idbcursor-primarykey.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor-primarykey.any.js.ini
@@ -1,5 +1,13 @@
 [idbcursor-primarykey.any.worker.html]
-  expected: CRASH
+  [IDBCursor.primaryKey]
+    expected: FAIL
+
+  [IDBCursor.primaryKey 1]
+    expected: FAIL
+
+  [IDBCursor.primaryKey 2]
+    expected: FAIL
+
 
 [idbcursor-primarykey.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbcursor-reused.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor-reused.any.js.ini
@@ -5,7 +5,9 @@
   expected: ERROR
 
 [idbcursor-reused.any.worker.html]
-  expected: CRASH
+  [IDBCursor is reused]
+    expected: FAIL
+
 
 [idbcursor-reused.any.html]
   [IDBCursor is reused]

--- a/tests/wpt/meta/indexeddb/idbcursor_advance_index.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_advance_index.any.js.ini
@@ -31,4 +31,26 @@
   expected: ERROR
 
 [idbcursor_advance_index.any.worker.html]
-  expected: CRASH
+  [index - iterate cursor number of times specified by count]
+    expected: FAIL
+
+  [attempt to pass a count parameter that is not a number]
+    expected: FAIL
+
+  [index - attempt to advance backwards]
+    expected: FAIL
+
+  [index - iterate to the next record]
+    expected: FAIL
+
+  [Calling advance() with count argument 0 should throw TypeError.]
+    expected: FAIL
+
+  [Calling advance() should throws an exception TransactionInactiveError when the transaction is not active.]
+    expected: FAIL
+
+  [Calling advance() should throw DOMException when the cursor is currently being iterated.]
+    expected: FAIL
+
+  [If the cursor's source or effective object store has been deleted, the implementation MUST throw a DOMException of type InvalidStateError]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbcursor_advance_objectstore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_advance_objectstore.any.js.ini
@@ -19,7 +19,21 @@
   expected: ERROR
 
 [idbcursor_advance_objectstore.any.worker.html]
-  expected: CRASH
+  [object store - iterate cursor number of times specified by count]
+    expected: FAIL
+
+  [Calling advance() with count argument 0 should throw TypeError.]
+    expected: FAIL
+
+  [Calling advance() should throws an exception TransactionInactiveError when the transaction is not active]
+    expected: FAIL
+
+  [Calling advance() should throw DOMException when the cursor is currently being iterated.]
+    expected: FAIL
+
+  [If the cursor's source or effective object store has been deleted, the implementation MUST throw a DOMException of type InvalidStateError]
+    expected: FAIL
+
 
 [idbcursor_advance_objectstore.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbcursor_continue_delete_objectstore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_continue_delete_objectstore.any.js.ini
@@ -10,4 +10,5 @@
   expected: ERROR
 
 [idbcursor_continue_delete_objectstore.any.worker.html]
-  expected: CRASH
+  [Object store - remove a record from the object store while iterating cursor]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbcursor_continue_index.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_continue_index.any.js.ini
@@ -37,4 +37,32 @@
 
 
 [idbcursor_continue_index.any.worker.html]
-  expected: CRASH
+  [Iterate to the next record]
+    expected: FAIL
+
+  [Attempt to pass a key parameter that is not a valid key]
+    expected: FAIL
+
+  [Attempt to iterate to the previous record when the direction is set for the next record]
+    expected: FAIL
+
+  [Attempt to iterate to the next record when the direction is set for the previous record]
+    expected: FAIL
+
+  [Iterate using 'prevunique']
+    expected: FAIL
+
+  [Iterate using nextunique]
+    expected: FAIL
+
+  [Calling continue() should throw an exception TransactionInactiveError when the transaction is not active.]
+    expected: FAIL
+
+  [If the cursor's source or effective object store has been deleted, the implementation MUST throw a DOMException of type InvalidStateError]
+    expected: FAIL
+
+  [Delete next element, and iterate to it]
+    expected: FAIL
+
+  [Add next element, and iterate to it]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbcursor_continue_invalid.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_continue_invalid.any.js.ini
@@ -10,4 +10,5 @@
   expected: ERROR
 
 [idbcursor_continue_invalid.any.worker.html]
-  expected: CRASH
+  [Attempt to call continue two times]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbcursor_continue_objectstore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_continue_objectstore.any.js.ini
@@ -1,5 +1,29 @@
 [idbcursor_continue_objectstore.any.worker.html]
-  expected: CRASH
+  expected: ERROR
+  [Iterate to the next record]
+    expected: FAIL
+
+  [Attempt to pass a key parameter is not a valid key]
+    expected: FAIL
+
+  [Attempt to iterate to the previous record when the direction is set for the next record]
+    expected: FAIL
+
+  [Attempt to iterate to the next record when the direction is set for the next record]
+    expected: FAIL
+
+  [Calling continue() should throws an exception TransactionInactiveError when the transaction is not active.]
+    expected: FAIL
+
+  [If the cursor's source or effective object store has been deleted, the implementation MUST throw a DOMException of type InvalidStateError]
+    expected: FAIL
+
+  [Delete next element, and iterate to it]
+    expected: FAIL
+
+  [Add next element, and iterate to it]
+    expected: TIMEOUT
+
 
 [idbcursor_continue_objectstore.any.serviceworker.html]
   expected: ERROR
@@ -28,7 +52,7 @@
     expected: FAIL
 
   [Add next element, and iterate to it]
-    expected: TIMEOUT
+    expected: FAIL
 
 
 [idbcursor_continue_objectstore.any.sharedworker.html]

--- a/tests/wpt/meta/indexeddb/idbcursor_delete_index.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_delete_index.any.js.ini
@@ -1,5 +1,19 @@
 [idbcursor_delete_index.any.worker.html]
-  expected: CRASH
+  [Remove a record from the object store]
+    expected: FAIL
+
+  [Attempt to remove a record in a read-only transaction]
+    expected: FAIL
+
+  [Attempt to remove a record in an inactive transaction]
+    expected: FAIL
+
+  [If the cursor's source or effective object store has been deleted, the implementation MUST throw a DOMException of type InvalidStateError]
+    expected: FAIL
+
+  [Throw InvalidStateError when the cursor is being iterated]
+    expected: FAIL
+
 
 [idbcursor_delete_index.any.html]
   [Remove a record from the object store]

--- a/tests/wpt/meta/indexeddb/idbcursor_delete_objectstore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_delete_objectstore.any.js.ini
@@ -2,7 +2,21 @@
   expected: ERROR
 
 [idbcursor_delete_objectstore.any.worker.html]
-  expected: CRASH
+  [Remove a record from the object store ]
+    expected: FAIL
+
+  [Attempt to remove a record in a read-only transaction]
+    expected: FAIL
+
+  [Index - attempt to remove a record in an inactive transaction]
+    expected: FAIL
+
+  [If the cursor's source or effective object store has been deleted, the implementation MUST throw a DOMException of type InvalidStateError]
+    expected: FAIL
+
+  [Throw InvalidStateError when the cursor is being iterated]
+    expected: FAIL
+
 
 [idbcursor_delete_objectstore.any.html]
   [Remove a record from the object store ]

--- a/tests/wpt/meta/indexeddb/idbcursor_iterating.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_iterating.any.js.ini
@@ -11,4 +11,6 @@
   expected: ERROR
 
 [idbcursor_iterating.any.worker.html]
-  expected: CRASH
+  expected: ERROR
+  [Iterate and Delete elements]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbcursor_update_index.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_update_index.any.js.ini
@@ -34,4 +34,29 @@
 
 
 [idbcursor_update_index.any.worker.html]
-  expected: CRASH
+  [Modify a record in the object store ]
+    expected: FAIL
+
+  [Attempt to modify a record in a read-only transaction]
+    expected: FAIL
+
+  [Attempt to modify a record in an inactive transaction]
+    expected: FAIL
+
+  [Attempt to modify a record after the cursor's source or effective object store has been deleted. The implementation MUST throw a DOMException of type InvalidStateError]
+    expected: FAIL
+
+  [Throw DataCloneError]
+    expected: FAIL
+
+  [No argument]
+    expected: FAIL
+
+  [Throw DataError]
+    expected: FAIL
+
+  [Throw InvalidStateError when the cursor is being iterated]
+    expected: FAIL
+
+  [Modify records during cursor iteration and verify updated records]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbcursor_update_objectstore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_update_objectstore.any.js.ini
@@ -2,7 +2,33 @@
   expected: ERROR
 
 [idbcursor_update_objectstore.any.worker.html]
-  expected: CRASH
+  [Modify a record in the object store ]
+    expected: FAIL
+
+  [Attempt to modify a record in a read-only transaction]
+    expected: FAIL
+
+  [Object store - attempt to modify a record in an inactive transaction]
+    expected: FAIL
+
+  [Index - modify a record in the object store ]
+    expected: FAIL
+
+  [Attempt to modify a record after the cursor's source or effective object store has been deleted. The implementation MUST throw a DOMException of type InvalidStateError]
+    expected: FAIL
+
+  [Throw DataCloneError]
+    expected: FAIL
+
+  [No argument]
+    expected: FAIL
+
+  [Throw DataError]
+    expected: FAIL
+
+  [Throw InvalidStateError when the cursor is being iterated]
+    expected: FAIL
+
 
 [idbcursor_update_objectstore.any.html]
   [Modify a record in the object store ]

--- a/tests/wpt/meta/indexeddb/idbdatabase-createObjectStore-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbdatabase-createObjectStore-exception-order.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [idbdatabase-createObjectStore-exception-order.any.html]
+  expected: TIMEOUT
   [IDBDatabase.createObjectStore exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
@@ -9,16 +10,17 @@
     expected: FAIL
 
   [IDBDatabase.createObjectStore exception order: SyntaxError vs. ConstraintError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBDatabase.createObjectStore exception order: ConstraintError vs. InvalidAccessError]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [idbdatabase-createObjectStore-exception-order.any.serviceworker.html]
   expected: ERROR
 
 [idbdatabase-createObjectStore-exception-order.any.worker.html]
+  expected: TIMEOUT
   [IDBDatabase.createObjectStore exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
@@ -26,7 +28,7 @@
     expected: FAIL
 
   [IDBDatabase.createObjectStore exception order: SyntaxError vs. ConstraintError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBDatabase.createObjectStore exception order: ConstraintError vs. InvalidAccessError]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/indexeddb/idbdatabase-transaction-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbdatabase-transaction-exception-order.any.js.ini
@@ -11,9 +11,6 @@
   [IDBDatabase.transaction exception order: InvalidStateError vs. InvalidAccessError]
     expected: FAIL
 
-  [IDBDatabase.transaction throws exception on invalid mode]
-    expected: FAIL
-
   [IDBDatabase.transaction exception order: NotFoundError vs. TypeError]
     expected: FAIL
 
@@ -23,9 +20,6 @@
     expected: FAIL
 
   [IDBDatabase.transaction exception order: InvalidStateError vs. InvalidAccessError]
-    expected: FAIL
-
-  [IDBDatabase.transaction throws exception on invalid mode]
     expected: FAIL
 
   [IDBDatabase.transaction exception order: NotFoundError vs. TypeError]

--- a/tests/wpt/meta/indexeddb/idbdatabase_close.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbdatabase_close.any.js.ini
@@ -1,5 +1,10 @@
 [idbdatabase_close.any.worker.html]
-  expected: CRASH
+  [Unblock the version change transaction created by an open database request]
+    expected: FAIL
+
+  [Unblock the delete database request.]
+    expected: FAIL
+
 
 [idbdatabase_close.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbdatabase_createObjectStore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbdatabase_createObjectStore.any.js.ini
@@ -1,5 +1,85 @@
 [idbdatabase_createObjectStore.any.worker.html]
-  expected: CRASH
+  [Both with empty name]
+    expected: FAIL
+
+  [Returns an instance of IDBObjectStore]
+    expected: FAIL
+
+  [Create 1000 object stores, add one item and delete]
+    expected: FAIL
+
+  [Empty name]
+    expected: FAIL
+
+  [Attempting to create an existing object store with a different keyPath throw ConstraintError ]
+    expected: FAIL
+
+  [Object store 'name' and 'keyPath' properties are correctly set ]
+    expected: FAIL
+
+  [Attempt to create an object store outside of a version change transaction ]
+    expected: FAIL
+
+  [Attempt to create an object store that already exists ]
+    expected: FAIL
+
+  [Object store's name appears in database's list ]
+    expected: FAIL
+
+  [Attempt to create an object store with an invalid key path ]
+    expected: FAIL
+
+  [Create an object store with an unknown optional parameter ]
+    expected: FAIL
+
+  [autoInc true]
+    expected: FAIL
+
+  [autoInc true, keyPath null]
+    expected: FAIL
+
+  [autoInc true, keyPath undefined]
+    expected: FAIL
+
+  [autoInc true, keyPath string]
+    expected: FAIL
+
+  [autoInc false, keyPath empty]
+    expected: FAIL
+
+  [autoInc false, keyPath array]
+    expected: FAIL
+
+  [autoInc false, keyPath string]
+    expected: FAIL
+
+  [keyPath empty]
+    expected: FAIL
+
+  [keyPath array]
+    expected: FAIL
+
+  [keyPath string]
+    expected: FAIL
+
+  [keyPath null]
+    expected: FAIL
+
+  [keyPath undefined]
+    expected: FAIL
+
+  [autoInc and empty keyPath]
+    expected: FAIL
+
+  [autoInc and keyPath array]
+    expected: FAIL
+
+  [autoInc and keyPath array 2]
+    expected: FAIL
+
+  [autoInc and keyPath object]
+    expected: FAIL
+
 
 [idbdatabase_createObjectStore.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbdatabase_deleteObjectStore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbdatabase_deleteObjectStore.any.js.ini
@@ -2,7 +2,15 @@
   expected: ERROR
 
 [idbdatabase_deleteObjectStore.any.worker.html]
-  expected: CRASH
+  [Deleted object store's name should be removed from database's list. Attempting to use a deleted IDBObjectStore should throw an InvalidStateError]
+    expected: FAIL
+
+  [Attempting to remove an object store that does not exist should throw a NotFoundError]
+    expected: FAIL
+
+  [Attempting to access an index that was deleted as part of object store deletion and then recreated using the same object store name should throw a NotFoundError]
+    expected: FAIL
+
 
 [idbdatabase_deleteObjectStore.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbdatabase_transaction.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbdatabase_transaction.any.js.ini
@@ -2,7 +2,21 @@
   expected: ERROR
 
 [idbdatabase_transaction.any.worker.html]
-  expected: CRASH
+  [Attempt to open a transaction with invalid scope]
+    expected: FAIL
+
+  [Opening a transaction defaults to a read-only mode]
+    expected: FAIL
+
+  [Attempt to open a transaction from closed database connection]
+    expected: FAIL
+
+  [Attempt to open a transaction with invalid mode]
+    expected: FAIL
+
+  [If storeNames is an empty list, the implementation must throw a DOMException of type InvalidAccessError]
+    expected: FAIL
+
 
 [idbdatabase_transaction.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbfactory-open-error-properties.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbfactory-open-error-properties.any.js.ini
@@ -7,7 +7,9 @@
   expected: ERROR
 
 [idbfactory-open-error-properties.any.worker.html]
-  expected: CRASH
+  [Properties of error event from failed open()]
+    expected: FAIL
+
 
 [idbfactory-open-error-properties.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbfactory_open.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbfactory_open.any.js.ini
@@ -43,4 +43,38 @@
   expected: ERROR
 
 [idbfactory_open.any.worker.html]
-  expected: CRASH
+  [IDBFactory.open() - database 'name' and 'version' are correctly set]
+    expected: FAIL
+
+  [IDBFactory.open() - no version opens current database]
+    expected: FAIL
+
+  [IDBFactory.open() - new database has default version]
+    expected: FAIL
+
+  [IDBFactory.open() - new database is empty]
+    expected: FAIL
+
+  [IDBFactory.open() - open database with a lower version than current]
+    expected: FAIL
+
+  [IDBFactory.open() - open database with a higher version than current]
+    expected: FAIL
+
+  [IDBFactory.open() - error in version change transaction aborts open]
+    expected: FAIL
+
+  [Calling open() with version argument 1.5 should not throw.]
+    expected: FAIL
+
+  [Calling open() with version argument 9007199254740991 should not throw.]
+    expected: FAIL
+
+  [Calling open() with version argument undefined should not throw.]
+    expected: FAIL
+
+  [IDBFactory.open() - error in upgradeneeded resets db]
+    expected: FAIL
+
+  [IDBFactory.open() - second open's transaction is available to get objectStores]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbindex-multientry.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbindex-multientry.any.js.ini
@@ -1,5 +1,13 @@
 [idbindex-multientry.any.worker.html]
-  expected: CRASH
+  [Array keyPath with multiEntry]
+    expected: FAIL
+
+  [A 1000 entry multiEntry array]
+    expected: FAIL
+
+  [Adding keys]
+    expected: FAIL
+
 
 [idbindex-multientry.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbindex-query-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbindex-query-exception-order.any.js.ini
@@ -2,76 +2,78 @@
   expected: ERROR
 
 [idbindex-query-exception-order.any.html]
+  expected: TIMEOUT
   [IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBIndex.get exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBIndex.getAll exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.getAllKeys exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBIndex.getAllKeys exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBIndex.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBIndex.openCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBIndex.openKeyCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
 
 [idbindex-query-exception-order.any.worker.html]
+  expected: TIMEOUT
   [IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBIndex.get exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBIndex.getAll exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.getAllKeys exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBIndex.getAllKeys exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBIndex.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBIndex.openCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBIndex.openKeyCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbindex_count.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbindex_count.any.js.ini
@@ -1,5 +1,16 @@
 [idbindex_count.any.worker.html]
-  expected: CRASH
+  [count() returns the number of records in the index]
+    expected: FAIL
+
+  [count() returns the number of records that have keys within the range]
+    expected: FAIL
+
+  [count() returns the number of records that have keys with the key]
+    expected: FAIL
+
+  [count() throws DataError when using invalid key]
+    expected: FAIL
+
 
 [idbindex_count.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbindex_get.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbindex_get.any.js.ini
@@ -31,4 +31,26 @@
 
 
 [idbindex_get.any.worker.html]
-  expected: CRASH
+  [get() returns the record]
+    expected: FAIL
+
+  [get() returns the record where the index contains duplicate values]
+    expected: FAIL
+
+  [get() attempts to retrieve a record that does not exist]
+    expected: FAIL
+
+  [get() returns the record with the first key in the range]
+    expected: FAIL
+
+  [get() throws DataError when using invalid key]
+    expected: FAIL
+
+  [get() throws InvalidStateError when the index is deleted]
+    expected: FAIL
+
+  [get() throws TransactionInactiveError on aborted transaction]
+    expected: FAIL
+
+  [get() throws InvalidStateError on index deleted by aborted upgrade]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbindex_getKey.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbindex_getKey.any.js.ini
@@ -28,7 +28,30 @@
   expected: ERROR
 
 [idbindex_getKey.any.worker.html]
-  expected: CRASH
+  [getKey() returns the record's primary key]
+    expected: FAIL
+
+  [getKey() returns the record's primary key where the index contains duplicate values]
+    expected: FAIL
+
+  [getKey() attempt to retrieve the primary key of a record that doesn't exist]
+    expected: FAIL
+
+  [getKey() returns the key of the first record within the range]
+    expected: FAIL
+
+  [getKey() throws DataError when using invalid key]
+    expected: FAIL
+
+  [getKey() throws InvalidStateError when the index is deleted]
+    expected: FAIL
+
+  [getKey() throws TransactionInactiveError on aborted transaction]
+    expected: FAIL
+
+  [getKey() throws InvalidStateError on index deleted by aborted upgrade]
+    expected: FAIL
+
 
 [idbindex_getKey.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbindex_indexNames.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbindex_indexNames.any.js.ini
@@ -4,7 +4,9 @@
 
 
 [idbindex_indexNames.any.worker.html]
-  expected: CRASH
+  [Verify IDBObjectStore.indexNames property]
+    expected: FAIL
+
 
 [idbindex_indexNames.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbindex_openCursor.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbindex_openCursor.any.js.ini
@@ -2,7 +2,15 @@
   expected: ERROR
 
 [idbindex_openCursor.any.worker.html]
-  expected: CRASH
+  [If the index is deleted, throw InvalidStateError]
+    expected: FAIL
+
+  [If the transaction has been aborted, throw TransactionInactiveError]
+    expected: FAIL
+
+  [If the index is deleted by an aborted upgrade, throw InvalidStateError]
+    expected: FAIL
+
 
 [idbindex_openCursor.any.html]
   [If the index is deleted, throw InvalidStateError]

--- a/tests/wpt/meta/indexeddb/idbindex_openKeyCursor.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbindex_openKeyCursor.any.js.ini
@@ -1,5 +1,16 @@
 [idbindex_openKeyCursor.any.worker.html]
-  expected: CRASH
+  [Throw DataError when using a invalid key]
+    expected: FAIL
+
+  [Throw InvalidStateError when the index is deleted]
+    expected: FAIL
+
+  [Throw TransactionInactiveError on aborted transaction]
+    expected: FAIL
+
+  [Throw InvalidStateError on index deleted by aborted upgrade]
+    expected: FAIL
+
 
 [idbindex_openKeyCursor.any.html]
   [Throw DataError when using a invalid key]

--- a/tests/wpt/meta/indexeddb/idbobjectstore-add-put-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore-add-put-exception-order.any.js.ini
@@ -2,8 +2,9 @@
   expected: ERROR
 
 [idbobjectstore-add-put-exception-order.any.worker.html]
+  expected: TIMEOUT
   [IDBObjectStore.put exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.put exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
@@ -12,7 +13,7 @@
     expected: FAIL
 
   [IDBObjectStore.add exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.add exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
@@ -22,8 +23,9 @@
 
 
 [idbobjectstore-add-put-exception-order.any.html]
+  expected: TIMEOUT
   [IDBObjectStore.put exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.put exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
@@ -32,7 +34,7 @@
     expected: FAIL
 
   [IDBObjectStore.add exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.add exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbobjectstore-clear-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore-clear-exception-order.any.js.ini
@@ -1,14 +1,16 @@
 [idbobjectstore-clear-exception-order.any.worker.html]
+  expected: TIMEOUT
   [IDBObjectStore.clear exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.clear exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
 
 
 [idbobjectstore-clear-exception-order.any.html]
+  expected: TIMEOUT
   [IDBObjectStore.clear exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.clear exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbobjectstore-delete-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore-delete-exception-order.any.js.ini
@@ -5,8 +5,9 @@
   expected: ERROR
 
 [idbobjectstore-delete-exception-order.any.html]
+  expected: TIMEOUT
   [IDBObjectStore.delete exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.delete exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
@@ -16,8 +17,9 @@
 
 
 [idbobjectstore-delete-exception-order.any.worker.html]
+  expected: TIMEOUT
   [IDBObjectStore.delete exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.delete exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbobjectstore-deleteIndex-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore-deleteIndex-exception-order.any.js.ini
@@ -1,26 +1,28 @@
 [idbobjectstore-deleteIndex-exception-order.any.worker.html]
+  expected: TIMEOUT
   [IDBObjectStore.deleteIndex exception order: InvalidStateError #1 vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBObjectStore.deleteIndex exception order: InvalidStateError #2 vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.deleteIndex exception order: TransactionInactiveError vs. NotFoundError]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [idbobjectstore-deleteIndex-exception-order.any.sharedworker.html]
   expected: ERROR
 
 [idbobjectstore-deleteIndex-exception-order.any.html]
+  expected: TIMEOUT
   [IDBObjectStore.deleteIndex exception order: InvalidStateError #1 vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBObjectStore.deleteIndex exception order: InvalidStateError #2 vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.deleteIndex exception order: TransactionInactiveError vs. NotFoundError]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [idbobjectstore-deleteIndex-exception-order.any.serviceworker.html]

--- a/tests/wpt/meta/indexeddb/idbobjectstore-query-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore-query-exception-order.any.js.ini
@@ -5,76 +5,78 @@
   expected: ERROR
 
 [idbobjectstore-query-exception-order.any.html]
+  expected: TIMEOUT
   [IDBObjectStore.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.get exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.getAll exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getAll exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.getAllKeys exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getAllKeys exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.openCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.openKeyCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
 
 [idbobjectstore-query-exception-order.any.worker.html]
+  expected: TIMEOUT
   [IDBObjectStore.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.get exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.getAll exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getAll exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.getAllKeys exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getAllKeys exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.openCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.openKeyCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbobjectstore_add.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_add.any.js.ini
@@ -5,7 +5,54 @@
   expected: ERROR
 
 [idbobjectstore_add.any.worker.html]
-  expected: CRASH
+  [add() with an inline key]
+    expected: FAIL
+
+  [add() with an out-of-line key]
+    expected: FAIL
+
+  [add() record with same key already exists]
+    expected: FAIL
+
+  [add() where an index has unique:true specified]
+    expected: FAIL
+
+  [add() object store's key path is an object attribute]
+    expected: FAIL
+
+  [add() autoIncrement and inline keys]
+    expected: FAIL
+
+  [add() autoIncrement and out-of-line keys]
+    expected: FAIL
+
+  [Object store has autoIncrement:true and the key path is an object attribute]
+    expected: FAIL
+
+  [Attempt to 'add()' a record that does not meet the constraints of an   object store's inline key requirements]
+    expected: FAIL
+
+  [Attempt to call 'add()' without a key parameter when the object store uses out-of-line keys]
+    expected: FAIL
+
+  [Attempt to 'add()' a record where the record's key does not meet the constraints of a valid key]
+    expected: FAIL
+
+  [Attempt to 'add()' a record where the record's in-line key is not  defined]
+    expected: FAIL
+
+  [Attempt to 'add()' a record where the out of line key provided does not meet the constraints of a valid key]
+    expected: FAIL
+
+  [add() a record where a value being indexed does not meet the constraints of a valid key]
+    expected: FAIL
+
+  [If the transaction this IDBObjectStore belongs to has its mode set to readonly, throw ReadOnlyError]
+    expected: FAIL
+
+  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError]
+    expected: FAIL
+
 
 [idbobjectstore_add.any.html]
   [add() with an inline key]

--- a/tests/wpt/meta/indexeddb/idbobjectstore_clear.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_clear.any.js.ini
@@ -1,5 +1,16 @@
 [idbobjectstore_clear.any.worker.html]
-  expected: CRASH
+  [Verify clear removes all records ]
+    expected: FAIL
+
+  [Clear removes all records from an index ]
+    expected: FAIL
+
+  [If the transaction this IDBObjectStore belongs to has its mode set to readonly, throw ReadOnlyError ]
+    expected: FAIL
+
+  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError ]
+    expected: FAIL
+
 
 [idbobjectstore_clear.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbobjectstore_count.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_count.any.js.ini
@@ -19,4 +19,14 @@
   expected: ERROR
 
 [idbobjectstore_count.any.worker.html]
-  expected: CRASH
+  [Returns the number of records in the object store ]
+    expected: FAIL
+
+  [Returns the number of records that have keys within the range ]
+    expected: FAIL
+
+  [Returns the number of records that have keys with the key]
+    expected: FAIL
+
+  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError ]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbobjectstore_createIndex.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_createIndex.any.js.ini
@@ -1,4 +1,5 @@
 [idbobjectstore_createIndex.any.html]
+  expected: TIMEOUT
   [Returns an IDBIndex and the properties are set correctly]
     expected: FAIL
 
@@ -42,16 +43,16 @@
     expected: FAIL
 
   [InvalidStateError(Deleted ObjectStore) vs. TransactionInactiveError. Deletion check should precede transaction-state check.]
-    expected: FAIL
+    expected: TIMEOUT
 
   [TransactionInactiveError vs. ConstraintError. Transaction-state check should precede index name check.]
-    expected: FAIL
+    expected: TIMEOUT
 
   [ConstraintError vs. SyntaxError. Index name check should precede syntax check of the key path]
-    expected: FAIL
+    expected: TIMEOUT
 
   [SyntaxError vs. InvalidAccessError. Syntax check should precede multiEntry check of the key path.]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Explicit Primary Key]
     expected: FAIL
@@ -67,7 +68,70 @@
   expected: ERROR
 
 [idbobjectstore_createIndex.any.worker.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [Returns an IDBIndex and the properties are set correctly]
+    expected: FAIL
+
+  [Attempt to create an index that requires unique values on an object store already contains duplicates]
+    expected: FAIL
+
+  [The index is usable right after being made]
+    expected: FAIL
+
+  [Event ordering for a later deleted index]
+    expected: FAIL
+
+  [Empty keyPath]
+    expected: FAIL
+
+  [Event order when unique constraint is triggered]
+    expected: FAIL
+
+  [Event ordering for ConstraintError on request]
+    expected: FAIL
+
+  [Index can be valid keys]
+    expected: FAIL
+
+  [IDBObjectStore.createIndex() - empty name]
+    expected: FAIL
+
+  [If an index with the name name already exists in this object store, the implementation must throw a DOMException of type ConstraintError]
+    expected: FAIL
+
+  [If keyPath is not a valid key path, the implementation must throw a DOMException of type SyntaxError]
+    expected: FAIL
+
+  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError]
+    expected: FAIL
+
+  [Operate out versionchange throw InvalidStateError]
+    expected: FAIL
+
+  [InvalidStateError(Incorrect mode) vs. TransactionInactiveError. Mode check should precede state check of the transaction.]
+    expected: FAIL
+
+  [InvalidStateError(Deleted ObjectStore) vs. TransactionInactiveError. Deletion check should precede transaction-state check.]
+    expected: TIMEOUT
+
+  [TransactionInactiveError vs. ConstraintError. Transaction-state check should precede index name check.]
+    expected: TIMEOUT
+
+  [ConstraintError vs. SyntaxError. Index name check should precede syntax check of the key path]
+    expected: TIMEOUT
+
+  [SyntaxError vs. InvalidAccessError. Syntax check should precede multiEntry check of the key path.]
+    expected: TIMEOUT
+
+  [Explicit Primary Key]
+    expected: FAIL
+
+  [Auto-Increment Primary Key]
+    expected: FAIL
+
+  [Auto-Increment Primary Key - invalid key values elsewhere]
+    expected: FAIL
+
 
 [idbobjectstore_createIndex.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbobjectstore_delete.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_delete.any.js.ini
@@ -25,7 +25,27 @@
 
 
 [idbobjectstore_delete.any.worker.html]
-  expected: CRASH
+  [delete() removes record (inline keys)]
+    expected: FAIL
+
+  [delete() key doesn't match any records]
+    expected: FAIL
+
+  [Object store's key path is an object attribute]
+    expected: FAIL
+
+  [delete() removes record (out-of-line keys)]
+    expected: FAIL
+
+  [delete() removes all of the records in the range]
+    expected: FAIL
+
+  [If the transaction this IDBObjectStore belongs to has its mode set to readonly, throw ReadOnlyError]
+    expected: FAIL
+
+  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError]
+    expected: FAIL
+
 
 [idbobjectstore_delete.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbobjectstore_deleteIndex.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_deleteIndex.any.js.ini
@@ -10,4 +10,5 @@
 
 
 [idbobjectstore_deleteIndex.any.worker.html]
-  expected: CRASH
+  [IDBObjectStore.deleteIndex() removes the index]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbobjectstore_get.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_get.any.js.ini
@@ -1,5 +1,25 @@
 [idbobjectstore_get.any.worker.html]
-  expected: CRASH
+  [Key is a number]
+    expected: FAIL
+
+  [Key is a string]
+    expected: FAIL
+
+  [Key is a date]
+    expected: FAIL
+
+  [Attempts to retrieve a record that doesn't exist]
+    expected: FAIL
+
+  [Returns the record with the first key in the range]
+    expected: FAIL
+
+  [When a transaction is aborted, throw TransactionInactiveError]
+    expected: FAIL
+
+  [When an invalid key is used, throw DataError]
+    expected: FAIL
+
 
 [idbobjectstore_get.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbobjectstore_index.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_index.any.js.ini
@@ -5,7 +5,9 @@
   expected: ERROR
 
 [idbobjectstore_index.any.worker.html]
-  expected: CRASH
+  [IDBObjectStore.index() - returns an index]
+    expected: FAIL
+
 
 [idbobjectstore_index.any.html]
   [IDBObjectStore.index() - returns an index]

--- a/tests/wpt/meta/indexeddb/idbobjectstore_openCursor.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_openCursor.any.js.ini
@@ -10,4 +10,5 @@
   expected: ERROR
 
 [idbobjectstore_openCursor.any.worker.html]
-  expected: CRASH
+  [IDBObjectStore.openCursor() - iterate through 100 objects]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbobjectstore_put.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_put.any.js.ini
@@ -55,4 +55,50 @@
   expected: ERROR
 
 [idbobjectstore_put.any.worker.html]
-  expected: CRASH
+  [put() with an inline key]
+    expected: FAIL
+
+  [put() with an out-of-line key]
+    expected: FAIL
+
+  [put() record with key already exists]
+    expected: FAIL
+
+  [put() where an index has unique:true specified]
+    expected: FAIL
+
+  [Object store's key path is an object attribute]
+    expected: FAIL
+
+  [autoIncrement and inline keys]
+    expected: FAIL
+
+  [autoIncrement and out-of-line keys]
+    expected: FAIL
+
+  [Object store has autoIncrement:true and the key path is an object attribute]
+    expected: FAIL
+
+  [Attempt to put() a record that does not meet the constraints of an object store's inline key requirements]
+    expected: FAIL
+
+  [Attempt to call put() without an key parameter when the object store uses out-of-line keys]
+    expected: FAIL
+
+  [Attempt to put() a record where the record's key does not meet the constraints of a valid key]
+    expected: FAIL
+
+  [Attempt to put() a record where the record's in-line key is not defined]
+    expected: FAIL
+
+  [Attempt to put() a record where the out of line key provided does not meet the constraints of a valid key]
+    expected: FAIL
+
+  [put() a record where a value being indexed does not meet the constraints of a valid key]
+    expected: FAIL
+
+  [If the transaction this IDBObjectStore belongs to has its mode set to readonly, throw ReadOnlyError]
+    expected: FAIL
+
+  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbrequest_error.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbrequest_error.any.js.ini
@@ -2,7 +2,9 @@
   expected: ERROR
 
 [idbrequest_error.any.worker.html]
-  expected: CRASH
+  [IDBRequest.error throws if ready state is pending]
+    expected: FAIL
+
 
 [idbrequest_error.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbrequest_result.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbrequest_result.any.js.ini
@@ -10,4 +10,5 @@
   expected: ERROR
 
 [idbrequest_result.any.worker.html]
-  expected: CRASH
+  [IDBRequest.result throws if ready state is pending]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbtransaction-oncomplete.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbtransaction-oncomplete.any.js.ini
@@ -5,7 +5,9 @@
   expected: ERROR
 
 [idbtransaction-oncomplete.any.worker.html]
-  expected: CRASH
+  [IDBTransaction - complete event]
+    expected: FAIL
+
 
 [idbtransaction-oncomplete.any.html]
   [IDBTransaction - complete event]

--- a/tests/wpt/meta/indexeddb/idbtransaction.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbtransaction.any.js.ini
@@ -5,7 +5,10 @@
   expected: ERROR
 
 [idbtransaction.any.worker.html]
-  expected: CRASH
+  expected: ERROR
+  [IDBTransaction - request returned by open()]
+    expected: TIMEOUT
+
 
 [idbtransaction.any.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbtransaction_abort.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbtransaction_abort.any.js.ini
@@ -5,7 +5,15 @@
   expected: ERROR
 
 [idbtransaction_abort.any.worker.html]
-  expected: CRASH
+  [Abort event should fire during transaction]
+    expected: FAIL
+
+  [Abort during auto-committing should throw InvalidStateError.]
+    expected: FAIL
+
+  [Abort on completed transaction should throw InvalidStateError.]
+    expected: FAIL
+
 
 [idbtransaction_abort.any.html]
   [Abort event should fire during transaction]

--- a/tests/wpt/meta/indexeddb/idbtransaction_objectStoreNames.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbtransaction_objectStoreNames.any.js.ini
@@ -5,9 +5,6 @@
   expected: ERROR
 
 [idbtransaction_objectStoreNames.any.html]
-  [IDBTransaction.objectStoreNames - during upgrade transaction]
-    expected: FAIL
-
   [IDBTransaction.objectStoreNames - value after close]
     expected: FAIL
 
@@ -31,9 +28,6 @@
 
 
 [idbtransaction_objectStoreNames.any.worker.html]
-  [IDBTransaction.objectStoreNames - during upgrade transaction]
-    expected: FAIL
-
   [IDBTransaction.objectStoreNames - value after close]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/index_sort_order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/index_sort_order.any.js.ini
@@ -1,5 +1,7 @@
 [index_sort_order.any.worker.html]
-  expected: CRASH
+  [Verify IDBIndex key sort order is 'number < Date < DOMString']
+    expected: FAIL
+
 
 [index_sort_order.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/key-conversion-exceptions.any.js.ini
+++ b/tests/wpt/meta/indexeddb/key-conversion-exceptions.any.js.ini
@@ -2,15 +2,6 @@
   [IDBFactory cmp() static with throwing/invalid keys]
     expected: FAIL
 
-  [IDBCursor continue() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IndexedDB: Exceptions thrown during key conversion]
-    expected: FAIL
-
-  [IDBCursor update() method with throwing/invalid keys]
-    expected: FAIL
-
   [IDBKeyRange only() static with throwing/invalid keys]
     expected: FAIL
 
@@ -23,55 +14,10 @@
   [IDBKeyRange bound() static with throwing/invalid keys]
     expected: FAIL
 
-  [IDBObjectStore add() method with throwing/invalid keys]
+  [IDBObjectStore getAllRecords() method with throwing/invalid keys]
     expected: FAIL
 
-  [IDBObjectStore put() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore delete() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore get() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore getKey() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore getAll() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore getAllKeys() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore count() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore openCursor() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore openKeyCursor() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex get() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getKey() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getAll() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getAllKeys() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex count() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex openCursor() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex openKeyCursor() method with throwing/invalid keys]
+  [IDBIndex getAllRecords() method with throwing/invalid keys]
     expected: FAIL
 
 
@@ -82,15 +28,6 @@
   [IDBFactory cmp() static with throwing/invalid keys]
     expected: FAIL
 
-  [IDBCursor continue() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IndexedDB: Exceptions thrown during key conversion]
-    expected: FAIL
-
-  [IDBCursor update() method with throwing/invalid keys]
-    expected: FAIL
-
   [IDBKeyRange only() static with throwing/invalid keys]
     expected: FAIL
 
@@ -103,55 +40,10 @@
   [IDBKeyRange bound() static with throwing/invalid keys]
     expected: FAIL
 
-  [IDBObjectStore add() method with throwing/invalid keys]
+  [IDBObjectStore getAllRecords() method with throwing/invalid keys]
     expected: FAIL
 
-  [IDBObjectStore put() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore delete() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore get() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore getKey() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore getAll() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore getAllKeys() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore count() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore openCursor() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore openKeyCursor() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex get() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getKey() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getAll() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getAllKeys() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex count() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex openCursor() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex openKeyCursor() method with throwing/invalid keys]
+  [IDBIndex getAllRecords() method with throwing/invalid keys]
     expected: FAIL
 
 

--- a/tests/wpt/meta/indexeddb/key_invalid.any.js.ini
+++ b/tests/wpt/meta/indexeddb/key_invalid.any.js.ini
@@ -112,4 +112,104 @@
   expected: ERROR
 
 [key_invalid.any.worker.html]
-  expected: CRASH
+  [Invalid key - true]
+    expected: FAIL
+
+  [Invalid key - false]
+    expected: FAIL
+
+  [Invalid key - null]
+    expected: FAIL
+
+  [Invalid key - NaN]
+    expected: FAIL
+
+  [Invalid key - undefined]
+    expected: FAIL
+
+  [Invalid key - undefined2]
+    expected: FAIL
+
+  [Invalid key - function() {}]
+    expected: FAIL
+
+  [Invalid key - {}]
+    expected: FAIL
+
+  [Invalid key - { obj: 1 }]
+    expected: FAIL
+
+  [Invalid key - Math]
+    expected: FAIL
+
+  [Invalid key - self]
+    expected: FAIL
+
+  [Invalid key - {length:0,constructor:Array}]
+    expected: FAIL
+
+  [Invalid key - Array clone’s instance]
+    expected: FAIL
+
+  [Invalid key - Array (object)]
+    expected: FAIL
+
+  [Invalid key - String (object)]
+    expected: FAIL
+
+  [Invalid key - new String()]
+    expected: FAIL
+
+  [Invalid key - new Number()]
+    expected: FAIL
+
+  [Invalid key - new Boolean()]
+    expected: FAIL
+
+  [Invalid key - [{}\]]
+    expected: FAIL
+
+  [Invalid key - [[\], [\], [\], [[ Date \]\]\]]
+    expected: FAIL
+
+  [Invalid key - [undefined\]]
+    expected: FAIL
+
+  [Invalid key - [,1\]]
+    expected: FAIL
+
+  [Invalid key - new Date(NaN)]
+    expected: FAIL
+
+  [Invalid key - new Date(Infinity)]
+    expected: FAIL
+
+  [Invalid key - /foo/]
+    expected: FAIL
+
+  [Invalid key - new RegExp()]
+    expected: FAIL
+
+  [Invalid key - sparse array]
+    expected: FAIL
+
+  [Invalid key - sparse array 2]
+    expected: FAIL
+
+  [Invalid key - [[1\], [3\], [7\], [[ sparse array \]\]\]]
+    expected: FAIL
+
+  [Invalid key - [1,2,3,,\]]
+    expected: FAIL
+
+  [Invalid key - array directly contains self]
+    expected: FAIL
+
+  [Invalid key - array indirectly contains self]
+    expected: FAIL
+
+  [Invalid key - array member contains self]
+    expected: FAIL
+
+  [Invalid key - proxy of an array]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/key_valid.any.js.ini
+++ b/tests/wpt/meta/indexeddb/key_valid.any.js.ini
@@ -61,4 +61,56 @@
   expected: ERROR
 
 [key_valid.any.worker.html]
-  expected: CRASH
+  [Valid key - new Date()]
+    expected: FAIL
+
+  [Valid key - new Date(0)]
+    expected: FAIL
+
+  [Valid key - [\]]
+    expected: FAIL
+
+  [Valid key - new Array()]
+    expected: FAIL
+
+  [Valid key - ["undefined"\]]
+    expected: FAIL
+
+  [Valid key - Infinity]
+    expected: FAIL
+
+  [Valid key - -Infinity]
+    expected: FAIL
+
+  [Valid key - 0]
+    expected: FAIL
+
+  [Valid key - 1.5]
+    expected: FAIL
+
+  [Valid key - 3e38]
+    expected: FAIL
+
+  [Valid key - 3e-38]
+    expected: FAIL
+
+  [Valid key - "foo"]
+    expected: FAIL
+
+  [Valid key - "\\n"]
+    expected: FAIL
+
+  [Valid key - ""]
+    expected: FAIL
+
+  [Valid key - "\\""]
+    expected: FAIL
+
+  [Valid key - "\\u1234"]
+    expected: FAIL
+
+  [Valid key - "\\u0000"]
+    expected: FAIL
+
+  [Valid key - "NaN"]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/keygenerator.any.js.ini
+++ b/tests/wpt/meta/indexeddb/keygenerator.any.js.ini
@@ -1,5 +1,67 @@
 [keygenerator.any.worker.html]
-  expected: CRASH
+  [Keygenerator - starts at one, and increments by one]
+    expected: FAIL
+
+  [Keygenerator - increments by one from last set key]
+    expected: FAIL
+
+  [Keygenerator - don't increment when new key is not bigger than current]
+    expected: FAIL
+
+  [Keygenerator ConstraintError when using same id as already generated]
+    expected: FAIL
+
+  [Key generator vs. explicit key 53 bits]
+    expected: FAIL
+
+  [Key generator vs. explicit key greater than 53 bits, less than 64 bits]
+    expected: FAIL
+
+  [Key generator vs. explicit key greater than 53 bits, less than 64 bits (negative)]
+    expected: FAIL
+
+  [Key generator vs. explicit key 63 bits]
+    expected: FAIL
+
+  [Key generator vs. explicit key 63 bits (negative)]
+    expected: FAIL
+
+  [Key generator vs. explicit key 64 bits]
+    expected: FAIL
+
+  [Key generator vs. explicit key 64 bits (negative)]
+    expected: FAIL
+
+  [Key generator vs. explicit key greater than 64 bits, but still finite]
+    expected: FAIL
+
+  [Key generator vs. explicit key greater than 64 bits, but still finite (negative)]
+    expected: FAIL
+
+  [Key generator vs. explicit key equal to Infinity]
+    expected: FAIL
+
+  [Key generator vs. explicit key equal to -Infinity]
+    expected: FAIL
+
+  [Key is injected into value - single segment path]
+    expected: FAIL
+
+  [Key is injected into value - multi-segment path]
+    expected: FAIL
+
+  [Key is injected into value - multi-segment path, partially populated]
+    expected: FAIL
+
+  [put() throws if key cannot be injected - single segment path]
+    expected: FAIL
+
+  [put() throws if key cannot be injected - multi-segment path]
+    expected: FAIL
+
+  [Keygenerator overflow]
+    expected: FAIL
+
 
 [keygenerator.any.html]
   [Keygenerator - starts at one, and increments by one]

--- a/tests/wpt/meta/indexeddb/keyorder.any.js.ini
+++ b/tests/wpt/meta/indexeddb/keyorder.any.js.ini
@@ -2,7 +2,78 @@
   expected: ERROR
 
 [keyorder.any.worker.html]
-  expected: CRASH
+  [Database readback sort - String < Array]
+    expected: FAIL
+
+  [IDBKey.cmp sort - String < Array]
+    expected: FAIL
+
+  [Database readback sort - float < String]
+    expected: FAIL
+
+  [IDBKey.cmp sort - float < String]
+    expected: FAIL
+
+  [Database readback sort - float < Date]
+    expected: FAIL
+
+  [IDBKey.cmp sort - float < Date]
+    expected: FAIL
+
+  [Database readback sort - float < Date < String < Array]
+    expected: FAIL
+
+  [IDBKey.cmp sort - float < Date < String < Array]
+    expected: FAIL
+
+  [Database readback sort - Date(1 sec ago) < Date(now) < Date(1 minute in future)]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Date(1 sec ago) < Date(now) < Date(1 minute in future)]
+    expected: FAIL
+
+  [Database readback sort - -1.1 < 1 < 1.01337 < 1.013373 < 2]
+    expected: FAIL
+
+  [IDBKey.cmp sort - -1.1 < 1 < 1.01337 < 1.013373 < 2]
+    expected: FAIL
+
+  [Database readback sort - -Infinity < -0.01 < 0 < Infinity]
+    expected: FAIL
+
+  [IDBKey.cmp sort - -Infinity < -0.01 < 0 < Infinity]
+    expected: FAIL
+
+  [Database readback sort - "" < "a" < "ab" < "b" < "ba"]
+    expected: FAIL
+
+  [IDBKey.cmp sort - "" < "a" < "ab" < "b" < "ba"]
+    expected: FAIL
+
+  [Database readback sort - Arrays]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Arrays]
+    expected: FAIL
+
+  [Database readback sort - Array.length: 10,000 < Array.length: 10,001]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Array.length: 10,000 < Array.length: 10,001]
+    expected: FAIL
+
+  [Database readback sort - Infinity inside arrays]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Infinity inside arrays]
+    expected: FAIL
+
+  [Database readback sort - Test different stuff at once]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Test different stuff at once]
+    expected: FAIL
+
 
 [keyorder.any.html]
   [Database readback sort - String < Array]

--- a/tests/wpt/meta/indexeddb/keypath-exceptions.any.js.ini
+++ b/tests/wpt/meta/indexeddb/keypath-exceptions.any.js.ini
@@ -5,36 +5,12 @@
   [The last element of keypath is validated]
     expected: FAIL
 
-  [Key path evaluation: Exceptions from non-enumerable getters]
-    expected: FAIL
-
-  [Key path evaluation: Exceptions from enumerable getters]
-    expected: FAIL
-
-  [Key path evaluation: Exceptions from non-enumerable getters on prototype]
-    expected: FAIL
-
-  [Key path evaluation: Exceptions from enumerable getters on prototype]
-    expected: FAIL
-
   [Array key conversion should not invoke prototype getters]
     expected: FAIL
 
 
 [keypath-exceptions.any.worker.html]
   [The last element of keypath is validated]
-    expected: FAIL
-
-  [Key path evaluation: Exceptions from non-enumerable getters]
-    expected: FAIL
-
-  [Key path evaluation: Exceptions from enumerable getters]
-    expected: FAIL
-
-  [Key path evaluation: Exceptions from non-enumerable getters on prototype]
-    expected: FAIL
-
-  [Key path evaluation: Exceptions from enumerable getters on prototype]
     expected: FAIL
 
   [Array key conversion should not invoke prototype getters]

--- a/tests/wpt/meta/indexeddb/keypath.any.js.ini
+++ b/tests/wpt/meta/indexeddb/keypath.any.js.ini
@@ -67,4 +67,62 @@
   expected: ERROR
 
 [keypath.any.worker.html]
-  expected: CRASH
+  [undefined - my.key]
+    expected: FAIL
+
+  [undefined - my.køi]
+    expected: FAIL
+
+  [undefined - my.key_ya]
+    expected: FAIL
+
+  [undefined - public.key$ya]
+    expected: FAIL
+
+  [undefined - true.$]
+    expected: FAIL
+
+  [undefined - my._]
+    expected: FAIL
+
+  [undefined - delete.a7]
+    expected: FAIL
+
+  [undefined - p.p.p.p.p.p.p.p.p.p.p.p.p.p]
+    expected: FAIL
+
+  [undefined - str.length]
+    expected: FAIL
+
+  [undefined - arr.length]
+    expected: FAIL
+
+  [undefined - length]
+    expected: FAIL
+
+  [undefined - '' uses value as key]
+    expected: FAIL
+
+  [undefined - [''\] uses value as [key\]]
+    expected: FAIL
+
+  [undefined - ['x', 'y'\]]
+    expected: FAIL
+
+  [undefined - [['x'\], 'y'\] (stringifies)]
+    expected: FAIL
+
+  [undefined - ['x', {toString->'y'}\] (stringifies)]
+    expected: FAIL
+
+  [undefined - name,type]
+    expected: FAIL
+
+  [undefined - name,type.name]
+    expected: FAIL
+
+  [undefined - list with 1 field]
+    expected: FAIL
+
+  [undefined - array loop -> stringify becomes [''\]]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/keypath_invalid.any.js.ini
+++ b/tests/wpt/meta/indexeddb/keypath_invalid.any.js.ini
@@ -1,5 +1,76 @@
 [keypath_invalid.any.worker.html]
-  expected: CRASH
+  [Invalid keyPath - "j a"]
+    expected: FAIL
+
+  [Invalid keyPath - ".yo"]
+    expected: FAIL
+
+  [Invalid keyPath - "yo,lo"]
+    expected: FAIL
+
+  [Invalid keyPath - [\]]
+    expected: FAIL
+
+  [Invalid keyPath - ["array with space"\]]
+    expected: FAIL
+
+  [Invalid keyPath - multidimensional array (invalid toString)]
+    expected: FAIL
+
+  [Invalid keyPath - "3m"]
+    expected: FAIL
+
+  [Invalid keyPath - {toString->3m}]
+    expected: FAIL
+
+  [Invalid keyPath - "my.1337"]
+    expected: FAIL
+
+  [Invalid keyPath - "..yo"]
+    expected: FAIL
+
+  [Invalid keyPath - "y..o"]
+    expected: FAIL
+
+  [Invalid keyPath - "y.o."]
+    expected: FAIL
+
+  [Invalid keyPath - "y.o.."]
+    expected: FAIL
+
+  [Invalid keyPath - "m.*"]
+    expected: FAIL
+
+  [Invalid keyPath - "\\"m\\""]
+    expected: FAIL
+
+  [Invalid keyPath - "m%"]
+    expected: FAIL
+
+  [Invalid keyPath - "m/"]
+    expected: FAIL
+
+  [Invalid keyPath - "m/a"]
+    expected: FAIL
+
+  [Invalid keyPath - "m&"]
+    expected: FAIL
+
+  [Invalid keyPath - "m!"]
+    expected: FAIL
+
+  [Invalid keyPath - "*"]
+    expected: FAIL
+
+  [Invalid keyPath - "*.*"]
+    expected: FAIL
+
+  [Invalid keyPath - "^m"]
+    expected: FAIL
+
+  [Invalid keyPath - "/m/"]
+    expected: FAIL
+
 
 [keypath_invalid.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/keypath_maxsize.any.js.ini
+++ b/tests/wpt/meta/indexeddb/keypath_maxsize.any.js.ini
@@ -2,7 +2,15 @@
   expected: ERROR
 
 [keypath_maxsize.any.worker.html]
-  expected: CRASH
+  [undefined - ~260 chars]
+    expected: FAIL
+
+  [undefined - ~530 chars]
+    expected: FAIL
+
+  [undefined - ~1050 chars]
+    expected: FAIL
+
 
 [keypath_maxsize.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/list_ordering.any.js.ini
+++ b/tests/wpt/meta/indexeddb/list_ordering.any.js.ini
@@ -16,4 +16,11 @@
   expected: ERROR
 
 [list_ordering.any.worker.html]
-  expected: CRASH
+  [Validate ObjectStoreNames and indexNames list order - numbers]
+    expected: FAIL
+
+  [Validate ObjectStoreNames and indexNames list order - numbers 'overflow']
+    expected: FAIL
+
+  [Validate ObjectStoreNames and indexNames list order - lexigraphical string sort]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/objectstore_keyorder.any.js.ini
+++ b/tests/wpt/meta/indexeddb/objectstore_keyorder.any.js.ini
@@ -5,7 +5,9 @@
   expected: ERROR
 
 [objectstore_keyorder.any.worker.html]
-  expected: CRASH
+  [Verify key sort order in an object store is 'number < Date < DOMString' ]
+    expected: FAIL
+
 
 [objectstore_keyorder.any.html]
   [Verify key sort order in an object store is 'number < Date < DOMString' ]

--- a/tests/wpt/meta/indexeddb/request_bubble-and-capture.any.js.ini
+++ b/tests/wpt/meta/indexeddb/request_bubble-and-capture.any.js.ini
@@ -10,4 +10,5 @@
   expected: ERROR
 
 [request_bubble-and-capture.any.worker.html]
-  expected: CRASH
+  [IndexedDB Request Event Propagation: Bubbling and Capturing]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/string-list-ordering.any.js.ini
+++ b/tests/wpt/meta/indexeddb/string-list-ordering.any.js.ini
@@ -1,5 +1,7 @@
 [string-list-ordering.any.worker.html]
-  expected: CRASH
+  [Test string list ordering in IndexedDB]
+    expected: FAIL
+
 
 [string-list-ordering.any.html]
   [Test string list ordering in IndexedDB]

--- a/tests/wpt/meta/indexeddb/transaction-create_in_versionchange.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction-create_in_versionchange.any.js.ini
@@ -7,7 +7,9 @@
   expected: ERROR
 
 [transaction-create_in_versionchange.any.worker.html]
-  expected: CRASH
+  [Attempt to create new transactions inside a versionchange transaction]
+    expected: FAIL
+
 
 [transaction-create_in_versionchange.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/transaction-requestqueue.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction-requestqueue.any.js.ini
@@ -10,4 +10,5 @@
   expected: ERROR
 
 [transaction-requestqueue.any.worker.html]
-  expected: CRASH
+  [Transactions have a request queue]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/transaction_bubble-and-capture.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction_bubble-and-capture.any.js.ini
@@ -1,5 +1,7 @@
 [transaction_bubble-and-capture.any.worker.html]
-  expected: CRASH
+  [Capture and bubble]
+    expected: FAIL
+
 
 [transaction_bubble-and-capture.any.html]
   [Capture and bubble]

--- a/tests/wpt/meta/indexeddb/upgrade-transaction-deactivation-timing.any.js.ini
+++ b/tests/wpt/meta/indexeddb/upgrade-transaction-deactivation-timing.any.js.ini
@@ -1,27 +1,9 @@
 [upgrade-transaction-deactivation-timing.any.worker.html]
-  [Upgrade transactions are active in upgradeneeded callback]
-    expected: FAIL
-
-  [Upgrade transactions are active in upgradeneeded callback and microtasks]
-    expected: FAIL
-
-  [Upgrade transactions are deactivated before next task]
-    expected: FAIL
-
 
 [upgrade-transaction-deactivation-timing.any.serviceworker.html]
   expected: ERROR
 
 [upgrade-transaction-deactivation-timing.any.html]
-  [Upgrade transactions are active in upgradeneeded callback]
-    expected: FAIL
-
-  [Upgrade transactions are active in upgradeneeded callback and microtasks]
-    expected: FAIL
-
-  [Upgrade transactions are deactivated before next task]
-    expected: FAIL
-
 
 [upgrade-transaction-deactivation-timing.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/value.any.js.ini
+++ b/tests/wpt/meta/indexeddb/value.any.js.ini
@@ -1,5 +1,28 @@
 [value.any.worker.html]
-  expected: CRASH
+  [BigInts as values in IndexedDB - primitive BigInt]
+    expected: FAIL
+
+  [BigInts as values in IndexedDB - BigInt object]
+    expected: FAIL
+
+  [BigInts as values in IndexedDB - primitive BigInt inside object]
+    expected: FAIL
+
+  [BigInts as values in IndexedDB - BigInt object inside object]
+    expected: FAIL
+
+  [BigInts as keys in IndexedDB - primitive BigInt]
+    expected: FAIL
+
+  [BigInts as keys in IndexedDB - BigInt object]
+    expected: FAIL
+
+  [Values - Date]
+    expected: FAIL
+
+  [Values - Array]
+    expected: FAIL
+
 
 [value.any.html]
   [BigInts as values in IndexedDB - primitive BigInt]

--- a/tests/wpt/meta/indexeddb/value_recursive.any.js.ini
+++ b/tests/wpt/meta/indexeddb/value_recursive.any.js.ini
@@ -10,7 +10,15 @@
 
 
 [value_recursive.any.worker.html]
-  expected: CRASH
+  [Recursive value - array directly contains self]
+    expected: FAIL
+
+  [Recursive value - array indirectly contains self]
+    expected: FAIL
+
+  [Recursive value - array member contains self]
+    expected: FAIL
+
 
 [value_recursive.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/writer-starvation.any.js.ini
+++ b/tests/wpt/meta/indexeddb/writer-starvation.any.js.ini
@@ -10,4 +10,5 @@
 
 
 [writer-starvation.any.worker.html]
-  expected: CRASH
+  [IDB read requests should not starve write requests]
+    expected: FAIL


### PR DESCRIPTION
There were a lot of crashing IndexedDB tests caused by code in DOMStringList that required a Window object despite being exposed to non-Window globals.

Testing: Lots of existing tests no longer crash.
Fixes: part of #6963