### PR TITLE
canvas: Make `draw_options` non optional in `fill_rect`

### DIFF
--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -93,7 +93,7 @@ pub(crate) trait GenericDrawTarget<B: Backend> {
         &mut self,
         rect: &Rect<f32>,
         pattern: B::Pattern<'_>,
-        draw_options: Option<&B::DrawOptions>,
+        draw_options: &B::DrawOptions,
     );
     fn get_size(&self) -> Size2D<i32>;
     fn get_transform(&self) -> Transform2D<f32>;

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -766,14 +766,14 @@ impl<'a, B: Backend> CanvasData<'a, B> {
                 new_draw_target.fill_rect(
                     &draw_rect,
                     self.state.fill_style.clone(),
-                    Some(&self.state.draw_options),
+                    &self.state.draw_options,
                 );
             });
         } else {
             self.drawtarget.fill_rect(
                 &draw_rect,
                 self.state.fill_style.clone(),
-                Some(&self.state.draw_options),
+                &self.state.draw_options,
             );
         }
     }

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -559,7 +559,7 @@ impl GenericDrawTarget<RaqoteBackend> for raqote::DrawTarget {
         &mut self,
         rect: &Rect<f32>,
         pattern: <RaqoteBackend as Backend>::Pattern<'_>,
-        draw_options: Option<&<RaqoteBackend as Backend>::DrawOptions>,
+        draw_options: &<RaqoteBackend as Backend>::DrawOptions,
     ) {
         let mut pb = raqote::PathBuilder::new();
         pb.rect(
@@ -568,18 +568,8 @@ impl GenericDrawTarget<RaqoteBackend> for raqote::DrawTarget {
             rect.size.width,
             rect.size.height,
         );
-        let draw_options = if let Some(options) = draw_options {
-            *options
-        } else {
-            raqote::DrawOptions::new()
-        };
 
-        <Self as GenericDrawTarget<RaqoteBackend>>::fill(
-            self,
-            &pb.finish(),
-            pattern,
-            &draw_options,
-        );
+        <Self as GenericDrawTarget<RaqoteBackend>>::fill(self, &pb.finish(), pattern, draw_options);
     }
     fn get_size(&self) -> Size2D<i32> {
         Size2D::new(self.width(), self.height())


### PR DESCRIPTION
All other draw functions already have them non-optional and we always passed `Some` anyway.

Testing: Existing WPT tests
