### PR TITLE
script: Remove the quirk of flooring rowSpan by 1

### DIFF
--- a/components/script/dom/htmltablecellelement.rs
+++ b/components/script/dom/htmltablecellelement.rs
@@ -7,7 +7,6 @@ use html5ever::{LocalName, Prefix, local_name, ns};
 use js::rust::HandleObject;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use style::color::AbsoluteColor;
-use style::context::QuirksMode;
 
 use super::attr::Attr;
 use super::element::AttributeMutation;
@@ -208,13 +207,8 @@ impl VirtualMethods for HTMLTableCellElement {
                     // From <https://html.spec.whatwg.org/multipage/#dom-tdth-rowspan>:
                     // > The rowSpan IDL attribute must reflect the rowspan content attribute. It is clamped to
                     // > the range [0, 65534], and its default value is 1.
-                    // Note that rowspan = 0 is not supported in quirks mode.
-                    let document = self.upcast::<Node>().owner_doc();
-                    if document.quirks_mode() == QuirksMode::Quirks {
-                        *value = (*value).clamp(1, 65534);
-                    } else {
-                        *value = (*value).clamp(0, 65534);
-                    }
+                    // Note Firefox floors by 1 in quirks mode, but like Chrome and Safari we don't do that.
+                    *value = (*value).clamp(0, 65534);
                 }
                 attr
             },

--- a/tests/wpt/tests/css/css-tables/tentative/table-quirks.html
+++ b/tests/wpt/tests/css/css-tables/tentative/table-quirks.html
@@ -55,7 +55,7 @@
 </div>
 
 <p><a href="https://quirks.spec.whatwg.org/#the-collapsing-table-quirk">The collapsing table quirk</a></p>
-<p class="error">Chrome Legacy/Edge/Safari ignore the quirk, FF does not. <b>Proposal: depreciate the quirk</b></p>
+<p class="error">Chrome Legacy/Edge/Safari ignore the quirk, FF does not. <b>Proposal: deprecate the quirk</b></p>
 <table style="border: 20px solid green" data-expected-height=40 data-expected-width=40></table>
 
 <p><a href="https://quirks.spec.whatwg.org/#the-table-cell-width-calculation-quirk">The table cell width calculation quirk</a></p>
@@ -64,10 +64,10 @@
 </table>
 
 <p><a href="https://html.spec.whatwg.org/multipage/tables.html#algorithm-for-processing-rows">The "let <i>cell grows downward</i> be false" quirk</a></p>
-<p class="error">Chrome LayoutNG and Safari ignore the quirk, FF does not.</p>
+<p class="error">Chrome LayoutNG and Safari ignore the quirk, FF does not. <b>Proposal: deprecate the quirk</b></p>
 <table>
   <tr style="height: 100px">
-    <td id="rowspan" rowspan="0" data-expected-height=100>100 height</td>
+    <td id="rowspan" rowspan="0" data-expected-height=208>208 height</td>
   </tr>
   <tr style="height: 100px"></tr>
 </table>
@@ -82,7 +82,7 @@
     assert_equals(window.getComputedStyle(document.querySelector("#notitalic")).fontStyle, "normal");
   }, "decoration does not propagate into table");
   test(_ => {
-    assert_equals(document.querySelector("#rowspan").rowSpan, 1);
-  }, "rowspan can't be zero");
+    assert_equals(document.querySelector("#rowspan").rowSpan, 0);
+  }, "rowspan can be zero");
   document.fonts.ready.then(() => checkLayout("table"));
 </script>


### PR DESCRIPTION
Only Firefox has this quirk, Chrome and Safari don't. So it's simpler to just remove it.

Testing: tested by WPT
