### PR TITLE
[WebDriver] Grant `top_level_script_command` and `browsing_context_script_command` freedom to not verify existence of pipeline

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3137,7 +3137,10 @@ where
             .send(EmbedderMsg::WebViewClosed(webview_id));
 
         let Some(browsing_context) = browsing_context else {
-            return;
+            return warn!(
+                "fn handle_close_top_level_browsing_context {}: Closing twice",
+                browsing_context_id
+            );
         };
         // https://html.spec.whatwg.org/multipage/#bcg-remove
         let bc_group_id = browsing_context.bc_group_id;
@@ -5523,7 +5526,7 @@ where
         let browsing_context = match self.browsing_contexts.remove(&browsing_context_id) {
             Some(ctx) => ctx,
             None => {
-                warn!("{browsing_context_id}: Closing twice");
+                warn!("fn close_browsing_context: {browsing_context_id}: Closing twice");
                 return None;
             },
         };
@@ -5679,7 +5682,7 @@ where
         // the pipeline.
         let pipeline = match self.pipelines.get(&pipeline_id) {
             Some(pipeline) => pipeline,
-            None => return warn!("{}: Closing twice", pipeline_id),
+            None => return warn!("fn close_pipeline: {pipeline_id}: Closing twice"),
         };
 
         // Remove this pipeline from pending changes if it hasn't loaded yet.

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -764,10 +764,9 @@ impl Handler {
         web_element: &WebElement,
     ) -> Result<(i64, i64), ErrorStatus> {
         let (sender, receiver) = ipc::channel().unwrap();
-        self.browsing_context_script_command(WebDriverScriptCommand::GetElementInViewCenterPoint(
-            web_element.to_string(),
-            sender,
-        ))
+        self.browsing_context_script_command::<false>(
+            WebDriverScriptCommand::GetElementInViewCenterPoint(web_element.to_string(), sender),
+        )
         .unwrap();
         let response = match wait_for_script_response(receiver) {
             Ok(response) => response,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -703,7 +703,7 @@ impl Handler {
         Ok(WebDriverResponse::DeleteSession)
     }
 
-    // https://w3c.github.io/webdriver/#status
+    /// <https://w3c.github.io/webdriver/#status>
     fn handle_status(&self) -> WebDriverResult<WebDriverResponse> {
         Ok(WebDriverResponse::Generic(ValueResponse(
             if self.session.is_none() {
@@ -714,6 +714,8 @@ impl Handler {
         )))
     }
 
+    /// Send command to Script Thread with session's current browsing context.
+    /// If CHECK_OPEN is true, it would verify the existence of browsing context before sending.  
     fn browsing_context_script_command<const CHECK_OPEN: bool>(
         &self,
         cmd_msg: WebDriverScriptCommand,
@@ -729,6 +731,9 @@ impl Handler {
         Ok(())
     }
 
+    /// Send command to Script Thread with session's current top-level browsing context.
+    /// If CHECK_OPEN is true, it would verify the existence of top-level
+    /// browsing context before sending.
     fn top_level_script_command<const CHECK_OPEN: bool>(
         &self,
         cmd_msg: WebDriverScriptCommand,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -714,12 +714,14 @@ impl Handler {
         )))
     }
 
-    fn browsing_context_script_command(
+    fn browsing_context_script_command<const CHECK_OPEN: bool>(
         &self,
         cmd_msg: WebDriverScriptCommand,
     ) -> WebDriverResult<()> {
         let browsing_context_id = self.session()?.browsing_context_id;
-        self.verify_browsing_context_is_open(browsing_context_id)?;
+        if CHECK_OPEN {
+            self.verify_browsing_context_is_open(browsing_context_id)?;
+        }
         let msg = EmbedderToConstellationMessage::WebDriverCommand(
             WebDriverCommandMsg::ScriptCommand(browsing_context_id, cmd_msg),
         );
@@ -727,9 +729,14 @@ impl Handler {
         Ok(())
     }
 
-    fn top_level_script_command(&self, cmd_msg: WebDriverScriptCommand) -> WebDriverResult<()> {
+    fn top_level_script_command<const CHECK_OPEN: bool>(
+        &self,
+        cmd_msg: WebDriverScriptCommand,
+    ) -> WebDriverResult<()> {
         let webview_id = self.session()?.webview_id;
-        self.verify_top_level_browsing_context_is_open(webview_id)?;
+        if CHECK_OPEN {
+            self.verify_top_level_browsing_context_is_open(webview_id)?;
+        }
         let browsing_context_id = BrowsingContextId::from(webview_id);
         let msg = EmbedderToConstellationMessage::WebDriverCommand(
             WebDriverCommandMsg::ScriptCommand(browsing_context_id, cmd_msg),
@@ -780,7 +787,7 @@ impl Handler {
 
     fn handle_current_url(&self) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
-        self.top_level_script_command(WebDriverScriptCommand::GetUrl(sender))?;
+        self.top_level_script_command::<true>(WebDriverScriptCommand::GetUrl(sender))?;
 
         let url = wait_for_script_response(receiver)?;
 
@@ -861,13 +868,9 @@ impl Handler {
     }
 
     fn handle_is_enabled(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
-        // Step 1. If session's current browsing context is no longer open,
-        // return error with error code no such window.
-        self.verify_browsing_context_is_open(self.session()?.browsing_context_id)?;
-
         let (sender, receiver) = ipc::channel().unwrap();
 
-        self.top_level_script_command(WebDriverScriptCommand::IsEnabled(
+        self.browsing_context_script_command::<true>(WebDriverScriptCommand::IsEnabled(
             element.to_string(),
             sender,
         ))?;
@@ -881,13 +884,9 @@ impl Handler {
     }
 
     fn handle_is_selected(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
-        // Step 1. If session's current browsing context is no longer open,
-        // return error with error code no such window.
-        self.verify_browsing_context_is_open(self.session()?.browsing_context_id)?;
-
         let (sender, receiver) = ipc::channel().unwrap();
 
-        self.top_level_script_command(WebDriverScriptCommand::IsSelected(
+        self.browsing_context_script_command::<true>(WebDriverScriptCommand::IsSelected(
             element.to_string(),
             sender,
         ))?;
@@ -939,7 +938,7 @@ impl Handler {
     fn handle_title(&self) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
 
-        self.top_level_script_command(WebDriverScriptCommand::GetTitle(sender))?;
+        self.top_level_script_command::<true>(WebDriverScriptCommand::GetTitle(sender))?;
 
         let value = wait_for_script_response(receiver)?;
         Ok(WebDriverResponse::Generic(ValueResponse(
@@ -991,7 +990,7 @@ impl Handler {
                     parameters.value.clone(),
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
                 let cmd = WebDriverScriptCommand::FindElementLinkText(
@@ -999,12 +998,12 @@ impl Handler {
                     parameters.using == LocatorStrategy::PartialLinkText,
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             LocatorStrategy::TagName => {
                 let cmd =
                     WebDriverScriptCommand::FindElementTagName(parameters.value.clone(), sender);
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             _ => {
                 return Err(WebDriverError::new(
@@ -1165,7 +1164,7 @@ impl Handler {
 
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetBrowsingContextId(frame_id, sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
 
         match wait_for_script_response(receiver)? {
             Ok(browsing_context_id) => {
@@ -1192,7 +1191,7 @@ impl Handler {
                     parameters.value.clone(),
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
                 let cmd = WebDriverScriptCommand::FindElementsLinkText(
@@ -1200,12 +1199,12 @@ impl Handler {
                     parameters.using == LocatorStrategy::PartialLinkText,
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             LocatorStrategy::TagName => {
                 let cmd =
                     WebDriverScriptCommand::FindElementsTagName(parameters.value.clone(), sender);
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             _ => {
                 return Err(WebDriverError::new(
@@ -1245,7 +1244,7 @@ impl Handler {
                     element.to_string(),
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
                 let cmd = WebDriverScriptCommand::FindElementElementLinkText(
@@ -1254,7 +1253,7 @@ impl Handler {
                     parameters.using == LocatorStrategy::PartialLinkText,
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             LocatorStrategy::TagName => {
                 let cmd = WebDriverScriptCommand::FindElementElementTagName(
@@ -1262,7 +1261,7 @@ impl Handler {
                     element.to_string(),
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             _ => {
                 return Err(WebDriverError::new(
@@ -1304,7 +1303,7 @@ impl Handler {
                     element.to_string(),
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
                 let cmd = WebDriverScriptCommand::FindElementElementsLinkText(
@@ -1313,7 +1312,7 @@ impl Handler {
                     parameters.using == LocatorStrategy::PartialLinkText,
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             LocatorStrategy::TagName => {
                 let cmd = WebDriverScriptCommand::FindElementElementsTagName(
@@ -1321,7 +1320,7 @@ impl Handler {
                     element.to_string(),
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             _ => {
                 return Err(WebDriverError::new(
@@ -1364,7 +1363,7 @@ impl Handler {
                     shadow_root.to_string(),
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
                 let cmd = WebDriverScriptCommand::FindShadowElementsLinkText(
@@ -1373,7 +1372,7 @@ impl Handler {
                     parameters.using == LocatorStrategy::PartialLinkText,
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             LocatorStrategy::TagName => {
                 let cmd = WebDriverScriptCommand::FindShadowElementsTagName(
@@ -1381,7 +1380,7 @@ impl Handler {
                     shadow_root.to_string(),
                     sender,
                 );
-                self.browsing_context_script_command(cmd)?;
+                self.browsing_context_script_command::<true>(cmd)?;
             },
             _ => {
                 return Err(WebDriverError::new(
@@ -1432,7 +1431,7 @@ impl Handler {
     fn handle_get_shadow_root(&self, element: WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetElementShadowRoot(element.to_string(), sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => {
                 let Some(value) = value else {
@@ -1450,7 +1449,7 @@ impl Handler {
     fn handle_element_rect(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetElementRect(element.to_string(), sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         match wait_for_script_response(receiver)? {
             Ok(rect) => {
                 let response = ElementRectResponse {
@@ -1469,7 +1468,7 @@ impl Handler {
     fn handle_element_text(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetElementText(element.to_string(), sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse(
                 serde_json::to_value(value)?,
@@ -1482,7 +1481,7 @@ impl Handler {
     fn handle_active_element(&self) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetActiveElement(sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         let value = wait_for_script_response(receiver)?
             .map(|x| serde_json::to_value(WebElement(x)).unwrap());
         // Step 4. If active element is a non-null element, return success
@@ -1503,7 +1502,7 @@ impl Handler {
     fn handle_computed_role(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetComputedRole(element.to_string(), sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse(
                 serde_json::to_value(value)?,
@@ -1515,7 +1514,7 @@ impl Handler {
     fn handle_element_tag_name(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetElementTagName(element.to_string(), sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse(
                 serde_json::to_value(value)?,
@@ -1535,7 +1534,7 @@ impl Handler {
             name.to_owned(),
             sender,
         );
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse(
                 serde_json::to_value(value)?,
@@ -1556,7 +1555,7 @@ impl Handler {
             name.to_owned(),
             sender,
         );
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
 
         match wait_for_script_response(receiver)? {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse(
@@ -1574,7 +1573,7 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd =
             WebDriverScriptCommand::GetElementCSS(element.to_string(), name.to_owned(), sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse(
                 serde_json::to_value(value)?,
@@ -1586,7 +1585,7 @@ impl Handler {
     fn handle_get_cookies(&self) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetCookies(sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         let cookies = match wait_for_script_response(receiver)? {
             Ok(cookies) => cookies,
             Err(error) => return Err(WebDriverError::new(error, "")),
@@ -1601,7 +1600,7 @@ impl Handler {
     fn handle_get_cookie(&self, name: String) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetCookie(name, sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         let cookies = match wait_for_script_response(receiver)? {
             Ok(cookies) => cookies,
             Err(error) => return Err(WebDriverError::new(error, "")),
@@ -1635,7 +1634,7 @@ impl Handler {
         };
 
         let cmd = WebDriverScriptCommand::AddCookie(cookie_builder.build(), sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         match wait_for_script_response(receiver)? {
             Ok(_) => Ok(WebDriverResponse::Void),
             Err(error) => Err(WebDriverError::new(error, "")),
@@ -1645,7 +1644,7 @@ impl Handler {
     fn handle_delete_cookie(&self, name: String) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::DeleteCookie(name, sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         match wait_for_script_response(receiver)? {
             Ok(_) => Ok(WebDriverResponse::Void),
             Err(error) => Err(WebDriverError::new(error, "")),
@@ -1655,7 +1654,7 @@ impl Handler {
     fn handle_delete_cookies(&self) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::DeleteCookies(sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
         match wait_for_script_response(receiver)? {
             Ok(_) => Ok(WebDriverResponse::Void),
             Err(error) => Err(WebDriverError::new(error, "")),
@@ -1712,7 +1711,7 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
 
         let cmd = WebDriverScriptCommand::GetPageSource(sender);
-        self.browsing_context_script_command(cmd)?;
+        self.browsing_context_script_command::<true>(cmd)?;
 
         match wait_for_script_response(receiver)? {
             Ok(source) => Ok(WebDriverResponse::Generic(ValueResponse(
@@ -1802,7 +1801,7 @@ impl Handler {
 
         let (sender, receiver) = ipc::channel().unwrap();
         let command = WebDriverScriptCommand::ExecuteScript(script, sender);
-        self.browsing_context_script_command(command)?;
+        self.browsing_context_script_command::<true>(command)?;
         let result = wait_for_script_response(receiver)?;
         self.postprocess_js_result(result)
     }
@@ -1846,7 +1845,7 @@ impl Handler {
 
         let (sender, receiver) = ipc::channel().unwrap();
         let command = WebDriverScriptCommand::ExecuteAsyncScript(script, sender);
-        self.browsing_context_script_command(command)?;
+        self.browsing_context_script_command::<true>(command)?;
         let result = wait_for_script_response(receiver)?;
         self.postprocess_js_result(result)
     }
@@ -1933,7 +1932,7 @@ impl Handler {
 
         // Steps 1 - 7
         let command = WebDriverScriptCommand::ElementClick(element.to_string(), sender);
-        self.browsing_context_script_command(command)?;
+        self.browsing_context_script_command::<true>(command)?;
 
         match wait_for_script_response(receiver)? {
             Ok(element_id) => match element_id {
@@ -2086,7 +2085,7 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
 
         let command = WebDriverScriptCommand::GetBoundingClientRect(element.to_string(), sender);
-        self.browsing_context_script_command(command)?;
+        self.browsing_context_script_command::<true>(command)?;
 
         match wait_for_script_response(receiver)? {
             Ok(rect) => {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -715,7 +715,7 @@ impl Handler {
     }
 
     /// Send command to Script Thread with session's current browsing context.
-    /// If CHECK_OPEN is true, it would verify the existence of browsing context before sending.  
+    /// If CHECK_OPEN is true, it would verify the existence of browsing context before sending.
     fn browsing_context_script_command<const CHECK_OPEN: bool>(
         &self,
         cmd_msg: WebDriverScriptCommand,

--- a/tests/wpt/meta/webdriver/tests/classic/is_element_enabled/enabled.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/is_element_enabled/enabled.py.ini
@@ -2,9 +2,6 @@
   [test_no_browsing_context]
     expected: FAIL
 
-  [test_stale_element_reference[child_context\]]
-    expected: FAIL
-
   [test_option_with_select[disabled\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/is_element_selected/selected.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/is_element_selected/selected.py.ini
@@ -1,6 +1,3 @@
 [selected.py]
   [test_no_browsing_context]
     expected: FAIL
-
-  [test_stale_element_reference[child_context\]]
-    expected: FAIL


### PR DESCRIPTION
Sometimes, it is redundant to verify existence of pipeline over and over again.
Sometimes, it is just wrong to check it. See [Switch to Parent Frame](https://w3c.github.io/webdriver/#switch-to-parent-frame), where we only care about existence of parent frame.
1. This PR adds a constant compile-time bool flag to enable this. This will be essential to fix "no_browsing_context" next.
2. Fix some wrong usage of `top_level_script_command` in `is_selected` and `is_enabled`.
3. Add and unify some WARN info related to pipeline in Constellation

Testing: All WebDriver test with new passing cases