### PR TITLE
CI: Add commit hash to HOS bencher reports

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -260,4 +260,9 @@ jobs:
           echo "MODEL_NAME=$(hdc bugreport | head -n 20 | grep MarketName | awk '{for (i=2; i<NF; i++) printf $i " "; print $NF}' -)" >> $GITHUB_ENV
       - name: Uploading to bencher.dev
         run: |
-          bencher run --adapter json --file bench.json --project '${{ env.BENCHER_PROJECT }}' --token '${{ secrets.BENCHER_API_TOKEN }}' --github-actions '${{ secrets.GITHUB_TOKEN }}' --testbed="$MODEL_NAME"
+          bencher run --adapter json --file bench.json \
+                      --hash '${{ github.sha }}' \
+                      --project '${{ env.BENCHER_PROJECT }}' \
+                      --token '${{ secrets.BENCHER_API_TOKEN }}' \
+                      --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+                      --testbed="$MODEL_NAME"


### PR DESCRIPTION
Since we don't checkout servo in this job, bencher can't infer the commit hash and we need to pass it manually.
Bencher documentation for --hash:
https://github.com/bencherdev/bencher/blob/02034b83de9e8f61ab10383002a4fc396ba253cf/services/console/src/chunks/docs-explanation/branch-selection/en/hash.mdx

Testing: No testing. This could cause the HOS CI to fail, but wouldn't block the MQ. This kind of CI change is quite difficult to test without a lot of setup overhead. The change itself is trivial though, and the expected damage would also be low (merge queue would still work).

Issue with the missing commit was:
Reported by @webbeef 
