### PR TITLE
Fix indexeddb threadpool

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -223,6 +223,8 @@ pub struct Preferences {
     pub threadpools_fallback_worker_num: i64,
     /// Maximum number of workers for the Image Cache thread pool
     pub threadpools_image_cache_workers_max: i64,
+    /// Maximum number of workers for the IndexedDB thread pool
+    pub threadpools_indexeddb_workers_max: i64,
     /// Maximum number of workers for the Networking async runtime thread pool
     pub threadpools_async_runtime_workers_max: i64,
     /// Maximum number of workers for the Core Resource Manager
@@ -391,6 +393,7 @@ impl Preferences {
             threadpools_async_runtime_workers_max: 6,
             threadpools_fallback_worker_num: 3,
             threadpools_image_cache_workers_max: 4,
+            threadpools_indexeddb_workers_max: 4,
             threadpools_resource_workers_max: 4,
             threadpools_webrender_workers_max: 4,
             webgl_testing_context_creation_error: false,

--- a/components/net/indexeddb/idb_thread.rs
+++ b/components/net/indexeddb/idb_thread.rs
@@ -165,14 +165,14 @@ impl IndexedDBManager {
         let thread_count = thread::available_parallelism()
             .map(|i| i.get())
             .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
-            .min(pref!(threadpools_async_runtime_workers_max).max(1) as usize);
+            .min(pref!(threadpools_indexeddb_workers_max).max(1) as usize);
         IndexedDBManager {
             port,
             idb_base_dir,
             databases: HashMap::new(),
             thread_pool: Arc::new(CoreResourceThreadPool::new(
                 thread_count,
-                "ImageCache".to_string(),
+                "IndexedDB".to_string(),
             )),
         }
     }


### PR DESCRIPTION
Resolves #37638. Fixes threadpool name and adds a config preference (`threadpools_indexeddb_workers_max`).