### PR TITLE
[IndexedDB] Adhere better to the specification for idb object store related operations

### DIFF
--- a/components/net/indexeddb/engines/heed.rs
+++ b/components/net/indexeddb/engines/heed.rs
@@ -262,6 +262,16 @@ impl KvsEngine for HeedEngine {
                                 .expect("Could not get store");
                             // FIXME:(arihant2math) Return count with sender
                         },
+                        AsyncOperation::Clear => {
+                            let stores = stores
+                                .write()
+                                .expect("Could not acquire write lock on stores");
+                            let store = stores
+                                .get(&request.store_name)
+                                .expect("Could not get store");
+                            // FIXME:(arihant2math) Error handling
+                            let _ = store.inner.clear(&mut wtxn);
+                        },
                     }
                 }
 

--- a/components/net/indexeddb/engines/heed.rs
+++ b/components/net/indexeddb/engines/heed.rs
@@ -262,7 +262,7 @@ impl KvsEngine for HeedEngine {
                                 .expect("Could not get store");
                             // FIXME:(arihant2math) Return count with sender
                         },
-                        AsyncOperation::Clear => {
+                        AsyncOperation::ReadWrite(AsyncReadWriteOperation::Clear) => {
                             let stores = stores
                                 .write()
                                 .expect("Could not acquire write lock on stores");

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -390,10 +390,7 @@ impl IDBObjectStore {
     /// If writing is true, it then checks if the transaction is a read-only transaction, throwing a "ReadOnlyError" DOMException if so.
     fn check_transaction(&self, writing: bool) -> Fallible<()> {
         // Let transaction be this object store handle's transaction.
-        let transaction = self
-            .transaction
-            .get()
-            .ok_or(Error::TransactionInactive)?;
+        let transaction = self.transaction.get().ok_or(Error::TransactionInactive)?;
 
         // If transaction is not active, throw a "TransactionInactiveError" DOMException.
         if !transaction.is_active() {
@@ -596,7 +593,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
 
         // Step 6
         serialized_query.and_then(|q| {
-            IDBRequest::execute_async(&self, AsyncOperation::Count(q), None, CanGc::note())
+            IDBRequest::execute_async(self, AsyncOperation::Count(q), None, CanGc::note())
         })
     }
 

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -386,6 +386,29 @@ impl IDBObjectStore {
         self.key_path.is_some()
     }
 
+    /// Checks if the transation is active, throwing a "TransactionInactiveError" DOMException if not.
+    /// If writing is true, it then checks if the transaction is a read-only transaction, throwing a "ReadOnlyError" DOMException if so.
+    fn check_transaction(&self, writing: bool) -> Fallible<()> {
+        // Let transaction be this object store handle's transaction.
+        let transaction = self
+            .transaction
+            .get()
+            .ok_or(Error::TransactionInactive)?;
+
+        // If transaction is not active, throw a "TransactionInactiveError" DOMException.
+        if !transaction.is_active() {
+            return Err(Error::TransactionInactive);
+        }
+
+        // If transaction is a read-only transaction, throw a "ReadOnlyError" DOMException.
+        if writing {
+            if let IDBTransactionMode::Readonly = transaction.get_mode() {
+                return Err(Error::ReadOnly);
+            }
+        }
+        Ok(())
+    }
+
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-put
     fn put(
         &self,
@@ -395,27 +418,15 @@ impl IDBObjectStore {
         overwrite: bool,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<IDBRequest>> {
-        // Step 1: Let transaction be this object store handle's transaction.
-        let transaction = self
-            .transaction
-            .get()
-            .expect("No transaction in Object Store");
-
+        // Step 1: Unneeded, handled by self.check_transaction()
         // Step 2: Let store be this object store handle's object store.
         // This is resolved in the `execute_async` function.
 
         // Step 3: If store has been deleted, throw an "InvalidStateError" DOMException.
         // FIXME:(rasviitanen)
 
-        // Step 4-5: If transaction is not active, throw a "TransactionInactiveError" DOMException.
-        if !transaction.is_active() {
-            return Err(Error::TransactionInactive);
-        }
-
-        // Step 5: If transaction is a read-only transaction, throw a "ReadOnlyError" DOMException.
-        if let IDBTransactionMode::Readonly = transaction.get_mode() {
-            return Err(Error::ReadOnly);
-        }
+        // Steps 4-5
+        self.check_transaction(true)?;
 
         // Step 6: If store uses in-line keys and key was given, throw a "DataError" DOMException.
         if !key.is_undefined() && self.uses_inline_keys() {
@@ -489,7 +500,15 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
 
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-delete
     fn Delete(&self, cx: SafeJSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
+        // Step 1: Unneeded, handled by self.check_transaction()
+        // TODO: Step 2
+        // TODO: Step 3
+        // Steps 4-5
+        self.check_transaction(true)?;
+        // Step 6
+        // TODO: Convert to key range instead
         let serialized_query = IDBObjectStore::convert_value_to_key(cx, query, None);
+        // Step 7
         serialized_query.and_then(|q| {
             IDBRequest::execute_async(
                 self,
@@ -502,12 +521,25 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
 
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-clear
     fn Clear(&self) -> Fallible<DomRoot<IDBRequest>> {
-        unimplemented!();
+        // Step 1: Unneeded, handled by self.check_transaction()
+        // TODO: Step 2
+        // TODO: Step 3
+        // Steps 4-5
+        self.check_transaction(true)?;
+        IDBRequest::execute_async(self, AsyncOperation::Clear, None, CanGc::note())
     }
 
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-get
     fn Get(&self, cx: SafeJSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
+        // Step 1: Unneeded, handled by self.check_transaction()
+        // TODO: Step 2
+        // TODO: Step 3
+        // Step 4
+        self.check_transaction(false)?;
+        // Step 5
+        // TODO: Convert to key range instead
         let serialized_query = IDBObjectStore::convert_value_to_key(cx, query, None);
+        // Step 6
         serialized_query.and_then(|q| {
             IDBRequest::execute_async(
                 self,
@@ -520,6 +552,14 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
 
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-getkey
     // fn GetKey(&self, _cx: SafeJSContext, _query: HandleValue) -> DomRoot<IDBRequest> {
+    //     // Step 1: Unneeded, handled by self.check_transaction()
+    //     // TODO: Step 2
+    //     // TODO: Step 3
+    //     // Step 4
+    //     self.check_transaction(false)?;
+    //     // Step 5
+    //     // TODO: Convert to key range instead
+    //     let serialized_query = IDBObjectStore::convert_value_to_key(cx, query, None);
     //     unimplemented!();
     // }
 
@@ -545,29 +585,19 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
 
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-count
     fn Count(&self, cx: SafeJSContext, query: HandleValue) -> Fallible<DomRoot<IDBRequest>> {
-        // Step 1
-        let transaction = self.transaction.get().expect("Could not get transaction");
-
-        // Step 2
-        // FIXME(arihant2math): investigate further
-
-        // Step 3
-        // FIXME(arihant2math): Cannot tell if store has been deleted
-
-        // Step 4
-        if !transaction.is_active() {
-            return Err(Error::TransactionInactive);
-        }
+        // Step 1: Unneeded, handled by self.check_transaction()
+        // TODO: Step 2
+        // TODO: Step 3
+        // Steps 4
+        self.check_transaction(false)?;
 
         // Step 5
-        let _serialized_query = IDBObjectStore::convert_value_to_key(cx, query, None);
+        let serialized_query = IDBObjectStore::convert_value_to_key(cx, query, None);
 
         // Step 6
-        // match serialized_query {
-        //     Ok(q) => IDBRequest::execute_async(&*self, AsyncOperation::Count(q), None),
-        //     Err(e) => Err(e),
-        // }
-        Err(Error::NotSupported)
+        serialized_query.and_then(|q| {
+            IDBRequest::execute_async(&self, AsyncOperation::Count(q), None, CanGc::note())
+        })
     }
 
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-name

--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -77,6 +77,7 @@ pub enum AsyncReadOnlyOperation {
     Count(
         IndexedDBKeyType, // Key
     ),
+    Clear
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -77,7 +77,6 @@ pub enum AsyncReadOnlyOperation {
     Count(
         IndexedDBKeyType, // Key
     ),
-    Clear
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -93,6 +92,8 @@ pub enum AsyncReadWriteOperation {
     RemoveItem(
         IndexedDBKeyType, // Key
     ),
+    /// Clears all key/value pairs in the associated idb data
+    Clear,
 }
 
 /// Operations that are not executed instantly, but rather added to a


### PR DESCRIPTION
Many object store related operations require the transaction to be checked: to ensure it is still active, and, if the operation is a write, that the transaction is not read-only. I've added the `check_transaction` method to perform these checks.

Additionally `Clear` was still half-implemented, so I went ahead and implemented that.