### PR TITLE
Fix DBus warning when running `mach`

### DIFF
--- a/servobuild.example
+++ b/servobuild.example
@@ -5,12 +5,6 @@
 # Tool options
 [tools]
 
-# If uncommented, this command is used instead of the platform’s default
-# to notify at the end of a compilation that took a long time.
-# This is the name or path of an executable called with two arguments:
-# the summary and content of the notification.
-#notify-command = "notify-send"
-
 [build]
 # Set "mode = dev" or use `mach build --dev` to build the project with warning.
 # or Set "mode = release" or use `mach build --release` for optimized build.

--- a/shell.nix
+++ b/shell.nix
@@ -89,7 +89,6 @@ stdenv.mkDerivation (androidEnvironment // {
     # Ensure the Python version is same as the one in `.python-version` file so
     # that `uv` will just symlink to the one in nix store. Otherwise `uv` will
     # download a pre-built binary that won't work on nix.
-    # FIXME: dbus python module needs to be installed into the virtual environment.
     python311
     uv
 


### PR DESCRIPTION
I get the following warning message I run ./mach build:
```console
Could not generate notification: No module named 'dbus'
```

I asked in the Zulip chat[1] if anyone was still using the feature and
it sounds like most people do not use it anymore. It has been broken a
while too and no one has stepped up to fix it.

Gnome Terminal will automatically show a notification when a long
running command is done. Some other terminals can also be configured to
automatically show a notification when a long running command is done.

I think it is safe to remove the feature.

[1] https://servo.zulipchat.com/#narrow/channel/263398-general/topic/DBus.20warning.20when.20running.20.60.2E.2Fmach.20build.60

Testing: I manually tested it on Linux by running ./mach bootstrap followed by ./mach build