### PR TITLE
servoshell: Select address bar text on click

### DIFF
--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -340,7 +340,11 @@ impl Minibrowser {
                                                 i.clone().consume_key(Modifiers::ALT, Key::D)
                                         }
                                     }) {
+                                        // The focus request immediately makes gained_focus return true.
                                         location_field.request_focus();
+                                    }
+                                    // Select address bar text when it's focused (click or shortcut).
+                                    if location_field.gained_focus() {
                                         if let Some(mut state) =
                                             TextEditState::load(ui.ctx(), location_id)
                                         {
@@ -352,6 +356,7 @@ impl Minibrowser {
                                             state.store(ui.ctx(), location_id);
                                         }
                                     }
+                                    // Navigate to address when enter is pressed in the address bar.
                                     if location_field.lost_focus() &&
                                         ui.input(|i| i.clone().key_pressed(Key::Enter))
                                     {


### PR DESCRIPTION
In Firefox, clicking on the address bar selects all the text. This makes Servo to do the same. I reworked the code so that the shortcut only changes the focus. That means that either clicking or the shortcut changes the focus which in turn selects the text.

Testing: I tested it manually by clicking in the address bar and using the shortcuts and noticing that the text was selected.