### PR TITLE
Disable IndexedDB wpt tests in CI.

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -179,7 +179,7 @@ skip: true
 [import-maps]
   skip: false
 [IndexedDB]
-  skip: false
+  skip: true
 [intersection-observer]
   skip: false
 [js]


### PR DESCRIPTION
Per a zulip thread, the tests have too many intermittent results right now.