### PR TITLE
net: Avoid all-encompassing synchronous IPC return type for IndexedDB operations

### DIFF
--- a/components/net/indexeddb/idb_thread.rs
+++ b/components/net/indexeddb/idb_thread.rs
@@ -11,7 +11,7 @@ use std::thread;
 use ipc_channel::ipc::{self, IpcError, IpcReceiver, IpcSender};
 use log::{debug, warn};
 use net_traits::indexeddb_thread::{
-    AsyncOperation, IndexedDBThreadMsg, IndexedDBThreadReturnType, IndexedDBTxnMode, SyncOperation,
+    AsyncOperation, IndexedDBThreadMsg, IndexedDBTxnMode, SyncOperation,
 };
 use servo_config::pref;
 use servo_url::origin::ImmutableOrigin;
@@ -315,9 +315,7 @@ impl IndexedDBManager {
             },
             SyncOperation::Commit(sender, _origin, _db_name, _txn) => {
                 // FIXME:(arihant2math) This does nothing at the moment
-                sender
-                    .send(IndexedDBThreadReturnType::Commit(Err(())))
-                    .expect("Could not send commit status");
+                sender.send(Err(())).expect("Could not send commit status");
             },
             SyncOperation::UpgradeVersion(sender, origin, db_name, _txn, version) => {
                 if let Some(db) = self.get_database_mut(origin, db_name) {
@@ -327,9 +325,7 @@ impl IndexedDBManager {
                 // FIXME:(arihant2math) Get the version from the database instead
                 // We never fail as of now, so we can just return it like this
                 // for now...
-                sender
-                    .send(IndexedDBThreadReturnType::UpgradeVersion(Ok(version)))
-                    .expect("Could not upgrade version");
+                sender.send(Ok(version)).expect("Could not upgrade version");
             },
             SyncOperation::CreateObjectStore(
                 sender,
@@ -367,7 +363,7 @@ impl IndexedDBManager {
             },
             SyncOperation::Exit(sender) => {
                 // FIXME:(rasviitanen) Nothing to do?
-                let _ = sender.send(IndexedDBThreadReturnType::Exit);
+                let _ = sender.send(());
             },
         }
     }

--- a/components/script/dom/idbtransaction.rs
+++ b/components/script/dom/idbtransaction.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSender;
 use net_traits::IpcSend;
-use net_traits::indexeddb_thread::{IndexedDBThreadMsg, IndexedDBThreadReturnType, SyncOperation};
+use net_traits::indexeddb_thread::{IndexedDBThreadMsg, SyncOperation};
 use profile_traits::ipc;
 use stylo_atoms::Atom;
 
@@ -178,7 +178,8 @@ impl IDBTransaction {
             .send(IndexedDBThreadMsg::Sync(upgrade_version_operation))
             .unwrap();
         // Wait for the version to be updated
-        receiver.recv().unwrap();
+        // TODO(jdm): This returns a Result; what do we do with an error?
+        let _ = receiver.recv().unwrap();
     }
 
     fn dispatch_complete(&self) {
@@ -260,7 +261,7 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
         let result = receiver.recv().unwrap();
 
         // Step 2
-        if let IndexedDBThreadReturnType::Commit(Err(_result)) = result {
+        if let Err(_result) = result {
             // FIXME:(rasviitanen) also support Unknown error
             return Err(Error::QuotaExceeded);
         }

--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -6,19 +6,6 @@ use ipc_channel::ipc::IpcSender;
 use serde::{Deserialize, Serialize};
 use servo_url::origin::ImmutableOrigin;
 
-#[derive(Debug, Deserialize, Serialize)]
-pub enum IndexedDBThreadReturnType {
-    Open(Option<u64>),
-    NextSerialNumber(u64),
-    StartTransaction(Result<(), ()>),
-    Commit(Result<(), ()>),
-    Version(u64),
-    CreateObjectStore(Option<String>),
-    UpgradeVersion(Result<u64, ()>),
-    KVResult(Option<Vec<u8>>),
-    Exit,
-}
-
 // https://www.w3.org/TR/IndexedDB-2/#enumdef-idbtransactionmode
 #[derive(Debug, Deserialize, Serialize)]
 pub enum IndexedDBTxnMode {
@@ -72,7 +59,7 @@ pub enum AsyncOperation {
 pub enum SyncOperation {
     // Upgrades the version of the database
     UpgradeVersion(
-        IpcSender<IndexedDBThreadReturnType>,
+        IpcSender<Result<u64, ()>>,
         ImmutableOrigin,
         String, // Database
         u64,    // Serial number for the transaction
@@ -88,7 +75,7 @@ pub enum SyncOperation {
 
     // Commits changes of a transaction to the database
     Commit(
-        IpcSender<IndexedDBThreadReturnType>,
+        IpcSender<Result<(), ()>>,
         ImmutableOrigin,
         String, // Database
         u64,    // Transaction serial number
@@ -155,7 +142,7 @@ pub enum SyncOperation {
     ),
 
     /// Send a reply when done cleaning up thread resources and then shut it down
-    Exit(IpcSender<IndexedDBThreadReturnType>),
+    Exit(IpcSender<()>),
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This is finishing some incomplete cleanup from #33044. Kitchen sink enum types like IndexedDBThreadReturnType make code harder to read and require ignoring variants that will never be sent in many cases.

Testing: No behaviour change; existing WPT tests suffice.
Fixes: part of #6963 
