### PR TITLE
servoshell: Fix typo in `NewWebView`

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -343,7 +343,7 @@ impl App {
                 },
                 WebDriverCommandMsg::NewWebView(response_sender, load_status_sender) => {
                     let new_webview =
-                        running_state.create_toplevel_webview(Url::parse("auto:blank").unwrap());
+                        running_state.create_toplevel_webview(Url::parse("about:blank").unwrap());
 
                     if let Err(error) = response_sender.send(new_webview.id()) {
                         warn!("Failed to send response of NewWebview: {error}");


### PR DESCRIPTION
It was wrongly typed as "auto:blank" instead of "about:blank". This affects all default new tab as it fails to load.

Testing: `webdriver\tests\classic\new_window\new_window.py` is now passing. Previously it has an error as it expects "about:blank"
