### PR TITLE
layout: Implement `list-style-position` quirk

### DIFF
--- a/components/layout/stylesheets/quirks-mode.css
+++ b/components/layout/stylesheets/quirks-mode.css
@@ -42,3 +42,8 @@ input:not([type=image]), textarea { box-sizing: border-box; }
 
 img[align=left i] { margin-right: 3px; }
 img[align=right i] { margin-left: 3px; }
+
+/* https://html.spec.whatwg.org/multipage/rendering.html#lists:quirks-mode */
+li { list-style-position: inside; }
+li :is(dir, menu, ol, ul) { list-style-position: outside; }
+:is(dir, menu, ol, ul) :is(dir, menu, ol, ul, li) { list-style-position: unset; }

--- a/tests/wpt/meta/html/rendering/non-replaced-elements/lists/lists-styles-quirks.html.ini
+++ b/tests/wpt/meta/html/rendering/non-replaced-elements/lists/lists-styles-quirks.html.ini
@@ -1,7 +1,4 @@
 [lists-styles-quirks.html]
-  [<li> - list-style-position]
-    expected: FAIL
-
   [<dir> (in <dir>) - margin-top]
     expected: FAIL
 
@@ -540,43 +537,4 @@
     expected: FAIL
 
   [<ul> (in <ul><ul>) - list-style-type]
-    expected: FAIL
-
-  [<li type="1"> - list-style-position]
-    expected: FAIL
-
-  [<li type="a" class="type-a"> - list-style-position]
-    expected: FAIL
-
-  [<li type="A" class="type-A"> - list-style-position]
-    expected: FAIL
-
-  [<li type="i" class="type-i"> - list-style-position]
-    expected: FAIL
-
-  [<li type="I" class="type-I"> - list-style-position]
-    expected: FAIL
-
-  [<li type="none"> - list-style-position]
-    expected: FAIL
-
-  [<li type="NONE"> - list-style-position]
-    expected: FAIL
-
-  [<li type="disc"> - list-style-position]
-    expected: FAIL
-
-  [<li type="DISC"> - list-style-position]
-    expected: FAIL
-
-  [<li type="circle"> - list-style-position]
-    expected: FAIL
-
-  [<li type="CIRCLE"> - list-style-position]
-    expected: FAIL
-
-  [<li type="square"> - list-style-position]
-    expected: FAIL
-
-  [<li type="SQUARE"> - list-style-position]
     expected: FAIL

--- a/tests/wpt/meta/quirks/line-height-in-list-item.html.ini
+++ b/tests/wpt/meta/quirks/line-height-in-list-item.html.ini
@@ -1,2 +1,0 @@
-[line-height-in-list-item.html]
-  expected: FAIL


### PR DESCRIPTION
In quirks mode, the ::marker of a bare `<li>` should be `list-style-position: inside`,

Testing: Some WPT improvement