### PR TITLE
webdriver: Move navigation commands to servoshell

### DIFF
--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -33,11 +33,15 @@ pub enum WebDriverCommandMsg {
     /// Get the window size.
     GetWindowSize(WebViewId, IpcSender<Size2D<i32, DevicePixel>>),
     /// Get the viewport size.
-    GetViewportSize(WebViewId, IpcSender<Size2D<f32, CSSPixel>>),
+    GetViewportSize(WebViewId, IpcSender<Size2D<u32, DevicePixel>>),
     /// Load a URL in the top-level browsing context with the given ID.
     LoadUrl(WebViewId, ServoUrl, IpcSender<WebDriverLoadStatus>),
     /// Refresh the top-level browsing context with the given ID.
     Refresh(WebViewId, IpcSender<WebDriverLoadStatus>),
+    /// Navigate the webview with the given ID to the previous page in the browsing context's history.
+    GoBack(WebViewId),
+    /// Navigate the webview with the given ID to the next page in the browsing context's history.
+    GoForward(WebViewId),
     /// Pass a webdriver command to the script thread of the current pipeline
     /// of a browsing context.
     ScriptCommand(BrowsingContextId, WebDriverScriptCommand),

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -743,10 +743,9 @@ impl Handler {
     fn check_viewport_bound(&self, x: f64, y: f64) -> Result<(), ErrorStatus> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd_msg =
-            WebDriverCommandMsg::GetWindowSize(self.session.as_ref().unwrap().webview_id, sender);
-        self.constellation_chan
-            .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
-            .unwrap();
+            WebDriverCommandMsg::GetViewportSize(self.session.as_ref().unwrap().webview_id, sender);
+        self.send_message_to_embedder(cmd_msg)
+            .map_err(|_| ErrorStatus::UnknownError)?;
 
         let viewport_size = match wait_for_script_response(receiver) {
             Ok(response) => response,


### PR DESCRIPTION
- Move webdriver `GetViewportSize`, `LoadURL` and `Refresh` to servoshell.
- Add `GoBack` and `GoFoward` commands.

Testing: Need to finish moving webdriver to servoshell then evaluate again
Fixes: https://github.com/servo/servo/issues/37370
