### PR TITLE
layout: Fix block SizeConstraint for replaced elements

### DIFF
--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -534,6 +534,7 @@ fn compute_inline_content_sizes_for_block_level_boxes(
                     |constraint_space| {
                         base.inline_content_sizes(layout_context, constraint_space, contents)
                     },
+                    |_aspect_ratio| None,
                 );
                 // A block in the same BFC can overlap floats, it's not moved next to them,
                 // so we shouldn't add its size to the size of the floats.

--- a/tests/wpt/tests/css/css-sizing/keyword-sizes-for-intrinsic-contributions-002.html
+++ b/tests/wpt/tests/css/css-sizing/keyword-sizes-for-intrinsic-contributions-002.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<title>Keyword sizes for intrinsic contributions</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#sizing-values">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-contribution">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12333">
+<link rel="help" href="https://github.com/servo/servo/issues/37478">
+<meta assert="Intrinsic keywords for min/max block sizes on a replaced element affect the inline min/max-content contributions.">
+
+<style>
+.test { width: max-content; background: red; border: 5px solid; margin: 5px; }
+.test.flex-row { display: flex; flex-direction: row; }
+.test.flex-col { display: flex; flex-direction: column; }
+canvas { display: block; background: green; height: 0px; width: max-content; }
+</style>
+<div id="log"></div>
+
+<div class="test" data-expected-width="60" data-expected-height="60">
+  <canvas width="50" height="50" style="height: 0px; min-height: max-content">
+</div>
+<div class="test" data-expected-width="60" data-expected-height="60">
+  <canvas width="50" height="50" style="height: 100px; max-height: max-content"></canvas>
+</div>
+
+<div class="test flex-row" data-expected-width="60" data-expected-height="60">
+  <canvas width="50" height="50" style="height: 0px; min-height: max-content">
+</div>
+<div class="test flex-row" data-expected-width="60" data-expected-height="60">
+  <canvas width="50" height="50" style="height: 100px; max-height: max-content"></canvas>
+</div>
+
+<div class="test flex-col" data-expected-width="60" data-expected-height="60">
+  <canvas width="50" height="50" style="height: 0px; min-height: max-content">
+</div>
+<div class="test flex-col" data-expected-width="60" data-expected-height="60">
+  <canvas width="50" height="50" style="height: 100px; max-height: max-content"></canvas>
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script>
+checkLayout(".test");
+</script>


### PR DESCRIPTION
#37433 didn't handle intrinsic contributions. This patch computes the correct SizeConstraint to be used as the ConstraintSpace's block size when computing intrinsic inline sizes.

Testing: Adding new test
Fixes: #37478
