### PR TITLE
Allow console commands to appear in log files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1647,6 +1647,7 @@ dependencies = [
  "embedder_traits",
  "http 1.3.1",
  "ipc-channel",
+ "log",
  "malloc_size_of_derive",
  "net_traits",
  "serde",

--- a/components/shared/devtools/Cargo.toml
+++ b/components/shared/devtools/Cargo.toml
@@ -14,6 +14,7 @@ path = "lib.rs"
 [dependencies]
 base = { workspace = true }
 bitflags = { workspace = true }
+log = { workspace = true }
 http = { workspace = true }
 ipc-channel = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -308,6 +308,21 @@ pub enum LogLevel {
     Trace,
 }
 
+impl From<LogLevel> for log::Level {
+    fn from(value: LogLevel) -> Self {
+        match value {
+            LogLevel::Log => log::Level::Info,
+            LogLevel::Clear => log::Level::Info,
+
+            LogLevel::Debug => log::Level::Debug,
+            LogLevel::Info => log::Level::Info,
+            LogLevel::Warn => log::Level::Warn,
+            LogLevel::Error => log::Level::Error,
+            LogLevel::Trace => log::Level::Trace,
+        }
+    }
+}
+
 /// A console message as it is sent from script to the constellation
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
This enables console.* commands in javascript to be forwarded to the logger and not just stdout.
The domain for this will be `script::dom::console` which seems appropate.

Testing: Logs do not have any tests.
