### PR TITLE
resource_thread: Optimize writing JSON

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -526,7 +526,7 @@ where
     };
 
     serde_json::to_writer_pretty(&mut file, data).expect("Could not serialize to file");
-    trace!("successfully wrote to {}", display);
+    trace!("successfully wrote to {display}");
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -517,10 +517,6 @@ pub fn write_json_to_file<T>(data: &T, config_dir: &Path, filename: &str)
 where
     T: Serialize,
 {
-    let json_encoded: String = match serde_json::to_string_pretty(&data) {
-        Ok(d) => d,
-        Err(_) => return,
-    };
     let path = config_dir.join(filename);
     let display = path.display();
 
@@ -529,10 +525,8 @@ where
         Ok(file) => file,
     };
 
-    match file.write_all(json_encoded.as_bytes()) {
-        Err(why) => panic!("couldn't write to {}: {}", display, why),
-        Ok(_) => trace!("successfully wrote to {}", display),
-    }
+    serde_json::to_writer_pretty(&mut file, data).expect("Could not serialize to file");
+    trace!("successfully wrote to {}", display);
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Instead of serializing everything at once in memory it is more efficient to use `to_writer_pretty`.
The memory allocations from writing the HSTS file to disk showed up very visibly in DHAT and
should be fixed by streaming the writing.  This change should reduce allocations.

Testing: This change should not modify behavior, and thus is covered by existing tests.
