### PR TITLE
script: Clean up `Window::force_reflow` a little

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -617,9 +617,28 @@ impl LayoutThread {
         !self.need_new_display_list.get()
     }
 
+    fn maybe_print_reflow_event(&self, reflow_request: &ReflowRequest) {
+        if !self.debug.relayout_event {
+            return;
+        }
+
+        println!(
+            "**** Reflow({}) => {:?}, {:?}",
+            self.id,
+            reflow_request.reflow_goal,
+            reflow_request
+                .restyle
+                .as_ref()
+                .map(|restyle| restyle.reason)
+                .unwrap_or_default()
+        );
+    }
+
     /// The high-level routine that performs layout.
     #[servo_tracing::instrument(skip_all)]
     fn handle_reflow(&mut self, mut reflow_request: ReflowRequest) -> Option<ReflowResult> {
+        self.maybe_print_reflow_event(&reflow_request);
+
         if self.can_skip_reflow_request_entirely(&reflow_request) {
             if let ReflowGoal::UpdateScrollNode(external_scroll_id, offset) =
                 reflow_request.reflow_goal

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -295,9 +295,6 @@ pub struct ScriptThread {
     /// Print Progressive Web Metrics to console.
     print_pwm: bool,
 
-    /// Emits notifications when there is a relayout.
-    relayout_event: bool,
-
     /// Unminify Javascript.
     unminify_js: bool,
 
@@ -964,7 +961,6 @@ impl ScriptThread {
             compositor_api: state.compositor_api,
             profile_script_events: opts.debug.profile_script_events,
             print_pwm: opts.print_pwm,
-            relayout_event: opts.debug.relayout_event,
             unminify_js: opts.unminify_js,
             local_script_source: opts.local_script_source.clone(),
             unminify_css: opts.unminify_css,
@@ -3401,7 +3397,6 @@ impl ScriptThread {
             self.webxr_registry.clone(),
             self.microtask_queue.clone(),
             self.compositor_api.clone(),
-            self.relayout_event,
             self.unminify_js,
             self.unminify_css,
             self.local_script_source.clone(),

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -360,7 +360,7 @@ pub type IFrameSizes = FnvHashMap<BrowsingContextId, IFrameSize>;
 bitflags! {
     /// Conditions which cause a [`Document`] to need to be restyled during reflow, which
     /// might cause the rest of layout to happen as well.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
     pub struct RestyleReason: u16 {
         const StylesheetsChanged = 1 << 0;
         const DOMChanged = 1 << 1;


### PR DESCRIPTION
 - Move some of the image handling code to a separate function.
 - Move reflow event debugging into layout itself and use the `Debug`
   implementation to print the event.
 - A few other small cleanups

Testing: This should not change behavior and is thus covered by existing WPT
tests.
