### PR TITLE
OHOS: Use new file logger.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3681,9 +3681,9 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hilog"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08aa7468a47ecda3066458d5ecc6c8162f7c8b14c3df5f8835e97a11507d4cb"
+checksum = "2cde43461a56942d36c0392c0eb8e108af2fbb48966c145fd126df4ce7b5c6c1"
 dependencies = [
  "arc-swap",
  "env_filter",

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -87,7 +87,7 @@ backtrace = { workspace = true }
 [target.'cfg(target_env = "ohos")'.dependencies]
 env_filter = "0.1.3"
 euclid = { workspace = true }
-hilog = "0.2.1"
+hilog = "0.2.2"
 # force inprocess until we add multi-process support for ohos
 ipc-channel = { workspace = true, features = ["force-inprocess"] }
 napi-derive-ohos = "1.0.4"

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -507,6 +507,7 @@ static LOGGER: LazyLock<hilog::Logger> = LazyLock::new(|| {
         "servoshell::egl::log",
         // Show JS errors by default.
         "script::dom::bindings::error",
+        "script::dom::console",
         // Show GL errors by default.
         "canvas::webgl_thread",
         "compositing::compositor",

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -152,6 +152,14 @@ pub fn init(
         },
     };
 
+    if servoshell_preferences.log_to_file {
+        let mut servo_log = PathBuf::from(&native_values.cache_dir);
+        servo_log.push("servo.log");
+        if crate::egl::ohos::LOGGER.set_file_writer(servo_log).is_err() {
+            warn!("Could not set log file");
+        }
+    }
+
     crate::init_tracing(servoshell_preferences.tracing_filter.as_deref());
     #[cfg(target_env = "ohos")]
     crate::egl::ohos::set_log_filter(servoshell_preferences.log_filter.as_deref());

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -62,6 +62,10 @@ pub(crate) struct ServoShellPreferences {
     /// If a filter is passed, the logger should adjust accordingly.
     #[cfg(target_env = "ohos")]
     pub log_filter: Option<String>,
+
+    /// Log also to a file
+    #[cfg(target_env = "ohos")]
+    pub log_to_file: bool,
 }
 
 impl Default for ServoShellPreferences {
@@ -82,6 +86,8 @@ impl Default for ServoShellPreferences {
             userscripts_directory: None,
             #[cfg(target_env = "ohos")]
             log_filter: None,
+            #[cfg(target_env = "ohos")]
+            log_to_file: false,
         }
     }
 }
@@ -363,6 +369,13 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         "FILTER",
     );
 
+    #[cfg(target_env = "ohos")]
+    opts.optflag(
+        "",
+        "log-to-file",
+        "Also log to a file (/data/app/el2/100/base/org.servo.servo/cache/servo.log)",
+    );
+
     opts.optflag(
         "",
         "enable-experimental-web-platform-features",
@@ -434,6 +447,9 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         log::debug!("Set log_filter to: {:?}", log_filter);
         log_filter
     };
+
+    #[cfg(target_env = "ohos")]
+    let log_to_file = opt_match.opt_present("log-to-file");
 
     let mut debug_options = DebugOptions::default();
     for debug_string in opt_match.opt_strs("Z") {
@@ -648,6 +664,8 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
             .map(PathBuf::from),
         #[cfg(target_env = "ohos")]
         log_filter,
+        #[cfg(target_env = "ohos")]
+        log_to_file,
         ..Default::default()
     };
 


### PR DESCRIPTION
Hilog 0.2.1 allows us to additionally log to a file. This is sometimes more convinient when
benchmarking.
Also added the new log domain of `script::dom::console`.

Testing: Tested on device.
