### PR TITLE
storage: Isolate sessionStorage per top-level browsing context and copy sessionStorage when creating a new auxiliary browsing context

### DIFF
--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -73,28 +73,28 @@ impl StorageManager {
     fn start(&mut self) {
         loop {
             match self.port.recv().unwrap() {
-                StorageThreadMsg::Length(sender, url, storage_type) => {
-                    self.length(sender, url, storage_type)
+                StorageThreadMsg::Length(sender, storage_type, url) => {
+                    self.length(sender, storage_type, url)
                 },
-                StorageThreadMsg::Key(sender, url, storage_type, index) => {
-                    self.key(sender, url, storage_type, index)
+                StorageThreadMsg::Key(sender, storage_type, url, index) => {
+                    self.key(sender, storage_type, url, index)
                 },
-                StorageThreadMsg::Keys(sender, url, storage_type) => {
-                    self.keys(sender, url, storage_type)
+                StorageThreadMsg::Keys(sender, storage_type, url) => {
+                    self.keys(sender, storage_type, url)
                 },
-                StorageThreadMsg::SetItem(sender, url, storage_type, name, value) => {
-                    self.set_item(sender, url, storage_type, name, value);
+                StorageThreadMsg::SetItem(sender, storage_type, url, name, value) => {
+                    self.set_item(sender, storage_type, url, name, value);
                     self.save_state()
                 },
-                StorageThreadMsg::GetItem(sender, url, storage_type, name) => {
-                    self.request_item(sender, url, storage_type, name)
+                StorageThreadMsg::GetItem(sender, storage_type, url, name) => {
+                    self.request_item(sender, storage_type, url, name)
                 },
-                StorageThreadMsg::RemoveItem(sender, url, storage_type, name) => {
-                    self.remove_item(sender, url, storage_type, name);
+                StorageThreadMsg::RemoveItem(sender, storage_type, url, name) => {
+                    self.remove_item(sender, storage_type, url, name);
                     self.save_state()
                 },
-                StorageThreadMsg::Clear(sender, url, storage_type) => {
-                    self.clear(sender, url, storage_type);
+                StorageThreadMsg::Clear(sender, storage_type, url) => {
+                    self.clear(sender, storage_type, url);
                     self.save_state()
                 },
                 StorageThreadMsg::CollectMemoryReport(sender) => {
@@ -154,7 +154,7 @@ impl StorageManager {
         }
     }
 
-    fn length(&self, sender: IpcSender<usize>, url: ServoUrl, storage_type: StorageType) {
+    fn length(&self, sender: IpcSender<usize>, storage_type: StorageType, url: ServoUrl) {
         let origin = self.origin_as_string(url);
         let data = self.select_data(storage_type);
         sender
@@ -165,8 +165,8 @@ impl StorageManager {
     fn key(
         &self,
         sender: IpcSender<Option<String>>,
-        url: ServoUrl,
         storage_type: StorageType,
+        url: ServoUrl,
         index: u32,
     ) {
         let origin = self.origin_as_string(url);
@@ -178,7 +178,7 @@ impl StorageManager {
         sender.send(key).unwrap();
     }
 
-    fn keys(&self, sender: IpcSender<Vec<String>>, url: ServoUrl, storage_type: StorageType) {
+    fn keys(&self, sender: IpcSender<Vec<String>>, storage_type: StorageType, url: ServoUrl) {
         let origin = self.origin_as_string(url);
         let data = self.select_data(storage_type);
         let keys = data
@@ -195,8 +195,8 @@ impl StorageManager {
     fn set_item(
         &mut self,
         sender: IpcSender<Result<(bool, Option<String>), ()>>,
-        url: ServoUrl,
         storage_type: StorageType,
+        url: ServoUrl,
         name: String,
         value: String,
     ) {
@@ -252,8 +252,8 @@ impl StorageManager {
     fn request_item(
         &self,
         sender: IpcSender<Option<String>>,
-        url: ServoUrl,
         storage_type: StorageType,
+        url: ServoUrl,
         name: String,
     ) {
         let origin = self.origin_as_string(url);
@@ -271,8 +271,8 @@ impl StorageManager {
     fn remove_item(
         &mut self,
         sender: IpcSender<Option<String>>,
-        url: ServoUrl,
         storage_type: StorageType,
+        url: ServoUrl,
         name: String,
     ) {
         let origin = self.origin_as_string(url);
@@ -287,7 +287,7 @@ impl StorageManager {
         sender.send(old_value).unwrap();
     }
 
-    fn clear(&mut self, sender: IpcSender<bool>, url: ServoUrl, storage_type: StorageType) {
+    fn clear(&mut self, sender: IpcSender<bool>, storage_type: StorageType, url: ServoUrl) {
         let origin = self.origin_as_string(url);
         let data = self.select_data_mut(storage_type);
         sender

--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -48,10 +48,12 @@ impl StorageThreadFactory for IpcSender<StorageThreadMsg> {
     }
 }
 
+type OriginEntry = (usize, BTreeMap<String, String>);
+
 struct StorageManager {
     port: IpcReceiver<StorageThreadMsg>,
-    session_data: HashMap<String, (usize, BTreeMap<String, String>)>,
-    local_data: HashMap<String, (usize, BTreeMap<String, String>)>,
+    session_data: HashMap<String, OriginEntry>,
+    local_data: HashMap<String, OriginEntry>,
     config_dir: Option<PathBuf>,
 }
 
@@ -140,7 +142,7 @@ impl StorageManager {
         storage_type: StorageType,
         _webview_id: WebViewId,
         origin: &str,
-    ) -> Option<&(usize, BTreeMap<String, String>)> {
+    ) -> Option<&OriginEntry> {
         match storage_type {
             StorageType::Session => self.session_data.get(origin),
             StorageType::Local => self.local_data.get(origin),
@@ -152,7 +154,7 @@ impl StorageManager {
         storage_type: StorageType,
         _webview_id: WebViewId,
         origin: &str,
-    ) -> Option<&mut (usize, BTreeMap<String, String>)> {
+    ) -> Option<&mut OriginEntry> {
         match storage_type {
             StorageType::Session => self.session_data.get_mut(origin),
             StorageType::Local => self.local_data.get_mut(origin),
@@ -164,7 +166,7 @@ impl StorageManager {
         storage_type: StorageType,
         _webview_id: WebViewId,
         origin: &str,
-    ) -> &mut (usize, BTreeMap<String, String>) {
+    ) -> &mut OriginEntry {
         match storage_type {
             StorageType::Session => self.session_data.entry(origin.to_string()).or_default(),
             StorageType::Local => self.local_data.entry(origin.to_string()).or_default(),

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -66,8 +66,8 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
         self.get_storage_thread()
             .send(StorageThreadMsg::Length(
                 sender,
-                self.get_url(),
                 self.storage_type,
+                self.get_url(),
             ))
             .unwrap();
         receiver.recv().unwrap() as u32
@@ -80,8 +80,8 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
         self.get_storage_thread()
             .send(StorageThreadMsg::Key(
                 sender,
-                self.get_url(),
                 self.storage_type,
+                self.get_url(),
                 index,
             ))
             .unwrap();
@@ -93,7 +93,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
         let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
         let name = String::from(name);
 
-        let msg = StorageThreadMsg::GetItem(sender, self.get_url(), self.storage_type, name);
+        let msg = StorageThreadMsg::GetItem(sender, self.storage_type, self.get_url(), name);
         self.get_storage_thread().send(msg).unwrap();
         receiver.recv().unwrap().map(DOMString::from)
     }
@@ -106,8 +106,8 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
 
         let msg = StorageThreadMsg::SetItem(
             sender,
-            self.get_url(),
             self.storage_type,
+            self.get_url(),
             name.clone(),
             value.clone(),
         );
@@ -129,7 +129,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
         let name = String::from(name);
 
         let msg =
-            StorageThreadMsg::RemoveItem(sender, self.get_url(), self.storage_type, name.clone());
+            StorageThreadMsg::RemoveItem(sender, self.storage_type, self.get_url(), name.clone());
         self.get_storage_thread().send(msg).unwrap();
         if let Some(old_value) = receiver.recv().unwrap() {
             self.broadcast_change_notification(Some(name), Some(old_value), None);
@@ -143,8 +143,8 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
         self.get_storage_thread()
             .send(StorageThreadMsg::Clear(
                 sender,
-                self.get_url(),
                 self.storage_type,
+                self.get_url(),
             ))
             .unwrap();
         if receiver.recv().unwrap() {
@@ -159,8 +159,8 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
         self.get_storage_thread()
             .send(StorageThreadMsg::Keys(
                 sender,
-                self.get_url(),
                 self.storage_type,
+                self.get_url(),
             ))
             .unwrap();
         receiver

--- a/components/shared/net/storage_thread.rs
+++ b/components/shared/net/storage_thread.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::id::WebViewId;
 use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
 use profile_traits::mem::ReportsChan;
@@ -18,31 +19,50 @@ pub enum StorageType {
 #[derive(Debug, Deserialize, Serialize)]
 pub enum StorageThreadMsg {
     /// gets the number of key/value pairs present in the associated storage data
-    Length(IpcSender<usize>, StorageType, ServoUrl),
+    Length(IpcSender<usize>, StorageType, WebViewId, ServoUrl),
 
     /// gets the name of the key at the specified index in the associated storage data
-    Key(IpcSender<Option<String>>, StorageType, ServoUrl, u32),
+    Key(
+        IpcSender<Option<String>>,
+        StorageType,
+        WebViewId,
+        ServoUrl,
+        u32,
+    ),
 
     /// Gets the available keys in the associated storage data
-    Keys(IpcSender<Vec<String>>, StorageType, ServoUrl),
+    Keys(IpcSender<Vec<String>>, StorageType, WebViewId, ServoUrl),
 
     /// gets the value associated with the given key in the associated storage data
-    GetItem(IpcSender<Option<String>>, StorageType, ServoUrl, String),
+    GetItem(
+        IpcSender<Option<String>>,
+        StorageType,
+        WebViewId,
+        ServoUrl,
+        String,
+    ),
 
     /// sets the value of the given key in the associated storage data
     SetItem(
         IpcSender<Result<(bool, Option<String>), ()>>,
         StorageType,
+        WebViewId,
         ServoUrl,
         String,
         String,
     ),
 
     /// removes the key/value pair for the given key in the associated storage data
-    RemoveItem(IpcSender<Option<String>>, StorageType, ServoUrl, String),
+    RemoveItem(
+        IpcSender<Option<String>>,
+        StorageType,
+        WebViewId,
+        ServoUrl,
+        String,
+    ),
 
     /// clears the associated storage data by removing all the key/value pairs
-    Clear(IpcSender<bool>, StorageType, ServoUrl),
+    Clear(IpcSender<bool>, StorageType, WebViewId, ServoUrl),
 
     /// send a reply when done cleaning up thread resources and then shut it down
     Exit(IpcSender<()>),

--- a/components/shared/net/storage_thread.rs
+++ b/components/shared/net/storage_thread.rs
@@ -64,6 +64,14 @@ pub enum StorageThreadMsg {
     /// clears the associated storage data by removing all the key/value pairs
     Clear(IpcSender<bool>, StorageType, WebViewId, ServoUrl),
 
+    /// clones all storage data of the given top-level browsing context for a new browsing context.
+    /// should only be used for sessionStorage.
+    Clone {
+        sender: IpcSender<()>,
+        src: WebViewId,
+        dest: WebViewId,
+    },
+
     /// send a reply when done cleaning up thread resources and then shut it down
     Exit(IpcSender<()>),
 

--- a/components/shared/net/storage_thread.rs
+++ b/components/shared/net/storage_thread.rs
@@ -18,31 +18,31 @@ pub enum StorageType {
 #[derive(Debug, Deserialize, Serialize)]
 pub enum StorageThreadMsg {
     /// gets the number of key/value pairs present in the associated storage data
-    Length(IpcSender<usize>, ServoUrl, StorageType),
+    Length(IpcSender<usize>, StorageType, ServoUrl),
 
     /// gets the name of the key at the specified index in the associated storage data
-    Key(IpcSender<Option<String>>, ServoUrl, StorageType, u32),
+    Key(IpcSender<Option<String>>, StorageType, ServoUrl, u32),
 
     /// Gets the available keys in the associated storage data
-    Keys(IpcSender<Vec<String>>, ServoUrl, StorageType),
+    Keys(IpcSender<Vec<String>>, StorageType, ServoUrl),
 
     /// gets the value associated with the given key in the associated storage data
-    GetItem(IpcSender<Option<String>>, ServoUrl, StorageType, String),
+    GetItem(IpcSender<Option<String>>, StorageType, ServoUrl, String),
 
     /// sets the value of the given key in the associated storage data
     SetItem(
         IpcSender<Result<(bool, Option<String>), ()>>,
-        ServoUrl,
         StorageType,
+        ServoUrl,
         String,
         String,
     ),
 
     /// removes the key/value pair for the given key in the associated storage data
-    RemoveItem(IpcSender<Option<String>>, ServoUrl, StorageType, String),
+    RemoveItem(IpcSender<Option<String>>, StorageType, ServoUrl, String),
 
     /// clears the associated storage data by removing all the key/value pairs
-    Clear(IpcSender<bool>, ServoUrl, StorageType),
+    Clear(IpcSender<bool>, StorageType, ServoUrl),
 
     /// send a reply when done cleaning up thread resources and then shut it down
     Exit(IpcSender<()>),

--- a/tests/wpt/meta/webstorage/storage_session_window_noopener.window.js.ini
+++ b/tests/wpt/meta/webstorage/storage_session_window_noopener.window.js.ini
@@ -1,3 +1,0 @@
-[storage_session_window_noopener.window.html]
-  [A new noopener window to make sure there is a not copy of the previous window's sessionStorage]
-    expected: FAIL

--- a/tests/wpt/meta/webstorage/storage_session_window_open.window.js.ini
+++ b/tests/wpt/meta/webstorage/storage_session_window_open.window.js.ini
@@ -1,3 +1,0 @@
-[storage_session_window_open.window.html]
-  [A new window to make sure there is a copy of the previous window's sessionStorage, and that they diverge after a change]
-    expected: FAIL


### PR DESCRIPTION
This pull request introduces changes to the storage subsystem to:
- Isolate sessionStorage per top-level browsing context (WebViewId), in
  addition to origin.
- Copy sessionStorage when creating a new auxiliary browsing context without
  noopener, as required by the corresponding spec
 
These changes bring Servo closer to spec compliance, matching expected browser
behavior.

Testing: This work affects observable behavior. As a result, some previously
failing WPT tests now pass. No new tests are added, since the behavior is
already covered by existing web-platform-tests.

Fixes: #21291
