### PR TITLE
deps: Bump `html5ever` and friends to version `0.35.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3727,12 +3727,11 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d485f1d312f0938f1d8c175a115a1e9f357f8b63262a043b66ce11e1e48128b"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
 dependencies = [
  "log",
- "mac",
  "markup5ever",
  "match_token",
 ]
@@ -5025,9 +5024,9 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.16.2"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4cd8c02f18a011991a039855480c64d74291c5792fcc160d55d77dc4de4a39"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
 dependencies = [
  "log",
  "tendril",
@@ -5036,9 +5035,9 @@ dependencies = [
 
 [[package]]
 name = "match_token"
-version = "0.2.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c8968ae498413293a741c58ef9dc583a4d77a3d7eae7f80eedfe3acf667e7f"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10330,12 +10329,11 @@ checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "xml5ever"
-version = "0.22.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a91563ba5a5ab749488164063f1317e327ca1daa80f00e5bd1e670ad0d78154"
+checksum = "ee3f1e41afb31a75aef076563b0ad3ecc24f5bd9d12a72b132222664eb76b494"
 dependencies = [
  "log",
- "mac",
  "markup5ever",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ gstreamer-video = "0.23"
 harfbuzz-sys = "0.6.1"
 headers = "0.4"
 hitrace = "0.1.5"
-html5ever = "0.33"
+html5ever = "0.35"
 http = "1.3"
 http-body-util = "0.1"
 hyper = "1.6"
@@ -92,7 +92,7 @@ log = "0.4"
 mach2 = "0.4"
 malloc_size_of = { package = "servo_malloc_size_of", path = "components/malloc_size_of" }
 malloc_size_of_derive = "0.1"
-markup5ever = "0.16.2"
+markup5ever = "0.35"
 memmap2 = "0.9.5"
 mime = "0.3.13"
 mime_guess = "2.0.5"
@@ -177,7 +177,7 @@ windows-sys = "0.59"
 wio = "0.2"
 wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.67" }
 xi-unicode = "0.3.0"
-xml5ever = "0.22"
+xml5ever = "0.35"
 
 [profile.release]
 opt-level = 3

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -67,7 +67,6 @@ impl Tokenizer {
         };
 
         let options = TreeBuilderOpts {
-            ignore_missing_rules: true,
             scripting_enabled: document.scripting_enabled(),
             iframe_srcdoc: document.url().as_str() == "about:srcdoc",
             quirks_mode,


### PR DESCRIPTION
Companion PR for https://github.com/servo/html5ever/pull/637.

Testing: Covered by existing web platform tests
