### PR TITLE
webdriver: enable getting closed shadow root

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1047,7 +1047,7 @@ pub(crate) fn handle_get_element_shadow_root(
         .send(
             get_known_element(documents, pipeline, element_id).map(|element| {
                 element
-                    .GetShadowRoot()
+                    .shadow_root()
                     .map(|x| x.upcast::<Node>().unique_id(pipeline))
             }),
         )

--- a/tests/wpt/meta/webdriver/tests/classic/find_element_from_shadow_root/find.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/find_element_from_shadow_root/find.py.ini
@@ -1,21 +1,3 @@
 [find.py]
   [test_no_browsing_context]
     expected: FAIL
-
-  [test_find_element[closed-css selector-#linkText\]]
-    expected: FAIL
-
-  [test_find_element[closed-link text-full link text\]]
-    expected: FAIL
-
-  [test_find_element[closed-partial link text-link text\]]
-    expected: FAIL
-
-  [test_find_element[closed-tag name-a\]]
-    expected: FAIL
-
-  [test_find_element[closed-xpath-//a\]]
-    expected: FAIL
-
-  [test_find_element_in_nested_shadow_root[closed\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/find_elements_from_shadow_root/find.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/find_elements_from_shadow_root/find.py.ini
@@ -1,21 +1,3 @@
 [find.py]
   [test_no_browsing_context]
     expected: FAIL
-
-  [test_find_elements[closed-css selector-#linkText\]]
-    expected: FAIL
-
-  [test_find_elements[closed-link text-full link text\]]
-    expected: FAIL
-
-  [test_find_elements[closed-partial link text-link text\]]
-    expected: FAIL
-
-  [test_find_elements[closed-tag name-a\]]
-    expected: FAIL
-
-  [test_find_elements[closed-xpath-//a\]]
-    expected: FAIL
-
-  [test_find_elements_in_nested_shadow_root[closed\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/key.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/key.py.ini
@@ -4,9 +4,3 @@
 
   [test_key_down_closes_browsing_context]
     expected: FAIL
-
-  [test_element_in_shadow_tree[outer-closed\]]
-    expected: FAIL
-
-  [test_element_in_shadow_tree[inner-closed\]]
-    expected: FAIL


### PR DESCRIPTION
Previously, when getting element shadow root, we are using [GetShadowRoot](https://dom.spec.whatwg.org/#dom-element-shadowroot). This is a getter which only allows javascript to access shadow root with `open` mode.

In [webdriver spec](https://www.w3.org/TR/webdriver2/#dfn-get-element-shadow-root), particularly step 5, it seems that they imply for us to get the shadow root without going through the above getter.

P.S. Other browser seems to also allows getting closed shadow root, like Chromium here: https://chromium-review.googlesource.com/c/chromium/src/+/5923865.

Testing: Covered in webdriver WPT test that access closed shadow root.
