### PR TITLE
Enable LinuxSampler to be used on Android

### DIFF
--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -29,5 +29,8 @@ mach2 = { version = "0.4", optional = true }
 [target.'cfg(all(target_os = "linux", not(any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos", target_env = "musl"))))'.dependencies]
 nix = { workspace = true, features = ["signal"], optional = true }
 
+[target.'cfg(target_os = "android")'.dependencies]
+nix = { workspace = true, features = ["signal"], optional = true }
+
 [features]
 sampler = ["mach2", "nix"]

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -97,6 +97,8 @@ impl BackgroundHangMonitorRegister for HangMonitorRegister {
         let sampler = crate::sampler_windows::WindowsSampler::new_boxed();
         #[cfg(all(feature = "sampler", target_os = "macos"))]
         let sampler = crate::sampler_mac::MacOsSampler::new_boxed();
+        #[cfg(all(feature = "sampler", target_os = "android"))]
+        let sampler = crate::sampler_linux::LinuxSampler::new_boxed();
         #[cfg(all(
             feature = "sampler",
             target_os = "linux",
@@ -110,7 +112,7 @@ impl BackgroundHangMonitorRegister for HangMonitorRegister {
         let sampler = crate::sampler_linux::LinuxSampler::new_boxed();
         #[cfg(any(
             not(feature = "sampler"),
-            target_os = "android",
+            // target_os = "android",
             all(
                 target_os = "linux",
                 any(

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -112,7 +112,6 @@ impl BackgroundHangMonitorRegister for HangMonitorRegister {
         let sampler = crate::sampler_linux::LinuxSampler::new_boxed();
         #[cfg(any(
             not(feature = "sampler"),
-            // target_os = "android",
             all(
                 target_os = "linux",
                 any(

--- a/components/background_hang_monitor/lib.rs
+++ b/components/background_hang_monitor/lib.rs
@@ -21,5 +21,7 @@ mod sampler_linux;
 mod sampler_mac;
 #[cfg(all(feature = "sampler", target_os = "windows"))]
 mod sampler_windows;
+#[cfg(all(feature = "sampler", target_os = "android"))]
+mod sampler_linux;
 
 pub use self::background_hang_monitor::*;

--- a/components/background_hang_monitor/lib.rs
+++ b/components/background_hang_monitor/lib.rs
@@ -17,11 +17,11 @@ mod sampler;
     ))
 ))]
 mod sampler_linux;
+#[cfg(all(feature = "sampler", target_os = "android"))]
+mod sampler_linux;
 #[cfg(all(feature = "sampler", target_os = "macos"))]
 mod sampler_mac;
 #[cfg(all(feature = "sampler", target_os = "windows"))]
 mod sampler_windows;
-#[cfg(all(feature = "sampler", target_os = "android"))]
-mod sampler_linux;
 
 pub use self::background_hang_monitor::*;


### PR DESCRIPTION
This enables `background_hang_monitor` to work on Android. Relevant Zulip thread: [#general > Android stack walking questions @ 💬](https://servo.zulipchat.com/#narrow/channel/263398-general/topic/Android.20stack.20walking.20questions/near/526369883)


Testing: Manually tested on a Pixel 6a with Android 16 with following page:
```html
<!DOCTYPE html>
<html>
    <head>
        <title>Infinite Loop Test</title>
    </head>
    <body>
        Will it print? That is the question.
    </body>
    <script>
        console.log("hello. you're about to loop infinitely.");

        while (true) {
            //do nothing, just block the thread
        }
    </script>
</html>
```
Fixes: #23136