### PR TITLE
script: Properly root nodes with animating images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,7 +1358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2384,7 +2384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3003,7 +3003,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4507,7 +4507,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4735,6 +4735,7 @@ dependencies = [
  "libc",
  "malloc_size_of_derive",
  "net_traits",
+ "parking_lot",
  "pixels",
  "profile_traits",
  "range",
@@ -4803,7 +4804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6898,7 +6899,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7078,6 +7079,7 @@ dependencies = [
  "nom",
  "num-traits",
  "num_cpus",
+ "parking_lot",
  "percent-encoding",
  "phf",
  "pixels",
@@ -8288,7 +8290,7 @@ dependencies = [
  "getrandom 0.2.16",
  "once_cell",
  "rustix 0.38.44",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9731,7 +9733,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -58,7 +58,10 @@ impl FragmentTree {
         // them. Create a set of all elements that used to be animating.
         let mut animations = layout_context.style_context.animations.sets.write();
         let mut invalid_animating_nodes: FxHashSet<_> = animations.keys().cloned().collect();
-        let mut image_animations = layout_context.node_image_animation_map.write().to_owned();
+        let mut image_animations = layout_context
+            .node_to_animating_image_map
+            .write()
+            .to_owned();
         let mut invalid_image_animating_nodes: FxHashSet<_> = image_animations
             .keys()
             .cloned()

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -644,9 +644,7 @@ impl LayoutThread {
             resolved_images_cache: self.resolved_images_cache.clone(),
             pending_images: Mutex::default(),
             pending_rasterization_images: Mutex::default(),
-            node_image_animation_map: Arc::new(RwLock::new(std::mem::take(
-                &mut reflow_request.node_to_image_animation_map,
-            ))),
+            node_to_animating_image_map: reflow_request.node_to_animating_image_map.clone(),
             iframe_sizes: Mutex::default(),
             use_rayon: rayon_pool.is_some(),
             highlighted_dom_node: reflow_request.highlighted_dom_node,
@@ -687,15 +685,12 @@ impl LayoutThread {
         let pending_rasterization_images =
             std::mem::take(&mut *layout_context.pending_rasterization_images.lock());
         let iframe_sizes = std::mem::take(&mut *layout_context.iframe_sizes.lock());
-        let node_to_image_animation_map =
-            std::mem::take(&mut *layout_context.node_image_animation_map.write());
 
         Some(ReflowResult {
             built_display_list,
             pending_images,
             pending_rasterization_images,
             iframe_sizes,
-            node_to_image_animation_map,
         })
     }
 

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -95,6 +95,7 @@ net_traits = { workspace = true }
 nom = "7.1.3"
 num-traits = { workspace = true }
 num_cpus = { workspace = true }
+parking_lot = { workspace = true }
 percent-encoding = { workspace = true }
 phf = "0.11"
 pixels = { path = "../pixels" }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2218,9 +2218,7 @@ impl Window {
             pending_restyles,
             animation_timeline_value: document.current_animation_timeline_value(),
             animations: document.animations().sets.clone(),
-            node_to_image_animation_map: document
-                .image_animation_manager_mut()
-                .take_image_animate_set(),
+            node_to_animating_image_map: document.image_animation_manager().node_to_image_map(),
             theme: self.theme.get(),
             highlighted_dom_node,
         };
@@ -2297,9 +2295,6 @@ impl Window {
         if !size_messages.is_empty() {
             self.send_to_constellation(ScriptToConstellationMessage::IFrameSizes(size_messages));
         }
-        document
-            .image_animation_manager_mut()
-            .restore_image_animate_set(results.node_to_image_animation_map);
         document.update_animations_post_reflow();
         self.update_constellation_epoch();
 

--- a/components/script/image_animation.rs
+++ b/components/script/image_animation.rs
@@ -2,12 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
+
 use compositing_traits::{ImageUpdate, SerializableImageData};
 use embedder_traits::UntrustedNodeAddress;
-use fxhash::{FxHashMap, FxHashSet};
+use fxhash::FxHashMap;
 use ipc_channel::ipc::IpcSharedMemory;
 use layout_api::ImageAnimationState;
 use libc::c_void;
+use malloc_size_of::MallocSizeOf;
+use parking_lot::RwLock;
 use script_bindings::root::Dom;
 use style::dom::OpaqueNode;
 use webrender_api::units::DeviceIntSize;
@@ -18,97 +22,90 @@ use crate::dom::bindings::trace::NoTrace;
 use crate::dom::node::{Node, from_untrusted_node_address};
 use crate::dom::window::Window;
 
-#[derive(Clone, Debug, Default, JSTraceable, MallocSizeOf)]
+#[derive(Clone, Debug, Default, JSTraceable)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub struct ImageAnimationManager {
     #[no_trace]
-    pub node_to_image_map: FxHashMap<OpaqueNode, ImageAnimationState>,
+    node_to_image_map: Arc<RwLock<FxHashMap<OpaqueNode, ImageAnimationState>>>,
 
     /// A list of nodes with in-progress image animations.
+    ///
+    /// TODO(mrobinson): This does not properly handle animating images that are in pseudo-elements.
     rooted_nodes: DomRefCell<FxHashMap<NoTrace<OpaqueNode>, Dom<Node>>>,
 }
 
+impl MallocSizeOf for ImageAnimationManager {
+    fn size_of(&self, ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
+        (*self.node_to_image_map.read()).size_of(ops) + self.rooted_nodes.size_of(ops)
+    }
+}
+
 impl ImageAnimationManager {
-    pub fn new() -> Self {
-        ImageAnimationManager {
-            node_to_image_map: Default::default(),
-            rooted_nodes: DomRefCell::new(FxHashMap::default()),
-        }
+    pub(crate) fn node_to_image_map(
+        &self,
+    ) -> Arc<RwLock<FxHashMap<OpaqueNode, ImageAnimationState>>> {
+        self.node_to_image_map.clone()
     }
 
-    pub fn take_image_animate_set(&mut self) -> FxHashMap<OpaqueNode, ImageAnimationState> {
-        std::mem::take(&mut self.node_to_image_map)
-    }
-
-    pub fn restore_image_animate_set(&mut self, map: FxHashMap<OpaqueNode, ImageAnimationState>) {
-        let _ = std::mem::replace(&mut self.node_to_image_map, map);
-        self.root_newly_animating_dom_nodes();
-        self.unroot_unused_nodes();
-    }
-
-    pub fn next_schedule_time(&self, now: f64) -> Option<f64> {
+    pub(crate) fn next_scheduled_time(&self, now: f64) -> Option<f64> {
         self.node_to_image_map
+            .read()
             .values()
             .map(|state| state.time_to_next_frame(now))
             .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
     }
 
-    pub fn image_animations_present(&self) -> bool {
-        !self.node_to_image_map.is_empty()
+    pub(crate) fn image_animations_present(&self) -> bool {
+        !self.node_to_image_map.read().is_empty()
     }
 
-    pub fn update_active_frames(&mut self, window: &Window, now: f64) {
+    pub(crate) fn update_active_frames(&self, window: &Window, now: f64) {
         let rooted_nodes = self.rooted_nodes.borrow();
-        let updates: Vec<ImageUpdate> = self
+        let updates = self
             .node_to_image_map
+            .write()
             .iter_mut()
             .filter_map(|(node, state)| {
-                if state.update_frame_for_animation_timeline_value(now) {
-                    let image = &state.image;
-                    let frame = image
-                        .frames()
-                        .nth(state.active_frame)
-                        .expect("active_frame should within range of frames");
-
-                    if let Some(node) = rooted_nodes.get(&NoTrace(*node)) {
-                        node.dirty(crate::dom::node::NodeDamage::Other);
-                    }
-                    Some(ImageUpdate::UpdateImage(
-                        image.id.unwrap(),
-                        ImageDescriptor {
-                            format: ImageFormat::BGRA8,
-                            size: DeviceIntSize::new(
-                                image.metadata.width as i32,
-                                image.metadata.height as i32,
-                            ),
-                            stride: None,
-                            offset: 0,
-                            flags: ImageDescriptorFlags::ALLOW_MIPMAPS,
-                        },
-                        SerializableImageData::Raw(IpcSharedMemory::from_bytes(frame.bytes)),
-                    ))
-                } else {
-                    None
+                if !state.update_frame_for_animation_timeline_value(now) {
+                    return None;
                 }
+
+                let image = &state.image;
+                let frame = image
+                    .frames()
+                    .nth(state.active_frame)
+                    .expect("active_frame should within range of frames");
+
+                if let Some(node) = rooted_nodes.get(&NoTrace(*node)) {
+                    node.dirty(crate::dom::node::NodeDamage::Other);
+                }
+                Some(ImageUpdate::UpdateImage(
+                    image.id.unwrap(),
+                    ImageDescriptor {
+                        format: ImageFormat::BGRA8,
+                        size: DeviceIntSize::new(
+                            image.metadata.width as i32,
+                            image.metadata.height as i32,
+                        ),
+                        stride: None,
+                        offset: 0,
+                        flags: ImageDescriptorFlags::ALLOW_MIPMAPS,
+                    },
+                    SerializableImageData::Raw(IpcSharedMemory::from_bytes(frame.bytes)),
+                ))
             })
             .collect();
         window.compositor_api().update_images(updates);
     }
-
-    // Unroot any nodes that we have rooted but no longer have animating images.
-    fn unroot_unused_nodes(&self) {
-        let nodes: FxHashSet<&OpaqueNode> = self.node_to_image_map.keys().collect();
-        self.rooted_nodes
-            .borrow_mut()
-            .retain(|node, _| nodes.contains(&node.0));
-    }
-
-    /// Ensure that all nodes with Image animations are rooted. This should be called
-    /// immediately after a restyle, to ensure that these addresses are still valid.
+    /// Ensure that all nodes with animating images are rooted and unroots any nodes that
+    /// no longer have an animating image. This should be called immediately after a
+    /// restyle, to ensure that these addresses are still valid.
     #[allow(unsafe_code)]
-    fn root_newly_animating_dom_nodes(&self) {
+    pub(crate) fn update_rooted_dom_nodes(&self) {
         let mut rooted_nodes = self.rooted_nodes.borrow_mut();
-        for opaque_node in self.node_to_image_map.keys() {
+        let node_to_image_map = self.node_to_image_map.read();
+
+        for opaque_node in node_to_image_map.keys() {
             let opaque_node = *opaque_node;
             if rooted_nodes.contains_key(&NoTrace(opaque_node)) {
                 continue;
@@ -121,5 +118,7 @@ impl ImageAnimationManager {
                 )
             };
         }
+
+        rooted_nodes.retain(|node, _| node_to_image_map.contains_key(&node.0));
     }
 }

--- a/components/shared/layout/Cargo.toml
+++ b/components/shared/layout/Cargo.toml
@@ -29,6 +29,7 @@ libc = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 net_traits = { workspace = true }
+parking_lot = { workspace = true }
 pixels = { path = "../../pixels" }
 profile_traits = { workspace = true }
 range = { path = "../../range" }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -31,6 +31,7 @@ use libc::c_void;
 use malloc_size_of::{MallocSizeOf as MallocSizeOfTrait, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::image_cache::{ImageCache, PendingImageId};
+use parking_lot::RwLock;
 use pixels::RasterImage;
 use profile_traits::mem::Report;
 use profile_traits::time;
@@ -412,8 +413,6 @@ pub struct ReflowResult {
     /// to communicate them with the Constellation and also the `Window`
     /// element of their content pages.
     pub iframe_sizes: IFrameSizes,
-    /// The mapping of node to animated image, need to be returned to ImageAnimationManager
-    pub node_to_image_animation_map: FxHashMap<OpaqueNode, ImageAnimationState>,
 }
 
 /// Information needed for a script-initiated reflow.
@@ -440,7 +439,7 @@ pub struct ReflowRequest {
     /// The set of animations for this document.
     pub animations: DocumentAnimationSet,
     /// The set of image animations.
-    pub node_to_image_animation_map: FxHashMap<OpaqueNode, ImageAnimationState>,
+    pub node_to_animating_image_map: Arc<RwLock<FxHashMap<OpaqueNode, ImageAnimationState>>>,
     /// The theme for the window
     pub theme: Theme,
     /// The node highlighted by the devtools, if any


### PR DESCRIPTION
This change fixes an issue and makes a few more minor improvements to
the `ImageAnimationState`:

1. Image rooting and unrooted now happens in one step from
   `Window::update_animations_post_reflow`.
2. The `node_to_animating_image_map` is now stored as a shared `RwLock`
   so that it doesn't need to be taken and then replaced in the
   `ImageAnimationState` during reflow. This should prevent a hypothetical issue
   where image animations are restarted during empty reflows.
3. General naming and idiomatic Rust usage improvements.

Testing: This doesn't really have any obvious behavioral changes, because all
reflows currently trigger a restyle. It becomes a serious problem with #37677
and this change fixes the failing test there.
