### PR TITLE
Chore: Remove unused `GetFocusTopLevelBrowsingContext` from `EmbedderToConstellationMessage`

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1277,17 +1277,6 @@ where
             EmbedderToConstellationMessage::Exit => {
                 self.handle_exit();
             },
-            EmbedderToConstellationMessage::GetFocusTopLevelBrowsingContext(resp_chan) => {
-                let focused_context = self
-                    .webviews
-                    .focused_webview()
-                    .filter(|(_, webview)| {
-                        self.browsing_contexts
-                            .contains_key(&webview.focused_browsing_context_id)
-                    })
-                    .map(|(id, _)| id);
-                let _ = resp_chan.send(focused_context);
-            },
             // Perform a navigation previously requested by script, if approved by the embedder.
             // If there is already a pending page (self.pending_changes), it will not be overridden;
             // However, if the id is not encompassed by another change, it will be.

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -50,9 +50,6 @@ mod from_compositor {
         fn log_target(&self) -> &'static str {
             match self {
                 Self::Exit => target!("Exit"),
-                Self::GetFocusTopLevelBrowsingContext(..) => {
-                    target!("GetFocusTopLevelBrowsingContext")
-                },
                 Self::IsReadyToSaveImage(..) => target!("IsReadyToSaveImage"),
                 Self::AllowNavigationResponse(..) => target!("AllowNavigationResponse"),
                 Self::LoadUrl(..) => target!("LoadUrl"),

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -39,9 +39,6 @@ use webrender_api::units::LayoutVector2D;
 pub enum EmbedderToConstellationMessage {
     /// Exit the constellation.
     Exit,
-    /// Request that the constellation send the current focused top-level browsing context id,
-    /// over a provided channel.
-    GetFocusTopLevelBrowsingContext(IpcSender<Option<WebViewId>>),
     /// Query the constellation to see if the current compositor output is stable
     IsReadyToSaveImage(HashMap<PipelineId, Epoch>),
     /// Whether to allow script to navigate.


### PR DESCRIPTION
This is a legacy message used only by WebDriver to focus the webview, when session just created. Right now this is just dead_code which is not detected by Lint.

Testing: No behaviour change.