### PR TITLE
script: Consolidate step 22 of per-`Document` rendering update

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2173,17 +2173,8 @@ impl Window {
         let document = self.Document();
 
         let stylesheets_changed = document.flush_stylesheets_for_reflow();
-
-        // If this reflow is for display, ensure webgl canvases are composited with
-        // up-to-date contents.
         let for_display = reflow_goal.needs_display();
-        if for_display {
-            document.flush_dirty_webgl_canvases();
-            document.flush_dirty_2d_canvases();
-        }
-
         let pending_restyles = document.drain_pending_restyles();
-
         let dirty_root = document
             .take_dirty_root()
             .filter(|_| !stylesheets_changed)

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -68,7 +68,7 @@ use js::jsapi::{
 };
 use js::jsval::UndefinedValue;
 use js::rust::ParentRuntime;
-use layout_api::{LayoutConfig, LayoutFactory, ReflowGoal, ScriptThreadFactory};
+use layout_api::{LayoutConfig, LayoutFactory, ScriptThreadFactory};
 use media::WindowGLContext;
 use metrics::MAX_TASK_NS;
 use net_traits::image_cache::{ImageCache, ImageCacheResponseMessage};
@@ -1328,19 +1328,9 @@ impl ScriptThread {
 
             // TODO: Mark paint timing from https://w3c.github.io/paint-timing.
 
-            // Update the rendering of those does not require a reflow.
-            // e.g. animated images.
-            document.update_animating_images();
-
-            #[cfg(feature = "webgpu")]
-            document.update_rendering_of_webgpu_canvases();
-
             // > Step 22: For each doc of docs, update the rendering or user interface of
             // > doc and its node navigable to reflect the current state.
-            saw_any_reflows = document
-                .window()
-                .reflow(ReflowGoal::UpdateTheRendering, can_gc) ||
-                saw_any_reflows;
+            saw_any_reflows = document.update_the_rendering(can_gc) || saw_any_reflows;
 
             // TODO: Process top layer removals according to
             // https://drafts.csswg.org/css-position-4/#process-top-layer-removals.


### PR DESCRIPTION
The parts of step 22 were a bit scattered throughout the codebase, so this
change moves them all to a single method which does three things:

1. Update all animating images
2. Flush all dirty canvases (2D, WebGL, and WebGPU)
3. Calls reflow on the `Document`

Testing: This shouldn't change behavior in any major way so it should
be covered by existing WPT tests.
