### PR TITLE
[WebDriver: Action] Fix panic of Scroll and PointerMove

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -743,7 +743,7 @@ impl Handler {
     fn check_viewport_bound(&self, x: f64, y: f64) -> Result<(), ErrorStatus> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd_msg =
-            WebDriverCommandMsg::GetWindowSize(self.session.as_ref().unwrap().webview_id, sender);
+            WebDriverCommandMsg::GetViewportSize(self.session.as_ref().unwrap().webview_id, sender);
         self.constellation_chan
             .send(EmbedderToConstellationMessage::WebDriverCommand(cmd_msg))
             .unwrap();


### PR DESCRIPTION
#37555 moves `GetWindowSize` to Servoshell, but forget to move it in `check_viewport_bound` which still sends to Constellation, causing unreachable panic: `unreachable!("This command should be send directly to the embedder.");`

Testing: Previously, almost all test that relies on Element Click/Scroll/PointerMove panics. Not anymore.