### PR TITLE
canvas: Remove support for stroking rectangles with zero width or height like lines

### DIFF
--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -107,14 +107,6 @@ pub(crate) trait GenericDrawTarget<B: Backend> {
         stroke_options: &B::StrokeOptions,
         draw_options: &B::DrawOptions,
     );
-    fn stroke_line(
-        &mut self,
-        start: Point2D<f32>,
-        end: Point2D<f32>,
-        pattern: &B::Pattern<'_>,
-        stroke_options: &B::StrokeOptions,
-        draw_options: &B::DrawOptions,
-    );
     fn stroke_rect(
         &mut self,
         rect: &Rect<f32>,

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -23,7 +23,6 @@ use servo_arc::Arc as ServoArc;
 use style::color::AbsoluteColor;
 use style::properties::style_structs::Font as FontStyleStruct;
 use unicode_script::Script;
-use webrender_api::units::RectExt as RectExt_;
 use webrender_api::{ImageDescriptor, ImageDescriptorFlags, ImageFormat, ImageKey};
 
 use crate::backend::{
@@ -793,16 +792,6 @@ impl<'a, B: Backend> CanvasData<'a, B> {
                     &self.state.draw_options,
                 );
             });
-        } else if rect.size.width == 0. || rect.size.height == 0. {
-            let mut stroke_opts = self.state.stroke_opts.clone();
-            stroke_opts.set_line_cap(LineCapStyle::Butt);
-            self.drawtarget.stroke_line(
-                rect.origin,
-                rect.bottom_right(),
-                &self.state.stroke_style,
-                &stroke_opts,
-                &self.state.draw_options,
-            );
         } else {
             self.drawtarget.stroke_rect(
                 rect,

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -603,31 +603,6 @@ impl GenericDrawTarget<RaqoteBackend> for raqote::DrawTarget {
     ) {
         self.stroke(path, &source(pattern), stroke_options, draw_options);
     }
-    fn stroke_line(
-        &mut self,
-        start: Point2D<f32>,
-        end: Point2D<f32>,
-        pattern: &<RaqoteBackend as Backend>::Pattern<'_>,
-        stroke_options: &<RaqoteBackend as Backend>::StrokeOptions,
-        draw_options: &<RaqoteBackend as Backend>::DrawOptions,
-    ) {
-        let mut pb = raqote::PathBuilder::new();
-        pb.move_to(start.x, start.y);
-        pb.line_to(end.x, end.y);
-        let mut stroke_options = stroke_options.clone();
-        let cap = match stroke_options.join {
-            raqote::LineJoin::Round => raqote::LineCap::Round,
-            _ => raqote::LineCap::Butt,
-        };
-        stroke_options.cap = cap;
-
-        self.stroke(
-            &pb.finish(),
-            &source(pattern),
-            &stroke_options,
-            draw_options,
-        );
-    }
     fn stroke_rect(
         &mut self,
         rect: &Rect<f32>,


### PR DESCRIPTION
This causes wrong rendering on vello. Current backends already handle one dim zero correctly by themself (this was probably needed for azure), but if we ever needed this, it should be implemented inside faulty backend.

Testing: Existing WPT tests
