### PR TITLE
Add common resourceId to network events

### DIFF
--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -22,6 +22,7 @@ use crate::protocol::JsonPacketStream;
 
 pub struct NetworkEventActor {
     pub name: String,
+    pub resource_id: u64,
     pub is_xhr: bool,
     pub request_url: String,
     pub request_method: Method,
@@ -55,6 +56,7 @@ pub struct NetworkEventResource {
 #[serde(rename_all = "camelCase")]
 pub struct EventActor {
     pub actor: String,
+    pub resource_id: u64,
     pub url: String,
     pub method: String,
     pub started_date_time: String,
@@ -340,9 +342,10 @@ impl Actor for NetworkEventActor {
 }
 
 impl NetworkEventActor {
-    pub fn new(name: String) -> NetworkEventActor {
+    pub fn new(name: String, resource_id: u64) -> NetworkEventActor {
         NetworkEventActor {
             name,
+            resource_id,
             is_xhr: false,
             request_url: String::new(),
             request_method: Method::GET,
@@ -414,6 +417,7 @@ impl NetworkEventActor {
 
         EventActor {
             actor: self.name(),
+            resource_id: self.resource_id,
             url: self.request_url.clone(),
             method: format!("{}", self.request_method),
             started_date_time: started_datetime_rfc3339,
@@ -587,7 +591,7 @@ impl NetworkEventActor {
 
         // TODO: Set the correct values for these fields
         NetworkEventResource {
-            resource_id: 0,
+            resource_id: self.resource_id,
             resource_updates,
             browsing_context_id: 0,
             inner_window_id: 0,

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -120,6 +120,7 @@ struct DevtoolsInstance {
     actor_workers: HashMap<WorkerId, String>,
     actor_requests: HashMap<String, String>,
     connections: HashMap<StreamId, TcpStream>,
+    next_resource_id: u64,
 }
 
 impl DevtoolsInstance {
@@ -182,6 +183,7 @@ impl DevtoolsInstance {
             actor_requests: HashMap::new(),
             actor_workers: HashMap::new(),
             connections: HashMap::new(),
+            next_resource_id: 1,
         };
 
         thread::Builder::new()
@@ -509,8 +511,10 @@ impl DevtoolsInstance {
                 name.into_mut().clone()
             },
             Vacant(entry) => {
+                let resource_id = self.next_resource_id;
+                self.next_resource_id += 1;
                 let actor_name = actors.new_name("netevent");
-                let actor = NetworkEventActor::new(actor_name.clone());
+                let actor = NetworkEventActor::new(actor_name.clone(), resource_id);
                 entry.insert(actor_name.clone());
                 actors.register(Box::new(actor));
                 actor_name


### PR DESCRIPTION
- Add a `resource_id` field to `EventActor` and `NetworkEventActor`
- Store a `next_resource_id` field in DevtoolsInstance
- Add `resource_id` parameter to `NetworkEventActor::new`
- Increment `next_resource_id` when `DevtoolsInstance::find_network_event_actor` is called so each network event has a unique id

Testing: Ran servo in devtools mode and can see the data showing in `status`,`type`, `transferred` ,`size` and `timeline` columns of each request, also logged the devtools instance and can see unique `resourceId` for each request.
Fixes: https://github.com/servo/servo/issues/37661
