### PR TITLE
[WebDriver] Reuse "Find Elements" handler in "Find element"

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2247,33 +2247,6 @@ impl ScriptThread {
             WebDriverScriptCommand::DeleteCookie(name, reply) => {
                 webdriver_handlers::handle_delete_cookie(&documents, pipeline_id, name, reply)
             },
-            WebDriverScriptCommand::FindElementCSSSelector(selector, reply) => {
-                webdriver_handlers::handle_find_element_css_selector(
-                    &documents,
-                    pipeline_id,
-                    selector,
-                    reply,
-                )
-            },
-            WebDriverScriptCommand::FindElementLinkText(selector, partial, reply) => {
-                webdriver_handlers::handle_find_element_link_text(
-                    &documents,
-                    pipeline_id,
-                    selector,
-                    partial,
-                    reply,
-                    can_gc,
-                )
-            },
-            WebDriverScriptCommand::FindElementTagName(selector, reply) => {
-                webdriver_handlers::handle_find_element_tag_name(
-                    &documents,
-                    pipeline_id,
-                    selector,
-                    reply,
-                    can_gc,
-                )
-            },
             WebDriverScriptCommand::FindElementsCSSSelector(selector, reply) => {
                 webdriver_handlers::handle_find_elements_css_selector(
                     &documents,
@@ -2296,39 +2269,6 @@ impl ScriptThread {
                 webdriver_handlers::handle_find_elements_tag_name(
                     &documents,
                     pipeline_id,
-                    selector,
-                    reply,
-                    can_gc,
-                )
-            },
-            WebDriverScriptCommand::FindElementElementCSSSelector(selector, element_id, reply) => {
-                webdriver_handlers::handle_find_element_element_css_selector(
-                    &documents,
-                    pipeline_id,
-                    element_id,
-                    selector,
-                    reply,
-                )
-            },
-            WebDriverScriptCommand::FindElementElementLinkText(
-                selector,
-                element_id,
-                partial,
-                reply,
-            ) => webdriver_handlers::handle_find_element_element_link_text(
-                &documents,
-                pipeline_id,
-                element_id,
-                selector,
-                partial,
-                reply,
-                can_gc,
-            ),
-            WebDriverScriptCommand::FindElementElementTagName(selector, element_id, reply) => {
-                webdriver_handlers::handle_find_element_element_tag_name(
-                    &documents,
-                    pipeline_id,
-                    element_id,
                     selector,
                     reply,
                     can_gc,

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -131,28 +131,9 @@ pub enum WebDriverScriptCommand {
     DeleteCookie(String, IpcSender<Result<(), ErrorStatus>>),
     ExecuteScript(String, IpcSender<WebDriverJSResult>),
     ExecuteAsyncScript(String, IpcSender<WebDriverJSResult>),
-    FindElementCSSSelector(String, IpcSender<Result<Option<String>, ErrorStatus>>),
-    FindElementLinkText(String, bool, IpcSender<Result<Option<String>, ErrorStatus>>),
-    FindElementTagName(String, IpcSender<Result<Option<String>, ErrorStatus>>),
     FindElementsCSSSelector(String, IpcSender<Result<Vec<String>, ErrorStatus>>),
     FindElementsLinkText(String, bool, IpcSender<Result<Vec<String>, ErrorStatus>>),
     FindElementsTagName(String, IpcSender<Result<Vec<String>, ErrorStatus>>),
-    FindElementElementCSSSelector(
-        String,
-        String,
-        IpcSender<Result<Option<String>, ErrorStatus>>,
-    ),
-    FindElementElementLinkText(
-        String,
-        String,
-        bool,
-        IpcSender<Result<Option<String>, ErrorStatus>>,
-    ),
-    FindElementElementTagName(
-        String,
-        String,
-        IpcSender<Result<Option<String>, ErrorStatus>>,
-    ),
     FindElementElementsCSSSelector(String, String, IpcSender<Result<Vec<String>, ErrorStatus>>),
     FindElementElementsLinkText(
         String,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2282,9 +2282,7 @@ where
         .map_err(|_| WebDriverError::new(ErrorStatus::NoSuchWindow, ""))
 }
 
-fn unwrap_first_element_response(
-    res: WebDriverResponse,
-) -> WebDriverResult<WebDriverResponse> {
+fn unwrap_first_element_response(res: WebDriverResponse) -> WebDriverResult<WebDriverResponse> {
     if let WebDriverResponse::Generic(ValueResponse(values)) = res {
         let arr = values.as_array().unwrap();
         if let Some(first) = arr.first() {
@@ -2293,9 +2291,6 @@ fn unwrap_first_element_response(
             Err(WebDriverError::new(ErrorStatus::NoSuchElement, ""))
         }
     } else {
-        Err(WebDriverError::new(
-            ErrorStatus::UnknownError,
-            "Unexpected response",
-        ))
+        unreachable!()
     }
 }

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -970,52 +970,21 @@ impl Handler {
         &self,
         parameters: &LocatorParameters,
     ) -> WebDriverResult<WebDriverResponse> {
-        // Step 4. If selector is undefined, return error with error code invalid argument.
-        if parameters.value.is_empty() {
-            return Err(WebDriverError::new(ErrorStatus::InvalidArgument, ""));
-        }
-        let (sender, receiver) = ipc::channel().unwrap();
-
-        match parameters.using {
-            LocatorStrategy::CSSSelector => {
-                let cmd = WebDriverScriptCommand::FindElementCSSSelector(
-                    parameters.value.clone(),
-                    sender,
-                );
-                self.browsing_context_script_command::<true>(cmd)?;
-            },
-            LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
-                let cmd = WebDriverScriptCommand::FindElementLinkText(
-                    parameters.value.clone(),
-                    parameters.using == LocatorStrategy::PartialLinkText,
-                    sender,
-                );
-                self.browsing_context_script_command::<true>(cmd)?;
-            },
-            LocatorStrategy::TagName => {
-                let cmd =
-                    WebDriverScriptCommand::FindElementTagName(parameters.value.clone(), sender);
-                self.browsing_context_script_command::<true>(cmd)?;
-            },
-            _ => {
-                return Err(WebDriverError::new(
-                    ErrorStatus::UnsupportedOperation,
-                    "Unsupported locator strategy",
-                ));
-            },
-        }
-
-        // Step 10. If result is empty, return error with error code no such element.
+        let res = self.handle_find_elements(parameters)?;
+        // Step 9. If result is empty, return error with error code no such element.
         // Otherwise, return the first element of result.
-        match wait_for_script_response(receiver)? {
-            Ok(value) => match value {
-                Some(value) => {
-                    let value_resp = serde_json::to_value(WebElement(value)).unwrap();
-                    Ok(WebDriverResponse::Generic(ValueResponse(value_resp)))
-                },
-                None => Err(WebDriverError::new(ErrorStatus::NoSuchElement, "")),
-            },
-            Err(error) => Err(WebDriverError::new(error, "")),
+        if let WebDriverResponse::Generic(ValueResponse(values)) = res {
+            let arr = values.as_array().unwrap();
+            if let Some(first) = arr.first() {
+                Ok(WebDriverResponse::Generic(ValueResponse(first.clone())))
+            } else {
+                Err(WebDriverError::new(ErrorStatus::NoSuchElement, ""))
+            }
+        } else {
+            Err(WebDriverError::new(
+                ErrorStatus::UnknownError,
+                "Unexpected response",
+            ))
         }
     }
 
@@ -1234,61 +1203,26 @@ impl Handler {
     }
 
     /// <https://w3c.github.io/webdriver/#find-element-from-element>
-    fn handle_find_element_element(
+    fn handle_find_element_from_element(
         &self,
         element: &WebElement,
         parameters: &LocatorParameters,
     ) -> WebDriverResult<WebDriverResponse> {
-        // Step 4. If selector is undefined, return error with error code invalid argument.
-        if parameters.value.is_empty() {
-            return Err(WebDriverError::new(ErrorStatus::InvalidArgument, ""));
-        }
-        let (sender, receiver) = ipc::channel().unwrap();
-
-        match parameters.using {
-            LocatorStrategy::CSSSelector => {
-                let cmd = WebDriverScriptCommand::FindElementElementCSSSelector(
-                    parameters.value.clone(),
-                    element.to_string(),
-                    sender,
-                );
-                self.browsing_context_script_command::<true>(cmd)?;
-            },
-            LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
-                let cmd = WebDriverScriptCommand::FindElementElementLinkText(
-                    parameters.value.clone(),
-                    element.to_string(),
-                    parameters.using == LocatorStrategy::PartialLinkText,
-                    sender,
-                );
-                self.browsing_context_script_command::<true>(cmd)?;
-            },
-            LocatorStrategy::TagName => {
-                let cmd = WebDriverScriptCommand::FindElementElementTagName(
-                    parameters.value.clone(),
-                    element.to_string(),
-                    sender,
-                );
-                self.browsing_context_script_command::<true>(cmd)?;
-            },
-            _ => {
-                return Err(WebDriverError::new(
-                    ErrorStatus::UnsupportedOperation,
-                    "Unsupported locator strategy",
-                ));
-            },
-        }
+        let res = self.handle_find_elements_from_element(element, parameters)?;
         // Step 9. If result is empty, return error with error code no such element.
         // Otherwise, return the first element of result.
-        match wait_for_script_response(receiver)? {
-            Ok(value) => match value {
-                Some(value) => {
-                    let value_resp = serde_json::to_value(WebElement(value))?;
-                    Ok(WebDriverResponse::Generic(ValueResponse(value_resp)))
-                },
-                None => Err(WebDriverError::new(ErrorStatus::NoSuchElement, "")),
-            },
-            Err(error) => Err(WebDriverError::new(error, "")),
+        if let WebDriverResponse::Generic(ValueResponse(values)) = res {
+            let arr = values.as_array().unwrap();
+            if let Some(first) = arr.first() {
+                Ok(WebDriverResponse::Generic(ValueResponse(first.clone())))
+            } else {
+                Err(WebDriverError::new(ErrorStatus::NoSuchElement, ""))
+            }
+        } else {
+            Err(WebDriverError::new(
+                ErrorStatus::UnknownError,
+                "Unexpected response",
+            ))
         }
     }
 
@@ -2255,7 +2189,7 @@ impl WebDriverHandler<ServoExtensionRoute> for Handler {
             WebDriverCommand::FindElement(ref parameters) => self.handle_find_element(parameters),
             WebDriverCommand::FindElements(ref parameters) => self.handle_find_elements(parameters),
             WebDriverCommand::FindElementElement(ref element, ref parameters) => {
-                self.handle_find_element_element(element, parameters)
+                self.handle_find_element_from_element(element, parameters)
             },
             WebDriverCommand::FindElementElements(ref element, ref parameters) => {
                 self.handle_find_elements_from_element(element, parameters)

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -970,22 +970,11 @@ impl Handler {
         &self,
         parameters: &LocatorParameters,
     ) -> WebDriverResult<WebDriverResponse> {
+        // Step 1 - 9.
         let res = self.handle_find_elements(parameters)?;
-        // Step 9. If result is empty, return error with error code no such element.
+        // Step 10. If result is empty, return error with error code no such element.
         // Otherwise, return the first element of result.
-        if let WebDriverResponse::Generic(ValueResponse(values)) = res {
-            let arr = values.as_array().unwrap();
-            if let Some(first) = arr.first() {
-                Ok(WebDriverResponse::Generic(ValueResponse(first.clone())))
-            } else {
-                Err(WebDriverError::new(ErrorStatus::NoSuchElement, ""))
-            }
-        } else {
-            Err(WebDriverError::new(
-                ErrorStatus::UnknownError,
-                "Unexpected response",
-            ))
-        }
+        unwrap_first_element_response(res)
     }
 
     /// <https://w3c.github.io/webdriver/#close-window>
@@ -1208,22 +1197,11 @@ impl Handler {
         element: &WebElement,
         parameters: &LocatorParameters,
     ) -> WebDriverResult<WebDriverResponse> {
+        // Step 1 - 8.
         let res = self.handle_find_elements_from_element(element, parameters)?;
         // Step 9. If result is empty, return error with error code no such element.
         // Otherwise, return the first element of result.
-        if let WebDriverResponse::Generic(ValueResponse(values)) = res {
-            let arr = values.as_array().unwrap();
-            if let Some(first) = arr.first() {
-                Ok(WebDriverResponse::Generic(ValueResponse(first.clone())))
-            } else {
-                Err(WebDriverError::new(ErrorStatus::NoSuchElement, ""))
-            }
-        } else {
-            Err(WebDriverError::new(
-                ErrorStatus::UnknownError,
-                "Unexpected response",
-            ))
-        }
+        unwrap_first_element_response(res)
     }
 
     /// <https://w3c.github.io/webdriver/#find-elements-from-element>
@@ -1352,22 +1330,11 @@ impl Handler {
         shadow_root: &ShadowRoot,
         parameters: &LocatorParameters,
     ) -> WebDriverResult<WebDriverResponse> {
+        // Step 1 - 8.
         let res = self.handle_find_elements_from_shadow_root(shadow_root, parameters)?;
         // Step 9. If result is empty, return error with error code no such element.
         // Otherwise, return the first element of result.
-        if let WebDriverResponse::Generic(ValueResponse(values)) = res {
-            let arr = values.as_array().unwrap();
-            if let Some(first) = arr.first() {
-                Ok(WebDriverResponse::Generic(ValueResponse(first.clone())))
-            } else {
-                Err(WebDriverError::new(ErrorStatus::NoSuchElement, ""))
-            }
-        } else {
-            Err(WebDriverError::new(
-                ErrorStatus::UnknownError,
-                "Unexpected response",
-            ))
-        }
+        unwrap_first_element_response(res)
     }
 
     fn handle_get_shadow_root(&self, element: WebElement) -> WebDriverResult<WebDriverResponse> {
@@ -2313,4 +2280,22 @@ where
     receiver
         .recv()
         .map_err(|_| WebDriverError::new(ErrorStatus::NoSuchWindow, ""))
+}
+
+fn unwrap_first_element_response(
+    res: WebDriverResponse,
+) -> WebDriverResult<WebDriverResponse> {
+    if let WebDriverResponse::Generic(ValueResponse(values)) = res {
+        let arr = values.as_array().unwrap();
+        if let Some(first) = arr.first() {
+            Ok(WebDriverResponse::Generic(ValueResponse(first.clone())))
+        } else {
+            Err(WebDriverError::new(ErrorStatus::NoSuchElement, ""))
+        }
+    } else {
+        Err(WebDriverError::new(
+            ErrorStatus::UnknownError,
+            "Unexpected response",
+        ))
+    }
 }


### PR DESCRIPTION
All "Find Element ..." in [spec](https://w3c.github.io/webdriver/#find-element-from-element) has exactly same step has "Find Elements ...", except they extract the first element if there is any. We now reuse the handler instead of running numerous repetitive steps, same as what we did for ["Find Element from Shadow Root"](https://w3c.github.io/webdriver/#find-element-from-shadow-root) in #37578.

This reduces binary size by 98KB for Release profile in Windows and improves maintainability.

Testing: `./mach test-wpt -r .\tests\wpt\tests\webdriver\tests\classic\find_element* --product servodriver`