### PR TITLE
canvas: Add OffscreenCanvas 'convertToBlob' method

### DIFF
--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -226,6 +226,42 @@ pub fn clip(
         .filter(|rect| !rect.is_empty())
 }
 
+#[derive(PartialEq)]
+pub enum EncodedImageType {
+    Png,
+    Jpeg,
+    Webp,
+}
+
+impl From<String> for EncodedImageType {
+    // From: https://html.spec.whatwg.org/multipage/#serialising-bitmaps-to-a-file
+    // User agents must support PNG ("image/png"). User agents may support other
+    // types. If the user agent does not support the requested type, then it
+    // must create the file using the PNG format.
+    // Anything different than image/jpeg or image/webp is thus treated as PNG.
+    fn from(mime_type: String) -> Self {
+        let mime = mime_type.to_lowercase();
+        if mime == "image/jpeg" {
+            Self::Jpeg
+        } else if mime == "image/webp" {
+            Self::Webp
+        } else {
+            Self::Png
+        }
+    }
+}
+
+impl EncodedImageType {
+    pub fn as_mime_type(&self) -> String {
+        match self {
+            Self::Png => "image/png",
+            Self::Jpeg => "image/jpeg",
+            Self::Webp => "image/webp",
+        }
+        .to_owned()
+    }
+}
+
 /// Whether this response passed any CORS checks, and is thus safe to read from
 /// in cross-origin environments.
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -519,7 +519,7 @@ DOMInterfaces = {
 },
 
 'OffscreenCanvas': {
-    'canGc': ['GetContext', 'SetHeight', 'SetWidth'],
+    'canGc': ['ConvertToBlob', 'GetContext', 'SetHeight', 'SetWidth'],
 },
 
 'OffscreenCanvasRenderingContext2D': {

--- a/components/script_bindings/webidls/OffscreenCanvas.webidl
+++ b/components/script_bindings/webidls/OffscreenCanvas.webidl
@@ -8,7 +8,7 @@ OffscreenRenderingContext;
 
 dictionary ImageEncodeOptions {
   DOMString type = "image/png";
-  unrestricted double quality = 1.0;
+  unrestricted double quality;
 };
 
 //enum OffscreenRenderingContextId { "2d", "webgl", "webgl2" };
@@ -21,5 +21,5 @@ interface OffscreenCanvas : EventTarget {
 
   [Throws] OffscreenRenderingContext? getContext(DOMString contextId, optional any options = null);
   //ImageBitmap transferToImageBitmap();
-  //Promise<Blob> convertToBlob(optional ImageEncodeOptions options);
+  Promise<Blob> convertToBlob(optional ImageEncodeOptions options = {});
 };

--- a/tests/wpt/meta/html/canvas/offscreen/manual/convert-to-blob/offscreencanvas.convert.to.blob.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/convert-to-blob/offscreencanvas.convert.to.blob.html.ini
@@ -1,22 +1,3 @@
 [offscreencanvas.convert.to.blob.html]
-  [Test that convertToBlob with webp produces correct result]
-    expected: FAIL
-
-  [Test that convertToBlob with default type produces correct result]
-    expected: FAIL
-
-  [Test that convertToBlob with png produces correct result]
-    expected: FAIL
-
-  [Test that convertToBlob with jpge produces correct result]
-    expected: FAIL
-
-  [Test that call convertToBlob on a OffscreenCanvas with size 0 throws exception]
-    expected: FAIL
-
   [Test that call convertToBlob on a detached OffscreenCanvas throws exception]
     expected: FAIL
-
-  [Test that call convertToBlob on a OffscreenCanvas with tainted origin throws exception]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/manual/convert-to-blob/offscreencanvas.convert.to.blob.w.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/convert-to-blob/offscreencanvas.convert.to.blob.w.html.ini
@@ -1,43 +1,4 @@
 [offscreencanvas.convert.to.blob.w.html]
   expected: ERROR
-  [Test that convertToBlob with jpeg/default quality produces correct result in a worker]
-    expected: FAIL
-
-  [Test that convertToBlob with png/0.2 quality produces correct result in a worker]
-    expected: FAIL
-
-  [Test that convertToBlob with webp/1.0 quality produces correct result in a worker]
-    expected: FAIL
-
-  [Test that call convertToBlob on a OffscreenCanvas with size 0 throws exception in a worker]
-    expected: FAIL
-
-  [Test that convertToBlob with png/1.0 quality produces correct result in a worker]
-    expected: FAIL
-
-  [Test that convertToBlob with default type/1.0 quality produces correct result in a worker]
-    expected: FAIL
-
-  [Test that convertToBlob with jpeg/1.0 quality produces correct result in a worker]
-    expected: FAIL
-
-  [Test that convertToBlob with webp/0.2 quality produces correct result in a worker]
-    expected: FAIL
-
-  [Test that convertToBlob with webp/default quality produces correct result in a worker]
-    expected: FAIL
-
   [Test that call convertToBlob on a detached OffscreenCanvas throws exception in a worker]
-    expected: FAIL
-
-  [Test that convertToBlob with jpeg/0.2 quality produces correct result in a worker]
-    expected: FAIL
-
-  [Test that convertToBlob with default type/0.2 quality produces correct result in a worker]
-    expected: FAIL
-
-  [Test that convertToBlob with png/default quality produces correct result in a worker]
-    expected: FAIL
-
-  [Test that convertToBlob with default arguments produces correct result in a worker]
     expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/manual/wide-gamut-canvas/2d.color.space.p3.convertToBlobp3.canvas.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/wide-gamut-canvas/2d.color.space.p3.convertToBlobp3.canvas.html.ini
@@ -1,3 +1,0 @@
-[2d.color.space.p3.convertToBlobp3.canvas.html]
-  [test if toblob returns p3 data from p3 color space canvas]
-    expected: FAIL

--- a/tests/wpt/meta/html/dom/idlharness.any.js.ini
+++ b/tests/wpt/meta/html/dom/idlharness.any.js.ini
@@ -29,9 +29,6 @@
   [OffscreenCanvas interface: operation transferToImageBitmap()]
     expected: FAIL
 
-  [OffscreenCanvas interface: operation convertToBlob(optional ImageEncodeOptions)]
-    expected: FAIL
-
   [OffscreenCanvas interface: attribute oncontextlost]
     expected: FAIL
 

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -4373,9 +4373,6 @@
   [OffscreenCanvas interface: operation transferToImageBitmap()]
     expected: FAIL
 
-  [OffscreenCanvas interface: operation convertToBlob(optional ImageEncodeOptions)]
-    expected: FAIL
-
   [OffscreenCanvas interface: attribute oncontextlost]
     expected: FAIL
 


### PR DESCRIPTION
Follow the HTML speficication and add missing 'convertToBlob' method
to OffscreenCanvas interface.
https://html.spec.whatwg.org/multipage/#dom-offscreencanvas-converttoblob

Testing: Improvements in the following tests
- html/canvas/offscreen/manual/convert-to-blob/offscreencanvas.convert.to.blob*
- html/canvas/offscreen/manual/wide-gamut-canvas/2d.color.space.p3.convertToBlobp3.canvas.html

Fixes: #24272
