### PR TITLE
layout: Remove `TryFrom<Contents> for NonReplacedContents`

### DIFF
--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -376,19 +376,6 @@ impl From<NonReplacedContents> for Contents {
     }
 }
 
-impl std::convert::TryFrom<Contents> for NonReplacedContents {
-    type Error = &'static str;
-
-    fn try_from(contents: Contents) -> Result<Self, Self::Error> {
-        match contents {
-            Contents::NonReplaced(non_replaced_contents) => Ok(non_replaced_contents),
-            Contents::Replaced(_) => {
-                Err("Tried to covnert a `Contents::Replaced` into `NonReplacedContent`")
-            },
-        }
-    }
-}
-
 impl NonReplacedContents {
     pub(crate) fn traverse<'dom>(
         self,


### PR DESCRIPTION
This implementation is quite confusing as it makes it harder to tell
that we are just looking for the case that `Contents` contains
`NonReplacedContents`.

Testing: This shouldn't have any functional change, so is covered by
existing tests.
