### PR TITLE
ci: copy `resources` to C:\ drive on GH hosted runners

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -167,6 +167,10 @@ jobs:
         run: |
           .\mach build --use-crown --locked --${{ inputs.profile }} ${{ inputs.build-args }}
           cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows -Recurse
+      - name: Copy resources
+        # GitHub-hosted runners sometimes check out the repo on D: drive.
+        if: ${{ runner.environment != 'self-hosted' && startsWith(github.workspace, 'D:\') }}
+        run: cp D:\a\servo\servo\resources C:\a\servo\servo -Recurse
       - name: Smoketest
         run: .\mach smoketest --${{ inputs.profile }}
       - name: Unit tests


### PR DESCRIPTION
This logic was removed in #37311. However, based on the recent failures
identified in #37626, it seems like GH hosted runners sometimes do use
the `D:` drive for checkouts. It is unclear if this is always the case
or not, so this patch adds the logic back but with a conditional check
on the workspace path.

Testing: This patch has been tested on a fork.
Fixes: #37626