### PR TITLE
script: Add a Constraint `DOMException` for IndexedDB

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -98,6 +98,7 @@ pub(crate) fn throw_dom_exception(
         Error::Operation => DOMErrorName::OperationError,
         Error::NotAllowed => DOMErrorName::NotAllowedError,
         Error::Encoding => DOMErrorName::EncodingError,
+        Error::Constraint => DOMErrorName::ConstraintError,
         Error::Type(message) => unsafe {
             assert!(!JS_IsExceptionPending(*cx));
             throw_type_error(*cx, &message);

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -57,6 +57,7 @@ pub(crate) enum DOMErrorName {
     NotReadableError,
     OperationError,
     NotAllowedError,
+    ConstraintError,
 }
 
 impl DOMErrorName {
@@ -92,6 +93,7 @@ impl DOMErrorName {
             "NotReadableError" => Some(DOMErrorName::NotReadableError),
             "OperationError" => Some(DOMErrorName::OperationError),
             "NotAllowedError" => Some(DOMErrorName::NotAllowedError),
+            "ConstraintError" => Some(DOMErrorName::ConstraintError),
             _ => None,
         }
     }
@@ -155,6 +157,9 @@ impl DOMException {
             DOMErrorName::NotAllowedError => {
                 r#"The request is not allowed by the user agent or the platform in the current context,
                 possibly because the user denied permission."#
+            },
+            DOMErrorName::ConstraintError => {
+                "A mutation operation in a transaction failed because a constraint was not satisfied."
             },
         };
 

--- a/components/script/dom/idbdatabase.rs
+++ b/components/script/dom/idbdatabase.rs
@@ -213,8 +213,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
             .iter()
             .any(|store_name| store_name.to_string() == name.to_string())
         {
-            // TODO: Add constraint as an dom exception and throw that instead
-            return Err(Error::InvalidState);
+            return Err(Error::Constraint);
         }
 
         // Step 7

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -70,6 +70,8 @@ pub enum Error {
     NotAllowed,
     /// EncodingError DOMException
     Encoding,
+    /// ConstraintError DOMException
+    Constraint,
 
     /// TypeError JavaScript Error
     Type(String),


### PR DESCRIPTION
Add Constraint DOMException to handle the name conflict error in `IDBDatabase::createObjectStore` method.

Testing: `./mach test-wpt tests/wpt/tests/IndexedDB/`, but it seems there are many test failures even in main branch already ([related comment](https://github.com/servo/servo/pull/37605#issuecomment-2993889163)). 
Fixes: #37571 
