### PR TITLE
indexedDB: replace SanitizedName with Uuid

### DIFF
--- a/components/net/indexeddb/engines/mod.rs
+++ b/components/net/indexeddb/engines/mod.rs
@@ -7,47 +7,15 @@ use std::collections::VecDeque;
 use ipc_channel::ipc::IpcSender;
 use net_traits::indexeddb_thread::{AsyncOperation, IndexedDBTxnMode};
 use tokio::sync::oneshot;
+use uuid::Uuid;
 
 pub use self::heed::HeedEngine;
 
 mod heed;
 
-#[derive(Eq, Hash, PartialEq)]
-pub struct SanitizedName {
-    name: String,
-}
-
-impl SanitizedName {
-    pub fn new(name: String) -> SanitizedName {
-        let name = name.replace("https://", "");
-        let name = name.replace("http://", "");
-        // FIXME:(arihant2math) Disallowing special characters might be a big problem,
-        // but better safe than sorry. E.g. the db name '../other_origin/db',
-        // would let us access databases from another origin.
-        let name = name
-            .chars()
-            .map(|c| match c {
-                'A'..='Z' => c,
-                'a'..='z' => c,
-                '0'..='9' => c,
-                '-' => c,
-                '_' => c,
-                _ => '-',
-            })
-            .collect();
-        SanitizedName { name }
-    }
-}
-
-impl std::fmt::Display for SanitizedName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.name)
-    }
-}
-
 pub struct KvsOperation {
     pub sender: IpcSender<Option<Vec<u8>>>,
-    pub store_name: SanitizedName,
+    pub store_name: Uuid,
     pub operation: AsyncOperation,
 }
 
@@ -57,17 +25,17 @@ pub struct KvsTransaction {
 }
 
 pub trait KvsEngine {
-    fn create_store(&self, store_name: SanitizedName, auto_increment: bool);
+    fn create_store(&self, store_name: Uuid, auto_increment: bool);
 
-    fn delete_store(&self, store_name: SanitizedName);
+    fn delete_store(&self, store_name: Uuid);
 
     #[expect(dead_code)]
-    fn close_store(&self, store_name: SanitizedName);
+    fn close_store(&self, store_name: Uuid);
 
     fn process_transaction(
         &self,
         transaction: KvsTransaction,
     ) -> oneshot::Receiver<Option<Vec<u8>>>;
 
-    fn has_key_generator(&self, store_name: SanitizedName) -> bool;
+    fn has_key_generator(&self, store_name: Uuid) -> bool;
 }


### PR DESCRIPTION
Replace SanitizedName with Uuid, so IndexedDB object stores can use a unique ID.

Testing: Existing WPT test for indexedDB should remain the same
Fixes: #37569