### PR TITLE
pixels: Ensure expected formats when accesing bytes of snapshot

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -17,7 +17,7 @@ use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use log::warn;
 use net_traits::ResourceThreads;
-use pixels::Snapshot;
+use pixels::{Snapshot, SnapshotPixelFormat};
 use style::color::AbsoluteColor;
 use style::properties::style_structs::Font as FontStyleStruct;
 use webrender_api::ImageKey;
@@ -175,14 +175,17 @@ impl<'a> CanvasPaintThread<'a> {
                 .canvas(canvas_id)
                 .is_point_in_path_(&path[..], x, y, fill_rule, chan),
             Canvas2dMsg::DrawImage(snapshot, dest_rect, source_rect, smoothing_enabled) => {
-                let snapshot = snapshot.to_owned();
+                let mut snapshot = snapshot.to_owned();
+                let size = snapshot.size();
+                let (data, alpha_mode, _) =
+                    snapshot.as_bytes(None, Some(SnapshotPixelFormat::BGRA));
                 self.canvas(canvas_id).draw_image(
-                    snapshot.data(),
-                    snapshot.size(),
+                    data,
+                    size,
                     dest_rect,
                     source_rect,
                     smoothing_enabled,
-                    snapshot.alpha_mode().alpha().needs_premulti(),
+                    alpha_mode.alpha().needs_premulti(),
                 )
             },
             Canvas2dMsg::DrawEmptyImage(image_size, dest_rect, source_rect) => {
@@ -202,16 +205,18 @@ impl<'a> CanvasPaintThread<'a> {
                 source_rect,
                 smoothing,
             ) => {
-                let image_data = self
+                let mut snapshot = self
                     .canvas(canvas_id)
                     .read_pixels(Some(source_rect.to_u32()), Some(image_size));
+                let (data, alpha_mode, _) =
+                    snapshot.as_bytes(None, Some(SnapshotPixelFormat::BGRA));
                 self.canvas(other_canvas_id).draw_image(
-                    image_data.data(),
+                    data,
                     source_rect.size.to_u32(),
                     dest_rect,
                     source_rect,
                     smoothing,
-                    false,
+                    alpha_mode.alpha().needs_premulti(),
                 );
             },
             Canvas2dMsg::MoveTo(ref point) => self.canvas(canvas_id).move_to(point),

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -185,7 +185,7 @@ impl<'a> CanvasPaintThread<'a> {
                     dest_rect,
                     source_rect,
                     smoothing_enabled,
-                    alpha_mode.alpha().needs_premulti(),
+                    alpha_mode.alpha().needs_alpha_multiplication(),
                 )
             },
             Canvas2dMsg::DrawEmptyImage(image_size, dest_rect, source_rect) => {
@@ -216,7 +216,7 @@ impl<'a> CanvasPaintThread<'a> {
                     dest_rect,
                     source_rect,
                     smoothing,
-                    alpha_mode.alpha().needs_premulti(),
+                    alpha_mode.alpha().needs_alpha_multiplication(),
                 );
             },
             Canvas2dMsg::MoveTo(ref point) => self.canvas(canvas_id).move_to(point),

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -182,7 +182,7 @@ impl<'a> CanvasPaintThread<'a> {
                     dest_rect,
                     source_rect,
                     smoothing_enabled,
-                    !snapshot.alpha_mode().is_premultiplied(),
+                    snapshot.alpha_mode().alpha().needs_premulti(),
                 )
             },
             Canvas2dMsg::DrawEmptyImage(image_size, dest_rect, source_rect) => {
@@ -403,7 +403,7 @@ impl Canvas<'_> {
         dest_rect: Rect<f64>,
         source_rect: Rect<f64>,
         smoothing_enabled: bool,
-        is_premultiplied: bool,
+        premultiply: bool,
     ) {
         match self {
             Canvas::Raqote(canvas_data) => canvas_data.draw_image(
@@ -412,7 +412,7 @@ impl Canvas<'_> {
                 dest_rect,
                 source_rect,
                 smoothing_enabled,
-                is_premultiplied,
+                premultiply,
             ),
         }
     }

--- a/components/pixels/snapshot.rs
+++ b/components/pixels/snapshot.rs
@@ -22,8 +22,8 @@ pub enum SnapshotPixelFormat {
 pub enum Alpha {
     Premultiplied,
     NotPremultiplied,
-    /// This is used for opaque texture
-    /// where you can choose the one that represents less work
+    /// This is used for opaque textures for which the presence of alpha in the
+    /// output data format does not matter.
     DontCare,
 }
 

--- a/components/pixels/snapshot.rs
+++ b/components/pixels/snapshot.rs
@@ -36,7 +36,7 @@ impl Alpha {
         }
     }
 
-    pub const fn needs_premulti(&self) -> bool {
+    pub const fn needs_alpha_multiplication(&self) -> bool {
         match self {
             Alpha::Premultiplied => false,
             Alpha::NotPremultiplied => true,
@@ -44,7 +44,7 @@ impl Alpha {
         }
     }
 
-    pub const fn needs_unmulti(&self) -> bool {
+    pub const fn needs_alpha_unmultiplication(&self) -> bool {
         match self {
             Alpha::Premultiplied => true,
             Alpha::NotPremultiplied => false,

--- a/components/pixels/snapshot.rs
+++ b/components/pixels/snapshot.rs
@@ -43,14 +43,6 @@ impl Alpha {
             Alpha::DontCare => false,
         }
     }
-
-    pub const fn needs_alpha_unmultiplication(&self) -> bool {
-        match self {
-            Alpha::Premultiplied => true,
-            Alpha::NotPremultiplied => false,
-            Alpha::DontCare => false,
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]

--- a/components/pixels/snapshot.rs
+++ b/components/pixels/snapshot.rs
@@ -72,7 +72,6 @@ impl Default for SnapshotAlphaMode {
 }
 
 impl SnapshotAlphaMode {
-    /// Returns None if it's opaque (can be considered as or not as premultiplied)
     pub const fn alpha(&self) -> Alpha {
         match self {
             SnapshotAlphaMode::Opaque => Alpha::DontCare,

--- a/components/script/dom/imagebitmap.rs
+++ b/components/script/dom/imagebitmap.rs
@@ -198,10 +198,10 @@ impl ImageBitmap {
         pixels::copy_rgba8_image(
             input.size(),
             input_rect_cropped.cast(),
-            input.data(),
+            input.as_raw_bytes(),
             source.size(),
             source_rect_cropped.cast(),
-            source.data_mut(),
+            source.as_raw_bytes_mut(),
         );
 
         // Step 7. Scale output to the size specified by outputWidth and outputHeight.
@@ -213,9 +213,12 @@ impl ImageBitmap {
                 ResizeQuality::High => pixels::FilterQuality::High,
             };
 
-            let Some(output_data) =
-                pixels::scale_rgba8_image(source.size(), source.data(), output_size, quality)
-            else {
+            let Some(output_data) = pixels::scale_rgba8_image(
+                source.size(),
+                source.as_raw_bytes(),
+                output_size,
+                quality,
+            ) else {
                 log::warn!(
                     "Failed to scale the bitmap of size {:?} to required size {:?}",
                     source.size(),
@@ -240,7 +243,7 @@ impl ImageBitmap {
         // output must be flipped vertically, disregarding any image orientation metadata
         // of the source (such as EXIF metadata), if any.
         if options.imageOrientation == ImageOrientation::FlipY {
-            pixels::flip_y_rgba8_image_inplace(output.size(), output.data_mut());
+            pixels::flip_y_rgba8_image_inplace(output.size(), output.as_raw_bytes_mut());
         }
 
         // TODO: Step 9. If image is an img element or a Blob object, let val be the value

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -21,7 +21,7 @@ use js::jsapi::{JSObject, Type};
 use js::jsval::{BooleanValue, DoubleValue, Int32Value, NullValue, ObjectValue, UInt32Value};
 use js::rust::{CustomAutoRooterGuard, HandleObject, MutableHandleValue};
 use js::typedarray::{ArrayBufferView, CreateWith, Float32, Int32Array, Uint32, Uint32Array};
-use pixels::Snapshot;
+use pixels::{Alpha, Snapshot};
 use script_bindings::interfaces::WebGL2RenderingContextHelpers;
 use servo_config::pref;
 use url::Host;
@@ -3257,7 +3257,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
         let size = Size2D::new(width, height);
 
-        let (alpha_treatment, y_axis_treatment) = self.base.get_current_unpack_state(false);
+        let (alpha_treatment, y_axis_treatment) = self.base.get_current_unpack_state(Alpha::NotPremultiplied);
 
         self.base.tex_image_2d(
             &texture,

--- a/components/script/dom/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl2renderingcontext.rs
@@ -3257,7 +3257,8 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
         let size = Size2D::new(width, height);
 
-        let (alpha_treatment, y_axis_treatment) = self.base.get_current_unpack_state(Alpha::NotPremultiplied);
+        let (alpha_treatment, y_axis_treatment) =
+            self.base.get_current_unpack_state(Alpha::NotPremultiplied);
 
         self.base.tex_image_2d(
             &texture,

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -11,7 +11,6 @@ use std::rc::Rc;
 #[cfg(feature = "webgl_backtrace")]
 use backtrace::Backtrace;
 use bitflags::bitflags;
-use pixels::Alpha;
 use canvas_traits::webgl::WebGLError::*;
 use canvas_traits::webgl::{
     AlphaTreatment, GLContextAttributes, GLLimits, GlType, Parameter, SizedDataType, TexDataType,
@@ -30,7 +29,8 @@ use js::typedarray::{
     ArrayBufferView, CreateWith, Float32, Float32Array, Int32, Int32Array, TypedArray,
     TypedArrayElementCreator, Uint32Array,
 };
-use pixels::{self, PixelFormat, Snapshot, SnapshotPixelFormat};
+use net_traits::image_cache::ImageResponse;
+use pixels::{self, Alpha, PixelFormat, Snapshot, SnapshotPixelFormat};
 use serde::{Deserialize, Serialize};
 use servo_config::pref;
 use webrender_api::ImageKey;
@@ -627,7 +627,8 @@ impl WebGLRenderingContext {
                 )
             },
             TexImageSource::ImageData(image_data) => {
-                let (alpha_treatment, y_axis_treatment) = self.get_current_unpack_state(Alpha::NotPremultiplied);
+                let (alpha_treatment, y_axis_treatment) =
+                    self.get_current_unpack_state(Alpha::NotPremultiplied);
 
                 TexPixels::new(
                     image_data.to_shared_memory(),
@@ -665,7 +666,8 @@ impl WebGLRenderingContext {
                     SnapshotPixelFormat::BGRA => PixelFormat::BGRA8,
                 };
 
-                let (alpha_treatment, y_axis_treatment) = self.get_current_unpack_state(Alpha::NotPremultiplied);
+                let (alpha_treatment, y_axis_treatment) =
+                    self.get_current_unpack_state(Alpha::NotPremultiplied);
 
                 TexPixels::new(
                     snapshot.to_ipc_shared_memory(),
@@ -4539,7 +4541,8 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
         let size = Size2D::new(width, height);
 
-        let (alpha_treatment, y_axis_treatment) = self.get_current_unpack_state(Alpha::NotPremultiplied);
+        let (alpha_treatment, y_axis_treatment) =
+            self.get_current_unpack_state(Alpha::NotPremultiplied);
 
         self.tex_image_2d(
             &texture,
@@ -4716,7 +4719,8 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             };
         }
 
-        let (alpha_treatment, y_axis_treatment) = self.get_current_unpack_state(Alpha::NotPremultiplied);
+        let (alpha_treatment, y_axis_treatment) =
+            self.get_current_unpack_state(Alpha::NotPremultiplied);
 
         self.tex_sub_image_2d(
             texture,

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -29,7 +29,6 @@ use js::typedarray::{
     ArrayBufferView, CreateWith, Float32, Float32Array, Int32, Int32Array, TypedArray,
     TypedArrayElementCreator, Uint32Array,
 };
-use net_traits::image_cache::ImageResponse;
 use pixels::{self, Alpha, PixelFormat, Snapshot, SnapshotPixelFormat};
 use serde::{Deserialize, Serialize};
 use servo_config::pref;


### PR DESCRIPTION
I introduced snapshot in #36119 to pack raw bytes and metadata together, now we take the next step and require for user to always specify what kind of byte data they want when calling `as_bytes` or `to_vec` (basically joining transform and data). There are also valid usages when one might require just one property of bytes (textures can generally handle both RGBA and BGRA). There are also valid usages of using just raw bytes (when cropping). This PR tries to make such usages more obvious.

This will make it easier to fix stuff around 2d canvas (we do not want to assume any bytes properties in abstraction).

Testing: Code is covered by WPT tests.
