### PR TITLE
Add alt-d shortcut to select address bar text

### DIFF
--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -331,9 +331,14 @@ impl Minibrowser {
                                     if location_field.changed() {
                                         location_dirty.set(true);
                                     }
+                                    // Handle adddress bar shortcut.
                                     if ui.input(|i| {
-                                        i.clone().consume_key(Modifiers::COMMAND, Key::L) ||
-                                            i.clone().consume_key(Modifiers::ALT, Key::D)
+                                        if cfg!(target_os = "macos") {
+                                            i.clone().consume_key(Modifiers::COMMAND, Key::L)
+                                        } else {
+                                            i.clone().consume_key(Modifiers::COMMAND, Key::L) ||
+                                                i.clone().consume_key(Modifiers::ALT, Key::D)
+                                        }
                                     }) {
                                         location_field.request_focus();
                                         if let Some(mut state) =

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -332,7 +332,8 @@ impl Minibrowser {
                                         location_dirty.set(true);
                                     }
                                     if ui.input(|i| {
-                                        i.clone().consume_key(Modifiers::COMMAND, Key::L)
+                                        i.clone().consume_key(Modifiers::COMMAND, Key::L) ||
+                                            i.clone().consume_key(Modifiers::ALT, Key::D)
                                     }) {
                                         location_field.request_focus();
                                         if let Some(mut state) =


### PR DESCRIPTION
I usually use the alt-d in shortcut in Firefox to select the text in the address bar. Firefox supports both alt-d and ctrl-l. This change adds the alt-d shortcut so you can use either.

Testing: I tested it by running Servo and pressing alt-d. I don't know if there is a way to create a test for it?
