### PR TITLE
script: Reduce usage of Trusted in Node::insert.

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -212,7 +212,7 @@ use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
 use crate::script_runtime::{CanGc, ScriptThreadEventCategory};
 use crate::script_thread::{ScriptThread, with_script_thread};
 use crate::stylesheet_set::StylesheetSetRef;
-use crate::task::TaskBox;
+use crate::task::NonSendTaskBox;
 use crate::task_source::TaskSourceName;
 use crate::timers::OneshotTimerCallback;
 
@@ -477,7 +477,7 @@ pub(crate) struct Document {
     script_and_layout_blockers: Cell<u32>,
     /// List of tasks to execute as soon as last script/layout blocker is removed.
     #[ignore_malloc_size_of = "Measuring trait objects is hard"]
-    delayed_tasks: DomRefCell<Vec<Box<dyn TaskBox>>>,
+    delayed_tasks: DomRefCell<Vec<Box<dyn NonSendTaskBox>>>,
     /// <https://html.spec.whatwg.org/multipage/#completely-loaded>
     completely_loaded: Cell<bool>,
     /// Set of shadow roots connected to the document tree.
@@ -4338,7 +4338,7 @@ impl Document {
     }
 
     /// Enqueue a task to run as soon as any JS and layout blockers are removed.
-    pub(crate) fn add_delayed_task<T: 'static + TaskBox>(&self, task: T) {
+    pub(crate) fn add_delayed_task<T: 'static + NonSendTaskBox>(&self, task: T) {
         self.delayed_tasks.borrow_mut().push(Box::new(task));
     }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1411,15 +1411,15 @@ impl VirtualMethods for HTMLScriptElement {
         }
 
         if self.upcast::<Node>().is_connected() && !self.parser_inserted.get() {
-            let script = Trusted::new(self);
+            let script = DomRoot::from_ref(self);
             // This method can be invoked while there are script/layout blockers present
             // as DOM mutations have not yet settled. We use a delayed task to avoid
             // running any scripts until the DOM tree is safe for interactions.
-            self.owner_document()
-                .add_delayed_task(task!(ScriptPrepare: move || {
-                    let this = script.root();
-                    this.prepare(CanGc::note());
-                }));
+            self.owner_document().add_delayed_task(
+                task!(ScriptPrepare: |script: DomRoot<HTMLScriptElement>| {
+                    script.prepare(CanGc::note());
+                }),
+            );
         }
     }
 

--- a/components/script/dom/userscripts.rs
+++ b/components/script/dom/userscripts.rs
@@ -5,12 +5,13 @@
 use std::rc::Rc;
 
 use js::jsval::UndefinedValue;
+use script_bindings::root::DomRoot;
 
-use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::htmlheadelement::HTMLHeadElement;
 use crate::dom::htmlscriptelement::SourceCode;
 use crate::dom::node::NodeTraits;
+use crate::dom::window::Window;
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::CanGc;
 
@@ -20,9 +21,8 @@ pub(crate) fn load_script(head: &HTMLHeadElement) {
     if userscripts.is_empty() {
         return;
     }
-    let window = Trusted::new(doc.window());
-    doc.add_delayed_task(task!(UserScriptExecute: move || {
-        let win = window.root();
+    let win = DomRoot::from_ref(doc.window());
+    doc.add_delayed_task(task!(UserScriptExecute: |win: DomRoot<Window>| {
         let cx = win.get_cx();
         rooted!(in(*cx) let mut rval = UndefinedValue());
 


### PR DESCRIPTION
These changes introduce a new kind of task that uses a variation of the `task!` syntax. Existing `task!` usages create task structs that have a `Send` bound, which requires the use of `Trusted<T>` to reference a DOM object T inside of the task closure. The new syntax replaces the `Send` bound with a `JSTraceable` bound, which requires explicit capture clauses with types. This looks like:
```rust
task!(ScriptPrepare: {script: DomRoot<HTMLScriptElement>} |script| {
    script.prepare(CanGc::note());
}),
```

The capture clauses must list every value that will be referenced from the closure's environment—these values are moved into fields in the generated task structure, which allows them to be traced by the GC as part of a generated JSTraceable implementation. Since the closure itself is not a `move` closure, any attempts to reference values not explicitly captured will generate a borrow checker error since the closure requires the `'static` lifetime.

Testing: Existing WPT tests exercise these code paths. I also attempted to write incorrect tasks that capture references or use values not explicitly captured, and the compiler correctly errors out.
Fixes: part of #35517
