### PR TITLE
[WebDriver: Release Action] Fix panic by work around buggy spec

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1758,12 +1758,17 @@ impl Handler {
         // only one command can run at a time, so this will never block."
 
         // Step 6. Let undo actions be input cancel list in reverse order.
-        let mut input_cancel_list = session.input_cancel_list.borrow_mut();
-        let undo_actions: ActionsByTick = input_cancel_list
-            .drain(..)
-            .rev()
-            .map(|(id, action_item)| HashMap::from([(id, action_item)]))
-            .collect();
+
+        let undo_actions: ActionsByTick = {
+            // Drop the mut borrow ASAP to avoid "already borrowed: BorrowMutError",
+            // as `dispatch_actions` later may also MutBorrow `input_cancel_list`
+            let mut input_cancel_list = session.input_cancel_list.borrow_mut();
+            input_cancel_list
+                .drain(..)
+                .rev()
+                .map(|(id, action_item)| HashMap::from([(id, action_item)]))
+                .collect()
+        };
         // Step 7. Dispatch undo actions with current browsing context.
         if let Err(err) = self.dispatch_actions(undo_actions, session.browsing_context_id) {
             return Err(WebDriverError::new(err, "Failed to dispatch undo actions"));

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/send_keys.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/send_keys.py.ini
@@ -1,9 +1,3 @@
 [send_keys.py]
   [test_no_browsing_context]
     expected: FAIL
-
-  [test_no_such_element_with_shadow_root]
-    expected: FAIL
-
-  [test_surrogates]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/find_element_from_element/find.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/find_element_from_element/find.py.ini
@@ -2,9 +2,6 @@
   [test_no_browsing_context]
     expected: FAIL
 
-  [test_no_such_element_with_shadow_root]
-    expected: FAIL
-
   [test_no_such_element_with_startnode_from_other_frame]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/find_elements_from_element/find.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/find_elements_from_element/find.py.ini
@@ -2,9 +2,6 @@
   [test_no_browsing_context]
     expected: FAIL
 
-  [test_no_such_element_with_shadow_root]
-    expected: FAIL
-
   [test_no_such_element_with_startnode_from_other_frame]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/key.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/key.py.ini
@@ -5,13 +5,7 @@
   [test_key_down_closes_browsing_context]
     expected: FAIL
 
-  [test_element_in_shadow_tree[outer-open\]]
-    expected: FAIL
-
   [test_element_in_shadow_tree[outer-closed\]]
-    expected: FAIL
-
-  [test_element_in_shadow_tree[inner-open\]]
     expected: FAIL
 
   [test_element_in_shadow_tree[inner-closed\]]

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_contextmenu.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_contextmenu.py.ini
@@ -4,6 +4,3 @@
 
   [test_control_click[\\ue051-ctrlKey\]]
     expected: FAIL
-
-  [test_release_control_click]
-    expected: FAIL


### PR DESCRIPTION
1. Narrow the lifetime of `input_cancel_list` to avoid Runtime multiple BorrowMut error.
2. Work around the buggy spec by removing matching item in `input_cancel_list` when dispatch `keyUp` and `mouseUp`. See https://github.com/servo/servo/issues/37579#issuecomment-2990762713

Testing: All WebDriver WPT test.
Fixes: #37579
