### PR TITLE
OHOS: Run speedometer in CI

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -169,18 +169,11 @@ jobs:
       - name: Build for aarch64 HarmonyOS
         run: |
           ./mach build --locked --target aarch64-unknown-linux-ohos --profile=${{ inputs.profile }} --flavor=harmonyos --no-default-features --features tracing,tracing-hitrace
-      - name: Upload supprt/hitrace-bencher/runs.json
-        uses: actions/upload-artifact@v4
-        with:
-          name: runs.json
-          path: support/hitrace-bencher/runs.json
-          overwrite: true
       - uses: actions/upload-artifact@v4
         with:
           # Upload the **unsigned** artifact - We don't have the signing materials in pull request workflows
           name: servoshell-hos-${{ inputs.profile }}.hap
           path: target/openharmony/aarch64-unknown-linux-ohos/${{ inputs.profile }}/entry/build/harmonyos/outputs/default/servoshell-default-unsigned.hap
-
 
   test-harmonyos-aarch64:
     name: Test HarmonyOS aarch64
@@ -245,19 +238,56 @@ jobs:
           [[ $servo_pid =~ ^[0-9]+$ ]] || { echo "It looks like servo crashed!" ; exit 1; }
           # If the grep fails, then the trace output for the "page loaded" prompt is missing
           grep 'org\.servo\.servo-.* tracing_mark_write.*PageLoadEndedPrompt' test_output/servo.ftrace
-      - name: Getting runs file
-        uses: actions/download-artifact@v4
+
+  # speedometer ohos needs the command-line-tools and the repository for mach installed
+  # we require that this runs after test-harmonyos-aarch64 because then we know the binary is installed on the phone
+  bench-harmonyos-aarch64:
+    name: Benching HarmonyOS aarch64
+    continue-on-error: true
+    runs-on: hos-runner
+    needs: test-harmonyos-aarch64
+    if: github.repository == 'servo/servo'
+    steps:
+      - uses: actions/download-artifact@v4
         with:
           # Name of the artifact to download.
           # If unspecified, all artifacts for the run are downloaded.
-          name: runs.json
+          name: servoshell-hos-${{ inputs.profile }}.hap
+      - name: Test hdc device
+        # First we ensure a device is actually connected and working.
+        run: hdc list targets && hdc shell echo hello world
+      - name: Sign the hap
+        run: |
+          ls -la
+          /usr/bin/sign-hos.sh servoshell-default-unsigned.hap servoshell-hos-signed.hap
+      - name: Install
+        run: |
+          # Uninstall first. hdc is not very reliable in terms of exiting with an error, so we uninstall first
+          # to make sure we don't use a previous version if installation failed for some reason.
+          hdc uninstall org.servo.servo
+          hdc install -r servoshell-hos-signed.hap
+      - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request_target'
+        with:
+          fetch-depth: 2
+      # This is necessary to checkout the pull request if this run was triggered via a
+      # `pull_request_target` event.
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request_target'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+      - name: Setup Python
+        uses: ./.github/actions/setup-python
       - name: "Run benchmark"
-        run: hitrace-bench -r runs.json
-      - name: Getting bencher
-        uses: bencherdev/bencher@main
+        run: hitrace-bench -r support/hitrace-bencher/runs.json
+      - name: Run speedometer
+        run: python3 ./mach test-speedometer-ohos --bmf-output speedometer.json
       - name: Getting model name
         run: |
           echo "MODEL_NAME=$(hdc bugreport | head -n 20 | grep MarketName | awk '{for (i=2; i<NF; i++) printf $i " "; print $NF}' -)" >> $GITHUB_ENV
-      - name: Uploading to bencher.dev
-        run: |
-          bencher run --adapter json --file bench.json --project '${{ env.BENCHER_PROJECT }}' --token '${{ secrets.BENCHER_API_TOKEN }}' --github-actions '${{ secrets.GITHUB_TOKEN }}' --testbed="$MODEL_NAME"
+      - name: Combining bencher files
+        run: jq --compact-output --slurp add speedometer.json bench.json > combined-bencher.json
+      - uses: bencherdev/bencher@main
+      - name: Uploading to bencher
+        run: bencher run --adapter json --file combined-bencher.json --project '${{ env.BENCHER_PROJECT }}' --token '${{ secrets.BENCHER_API_TOKEN }}' --github-actions '${{ secrets.GITHUB_TOKEN }}' --testbed="$MODEL_NAME"

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -239,8 +239,6 @@ jobs:
           # If the grep fails, then the trace output for the "page loaded" prompt is missing
           grep 'org\.servo\.servo-.* tracing_mark_write.*PageLoadEndedPrompt' test_output/servo.ftrace
 
-  # speedometer ohos needs the command-line-tools and the repository for mach installed
-  # we require that this runs after test-harmonyos-aarch64 because then we know the binary is installed on the phone
   bench-harmonyos-aarch64:
     name: Benching HarmonyOS aarch64
     continue-on-error: true

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -703,6 +703,8 @@ class MachCommands(CommandBase):
                 "org.servo.servo",
                 "-U",
                 "https://servospeedometer.netlify.app?headless=1",
+                "--ps=--pref",
+                "js_disable_jit=true",
                 "--ps",
                 "--log-filter",
                 "script::dom::console",


### PR DESCRIPTION
OHOS: Run speedometer in CI for OHOS.
This also adds the forgotten flag to disable jit for HarmonyOs devices.

Need https://github.com/servo/servo/pull/37636 to be merged first and CI updated which will be done when this PR is marked ready.

Testing: Custom run: https://github.com/Narfinger/servo/actions/runs/15927927047/job/44929872906
Bencher output: https://bencher.dev/perf/servo-ci/reports/4f778f61-699e-4e70-8994-bd526733eab1?utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr%2Bcomments&utm_term=servo-ci
No other tests available because CI.
