### PR TITLE
layout: Only create a `LayoutContext` if restyling

### DIFF
--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -4,7 +4,6 @@
 
 use std::sync::Arc;
 
-use base::id::PipelineId;
 use euclid::Size2D;
 use fnv::FnvHashMap;
 use fonts::FontContext;
@@ -26,10 +25,8 @@ use webrender_api::units::{DeviceIntSize, DeviceSize};
 
 pub(crate) type CachedImageOrError = Result<CachedImage, ResolveImageError>;
 
-pub struct LayoutContext<'a> {
-    pub id: PipelineId,
+pub(crate) struct LayoutContext<'a> {
     pub use_rayon: bool,
-    pub origin: ImmutableOrigin,
 
     /// Bits shared by the layout and style system.
     pub style_context: SharedStyleContext<'a>,
@@ -37,31 +34,12 @@ pub struct LayoutContext<'a> {
     /// A FontContext to be used during layout.
     pub font_context: Arc<FontContext>,
 
-    /// Reference to the script thread image cache.
-    pub image_cache: Arc<dyn ImageCache>,
-
-    /// A list of in-progress image loads to be shared with the script thread.
-    pub pending_images: Mutex<Vec<PendingImage>>,
-
-    /// A list of fully loaded vector images that need to be rasterized to a specific
-    /// size determined by layout. This will be shared with the script thread.
-    pub pending_rasterization_images: Mutex<Vec<PendingRasterizationImage>>,
-
     /// A collection of `<iframe>` sizes to send back to script.
     pub iframe_sizes: Mutex<IFrameSizes>,
 
-    // A cache that maps image resources used in CSS (e.g as the `url()` value
-    // for `background-image` or `content` property) to the final resolved image data.
-    pub resolved_images_cache:
-        Arc<RwLock<FnvHashMap<(ServoUrl, UsePlaceholder), CachedImageOrError>>>,
-
-    /// A shared reference to script's map of DOM nodes with animated images. This is used
-    /// to manage image animations in script and inform the script about newly animating
-    /// nodes.
-    pub node_to_animating_image_map: Arc<RwLock<FxHashMap<OpaqueNode, ImageAnimationState>>>,
-
-    /// The DOM node that is highlighted by the devtools inspector, if any
-    pub highlighted_dom_node: Option<OpaqueNode>,
+    /// An [`ImageResolver`] used for resolving images during box and fragment
+    /// tree construction. Later passed to display list construction.
+    pub image_resolver: Arc<ImageResolver>,
 }
 
 pub enum ResolvedImage<'a> {
@@ -72,15 +50,6 @@ pub enum ResolvedImage<'a> {
         image: CachedImage,
         size: DeviceSize,
     },
-}
-
-impl Drop for LayoutContext<'_> {
-    fn drop(&mut self) {
-        if !std::thread::panicking() {
-            assert!(self.pending_images.lock().is_empty());
-            assert!(self.pending_rasterization_images.lock().is_empty());
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -103,12 +72,44 @@ pub(crate) enum LayoutImageCacheResult {
     LoadError,
 }
 
-impl LayoutContext<'_> {
-    #[inline(always)]
-    pub fn shared_context(&self) -> &SharedStyleContext {
-        &self.style_context
-    }
+pub(crate) struct ImageResolver {
+    /// The origin of the `Document` that this [`ImageResolver`] resolves images for.
+    pub origin: ImmutableOrigin,
 
+    /// Reference to the script thread image cache.
+    pub image_cache: Arc<dyn ImageCache>,
+
+    /// A list of in-progress image loads to be shared with the script thread.
+    pub pending_images: Mutex<Vec<PendingImage>>,
+
+    /// A list of fully loaded vector images that need to be rasterized to a specific
+    /// size determined by layout. This will be shared with the script thread.
+    pub pending_rasterization_images: Mutex<Vec<PendingRasterizationImage>>,
+
+    /// A shared reference to script's map of DOM nodes with animated images. This is used
+    /// to manage image animations in script and inform the script about newly animating
+    /// nodes.
+    pub node_to_animating_image_map: Arc<RwLock<FxHashMap<OpaqueNode, ImageAnimationState>>>,
+
+    // A cache that maps image resources used in CSS (e.g as the `url()` value
+    // for `background-image` or `content` property) to the final resolved image data.
+    pub resolved_images_cache:
+        Arc<RwLock<FnvHashMap<(ServoUrl, UsePlaceholder), CachedImageOrError>>>,
+
+    /// The current animation timeline value used to properly initialize animating images.
+    pub animation_timeline_value: f64,
+}
+
+impl Drop for ImageResolver {
+    fn drop(&mut self) {
+        if !std::thread::panicking() {
+            assert!(self.pending_images.lock().is_empty());
+            assert!(self.pending_rasterization_images.lock().is_empty());
+        }
+    }
+}
+
+impl ImageResolver {
     pub(crate) fn get_or_request_image_or_meta(
         &self,
         node: OpaqueNode,
@@ -155,18 +156,14 @@ impl LayoutContext<'_> {
         }
     }
 
-    pub fn handle_animated_image(&self, node: OpaqueNode, image: Arc<RasterImage>) {
+    pub(crate) fn handle_animated_image(&self, node: OpaqueNode, image: Arc<RasterImage>) {
         let mut map = self.node_to_animating_image_map.write();
         if !image.should_animate() {
             map.remove(&node);
             return;
         }
-        let new_image_animation_state = || {
-            ImageAnimationState::new(
-                image.clone(),
-                self.shared_context().current_time_for_animations,
-            )
-        };
+        let new_image_animation_state =
+            || ImageAnimationState::new(image.clone(), self.animation_timeline_value);
 
         let entry = map.entry(node).or_insert_with(new_image_animation_state);
 
@@ -218,7 +215,7 @@ impl LayoutContext<'_> {
         }
     }
 
-    pub fn rasterize_vector_image(
+    pub(crate) fn rasterize_vector_image(
         &self,
         image_id: PendingImageId,
         size: DeviceIntSize,
@@ -237,7 +234,7 @@ impl LayoutContext<'_> {
         result
     }
 
-    pub fn resolve_image<'a>(
+    pub(crate) fn resolve_image<'a>(
         &self,
         node: Option<OpaqueNode>,
         image: &'a Image,

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -71,7 +71,7 @@ impl<'dom> NodeAndStyleInfo<'dom> {
             .to_threadsafe()
             .as_element()?
             .with_pseudo(pseudo_element_type)?
-            .style(context.shared_context());
+            .style(&context.style_context);
         Some(NodeAndStyleInfo {
             node: self.node,
             pseudo_element_type: Some(pseudo_element_type),
@@ -200,10 +200,8 @@ fn traverse_children_of<'dom>(
     traverse_eager_pseudo_element(PseudoElement::Before, parent_element, context, handler);
 
     if parent_element.is_text_input() {
-        let info = NodeAndStyleInfo::new(
-            parent_element,
-            parent_element.style(context.shared_context()),
-        );
+        let info =
+            NodeAndStyleInfo::new(parent_element, parent_element.style(&context.style_context));
         let node_text_content = parent_element.to_threadsafe().node_text_content();
         if node_text_content.is_empty() {
             // The addition of zero-width space here forces the text input to have an inline formatting
@@ -220,7 +218,7 @@ fn traverse_children_of<'dom>(
     } else {
         for child in iter_child_nodes(parent_element) {
             if child.is_text_node() {
-                let info = NodeAndStyleInfo::new(child, child.style(context.shared_context()));
+                let info = NodeAndStyleInfo::new(child, child.style(&context.style_context));
                 handler.handle_text(&info, child.to_threadsafe().node_text_content());
             } else if child.is_element() {
                 traverse_element(child, context, handler);
@@ -241,7 +239,7 @@ fn traverse_element<'dom>(
     element.unset_pseudo_element_box(PseudoElement::Marker);
 
     let replaced = ReplacedContents::for_element(element, context);
-    let style = element.style(context.shared_context());
+    let style = element.style(&context.style_context);
     match Display::from(style.get_box().display) {
         Display::None => element.unset_all_boxes(),
         Display::Contents => {
@@ -300,7 +298,7 @@ fn traverse_eager_pseudo_element<'dom>(
         return;
     };
 
-    let style = pseudo_element.style(context.shared_context());
+    let style = pseudo_element.style(&context.style_context);
     if style.ineffective_content_property() {
         return;
     }

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -111,10 +111,10 @@ impl IndependentFormattingContext {
                     },
                     DisplayInside::Table => {
                         let table_grid_style = context
-                            .shared_context()
+                            .style_context
                             .stylist
                             .style_for_anonymous::<ServoLayoutElement>(
-                                &context.shared_context().guards,
+                                &context.style_context.guards,
                                 &PseudoElement::ServoTableGrid,
                                 &node_and_style_info.style,
                             );

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -59,6 +59,7 @@ impl FragmentTree {
         let mut animations = layout_context.style_context.animations.sets.write();
         let mut invalid_animating_nodes: FxHashSet<_> = animations.keys().cloned().collect();
         let mut image_animations = layout_context
+            .image_resolver
             .node_to_animating_image_map
             .write()
             .to_owned();

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -20,11 +20,11 @@ pub struct RecalcStyle<'a> {
 }
 
 impl<'a> RecalcStyle<'a> {
-    pub fn new(context: &'a LayoutContext<'a>) -> Self {
+    pub(crate) fn new(context: &'a LayoutContext<'a>) -> Self {
         RecalcStyle { context }
     }
 
-    pub fn context(&self) -> &LayoutContext<'a> {
+    pub(crate) fn context(&self) -> &LayoutContext<'a> {
         self.context
     }
 }


### PR DESCRIPTION
The creation of `LayoutContext` does more work than necessary if layout
just needs to do something like make a display list and not restyle and
relayout. This change makes it so that these kind of non-restyle layouts
do not need to create a display list. In addition, the creation of
`LayoutContext` is better encapsulate

Testing: This should not change observable behavior and is thus covered
by existing WPT tests.
