### PR TITLE
Fix scrollWidthHeight-negative-margin-002.html

### DIFF
--- a/tests/wpt/meta/css/cssom-view/scrollWidthHeight-negative-margin-002.html.ini
+++ b/tests/wpt/meta/css/cssom-view/scrollWidthHeight-negative-margin-002.html.ini
@@ -1,217 +1,30 @@
 [scrollWidthHeight-negative-margin-002.html]
-  expected: ERROR
-  [scrollWidth with negative margins: display: block; overflow: visible;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: visible;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: hidden;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: hidden;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: auto;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: auto;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: scroll;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: scroll;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: visible; direction: ltr;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: visible; direction: ltr;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: hidden; direction: ltr;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: hidden; direction: ltr;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: auto; direction: ltr;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: auto; direction: ltr;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: scroll; direction: ltr;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: scroll; direction: ltr;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: visible; direction: rtl;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: visible; direction: rtl;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: hidden; direction: rtl;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: hidden; direction: rtl;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: auto; direction: rtl;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: auto; direction: rtl;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: scroll; direction: rtl;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: scroll; direction: rtl;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: visible; direction: ltr; flex-direction: row;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: visible; direction: ltr; flex-direction: row;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: hidden; direction: ltr; flex-direction: row;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: hidden; direction: ltr; flex-direction: row;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: auto; direction: ltr; flex-direction: row;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: auto; direction: ltr; flex-direction: row;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: scroll; direction: ltr; flex-direction: row;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: scroll; direction: ltr; flex-direction: row;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: visible; direction: rtl; flex-direction: row;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: visible; direction: rtl; flex-direction: row;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: hidden; direction: rtl; flex-direction: row;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: hidden; direction: rtl; flex-direction: row;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: auto; direction: rtl; flex-direction: row;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: auto; direction: rtl; flex-direction: row;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: block; overflow: scroll; direction: rtl; flex-direction: row;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: block; overflow: scroll; direction: rtl; flex-direction: row;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: flex; overflow: visible; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: visible; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: hidden; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: hidden; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: auto; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: auto; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: scroll; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: scroll; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: visible; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: visible; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: hidden; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: hidden; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: auto; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: auto; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: scroll; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: scroll; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: visible; direction: ltr; flex-flow: wrap-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollHeight with negative margins: display: flex; overflow: visible; direction: ltr; flex-flow: wrap-reverse;]
     expected: FAIL
-
-  [scrollWidth with negative margins: display: flex; overflow: hidden; direction: ltr; flex-flow: wrap-reverse;]
-    expected: [FAIL, PASS]
 
   [scrollHeight with negative margins: display: flex; overflow: hidden; direction: ltr; flex-flow: wrap-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: flex; overflow: auto; direction: ltr; flex-flow: wrap-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollHeight with negative margins: display: flex; overflow: auto; direction: ltr; flex-flow: wrap-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: flex; overflow: scroll; direction: ltr; flex-flow: wrap-reverse;]
-    expected: [FAIL, PASS]
+  [scrollHeight with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: wrap-reverse;]
+    expected: FAIL
 
   [scrollHeight with negative margins: display: flex; overflow: scroll; direction: ltr; flex-flow: wrap-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: flex; overflow: visible; direction: rtl; flex-flow: wrap-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollHeight with negative margins: display: flex; overflow: visible; direction: rtl; flex-flow: wrap-reverse;]
     expected: FAIL
-
-  [scrollWidth with negative margins: display: flex; overflow: hidden; direction: rtl; flex-flow: wrap-reverse;]
-    expected: [FAIL, PASS]
 
   [scrollHeight with negative margins: display: flex; overflow: hidden; direction: rtl; flex-flow: wrap-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: flex; overflow: auto; direction: rtl; flex-flow: wrap-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollHeight with negative margins: display: flex; overflow: auto; direction: rtl; flex-flow: wrap-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: flex; overflow: scroll; direction: rtl; flex-flow: wrap-reverse;]
-    expected: [FAIL, PASS]
+  [scrollHeight with negative margins: display: flex; overflow: clip; direction: rtl; flex-flow: wrap-reverse;]
+    expected: FAIL
 
   [scrollHeight with negative margins: display: flex; overflow: scroll; direction: rtl; flex-flow: wrap-reverse;]
     expected: FAIL
@@ -219,50 +32,32 @@
   [scrollWidth with negative margins: display: flex; overflow: visible; direction: ltr; flex-direction: row-reverse;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: flex; overflow: visible; direction: ltr; flex-direction: row-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollWidth with negative margins: display: flex; overflow: hidden; direction: ltr; flex-direction: row-reverse;]
     expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: hidden; direction: ltr; flex-direction: row-reverse;]
-    expected: [FAIL, PASS]
 
   [scrollWidth with negative margins: display: flex; overflow: auto; direction: ltr; flex-direction: row-reverse;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: flex; overflow: auto; direction: ltr; flex-direction: row-reverse;]
-    expected: [FAIL, PASS]
+  [scrollWidth with negative margins: display: flex; overflow: clip; direction: ltr; flex-direction: row-reverse;]
+    expected: FAIL
 
   [scrollWidth with negative margins: display: flex; overflow: scroll; direction: ltr; flex-direction: row-reverse;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: flex; overflow: scroll; direction: ltr; flex-direction: row-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollWidth with negative margins: display: flex; overflow: visible; direction: rtl; flex-direction: row-reverse;]
     expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: visible; direction: rtl; flex-direction: row-reverse;]
-    expected: [FAIL, PASS]
 
   [scrollWidth with negative margins: display: flex; overflow: hidden; direction: rtl; flex-direction: row-reverse;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: flex; overflow: hidden; direction: rtl; flex-direction: row-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollWidth with negative margins: display: flex; overflow: auto; direction: rtl; flex-direction: row-reverse;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: flex; overflow: auto; direction: rtl; flex-direction: row-reverse;]
-    expected: [FAIL, PASS]
+  [scrollWidth with negative margins: display: flex; overflow: clip; direction: rtl; flex-direction: row-reverse;]
+    expected: FAIL
 
   [scrollWidth with negative margins: display: flex; overflow: scroll; direction: rtl; flex-direction: row-reverse;]
     expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: scroll; direction: rtl; flex-direction: row-reverse;]
-    expected: [FAIL, PASS]
 
   [scrollWidth with negative margins: display: flex; overflow: visible; direction: ltr; flex-flow: row-reverse wrap-reverse;]
     expected: FAIL
@@ -280,6 +75,12 @@
     expected: FAIL
 
   [scrollHeight with negative margins: display: flex; overflow: auto; direction: ltr; flex-flow: row-reverse wrap-reverse;]
+    expected: FAIL
+
+  [scrollWidth with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: row-reverse wrap-reverse;]
+    expected: FAIL
+
+  [scrollHeight with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: row-reverse wrap-reverse;]
     expected: FAIL
 
   [scrollWidth with negative margins: display: flex; overflow: scroll; direction: ltr; flex-flow: row-reverse wrap-reverse;]
@@ -306,152 +107,74 @@
   [scrollHeight with negative margins: display: flex; overflow: auto; direction: rtl; flex-flow: row-reverse wrap-reverse;]
     expected: FAIL
 
+  [scrollWidth with negative margins: display: flex; overflow: clip; direction: rtl; flex-flow: row-reverse wrap-reverse;]
+    expected: FAIL
+
+  [scrollHeight with negative margins: display: flex; overflow: clip; direction: rtl; flex-flow: row-reverse wrap-reverse;]
+    expected: FAIL
+
   [scrollWidth with negative margins: display: flex; overflow: scroll; direction: rtl; flex-flow: row-reverse wrap-reverse;]
     expected: FAIL
 
   [scrollHeight with negative margins: display: flex; overflow: scroll; direction: rtl; flex-flow: row-reverse wrap-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: flex; overflow: visible; direction: ltr; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: visible; direction: ltr; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: hidden; direction: ltr; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: hidden; direction: ltr; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: auto; direction: ltr; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: auto; direction: ltr; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: scroll; direction: ltr; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: scroll; direction: ltr; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: visible; direction: rtl; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: visible; direction: rtl; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: hidden; direction: rtl; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: hidden; direction: rtl; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: auto; direction: rtl; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: auto; direction: rtl; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: scroll; direction: rtl; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: scroll; direction: rtl; flex-direction: column;]
-    expected: [FAIL, PASS]
-
   [scrollWidth with negative margins: display: flex; overflow: visible; direction: ltr; flex-flow: column wrap-reverse;]
     expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: visible; direction: ltr; flex-flow: column wrap-reverse;]
-    expected: [FAIL, PASS]
 
   [scrollWidth with negative margins: display: flex; overflow: hidden; direction: ltr; flex-flow: column wrap-reverse;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: flex; overflow: hidden; direction: ltr; flex-flow: column wrap-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollWidth with negative margins: display: flex; overflow: auto; direction: ltr; flex-flow: column wrap-reverse;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: flex; overflow: auto; direction: ltr; flex-flow: column wrap-reverse;]
-    expected: [FAIL, PASS]
+  [scrollWidth with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: column wrap-reverse;]
+    expected: FAIL
 
   [scrollWidth with negative margins: display: flex; overflow: scroll; direction: ltr; flex-flow: column wrap-reverse;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: flex; overflow: scroll; direction: ltr; flex-flow: column wrap-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollWidth with negative margins: display: flex; overflow: visible; direction: rtl; flex-flow: column wrap-reverse;]
     expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: visible; direction: rtl; flex-flow: column wrap-reverse;]
-    expected: [FAIL, PASS]
 
   [scrollWidth with negative margins: display: flex; overflow: hidden; direction: rtl; flex-flow: column wrap-reverse;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: flex; overflow: hidden; direction: rtl; flex-flow: column wrap-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollWidth with negative margins: display: flex; overflow: auto; direction: rtl; flex-flow: column wrap-reverse;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: flex; overflow: auto; direction: rtl; flex-flow: column wrap-reverse;]
-    expected: [FAIL, PASS]
+  [scrollWidth with negative margins: display: flex; overflow: clip; direction: rtl; flex-flow: column wrap-reverse;]
+    expected: FAIL
 
   [scrollWidth with negative margins: display: flex; overflow: scroll; direction: rtl; flex-flow: column wrap-reverse;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: flex; overflow: scroll; direction: rtl; flex-flow: column wrap-reverse;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: visible; direction: ltr; flex-direction: column-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollHeight with negative margins: display: flex; overflow: visible; direction: ltr; flex-direction: column-reverse;]
     expected: FAIL
-
-  [scrollWidth with negative margins: display: flex; overflow: hidden; direction: ltr; flex-direction: column-reverse;]
-    expected: [FAIL, PASS]
 
   [scrollHeight with negative margins: display: flex; overflow: hidden; direction: ltr; flex-direction: column-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: flex; overflow: auto; direction: ltr; flex-direction: column-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollHeight with negative margins: display: flex; overflow: auto; direction: ltr; flex-direction: column-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: flex; overflow: scroll; direction: ltr; flex-direction: column-reverse;]
-    expected: [FAIL, PASS]
+  [scrollHeight with negative margins: display: flex; overflow: clip; direction: ltr; flex-direction: column-reverse;]
+    expected: FAIL
 
   [scrollHeight with negative margins: display: flex; overflow: scroll; direction: ltr; flex-direction: column-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: flex; overflow: visible; direction: rtl; flex-direction: column-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollHeight with negative margins: display: flex; overflow: visible; direction: rtl; flex-direction: column-reverse;]
     expected: FAIL
-
-  [scrollWidth with negative margins: display: flex; overflow: hidden; direction: rtl; flex-direction: column-reverse;]
-    expected: [FAIL, PASS]
 
   [scrollHeight with negative margins: display: flex; overflow: hidden; direction: rtl; flex-direction: column-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: flex; overflow: auto; direction: rtl; flex-direction: column-reverse;]
-    expected: [FAIL, PASS]
-
   [scrollHeight with negative margins: display: flex; overflow: auto; direction: rtl; flex-direction: column-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: flex; overflow: scroll; direction: rtl; flex-direction: column-reverse;]
-    expected: [FAIL, PASS]
+  [scrollHeight with negative margins: display: flex; overflow: clip; direction: rtl; flex-direction: column-reverse;]
+    expected: FAIL
 
   [scrollHeight with negative margins: display: flex; overflow: scroll; direction: rtl; flex-direction: column-reverse;]
     expected: FAIL
@@ -472,6 +195,12 @@
     expected: FAIL
 
   [scrollHeight with negative margins: display: flex; overflow: auto; direction: ltr; flex-flow: column-reverse wrap-reverse;]
+    expected: FAIL
+
+  [scrollWidth with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: column-reverse wrap-reverse;]
+    expected: FAIL
+
+  [scrollHeight with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: column-reverse wrap-reverse;]
     expected: FAIL
 
   [scrollWidth with negative margins: display: flex; overflow: scroll; direction: ltr; flex-flow: column-reverse wrap-reverse;]
@@ -498,194 +227,29 @@
   [scrollHeight with negative margins: display: flex; overflow: auto; direction: rtl; flex-flow: column-reverse wrap-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: flex; overflow: scroll; direction: rtl; flex-flow: column-reverse wrap-reverse;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: scroll; direction: rtl; flex-flow: column-reverse wrap-reverse;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: flow-root; overflow: visible; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flow-root; overflow: hidden; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flow-root; overflow: auto; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flow-root; overflow: scroll; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flow-root; overflow: visible; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flow-root; overflow: visible; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flow-root; overflow: hidden; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flow-root; overflow: hidden; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flow-root; overflow: auto; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flow-root; overflow: auto; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flow-root; overflow: scroll; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flow-root; overflow: scroll; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flow-root; overflow: clip; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flow-root; overflow: clip; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flow-root; overflow: clip; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: wrap-reverse;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: wrap-reverse;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: rtl; flex-flow: wrap-reverse;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: rtl; flex-flow: wrap-reverse;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: ltr; flex-direction: row-reverse;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: ltr; flex-direction: row-reverse;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: rtl; flex-direction: row-reverse;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: rtl; flex-direction: row-reverse;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: row-reverse wrap-reverse;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: row-reverse wrap-reverse;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: rtl; flex-flow: row-reverse wrap-reverse;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: rtl; flex-flow: row-reverse wrap-reverse;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: ltr; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: ltr; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: rtl; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: rtl; flex-direction: column;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: column wrap-reverse;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: column wrap-reverse;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: rtl; flex-flow: column wrap-reverse;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: rtl; flex-flow: column wrap-reverse;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: ltr; flex-direction: column-reverse;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: ltr; flex-direction: column-reverse;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: rtl; flex-direction: column-reverse;]
-    expected: [FAIL, PASS]
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: rtl; flex-direction: column-reverse;]
-    expected: FAIL
-
-  [scrollWidth with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: column-reverse wrap-reverse;]
-    expected: FAIL
-
-  [scrollHeight with negative margins: display: flex; overflow: clip; direction: ltr; flex-flow: column-reverse wrap-reverse;]
-    expected: FAIL
-
   [scrollWidth with negative margins: display: flex; overflow: clip; direction: rtl; flex-flow: column-reverse wrap-reverse;]
     expected: FAIL
 
   [scrollHeight with negative margins: display: flex; overflow: clip; direction: rtl; flex-flow: column-reverse wrap-reverse;]
     expected: FAIL
 
-  [scrollWidth with negative margins: display: grid; overflow: visible; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
+  [scrollWidth with negative margins: display: flex; overflow: scroll; direction: rtl; flex-flow: column-reverse wrap-reverse;]
+    expected: FAIL
 
-  [scrollWidth with negative margins: display: grid; overflow: hidden; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: grid; overflow: auto; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: grid; overflow: clip; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
-
-  [scrollWidth with negative margins: display: grid; overflow: scroll; direction: ltr; flex-direction: row;]
-    expected: [FAIL, PASS]
+  [scrollHeight with negative margins: display: flex; overflow: scroll; direction: rtl; flex-flow: column-reverse wrap-reverse;]
+    expected: FAIL
 
   [scrollWidth with negative margins: display: grid; overflow: visible; direction: rtl; flex-direction: row;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: grid; overflow: visible; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
   [scrollWidth with negative margins: display: grid; overflow: hidden; direction: rtl; flex-direction: row;]
     expected: FAIL
-
-  [scrollHeight with negative margins: display: grid; overflow: hidden; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
 
   [scrollWidth with negative margins: display: grid; overflow: auto; direction: rtl; flex-direction: row;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: grid; overflow: auto; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
   [scrollWidth with negative margins: display: grid; overflow: clip; direction: rtl; flex-direction: row;]
     expected: FAIL
 
-  [scrollHeight with negative margins: display: grid; overflow: clip; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]
-
   [scrollWidth with negative margins: display: grid; overflow: scroll; direction: rtl; flex-direction: row;]
     expected: FAIL
-
-  [scrollHeight with negative margins: display: grid; overflow: scroll; direction: rtl; flex-direction: row;]
-    expected: [FAIL, PASS]

--- a/tests/wpt/tests/css/cssom-view/scrollWidthHeight-negative-margin-002.html
+++ b/tests/wpt/tests/css/cssom-view/scrollWidthHeight-negative-margin-002.html
@@ -39,6 +39,10 @@ const paddingBox = {
   width: contentBox.width + 4 + 16,
   height: contentBox.height + 1 + 8,
 };
+function* writingModes() {
+  yield "horizontal-tb";
+  yield* ["vertical-lr", "vertical-rl"].filter(writingMode => CSS.supports("writing-mode", writingMode));
+}
 for (let display of ["flow-root", "flex", "grid"]) {
   for (let flexDirection of ["row", "row-reverse", "column", "column-reverse"]) {
     if (flexDirection != "row" && display != "flex") {
@@ -51,7 +55,7 @@ for (let display of ["flow-root", "flex", "grid"]) {
         continue;
       }
       for (let direction of ["ltr", "rtl"]) {
-        for (let writingMode of ["horizontal-tb", "vertical-lr", "vertical-rl"]) {
+        for (let writingMode of writingModes()) {
           for (let overflow of ["visible", "hidden", "auto", "clip", "scroll"]) {
             wrapper.style.display = display;
             wrapper.style.overflow = overflow;


### PR DESCRIPTION
Since we don't support `writing-mode` yet, we got different testcases with the same title, some passing and some failing. So we had to expect both PASS and FAIL, making the test useless to detect regressions.

This changes the test to only generate testcases for supported values of `writing-mode`.

Testing: This is just a test change.
