### PR TITLE
net: Split read-only and read-write IndexedDB operations into separate enums

### DIFF
--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -16,7 +16,8 @@ use js::rust::{HandleValue, MutableHandleValue};
 use log::error;
 use net_traits::IpcSend;
 use net_traits::indexeddb_thread::{
-    AsyncOperation, IndexedDBKeyType, IndexedDBThreadMsg, SyncOperation,
+    AsyncOperation, AsyncReadOnlyOperation, AsyncReadWriteOperation, IndexedDBKeyType,
+    IndexedDBThreadMsg, SyncOperation,
 };
 use profile_traits::ipc;
 
@@ -454,7 +455,11 @@ impl IDBObjectStore {
 
         IDBRequest::execute_async(
             self,
-            AsyncOperation::PutItem(serialized_key, serialized_value.serialized, overwrite),
+            AsyncOperation::ReadWrite(AsyncReadWriteOperation::PutItem(
+                serialized_key,
+                serialized_value.serialized,
+                overwrite,
+            )),
             None,
             can_gc,
         )
@@ -486,7 +491,12 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
     fn Delete(&self, cx: SafeJSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
         let serialized_query = IDBObjectStore::convert_value_to_key(cx, query, None);
         serialized_query.and_then(|q| {
-            IDBRequest::execute_async(self, AsyncOperation::RemoveItem(q), None, CanGc::note())
+            IDBRequest::execute_async(
+                self,
+                AsyncOperation::ReadWrite(AsyncReadWriteOperation::RemoveItem(q)),
+                None,
+                CanGc::note(),
+            )
         })
     }
 
@@ -499,7 +509,12 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
     fn Get(&self, cx: SafeJSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
         let serialized_query = IDBObjectStore::convert_value_to_key(cx, query, None);
         serialized_query.and_then(|q| {
-            IDBRequest::execute_async(self, AsyncOperation::GetItem(q), None, CanGc::note())
+            IDBRequest::execute_async(
+                self,
+                AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetItem(q)),
+                None,
+                CanGc::note(),
+            )
         })
     }
 

--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -94,8 +94,8 @@ pub enum AsyncReadWriteOperation {
     ),
 }
 
-// Operations that are not executed instantly, but rather added to a
-// queue that is eventually run.
+/// Operations that are not executed instantly, but rather added to a
+/// queue that is eventually run.
 #[derive(Debug, Deserialize, Serialize)]
 pub enum AsyncOperation {
     ReadOnly(AsyncReadOnlyOperation),
@@ -104,7 +104,7 @@ pub enum AsyncOperation {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum SyncOperation {
-    // Upgrades the version of the database
+    /// Upgrades the version of the database
     UpgradeVersion(
         IpcSender<Result<u64, ()>>,
         ImmutableOrigin,
@@ -112,7 +112,7 @@ pub enum SyncOperation {
         u64,    // Serial number for the transaction
         u64,    // Version to upgrade to
     ),
-    // Checks if an object store has a key generator, used in e.g. Put
+    /// Checks if an object store has a key generator, used in e.g. Put
     HasKeyGenerator(
         IpcSender<bool>,
         ImmutableOrigin,
@@ -120,7 +120,7 @@ pub enum SyncOperation {
         String, // Store
     ),
 
-    // Commits changes of a transaction to the database
+    /// Commits changes of a transaction to the database
     Commit(
         IpcSender<Result<(), ()>>,
         ImmutableOrigin,
@@ -128,7 +128,7 @@ pub enum SyncOperation {
         u64,    // Transaction serial number
     ),
 
-    // Creates a new store for the database
+    /// Creates a new store for the database
     CreateObjectStore(
         IpcSender<Result<(), ()>>,
         ImmutableOrigin,
@@ -157,23 +157,23 @@ pub enum SyncOperation {
         Option<u64>, // Eventual version
     ),
 
-    // Deletes the database
+    /// Deletes the database
     DeleteDatabase(
         IpcSender<Result<(), ()>>,
         ImmutableOrigin,
         String, // Database
     ),
 
-    // Returns an unique identifier that is used to be able to
-    // commit/abort transactions.
+    /// Returns an unique identifier that is used to be able to
+    /// commit/abort transactions.
     RegisterNewTxn(
         IpcSender<u64>,
         ImmutableOrigin,
         String, // Database
     ),
 
-    // Starts executing the requests of a transaction
-    // https://www.w3.org/TR/IndexedDB-2/#transaction-start
+    /// Starts executing the requests of a transaction
+    /// <https://www.w3.org/TR/IndexedDB-2/#transaction-start>
     StartTransaction(
         IpcSender<Result<(), ()>>,
         ImmutableOrigin,
@@ -181,7 +181,7 @@ pub enum SyncOperation {
         u64,    // The serial number of the mutating transaction
     ),
 
-    // Returns the version of the database
+    /// Returns the version of the database
     Version(
         IpcSender<u64>,
         ImmutableOrigin,

--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -67,15 +67,20 @@ impl IndexedDBKeyRange {
     }
 }
 
-// Operations that are not executed instantly, but rather added to a
-// queue that is eventually run.
 #[derive(Debug, Deserialize, Serialize)]
-pub enum AsyncOperation {
+pub enum AsyncReadOnlyOperation {
     /// Gets the value associated with the given key in the associated idb data
     GetItem(
         IndexedDBKeyType, // Key
     ),
 
+    Count(
+        IndexedDBKeyType, // Key
+    ),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum AsyncReadWriteOperation {
     /// Sets the value of the given key in the associated idb data
     PutItem(
         IndexedDBKeyType, // Key
@@ -87,10 +92,14 @@ pub enum AsyncOperation {
     RemoveItem(
         IndexedDBKeyType, // Key
     ),
+}
 
-    Count(
-        IndexedDBKeyType, // Key
-    ),
+// Operations that are not executed instantly, but rather added to a
+// queue that is eventually run.
+#[derive(Debug, Deserialize, Serialize)]
+pub enum AsyncOperation {
+    ReadOnly(AsyncReadOnlyOperation),
+    ReadWrite(AsyncReadWriteOperation),
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This change allows the compiler to recognize if any read-only operations are missing an implementation when processing a readonly transaction.

Testing: The existing behaviour is unchanged, so current tests suffice. The new code is unused and cannot be tested.
Fixes: part of #6963 
