### PR TITLE
compositor: Allow canvas to upload rendered contents asynchronously

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,7 @@ name = "canvas"
 version = "0.0.1"
 dependencies = [
  "app_units",
+ "base",
  "bytemuck",
  "canvas_traits",
  "compositing_traits",

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -18,6 +18,7 @@ tracing = ["dep:tracing"]
 
 [dependencies]
 app_units = { workspace = true }
+base = { workspace = true }
 bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 canvas_traits = { workspace = true }
 compositing_traits = { workspace = true }

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::Epoch;
 use canvas_traits::canvas::*;
 use compositing_traits::CrossProcessCompositorApi;
 use euclid::default::{Point2D, Rect, Size2D, Transform2D};
@@ -279,11 +280,11 @@ impl<DrawTarget: GenericDrawTarget> CanvasData<DrawTarget> {
             .drawtarget
             .create_similar_draw_target(&Size2D::new(size.width, size.height).cast());
 
-        self.update_image_rendering();
+        self.update_image_rendering(None);
     }
 
     /// Update image in WebRender
-    pub(crate) fn update_image_rendering(&mut self) {
+    pub(crate) fn update_image_rendering(&mut self, canvas_epoch: Option<Epoch>) {
         let (descriptor, data) = {
             #[cfg(feature = "tracing")]
             let _span = tracing::trace_span!(
@@ -295,7 +296,7 @@ impl<DrawTarget: GenericDrawTarget> CanvasData<DrawTarget> {
         };
 
         self.compositor_api
-            .update_image(self.image_key, descriptor, data);
+            .update_image(self.image_key, descriptor, data, canvas_epoch);
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -6,6 +6,7 @@ use std::borrow::ToOwned;
 use std::collections::HashMap;
 use std::{f32, thread};
 
+use base::Epoch;
 use canvas_traits::ConstellationCanvasMsg;
 use canvas_traits::canvas::*;
 use compositing_traits::CrossProcessCompositorApi;
@@ -253,9 +254,8 @@ impl CanvasPaintThread {
                 self.canvas(canvas_id)
                     .put_image_data(snapshot.to_owned(), rect);
             },
-            Canvas2dMsg::UpdateImage(sender) => {
-                self.canvas(canvas_id).update_image_rendering();
-                sender.send(()).unwrap();
+            Canvas2dMsg::UpdateImage(canvas_epoch) => {
+                self.canvas(canvas_id).update_image_rendering(canvas_epoch);
             },
             Canvas2dMsg::PopClips(clips) => self.canvas(canvas_id).pop_clips(clips),
         }
@@ -526,12 +526,12 @@ impl Canvas {
         }
     }
 
-    fn update_image_rendering(&mut self) {
+    fn update_image_rendering(&mut self, canvas_epoch: Option<Epoch>) {
         match self {
             #[cfg(feature = "vello")]
-            Canvas::Vello(canvas_data) => canvas_data.update_image_rendering(),
+            Canvas::Vello(canvas_data) => canvas_data.update_image_rendering(canvas_epoch),
             #[cfg(feature = "vello_cpu")]
-            Canvas::VelloCPU(canvas_data) => canvas_data.update_image_rendering(),
+            Canvas::VelloCPU(canvas_data) => canvas_data.update_image_rendering(canvas_epoch),
         }
     }
 

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -53,6 +53,7 @@ mod from_constellation {
                 Self::CollectMemoryReport(..) => target!("CollectMemoryReport"),
                 Self::Viewport(..) => target!("Viewport"),
                 Self::GenerateImageKeysForPipeline(..) => target!("GenerateImageKeysForPipeline"),
+                Self::DelayNewFrameForCanvas(..) => target!("DelayFramesForCanvas"),
             }
         }
     }

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -79,6 +79,9 @@ mod from_compositor {
                 Self::SendImageKeysForPipeline(..) => target!("SendImageKeysForPipeline"),
                 Self::SetWebDriverResponseSender(..) => target!("SetWebDriverResponseSender"),
                 Self::PreferencesUpdated(..) => target!("PreferencesUpdated"),
+                Self::NoLongerWaitingOnAsynchronousImageUpdates(..) => {
+                    target!("NoLongerWaitingOnCanvas")
+                },
             }
         }
     }

--- a/components/script/canvas_context.rs
+++ b/components/script/canvas_context.rs
@@ -4,6 +4,7 @@
 
 //! Common interfaces for Canvas Contexts
 
+use base::Epoch;
 use euclid::default::Size2D;
 use layout_api::HTMLCanvasData;
 use pixels::Snapshot;
@@ -66,7 +67,14 @@ pub(crate) trait CanvasContext {
         }
     }
 
-    fn update_rendering(&self) {}
+    /// The WebRender [`ImageKey`] of this [`CanvasContext`] if any.
+    fn image_key(&self) -> Option<ImageKey>;
+
+    /// Request that the [`CanvasContext`] update the rendering of its contents, returning
+    /// the new [`Epoch`] of the image produced, if one was.
+    fn update_rendering(&self, _canvas_epoch: Option<Epoch>) -> bool {
+        false
+    }
 
     fn onscreen(&self) -> bool {
         let Some(canvas) = self.canvas() else {
@@ -228,19 +236,31 @@ impl CanvasContext for RenderingContext {
         }
     }
 
-    fn update_rendering(&self) {
+    fn image_key(&self) -> Option<ImageKey> {
         match self {
-            RenderingContext::Placeholder(offscreen_canvas) => {
-                if let Some(context) = offscreen_canvas.context() {
-                    context.update_rendering()
-                }
-            },
-            RenderingContext::Context2d(context) => context.update_rendering(),
-            RenderingContext::BitmapRenderer(context) => context.update_rendering(),
-            RenderingContext::WebGL(context) => context.update_rendering(),
-            RenderingContext::WebGL2(context) => context.update_rendering(),
+            RenderingContext::Placeholder(offscreen_canvas) => offscreen_canvas
+                .context()
+                .and_then(|context| context.image_key()),
+            RenderingContext::Context2d(context) => context.image_key(),
+            RenderingContext::BitmapRenderer(context) => context.image_key(),
+            RenderingContext::WebGL(context) => context.image_key(),
+            RenderingContext::WebGL2(context) => context.image_key(),
             #[cfg(feature = "webgpu")]
-            RenderingContext::WebGPU(context) => context.update_rendering(),
+            RenderingContext::WebGPU(context) => context.image_key(),
+        }
+    }
+
+    fn update_rendering(&self, canvas_epoch: Option<Epoch>) -> bool {
+        match self {
+            RenderingContext::Placeholder(offscreen_canvas) => offscreen_canvas
+                .context()
+                .is_some_and(|context| context.update_rendering(canvas_epoch)),
+            RenderingContext::Context2d(context) => context.update_rendering(canvas_epoch),
+            RenderingContext::BitmapRenderer(context) => context.update_rendering(canvas_epoch),
+            RenderingContext::WebGL(context) => context.update_rendering(canvas_epoch),
+            RenderingContext::WebGL2(context) => context.update_rendering(canvas_epoch),
+            #[cfg(feature = "webgpu")]
+            RenderingContext::WebGPU(context) => context.update_rendering(canvas_epoch),
         }
     }
 
@@ -333,11 +353,17 @@ impl CanvasContext for OffscreenRenderingContext {
         }
     }
 
-    fn update_rendering(&self) {
+    fn image_key(&self) -> Option<ImageKey> {
+        None
+    }
+
+    fn update_rendering(&self, canvas_epoch: Option<Epoch>) -> bool {
         match self {
-            OffscreenRenderingContext::Context2d(context) => context.update_rendering(),
-            OffscreenRenderingContext::BitmapRenderer(context) => context.update_rendering(),
-            OffscreenRenderingContext::Detached => {},
+            OffscreenRenderingContext::Context2d(context) => context.update_rendering(canvas_epoch),
+            OffscreenRenderingContext::BitmapRenderer(context) => {
+                context.update_rendering(canvas_epoch)
+            },
+            OffscreenRenderingContext::Detached => false,
         }
     }
 

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use app_units::Au;
+use base::Epoch;
 use canvas_traits::canvas::{
     Canvas2dMsg, CanvasFont, CanvasId, CanvasMsg, CompositionOptions, CompositionOrBlending,
     FillOrStrokeStyle, FillRule, GlyphAndPosition, LineCapStyle, LineJoinStyle, LineOptions,
@@ -287,19 +288,18 @@ impl CanvasState {
     }
 
     /// Updates WR image and blocks on completion
-    pub(crate) fn update_rendering(&self) {
+    pub(crate) fn update_rendering(&self, canvas_epoch: Option<Epoch>) -> bool {
         if !self.is_paintable() {
-            return;
+            return false;
         }
 
-        let (sender, receiver) = ipc::channel().unwrap();
         self.ipc_renderer
             .send(CanvasMsg::Canvas2d(
-                Canvas2dMsg::UpdateImage(sender),
+                Canvas2dMsg::UpdateImage(canvas_epoch),
                 self.canvas_id,
             ))
             .unwrap();
-        receiver.recv().unwrap();
+        true
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-canvas-set-bitmap-dimensions>

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::Epoch;
 use canvas_traits::canvas::{Canvas2dMsg, CanvasId};
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
@@ -122,8 +123,11 @@ impl CanvasContext for CanvasRenderingContext2D {
         Some(self.canvas.clone())
     }
 
-    fn update_rendering(&self) {
-        self.canvas_state.update_rendering();
+    fn update_rendering(&self, canvas_epoch: Option<Epoch>) -> bool {
+        if !self.onscreen() {
+            return false;
+        }
+        self.canvas_state.update_rendering(canvas_epoch)
     }
 
     fn resize(&self) {
@@ -154,6 +158,10 @@ impl CanvasContext for CanvasRenderingContext2D {
             canvas.upcast::<Node>().dirty(NodeDamage::Other);
             canvas.owner_document().add_dirty_2d_canvas(self);
         }
+    }
+
+    fn image_key(&self) -> Option<ImageKey> {
+        Some(self.canvas_state.image_key())
     }
 }
 

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::Epoch;
 use dom_struct::dom_struct;
 use webrender_api::ImageKey;
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -224,6 +224,7 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                         current_frame.image_key,
                         descriptor,
                         SerializableImageData::Raw(IpcSharedMemory::from_bytes(&frame.get_data())),
+                        None,
                     ));
                 }
 

--- a/components/script/dom/imagebitmaprenderingcontext.rs
+++ b/components/script/dom/imagebitmaprenderingcontext.rs
@@ -150,6 +150,10 @@ impl CanvasContext for ImageBitmapRenderingContext {
             .as_ref()
             .map_or_else(|| self.canvas.size(), |bitmap| bitmap.size())
     }
+
+    fn image_key(&self) -> Option<ImageKey> {
+        None
+    }
 }
 
 impl ImageBitmapRenderingContextMethods<crate::DomTypeHolder> for ImageBitmapRenderingContext {

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -97,6 +97,10 @@ impl CanvasContext for OffscreenCanvasRenderingContext2D {
     fn origin_is_clean(&self) -> bool {
         self.context.origin_is_clean()
     }
+
+    fn image_key(&self) -> Option<webrender_api::ImageKey> {
+        None
+    }
 }
 
 impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -63,9 +63,12 @@ impl PaintRenderingContext2D {
         ))
     }
 
+    pub(crate) fn update_rendering(&self) -> bool {
+        self.canvas_state.update_rendering(None)
+    }
+
     /// Send update to canvas paint thread and returns [`ImageKey`]
     pub(crate) fn image_key(&self) -> ImageKey {
-        self.canvas_state.update_rendering();
         self.canvas_state.image_key()
     }
 

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -348,13 +348,13 @@ impl PaintWorkletGlobalScope {
             return self.invalid_image(size_in_dpx, missing_image_urls);
         }
 
-        let image_key = rendering_context.image_key();
+        rendering_context.update_rendering();
 
         DrawAPaintImageResult {
             width: size_in_dpx.width,
             height: size_in_dpx.height,
             format: PixelFormat::BGRA8,
-            image_key: Some(image_key),
+            image_key: Some(rendering_context.image_key()),
             missing_image_urls,
         }
     }

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -992,6 +992,10 @@ impl CanvasContext for WebGL2RenderingContext {
     fn mark_as_dirty(&self) {
         self.base.mark_as_dirty()
     }
+
+    fn image_key(&self) -> Option<ImageKey> {
+        self.base.image_key()
+    }
 }
 
 impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingContext {

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -2042,6 +2042,10 @@ impl CanvasContext for WebGLRenderingContext {
             HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(_) => {},
         }
     }
+
+    fn image_key(&self) -> Option<ImageKey> {
+        Some(self.webrender_image)
+    }
 }
 
 #[cfg(not(feature = "webgl_backtrace"))]

--- a/components/script/image_animation.rs
+++ b/components/script/image_animation.rs
@@ -101,6 +101,7 @@ impl ImageAnimationManager {
                         flags: ImageDescriptorFlags::ALLOW_MIPMAPS,
                     },
                     SerializableImageData::Raw(IpcSharedMemory::from_bytes(frame.bytes)),
+                    None,
                 ))
             })
             .collect();

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -98,6 +98,7 @@ impl MixedMessage {
                 ScriptThreadMessage::EvaluateJavaScript(id, _, _) => Some(*id),
                 ScriptThreadMessage::SendImageKeysBatch(..) => None,
                 ScriptThreadMessage::PreferencesUpdated(..) => None,
+                ScriptThreadMessage::NoLongerWaitingOnAsychronousImageUpdates(_) => None,
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1424,6 +1424,13 @@ impl ScriptThread {
                 )) => {
                     self.set_needs_rendering_update();
                 },
+                MixedMessage::FromConstellation(
+                    ScriptThreadMessage::NoLongerWaitingOnAsychronousImageUpdates(pipeline_id),
+                ) => {
+                    if let Some(document) = self.documents.borrow().find_document(pipeline_id) {
+                        document.handle_no_longer_waiting_on_asynchronous_image_updates();
+                    }
+                },
                 MixedMessage::FromConstellation(ScriptThreadMessage::SendInputEvent(id, event)) => {
                     self.handle_input_event(id, event)
                 },
@@ -1891,6 +1898,7 @@ impl ScriptThread {
             msg @ ScriptThreadMessage::ExitFullScreen(..) |
             msg @ ScriptThreadMessage::SendInputEvent(..) |
             msg @ ScriptThreadMessage::TickAllAnimations(..) |
+            msg @ ScriptThreadMessage::NoLongerWaitingOnAsychronousImageUpdates(..) |
             msg @ ScriptThreadMessage::ExitScriptThread => {
                 panic!("should have handled {:?} already", msg)
             },

--- a/components/shared/base/lib.rs
+++ b/components/shared/base/lib.rs
@@ -16,11 +16,14 @@ pub mod print_tree;
 pub mod text;
 mod unicode_block;
 
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use webrender_api::Epoch as WebRenderEpoch;
 
 /// A struct for denoting the age of messages; prevents race conditions.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, MallocSizeOf,
+)]
 pub struct Epoch(pub u32);
 
 impl Epoch {

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -5,6 +5,7 @@
 use std::default::Default;
 use std::str::FromStr;
 
+use base::Epoch;
 use euclid::Angle;
 use euclid::approxeq::ApproxEq;
 use euclid::default::{Point2D, Rect, Size2D, Transform2D};
@@ -516,7 +517,7 @@ pub enum Canvas2dMsg {
         CompositionOptions,
         Transform2D<f64>,
     ),
-    UpdateImage(IpcSender<()>),
+    UpdateImage(Option<Epoch>),
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use std::num::{NonZeroU32, NonZeroU64};
 use std::ops::Deref;
 
+use base::Epoch;
 /// Receiver type used in WebGLCommands.
 pub use base::generic_channel::GenericReceiver as WebGLReceiver;
 /// Sender type used in WebGLCommands.
@@ -107,7 +108,7 @@ pub enum WebGLMsg {
     /// The third field contains the time (in ns) when the request
     /// was initiated. The u64 in the second field will be the time the
     /// request is fulfilled
-    SwapBuffers(Vec<WebGLContextId>, WebGLSender<u64>, u64),
+    SwapBuffers(Vec<WebGLContextId>, Option<Epoch>, u64),
     /// Frees all resources and closes the thread.
     Exit(IpcSender<()>),
 }

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -57,6 +57,10 @@ pub enum EmbedderToConstellationMessage {
     /// Requests that the constellation instruct script/layout to try to layout again and tick
     /// animations.
     TickAnimation(Vec<WebViewId>),
+    /// Notify the `ScriptThread` that the Servo renderer is no longer waiting on
+    /// asynchronous image uploads for the given `Pipeline`. These are mainly used
+    /// by canvas to perform uploads while the display list is being built.
+    NoLongerWaitingOnAsynchronousImageUpdates(Vec<PipelineId>),
     /// Dispatch a webdriver command
     WebDriverCommand(WebDriverCommandMsg),
     /// Reload a top-level browsing context.

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -261,6 +261,10 @@ pub enum ScriptThreadMessage {
     SendImageKeysBatch(PipelineId, Vec<ImageKey>),
     /// Preferences were updated in the parent process.
     PreferencesUpdated(Vec<(String, PrefValue)>),
+    /// Notify the `ScriptThread` that the Servo renderer is no longer waiting on
+    /// asynchronous image uploads for the given `Pipeline`. These are mainly used
+    /// by canvas to perform uploads while the display list is being built.
+    NoLongerWaitingOnAsychronousImageUpdates(PipelineId),
 }
 
 impl fmt::Debug for ScriptThreadMessage {

--- a/components/shared/webgpu/messages/recv.rs
+++ b/components/shared/webgpu/messages/recv.rs
@@ -6,6 +6,7 @@
 //! (usually from the ScriptThread, and more specifically from DOM objects)
 
 use arrayvec::ArrayVec;
+use base::Epoch;
 use base::id::PipelineId;
 use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
 use pixels::IpcSnapshot;
@@ -162,6 +163,7 @@ pub enum WebGPURequest {
         context_id: WebGPUContextId,
         texture_id: TextureId,
         encoder_id: CommandEncoderId,
+        canvas_epoch: Option<Epoch>,
     },
     /// Obtains image from latest presentation buffer (same as wr update)
     GetImage {

--- a/components/webgl/Cargo.toml
+++ b/components/webgl/Cargo.toml
@@ -16,7 +16,7 @@ webgl_backtrace = ["canvas_traits/webgl_backtrace"]
 webxr = ["dep:webxr", "dep:webxr-api"]
 
 [dependencies]
-base = { path = "../shared/base" }
+base = { workspace = true }
 bitflags = { workspace = true }
 byteorder = { workspace = true }
 canvas_traits = { workspace = true }

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -520,8 +520,14 @@ impl WGPU {
                         context_id,
                         texture_id,
                         encoder_id,
+                        canvas_epoch,
                     } => {
-                        let result = self.swapchain_present(context_id, encoder_id, texture_id);
+                        let result = self.swapchain_present(
+                            context_id,
+                            encoder_id,
+                            texture_id,
+                            canvas_epoch,
+                        );
                         if let Err(e) = result {
                             log::error!("Error occured in SwapChainPresent: {e:?}");
                         }

--- a/tests/wpt/webgl/meta/conformance2/transform_feedback/too-small-buffers.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/transform_feedback/too-small-buffers.html.ini
@@ -1,5 +1,4 @@
 [too-small-buffers.html]
-  expected: TIMEOUT
   [WebGL test #100]
     expected: FAIL
 


### PR DESCRIPTION
Adds epoch to each WR image op command that is sent to compositor. The renderer now has a `FrameDelayer` data structure that is responsible for tracking when a frame is ready to be displayed. When asking canvases to update their rendering, they are given an optional `Epoch` which denotes the `Document`'s canvas epoch. When all image updates for that `Epoch` are seen in the renderer, the frame can be displayed.

Testing: Existing WPT tests
Fixes: #35733
