### PR TITLE
Clean up unused dependencies / features and centralize more feature selection into root `Cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7594,7 +7594,6 @@ dependencies = [
  "stylo_dom",
  "stylo_malloc_size_of",
  "taffy",
- "thin-vec",
  "tokio",
  "unicode-bidi",
  "unicode-script",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ http = "1.3"
 http-body-util = "0.1"
 hyper = "1.6"
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "logging", "tls12", "webpki-tokio"] }
-hyper-util = { version = "0.1", features = ["client", "client-legacy", "http2", "tokio"] }
+hyper-util = { version = "0.1", features = ["client", "http2", "tokio"] }
 hyper_serde = { path = "components/hyper_serde" }
 icu_locid = "1.5.0"
 icu_segmenter = "1.5.0"
@@ -130,7 +130,7 @@ servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
 servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-06-03" }
 smallbitvec = "2.6.0"
-smallvec = "1.15"
+smallvec = { version = "1.15", features = ["union"] }
 static_assertions = "1.1"
 string_cache = "0.8"
 string_cache_codegen = "0.5"
@@ -146,7 +146,6 @@ surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4b
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 taffy = { version = "0.8.3", default-features = false, features = ["detailed_layout_info", "grid", "serde", "std"] }
-thin-vec = "0.2.14"
 tikv-jemalloc-sys = "0.6.0"
 tikv-jemallocator = "0.6.0"
 time = { package = "time", version = "0.3", features = ["large-dates", "local-offset", "serde"] }

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -45,7 +45,7 @@ serde = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { path = "../config" }
 servo_url = { path = "../url" }
-smallvec = { workspace = true, features = ["union"] }
+smallvec = { workspace = true }
 stylo = { workspace = true }
 stylo_atoms = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -32,7 +32,6 @@ stylo = { workspace = true }
 stylo_dom = { workspace = true }
 stylo_malloc_size_of = { workspace = true }
 taffy = { workspace = true }
-thin-vec = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 unicode-bidi = { workspace = true }
 unicode-script = { workspace = true }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -352,31 +352,6 @@ where
     }
 }
 
-impl<T> MallocShallowSizeOf for thin_vec::ThinVec<T> {
-    fn shallow_size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        if self.capacity() == 0 {
-            // If it's the singleton we might not be a heap pointer.
-            return 0;
-        }
-
-        assert_eq!(
-            std::mem::size_of::<Self>(),
-            std::mem::size_of::<*const ()>()
-        );
-        unsafe { ops.malloc_size_of(*(self as *const Self as *const *const ())) }
-    }
-}
-
-impl<T: MallocSizeOf> MallocSizeOf for thin_vec::ThinVec<T> {
-    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        let mut n = self.shallow_size_of(ops);
-        for elem in self.iter() {
-            n += elem.size_of(ops);
-        }
-        n
-    }
-}
-
 impl<T: MallocSizeOf> MallocSizeOf for BinaryHeap<T> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.iter().map(|element| element.size_of(ops)).sum()

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -114,7 +114,7 @@ servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
 servo_rand = { path = "../rand" }
 servo_url = { path = "../url" }
-smallvec = { workspace = true, features = ["union"] }
+smallvec = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 stylo = { workspace = true }


### PR DESCRIPTION
- Make feature flag of smallvec global.
- Removed unused dependency of thinvec.
- Removed unused flag of hyper-util.

Reduces the binary size by an astonishing 3.352k.

Testing: Compilation 'tests' this change.
