### PR TITLE
canvas: Do not draw arc/ellipse with small sweep

### DIFF
--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -209,7 +209,6 @@ pub(crate) trait GenericPathBuilder<B: Backend> {
         self.line_to(arc.from());
 
         if sweep.radians.abs() < 1e-3 {
-            self.move_to(arc.from());
             return;
         }
 

--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -208,6 +208,11 @@ pub(crate) trait GenericPathBuilder<B: Backend> {
 
         self.line_to(arc.from());
 
+        if sweep.radians.abs() < 1e-3 {
+            self.move_to(arc.from());
+            return;
+        }
+
         arc.for_each_quadratic_bezier(&mut |q| {
             self.quadratic_curve_to(&q.ctrl, &q.to);
         });


### PR DESCRIPTION
While raqote does already passes this test, but small line is still visible and this PR will fix this. Vello will not work correctly without this.

![slika](https://github.com/user-attachments/assets/195cd2c8-bea4-46d8-bf34-9c2d0b2e996e)


Testing: `/html/canvas/element/path-objects/2d.path.arc.twopie.1.html`
