### PR TITLE
Rename original `window_resizeTo.html` to `window_resize_event.html` & Fix wrong usage of `innerHeight` & add new test

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14379,7 +14379,14 @@
      ]
     ],
     "window_resizeTo.html": [
-     "3f6c5a610d52b64bf4457d478b929e95d79e9ab8",
+     "d104be2bc840eecc7c32e27a6fdf1850d945f1e5",
+     [
+      null,
+      {}
+     ]
+    ],
+    "window_resize_event.html": [
+     "68222f978909022ae1abfbdce6c4ea1c5787c554",
      [
       null,
       {}

--- a/tests/wpt/mozilla/meta/mozilla/window_resizeTo.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/window_resizeTo.html.ini
@@ -1,0 +1,3 @@
+[window_resizeTo.html]
+  [Correctly resize outerWidth and outerHeight]
+    expected: FAIL

--- a/tests/wpt/mozilla/tests/mozilla/window_resizeTo.html
+++ b/tests/wpt/mozilla/tests/mozilla/window_resizeTo.html
@@ -1,21 +1,18 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>Verify that the resize event is fired when the window is resized (in popup)</title>
+<title>Verify that the resize dimension is outerWidth & outerHeight</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script>
-    async_test(function (t) {
-        var popup = window.open("about:blank", "_blank", "width=100,height=100");
+    promise_test(async (t) => {
+        const popup = window.open("about:blank", "_blank", "width=100,height=100");
         assert_not_equals(popup, null, "Popup must be successfully opened");
 
-        popup.onload = function () {
-            popup.onresize = t.step_func(function () {
-                assert_approx_equals(popup.innerWidth, 200, 10, "Popup width should be ~200");
-                assert_approx_equals(popup.innerHeight, 200, 10, "Popup height should be ~200");
-                t.done();
-            });
+        popup.resizeTo(200, 200);
+        // wait briefly for resize to complete
+        await new Promise(resolve => setTimeout(resolve, 100));
 
-            popup.resizeTo(200, 200);
-        };
-    }, "Popup onresize event fires after resizeTo");
+        assert_approx_equals(popup.outerWidth, 200, 10, "Popup width should be ~200");
+        assert_approx_equals(popup.outerHeight, 200, 10, "Popup height should be ~200");
+    }, "Correctly resize outerWidth and outerHeight");
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/window_resize_event.html
+++ b/tests/wpt/mozilla/tests/mozilla/window_resize_event.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Verify that the resize event is fired when the window is resized (in popup)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+    async_test(function (t) {
+        var popup = window.open("about:blank", "_blank", "width=100,height=100");
+        assert_not_equals(popup, null, "Popup must be successfully opened");
+
+        popup.onload = function () {
+            popup.onresize = t.step_func(function () {
+                assert_approx_equals(popup.outerWidth, 200, 10, "Popup width should be ~200");
+                assert_approx_equals(popup.outerHeight, 200, 10, "Popup height should be ~200");
+                t.done();
+            });
+
+            popup.resizeTo(200, 200);
+        };
+    }, "Popup onresize event fires after resizeTo");
+</script>


### PR DESCRIPTION
1. rename original `window_resizeTo.html` to `window_resize_event.html` to reflect the purpose. Also change {innerWidth, innerHeight} to {outerWidth, outerHeight} to match spec.
2. Add a new test `window_resizeTo.html` for https://github.com/servo/servo/pull/37848

Testing: new test always fails because of https://github.com/servo/servo/issues/37824, which gives inaccurate outerHeight.

