### PR TITLE
OHOS: Allow some log domains to be written to a file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2064,7 +2064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2649,7 +2649,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4138,7 +4138,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4434,7 +4434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6484,7 +6484,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7241,6 +7241,7 @@ dependencies = [
  "serde_json",
  "servo_allocator",
  "sig",
+ "simplelog",
  "surfman",
  "tokio",
  "tracing",
@@ -7330,6 +7331,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "simplelog"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
+dependencies = [
+ "log",
+ "time",
 ]
 
 [[package]]
@@ -7840,7 +7851,7 @@ dependencies = [
  "getrandom 0.2.16",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9272,7 +9283,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -88,6 +88,7 @@ backtrace = { workspace = true }
 env_filter = "0.1.3"
 euclid = { workspace = true }
 hilog = "0.2.0"
+simplelog = { version = "0.12.2", default-features = false }
 # force inprocess until we add multi-process support for ohos
 ipc-channel = { workspace = true, features = ["force-inprocess"] }
 napi-derive-ohos = "1.0.4"

--- a/ports/servoshell/egl/ohos/multilogger.rs
+++ b/ports/servoshell/egl/ohos/multilogger.rs
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//  Code from [https://github.com/davechallis/multi_log] originally under MIT.
+
+/// Logger that writes log messages to all the loggers it encapsulates.
+pub struct MultiLogger {
+    loggers: Vec<Box<dyn log::Log>>,
+}
+
+impl MultiLogger {
+    /// Creates a MultiLogger from any number of other loggers.
+    ///
+    /// Once initialised, this will need setting as the
+    /// [`log`](https://docs.rs/log/0.4.1/log/) crate's global logger using
+    /// [`log::set_boxed_logger`](https://docs.rs/log/0.4.1/log/fn.set_boxed_logger.html).
+    pub(crate) fn new(loggers: Vec<Box<dyn log::Log>>) -> Self {
+        MultiLogger { loggers }
+    }
+
+    /// Initialises the [`log`](https://docs.rs/log/0.4.1/log/) crate's global logging facility
+    /// with a MultiLogger built from any number of given loggers.
+    ///
+    /// The log level threshold of individual loggers can't always be determined, so a `level`
+    /// parameter is provided as an optimisation to avoid sending unnecessary messages to
+    /// loggers that will discard them.
+    ///
+    /// # Arguments
+    /// * `loggers` - one more more boxed loggers
+    /// * `level` - minimum log level to send to all loggers
+    pub(crate) fn init(
+        loggers: Vec<Box<dyn log::Log>>,
+        level: log::Level,
+    ) -> Result<(), log::SetLoggerError> {
+        log::set_max_level(level.to_level_filter());
+        log::set_boxed_logger(Box::new(MultiLogger::new(loggers)))
+    }
+}
+
+impl log::Log for MultiLogger {
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        self.loggers.iter().any(|logger| logger.enabled(metadata))
+    }
+
+    fn log(&self, record: &log::Record) {
+        self.loggers.iter().for_each(|logger| logger.log(record));
+    }
+
+    fn flush(&self) {
+        self.loggers.iter().for_each(|logger| logger.flush());
+    }
+}

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -122,6 +122,8 @@ pub fn init(
             );
         });
 
+    crate::egl::ohos::initialize_logging_once();
+
     // Ensure cache dir exists before copy `prefs.json`
     let _ = crate::prefs::default_config_dir().inspect(|path| {
         if !path.exists() {


### PR DESCRIPTION
This allows some log domains to be written to a file in addition to output to hilog.
This also includes the new log domain of console.log in javascript.

This changes the initialization order of the logging slightly and puts it after the resource directory is available.

Testing: Tested on device.
