### PR TITLE
canvas: use `Transform2D` instead of `Transform3D` when possible

### DIFF
--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -1935,21 +1935,14 @@ impl CanvasState {
             !matrix.m12.is_finite() ||
             !matrix.m21.is_finite() ||
             !matrix.m22.is_finite() ||
-            !matrix.m41.is_finite() ||
-            !matrix.m42.is_finite()
+            !matrix.m31.is_finite() ||
+            !matrix.m32.is_finite()
         {
             return Ok(());
         }
 
         // Step 3. Reset the current transformation matrix to matrix.
-        self.state.borrow_mut().transform = Transform2D::new(
-            matrix.m11 as f32,
-            matrix.m12 as f32,
-            matrix.m21 as f32,
-            matrix.m22 as f32,
-            matrix.m41 as f32,
-            matrix.m42 as f32,
-        );
+        self.state.borrow_mut().transform = matrix.cast();
         self.update_transform();
         Ok(())
     }

--- a/components/script/dom/canvaspattern.rs
+++ b/components/script/dom/canvaspattern.rs
@@ -93,21 +93,14 @@ impl CanvasPatternMethods<crate::DomTypeHolder> for CanvasPattern {
             !matrix.m12.is_finite() ||
             !matrix.m21.is_finite() ||
             !matrix.m22.is_finite() ||
-            !matrix.m41.is_finite() ||
-            !matrix.m42.is_finite()
+            !matrix.m31.is_finite() ||
+            !matrix.m32.is_finite()
         {
             return Ok(());
         }
 
         // Step 3. Reset the pattern's transformation matrix to matrix.
-        *self.transform.borrow_mut() = Transform2D::new(
-            matrix.m11 as f32,
-            matrix.m12 as f32,
-            matrix.m21 as f32,
-            matrix.m22 as f32,
-            matrix.m41 as f32,
-            matrix.m42 as f32,
-        );
+        *self.transform.borrow_mut() = matrix.cast();
 
         Ok(())
     }

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -1058,10 +1058,6 @@ fn validate_and_fixup(dict: &DOMMatrixInit) -> Fallible<(bool, Transform3D<f64>)
     transform.m43 = dict.m43;
     transform.m44 = dict.m44;
 
-    // Only `true` value of is_2d is correct
-    // https://github.com/w3c/fxtf-drafts/issues/600
-    // assert_eq!(is_2d, transform.is_2d());
-
     Ok((is_2d, transform))
 }
 

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -1057,7 +1057,10 @@ fn validate_and_fixup(dict: &DOMMatrixInit) -> Fallible<(bool, Transform3D<f64>)
     transform.m34 = dict.m34;
     transform.m43 = dict.m43;
     transform.m44 = dict.m44;
-    assert_eq!(is_2d, transform.is_2d());
+
+    // Only `true` value of is_2d is correct
+    // https://github.com/w3c/fxtf-drafts/issues/600
+    // assert_eq!(is_2d, transform.is_2d());
 
     Ok((is_2d, transform))
 }


### PR DESCRIPTION
While this makes our implementation deviate slightly from the specification, this clarifies an invariant with the code itself. This helps to resolve some confusion as seen in  https://github.com/servo/servo/issues/37695#issuecomment-3013823350.

Testing: This should not change behavior and is thus covered by existing WPT tests.