### PR TITLE
Upgrade Stylo to 2025-07-01

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7234,8 +7234,8 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.29.0"
-source = "git+https://github.com/servo/stylo?branch=2025-06-03#da53c540faa7dd5556c6718d4644a6e957947893"
+version = "0.30.0"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#31a2c9cfa9a8fe8e980ada1a7502d07397a03873"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -7541,7 +7541,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-06-03#da53c540faa7dd5556c6718d4644a6e957947893"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#31a2c9cfa9a8fe8e980ada1a7502d07397a03873"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8002,8 +8002,8 @@ dependencies = [
 
 [[package]]
 name = "stylo"
-version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-06-03#da53c540faa7dd5556c6718d4644a6e957947893"
+version = "0.5.0"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#31a2c9cfa9a8fe8e980ada1a7502d07397a03873"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8059,8 +8059,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_atoms"
-version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-06-03#da53c540faa7dd5556c6718d4644a6e957947893"
+version = "0.5.0"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#31a2c9cfa9a8fe8e980ada1a7502d07397a03873"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8068,13 +8068,13 @@ dependencies = [
 
 [[package]]
 name = "stylo_config"
-version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-06-03#da53c540faa7dd5556c6718d4644a6e957947893"
+version = "0.5.0"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#31a2c9cfa9a8fe8e980ada1a7502d07397a03873"
 
 [[package]]
 name = "stylo_derive"
-version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-06-03#da53c540faa7dd5556c6718d4644a6e957947893"
+version = "0.5.0"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#31a2c9cfa9a8fe8e980ada1a7502d07397a03873"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8085,8 +8085,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_dom"
-version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-06-03#da53c540faa7dd5556c6718d4644a6e957947893"
+version = "0.5.0"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#31a2c9cfa9a8fe8e980ada1a7502d07397a03873"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -8094,8 +8094,8 @@ dependencies = [
 
 [[package]]
 name = "stylo_malloc_size_of"
-version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-06-03#da53c540faa7dd5556c6718d4644a6e957947893"
+version = "0.5.0"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#31a2c9cfa9a8fe8e980ada1a7502d07397a03873"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8111,13 +8111,13 @@ dependencies = [
 
 [[package]]
 name = "stylo_static_prefs"
-version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-06-03#da53c540faa7dd5556c6718d4644a6e957947893"
+version = "0.5.0"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#31a2c9cfa9a8fe8e980ada1a7502d07397a03873"
 
 [[package]]
 name = "stylo_traits"
-version = "0.4.0"
-source = "git+https://github.com/servo/stylo?branch=2025-06-03#da53c540faa7dd5556c6718d4644a6e957947893"
+version = "0.5.0"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#31a2c9cfa9a8fe8e980ada1a7502d07397a03873"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -8534,7 +8534,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-06-03#da53c540faa7dd5556c6718d4644a6e957947893"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#31a2c9cfa9a8fe8e980ada1a7502d07397a03873"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8547,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-06-03#da53c540faa7dd5556c6718d4644a6e957947893"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#31a2c9cfa9a8fe8e980ada1a7502d07397a03873"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ rustls-pemfile = "2.0"
 rustls-pki-types = "1.12"
 layout_api = { path = "components/shared/layout" }
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2025-06-03" }
+selectors = { git = "https://github.com/servo/stylo", branch = "2025-07-01" }
 serde = "1.0.219"
 serde_bytes = "0.11"
 serde_json = "1.0"
@@ -128,7 +128,7 @@ servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-06-03" }
+servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-07-01" }
 smallbitvec = "2.6.0"
 smallvec = { version = "1.15", features = ["union"] }
 static_assertions = "1.1"
@@ -136,12 +136,12 @@ string_cache = "0.8"
 string_cache_codegen = "0.5"
 strum = "0.26"
 strum_macros = "0.26"
-stylo = { git = "https://github.com/servo/stylo", branch = "2025-06-03" }
-stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-06-03" }
-stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-06-03" }
-stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-06-03" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-06-03" }
-stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-06-03" }
+stylo = { git = "https://github.com/servo/stylo", branch = "2025-07-01" }
+stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-07-01" }
+stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-07-01" }
+stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-07-01" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-07-01" }
+stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-07-01" }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/tests/wpt/meta/css/css-color/parsing/color-valid.html.ini
+++ b/tests/wpt/meta/css/css-color/parsing/color-valid.html.ini
@@ -661,6 +661,3 @@
 
   [e.style['color'\] = "oklch(10% 20 -700)" should set the property value]
     expected: FAIL
-
-  [e.style['color'\] = "light-dark(black, white)" should set the property value]
-    expected: FAIL


### PR DESCRIPTION
This continues #37444

Changelog:
 - No-op change because of https://github.com/servo/stylo/pull/186: https://github.com/servo/stylo/compare/7e2201c32c991d20faaf05a67aaee2c715361e8e..0a5440a8afa32501c27c9eca4deea9bc4f04772d
 - Upstream: https://github.com/servo/stylo/compare/0a5440a8afa32501c27c9eca4deea9bc4f04772d...fe9eadf47bc771d5f7e4ab5908370400dea47568
 - Servo fixups: https://github.com/servo/stylo/compare/e8dbccb2542040aa871c7824b4ab4d3c48ecd4fb...31a2c9cfa9a8fe8e980ada1a7502d07397a03873

Stylo tracking issue: https://github.com/servo/stylo/issues/211