### PR TITLE
script: Store result value in IDBRequest. 

### DIFF
--- a/components/script/dom/idbrequest.rs
+++ b/components/script/dom/idbrequest.rs
@@ -244,8 +244,8 @@ impl IDBRequest {
 
 impl IDBRequestMethods<crate::DomTypeHolder> for IDBRequest {
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbrequest-result
-    fn Result(&self, _cx: SafeJSContext, _val: js::rust::MutableHandle<'_, js::jsapi::Value>) {
-        self.result.get();
+    fn Result(&self, _cx: SafeJSContext, mut val: js::rust::MutableHandle<'_, js::jsapi::Value>) {
+        val.set(self.result.get());
     }
 
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbrequest-error

--- a/tests/wpt/meta/indexeddb/blob-contenttype.any.js.ini
+++ b/tests/wpt/meta/indexeddb/blob-contenttype.any.js.ini
@@ -1,9 +1,10 @@
 [blob-contenttype.any.html]
+  expected: CRASH
   [Ensure that content type round trips when reading blob data]
     expected: FAIL
 
 
 [blob-contenttype.any.worker.html]
+  expected: CRASH
   [Ensure that content type round trips when reading blob data]
     expected: FAIL
-

--- a/tests/wpt/meta/indexeddb/blob-valid-after-deletion.any.js.ini
+++ b/tests/wpt/meta/indexeddb/blob-valid-after-deletion.any.js.ini
@@ -1,9 +1,10 @@
 [blob-valid-after-deletion.any.worker.html]
+  expected: CRASH
   [Blobs stay alive after their records are deleted.]
     expected: FAIL
 
 
 [blob-valid-after-deletion.any.html]
+  expected: CRASH
   [Blobs stay alive after their records are deleted.]
     expected: FAIL
-

--- a/tests/wpt/meta/indexeddb/blob-valid-before-commit.any.js.ini
+++ b/tests/wpt/meta/indexeddb/blob-valid-before-commit.any.js.ini
@@ -1,9 +1,10 @@
 [blob-valid-before-commit.any.worker.html]
+  expected: CRASH
   [Blobs can be read back before their records are committed.]
     expected: FAIL
 
 
 [blob-valid-before-commit.any.html]
+  expected: CRASH
   [Blobs can be read back before their records are committed.]
     expected: FAIL
-

--- a/tests/wpt/meta/indexeddb/clone-before-keypath-eval.any.js.ini
+++ b/tests/wpt/meta/indexeddb/clone-before-keypath-eval.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [clone-before-keypath-eval.any.html]
+  expected: CRASH
   [Key generator and key path validity check operates on a clone]
     expected: FAIL
 
@@ -19,6 +20,7 @@
 
 
 [clone-before-keypath-eval.any.worker.html]
+  expected: CRASH
   [Key generator and key path validity check operates on a clone]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/delete-range.any.js.ini
+++ b/tests/wpt/meta/indexeddb/delete-range.any.js.ini
@@ -1,4 +1,5 @@
 [delete-range.any.worker.html]
+  expected: CRASH
   [Delete range]
     expected: FAIL
 
@@ -13,6 +14,7 @@
 
 
 [delete-range.any.html]
+  expected: CRASH
   [Delete range]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/delete-request-queue.any.js.ini
+++ b/tests/wpt/meta/indexeddb/delete-request-queue.any.js.ini
@@ -1,12 +1,6 @@
 [delete-request-queue.any.worker.html]
-  [Deletes are processed as a FIFO queue]
-    expected: FAIL
-
 
 [delete-request-queue.any.html]
-  [Deletes are processed as a FIFO queue]
-    expected: FAIL
-
 
 [delete-request-queue.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/error-attributes.any.js.ini
+++ b/tests/wpt/meta/indexeddb/error-attributes.any.js.ini
@@ -1,4 +1,5 @@
 [error-attributes.any.worker.html]
+  expected: CRASH
   [IDBRequest and IDBTransaction error properties should be DOMExceptions]
     expected: FAIL
 
@@ -10,5 +11,6 @@
   expected: ERROR
 
 [error-attributes.any.html]
+  expected: CRASH
   [IDBRequest and IDBTransaction error properties should be DOMExceptions]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/event-dispatch-active-flag.any.js.ini
+++ b/tests/wpt/meta/indexeddb/event-dispatch-active-flag.any.js.ini
@@ -1,4 +1,5 @@
 [event-dispatch-active-flag.any.html]
+  expected: CRASH
   [Active during success handlers]
     expected: FAIL
 
@@ -16,6 +17,7 @@
   expected: ERROR
 
 [event-dispatch-active-flag.any.worker.html]
+  expected: CRASH
   [Active during success handlers]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/fire-error-event-exception.any.js.ini
+++ b/tests/wpt/meta/indexeddb/fire-error-event-exception.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [fire-error-event-exception.any.worker.html]
+  expected: CRASH
   [Exception in error event handler on request]
     expected: FAIL
 
@@ -55,6 +56,7 @@
 
 
 [fire-error-event-exception.any.html]
+  expected: CRASH
   [Exception in error event handler on request]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/fire-success-event-exception.any.js.ini
+++ b/tests/wpt/meta/indexeddb/fire-success-event-exception.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [fire-success-event-exception.any.worker.html]
+  expected: CRASH
   [Exception in success event handler on request]
     expected: FAIL
 
@@ -22,6 +23,7 @@
 
 
 [fire-success-event-exception.any.html]
+  expected: CRASH
   [Exception in success event handler on request]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idb-binary-key-detached.htm.ini
+++ b/tests/wpt/meta/indexeddb/idb-binary-key-detached.htm.ini
@@ -1,4 +1,5 @@
 [idb-binary-key-detached.htm]
+  expected: CRASH
   [Detached TypedArray]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idb-partitioned-persistence.sub.html.ini
+++ b/tests/wpt/meta/indexeddb/idb-partitioned-persistence.sub.html.ini
@@ -1,4 +1,3 @@
 [idb-partitioned-persistence.sub.html]
-  expected: TIMEOUT
   [Persistence test for partitioned IndexedDB]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idb_webworkers.htm.ini
+++ b/tests/wpt/meta/indexeddb/idb_webworkers.htm.ini
@@ -1,4 +1,4 @@
 [idb_webworkers.htm]
-  expected: ERROR
+  expected: CRASH
   [IndexedDB inside of a WebWorker ]
     expected: TIMEOUT

--- a/tests/wpt/meta/indexeddb/idbcursor-continuePrimaryKey-exceptions.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor-continuePrimaryKey-exceptions.any.js.ini
@@ -2,19 +2,17 @@
   expected: ERROR
 
 [idbcursor-continuePrimaryKey-exceptions.any.worker.html]
-  expected: ERROR
   [IDBCursor continuePrimaryKey() on object store cursor]
     expected: FAIL
 
   [IDBCursor continuePrimaryKey() on "nextunique" cursor]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBCursor continuePrimaryKey() on "prevunique" cursor]
-    expected: TIMEOUT
+    expected: FAIL
 
 
 [idbcursor-continuePrimaryKey-exceptions.any.html]
-  expected: ERROR
   [IDBCursor continuePrimaryKey() on object store cursor]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbcursor-direction.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor-direction.any.js.ini
@@ -2,7 +2,7 @@
   expected: ERROR
 
 [idbcursor-direction.any.worker.html]
-  expected: ERROR
+  expected: CRASH
   [IDBCursor.direction - undefined]
     expected: FAIL
 
@@ -20,7 +20,7 @@
 
 
 [idbcursor-direction.any.html]
-  expected: ERROR
+  expected: CRASH
   [IDBCursor.direction - undefined]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbcursor-key.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor-key.any.js.ini
@@ -5,6 +5,7 @@
   expected: ERROR
 
 [idbcursor-key.any.worker.html]
+  expected: CRASH
   [IDBCursor.key]
     expected: FAIL
 
@@ -16,6 +17,7 @@
 
 
 [idbcursor-key.any.html]
+  expected: CRASH
   [IDBCursor.key]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbcursor_advance_objectstore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_advance_objectstore.any.js.ini
@@ -1,4 +1,5 @@
 [idbcursor_advance_objectstore.any.html]
+  expected: CRASH
   [object store - iterate cursor number of times specified by count]
     expected: FAIL
 
@@ -19,6 +20,7 @@
   expected: ERROR
 
 [idbcursor_advance_objectstore.any.worker.html]
+  expected: CRASH
   [object store - iterate cursor number of times specified by count]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbcursor_continue_objectstore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_continue_objectstore.any.js.ini
@@ -1,5 +1,5 @@
 [idbcursor_continue_objectstore.any.worker.html]
-  expected: ERROR
+  expected: CRASH
   [Iterate to the next record]
     expected: FAIL
 
@@ -29,7 +29,7 @@
   expected: ERROR
 
 [idbcursor_continue_objectstore.any.html]
-  expected: ERROR
+  expected: CRASH
   [Iterate to the next record]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbcursor_delete_objectstore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_delete_objectstore.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [idbcursor_delete_objectstore.any.worker.html]
+  expected: CRASH
   [Remove a record from the object store ]
     expected: FAIL
 
@@ -19,6 +20,7 @@
 
 
 [idbcursor_delete_objectstore.any.html]
+  expected: CRASH
   [Remove a record from the object store ]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbcursor_iterating.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_iterating.any.js.ini
@@ -2,7 +2,6 @@
   expected: ERROR
 
 [idbcursor_iterating.any.html]
-  expected: ERROR
   [Iterate and Delete elements]
     expected: FAIL
 
@@ -11,6 +10,5 @@
   expected: ERROR
 
 [idbcursor_iterating.any.worker.html]
-  expected: ERROR
   [Iterate and Delete elements]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbcursor_update_objectstore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbcursor_update_objectstore.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [idbcursor_update_objectstore.any.worker.html]
+  expected: CRASH
   [Modify a record in the object store ]
     expected: FAIL
 
@@ -31,6 +32,7 @@
 
 
 [idbcursor_update_objectstore.any.html]
+  expected: CRASH
   [Modify a record in the object store ]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbdatabase-transaction-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbdatabase-transaction-exception-order.any.js.ini
@@ -5,22 +5,16 @@
   expected: ERROR
 
 [idbdatabase-transaction-exception-order.any.html]
-  [IDBDatabase.transaction exception order: InvalidStateError vs. NotFoundError]
-    expected: FAIL
-
-  [IDBDatabase.transaction exception order: InvalidStateError vs. InvalidAccessError]
-    expected: FAIL
-
   [IDBDatabase.transaction exception order: NotFoundError vs. TypeError]
+    expected: FAIL
+
+  [IDBDatabase.transaction throws exception on invalid mode]
     expected: FAIL
 
 
 [idbdatabase-transaction-exception-order.any.worker.html]
-  [IDBDatabase.transaction exception order: InvalidStateError vs. NotFoundError]
-    expected: FAIL
-
-  [IDBDatabase.transaction exception order: InvalidStateError vs. InvalidAccessError]
-    expected: FAIL
-
   [IDBDatabase.transaction exception order: NotFoundError vs. TypeError]
+    expected: FAIL
+
+  [IDBDatabase.transaction throws exception on invalid mode]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbdatabase_createObjectStore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbdatabase_createObjectStore.any.js.ini
@@ -1,4 +1,5 @@
 [idbdatabase_createObjectStore.any.worker.html]
+  expected: CRASH
   [Both with empty name]
     expected: FAIL
 
@@ -88,6 +89,7 @@
   expected: ERROR
 
 [idbdatabase_createObjectStore.any.html]
+  expected: CRASH
   [Both with empty name]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbdatabase_deleteObjectStore.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbdatabase_deleteObjectStore.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [idbdatabase_deleteObjectStore.any.worker.html]
+  expected: CRASH
   [Deleted object store's name should be removed from database's list. Attempting to use a deleted IDBObjectStore should throw an InvalidStateError]
     expected: FAIL
 
@@ -16,6 +17,7 @@
   expected: ERROR
 
 [idbdatabase_deleteObjectStore.any.html]
+  expected: CRASH
   [Deleted object store's name should be removed from database's list. Attempting to use a deleted IDBObjectStore should throw an InvalidStateError]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbdatabase_transaction.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbdatabase_transaction.any.js.ini
@@ -5,15 +5,6 @@
   [Attempt to open a transaction with invalid scope]
     expected: FAIL
 
-  [Opening a transaction defaults to a read-only mode]
-    expected: FAIL
-
-  [Attempt to open a transaction from closed database connection]
-    expected: FAIL
-
-  [Attempt to open a transaction with invalid mode]
-    expected: FAIL
-
   [If storeNames is an empty list, the implementation must throw a DOMException of type InvalidAccessError]
     expected: FAIL
 
@@ -23,15 +14,6 @@
 
 [idbdatabase_transaction.any.html]
   [Attempt to open a transaction with invalid scope]
-    expected: FAIL
-
-  [Opening a transaction defaults to a read-only mode]
-    expected: FAIL
-
-  [Attempt to open a transaction from closed database connection]
-    expected: FAIL
-
-  [Attempt to open a transaction with invalid mode]
     expected: FAIL
 
   [If storeNames is an empty list, the implementation must throw a DOMException of type InvalidAccessError]

--- a/tests/wpt/meta/indexeddb/idbfactory_deleteDatabase.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbfactory_deleteDatabase.any.js.ini
@@ -2,30 +2,12 @@
   expected: ERROR
 
 [idbfactory_deleteDatabase.any.html]
-  [deleteDatabase() request should have no source]
-    expected: FAIL
-
-  [Result of the deleteDatabase() request is set to undefined.]
-    expected: FAIL
-
   [The deleteDatabase() request's success event is an IDBVersionChangeEvent.]
-    expected: FAIL
-
-  [Delete an existing database - Test events opening a second database when one connection is open already]
     expected: FAIL
 
 
 [idbfactory_deleteDatabase.any.worker.html]
-  [deleteDatabase() request should have no source]
-    expected: FAIL
-
-  [Result of the deleteDatabase() request is set to undefined.]
-    expected: FAIL
-
   [The deleteDatabase() request's success event is an IDBVersionChangeEvent.]
-    expected: FAIL
-
-  [Delete an existing database - Test events opening a second database when one connection is open already]
     expected: FAIL
 
 

--- a/tests/wpt/meta/indexeddb/idbfactory_open.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbfactory_open.any.js.ini
@@ -2,19 +2,7 @@
   expected: ERROR
 
 [idbfactory_open.any.html]
-  [IDBFactory.open() - database 'name' and 'version' are correctly set]
-    expected: FAIL
-
   [IDBFactory.open() - no version opens current database]
-    expected: FAIL
-
-  [IDBFactory.open() - new database has default version]
-    expected: FAIL
-
-  [IDBFactory.open() - new database is empty]
-    expected: FAIL
-
-  [IDBFactory.open() - open database with a lower version than current]
     expected: FAIL
 
   [IDBFactory.open() - open database with a higher version than current]
@@ -43,19 +31,7 @@
   expected: ERROR
 
 [idbfactory_open.any.worker.html]
-  [IDBFactory.open() - database 'name' and 'version' are correctly set]
-    expected: FAIL
-
   [IDBFactory.open() - no version opens current database]
-    expected: FAIL
-
-  [IDBFactory.open() - new database has default version]
-    expected: FAIL
-
-  [IDBFactory.open() - new database is empty]
-    expected: FAIL
-
-  [IDBFactory.open() - open database with a lower version than current]
     expected: FAIL
 
   [IDBFactory.open() - open database with a higher version than current]

--- a/tests/wpt/meta/indexeddb/idbindex_getAll-options.tentative.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbindex_getAll-options.tentative.any.js.ini
@@ -1,0 +1,46 @@
+[idbindex_getAll-options.tentative.any.serviceworker.html]
+  expected: ERROR
+
+[idbindex_getAll-options.tentative.any.worker.html]
+  expected: ERROR
+  [Single item get]
+    expected: FAIL
+
+  [Empty object store]
+    expected: FAIL
+
+  [Get all]
+    expected: FAIL
+
+  [Get all with generated keys]
+    expected: FAIL
+
+  [Get all with large values]
+    expected: FAIL
+
+  [maxCount=10]
+    expected: FAIL
+
+
+[idbindex_getAll-options.tentative.any.sharedworker.html]
+  expected: ERROR
+
+[idbindex_getAll-options.tentative.any.html]
+  expected: ERROR
+  [Single item get]
+    expected: FAIL
+
+  [Empty object store]
+    expected: FAIL
+
+  [Get all]
+    expected: FAIL
+
+  [Get all with generated keys]
+    expected: FAIL
+
+  [Get all with large values]
+    expected: FAIL
+
+  [maxCount=10]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbindex_getAllKeys-options.tentative.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbindex_getAllKeys-options.tentative.any.js.ini
@@ -1,0 +1,41 @@
+[idbindex_getAllKeys-options.tentative.any.worker.html]
+  expected: ERROR
+  [Single item get]
+    expected: FAIL
+
+  [Empty object store]
+    expected: FAIL
+
+  [Get all keys]
+    expected: FAIL
+
+  [Get all generated keys]
+    expected: FAIL
+
+  [maxCount=10]
+    expected: FAIL
+
+
+[idbindex_getAllKeys-options.tentative.any.sharedworker.html]
+  expected: ERROR
+
+[idbindex_getAllKeys-options.tentative.any.html]
+  expected: ERROR
+  [Single item get]
+    expected: FAIL
+
+  [Empty object store]
+    expected: FAIL
+
+  [Get all keys]
+    expected: FAIL
+
+  [Get all generated keys]
+    expected: FAIL
+
+  [maxCount=10]
+    expected: FAIL
+
+
+[idbindex_getAllKeys-options.tentative.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbobjectstore-add-put-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore-add-put-exception-order.any.js.ini
@@ -9,16 +9,10 @@
   [IDBObjectStore.put exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
 
-  [IDBObjectStore.put exception order: ReadOnlyError vs. DataError]
-    expected: FAIL
-
   [IDBObjectStore.add exception order: InvalidStateError vs. TransactionInactiveError]
     expected: TIMEOUT
 
   [IDBObjectStore.add exception order: TransactionInactiveError vs. ReadOnlyError]
-    expected: FAIL
-
-  [IDBObjectStore.add exception order: ReadOnlyError vs. DataError]
     expected: FAIL
 
 
@@ -30,16 +24,10 @@
   [IDBObjectStore.put exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
 
-  [IDBObjectStore.put exception order: ReadOnlyError vs. DataError]
-    expected: FAIL
-
   [IDBObjectStore.add exception order: InvalidStateError vs. TransactionInactiveError]
     expected: TIMEOUT
 
   [IDBObjectStore.add exception order: TransactionInactiveError vs. ReadOnlyError]
-    expected: FAIL
-
-  [IDBObjectStore.add exception order: ReadOnlyError vs. DataError]
     expected: FAIL
 
 

--- a/tests/wpt/meta/indexeddb/idbobjectstore-clear-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore-clear-exception-order.any.js.ini
@@ -1,5 +1,5 @@
 [idbobjectstore-clear-exception-order.any.worker.html]
-  expected: TIMEOUT
+  expected: CRASH
   [IDBObjectStore.clear exception order: InvalidStateError vs. TransactionInactiveError]
     expected: TIMEOUT
 
@@ -8,7 +8,7 @@
 
 
 [idbobjectstore-clear-exception-order.any.html]
-  expected: TIMEOUT
+  expected: CRASH
   [IDBObjectStore.clear exception order: InvalidStateError vs. TransactionInactiveError]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/indexeddb/idbobjectstore-delete-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore-delete-exception-order.any.js.ini
@@ -5,7 +5,7 @@
   expected: ERROR
 
 [idbobjectstore-delete-exception-order.any.html]
-  expected: TIMEOUT
+  expected: CRASH
   [IDBObjectStore.delete exception order: InvalidStateError vs. TransactionInactiveError]
     expected: TIMEOUT
 
@@ -17,7 +17,7 @@
 
 
 [idbobjectstore-delete-exception-order.any.worker.html]
-  expected: TIMEOUT
+  expected: CRASH
   [IDBObjectStore.delete exception order: InvalidStateError vs. TransactionInactiveError]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/indexeddb/idbobjectstore-getAll-enforcerange.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore-getAll-enforcerange.any.js.ini
@@ -1,15 +1,9 @@
 [idbobjectstore-getAll-enforcerange.any.html]
-  [IDBObjectStore.getAll() uses [EnforceRange\]]
-    expected: FAIL
-
 
 [idbobjectstore-getAll-enforcerange.any.sharedworker.html]
   expected: ERROR
 
 [idbobjectstore-getAll-enforcerange.any.worker.html]
-  [IDBObjectStore.getAll() uses [EnforceRange\]]
-    expected: FAIL
-
 
 [idbobjectstore-getAll-enforcerange.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbobjectstore-getAllKeys-enforcerange.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore-getAllKeys-enforcerange.any.js.ini
@@ -5,10 +5,5 @@
   expected: ERROR
 
 [idbobjectstore-getAllKeys-enforcerange.any.html]
-  [IDBObjectStore.getAllKeys() uses [EnforceRange\]]
-    expected: FAIL
-
 
 [idbobjectstore-getAllKeys-enforcerange.any.worker.html]
-  [IDBObjectStore.getAllKeys() uses [EnforceRange\]]
-    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbobjectstore-request-source.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore-request-source.any.js.ini
@@ -1,4 +1,5 @@
 [idbobjectstore-request-source.any.worker.html]
+  expected: CRASH
   [The source of the request from store => store.put(0) is the object store itself]
     expected: FAIL
 
@@ -40,6 +41,7 @@
   expected: ERROR
 
 [idbobjectstore-request-source.any.html]
+  expected: CRASH
   [The source of the request from store => store.put(0) is the object store itself]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbobjectstore-transaction-SameObject.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore-transaction-SameObject.any.js.ini
@@ -5,10 +5,5 @@
   expected: ERROR
 
 [idbobjectstore-transaction-SameObject.any.worker.html]
-  [IDBObjectStore.transaction [SameObject\]]
-    expected: FAIL
-
 
 [idbobjectstore-transaction-SameObject.any.html]
-  [IDBObjectStore.transaction [SameObject\]]
-    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbobjectstore_add.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_add.any.js.ini
@@ -5,6 +5,7 @@
   expected: ERROR
 
 [idbobjectstore_add.any.worker.html]
+  expected: CRASH
   [add() with an inline key]
     expected: FAIL
 
@@ -55,6 +56,7 @@
 
 
 [idbobjectstore_add.any.html]
+  expected: CRASH
   [add() with an inline key]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbobjectstore_clear.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_clear.any.js.ini
@@ -1,4 +1,5 @@
 [idbobjectstore_clear.any.worker.html]
+  expected: CRASH
   [Verify clear removes all records ]
     expected: FAIL
 
@@ -19,6 +20,7 @@
   expected: ERROR
 
 [idbobjectstore_clear.any.html]
+  expected: CRASH
   [Verify clear removes all records ]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbobjectstore_count.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_count.any.js.ini
@@ -1,4 +1,5 @@
 [idbobjectstore_count.any.html]
+  expected: CRASH
   [Returns the number of records in the object store ]
     expected: FAIL
 
@@ -19,6 +20,7 @@
   expected: ERROR
 
 [idbobjectstore_count.any.worker.html]
+  expected: CRASH
   [Returns the number of records in the object store ]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbobjectstore_createIndex.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_createIndex.any.js.ini
@@ -1,5 +1,5 @@
 [idbobjectstore_createIndex.any.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Returns an IDBIndex and the properties are set correctly]
     expected: FAIL
 
@@ -68,7 +68,7 @@
   expected: ERROR
 
 [idbobjectstore_createIndex.any.worker.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Returns an IDBIndex and the properties are set correctly]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbobjectstore_delete.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_delete.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [idbobjectstore_delete.any.html]
+  expected: CRASH
   [delete() removes record (inline keys)]
     expected: FAIL
 
@@ -25,6 +26,7 @@
 
 
 [idbobjectstore_delete.any.worker.html]
+  expected: CRASH
   [delete() removes record (inline keys)]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbobjectstore_get.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_get.any.js.ini
@@ -1,4 +1,5 @@
 [idbobjectstore_get.any.worker.html]
+  expected: CRASH
   [Key is a number]
     expected: FAIL
 
@@ -25,6 +26,7 @@
   expected: ERROR
 
 [idbobjectstore_get.any.html]
+  expected: CRASH
   [Key is a number]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbobjectstore_getAll-options.tentative.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_getAll-options.tentative.any.js.ini
@@ -1,0 +1,46 @@
+[idbobjectstore_getAll-options.tentative.any.sharedworker.html]
+  expected: ERROR
+
+[idbobjectstore_getAll-options.tentative.any.worker.html]
+  expected: ERROR
+  [Single item get]
+    expected: FAIL
+
+  [Single item get (generated key)]
+    expected: FAIL
+
+  [getAll on empty object store]
+    expected: FAIL
+
+  [Get all values]
+    expected: FAIL
+
+  [Get all with large values]
+    expected: FAIL
+
+  [Test maxCount]
+    expected: FAIL
+
+
+[idbobjectstore_getAll-options.tentative.any.serviceworker.html]
+  expected: ERROR
+
+[idbobjectstore_getAll-options.tentative.any.html]
+  expected: ERROR
+  [Single item get]
+    expected: FAIL
+
+  [Single item get (generated key)]
+    expected: FAIL
+
+  [getAll on empty object store]
+    expected: FAIL
+
+  [Get all values]
+    expected: FAIL
+
+  [Get all with large values]
+    expected: FAIL
+
+  [Test maxCount]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbobjectstore_getAllKeys-options.tentative.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_getAllKeys-options.tentative.any.js.ini
@@ -1,0 +1,40 @@
+[idbobjectstore_getAllKeys-options.tentative.any.html]
+  expected: ERROR
+  [Single item get]
+    expected: FAIL
+
+  [Single item get (generated key)]
+    expected: FAIL
+
+  [getAllKeys on empty object store]
+    expected: FAIL
+
+  [Get all keys]
+    expected: FAIL
+
+  [Test maxCount]
+    expected: FAIL
+
+
+[idbobjectstore_getAllKeys-options.tentative.any.sharedworker.html]
+  expected: ERROR
+
+[idbobjectstore_getAllKeys-options.tentative.any.serviceworker.html]
+  expected: ERROR
+
+[idbobjectstore_getAllKeys-options.tentative.any.worker.html]
+  expected: ERROR
+  [Single item get]
+    expected: FAIL
+
+  [Single item get (generated key)]
+    expected: FAIL
+
+  [getAllKeys on empty object store]
+    expected: FAIL
+
+  [Get all keys]
+    expected: FAIL
+
+  [Test maxCount]
+    expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbobjectstore_openCursor.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_openCursor.any.js.ini
@@ -1,4 +1,5 @@
 [idbobjectstore_openCursor.any.html]
+  expected: CRASH
   [IDBObjectStore.openCursor() - iterate through 100 objects]
     expected: FAIL
 
@@ -10,5 +11,6 @@
   expected: ERROR
 
 [idbobjectstore_openCursor.any.worker.html]
+  expected: CRASH
   [IDBObjectStore.openCursor() - iterate through 100 objects]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/idbobjectstore_put.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbobjectstore_put.any.js.ini
@@ -1,4 +1,5 @@
 [idbobjectstore_put.any.html]
+  expected: CRASH
   [put() with an inline key]
     expected: FAIL
 
@@ -55,6 +56,7 @@
   expected: ERROR
 
 [idbobjectstore_put.any.worker.html]
+  expected: CRASH
   [put() with an inline key]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbtransaction-db-SameObject.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbtransaction-db-SameObject.any.js.ini
@@ -1,15 +1,9 @@
 [idbtransaction-db-SameObject.any.html]
-  [IDBTransaction.db [SameObject\]]
-    expected: FAIL
-
 
 [idbtransaction-db-SameObject.any.serviceworker.html]
   expected: ERROR
 
 [idbtransaction-db-SameObject.any.worker.html]
-  [IDBTransaction.db [SameObject\]]
-    expected: FAIL
-
 
 [idbtransaction-db-SameObject.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbtransaction-objectStore-exception-order.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbtransaction-objectStore-exception-order.any.js.ini
@@ -1,11 +1,13 @@
 [idbtransaction-objectStore-exception-order.any.html]
+  expected: TIMEOUT
   [IDBTransaction.objectStore exception order: InvalidStateError vs. NotFoundError]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [idbtransaction-objectStore-exception-order.any.worker.html]
+  expected: TIMEOUT
   [IDBTransaction.objectStore exception order: InvalidStateError vs. NotFoundError]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [idbtransaction-objectStore-exception-order.any.sharedworker.html]

--- a/tests/wpt/meta/indexeddb/idbtransaction.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbtransaction.any.js.ini
@@ -5,10 +5,5 @@
   expected: ERROR
 
 [idbtransaction.any.worker.html]
-  expected: ERROR
-  [IDBTransaction - request returned by open()]
-    expected: TIMEOUT
-
 
 [idbtransaction.any.html]
-  expected: ERROR

--- a/tests/wpt/meta/indexeddb/idbtransaction_abort.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbtransaction_abort.any.js.ini
@@ -5,6 +5,7 @@
   expected: ERROR
 
 [idbtransaction_abort.any.worker.html]
+  expected: CRASH
   [Abort event should fire during transaction]
     expected: FAIL
 
@@ -16,6 +17,7 @@
 
 
 [idbtransaction_abort.any.html]
+  expected: CRASH
   [Abort event should fire during transaction]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/idbtransaction_objectStoreNames.any.js.ini
+++ b/tests/wpt/meta/indexeddb/idbtransaction_objectStoreNames.any.js.ini
@@ -5,6 +5,7 @@
   expected: ERROR
 
 [idbtransaction_objectStoreNames.any.html]
+  expected: CRASH
   [IDBTransaction.objectStoreNames - value after close]
     expected: FAIL
 
@@ -28,6 +29,7 @@
 
 
 [idbtransaction_objectStoreNames.any.worker.html]
+  expected: CRASH
   [IDBTransaction.objectStoreNames - value after close]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/key-conversion-exceptions.any.js.ini
+++ b/tests/wpt/meta/indexeddb/key-conversion-exceptions.any.js.ini
@@ -14,12 +14,6 @@
   [IDBKeyRange bound() static with throwing/invalid keys]
     expected: FAIL
 
-  [IDBObjectStore getAllRecords() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getAllRecords() method with throwing/invalid keys]
-    expected: FAIL
-
 
 [key-conversion-exceptions.any.sharedworker.html]
   expected: ERROR
@@ -38,12 +32,6 @@
     expected: FAIL
 
   [IDBKeyRange bound() static with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBObjectStore getAllRecords() method with throwing/invalid keys]
-    expected: FAIL
-
-  [IDBIndex getAllRecords() method with throwing/invalid keys]
     expected: FAIL
 
 

--- a/tests/wpt/meta/indexeddb/key_invalid.any.js.ini
+++ b/tests/wpt/meta/indexeddb/key_invalid.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [key_invalid.any.html]
+  expected: CRASH
   [Invalid key - true]
     expected: FAIL
 
@@ -112,6 +113,7 @@
   expected: ERROR
 
 [key_invalid.any.worker.html]
+  expected: CRASH
   [Invalid key - true]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/key_valid.any.js.ini
+++ b/tests/wpt/meta/indexeddb/key_valid.any.js.ini
@@ -1,4 +1,5 @@
 [key_valid.any.html]
+  expected: CRASH
   [Valid key - new Date()]
     expected: FAIL
 
@@ -61,6 +62,7 @@
   expected: ERROR
 
 [key_valid.any.worker.html]
+  expected: CRASH
   [Valid key - new Date()]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/keygenerator.any.js.ini
+++ b/tests/wpt/meta/indexeddb/keygenerator.any.js.ini
@@ -1,4 +1,5 @@
 [keygenerator.any.worker.html]
+  expected: CRASH
   [Keygenerator - starts at one, and increments by one]
     expected: FAIL
 
@@ -64,6 +65,7 @@
 
 
 [keygenerator.any.html]
+  expected: CRASH
   [Keygenerator - starts at one, and increments by one]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/keyorder.any.js.ini
+++ b/tests/wpt/meta/indexeddb/keyorder.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [keyorder.any.worker.html]
+  expected: CRASH
   [Database readback sort - String < Array]
     expected: FAIL
 
@@ -76,6 +77,7 @@
 
 
 [keyorder.any.html]
+  expected: CRASH
   [Database readback sort - String < Array]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/keypath-exceptions.any.js.ini
+++ b/tests/wpt/meta/indexeddb/keypath-exceptions.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [keypath-exceptions.any.html]
+  expected: CRASH
   [The last element of keypath is validated]
     expected: FAIL
 
@@ -10,6 +11,7 @@
 
 
 [keypath-exceptions.any.worker.html]
+  expected: CRASH
   [The last element of keypath is validated]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/keypath-special-identifiers.any.js.ini
+++ b/tests/wpt/meta/indexeddb/keypath-special-identifiers.any.js.ini
@@ -5,6 +5,7 @@
   expected: ERROR
 
 [keypath-special-identifiers.any.worker.html]
+  expected: CRASH
   [Type: String, identifier: length]
     expected: FAIL
 
@@ -25,6 +26,7 @@
 
 
 [keypath-special-identifiers.any.html]
+  expected: CRASH
   [Type: String, identifier: length]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/keypath.any.js.ini
+++ b/tests/wpt/meta/indexeddb/keypath.any.js.ini
@@ -1,4 +1,5 @@
 [keypath.any.html]
+  expected: CRASH
   [undefined - my.key]
     expected: FAIL
 
@@ -67,6 +68,7 @@
   expected: ERROR
 
 [keypath.any.worker.html]
+  expected: CRASH
   [undefined - my.key]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/keypath_maxsize.any.js.ini
+++ b/tests/wpt/meta/indexeddb/keypath_maxsize.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [keypath_maxsize.any.worker.html]
+  expected: CRASH
   [undefined - ~260 chars]
     expected: FAIL
 
@@ -16,6 +17,7 @@
   expected: ERROR
 
 [keypath_maxsize.any.html]
+  expected: CRASH
   [undefined - ~260 chars]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/open-request-queue.any.js.ini
+++ b/tests/wpt/meta/indexeddb/open-request-queue.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [open-request-queue.any.html]
+  expected: CRASH
   [IndexedDB: open and delete requests are processed as a FIFO queue]
     expected: FAIL
 
@@ -10,5 +11,6 @@
   expected: ERROR
 
 [open-request-queue.any.worker.html]
+  expected: CRASH
   [IndexedDB: open and delete requests are processed as a FIFO queue]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/transaction-abort-request-error.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction-abort-request-error.any.js.ini
@@ -1,4 +1,5 @@
 [transaction-abort-request-error.any.worker.html]
+  expected: CRASH
   [Properties of error events fired at requests when aborting a transaction]
     expected: FAIL
 
@@ -7,6 +8,7 @@
   expected: ERROR
 
 [transaction-abort-request-error.any.html]
+  expected: CRASH
   [Properties of error events fired at requests when aborting a transaction]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/transaction-deactivation-timing.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction-deactivation-timing.any.js.ini
@@ -5,6 +5,7 @@
   expected: ERROR
 
 [transaction-deactivation-timing.any.html]
+  expected: CRASH
   [New transactions are deactivated before next task]
     expected: FAIL
 
@@ -22,6 +23,7 @@
 
 
 [transaction-deactivation-timing.any.worker.html]
+  expected: CRASH
   [New transactions are deactivated before next task]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/transaction-lifetime-empty.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction-lifetime-empty.any.js.ini
@@ -5,6 +5,7 @@
   expected: ERROR
 
 [transaction-lifetime-empty.any.worker.html]
+  expected: CRASH
   [Transactions without requests complete in the expected order]
     expected: FAIL
 
@@ -13,6 +14,7 @@
 
 
 [transaction-lifetime-empty.any.html]
+  expected: CRASH
   [Transactions without requests complete in the expected order]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/transaction-requestqueue.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction-requestqueue.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [transaction-requestqueue.any.html]
+  expected: CRASH
   [Transactions have a request queue]
     expected: FAIL
 
@@ -10,5 +11,6 @@
   expected: ERROR
 
 [transaction-requestqueue.any.worker.html]
+  expected: CRASH
   [Transactions have a request queue]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/transaction-scheduling-across-connections.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction-scheduling-across-connections.any.js.ini
@@ -1,8 +1,10 @@
 [transaction-scheduling-across-connections.any.worker.html]
+  expected: CRASH
   [Check that readwrite transactions with overlapping scopes do not run in parallel.]
     expected: FAIL
 
 
 [transaction-scheduling-across-connections.any.html]
+  expected: CRASH
   [Check that readwrite transactions with overlapping scopes do not run in parallel.]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/transaction-scheduling-mixed-scopes.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction-scheduling-mixed-scopes.any.js.ini
@@ -1,8 +1,10 @@
 [transaction-scheduling-mixed-scopes.any.html]
+  expected: CRASH
   [Check that scope restrictions on mixed transactions are enforced.]
     expected: FAIL
 
 
 [transaction-scheduling-mixed-scopes.any.worker.html]
+  expected: CRASH
   [Check that scope restrictions on mixed transactions are enforced.]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/transaction-scheduling-ordering.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction-scheduling-ordering.any.js.ini
@@ -1,8 +1,10 @@
 [transaction-scheduling-ordering.any.html]
+  expected: CRASH
   [Verify Indexed DB transactions are ordered per spec]
     expected: FAIL
 
 
 [transaction-scheduling-ordering.any.worker.html]
+  expected: CRASH
   [Verify Indexed DB transactions are ordered per spec]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/transaction-scheduling-ro-waits-for-rw.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction-scheduling-ro-waits-for-rw.any.js.ini
@@ -1,8 +1,10 @@
 [transaction-scheduling-ro-waits-for-rw.any.html]
+  expected: CRASH
   [readonly transaction should see the result of a previous readwrite transaction]
     expected: FAIL
 
 
 [transaction-scheduling-ro-waits-for-rw.any.worker.html]
+  expected: CRASH
   [readonly transaction should see the result of a previous readwrite transaction]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/transaction-scheduling-rw-scopes.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction-scheduling-rw-scopes.any.js.ini
@@ -1,8 +1,10 @@
 [transaction-scheduling-rw-scopes.any.worker.html]
+  expected: CRASH
   [Check that scope restrictions on read-write transactions are enforced.]
     expected: FAIL
 
 
 [transaction-scheduling-rw-scopes.any.html]
+  expected: CRASH
   [Check that scope restrictions on read-write transactions are enforced.]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/transaction-scheduling-within-database.any.js.ini
+++ b/tests/wpt/meta/indexeddb/transaction-scheduling-within-database.any.js.ini
@@ -1,8 +1,10 @@
 [transaction-scheduling-within-database.any.html]
+  expected: CRASH
   [Check that read-only transactions within a database can run in parallel.]
     expected: FAIL
 
 
 [transaction-scheduling-within-database.any.worker.html]
+  expected: CRASH
   [Check that read-only transactions within a database can run in parallel.]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/value.any.js.ini
+++ b/tests/wpt/meta/indexeddb/value.any.js.ini
@@ -1,4 +1,5 @@
 [value.any.worker.html]
+  expected: CRASH
   [BigInts as values in IndexedDB - primitive BigInt]
     expected: FAIL
 
@@ -25,6 +26,7 @@
 
 
 [value.any.html]
+  expected: CRASH
   [BigInts as values in IndexedDB - primitive BigInt]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/value_recursive.any.js.ini
+++ b/tests/wpt/meta/indexeddb/value_recursive.any.js.ini
@@ -1,4 +1,5 @@
 [value_recursive.any.html]
+  expected: CRASH
   [Recursive value - array directly contains self]
     expected: FAIL
 
@@ -10,6 +11,7 @@
 
 
 [value_recursive.any.worker.html]
+  expected: CRASH
   [Recursive value - array directly contains self]
     expected: FAIL
 

--- a/tests/wpt/meta/indexeddb/worker-termination-aborts-upgrade.window.js.ini
+++ b/tests/wpt/meta/indexeddb/worker-termination-aborts-upgrade.window.js.ini
@@ -1,4 +1,3 @@
 [worker-termination-aborts-upgrade.window.html]
-  expected: ERROR
   [Worker Termination Aborts a Pending Upgrade]
     expected: FAIL

--- a/tests/wpt/meta/indexeddb/writer-starvation.any.js.ini
+++ b/tests/wpt/meta/indexeddb/writer-starvation.any.js.ini
@@ -5,10 +5,12 @@
   expected: ERROR
 
 [writer-starvation.any.html]
+  expected: CRASH
   [IDB read requests should not starve write requests]
     expected: FAIL
 
 
 [writer-starvation.any.worker.html]
+  expected: CRASH
   [IDB read requests should not starve write requests]
     expected: FAIL


### PR DESCRIPTION
While this introduces many new crashes in the test results, that's actually progress. Previously a huge number of tests were failing early because we never persisted the load-bearing `result` value for upgradeneeded events, so now we get to see much more interesting failures in our IndexedDB implementation.

Testing: Existing WPT testsuite for IndexedDB.
Fixes: part of #6963

Depends on #37567.
