### PR TITLE
Layout: Continue support incremental box tree reconstruction for flex&taffy level box

### DIFF
--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -113,13 +113,20 @@ impl FlexContainer {
             .into_iter()
             .map(|item| {
                 let box_ = match item.kind {
-                    ModernItemKind::InFlow => ArcRefCell::new(FlexLevelBox::FlexItem(
-                        FlexItemBox::new(item.formatting_context),
-                    )),
-                    ModernItemKind::OutOfFlow => {
-                        let abs_pos_box =
-                            ArcRefCell::new(AbsolutelyPositionedBox::new(item.formatting_context));
+                    ModernItemKind::InFlow(independent_formatting_context) => ArcRefCell::new(
+                        FlexLevelBox::FlexItem(FlexItemBox::new(independent_formatting_context)),
+                    ),
+                    ModernItemKind::OutOfFlow(independent_formatting_context) => {
+                        let abs_pos_box = ArcRefCell::new(AbsolutelyPositionedBox::new(
+                            independent_formatting_context,
+                        ));
                         ArcRefCell::new(FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(abs_pos_box))
+                    },
+                    ModernItemKind::ReusedBox(layout_box) => match layout_box {
+                        LayoutBox::FlexLevel(flex_level_box) => flex_level_box,
+                        _ => unreachable!(
+                            "Undamaged flex level element should be associated with flex level box"
+                        ),
                     },
                 };
 

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -46,15 +46,22 @@ impl TaffyContainer {
             .into_iter()
             .map(|item| {
                 let box_ = match item.kind {
-                    ModernItemKind::InFlow => ArcRefCell::new(TaffyItemBox::new(
-                        TaffyItemBoxInner::InFlowBox(item.formatting_context),
-                    )),
-                    ModernItemKind::OutOfFlow => {
-                        let abs_pos_box =
-                            ArcRefCell::new(AbsolutelyPositionedBox::new(item.formatting_context));
+                    ModernItemKind::InFlow(independent_formatting_context) => {
+                        ArcRefCell::new(TaffyItemBox::new(TaffyItemBoxInner::InFlowBox(
+                            independent_formatting_context,
+                        )))
+                    },
+                    ModernItemKind::OutOfFlow(independent_formatting_context) => {
+                        let abs_pos_box = ArcRefCell::new(AbsolutelyPositionedBox::new(
+                            independent_formatting_context,
+                        ));
                         ArcRefCell::new(TaffyItemBox::new(
                             TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(abs_pos_box),
                         ))
+                    },
+                    ModernItemKind::ReusedBox(layout_box) => match layout_box {
+                        LayoutBox::TaffyItemBox(taffy_item_box) => taffy_item_box,
+                        _ => unreachable!("Undamaged taffy level element should be associated with taffy level box"),
                     },
                 };
 


### PR DESCRIPTION
Layout: Continue support incremental box tree reconstruction for flex&taffy level box

This change reuse the flex/taffy level box from old box slot if the box slot is valid and there is no LayoutDamage to the element.

Testing: This should not change observable behavior and is thus covered by existing WPT tests.
