### PR TITLE
Webdriver: Call webdriver handler on headless EventLoop

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -316,7 +316,7 @@ impl App {
         }
     }
 
-    fn handle_webdriver_messages(&mut self) {
+    pub fn handle_webdriver_messages(&self) {
         let AppState::Running(running_state) = &self.state else {
             return;
         };

--- a/ports/servoshell/desktop/events_loop.rs
+++ b/ports/servoshell/desktop/events_loop.rs
@@ -93,6 +93,7 @@ impl EventsLoop {
                 app.init(None);
                 loop {
                     self.sleep(flag, condvar);
+                    app.handle_webdriver_messages();
                     if !app.handle_events_with_headless() {
                         break;
                     }


### PR DESCRIPTION
Previously, `handle_webdriver_messages` only called in `winit::ApplictionHandler`. This means the webdriver command only looped in headed (desktop) event loop.

Testing: this will fix webdriver test on headless `test-wpt`, which widely used in the CI.