### PR TITLE
webgpu: Use compositor_api instead of webrender_api

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -164,8 +164,6 @@ use style_traits::CSSPixel;
 use webgpu::swapchain::WGPUImageMap;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::{WebGPU, WebGPURequest};
-#[cfg(feature = "webgpu")]
-use webrender::RenderApi;
 use webrender::RenderApiSender;
 use webrender_api::units::LayoutVector2D;
 use webrender_api::{DocumentId, ExternalScrollId, ImageKey};
@@ -222,9 +220,6 @@ struct MessagePortInfo {
 #[cfg(feature = "webgpu")]
 /// Webrender related objects required by WebGPU threads
 struct WebrenderWGPU {
-    /// Webrender API.
-    webrender_api: RenderApi,
-
     /// List of Webrender external images
     webrender_external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
 
@@ -361,10 +356,6 @@ pub struct Constellation<STF, SWF> {
     /// A channel for the constellation to send messages to the
     /// memory profiler thread.
     mem_profiler_chan: mem::ProfilerChan,
-
-    /// A single WebRender document the constellation operates on.
-    #[cfg(feature = "webgpu")]
-    webrender_document: DocumentId,
 
     /// Webrender related objects required by WebGPU threads
     #[cfg(feature = "webgpu")]
@@ -657,7 +648,6 @@ where
 
                 #[cfg(feature = "webgpu")]
                 let webrender_wgpu = WebrenderWGPU {
-                    webrender_api: state.webrender_api_sender.create_api(),
                     webrender_external_images: state.webrender_external_images,
                     wgpu_image_map: state.wgpu_image_map,
                 };
@@ -704,8 +694,6 @@ where
                     phantom: PhantomData,
                     webdriver: WebDriverData::new(),
                     document_states: HashMap::new(),
-                    #[cfg(feature = "webgpu")]
-                    webrender_document: state.webrender_document,
                     #[cfg(feature = "webgpu")]
                     webrender_wgpu,
                     shutting_down: false,
@@ -2063,8 +2051,7 @@ where
         };
         let webgpu_chan = match browsing_context_group.webgpus.entry(host) {
             Entry::Vacant(v) => start_webgpu_thread(
-                self.webrender_wgpu.webrender_api.create_sender(),
-                self.webrender_document,
+                self.compositor_proxy.cross_process_compositor_api.clone(),
                 self.webrender_wgpu.webrender_external_images.clone(),
                 self.webrender_wgpu.wgpu_image_map.clone(),
             )

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -6,7 +6,6 @@ use log::warn;
 use swapchain::WGPUImageMap;
 pub use swapchain::{ContextData, WGPUExternalImages};
 use webgpu_traits::{WebGPU, WebGPUMsg};
-use webrender::RenderApiSender;
 use wgpu_thread::WGPU;
 pub use {wgpu_core as wgc, wgpu_types as wgt};
 
@@ -16,16 +15,14 @@ mod wgpu_thread;
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
-use compositing_traits::WebrenderExternalImageRegistry;
+use compositing_traits::{CrossProcessCompositorApi, WebrenderExternalImageRegistry};
 use ipc_channel::ipc::{self, IpcReceiver};
 use servo_config::pref;
-use webrender_api::DocumentId;
 
 pub mod swapchain;
 
 pub fn start_webgpu_thread(
-    webrender_api_sender: RenderApiSender,
-    webrender_document: DocumentId,
+    compositor_api: CrossProcessCompositorApi,
     external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
     wgpu_image_map: WGPUImageMap,
 ) -> Option<(WebGPU, IpcReceiver<WebGPUMsg>)> {
@@ -62,8 +59,7 @@ pub fn start_webgpu_thread(
                 receiver,
                 sender_clone,
                 script_sender,
-                webrender_api_sender,
-                webrender_document,
+                compositor_api,
                 external_images,
                 wgpu_image_map,
             )

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -8,7 +8,10 @@ use std::slice;
 use std::sync::{Arc, Mutex};
 
 use arrayvec::ArrayVec;
-use compositing_traits::{WebrenderExternalImageApi, WebrenderImageSource};
+use compositing_traits::{
+    CrossProcessCompositorApi, ImageUpdate, SerializableImageData, WebrenderExternalImageApi,
+    WebrenderImageSource,
+};
 use euclid::default::Size2D;
 use ipc_channel::ipc::IpcSender;
 use log::{error, warn};
@@ -17,11 +20,10 @@ use serde::{Deserialize, Serialize};
 use webgpu_traits::{
     ContextConfiguration, Error, PRESENTATION_BUFFER_COUNT, WebGPUContextId, WebGPUMsg,
 };
-use webrender::{RenderApi, Transaction};
 use webrender_api::units::DeviceIntSize;
 use webrender_api::{
-    DirtyRect, DocumentId, ExternalImageData, ExternalImageId, ExternalImageType, ImageData,
-    ImageDescriptor, ImageDescriptorFlags, ImageFormat, ImageKey,
+    ExternalImageData, ExternalImageId, ExternalImageType, ImageDescriptor, ImageDescriptorFlags,
+    ImageFormat, ImageKey,
 };
 use wgpu_core::device::HostMap;
 use wgpu_core::global::Global;
@@ -182,7 +184,7 @@ impl WebGPUImageDescriptor {
 pub struct ContextData {
     image_key: ImageKey,
     image_desc: WebGPUImageDescriptor,
-    image_data: ImageData,
+    image_data: ExternalImageData,
     buffer_ids: ArrayVec<(id::BufferId, PresentationBufferState), PRESENTATION_BUFFER_COUNT>,
     /// If there is no associated swapchain the context is dummy (transparent black)
     swap_chain: Option<SwapChain>,
@@ -202,12 +204,12 @@ impl ContextData {
         size: DeviceIntSize,
         buffer_ids: ArrayVec<id::BufferId, PRESENTATION_BUFFER_COUNT>,
     ) -> Self {
-        let image_data = ImageData::External(ExternalImageData {
+        let image_data = ExternalImageData {
             id: ExternalImageId(context_id.0),
             channel_index: 0,
             image_type: ExternalImageType::Buffer,
             normalized_uvs: false,
-        });
+        };
 
         Self {
             image_key,
@@ -300,8 +302,7 @@ impl ContextData {
         mut self,
         global: &Arc<Global>,
         script_sender: &IpcSender<WebGPUMsg>,
-        webrender_api: &Arc<Mutex<RenderApi>>,
-        webrender_document: DocumentId,
+        compositor_api: &CrossProcessCompositorApi,
     ) {
         self.destroy_swapchain(global);
         for (buffer_id, _) in self.buffer_ids {
@@ -309,12 +310,7 @@ impl ContextData {
                 warn!("Unable to send FreeBuffer({:?}) ({:?})", buffer_id, e);
             };
         }
-        let mut txn = Transaction::new();
-        txn.delete_image(self.image_key);
-        webrender_api
-            .lock()
-            .unwrap()
-            .send_transaction(webrender_document, txn);
+        compositor_api.update_images(vec![ImageUpdate::DeleteImage(self.image_key)]);
     }
 
     /// Returns true if presentation id was updated (was newer)
@@ -344,17 +340,11 @@ impl crate::WGPU {
         buffer_ids: ArrayVec<id::BufferId, PRESENTATION_BUFFER_COUNT>,
     ) {
         let context_data = ContextData::new(context_id, image_key, size, buffer_ids);
-        let mut txn = Transaction::new();
-        txn.add_image(
+        self.compositor_api.add_image(
             image_key,
             context_data.image_desc.0,
-            context_data.image_data.clone(),
-            None,
+            SerializableImageData::External(context_data.image_data),
         );
-        self.webrender_api
-            .lock()
-            .unwrap()
-            .send_transaction(self.webrender_document, txn);
         assert!(
             self.wgpu_image_map
                 .lock()
@@ -431,17 +421,12 @@ impl crate::WGPU {
         };
 
         if needs_image_update {
-            let mut txn = Transaction::new();
-            txn.update_image(
-                context_data.image_key,
-                context_data.image_desc.0,
-                context_data.image_data.clone(),
-                &DirtyRect::All,
-            );
-            self.webrender_api
-                .lock()
-                .unwrap()
-                .send_transaction(self.webrender_document, txn);
+            self.compositor_api
+                .update_images(vec![ImageUpdate::UpdateImage(
+                    context_data.image_key,
+                    context_data.image_desc.0,
+                    SerializableImageData::External(context_data.image_data),
+                )]);
         }
     }
 
@@ -521,8 +506,7 @@ impl crate::WGPU {
         let callback = {
             let global = Arc::clone(&self.global);
             let wgpu_image_map = Arc::clone(&self.wgpu_image_map);
-            let webrender_api = Arc::clone(&self.webrender_api);
-            let webrender_document = self.webrender_document;
+            let compositor_api = self.compositor_api.clone();
             let token = self.poller.token();
             Box::new(move |result| {
                 drop(token);
@@ -532,8 +516,7 @@ impl crate::WGPU {
                     buffer_id,
                     wgpu_image_map,
                     context_id,
-                    webrender_api,
-                    webrender_document,
+                    compositor_api,
                     image_desc,
                     presentation_id,
                 );
@@ -554,12 +537,7 @@ impl crate::WGPU {
             .unwrap()
             .remove(&context_id)
             .unwrap()
-            .destroy(
-                &self.global,
-                &self.script_sender,
-                &self.webrender_api,
-                self.webrender_document,
-            );
+            .destroy(&self.global, &self.script_sender, &self.compositor_api);
     }
 }
 
@@ -570,8 +548,7 @@ fn update_wr_image(
     buffer_id: id::BufferId,
     wgpu_image_map: WGPUImageMap,
     context_id: WebGPUContextId,
-    webrender_api: Arc<Mutex<RenderApi>>,
-    webrender_document: webrender_api::DocumentId,
+    compositor_api: CrossProcessCompositorApi,
     image_desc: WebGPUImageDescriptor,
     presentation_id: PresentationId,
 ) {
@@ -597,17 +574,11 @@ fn update_wr_image(
                     return;
                 };
                 let old_presentation_buffer = swap_chain.data.replace(presentation_buffer);
-                let mut txn = Transaction::new();
-                txn.update_image(
+                compositor_api.update_images(vec![ImageUpdate::UpdateImage(
                     context_data.image_key,
                     context_data.image_desc.0,
-                    context_data.image_data.clone(),
-                    &DirtyRect::All,
-                );
-                webrender_api
-                    .lock()
-                    .unwrap()
-                    .send_transaction(webrender_document, txn);
+                    SerializableImageData::External(context_data.image_data),
+                )]);
                 if let Some(old_presentation_buffer) = old_presentation_buffer {
                     context_data.unmap_old_buffer(old_presentation_buffer)
                 }


### PR DESCRIPTION
webgpu currently sends updates WebRender directly via WebRender API (same as webgl that I also plan to reform). 2D canvas uses Compositor API for that and with this PR so does webgpu. This will be helpful for #35733, where compositor must know state of image updates.

Testing: WebGPU CTS run: https://github.com/sagudev/servo/actions/runs/15895299748
