### PR TITLE
Fix testharnessreport-servo.js to stop polluting with global variables

### DIFF
--- a/tests/wpt/meta/css/css-backgrounds/border-width-cssom.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-width-cssom.html.ini
@@ -1,2 +1,0 @@
-[border-width-cssom.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/flow-content-0/search-styles-iso-8859-8.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/flow-content-0/search-styles-iso-8859-8.html.ini
@@ -1,2 +1,6 @@
 [search-styles-iso-8859-8.html]
-  expected: ERROR
+  [Verify document.characterSet is ISO-8859-8]
+    expected: FAIL
+
+  [<search> - display]
+    expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/flow-content-0/search-styles.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/flow-content-0/search-styles.html.ini
@@ -1,2 +1,3 @@
 [search-styles.html]
-  expected: ERROR
+  [<search> - display]
+    expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/form-controls/resets.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/form-controls/resets.html.ini
@@ -1,2 +1,9 @@
 [resets.html]
-  expected: ERROR
+  [<input type="file"> - text-align]
+    expected: FAIL
+
+  [<marquee> - text-align]
+    expected: FAIL
+
+  [<marquee> - overflow]
+    expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/lists/lists-styles-quirks.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/lists/lists-styles-quirks.html.ini
@@ -1,2 +1,582 @@
 [lists-styles-quirks.html]
-  expected: ERROR
+  [<li> - list-style-position]
+    expected: FAIL
+
+  [<dir> (in <dir>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <dir>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <dir>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <dir>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <dir>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <dir>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <dir>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <dir>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <dir>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <menu>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <menu>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <menu>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <menu>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <menu>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <menu>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <menu>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <menu>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <menu>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ol>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ol>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ol>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ol>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ol>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ol>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ol>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ol>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ol>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ul>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ul>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ul>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ul>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ul>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ul>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ul>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ul>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ul>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <dir><dir>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <dir><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <dir><dir>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <dir><dir>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <dir><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <dir><dir>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <dir><dir>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <dir><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <dir><dir>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <dir><menu>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <dir><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <dir><menu>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <dir><menu>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <dir><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <dir><menu>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <dir><menu>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <dir><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <dir><menu>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <dir><ol>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <dir><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <dir><ol>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <dir><ol>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <dir><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <dir><ol>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <dir><ol>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <dir><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <dir><ol>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <dir><ul>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <dir><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <dir><ul>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <dir><ul>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <dir><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <dir><ul>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <dir><ul>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <dir><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <dir><ul>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <menu><dir>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <menu><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <menu><dir>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <menu><dir>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <menu><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <menu><dir>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <menu><dir>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <menu><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <menu><dir>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <menu><menu>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <menu><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <menu><menu>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <menu><menu>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <menu><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <menu><menu>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <menu><menu>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <menu><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <menu><menu>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <menu><ol>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <menu><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <menu><ol>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <menu><ol>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <menu><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <menu><ol>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <menu><ol>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <menu><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <menu><ol>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <menu><ul>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <menu><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <menu><ul>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <menu><ul>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <menu><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <menu><ul>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <menu><ul>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <menu><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <menu><ul>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ol><dir>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ol><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ol><dir>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ol><dir>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ol><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ol><dir>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ol><dir>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ol><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ol><dir>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ol><menu>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ol><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ol><menu>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ol><menu>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ol><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ol><menu>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ol><menu>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ol><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ol><menu>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ol><ol>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ol><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ol><ol>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ol><ol>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ol><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ol><ol>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ol><ol>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ol><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ol><ol>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ol><ul>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ol><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ol><ul>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ol><ul>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ol><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ol><ul>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ol><ul>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ol><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ol><ul>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ul><dir>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ul><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ul><dir>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ul><dir>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ul><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ul><dir>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ul><dir>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ul><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ul><dir>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ul><menu>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ul><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ul><menu>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ul><menu>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ul><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ul><menu>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ul><menu>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ul><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ul><menu>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ul><ol>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ul><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ul><ol>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ul><ol>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ul><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ul><ol>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ul><ol>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ul><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ul><ol>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ul><ul>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ul><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ul><ul>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ul><ul>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ul><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ul><ul>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ul><ul>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ul><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ul><ul>) - list-style-type]
+    expected: FAIL
+
+  [<li type="1"> - list-style-position]
+    expected: FAIL
+
+  [<li type="a" class="type-a"> - list-style-position]
+    expected: FAIL
+
+  [<li type="A" class="type-A"> - list-style-position]
+    expected: FAIL
+
+  [<li type="i" class="type-i"> - list-style-position]
+    expected: FAIL
+
+  [<li type="I" class="type-I"> - list-style-position]
+    expected: FAIL
+
+  [<li type="none"> - list-style-position]
+    expected: FAIL
+
+  [<li type="NONE"> - list-style-position]
+    expected: FAIL
+
+  [<li type="disc"> - list-style-position]
+    expected: FAIL
+
+  [<li type="DISC"> - list-style-position]
+    expected: FAIL
+
+  [<li type="circle"> - list-style-position]
+    expected: FAIL
+
+  [<li type="CIRCLE"> - list-style-position]
+    expected: FAIL
+
+  [<li type="square"> - list-style-position]
+    expected: FAIL
+
+  [<li type="SQUARE"> - list-style-position]
+    expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/lists/lists-styles.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/lists/lists-styles.html.ini
@@ -1,2 +1,540 @@
 [lists-styles.html]
-  expected: ERROR
+  [<dir> (in <dir>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <dir>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <dir>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <dir>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <dir>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <dir>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <dir>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <dir>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <dir>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <menu>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <menu>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <menu>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <menu>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <menu>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <menu>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <menu>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <menu>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <menu>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ol>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ol>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ol>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ol>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ol>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ol>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ol>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ol>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ol>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ul>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ul>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ul>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ul>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ul>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ul>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ul>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ul>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ul>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <dir><dir>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <dir><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <dir><dir>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <dir><dir>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <dir><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <dir><dir>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <dir><dir>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <dir><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <dir><dir>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <dir><menu>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <dir><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <dir><menu>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <dir><menu>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <dir><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <dir><menu>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <dir><menu>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <dir><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <dir><menu>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <dir><ol>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <dir><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <dir><ol>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <dir><ol>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <dir><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <dir><ol>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <dir><ol>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <dir><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <dir><ol>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <dir><ul>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <dir><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <dir><ul>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <dir><ul>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <dir><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <dir><ul>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <dir><ul>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <dir><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <dir><ul>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <menu><dir>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <menu><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <menu><dir>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <menu><dir>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <menu><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <menu><dir>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <menu><dir>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <menu><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <menu><dir>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <menu><menu>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <menu><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <menu><menu>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <menu><menu>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <menu><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <menu><menu>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <menu><menu>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <menu><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <menu><menu>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <menu><ol>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <menu><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <menu><ol>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <menu><ol>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <menu><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <menu><ol>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <menu><ol>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <menu><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <menu><ol>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <menu><ul>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <menu><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <menu><ul>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <menu><ul>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <menu><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <menu><ul>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <menu><ul>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <menu><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <menu><ul>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ol><dir>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ol><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ol><dir>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ol><dir>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ol><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ol><dir>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ol><dir>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ol><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ol><dir>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ol><menu>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ol><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ol><menu>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ol><menu>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ol><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ol><menu>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ol><menu>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ol><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ol><menu>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ol><ol>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ol><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ol><ol>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ol><ol>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ol><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ol><ol>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ol><ol>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ol><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ol><ol>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ol><ul>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ol><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ol><ul>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ol><ul>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ol><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ol><ul>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ol><ul>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ol><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ol><ul>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ul><dir>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ul><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ul><dir>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ul><dir>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ul><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ul><dir>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ul><dir>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ul><dir>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ul><dir>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ul><menu>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ul><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ul><menu>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ul><menu>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ul><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ul><menu>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ul><menu>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ul><menu>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ul><menu>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ul><ol>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ul><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ul><ol>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ul><ol>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ul><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ul><ol>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ul><ol>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ul><ol>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ul><ol>) - list-style-type]
+    expected: FAIL
+
+  [<dir> (in <ul><ul>) - margin-top]
+    expected: FAIL
+
+  [<dir> (in <ul><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<dir> (in <ul><ul>) - list-style-type]
+    expected: FAIL
+
+  [<menu> (in <ul><ul>) - margin-top]
+    expected: FAIL
+
+  [<menu> (in <ul><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<menu> (in <ul><ul>) - list-style-type]
+    expected: FAIL
+
+  [<ul> (in <ul><ul>) - margin-top]
+    expected: FAIL
+
+  [<ul> (in <ul><ul>) - margin-bottom]
+    expected: FAIL
+
+  [<ul> (in <ul><ul>) - list-style-type]
+    expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/sections-and-headings/headings-styles-no-h1-in-section.tentative.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/sections-and-headings/headings-styles-no-h1-in-section.tentative.html.ini
@@ -1,2 +1,0 @@
-[headings-styles-no-h1-in-section.tentative.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/sections-and-headings/headings-styles.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/sections-and-headings/headings-styles.html.ini
@@ -1,2 +1,216 @@
 [headings-styles.html]
-  expected: ERROR
+  [<h1> (in <article>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <article>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <article>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <article><article>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <article><article>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <article><article>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <article><article><article>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <article><article><article>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <article><article><article>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <article><article><article><article>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <article><article><article><article>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <article><article><article><article>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <article><article><article><article><article>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <article><article><article><article><article>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <article><article><article><article><article>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <article><article><article><article><article><hgroup>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <article><article><article><article><article><hgroup>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <article><article><article><article><article><hgroup>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <aside>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <aside>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <aside>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <aside><aside>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <aside><aside>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <aside><aside>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <aside><aside><aside>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <aside><aside><aside>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <aside><aside><aside>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <aside><aside><aside><aside>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <aside><aside><aside><aside>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <aside><aside><aside><aside>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <aside><aside><aside><aside><aside>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <aside><aside><aside><aside><aside>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <aside><aside><aside><aside><aside>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <aside><aside><aside><aside><aside><hgroup>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <aside><aside><aside><aside><aside><hgroup>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <aside><aside><aside><aside><aside><hgroup>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <nav>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <nav>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <nav>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <nav><nav>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <nav><nav>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <nav><nav>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <nav><nav><nav>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <nav><nav><nav>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <nav><nav><nav>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <nav><nav><nav><nav>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <nav><nav><nav><nav>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <nav><nav><nav><nav>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <nav><nav><nav><nav><nav>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <nav><nav><nav><nav><nav>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <nav><nav><nav><nav><nav>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <nav><nav><nav><nav><nav><hgroup>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <nav><nav><nav><nav><nav><hgroup>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <nav><nav><nav><nav><nav><hgroup>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <section>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <section>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <section>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <section><section>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <section><section>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <section><section>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <section><section><section>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <section><section><section>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <section><section><section>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <section><section><section><section>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <section><section><section><section>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <section><section><section><section>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <section><section><section><section><section>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <section><section><section><section><section>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <section><section><section><section><section>) - font-size]
+    expected: FAIL
+
+  [<h1> (in <section><section><section><section><section><hgroup>) - margin-top]
+    expected: FAIL
+
+  [<h1> (in <section><section><section><section><section><hgroup>) - margin-bottom]
+    expected: FAIL
+
+  [<h1> (in <section><section><section><section><section><hgroup>) - font-size]
+    expected: FAIL

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/fieldset-default-style.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/fieldset-default-style.html.ini
@@ -1,2 +1,9 @@
 [fieldset-default-style.html]
-  expected: ERROR
+  [padding-right]
+    expected: FAIL
+
+  [padding-bottom]
+    expected: FAIL
+
+  [padding-left]
+    expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/images/img-sizes-auto.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/images/img-sizes-auto.html.ini
@@ -1,2 +1,0 @@
-[img-sizes-auto.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative.html.ini
@@ -1,2 +1,0 @@
-[select-as-listbox-default-styles.tentative.html]
-  expected: ERROR

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/testharnessreport-servo.js
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/testharnessreport-servo.js
@@ -1,22 +1,24 @@
-var props = {
-    output:%(output)d,
-    timeout_multiplier: %(timeout_multiplier)s,
-    explicit_timeout: %(explicit_timeout)s,
-    debug: %(debug)s
-};
-var start_loc = document.createElement('a');
-start_loc.href = location.href;
-setup(props);
+(function() {
+    var props = {
+        output:%(output)d,
+        timeout_multiplier: %(timeout_multiplier)s,
+        explicit_timeout: %(explicit_timeout)s,
+        debug: %(debug)s
+    };
+    var start_loc = document.createElement('a');
+    start_loc.href = location.href;
+    setup(props);
 
-add_completion_callback(function (tests, harness_status) {
-    var id = decodeURIComponent(start_loc.pathname) + decodeURIComponent(start_loc.search) + decodeURIComponent(start_loc.hash);
-    console.log("ALERT: RESULT: " + JSON.stringify([
-        id,
-        harness_status.status,
-        harness_status.message,
-        harness_status.stack,
-        tests.map(function(t) {
-            return [t.name, t.status, t.message, t.stack]
-        }),
-    ]));
-});
+    add_completion_callback(function (tests, harness_status) {
+        var id = decodeURIComponent(start_loc.pathname) + decodeURIComponent(start_loc.search) + decodeURIComponent(start_loc.hash);
+        console.log("ALERT: RESULT: " + JSON.stringify([
+            id,
+            harness_status.status,
+            harness_status.message,
+            harness_status.stack,
+            tests.map(function(t) {
+                return [t.name, t.status, t.message, t.stack]
+            }),
+        ]));
+    });
+})();


### PR DESCRIPTION
For example, if a test uses `let props = ...` then this was triggering an exception because testharnessreport-servo.js already created a global variable named `props`.

Testing: some wpt tests no longer result in ERROR
