### PR TITLE
libservo: Remove `TouchEventType` argument from `WebView::notify_scroll_event`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -28,7 +28,7 @@ use crossbeam_channel::{Receiver, Sender};
 use dpi::PhysicalSize;
 use embedder_traits::{
     CompositorHitTestResult, Cursor, InputEvent, MouseButtonEvent, MouseMoveEvent, ShutdownState,
-    TouchEventType, UntrustedNodeAddress, ViewportDetails, WheelDelta, WheelEvent, WheelMode,
+    UntrustedNodeAddress, ViewportDetails, WheelDelta, WheelEvent, WheelMode,
 };
 use euclid::{Point2D, Rect, Scale, Size2D, Transform3D, Vector2D};
 use ipc_channel::ipc::{self, IpcSharedMemory};
@@ -1833,10 +1833,9 @@ impl IOCompositor {
         webview_id: WebViewId,
         scroll_location: ScrollLocation,
         cursor: DeviceIntPoint,
-        event_type: TouchEventType,
     ) {
         if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-            webview_renderer.notify_scroll_event(scroll_location, cursor, event_type);
+            webview_renderer.notify_scroll_event(scroll_location, cursor);
         }
     }
 

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -799,21 +799,11 @@ impl WebViewRenderer {
         &mut self,
         scroll_location: ScrollLocation,
         cursor: DeviceIntPoint,
-        event_type: TouchEventType,
     ) {
         if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
             return;
         }
-
-        match event_type {
-            TouchEventType::Move => self.on_scroll_window_event(scroll_location, cursor),
-            TouchEventType::Up | TouchEventType::Cancel => {
-                self.on_scroll_window_event(scroll_location, cursor);
-            },
-            TouchEventType::Down => {
-                self.on_scroll_window_event(scroll_location, cursor);
-            },
-        }
+        self.on_scroll_window_event(scroll_location, cursor);
     }
 
     fn on_scroll_window_event(&mut self, scroll_location: ScrollLocation, cursor: DeviceIntPoint) {

--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -165,7 +165,6 @@ impl ApplicationHandler<WakerEvent> for App {
                         webview.notify_scroll_event(
                             ScrollLocation::Delta(moved_by),
                             DeviceIntPoint::new(10, 10),
-                            TouchEventType::Down,
                         );
                     }
                 }

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -14,7 +14,7 @@ use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use dpi::PhysicalSize;
 use embedder_traits::{
     Cursor, InputEvent, JSValue, JavaScriptEvaluationError, LoadStatus, MediaSessionActionType,
-    ScreenGeometry, Theme, TouchEventType, ViewportDetails,
+    ScreenGeometry, Theme, ViewportDetails,
 };
 use euclid::{Point2D, Scale, Size2D};
 use servo_geometry::DeviceIndependentPixel;
@@ -434,18 +434,11 @@ impl WebView {
             ))
     }
 
-    pub fn notify_scroll_event(
-        &self,
-        location: ScrollLocation,
-        point: DeviceIntPoint,
-        touch_event_action: TouchEventType,
-    ) {
-        self.inner().compositor.borrow_mut().notify_scroll_event(
-            self.id(),
-            location,
-            point,
-            touch_event_action,
-        );
+    pub fn notify_scroll_event(&self, location: ScrollLocation, point: DeviceIntPoint) {
+        self.inner()
+            .compositor
+            .borrow_mut()
+            .notify_scroll_event(self.id(), location, point);
     }
 
     pub fn notify_input_event(&self, event: InputEvent) {

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -19,7 +19,7 @@ use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 use servo::{
     AllowOrDenyRequest, AuthenticationRequest, FilterPattern, FormControl, GamepadHapticEffectType,
     KeyboardEvent, LoadStatus, PermissionRequest, Servo, ServoDelegate, ServoError, SimpleDialog,
-    TouchEventType, WebDriverCommandMsg, WebView, WebViewBuilder, WebViewDelegate,
+    WebDriverCommandMsg, WebView, WebViewBuilder, WebViewDelegate,
 };
 use url::Url;
 
@@ -350,36 +350,36 @@ impl RunningAppState {
                     0.0,
                     -self.inner().window.page_height() + 2.0 * LINE_HEIGHT,
                 ));
-                webview.notify_scroll_event(scroll_location, origin, TouchEventType::Move);
+                webview.notify_scroll_event(scroll_location, origin);
             })
             .shortcut(Modifiers::empty(), Key::PageUp, || {
                 let scroll_location = ScrollLocation::Delta(Vector2D::new(
                     0.0,
                     self.inner().window.page_height() - 2.0 * LINE_HEIGHT,
                 ));
-                webview.notify_scroll_event(scroll_location, origin, TouchEventType::Move);
+                webview.notify_scroll_event(scroll_location, origin);
             })
             .shortcut(Modifiers::empty(), Key::Home, || {
-                webview.notify_scroll_event(ScrollLocation::Start, origin, TouchEventType::Move);
+                webview.notify_scroll_event(ScrollLocation::Start, origin);
             })
             .shortcut(Modifiers::empty(), Key::End, || {
-                webview.notify_scroll_event(ScrollLocation::End, origin, TouchEventType::Move);
+                webview.notify_scroll_event(ScrollLocation::End, origin);
             })
             .shortcut(Modifiers::empty(), Key::ArrowUp, || {
                 let location = ScrollLocation::Delta(Vector2D::new(0.0, 3.0 * LINE_HEIGHT));
-                webview.notify_scroll_event(location, origin, TouchEventType::Move);
+                webview.notify_scroll_event(location, origin);
             })
             .shortcut(Modifiers::empty(), Key::ArrowDown, || {
                 let location = ScrollLocation::Delta(Vector2D::new(0.0, -3.0 * LINE_HEIGHT));
-                webview.notify_scroll_event(location, origin, TouchEventType::Move);
+                webview.notify_scroll_event(location, origin);
             })
             .shortcut(Modifiers::empty(), Key::ArrowLeft, || {
                 let location = ScrollLocation::Delta(Vector2D::new(LINE_HEIGHT, 0.0));
-                webview.notify_scroll_event(location, origin, TouchEventType::Move);
+                webview.notify_scroll_event(location, origin);
             })
             .shortcut(Modifiers::empty(), Key::ArrowRight, || {
                 let location = ScrollLocation::Delta(Vector2D::new(-LINE_HEIGHT, 0.0));
-                webview.notify_scroll_event(location, origin, TouchEventType::Move);
+                webview.notify_scroll_event(location, origin);
             });
     }
 }

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -588,7 +588,7 @@ impl WindowPortsMethods for Window {
                     webview.notify_input_event(InputEvent::MouseLeave(MouseLeaveEvent::new(point)));
                 }
             },
-            WindowEvent::MouseWheel { delta, phase, .. } => {
+            WindowEvent::MouseWheel { delta, .. } => {
                 let (mut dx, mut dy, mode) = match delta {
                     MouseScrollDelta::LineDelta(dx, dy) => {
                         (dx as f64, (dy * LINE_HEIGHT) as f64, WheelMode::DeltaLine)
@@ -618,11 +618,10 @@ impl WindowPortsMethods for Window {
                 }
 
                 let scroll_location = ScrollLocation::Delta(Vector2D::new(dx as f32, dy as f32));
-                let phase = winit_phase_to_touch_event_type(phase);
 
                 // Send events
                 webview.notify_input_event(InputEvent::Wheel(WheelEvent::new(delta, point)));
-                webview.notify_scroll_event(scroll_location, point.to_i32(), phase);
+                webview.notify_scroll_event(scroll_location, point.to_i32());
             },
             WindowEvent::Touch(touch) => {
                 webview.notify_input_event(InputEvent::Touch(TouchEvent::new(

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -481,11 +481,8 @@ impl RunningAppState {
     pub fn scroll_start(&self, dx: f32, dy: f32, x: i32, y: i32) {
         let delta = Vector2D::new(dx, dy);
         let scroll_location = ScrollLocation::Delta(delta);
-        self.active_webview().notify_scroll_event(
-            scroll_location,
-            Point2D::new(x, y),
-            TouchEventType::Down,
-        );
+        self.active_webview()
+            .notify_scroll_event(scroll_location, Point2D::new(x, y));
         self.perform_updates();
     }
 
@@ -495,11 +492,8 @@ impl RunningAppState {
     pub fn scroll(&self, dx: f32, dy: f32, x: i32, y: i32) {
         let delta = Vector2D::new(dx, dy);
         let scroll_location = ScrollLocation::Delta(delta);
-        self.active_webview().notify_scroll_event(
-            scroll_location,
-            Point2D::new(x, y),
-            TouchEventType::Move,
-        );
+        self.active_webview()
+            .notify_scroll_event(scroll_location, Point2D::new(x, y));
         self.perform_updates();
     }
 
@@ -510,11 +504,8 @@ impl RunningAppState {
     pub fn scroll_end(&self, dx: f32, dy: f32, x: i32, y: i32) {
         let delta = Vector2D::new(dx, dy);
         let scroll_location = ScrollLocation::Delta(delta);
-        self.active_webview().notify_scroll_event(
-            scroll_location,
-            Point2D::new(x, y),
-            TouchEventType::Up,
-        );
+        self.active_webview()
+            .notify_scroll_event(scroll_location, Point2D::new(x, y));
         self.perform_updates();
     }
 


### PR DESCRIPTION
The compositor always does the same thing with these events regardless
of the phase, so I think it is completely unecessary.

Testing: This shouldn't change behavior at all, so is covered by existing tests.
