### PR TITLE
layout: Add incremental box tree construction for table cell

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -181,7 +181,10 @@ impl BoxSlot<'_> {
         }
     }
 
-    pub(crate) fn take_layout_box(&self) -> Option<LayoutBox> {
+    pub(crate) fn take_layout_box_if_undamaged(&self, damage: LayoutDamage) -> Option<LayoutBox> {
+        if damage.has_box_damage() {
+            return None;
+        }
         self.slot.as_ref().and_then(|slot| slot.borrow_mut().take())
     }
 }


### PR DESCRIPTION
This change extends incremental box tree updates to table cells. In addition, for simplicity this refactors `BoxSlot::take_layout_box()` into `BoxSlot::take_layout_box_if_undamaged()`.

Testing: This should not change observable behavior and is thus covered by existing WPT tests.
