### PR TITLE
[IndexedDB] Reduce heed related panics

### DIFF
--- a/components/net/indexeddb/engines/mod.rs
+++ b/components/net/indexeddb/engines/mod.rs
@@ -57,12 +57,18 @@ pub struct KvsTransaction {
 }
 
 pub trait KvsEngine {
-    fn create_store(&self, store_name: SanitizedName, auto_increment: bool);
+    type Error;
 
-    fn delete_store(&self, store_name: SanitizedName);
+    fn create_store(
+        &self,
+        store_name: SanitizedName,
+        auto_increment: bool,
+    ) -> Result<(), Self::Error>;
+
+    fn delete_store(&self, store_name: SanitizedName) -> Result<(), Self::Error>;
 
     #[expect(dead_code)]
-    fn close_store(&self, store_name: SanitizedName);
+    fn close_store(&self, store_name: SanitizedName) -> Result<(), Self::Error>;
 
     fn process_transaction(
         &self,

--- a/components/net/indexeddb/idb_thread.rs
+++ b/components/net/indexeddb/idb_thread.rs
@@ -135,9 +135,13 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
         store_name: SanitizedName,
         auto_increment: bool,
     ) {
-        self.engine.create_store(store_name, auto_increment);
+        let result = self.engine.create_store(store_name, auto_increment);
 
-        let _ = sender.send(Ok(()));
+        if result.is_ok() {
+            let _ = sender.send(Ok(()));
+        } else {
+            let _ = sender.send(Err(()));
+        }
     }
 
     fn delete_object_store(
@@ -145,9 +149,13 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
         sender: IpcSender<Result<(), ()>>,
         store_name: SanitizedName,
     ) {
-        self.engine.delete_store(store_name);
+        let result = self.engine.delete_store(store_name);
 
-        let _ = sender.send(Ok(()));
+        if result.is_ok() {
+            let _ = sender.send(Ok(()));
+        } else {
+            let _ = sender.send(Err(()));
+        }
     }
 }
 

--- a/tests/wpt/meta/IndexedDB/list_ordering.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/list_ordering.any.js.ini
@@ -1,8 +1,24 @@
 [list_ordering.any.worker.html]
-  expected: CRASH
+  [Validate ObjectStoreNames and indexNames list order - numbers]
+    expected: FAIL
+
+  [Validate ObjectStoreNames and indexNames list order - numbers 'overflow']
+    expected: FAIL
+
+  [Validate ObjectStoreNames and indexNames list order - lexigraphical string sort]
+    expected: FAIL
+
 
 [list_ordering.any.html]
-  expected: CRASH
+  [Validate ObjectStoreNames and indexNames list order - numbers]
+    expected: FAIL
+
+  [Validate ObjectStoreNames and indexNames list order - numbers 'overflow']
+    expected: FAIL
+
+  [Validate ObjectStoreNames and indexNames list order - lexigraphical string sort]
+    expected: FAIL
+
 
 [list_ordering.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/string-list-ordering.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/string-list-ordering.any.js.ini
@@ -2,10 +2,13 @@
   expected: ERROR
 
 [string-list-ordering.any.worker.html]
-  expected: CRASH
+  [Test string list ordering in IndexedDB]
+    expected: FAIL
+
 
 [string-list-ordering.any.serviceworker.html]
   expected: ERROR
 
 [string-list-ordering.any.html]
-  expected: CRASH
+  [Test string list ordering in IndexedDB]
+    expected: FAIL


### PR DESCRIPTION
Allows indexeddb backends to return errors on certain operations. Currently the errors are not demarcated, as the result type is `Result<(), ()>`. If this is not appropriate then perhaps having a string error might be better.

Testing: Some tests might perhaps move from PANIC to FAIL
Fixes: Partially fixes a bit of #37647, more work needs to be done however