### PR TITLE
webgl: Ignore pixel storage parameters for ImageBitmap source

### DIFF
--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -3257,6 +3257,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
         let size = Size2D::new(width, height);
 
+        let (alpha_treatment, y_axis_treatment) = self.base.get_current_unpack_state(false);
+
         self.base.tex_image_2d(
             &texture,
             target,
@@ -3267,7 +3269,12 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             border,
             unpacking_alignment,
             size,
-            TexSource::Pixels(TexPixels::from_array(buff, size)),
+            TexSource::Pixels(TexPixels::from_array(
+                buff,
+                size,
+                alpha_treatment,
+                y_axis_treatment,
+            )),
         );
 
         Ok(())


### PR DESCRIPTION
Follow the WebGL specification and ignore the values of UNPACK_FLIP_Y,
UNPACK_PREMULTIPLY_ALPHA, and UNPACK_COLORSPACE_CONVERSION
if the TexImageSource is an ImageBitmap.
https://registry.khronos.org/webgl/specs/latest/1.0/#6.10

Testing: There are no dedicated test results changes without the PR #37634
which unblocks new testing scenarios with premultiplied ImageBitmap from Blob/Canvas/Image sources.