### PR TITLE
Fix: test-tidy can miss changed files 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,14 +16,14 @@ jobs:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
         with:
-          fetch-depth: 2 # This is necessary for `test-tidy`.
+          fetch-depth: 0 # This is necessary for `test-tidy`.
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
       - uses: actions/checkout@v4
         if: github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 2 # This is necessary for `test-tidy`.
+          fetch-depth: 0 # This is necessary for `test-tidy`.
       - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
       - name: Setup Python

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -148,7 +148,9 @@ def progress_wrapper(iterator):
 
 
 def git_changes_since_last_merge(path):
-    subprocess.check_call(["git", "remote", "add", "upstream", "https://github.com/servo/servo.git"])
+    remotes = subprocess.check_output(["git", "remote"], universal_newlines=True).splitlines()
+    if "upstream" not in remotes:
+        subprocess.check_call(["git", "remote", "add", "upstream", "https://github.com/servo/servo.git"])
     args = ["git", "merge-base", "upstream/main", "HEAD"]
     last_merge = subprocess.check_output(args, universal_newlines=True).strip()
     if not last_merge:

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -148,10 +148,14 @@ def progress_wrapper(iterator):
 
 
 def git_changes_since_last_merge(path):
-    remotes = subprocess.check_output(["git", "remote"], universal_newlines=True).splitlines()
-    if "upstream" not in remotes:
-        subprocess.check_call(["git", "remote", "add", "upstream", "https://github.com/servo/servo.git"])
-    args = ["git", "merge-base", "upstream/main", "HEAD"]
+    base_branch = "upstream/main"
+    if os.getenv("CI"):
+        base_branch = "origin/main"
+    else:
+        remotes = subprocess.check_output(["git", "remote"], universal_newlines=True).splitlines()
+        if "upstream" not in remotes:
+            subprocess.check_call(["git", "remote", "add", "upstream", "https://github.com/servo/servo.git"])
+    args = ["git", "merge-base", base_branch, "HEAD"]
     last_merge = subprocess.check_output(args, universal_newlines=True).strip()
     if not last_merge:
         return

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -148,12 +148,12 @@ def progress_wrapper(iterator):
 
 
 def git_changes_since_last_merge(path):
-    args = ["git", "log", "-n1", "--committer", "noreply@github.com", "--format=%H"]
+    args = ["git", "merge-base", "origin/main", "HEAD"]
     last_merge = subprocess.check_output(args, universal_newlines=True).strip()
     if not last_merge:
         return
 
-    args = ["git", "diff", "--name-only", last_merge, path]
+    args = ["git", "diff", "--name-only", last_merge, "--", path]
     file_list = normilize_paths(subprocess.check_output(args, universal_newlines=True).splitlines())
 
     return file_list

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -148,6 +148,7 @@ def progress_wrapper(iterator):
 
 
 def git_changes_since_last_merge(path):
+    subprocess.check_call(["git", "remote", "add", "upstream", "https://github.com/servo/servo.git"])
     args = ["git", "merge-base", "upstream/main", "HEAD"]
     last_merge = subprocess.check_output(args, universal_newlines=True).strip()
     if not last_merge:

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -148,7 +148,7 @@ def progress_wrapper(iterator):
 
 
 def git_changes_since_last_merge(path):
-    args = ["git", "merge-base", "origin/main", "HEAD"]
+    args = ["git", "merge-base", "upstream/main", "HEAD"]
     last_merge = subprocess.check_output(args, universal_newlines=True).strip()
     if not last_merge:
         return


### PR DESCRIPTION
To enable comparison between the base branch (main) and the PR branch, I set [fetch-depth: 0](https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches) to fetch the full Git history.

I also added the upstream remote and ran the comparison locally when executing test-tidy to avoid inconsistencies caused by the forked repository being out of sync with upstream.

Note:
There an issues on github when did upstream, so i just using the origin/main
https://github.com/jerensl/servo/actions/runs/15851382031/job/44685495067#step:10:49

Fixes: #31503 