### PR TITLE
script: const initialize LIVE_REFERENCES

### DIFF
--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -511,7 +511,6 @@ impl Runtime {
         parent: Option<ParentRuntime>,
         networking_task_source: Option<SendableTaskSource>,
     ) -> Runtime {
-        LiveDOMReferences::initialize();
         let (cx, runtime) = if let Some(parent) = parent {
             let runtime = RustRuntime::create_with_parent(parent);
             let cx = runtime.cx();


### PR DESCRIPTION
With Rust 1.85 it is possible to const initialize Hashmaps if the hash algorithm does not rely on a random seed.

Testing: No functional changes, covered by existing tests

