### PR TITLE
layout: Let `align-content: stretch` fall back to `unsafe flex-start`

### DIFF
--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -802,7 +802,7 @@ impl FlexContainer {
 
             if fallback_is_needed {
                 (resolved_align_content, is_safe) = match resolved_align_content {
-                    AlignFlags::STRETCH => (AlignFlags::FLEX_START, true),
+                    AlignFlags::STRETCH => (AlignFlags::FLEX_START, false),
                     AlignFlags::SPACE_BETWEEN => (AlignFlags::FLEX_START, true),
                     AlignFlags::SPACE_AROUND => (AlignFlags::CENTER, true),
                     AlignFlags::SPACE_EVENLY => (AlignFlags::CENTER, true),

--- a/tests/wpt/meta/css/css-flexbox/flexbox-align-self-baseline-horiz-003.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-align-self-baseline-horiz-003.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-align-self-baseline-horiz-003.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/negative-overflow.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/negative-overflow.html.ini
@@ -5,6 +5,9 @@
   [.flexbox 11]
     expected: FAIL
 
+  [.flexbox 5]
+    expected: FAIL
+
   [.flexbox 8]
     expected: FAIL
 

--- a/tests/wpt/tests/css/css-flexbox/align-content-007.htm
+++ b/tests/wpt/tests/css/css-flexbox/align-content-007.htm
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: Fallback alignment of 'align-content: stretch'</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-align/#valdef-align-content-stretch">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11641">
+<meta name="assert" content="The fallback alignment for `align-content: stretch` is `flex-start`, not `safe flex-start`.">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+
+<style>
+#flex {
+    display: flex;
+    width: 200px;
+    height: 200px;
+    flex-wrap: wrap-reverse;
+    align-content: stretch;
+}
+#item {
+    width: 200px;
+    height: 400px;
+    background: linear-gradient(to bottom, red 50%, green 50%);
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="overflow: hidden">
+  <div id="flex">
+    <div id="item"></div>
+  </div>
+</div>


### PR DESCRIPTION
This aligns Servo with other browsers, and adopts this CSSWG resolution: https://github.com/w3c/csswg-drafts/issues/11641#issuecomment-3005385155

Testing: adding new WPT test, and some expectation changes for existing tests.