### PR TITLE
webgl: Replace webrender API with compositor API for images handling

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -405,8 +405,8 @@ impl Servo {
             image_handler,
         } = WebGLComm::new(
             rendering_context.clone(),
+            compositor_proxy.cross_process_compositor_api.clone(),
             webrender_api.create_sender(),
-            webrender_document,
             external_images.clone(),
             gl_type,
         );

--- a/components/webgl/webgl_mode/inprocess.rs
+++ b/components/webgl/webgl_mode/inprocess.rs
@@ -9,7 +9,8 @@ use std::sync::{Arc, Mutex};
 use canvas_traits::webgl::{GlType, WebGLContextId, WebGLMsg, WebGLThreads, webgl_channel};
 use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::{
-    WebrenderExternalImageApi, WebrenderExternalImageRegistry, WebrenderImageSource,
+    CrossProcessCompositorApi, WebrenderExternalImageApi, WebrenderExternalImageRegistry,
+    WebrenderImageSource,
 };
 use euclid::default::Size2D;
 use fnv::FnvHashMap;
@@ -17,7 +18,6 @@ use log::debug;
 use surfman::chains::{SwapChainAPI, SwapChains, SwapChainsAPI};
 use surfman::{Device, SurfaceTexture};
 use webrender::RenderApiSender;
-use webrender_api::DocumentId;
 #[cfg(feature = "webxr")]
 use webxr::SurfmanGL as WebXRSurfman;
 #[cfg(feature = "webxr")]
@@ -36,8 +36,8 @@ impl WebGLComm {
     /// Creates a new `WebGLComm` object.
     pub fn new(
         rendering_context: Rc<dyn RenderingContext>,
+        compositor_api: CrossProcessCompositorApi,
         webrender_api_sender: RenderApiSender,
-        webrender_doc: DocumentId,
         external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
         api_type: GlType,
     ) -> WebGLComm {
@@ -57,8 +57,8 @@ impl WebGLComm {
 
         // This implementation creates a single `WebGLThread` for all the pipelines.
         let init = WebGLThreadInit {
+            compositor_api,
             webrender_api_sender,
-            webrender_doc,
             external_images,
             sender: sender.clone(),
             receiver,


### PR DESCRIPTION
Like in #37713, instead of updating images directly with webrender api we use the compositor api. We still keep webrender api available in webgl, because that's where we do shutdown, due to GL.

Testing: Existing WPT tests
