### PR TITLE
webdriver: Get the window position as well as the size when resolving "Get Window Rect"

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4534,7 +4534,7 @@ where
                 let is_open = self.browsing_contexts.contains_key(&browsing_context_id);
                 let _ = response_sender.send(is_open);
             },
-            WebDriverCommandMsg::GetWindowSize(..) => {
+            WebDriverCommandMsg::GetWindowRect(..) => {
                 unreachable!("This command should be send directly to the embedder.");
             },
             WebDriverCommandMsg::GetViewportSize(..) => {

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -20,7 +20,7 @@ use servo_url::ServoUrl;
 use style_traits::CSSPixel;
 use webdriver::common::{WebElement, WebFrame, WebWindow};
 use webdriver::error::ErrorStatus;
-use webrender_api::units::{DeviceIntSize, DevicePixel};
+use webrender_api::units::{DeviceIntRect, DeviceIntSize, DevicePixel};
 
 use crate::{MouseButton, MouseButtonAction};
 
@@ -31,7 +31,7 @@ pub struct WebDriverMessageId(pub usize);
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebDriverCommandMsg {
     /// Get the window size.
-    GetWindowSize(WebViewId, IpcSender<Size2D<i32, DevicePixel>>),
+    GetWindowRect(WebViewId, IpcSender<DeviceIntRect>),
     /// Get the viewport size.
     GetViewportSize(WebViewId, IpcSender<Size2D<u32, DevicePixel>>),
     /// Load a URL in the top-level browsing context with the given ID.

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -362,14 +362,14 @@ impl App {
                     // TODO: send a response to the WebDriver
                     // so it knows when the focus has finished.
                 },
-                WebDriverCommandMsg::GetWindowSize(_webview_id, response_sender) => {
+                WebDriverCommandMsg::GetWindowRect(_webview_id, response_sender) => {
                     let window = self
                         .windows
                         .values()
                         .next()
                         .expect("Should have at least one window in servoshell");
 
-                    if let Err(error) = response_sender.send(window.screen_geometry().size) {
+                    if let Err(error) = response_sender.send(window.window_rect()) {
                         warn!("Failed to send response of GetWindowSize: {error}");
                     }
                 },

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -484,18 +484,13 @@ impl WindowPortsMethods for Window {
     }
 
     fn window_rect(&self) -> DeviceIntRect {
-        let toolbar_height = (self.toolbar_height() * self.hidpi_scale_factor())
-            .get()
-            .ceil() as i32;
-        let inner_size = self.winit_window.inner_size();
-        let total_size = Size2D::new(
-            inner_size.width as i32,
-            inner_size.height as i32 + toolbar_height,
-        );
-        let (x, y) = match self.winit_window.inner_position() {
-            Ok(pos) => (pos.x, pos.y - toolbar_height),
-            Err(_) => (0, 0),
-        };
+        let outer_size = self.winit_window.outer_size();
+        let total_size = Size2D::new(outer_size.width as i32, outer_size.height as i32);
+        let (x, y) = self
+            .winit_window
+            .outer_position()
+            .map(|pos| (pos.x, pos.y))
+            .unwrap_or((0, 0));
         DeviceIntRect::from_origin_and_size(Point2D::new(x, y), total_size)
     }
 

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -17,7 +17,7 @@ use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
 use servo::servo_config::pref;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::ScrollLocation;
-use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize, DevicePixel};
+use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel};
 use servo::{
     Cursor, ImeEvent, InputEvent, Key, KeyState, KeyboardEvent, MouseButton as ServoMouseButton,
     MouseButtonAction, MouseButtonEvent, MouseLeaveEvent, MouseMoveEvent,
@@ -481,6 +481,22 @@ impl WindowPortsMethods for Window {
                     size.height.try_into().ok()?,
                 ))
             })
+    }
+
+    fn window_rect(&self) -> DeviceIntRect {
+        let toolbar_height = (self.toolbar_height() * self.hidpi_scale_factor())
+            .get()
+            .ceil() as i32;
+        let inner_size = self.winit_window.inner_size();
+        let total_size = Size2D::new(
+            inner_size.width as i32,
+            inner_size.height as i32 + toolbar_height,
+        );
+        let (x, y) = match self.winit_window.inner_position() {
+            Ok(pos) => (pos.x, pos.y - toolbar_height),
+            Err(_) => (0, 0),
+        };
+        DeviceIntRect::from_origin_and_size(Point2D::new(x, y), total_size)
     }
 
     fn set_position(&self, point: DeviceIntPoint) {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -486,12 +486,12 @@ impl WindowPortsMethods for Window {
     fn window_rect(&self) -> DeviceIntRect {
         let outer_size = self.winit_window.outer_size();
         let total_size = Size2D::new(outer_size.width as i32, outer_size.height as i32);
-        let (x, y) = self
+        let origin = self
             .winit_window
             .outer_position()
-            .map(|pos| (pos.x, pos.y))
-            .unwrap_or((0, 0));
-        DeviceIntRect::from_origin_and_size(Point2D::new(x, y), total_size)
+            .map(|point| Point2D::new(point.x, point.y))
+            .unwrap_or_default();
+        DeviceIntRect::from_origin_and_size(origin, total_size)
     }
 
     fn set_position(&self, point: DeviceIntPoint) {

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -8,9 +8,9 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use euclid::num::Zero;
-use euclid::{Length, Scale, Size2D};
+use euclid::{Length, Point2D, Scale, Size2D};
 use servo::servo_geometry::DeviceIndependentPixel;
-use servo::webrender_api::units::{DeviceIntSize, DevicePixel};
+use servo::webrender_api::units::{DeviceIntRect, DeviceIntSize, DevicePixel};
 use servo::{RenderingContext, ScreenGeometry, SoftwareRenderingContext};
 use winit::dpi::PhysicalSize;
 
@@ -133,6 +133,10 @@ impl WindowPortsMethods for Window {
 
     fn toolbar_height(&self) -> Length<f32, DeviceIndependentPixel> {
         Length::zero()
+    }
+
+    fn window_rect(&self) -> DeviceIntRect {
+        DeviceIntRect::from_origin_and_size(Point2D::zero(), self.inner_size.get())
     }
 
     fn set_toolbar_height(&self, _height: Length<f32, DeviceIndependentPixel>) {

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 
 use euclid::{Length, Scale};
 use servo::servo_geometry::DeviceIndependentPixel;
-use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize, DevicePixel};
+use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel};
 use servo::{Cursor, RenderingContext, ScreenGeometry, WebView};
 
 use super::app_state::RunningAppState;
@@ -52,4 +52,5 @@ pub trait WindowPortsMethods {
     fn theme(&self) -> servo::Theme {
         servo::Theme::Light
     }
+    fn window_rect(&self) -> DeviceIntRect;
 }


### PR DESCRIPTION
1. Rename `GetWindowSize` to `GetWindowRect`
2. Return the WindowRect in device pixels correctly. Previously, it returns `(0, 0, ScreenWidth, ScreenHeight)` which is a static value.
3. Add `fn window_rect` to `WindowPortsMethods`. Implement it for both Headless Window and Headed Window.

Testing: Tested manually with powershell script. Result is now dynamic and reflects the truth.
Fixes: Task 1 & 2 of https://github.com/servo/servo/issues/37804