### PR TITLE
net: Do not print SVG tree in `Debug` implementation of `VectorImageData`

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -267,11 +267,17 @@ impl CompletedLoad {
     }
 }
 
-#[derive(Clone, Debug, MallocSizeOf)]
+#[derive(Clone, MallocSizeOf)]
 struct VectorImageData {
     #[conditional_malloc_size_of]
     svg_tree: Arc<usvg::Tree>,
     cors_status: CorsStatus,
+}
+
+impl std::fmt::Debug for VectorImageData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VectorImageData").finish()
+    }
 }
 
 enum DecodedImage {


### PR DESCRIPTION
Manually implement Debug LoadResult so that VectorImageData doesn't get logged.

Testing: N/A
Fixes: #37771
