### PR TITLE
Move CSP code into one entrypoint

### DIFF
--- a/components/script/dom/csp.rs
+++ b/components/script/dom/csp.rs
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use content_security_policy::{PolicyDisposition, Violation, ViolationResource};
+use js::rust::describe_scripted_caller;
+
+use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::csppolicyviolationreport::CSPViolationReportBuilder;
+use crate::dom::element::Element;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::node::{Node, NodeTraits};
+use crate::dom::window::Window;
+use crate::security_manager::CSPViolationReportTask;
+
+/// <https://www.w3.org/TR/CSP/#report-violation>
+#[allow(unsafe_code)]
+pub(crate) fn report_csp_violations(
+    global: &GlobalScope,
+    violations: Vec<Violation>,
+    element: Option<&Element>,
+) {
+    let scripted_caller =
+        unsafe { describe_scripted_caller(*GlobalScope::get_cx()) }.unwrap_or_default();
+    for violation in violations {
+        let (sample, resource) = match violation.resource {
+            ViolationResource::Inline { sample } => (sample, "inline".to_owned()),
+            ViolationResource::Url(url) => (None, url.into()),
+            ViolationResource::TrustedTypePolicy { sample } => {
+                (Some(sample), "trusted-types-policy".to_owned())
+            },
+            ViolationResource::TrustedTypeSink { sample } => {
+                (Some(sample), "trusted-types-sink".to_owned())
+            },
+            ViolationResource::Eval { sample } => (sample, "eval".to_owned()),
+            ViolationResource::WasmEval => (None, "wasm-eval".to_owned()),
+        };
+        let report = CSPViolationReportBuilder::default()
+            .resource(resource)
+            .sample(sample)
+            .effective_directive(violation.directive.name)
+            .original_policy(violation.policy.to_string())
+            .report_only(violation.policy.disposition == PolicyDisposition::Report)
+            .source_file(scripted_caller.filename.clone())
+            .line_number(scripted_caller.line)
+            .column_number(scripted_caller.col + 1)
+            .build(global);
+        // Step 1: Let global be violation’s global object.
+        // We use `self` as `global`;
+        // Step 2: Let target be violation’s element.
+        let target = element.and_then(|event_target| {
+            // Step 3.1: If target is not null, and global is a Window,
+            // and target’s shadow-including root is not global’s associated Document, set target to null.
+            if let Some(window) = global.downcast::<Window>() {
+                // If a node is connected, its owner document is always the shadow-including root.
+                // If it isn't connected, then it also doesn't have a corresponding document, hence
+                // it can't be this document.
+                if event_target.upcast::<Node>().owner_document() != window.Document() {
+                    return None;
+                }
+            }
+            Some(event_target)
+        });
+        let target = match target {
+            // Step 3.2: If target is null:
+            None => {
+                // Step 3.2.2: If target is a Window, set target to target’s associated Document.
+                if let Some(window) = global.downcast::<Window>() {
+                    Trusted::new(window.Document().upcast())
+                } else {
+                    // Step 3.2.1: Set target to violation’s global object.
+                    Trusted::new(global.upcast())
+                }
+            },
+            Some(event_target) => Trusted::new(event_target.upcast()),
+        };
+        // Step 3: Queue a task to run the following steps:
+        let task =
+            CSPViolationReportTask::new(Trusted::new(global), target, report, violation.policy);
+        global
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task);
+    }
+}

--- a/components/script/dom/csp.rs
+++ b/components/script/dom/csp.rs
@@ -91,17 +91,14 @@ pub(crate) fn should_elements_inline_type_behavior_be_blocked(
     type_: InlineCheckType,
     source: &str,
 ) -> bool {
-    let (result, violations) = match global.get_csp_list() {
-        None => {
-            return false;
-        },
-        Some(csp_list) => {
-            let element = CspElement {
-                nonce: el.nonce_value_if_nonceable().map(Cow::Owned),
-            };
-            csp_list.should_elements_inline_type_behavior_be_blocked(&element, type_, source)
-        },
+    let Some(csp_list) = global.get_csp_list() else {
+        return false;
     };
+    let element = CspElement {
+        nonce: el.nonce_value_if_nonceable().map(Cow::Owned),
+    };
+    let (result, violations) =
+        csp_list.should_elements_inline_type_behavior_be_blocked(&element, type_, source);
 
     report_csp_violations(global, violations, Some(el));
 
@@ -115,7 +112,7 @@ pub(crate) fn is_trusted_type_policy_creation_allowed(
     created_policy_names: Vec<String>,
 ) -> bool {
     let Some(csp_list) = global.get_csp_list() else {
-        return false;
+        return true;
     };
 
     let (allowed_by_csp, violations) =

--- a/components/script/dom/csp.rs
+++ b/components/script/dom/csp.rs
@@ -70,7 +70,7 @@ impl CspReporting for Option<CspList> {
 
         let (is_js_evaluation_allowed, violations) = csp_list.is_js_evaluation_allowed(source);
 
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
 
         is_js_evaluation_allowed == CheckResult::Allowed
     }
@@ -83,7 +83,7 @@ impl CspReporting for Option<CspList> {
 
         let (is_wasm_evaluation_allowed, violations) = csp_list.is_wasm_evaluation_allowed();
 
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
 
         is_wasm_evaluation_allowed == CheckResult::Allowed
     }
@@ -116,7 +116,7 @@ impl CspReporting for Option<CspList> {
         let (result, violations) =
             csp_list.should_navigation_request_be_blocked(&request, NavigationCheckType::Other);
 
-        report_csp_violations(global, violations, element);
+        global.report_csp_violations(violations, element);
 
         result == CheckResult::Blocked
     }
@@ -138,7 +138,7 @@ impl CspReporting for Option<CspList> {
         let (result, violations) =
             csp_list.should_elements_inline_type_behavior_be_blocked(&element, type_, source);
 
-        report_csp_violations(global, violations, Some(el));
+        global.report_csp_violations(violations, Some(el));
 
         result == CheckResult::Blocked
     }
@@ -157,7 +157,7 @@ impl CspReporting for Option<CspList> {
         let (allowed_by_csp, violations) =
             csp_list.is_trusted_type_policy_creation_allowed(policy_name, created_policy_names);
 
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
 
         allowed_by_csp == CheckResult::Allowed
     }
@@ -190,7 +190,7 @@ impl CspReporting for Option<CspList> {
         let (allowed_by_csp, violations) = csp_list
             .should_sink_type_mismatch_violation_be_blocked_by_csp(sink, sink_group, source);
 
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
 
         allowed_by_csp == CheckResult::Blocked
     }
@@ -199,74 +199,75 @@ impl CspReporting for Option<CspList> {
 /// Used to determine which inline check to run
 pub use content_security_policy::Violation;
 
-/// <https://www.w3.org/TR/CSP/#report-violation>
-#[allow(unsafe_code)]
-pub(crate) fn report_csp_violations(
-    global: &GlobalScope,
-    violations: Vec<Violation>,
-    element: Option<&Element>,
-) {
-    let scripted_caller =
-        unsafe { describe_scripted_caller(*GlobalScope::get_cx()) }.unwrap_or_default();
-    for violation in violations {
-        let (sample, resource) = match violation.resource {
-            ViolationResource::Inline { sample } => (sample, "inline".to_owned()),
-            ViolationResource::Url(url) => (None, url.into()),
-            ViolationResource::TrustedTypePolicy { sample } => {
-                (Some(sample), "trusted-types-policy".to_owned())
-            },
-            ViolationResource::TrustedTypeSink { sample } => {
-                (Some(sample), "trusted-types-sink".to_owned())
-            },
-            ViolationResource::Eval { sample } => (sample, "eval".to_owned()),
-            ViolationResource::WasmEval => (None, "wasm-eval".to_owned()),
-        };
-        let report = CSPViolationReportBuilder::default()
-            .resource(resource)
-            .sample(sample)
-            .effective_directive(violation.directive.name)
-            .original_policy(violation.policy.to_string())
-            .report_only(violation.policy.disposition == PolicyDisposition::Report)
-            .source_file(scripted_caller.filename.clone())
-            .line_number(scripted_caller.line)
-            .column_number(scripted_caller.col + 1)
-            .build(global);
-        // Step 1: Let global be violation’s global object.
-        // We use `self` as `global`;
-        // Step 2: Let target be violation’s element.
-        let target = element.and_then(|event_target| {
-            // Step 3.1: If target is not null, and global is a Window,
-            // and target’s shadow-including root is not global’s associated Document, set target to null.
-            if let Some(window) = global.downcast::<Window>() {
-                // If a node is connected, its owner document is always the shadow-including root.
-                // If it isn't connected, then it also doesn't have a corresponding document, hence
-                // it can't be this document.
-                if event_target.upcast::<Node>().owner_document() != window.Document() {
-                    return None;
+pub(crate) trait GlobalCspReporting {
+    fn report_csp_violations(&self, violations: Vec<Violation>, element: Option<&Element>);
+}
+
+impl GlobalCspReporting for GlobalScope {
+    /// <https://www.w3.org/TR/CSP/#report-violation>
+    #[allow(unsafe_code)]
+    fn report_csp_violations(&self, violations: Vec<Violation>, element: Option<&Element>) {
+        let scripted_caller =
+            unsafe { describe_scripted_caller(*GlobalScope::get_cx()) }.unwrap_or_default();
+        for violation in violations {
+            let (sample, resource) = match violation.resource {
+                ViolationResource::Inline { sample } => (sample, "inline".to_owned()),
+                ViolationResource::Url(url) => (None, url.into()),
+                ViolationResource::TrustedTypePolicy { sample } => {
+                    (Some(sample), "trusted-types-policy".to_owned())
+                },
+                ViolationResource::TrustedTypeSink { sample } => {
+                    (Some(sample), "trusted-types-sink".to_owned())
+                },
+                ViolationResource::Eval { sample } => (sample, "eval".to_owned()),
+                ViolationResource::WasmEval => (None, "wasm-eval".to_owned()),
+            };
+            let report = CSPViolationReportBuilder::default()
+                .resource(resource)
+                .sample(sample)
+                .effective_directive(violation.directive.name)
+                .original_policy(violation.policy.to_string())
+                .report_only(violation.policy.disposition == PolicyDisposition::Report)
+                .source_file(scripted_caller.filename.clone())
+                .line_number(scripted_caller.line)
+                .column_number(scripted_caller.col + 1)
+                .build(self);
+            // Step 1: Let global be violation’s global object.
+            // We use `self` as `global`;
+            // Step 2: Let target be violation’s element.
+            let target = element.and_then(|event_target| {
+                // Step 3.1: If target is not null, and global is a Window,
+                // and target’s shadow-including root is not global’s associated Document, set target to null.
+                if let Some(window) = self.downcast::<Window>() {
+                    // If a node is connected, its owner document is always the shadow-including root.
+                    // If it isn't connected, then it also doesn't have a corresponding document, hence
+                    // it can't be this document.
+                    if event_target.upcast::<Node>().owner_document() != window.Document() {
+                        return None;
+                    }
                 }
-            }
-            Some(event_target)
-        });
-        let target = match target {
-            // Step 3.2: If target is null:
-            None => {
-                // Step 3.2.2: If target is a Window, set target to target’s associated Document.
-                if let Some(window) = global.downcast::<Window>() {
-                    Trusted::new(window.Document().upcast())
-                } else {
-                    // Step 3.2.1: Set target to violation’s global object.
-                    Trusted::new(global.upcast())
-                }
-            },
-            Some(event_target) => Trusted::new(event_target.upcast()),
-        };
-        // Step 3: Queue a task to run the following steps:
-        let task =
-            CSPViolationReportTask::new(Trusted::new(global), target, report, violation.policy);
-        global
-            .task_manager()
-            .dom_manipulation_task_source()
-            .queue(task);
+                Some(event_target)
+            });
+            let target = match target {
+                // Step 3.2: If target is null:
+                None => {
+                    // Step 3.2.2: If target is a Window, set target to target’s associated Document.
+                    if let Some(window) = self.downcast::<Window>() {
+                        Trusted::new(window.Document().upcast())
+                    } else {
+                        // Step 3.2.1: Set target to violation’s global object.
+                        Trusted::new(self.upcast())
+                    }
+                },
+                Some(event_target) => Trusted::new(event_target.upcast()),
+            };
+            // Step 3: Queue a task to run the following steps:
+            let task =
+                CSPViolationReportTask::new(Trusted::new(self), target, report, violation.policy);
+            self.task_manager()
+                .dom_manipulation_task_source()
+                .queue(task);
+        }
     }
 }
 

--- a/components/script/dom/csp.rs
+++ b/components/script/dom/csp.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use constellation_traits::{LoadData, LoadOrigin};
 use content_security_policy::{
     CheckResult, CspList, Destination, Element as CspElement, Initiator, NavigationCheckType,
-    Origin, ParserMetadata, PolicyDisposition, PolicySource, Request, Violation, ViolationResource,
+    Origin, ParserMetadata, PolicyDisposition, PolicySource, Request, ViolationResource,
 };
 use http::HeaderMap;
 use hyper_serde::Serde;
@@ -22,77 +22,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::window::Window;
 use crate::security_manager::CSPViolationReportTask;
-
-/// <https://www.w3.org/TR/CSP/#report-violation>
-#[allow(unsafe_code)]
-pub(crate) fn report_csp_violations(
-    global: &GlobalScope,
-    violations: Vec<Violation>,
-    element: Option<&Element>,
-) {
-    let scripted_caller =
-        unsafe { describe_scripted_caller(*GlobalScope::get_cx()) }.unwrap_or_default();
-    for violation in violations {
-        let (sample, resource) = match violation.resource {
-            ViolationResource::Inline { sample } => (sample, "inline".to_owned()),
-            ViolationResource::Url(url) => (None, url.into()),
-            ViolationResource::TrustedTypePolicy { sample } => {
-                (Some(sample), "trusted-types-policy".to_owned())
-            },
-            ViolationResource::TrustedTypeSink { sample } => {
-                (Some(sample), "trusted-types-sink".to_owned())
-            },
-            ViolationResource::Eval { sample } => (sample, "eval".to_owned()),
-            ViolationResource::WasmEval => (None, "wasm-eval".to_owned()),
-        };
-        let report = CSPViolationReportBuilder::default()
-            .resource(resource)
-            .sample(sample)
-            .effective_directive(violation.directive.name)
-            .original_policy(violation.policy.to_string())
-            .report_only(violation.policy.disposition == PolicyDisposition::Report)
-            .source_file(scripted_caller.filename.clone())
-            .line_number(scripted_caller.line)
-            .column_number(scripted_caller.col + 1)
-            .build(global);
-        // Step 1: Let global be violation’s global object.
-        // We use `self` as `global`;
-        // Step 2: Let target be violation’s element.
-        let target = element.and_then(|event_target| {
-            // Step 3.1: If target is not null, and global is a Window,
-            // and target’s shadow-including root is not global’s associated Document, set target to null.
-            if let Some(window) = global.downcast::<Window>() {
-                // If a node is connected, its owner document is always the shadow-including root.
-                // If it isn't connected, then it also doesn't have a corresponding document, hence
-                // it can't be this document.
-                if event_target.upcast::<Node>().owner_document() != window.Document() {
-                    return None;
-                }
-            }
-            Some(event_target)
-        });
-        let target = match target {
-            // Step 3.2: If target is null:
-            None => {
-                // Step 3.2.2: If target is a Window, set target to target’s associated Document.
-                if let Some(window) = global.downcast::<Window>() {
-                    Trusted::new(window.Document().upcast())
-                } else {
-                    // Step 3.2.1: Set target to violation’s global object.
-                    Trusted::new(global.upcast())
-                }
-            },
-            Some(event_target) => Trusted::new(event_target.upcast()),
-        };
-        // Step 3: Queue a task to run the following steps:
-        let task =
-            CSPViolationReportTask::new(Trusted::new(global), target, report, violation.policy);
-        global
-            .task_manager()
-            .dom_manipulation_task_source()
-            .queue(task);
-    }
-}
 
 /// <https://www.w3.org/TR/CSP/#can-compile-strings>
 pub(crate) fn is_js_evaluation_allowed(global: &GlobalScope, source: &str) -> bool {
@@ -177,6 +106,80 @@ pub(crate) fn should_elements_inline_type_behavior_be_blocked(
     report_csp_violations(global, violations, Some(el));
 
     result == CheckResult::Blocked
+}
+
+/// Used to determine which inline check to run
+pub use content_security_policy::Violation;
+
+/// <https://www.w3.org/TR/CSP/#report-violation>
+#[allow(unsafe_code)]
+pub(crate) fn report_csp_violations(
+    global: &GlobalScope,
+    violations: Vec<Violation>,
+    element: Option<&Element>,
+) {
+    let scripted_caller =
+        unsafe { describe_scripted_caller(*GlobalScope::get_cx()) }.unwrap_or_default();
+    for violation in violations {
+        let (sample, resource) = match violation.resource {
+            ViolationResource::Inline { sample } => (sample, "inline".to_owned()),
+            ViolationResource::Url(url) => (None, url.into()),
+            ViolationResource::TrustedTypePolicy { sample } => {
+                (Some(sample), "trusted-types-policy".to_owned())
+            },
+            ViolationResource::TrustedTypeSink { sample } => {
+                (Some(sample), "trusted-types-sink".to_owned())
+            },
+            ViolationResource::Eval { sample } => (sample, "eval".to_owned()),
+            ViolationResource::WasmEval => (None, "wasm-eval".to_owned()),
+        };
+        let report = CSPViolationReportBuilder::default()
+            .resource(resource)
+            .sample(sample)
+            .effective_directive(violation.directive.name)
+            .original_policy(violation.policy.to_string())
+            .report_only(violation.policy.disposition == PolicyDisposition::Report)
+            .source_file(scripted_caller.filename.clone())
+            .line_number(scripted_caller.line)
+            .column_number(scripted_caller.col + 1)
+            .build(global);
+        // Step 1: Let global be violation’s global object.
+        // We use `self` as `global`;
+        // Step 2: Let target be violation’s element.
+        let target = element.and_then(|event_target| {
+            // Step 3.1: If target is not null, and global is a Window,
+            // and target’s shadow-including root is not global’s associated Document, set target to null.
+            if let Some(window) = global.downcast::<Window>() {
+                // If a node is connected, its owner document is always the shadow-including root.
+                // If it isn't connected, then it also doesn't have a corresponding document, hence
+                // it can't be this document.
+                if event_target.upcast::<Node>().owner_document() != window.Document() {
+                    return None;
+                }
+            }
+            Some(event_target)
+        });
+        let target = match target {
+            // Step 3.2: If target is null:
+            None => {
+                // Step 3.2.2: If target is a Window, set target to target’s associated Document.
+                if let Some(window) = global.downcast::<Window>() {
+                    Trusted::new(window.Document().upcast())
+                } else {
+                    // Step 3.2.1: Set target to violation’s global object.
+                    Trusted::new(global.upcast())
+                }
+            },
+            Some(event_target) => Trusted::new(event_target.upcast()),
+        };
+        // Step 3: Queue a task to run the following steps:
+        let task =
+            CSPViolationReportTask::new(Trusted::new(global), target, report, violation.policy);
+        global
+            .task_manager()
+            .dom_manipulation_task_source()
+            .queue(task);
+    }
 }
 
 /// <https://www.w3.org/TR/CSP/#initialize-document-csp>

--- a/components/script/dom/csp.rs
+++ b/components/script/dom/csp.rs
@@ -7,6 +7,8 @@ use std::borrow::Cow;
 use constellation_traits::{LoadData, LoadOrigin};
 /// Used to determine which inline check to run
 pub use content_security_policy::InlineCheckType;
+/// Used to report CSP violations in Fetch handlers
+pub use content_security_policy::Violation;
 use content_security_policy::{
     CheckResult, CspList, Destination, Element as CspElement, Initiator, NavigationCheckType,
     Origin, ParserMetadata, PolicyDisposition, PolicySource, Request, ViolationResource,
@@ -195,9 +197,6 @@ impl CspReporting for Option<CspList> {
         allowed_by_csp == CheckResult::Blocked
     }
 }
-
-/// Used to determine which inline check to run
-pub use content_security_policy::Violation;
 
 pub(crate) trait GlobalCspReporting {
     fn report_csp_violations(&self, violations: Vec<Violation>, element: Option<&Element>);

--- a/components/script/dom/csp.rs
+++ b/components/script/dom/csp.rs
@@ -108,6 +108,56 @@ pub(crate) fn should_elements_inline_type_behavior_be_blocked(
     result == CheckResult::Blocked
 }
 
+/// <https://w3c.github.io/trusted-types/dist/spec/#should-block-create-policy>
+pub(crate) fn is_trusted_type_policy_creation_allowed(
+    global: &GlobalScope,
+    policy_name: String,
+    created_policy_names: Vec<String>,
+) -> bool {
+    let Some(csp_list) = global.get_csp_list() else {
+        return false;
+    };
+
+    let (allowed_by_csp, violations) =
+        csp_list.is_trusted_type_policy_creation_allowed(policy_name, created_policy_names);
+
+    report_csp_violations(global, violations, None);
+
+    allowed_by_csp == CheckResult::Allowed
+}
+
+/// <https://w3c.github.io/trusted-types/dist/spec/#abstract-opdef-does-sink-type-require-trusted-types>
+pub(crate) fn does_sink_type_require_trusted_types(
+    global: &GlobalScope,
+    sink_group: &str,
+    include_report_only_policies: bool,
+) -> bool {
+    let Some(csp_list) = global.get_csp_list() else {
+        return false;
+    };
+
+    csp_list.does_sink_type_require_trusted_types(sink_group, include_report_only_policies)
+}
+
+/// <https://w3c.github.io/trusted-types/dist/spec/#should-block-sink-type-mismatch>
+pub(crate) fn should_sink_type_mismatch_violation_be_blocked_by_csp(
+    global: &GlobalScope,
+    sink: &str,
+    sink_group: &str,
+    source: &str,
+) -> bool {
+    let Some(csp_list) = global.get_csp_list() else {
+        return false;
+    };
+
+    let (allowed_by_csp, violations) =
+        csp_list.should_sink_type_mismatch_violation_be_blocked_by_csp(sink, sink_group, source);
+
+    report_csp_violations(global, violations, None);
+
+    allowed_by_csp == CheckResult::Blocked
+}
+
 /// Used to determine which inline check to run
 pub use content_security_policy::Violation;
 

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -43,6 +43,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::bindings::trace::{CustomTraceable, RootedTraceableBox};
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
+use crate::dom::csp::parse_csp_list_from_metadata;
 use crate::dom::errorevent::ErrorEvent;
 use crate::dom::event::{Event, EventBubbles, EventCancelable, EventStatus};
 use crate::dom::eventtarget::EventTarget;
@@ -479,7 +480,7 @@ impl DedicatedWorkerGlobalScope {
                     Ok((metadata, bytes)) => (metadata, bytes),
                 };
                 scope.set_url(metadata.final_url.clone());
-                scope.set_csp_list(GlobalScope::parse_csp_list_from_metadata(&metadata.headers));
+                scope.set_csp_list(parse_csp_list_from_metadata(&metadata.headers));
                 global_scope.set_https_state(metadata.https_state);
                 let source = String::from_utf8_lossy(&bytes);
                 if let Some(chan) = global_scope.devtools_chan() {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -125,6 +125,7 @@ use crate::dom::cdatasection::CDATASection;
 use crate::dom::clipboardevent::{ClipboardEvent, ClipboardEventType};
 use crate::dom::comment::Comment;
 use crate::dom::compositionevent::CompositionEvent;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::customelementregistry::CustomElementDefinition;
 use crate::dom::customevent::CustomEvent;
@@ -4325,7 +4326,7 @@ impl Document {
             },
         };
 
-        self.global().report_csp_violations(violations, Some(el));
+        report_csp_violations(&self.global(), violations, Some(el));
 
         result
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
@@ -22,7 +21,7 @@ use canvas_traits::canvas::CanvasId;
 use canvas_traits::webgl::{self, WebGLContextId, WebGLMsg};
 use chrono::Local;
 use constellation_traits::{NavigationHistoryBehavior, ScriptToConstellationMessage};
-use content_security_policy::{self as csp, CspList, PolicyDisposition};
+use content_security_policy::{CspList, PolicyDisposition};
 use cookie::Cookie;
 use cssparser::match_ignore_ascii_case;
 use data_url::mime::Mime;
@@ -125,7 +124,6 @@ use crate::dom::cdatasection::CDATASection;
 use crate::dom::clipboardevent::{ClipboardEvent, ClipboardEventType};
 use crate::dom::comment::Comment;
 use crate::dom::compositionevent::CompositionEvent;
-use crate::dom::csp::report_csp_violations;
 use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::customelementregistry::CustomElementDefinition;
 use crate::dom::customevent::CustomEvent;
@@ -4305,30 +4303,6 @@ impl Document {
 
     pub(crate) fn get_csp_list(&self) -> Option<CspList> {
         self.policy_container.borrow().csp_list.clone()
-    }
-
-    /// <https://www.w3.org/TR/CSP/#should-block-inline>
-    pub(crate) fn should_elements_inline_type_behavior_be_blocked(
-        &self,
-        el: &Element,
-        type_: csp::InlineCheckType,
-        source: &str,
-    ) -> csp::CheckResult {
-        let (result, violations) = match self.get_csp_list() {
-            None => {
-                return csp::CheckResult::Allowed;
-            },
-            Some(csp_list) => {
-                let element = csp::Element {
-                    nonce: el.nonce_value_if_nonceable().map(Cow::Owned),
-                };
-                csp_list.should_elements_inline_type_behavior_be_blocked(&element, type_, source)
-            },
-        };
-
-        report_csp_violations(&self.global(), violations, Some(el));
-
-        result
     }
 
     /// Prevent any JS or layout from running until the corresponding call to

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -12,7 +12,6 @@ use std::rc::Rc;
 use std::str::FromStr;
 use std::{fmt, mem};
 
-use content_security_policy as csp;
 use cssparser::{Parser as CssParser, ParserInput as CssParserInput, match_ignore_ascii_case};
 use devtools_traits::AttrInfo;
 use dom_struct::dom_struct;
@@ -99,6 +98,7 @@ use crate::dom::bindings::xmlname::{
 };
 use crate::dom::characterdata::CharacterData;
 use crate::dom::create::create_element;
+use crate::dom::csp::{InlineCheckType, should_elements_inline_type_behavior_be_blocked};
 use crate::dom::customelementregistry::{
     CallbackReaction, CustomElementDefinition, CustomElementReaction, CustomElementState,
     is_valid_custom_element_name,
@@ -2263,12 +2263,12 @@ impl Element {
                     // Content Security Policy? algorithm returns "Blocked" when executed
                     // upon the attribute's element, "style attribute", and the attribute's value,
                     // then the style rules defined in the attribute's value must not be applied to the element. [CSP]
-                    if doc.should_elements_inline_type_behavior_be_blocked(
+                    if should_elements_inline_type_behavior_be_blocked(
+                        &self.owner_global(),
                         self,
-                        csp::InlineCheckType::StyleAttribute,
+                        InlineCheckType::StyleAttribute,
                         source,
-                    ) == csp::CheckResult::Blocked
-                    {
+                    ) {
                         return;
                     }
                     Arc::new(doc.style_shared_lock().wrap(parse_style_attribute(

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -8,7 +8,6 @@ use std::str::{Chars, FromStr};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use content_security_policy as csp;
 use dom_struct::dom_struct;
 use headers::ContentType;
 use http::StatusCode;
@@ -37,7 +36,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -475,9 +474,9 @@ impl FetchResponseListener for EventSourceContext {
         network_listener::submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -37,6 +37,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -476,7 +477,7 @@ impl FetchResponseListener for EventSourceContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -55,7 +55,7 @@ use crate::dom::bindings::reflector::{
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::HashMapTracedValues;
-use crate::dom::csp::{InlineCheckType, should_elements_inline_type_behavior_be_blocked};
+use crate::dom::csp::{CspReporting, InlineCheckType};
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::errorevent::ErrorEvent;
@@ -556,12 +556,16 @@ impl EventTarget {
     ) {
         if let Some(element) = self.downcast::<Element>() {
             let doc = element.owner_document();
-            if should_elements_inline_type_behavior_be_blocked(
-                &doc.global(),
-                element.upcast(),
-                InlineCheckType::ScriptAttribute,
-                source,
-            ) {
+            let global = &doc.global();
+            if global
+                .get_csp_list()
+                .should_elements_inline_type_behavior_be_blocked(
+                    global,
+                    element.upcast(),
+                    InlineCheckType::ScriptAttribute,
+                    source,
+                )
+            {
                 return;
             }
         };

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -11,7 +11,6 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 
-use content_security_policy as csp;
 use deny_public_fields::DenyPublicFields;
 use dom_struct::dom_struct;
 use fnv::FnvHasher;
@@ -56,6 +55,7 @@ use crate::dom::bindings::reflector::{
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::HashMapTracedValues;
+use crate::dom::csp::{InlineCheckType, should_elements_inline_type_behavior_be_blocked};
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::errorevent::ErrorEvent;
@@ -556,12 +556,12 @@ impl EventTarget {
     ) {
         if let Some(element) = self.downcast::<Element>() {
             let doc = element.owner_document();
-            if doc.should_elements_inline_type_behavior_be_blocked(
+            if should_elements_inline_type_behavior_be_blocked(
+                &doc.global(),
                 element.upcast(),
-                csp::InlineCheckType::ScriptAttribute,
+                InlineCheckType::ScriptAttribute,
                 source,
-            ) == csp::CheckResult::Blocked
-            {
+            ) {
                 return;
             }
         };

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2936,18 +2936,6 @@ impl GlobalScope {
         }))
     }
 
-    pub(crate) fn is_js_evaluation_allowed(&self, source: &str) -> bool {
-        let Some(csp_list) = self.get_csp_list() else {
-            return true;
-        };
-
-        let (is_js_evaluation_allowed, violations) = csp_list.is_js_evaluation_allowed(source);
-
-        report_csp_violations(self, violations, None);
-
-        is_js_evaluation_allowed == CheckResult::Allowed
-    }
-
     pub(crate) fn should_navigation_request_be_blocked(
         &self,
         load_data: &LoadData,

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -34,6 +34,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
+use crate::dom::csp::should_navigation_request_be_blocked;
 use crate::dom::document::{Document, determine_policy_for_token};
 use crate::dom::domtokenlist::DOMTokenList;
 use crate::dom::element::{
@@ -166,10 +167,11 @@ impl HTMLIFrameElement {
         if load_data.url.scheme() == "javascript" {
             let window_proxy = self.GetContentWindow();
             if let Some(window_proxy) = window_proxy {
-                if document
-                    .global()
-                    .should_navigation_request_be_blocked(&load_data, Some(self.upcast()))
-                {
+                if should_navigation_request_be_blocked(
+                    &document.global(),
+                    &load_data,
+                    Some(self.upcast()),
+                ) {
                     return;
                 }
                 // Important re security. See https://github.com/servo/servo/issues/23373

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -34,7 +34,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
-use crate::dom::csp::should_navigation_request_be_blocked;
+use crate::dom::csp::CspReporting;
 use crate::dom::document::{Document, determine_policy_for_token};
 use crate::dom::domtokenlist::DOMTokenList;
 use crate::dom::element::{
@@ -167,8 +167,9 @@ impl HTMLIFrameElement {
         if load_data.url.scheme() == "javascript" {
             let window_proxy = self.GetContentWindow();
             if let Some(window_proxy) = window_proxy {
-                if should_navigation_request_be_blocked(
-                    &document.global(),
+                let global = &document.global();
+                if global.get_csp_list().should_navigation_request_be_blocked(
+                    global,
                     &load_data,
                     Some(self.upcast()),
                 ) {

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use std::{char, mem};
 
 use app_units::{AU_PER_PX, Au};
-use content_security_policy as csp;
 use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use euclid::Point2D;
@@ -60,7 +59,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{Violation, report_csp_violations};
 use crate::dom::document::{Document, determine_policy_for_token};
 use crate::dom::element::{
     AttributeMutation, CustomElementCreationMode, Element, ElementCreator, LayoutElementHelpers,
@@ -296,7 +295,7 @@ impl FetchResponseListener for ImageContext {
         network_listener::submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         report_csp_violations(global, violations, None);
     }

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -60,6 +60,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
+use crate::dom::csp::report_csp_violations;
 use crate::dom::document::{Document, determine_policy_for_token};
 use crate::dom::element::{
     AttributeMutation, CustomElementCreationMode, Element, ElementCreator, LayoutElementHelpers,
@@ -297,7 +298,7 @@ impl FetchResponseListener for ImageContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -59,7 +59,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
-use crate::dom::csp::{Violation, report_csp_violations};
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::{Document, determine_policy_for_token};
 use crate::dom::element::{
     AttributeMutation, CustomElementCreationMode, Element, ElementCreator, LayoutElementHelpers,
@@ -297,7 +297,7 @@ impl FetchResponseListener for ImageContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -8,7 +8,6 @@ use std::default::Default;
 use std::str::FromStr;
 
 use base::id::WebViewId;
-use content_security_policy as csp;
 use dom_struct::dom_struct;
 use embedder_traits::EmbedderMsg;
 use html5ever::{LocalName, Prefix, local_name, ns};
@@ -39,7 +38,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{Violation, report_csp_violations};
 use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::document::Document;
 use crate::dom::domtokenlist::DOMTokenList;
@@ -1017,7 +1016,7 @@ impl FetchResponseListener for PrefetchContext {
         submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         report_csp_violations(global, violations, None);
     }
@@ -1091,7 +1090,7 @@ impl FetchResponseListener for PreloadContext {
         submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         report_csp_violations(global, violations, None);
     }

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -38,7 +38,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
-use crate::dom::csp::{Violation, report_csp_violations};
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::document::Document;
 use crate::dom::domtokenlist::DOMTokenList;
@@ -1018,7 +1018,7 @@ impl FetchResponseListener for PrefetchContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 
@@ -1092,7 +1092,7 @@ impl FetchResponseListener for PreloadContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -39,6 +39,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
+use crate::dom::csp::report_csp_violations;
 use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::document::Document;
 use crate::dom::domtokenlist::DOMTokenList;
@@ -1018,7 +1019,7 @@ impl FetchResponseListener for PrefetchContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 
@@ -1092,7 +1093,7 @@ impl FetchResponseListener for PreloadContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -73,7 +73,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::blob::Blob;
-use crate::dom::csp::{Violation, report_csp_violations};
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
 use crate::dom::element::{
     AttributeMutation, Element, ElementCreator, cors_setting_for_element,
@@ -3169,7 +3169,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -74,6 +74,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::blob::Blob;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::document::Document;
 use crate::dom::element::{
     AttributeMutation, Element, ElementCreator, cors_setting_for_element,
@@ -3169,7 +3170,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -10,7 +10,6 @@ use std::time::{Duration, Instant};
 use std::{f64, mem};
 
 use compositing_traits::{CrossProcessCompositorApi, ImageUpdate, SerializableImageData};
-use content_security_policy as csp;
 use dom_struct::dom_struct;
 use embedder_traits::{MediaPositionState, MediaSessionEvent, MediaSessionPlaybackState};
 use euclid::default::Size2D;
@@ -74,7 +73,7 @@ use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::blob::Blob;
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{Violation, report_csp_violations};
 use crate::dom::document::Document;
 use crate::dom::element::{
     AttributeMutation, Element, ElementCreator, cors_setting_for_element,
@@ -3168,7 +3167,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
         network_listener::submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         report_csp_violations(global, violations, None);
     }

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -57,10 +57,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::NoTrace;
-use crate::dom::csp::{
-    InlineCheckType, Violation, report_csp_violations,
-    should_elements_inline_type_behavior_be_blocked,
-};
+use crate::dom::csp::{CspReporting, InlineCheckType, Violation, report_csp_violations};
 use crate::dom::document::Document;
 use crate::dom::element::{
     AttributeMutation, Element, ElementCreator, cors_setting_for_element,
@@ -766,14 +763,18 @@ impl HTMLScriptElement {
             return;
         }
 
+        let global = &doc.global();
+
         // Step 19. CSP.
         if !element.has_attribute(&local_name!("src")) &&
-            should_elements_inline_type_behavior_be_blocked(
-                &doc.global(),
-                element,
-                InlineCheckType::Script,
-                &text,
-            )
+            global
+                .get_csp_list()
+                .should_elements_inline_type_behavior_be_blocked(
+                    global,
+                    element,
+                    InlineCheckType::Script,
+                    &text,
+                )
         {
             warn!("Blocking inline script due to CSP");
             return;

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -12,7 +12,6 @@ use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
 use base::id::{PipelineId, WebViewId};
-use content_security_policy as csp;
 use devtools_traits::{ScriptToDevtoolsControlMsg, SourceInfo};
 use dom_struct::dom_struct;
 use encoding_rs::Encoding;
@@ -58,7 +57,10 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::NoTrace;
-use crate::dom::csp::{report_csp_violations, should_elements_inline_type_behavior_be_blocked};
+use crate::dom::csp::{
+    InlineCheckType, Violation, report_csp_violations,
+    should_elements_inline_type_behavior_be_blocked,
+};
 use crate::dom::document::Document;
 use crate::dom::element::{
     AttributeMutation, Element, ElementCreator, cors_setting_for_element,
@@ -558,7 +560,7 @@ impl FetchResponseListener for ClassicContext {
         network_listener::submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         let elem = self.elem.root();
         report_csp_violations(global, violations, Some(elem.upcast::<Element>()));
@@ -769,7 +771,7 @@ impl HTMLScriptElement {
             should_elements_inline_type_behavior_be_blocked(
                 &doc.global(),
                 element,
-                csp::InlineCheckType::Script,
+                InlineCheckType::Script,
                 &text,
             )
         {

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -58,7 +58,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::NoTrace;
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{report_csp_violations, should_elements_inline_type_behavior_be_blocked};
 use crate::dom::document::Document;
 use crate::dom::element::{
     AttributeMutation, Element, ElementCreator, cors_setting_for_element,
@@ -766,11 +766,12 @@ impl HTMLScriptElement {
 
         // Step 19. CSP.
         if !element.has_attribute(&local_name!("src")) &&
-            doc.should_elements_inline_type_behavior_be_blocked(
+            should_elements_inline_type_behavior_be_blocked(
+                &doc.global(),
                 element,
                 csp::InlineCheckType::Script,
                 &text,
-            ) == csp::CheckResult::Blocked
+            )
         {
             warn!("Blocking inline script due to CSP");
             return;

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -58,6 +58,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::NoTrace;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::document::Document;
 use crate::dom::element::{
     AttributeMutation, Element, ElementCreator, cors_setting_for_element,
@@ -560,7 +561,7 @@ impl FetchResponseListener for ClassicContext {
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
         let elem = self.elem.root();
-        global.report_csp_violations(violations, Some(elem.upcast::<Element>()));
+        report_csp_violations(global, violations, Some(elem.upcast::<Element>()));
     }
 }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -57,7 +57,7 @@ use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::NoTrace;
-use crate::dom::csp::{CspReporting, InlineCheckType, Violation, report_csp_violations};
+use crate::dom::csp::{CspReporting, GlobalCspReporting, InlineCheckType, Violation};
 use crate::dom::document::Document;
 use crate::dom::element::{
     AttributeMutation, Element, ElementCreator, cors_setting_for_element,
@@ -560,7 +560,7 @@ impl FetchResponseListener for ClassicContext {
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         let elem = self.elem.root();
-        report_csp_violations(global, violations, Some(elem.upcast::<Element>()));
+        global.report_csp_violations(violations, Some(elem.upcast::<Element>()));
     }
 }
 

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -19,7 +19,7 @@ use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
-use crate::dom::csp::{InlineCheckType, should_elements_inline_type_behavior_be_blocked};
+use crate::dom::csp::{CspReporting, InlineCheckType};
 use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element, ElementCreator};
@@ -99,16 +99,20 @@ impl HTMLStyleElement {
         }
 
         let doc = self.owner_document();
+        let global = &self.owner_global();
 
         // Step 5: If the Should element's inline behavior be blocked by Content Security Policy? algorithm
         // returns "Blocked" when executed upon the style element, "style",
         // and the style element's child text content, then return. [CSP]
-        if should_elements_inline_type_behavior_be_blocked(
-            &self.owner_global(),
-            self.upcast(),
-            InlineCheckType::Style,
-            &node.child_text_content(),
-        ) {
+        if global
+            .get_csp_list()
+            .should_elements_inline_type_behavior_be_blocked(
+                global,
+                self.upcast(),
+                InlineCheckType::Style,
+                &node.child_text_content(),
+            )
+        {
             return;
         }
 

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -4,7 +4,6 @@
 
 use std::cell::Cell;
 
-use content_security_policy as csp;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix};
 use js::rust::HandleObject;
@@ -20,6 +19,7 @@ use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::csp::{InlineCheckType, should_elements_inline_type_behavior_be_blocked};
 use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element, ElementCreator};
@@ -103,12 +103,12 @@ impl HTMLStyleElement {
         // Step 5: If the Should element's inline behavior be blocked by Content Security Policy? algorithm
         // returns "Blocked" when executed upon the style element, "style",
         // and the style element's child text content, then return. [CSP]
-        if doc.should_elements_inline_type_behavior_be_blocked(
+        if should_elements_inline_type_behavior_be_blocked(
+            &self.owner_global(),
             self.upcast(),
-            csp::InlineCheckType::Style,
+            InlineCheckType::Style,
             &node.child_text_content(),
-        ) == csp::CheckResult::Blocked
-        {
+        ) {
             return;
         }
 

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -33,7 +33,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
-use crate::dom::csp::{Violation, report_csp_violations};
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
 use crate::dom::globalscope::GlobalScope;
@@ -465,7 +465,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -34,6 +34,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
 use crate::dom::globalscope::GlobalScope;
@@ -465,7 +466,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/dom/htmlvideoelement.rs
+++ b/components/script/dom/htmlvideoelement.rs
@@ -5,7 +5,6 @@
 use std::cell::Cell;
 use std::sync::Arc;
 
-use content_security_policy as csp;
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use html5ever::{LocalName, Prefix, local_name, ns};
@@ -34,7 +33,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{Violation, report_csp_violations};
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
 use crate::dom::globalscope::GlobalScope;
@@ -464,7 +463,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
         network_listener::submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         report_csp_violations(global, violations, None);
     }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -263,6 +263,7 @@ pub(crate) mod countqueuingstrategy;
 mod create;
 pub(crate) mod crypto;
 pub(crate) mod cryptokey;
+pub(crate) mod csp;
 pub(crate) mod csppolicyviolationreport;
 pub(crate) mod css;
 pub(crate) mod cssconditionrule;

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -53,7 +53,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::bindings::utils::to_frozen_array;
-use crate::dom::csp::{Violation, report_csp_violations};
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissions::{PermissionAlgorithm, Permissions, descriptor_permission_state};
@@ -794,7 +794,7 @@ impl FetchResponseListener for ResourceFetchListener {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -7,8 +7,6 @@ use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use content_security_policy as csp;
-use content_security_policy::Destination;
 use dom_struct::dom_struct;
 use embedder_traits::{
     EmbedderMsg, Notification as EmbedderNotification,
@@ -24,7 +22,7 @@ use net_traits::image_cache::{
     ImageCache, ImageCacheResponseMessage, ImageCacheResult, ImageLoadListener,
     ImageOrMetadataAvailable, ImageResponse, PendingImageId, UsePlaceholder,
 };
-use net_traits::request::{RequestBuilder, RequestId};
+use net_traits::request::{Destination, RequestBuilder, RequestId};
 use net_traits::{
     FetchMetadata, FetchResponseListener, FetchResponseMsg, NetworkError, ResourceFetchTiming,
     ResourceTimingType,
@@ -55,7 +53,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::bindings::utils::to_frozen_array;
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{Violation, report_csp_violations};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissions::{PermissionAlgorithm, Permissions, descriptor_permission_state};
@@ -794,7 +792,7 @@ impl FetchResponseListener for ResourceFetchListener {
         network_listener::submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         report_csp_violations(global, violations, None);
     }

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -55,6 +55,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::bindings::utils::to_frozen_array;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::permissions::{PermissionAlgorithm, Permissions, descriptor_permission_state};
@@ -795,7 +796,7 @@ impl FetchResponseListener for ResourceFetchListener {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -56,7 +56,7 @@ use crate::dom::bindings::settings_stack::is_execution_stack_empty;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::characterdata::CharacterData;
 use crate::dom::comment::Comment;
-use crate::dom::csp::{Violation, parse_csp_list_from_metadata, report_csp_violations};
+use crate::dom::csp::{GlobalCspReporting, Violation, parse_csp_list_from_metadata};
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
@@ -1112,7 +1112,7 @@ impl FetchResponseListener for ParserContext {
         let document = &parser.document;
         let global = &document.global();
         // TODO(https://github.com/w3c/webappsec-csp/issues/687): Update after spec is resolved
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -57,6 +57,7 @@ use crate::dom::bindings::settings_stack::is_execution_stack_empty;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::characterdata::CharacterData;
 use crate::dom::comment::Comment;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
@@ -1113,7 +1114,7 @@ impl FetchResponseListener for ParserContext {
         let document = &parser.document;
         let global = &document.global();
         // TODO(https://github.com/w3c/webappsec-csp/issues/687): Update after spec is resolved
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -9,7 +9,6 @@ use base::cross_process_instant::CrossProcessInstant;
 use base::id::PipelineId;
 use base64::Engine as _;
 use base64::engine::general_purpose;
-use content_security_policy as csp;
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
 use embedder_traits::resources::{self, Resource};
@@ -57,7 +56,7 @@ use crate::dom::bindings::settings_stack::is_execution_stack_empty;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::characterdata::CharacterData;
 use crate::dom::comment::Comment;
-use crate::dom::csp::{parse_csp_list_from_metadata, report_csp_violations};
+use crate::dom::csp::{Violation, parse_csp_list_from_metadata, report_csp_violations};
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
@@ -1105,7 +1104,7 @@ impl FetchResponseListener for ParserContext {
         );
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let parser = match self.parser.as_ref() {
             Some(parser) => parser.root(),
             None => return,

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -57,12 +57,11 @@ use crate::dom::bindings::settings_stack::is_execution_stack_empty;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::characterdata::CharacterData;
 use crate::dom::comment::Comment;
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{parse_csp_list_from_metadata, report_csp_violations};
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documenttype::DocumentType;
 use crate::dom::element::{CustomElementCreationMode, Element, ElementCreator};
-use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlformelement::{FormControlElementHelpers, HTMLFormElement};
 use crate::dom::htmlimageelement::HTMLImageElement;
 use crate::dom::htmlinputelement::HTMLInputElement;
@@ -909,7 +908,7 @@ impl FetchResponseListener for ParserContext {
 
         let csp_list = metadata
             .as_ref()
-            .and_then(|m| GlobalScope::parse_csp_list_from_metadata(&m.headers));
+            .and_then(|m| parse_csp_list_from_metadata(&m.headers));
 
         let parser = match ScriptThread::page_headers_available(&self.id, metadata, CanGc::note()) {
             Some(parser) => parser,

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -6,7 +6,6 @@ use std::cell::{Cell, RefCell};
 use std::ops::Deref;
 
 use base::id::{PipelineId, WebViewId};
-use content_security_policy::Destination;
 use html5ever::buffer_queue::BufferQueue;
 use html5ever::tokenizer::states::RawKind;
 use html5ever::tokenizer::{
@@ -17,7 +16,7 @@ use js::jsapi::JSTracer;
 use markup5ever::TokenizerResult;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
-    CorsSettings, CredentialsMode, InsecureRequestsPolicy, ParserMetadata, Referrer,
+    CorsSettings, CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata, Referrer,
 };
 use net_traits::{CoreResourceMsg, FetchChannels, IpcSend, ReferrerPolicy, ResourceThreads};
 use servo_url::{ImmutableOrigin, ServoUrl};

--- a/components/script/dom/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypepolicyfactory.rs
@@ -17,6 +17,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::trustedhtml::TrustedHTML;
 use crate::dom::trustedscript::TrustedScript;
@@ -66,7 +67,7 @@ impl TrustedTypePolicyFactory {
             (CheckResult::Allowed, Vec::new())
         };
 
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
 
         // Step 2: If allowedByCSP is "Blocked", throw a TypeError and abort further steps.
         if allowed_by_csp == CheckResult::Blocked {
@@ -229,7 +230,7 @@ impl TrustedTypePolicyFactory {
                     .should_sink_type_mismatch_violation_be_blocked_by_csp(
                         sink, sink_group, &input,
                     );
-                global.report_csp_violations(violations, None);
+                report_csp_violations(global, violations, None);
                 // Step 6.2: If disposition is “Allowed”, return stringified input and abort further steps.
                 if disposition == CheckResult::Allowed {
                     Ok(input)

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -38,6 +38,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, USVString, is_token};
 use crate::dom::blob::Blob;
 use crate::dom::closeevent::CloseEvent;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -471,7 +472,7 @@ struct ReportCSPViolationTask {
 impl TaskOnce for ReportCSPViolationTask {
     fn run_once(self) {
         let global = self.websocket.root().global();
-        global.report_csp_violations(self.violations, None);
+        report_csp_violations(&global, self.violations, None);
     }
 }
 

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -7,7 +7,6 @@ use std::cell::Cell;
 use std::ptr;
 
 use constellation_traits::BlobImpl;
-use content_security_policy::Violation;
 use dom_struct::dom_struct;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
@@ -38,7 +37,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, USVString, is_token};
 use crate::dom::blob::Blob;
 use crate::dom::closeevent::CloseEvent;
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{Violation, report_csp_violations};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -37,7 +37,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::{DOMString, USVString, is_token};
 use crate::dom::blob::Blob;
 use crate::dom::closeevent::CloseEvent;
-use crate::dom::csp::{Violation, report_csp_violations};
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -471,7 +471,7 @@ struct ReportCSPViolationTask {
 impl TaskOnce for ReportCSPViolationTask {
     fn run_once(self) {
         let global = self.websocket.root().global();
-        report_csp_violations(&global, self.violations, None);
+        global.report_csp_violations(self.violations, None);
     }
 }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -56,6 +56,7 @@ use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{ByteString, DOMString, USVString, is_token};
 use crate::dom::blob::{Blob, normalize_type_string};
+use crate::dom::csp::report_csp_violations;
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
@@ -149,7 +150,7 @@ impl FetchResponseListener for XHRContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -55,7 +55,7 @@ use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{ByteString, DOMString, USVString, is_token};
 use crate::dom::blob::{Blob, normalize_type_string};
-use crate::dom::csp::{Violation, report_csp_violations};
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
@@ -149,7 +149,7 @@ impl FetchResponseListener for XHRContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -11,7 +11,6 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use constellation_traits::BlobImpl;
-use content_security_policy as csp;
 use data_url::mime::Mime;
 use dom_struct::dom_struct;
 use encoding_rs::{Encoding, UTF_8};
@@ -56,7 +55,7 @@ use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::{ByteString, DOMString, USVString, is_token};
 use crate::dom::blob::{Blob, normalize_type_string};
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{Violation, report_csp_violations};
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
@@ -148,7 +147,7 @@ impl FetchResponseListener for XHRContext {
         network_listener::submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         report_csp_violations(global, violations, None);
     }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -6,7 +6,6 @@ use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
 use base::id::WebViewId;
-use content_security_policy as csp;
 use ipc_channel::ipc;
 use net_traits::policy_container::{PolicyContainer, RequestPolicyContainer};
 use net_traits::request::{
@@ -31,7 +30,7 @@ use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::RootedTraceableBox;
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{Violation, report_csp_violations};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::headers::Guard;
 use crate::dom::performanceresourcetiming::InitiatorType;
@@ -312,7 +311,7 @@ impl FetchResponseListener for FetchContext {
         }
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         report_csp_violations(global, violations, None);
     }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -31,6 +31,7 @@ use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::RootedTraceableBox;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::headers::Guard;
 use crate::dom::performanceresourcetiming::InitiatorType;
@@ -313,7 +314,7 @@ impl FetchResponseListener for FetchContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -30,7 +30,7 @@ use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::RootedTraceableBox;
-use crate::dom::csp::{Violation, report_csp_violations};
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::headers::Guard;
 use crate::dom::performanceresourcetiming::InitiatorType;
@@ -313,7 +313,7 @@ impl FetchResponseListener for FetchContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -8,7 +8,6 @@
 
 use std::sync::Arc;
 
-use content_security_policy as csp;
 use net_traits::image_cache::{ImageCache, PendingImageId};
 use net_traits::request::{Destination, RequestBuilder as FetchRequestInit, RequestId};
 use net_traits::{
@@ -20,7 +19,7 @@ use servo_url::ServoUrl;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::node::{Node, NodeTraits};
@@ -80,9 +79,9 @@ impl FetchResponseListener for LayoutImageContext {
         network_listener::submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -20,6 +20,7 @@ use servo_url::ServoUrl;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::document::Document;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::node::{Node, NodeTraits};
@@ -81,7 +82,7 @@ impl FetchResponseListener for LayoutImageContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -61,6 +61,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::settings_stack::AutoIncumbentScript;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::document::Document;
 use crate::dom::dynamicmoduleowner::{DynamicModuleId, DynamicModuleOwner};
 use crate::dom::element::Element;
@@ -1369,7 +1370,7 @@ impl FetchResponseListener for ModuleContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -11,7 +11,6 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::{mem, ptr};
 
-use content_security_policy as csp;
 use encoding_rs::UTF_8;
 use headers::{HeaderMapExt, ReferrerPolicy as ReferrerPolicyHeader};
 use html5ever::local_name;
@@ -61,7 +60,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::settings_stack::AutoIncumbentScript;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{Violation, report_csp_violations};
 use crate::dom::document::Document;
 use crate::dom::dynamicmoduleowner::{DynamicModuleId, DynamicModuleOwner};
 use crate::dom::element::Element;
@@ -1368,7 +1367,7 @@ impl FetchResponseListener for ModuleContext {
         network_listener::submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         report_csp_violations(global, violations, None);
     }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -60,7 +60,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::settings_stack::AutoIncumbentScript;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::RootedTraceableBox;
-use crate::dom::csp::{Violation, report_csp_violations};
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
 use crate::dom::dynamicmoduleowner::{DynamicModuleId, DynamicModuleOwner};
 use crate::dom::element::Element;
@@ -1369,7 +1369,7 @@ impl FetchResponseListener for ModuleContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -71,9 +71,7 @@ use crate::dom::bindings::reflector::{DomGlobal, DomObject};
 use crate::dom::bindings::root::trace_roots;
 use crate::dom::bindings::utils::DOM_CALLBACKS;
 use crate::dom::bindings::{principals, settings_stack};
-use crate::dom::csp::{
-    is_js_evaluation_allowed, is_wasm_evaluation_allowed,
-};
+use crate::dom::csp::{is_js_evaluation_allowed, is_wasm_evaluation_allowed};
 use crate::dom::event::{Event, EventBubbles, EventCancelable, EventStatus};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -71,7 +71,7 @@ use crate::dom::bindings::reflector::{DomGlobal, DomObject};
 use crate::dom::bindings::root::trace_roots;
 use crate::dom::bindings::utils::DOM_CALLBACKS;
 use crate::dom::bindings::{principals, settings_stack};
-use crate::dom::csp::{is_js_evaluation_allowed, is_wasm_evaluation_allowed};
+use crate::dom::csp::CspReporting;
 use crate::dom::event::{Event, EventBubbles, EventCancelable, EventStatus};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -388,9 +388,11 @@ unsafe extern "C" fn content_security_policy_allows(
                     sample if !sample.is_null() => &jsstr_to_string(*cx, *sample),
                     _ => "",
                 };
-                is_js_evaluation_allowed(global, source)
+                global
+                    .get_csp_list()
+                    .is_js_evaluation_allowed(global, source)
             },
-            RuntimeCode::WASM => is_wasm_evaluation_allowed(global),
+            RuntimeCode::WASM => global.get_csp_list().is_wasm_evaluation_allowed(global),
         };
     });
     allowed

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -72,6 +72,7 @@ use crate::dom::bindings::reflector::{DomGlobal, DomObject};
 use crate::dom::bindings::root::trace_roots;
 use crate::dom::bindings::utils::DOM_CALLBACKS;
 use crate::dom::bindings::{principals, settings_stack};
+use crate::dom::csp::report_csp_violations;
 use crate::dom::event::{Event, EventBubbles, EventCancelable, EventStatus};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -397,7 +398,7 @@ unsafe extern "C" fn content_security_policy_allows(
             RuntimeCode::WASM => csp_list.is_wasm_evaluation_allowed(),
         };
 
-        global.report_csp_violations(violations, None);
+        report_csp_violations(&global, violations, None);
         allowed = is_evaluation_allowed == CheckResult::Allowed;
     });
     allowed

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -118,7 +118,7 @@ use crate::dom::bindings::root::{
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::{HashMapTracedValues, JSTraceable};
-use crate::dom::csp::{CspReporting, Violation, report_csp_violations};
+use crate::dom::csp::{CspReporting, GlobalCspReporting, Violation};
 use crate::dom::customelementregistry::{
     CallbackReaction, CustomElementDefinition, CustomElementReactionStack,
 };
@@ -3849,7 +3849,7 @@ impl ScriptThread {
     fn handle_csp_violations(&self, id: PipelineId, _: RequestId, violations: Vec<Violation>) {
         if let Some(global) = self.documents.borrow().find_global(id) {
             // TODO(https://github.com/w3c/webappsec-csp/issues/687): Update after spec is resolved
-            report_csp_violations(&global, violations, None);
+            global.report_csp_violations(violations, None);
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -118,7 +118,7 @@ use crate::dom::bindings::root::{
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::{HashMapTracedValues, JSTraceable};
-use crate::dom::csp::{Violation, report_csp_violations, should_navigation_request_be_blocked};
+use crate::dom::csp::{CspReporting, Violation, report_csp_violations};
 use crate::dom::customelementregistry::{
     CallbackReaction, CustomElementDefinition, CustomElementReactionStack,
 };
@@ -622,9 +622,10 @@ impl ScriptThread {
                 let task = task!(navigate_javascript: move || {
                     // Important re security. See https://github.com/servo/servo/issues/23373
                     if let Some(window) = trusted_global.root().downcast::<Window>() {
+                        let global = &trusted_global.root();
                         // Step 5: If the result of should navigation request of type be blocked by
                         // Content Security Policy? given request and cspNavigationType is "Blocked", then return. [CSP]
-                        if should_navigation_request_be_blocked(&trusted_global.root(), &load_data, None) {
+                        if global.get_csp_list().should_navigation_request_be_blocked(global, &load_data, None) {
                             return;
                         }
                         if ScriptThread::check_load_origin(&load_data.load_origin, &window.get_url().origin()) {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -41,7 +41,6 @@ use constellation_traits::{
     JsEvalResult, LoadData, LoadOrigin, NavigationHistoryBehavior, ScriptToConstellationChan,
     ScriptToConstellationMessage, StructuredSerializedData, WindowSizeType,
 };
-use content_security_policy::{self as csp};
 use crossbeam_channel::unbounded;
 use data_url::mime::Mime;
 use devtools_traits::{
@@ -119,7 +118,7 @@ use crate::dom::bindings::root::{
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::{HashMapTracedValues, JSTraceable};
-use crate::dom::csp::{report_csp_violations, should_navigation_request_be_blocked};
+use crate::dom::csp::{Violation, report_csp_violations, should_navigation_request_be_blocked};
 use crate::dom::customelementregistry::{
     CallbackReaction, CustomElementDefinition, CustomElementReactionStack,
 };
@@ -3846,7 +3845,7 @@ impl ScriptThread {
         }
     }
 
-    fn handle_csp_violations(&self, id: PipelineId, _: RequestId, violations: Vec<csp::Violation>) {
+    fn handle_csp_violations(&self, id: PipelineId, _: RequestId, violations: Vec<Violation>) {
         if let Some(global) = self.documents.borrow().find_global(id) {
             // TODO(https://github.com/w3c/webappsec-csp/issues/687): Update after spec is resolved
             report_csp_violations(&global, violations, None);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -119,7 +119,7 @@ use crate::dom::bindings::root::{
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::{HashMapTracedValues, JSTraceable};
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{report_csp_violations, should_navigation_request_be_blocked};
 use crate::dom::customelementregistry::{
     CallbackReaction, CustomElementDefinition, CustomElementReactionStack,
 };
@@ -625,7 +625,7 @@ impl ScriptThread {
                     if let Some(window) = trusted_global.root().downcast::<Window>() {
                         // Step 5: If the result of should navigation request of type be blocked by
                         // Content Security Policy? given request and cspNavigationType is "Blocked", then return. [CSP]
-                        if trusted_global.root().should_navigation_request_be_blocked(&load_data, None) {
+                        if should_navigation_request_be_blocked(&trusted_global.root(), &load_data, None) {
                             return;
                         }
                         if ScriptThread::check_load_origin(&load_data.load_origin, &window.get_url().origin()) {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -119,6 +119,7 @@ use crate::dom::bindings::root::{
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::{HashMapTracedValues, JSTraceable};
+use crate::dom::csp::report_csp_violations;
 use crate::dom::customelementregistry::{
     CallbackReaction, CustomElementDefinition, CustomElementReactionStack,
 };
@@ -3848,7 +3849,7 @@ impl ScriptThread {
     fn handle_csp_violations(&self, id: PipelineId, _: RequestId, violations: Vec<csp::Violation>) {
         if let Some(global) = self.documents.borrow().find_global(id) {
             // TODO(https://github.com/w3c/webappsec-csp/issues/687): Update after spec is resolved
-            global.report_csp_violations(violations, None);
+            report_csp_violations(&global, violations, None);
         }
     }
 

--- a/components/script/security_manager.rs
+++ b/components/script/security_manager.rs
@@ -19,6 +19,7 @@ use crate::conversions::Convert;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::root::DomRoot;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::csppolicyviolationreport::{
     CSPReportUriViolationReport, SecurityPolicyViolationReport,
 };
@@ -206,7 +207,7 @@ impl FetchResponseListener for CSPReportUriFetchListener {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/security_manager.rs
+++ b/components/script/security_manager.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use content_security_policy as csp;
 use headers::{ContentType, HeaderMap, HeaderMapExt};
 use net_traits::request::{
-    CredentialsMode, RequestBody, RequestId, create_request_body_with_content,
+    CredentialsMode, Destination, RequestBody, RequestId, create_request_body_with_content,
 };
 use net_traits::{
     FetchMetadata, FetchResponseListener, NetworkError, ResourceFetchTiming, ResourceTimingType,
@@ -19,7 +19,7 @@ use crate::conversions::Convert;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{Violation, report_csp_violations};
 use crate::dom::csppolicyviolationreport::{
     CSPReportUriViolationReport, SecurityPolicyViolationReport,
 };
@@ -111,7 +111,7 @@ impl CSPViolationReportTask {
             let request = create_a_potential_cors_request(
                 None,
                 endpoint.clone(),
-                csp::Destination::Report,
+                Destination::Report,
                 None,
                 None,
                 global.get_referrer(),
@@ -205,7 +205,7 @@ impl FetchResponseListener for CSPReportUriFetchListener {
         submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         report_csp_violations(global, violations, None);
     }

--- a/components/script/security_manager.rs
+++ b/components/script/security_manager.rs
@@ -19,7 +19,7 @@ use crate::conversions::Convert;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::csp::{Violation, report_csp_violations};
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::csppolicyviolationreport::{
     CSPReportUriViolationReport, SecurityPolicyViolationReport,
 };
@@ -207,7 +207,7 @@ impl FetchResponseListener for CSPReportUriFetchListener {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -31,7 +31,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::csp::{Violation, report_csp_violations};
+use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::eventtarget::EventTarget;
@@ -298,7 +298,7 @@ impl FetchResponseListener for StylesheetContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        report_csp_violations(global, violations, None);
+        global.report_csp_violations(violations, None);
     }
 }
 

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -32,6 +32,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
+use crate::dom::csp::report_csp_violations;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::eventtarget::EventTarget;
@@ -298,7 +299,7 @@ impl FetchResponseListener for StylesheetContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
         let global = &self.resource_timing_global();
-        global.report_csp_violations(violations, None);
+        report_csp_violations(global, violations, None);
     }
 }
 

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -5,7 +5,6 @@
 use std::io::{Read, Seek, Write};
 use std::sync::atomic::AtomicBool;
 
-use content_security_policy as csp;
 use cssparser::SourceLocation;
 use encoding_rs::UTF_8;
 use mime::{self, Mime};
@@ -32,7 +31,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
-use crate::dom::csp::report_csp_violations;
+use crate::dom::csp::{Violation, report_csp_violations};
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::eventtarget::EventTarget;
@@ -297,7 +296,7 @@ impl FetchResponseListener for StylesheetContext {
         network_listener::submit_timing(self, CanGc::note())
     }
 
-    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<csp::Violation>) {
+    fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         report_csp_violations(global, violations, None);
     }

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -26,6 +26,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, DomObject};
 use crate::dom::bindings::root::Dom;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::csp::is_js_evaluation_allowed;
 use crate::dom::document::{ImageAnimationUpdateCallback, RefreshRedirectDue};
 use crate::dom::eventsource::EventSourceTimeoutCallback;
 use crate::dom::globalscope::GlobalScope;
@@ -426,7 +427,7 @@ impl JsTimers {
     ) -> i32 {
         let callback = match callback {
             TimerCallback::StringTimerCallback(code_str) => {
-                if global.is_js_evaluation_allowed(code_str.as_ref()) {
+                if is_js_evaluation_allowed(global, code_str.as_ref()) {
                     InternalTimerCallback::StringTimerCallback(code_str)
                 } else {
                     return 0;

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -26,7 +26,7 @@ use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, DomObject};
 use crate::dom::bindings::root::Dom;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::csp::is_js_evaluation_allowed;
+use crate::dom::csp::CspReporting;
 use crate::dom::document::{ImageAnimationUpdateCallback, RefreshRedirectDue};
 use crate::dom::eventsource::EventSourceTimeoutCallback;
 use crate::dom::globalscope::GlobalScope;
@@ -427,7 +427,10 @@ impl JsTimers {
     ) -> i32 {
         let callback = match callback {
             TimerCallback::StringTimerCallback(code_str) => {
-                if is_js_evaluation_allowed(global, code_str.as_ref()) {
+                if global
+                    .get_csp_list()
+                    .is_js_evaluation_allowed(global, code_str.as_ref())
+                {
                     InternalTimerCallback::StringTimerCallback(code_str)
                 } else {
                     return 0;


### PR DESCRIPTION
This refactoring moves various CSP-related methods away from GlobalScope and Document into a dedicated entrypoint. It also reduces the amount of imports of the CSP crate, so that types are consolidated into this one entrypoint. That way, we control how CSP code interacts with the script crate.

For reviewing purposes, I split up the refactoring into separate distinct commits that all move 1 method(group) into the new file.

Testing: no change in behavior, only a build improvement + code cleanup