### PR TITLE
Fix image_cache threadpool configuration

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -549,7 +549,7 @@ impl ImageCache for ImageCacheImpl {
         let thread_count = thread::available_parallelism()
             .map(|i| i.get())
             .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
-            .min(pref!(threadpools_async_runtime_workers_max).max(1) as usize);
+            .min(pref!(threadpools_image_cache_workers_max).max(1) as usize);
 
         ImageCacheImpl {
             store: Arc::new(Mutex::new(ImageCacheStore {


### PR DESCRIPTION
Similar to #37638. It was using `threadpools_async_runtime_workers_max`, and `threadpools_image_cache_workers_max` was unused, this PR fixes that.