### PR TITLE
layout: Add incremental box tree construction for table caption

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -180,6 +180,10 @@ impl BoxSlot<'_> {
             *slot.borrow_mut() = Some(box_);
         }
     }
+
+    pub(crate) fn take_layout_box(&self) -> Option<LayoutBox> {
+        self.slot.as_ref().and_then(|slot| slot.borrow_mut().take())
+    }
 }
 
 impl Drop for BoxSlot<'_> {

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -700,7 +700,6 @@ impl BlockLevelJob<'_> {
                 },
                 None => None,
             } {
-                block_level_box.borrow().invalidate_cached_fragment();
                 return block_level_box;
             }
         }

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -145,6 +145,10 @@ pub(crate) fn compute_damage_and_repair_style_inner(
         element_data.borrow_mut().damage.insert(element_damage);
     }
 
+    if element_damage.contains(LayoutDamage::recollect_box_tree_children()) {
+        node.invalidate_cached_fragment();
+    }
+
     // Only propagate up layout phases from children, as other types of damage are
     // incorporated into `element_damage` above.
     element_damage | (damage_from_children & RestyleDamage::RELAYOUT)


### PR DESCRIPTION
This change extends incremental box tree updates to table captions. In
addition, calls to `LayoutBox::invalidate_cached_fragment()` are moved
to the damage calculation traversal.

Testing: This should not change observable behavior and is thus covered by existing WPT tests.
