### PR TITLE
canvas: Reset the current path on canvas context resetting

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -1191,15 +1191,27 @@ impl<'a, B: Backend> CanvasData<'a, B> {
         self.backend.set_global_composition(op, &mut self.state);
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#reset-the-rendering-context-to-its-default-state>
     pub(crate) fn recreate(&mut self, size: Option<Size2D<u64>>) {
         let size = size
             .unwrap_or_else(|| self.drawtarget.get_size().to_u64())
             .max(MIN_WR_IMAGE_SIZE);
+
+        // Step 1. Clear canvas's bitmap to transparent black.
         self.drawtarget = self
             .backend
             .create_drawtarget(Size2D::new(size.width, size.height));
-        self.state = self.backend.new_paint_state();
+
+        // Step 2. Empty the list of subpaths in context's current default path.
+        self.path_state = None;
+
+        // Step 3. Clear the context's drawing state stack.
         self.saved_states.clear();
+
+        // Step 4. Reset everything that drawing state consists of to their
+        // initial values.
+        self.state = self.backend.new_paint_state();
+
         self.update_image_rendering();
     }
 

--- a/tests/wpt/meta/html/canvas/element/canvas-host/2d.canvas.host.initial.reset.path.html.ini
+++ b/tests/wpt/meta/html/canvas/element/canvas-host/2d.canvas.host.initial.reset.path.html.ini
@@ -1,3 +1,0 @@
-[2d.canvas.host.initial.reset.path.html]
-  [Resetting the canvas state resets the current path]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/canvas-host/2d.canvas.host.initial.reset.path.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/canvas-host/2d.canvas.host.initial.reset.path.html.ini
@@ -1,3 +1,0 @@
-[2d.canvas.host.initial.reset.path.html]
-  [Resetting the canvas state resets the current path]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/canvas-host/2d.canvas.host.initial.reset.path.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/canvas-host/2d.canvas.host.initial.reset.path.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.canvas.host.initial.reset.path.worker.html]
-  [Resetting the canvas state resets the current path]
-    expected: FAIL


### PR DESCRIPTION
Follow the HTML canvas specification and empty the list of subpaths
in context's current default path (step 2) on canvas context reseting
(reset() or set bitmap dimestion).
https://html.spec.whatwg.org/multipage/#reset-the-rendering-context-to-its-default-state

Testing: Improvements in the tests
- html/canvas/element/canvas-host/2d.canvas.host.initial.reset.path.html
- html/canvas/offscreen/canvas-host/2d.canvas.host.initial.reset.path*