### PR TITLE
Don't explicitly handle dirty roots that are shadow roots

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -663,14 +663,8 @@ impl Document {
             has_dirty_descendants &= *ancestor != *new_dirty_root;
         }
 
-        let maybe_shadow_host = new_dirty_root
-            .downcast::<ShadowRoot>()
-            .map(ShadowRootMethods::Host);
-        let new_dirty_root_element = new_dirty_root
-            .downcast::<Element>()
-            .or(maybe_shadow_host.as_deref());
-
-        self.dirty_root.set(new_dirty_root_element);
+        self.dirty_root
+            .set(Some(new_dirty_root.downcast::<Element>().unwrap()));
     }
 
     pub(crate) fn take_dirty_root(&self) -> Option<DomRoot<Element>> {


### PR DESCRIPTION
Dirty roots are never shadow roots, since we use the flat tree for invalidation. The flat tree does not contain shadow roots.

Reverts https://github.com/servo/servo/pull/35132. When that patch was submitted we used the DOM tree for invalidation, so it was possible to encounter shadow roots.

Testing: Covered by `shadow-dom/untriaged/events/event-dispatch/test-003.html`

