### PR TITLE
canvas: Use snapshot in canvas backends

### DIFF
--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -2,15 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
-
 use canvas_traits::canvas::{
     CompositionOrBlending, FillOrStrokeStyle, LineCapStyle, LineJoinStyle, PathSegment,
 };
+use compositing_traits::SerializableImageData;
 use euclid::Angle;
 use euclid::default::{Point2D, Rect, Size2D, Transform2D, Vector2D};
 use lyon_geom::Arc;
+use pixels::Snapshot;
 use style::color::AbsoluteColor;
+use webrender_api::ImageDescriptor;
 
 use crate::canvas_data::{CanvasPaintState, Filter, PathBuilderRef, TextRun};
 
@@ -113,7 +114,8 @@ pub(crate) trait GenericDrawTarget<B: Backend> {
         draw_options: &B::DrawOptions,
     );
     fn surface(&self) -> B::SourceSurface;
-    fn bytes(&self) -> Cow<[u8]>;
+    fn wr_data(&self) -> (ImageDescriptor, SerializableImageData);
+    fn snapshot(&self) -> Snapshot;
 }
 
 /// A generic Path that abstracts the interface for raqote's PathBuilder/Path.

--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -114,7 +114,7 @@ pub(crate) trait GenericDrawTarget<B: Backend> {
         draw_options: &B::DrawOptions,
     );
     fn surface(&self) -> B::SourceSurface;
-    fn wr_data(&self) -> (ImageDescriptor, SerializableImageData);
+    fn image_descriptor_and_serializable_data(&self) -> (ImageDescriptor, SerializableImageData);
     fn snapshot(&self) -> Snapshot;
 }
 

--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -62,7 +62,7 @@ pub(crate) trait GenericDrawTarget<B: Backend> {
         destination: Point2D<i32>,
     );
     fn create_similar_draw_target(&self, size: &Size2D<i32>) -> Self;
-    fn create_source_surface_from_data(&self, data: &[u8]) -> Option<B::SourceSurface>;
+    fn create_source_surface_from_data(&self, data: Snapshot) -> Option<B::SourceSurface>;
     fn draw_surface(
         &mut self,
         surface: B::SourceSurface,

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -352,7 +352,7 @@ impl<'a, B: Backend> CanvasData<'a, B> {
         let size = size.max(MIN_WR_IMAGE_SIZE);
         let draw_target = backend.create_drawtarget(size);
         let image_key = compositor_api.generate_image_key_blocking().unwrap();
-        let (descriptor, data) = draw_target.wr_data();
+        let (descriptor, data) = draw_target.image_descriptor_and_serializable_data();
         compositor_api.add_image(image_key, descriptor, data);
         CanvasData {
             state: backend.new_paint_state(),
@@ -1095,7 +1095,7 @@ impl<'a, B: Backend> CanvasData<'a, B> {
 
     /// Update image in WebRender
     pub(crate) fn update_image_rendering(&mut self) {
-        let (descriptor, data) = self.drawtarget.wr_data();
+        let (descriptor, data) = self.drawtarget.image_descriptor_and_serializable_data();
 
         self.compositor_api
             .update_image(self.image_key, descriptor, data);

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -388,9 +388,17 @@ impl GenericDrawTarget<RaqoteBackend> for raqote::DrawTarget {
     }
     fn create_source_surface_from_data(
         &self,
-        data: &[u8],
+        data: Snapshot,
     ) -> Option<<RaqoteBackend as Backend>::SourceSurface> {
-        Some(data.to_vec())
+        Some(
+            data.to_vec(
+                Some(SnapshotAlphaMode::Transparent {
+                    premultiplied: true,
+                }),
+                Some(SnapshotPixelFormat::BGRA),
+            )
+            .0,
+        )
     }
     #[allow(unsafe_code)]
     fn draw_surface(

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -12,6 +12,7 @@ use euclid::default::{Point2D, Rect, Size2D, Transform2D, Vector2D};
 use font_kit::font::Font;
 use fonts::{ByteIndex, FontIdentifier, FontTemplateRefMethods};
 use log::warn;
+use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 use range::Range;
 use raqote::PathOp;
 use style::color::AbsoluteColor;
@@ -34,7 +35,7 @@ thread_local! {
 pub(crate) struct RaqoteBackend;
 
 impl Backend for RaqoteBackend {
-    type Pattern<'a> = Pattern<'a>;
+    type Pattern<'a> = Pattern;
     type StrokeOptions = raqote::StrokeStyle;
     type Color = raqote::SolidSource;
     type DrawOptions = raqote::DrawOptions;
@@ -112,12 +113,12 @@ impl Backend for RaqoteBackend {
 }
 
 #[derive(Clone)]
-pub enum Pattern<'a> {
+pub enum Pattern {
     // argb
     Color(u8, u8, u8, u8),
     LinearGradient(LinearGradientPattern),
     RadialGradient(RadialGradientPattern),
-    Surface(SurfacePattern<'a>),
+    Surface(SurfacePattern),
 }
 
 #[derive(Clone)]
@@ -165,17 +166,17 @@ impl RadialGradientPattern {
 }
 
 #[derive(Clone)]
-pub struct SurfacePattern<'a> {
-    image: raqote::Image<'a>,
+pub struct SurfacePattern {
+    image: Snapshot,
     filter: raqote::FilterMode,
     extend: raqote::ExtendMode,
     repeat: Repetition,
     transform: Transform2D<f32>,
 }
 
-impl<'a> SurfacePattern<'a> {
+impl SurfacePattern {
     fn new(
-        image: raqote::Image<'a>,
+        image: Snapshot,
         filter: raqote::FilterMode,
         repeat: Repetition,
         transform: Transform2D<f32>,
@@ -195,7 +196,7 @@ impl<'a> SurfacePattern<'a> {
         }
     }
     pub fn size(&self) -> Size2D<f32> {
-        Size2D::new(self.image.width as f32, self.image.height as f32)
+        self.image.size().cast()
     }
     pub fn repetition(&self) -> &Repetition {
         &self.repeat
@@ -224,7 +225,7 @@ impl Repetition {
     }
 }
 
-pub fn source<'a>(pattern: &Pattern<'a>) -> raqote::Source<'a> {
+pub fn source(pattern: &Pattern) -> raqote::Source {
     match pattern {
         Pattern::Color(a, r, g, b) => raqote::Source::Solid(
             raqote::SolidSource::from_unpremultiplied_argb(*a, *r, *g, *b),
@@ -243,16 +244,30 @@ pub fn source<'a>(pattern: &Pattern<'a>) -> raqote::Source<'a> {
             pattern.radius2,
             raqote::Spread::Pad,
         ),
-        Pattern::Surface(pattern) => raqote::Source::Image(
-            pattern.image,
-            pattern.extend,
-            pattern.filter,
-            pattern.transform,
-        ),
+        Pattern::Surface(pattern) => {
+            #[allow(unsafe_code)]
+            let data = unsafe {
+                let data = pattern.image.as_raw_bytes();
+                std::slice::from_raw_parts(
+                    data.as_ptr() as *const u32,
+                    data.len() / std::mem::size_of::<u32>(),
+                )
+            };
+            raqote::Source::Image(
+                raqote::Image {
+                    width: pattern.image.size().width as i32,
+                    height: pattern.image.size().height as i32,
+                    data,
+                },
+                pattern.extend,
+                pattern.filter,
+                pattern.transform,
+            )
+        },
     }
 }
 
-impl PatternHelpers for Pattern<'_> {
+impl PatternHelpers for Pattern {
     fn is_zero_size_gradient(&self) -> bool {
         match self {
             Pattern::RadialGradient(pattern) => {
@@ -384,23 +399,20 @@ impl GenericDrawTarget<RaqoteBackend> for raqote::DrawTarget {
         filter: Filter,
         draw_options: &<RaqoteBackend as Backend>::DrawOptions,
     ) {
-        let surface_data = surface;
-        let image = raqote::Image {
-            width: source.size.width as i32,
-            height: source.size.height as i32,
-            data: unsafe {
-                std::slice::from_raw_parts(
-                    surface_data.as_ptr() as *const u32,
-                    surface_data.len() / std::mem::size_of::<u32>(),
-                )
+        let image = Snapshot::from_vec(
+            source.size.cast(),
+            SnapshotPixelFormat::BGRA,
+            SnapshotAlphaMode::Transparent {
+                premultiplied: true,
             },
-        };
+            surface,
+        );
 
         let transform =
             raqote::Transform::translation(-dest.origin.x as f32, -dest.origin.y as f32)
                 .then_scale(
-                    image.width as f32 / dest.size.width as f32,
-                    image.height as f32 / dest.size.height as f32,
+                    source.size.width as f32 / dest.size.width as f32,
+                    source.size.height as f32 / dest.size.height as f32,
                 );
 
         let pattern = Pattern::Surface(SurfacePattern::new(
@@ -434,7 +446,7 @@ impl GenericDrawTarget<RaqoteBackend> for raqote::DrawTarget {
     fn fill(
         &mut self,
         path: &<RaqoteBackend as Backend>::Path,
-        pattern: &<RaqoteBackend as Backend>::Pattern<'_>,
+        pattern: &Pattern,
         draw_options: &<RaqoteBackend as Backend>::DrawOptions,
     ) {
         let path = path.into();
@@ -470,7 +482,7 @@ impl GenericDrawTarget<RaqoteBackend> for raqote::DrawTarget {
         &mut self,
         text_runs: Vec<TextRun>,
         start: Point2D<f32>,
-        pattern: &<RaqoteBackend as Backend>::Pattern<'_>,
+        pattern: &Pattern,
         draw_options: &<RaqoteBackend as Backend>::DrawOptions,
     ) {
         let mut advance = 0.;
@@ -563,7 +575,7 @@ impl GenericDrawTarget<RaqoteBackend> for raqote::DrawTarget {
     fn stroke(
         &mut self,
         path: &<RaqoteBackend as Backend>::Path,
-        pattern: &Pattern<'_>,
+        pattern: &Pattern,
         stroke_options: &<RaqoteBackend as Backend>::StrokeOptions,
         draw_options: &<RaqoteBackend as Backend>::DrawOptions,
     ) {
@@ -728,8 +740,8 @@ impl ToRaqoteStyle for LineCapStyle {
     }
 }
 
-pub trait ToRaqotePattern<'a> {
-    fn to_raqote_pattern(self) -> Option<Pattern<'a>>;
+pub trait ToRaqotePattern {
+    fn to_raqote_pattern(self) -> Option<Pattern>;
 }
 
 pub trait ToRaqoteGradientStop {
@@ -750,9 +762,9 @@ impl ToRaqoteGradientStop for CanvasGradientStop {
     }
 }
 
-impl ToRaqotePattern<'_> for FillOrStrokeStyle {
+impl ToRaqotePattern for FillOrStrokeStyle {
     #[allow(unsafe_code)]
-    fn to_raqote_pattern(self) -> Option<Pattern<'static>> {
+    fn to_raqote_pattern(self) -> Option<Pattern> {
         use canvas_traits::canvas::FillOrStrokeStyle::*;
 
         match self {
@@ -785,19 +797,17 @@ impl ToRaqotePattern<'_> for FillOrStrokeStyle {
                     stops,
                 )))
             },
-            Surface(ref style) => {
+            Surface(style) => {
                 let repeat = Repetition::from_xy(style.repeat_x, style.repeat_y);
-                let data = &style.surface_data[..];
-
-                let image = raqote::Image {
-                    width: style.surface_size.width as i32,
-                    height: style.surface_size.height as i32,
-                    data: unsafe {
-                        std::slice::from_raw_parts(data.as_ptr() as *const u32, data.len() / 4)
+                let mut snapshot = style.surface_data.to_owned();
+                snapshot.transform(
+                    SnapshotAlphaMode::Transparent {
+                        premultiplied: true,
                     },
-                };
+                    SnapshotPixelFormat::BGRA,
+                );
                 Some(Pattern::Surface(SurfacePattern::new(
-                    image,
+                    snapshot,
                     raqote::FilterMode::Nearest,
                     repeat,
                     style.transform,

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -609,7 +609,7 @@ impl GenericDrawTarget<RaqoteBackend> for raqote::DrawTarget {
         self.stroke(&pb.finish(), &source(pattern), stroke_options, draw_options);
     }
 
-    fn wr_data(
+    fn image_descriptor_and_serializable_data(
         &self,
     ) -> (
         webrender_api::ImageDescriptor,

--- a/components/pixels/snapshot.rs
+++ b/components/pixels/snapshot.rs
@@ -182,7 +182,7 @@ impl Snapshot<SnapshotData> {
 
     pub fn get_rect(&self, rect: Rect<u32>) -> Self {
         let data = rgba8_get_rect(self.as_raw_bytes(), self.size(), rect).to_vec();
-        Self::from_vec(self.size, self.format, self.alpha_mode, data)
+        Self::from_vec(rect.size, self.format, self.alpha_mode, data)
     }
 
     // TODO: https://github.com/servo/servo/issues/36594

--- a/components/pixels/snapshot.rs
+++ b/components/pixels/snapshot.rs
@@ -4,7 +4,7 @@
 
 use std::ops::{Deref, DerefMut};
 
-use euclid::default::Size2D;
+use euclid::default::{Rect, Size2D};
 use image::codecs::jpeg::JpegEncoder;
 use image::codecs::png::PngEncoder;
 use image::codecs::webp::WebPEncoder;
@@ -13,7 +13,7 @@ use ipc_channel::ipc::IpcSharedMemory;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
-use crate::{EncodedImageType, Multiply, transform_inplace};
+use crate::{EncodedImageType, Multiply, rgba8_get_rect, transform_inplace};
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
 pub enum SnapshotPixelFormat {
@@ -178,6 +178,11 @@ impl Snapshot<SnapshotData> {
             format,
             alpha_mode,
         }
+    }
+
+    pub fn get_rect(&self, rect: Rect<u32>) -> Self {
+        let data = rgba8_get_rect(self.as_raw_bytes(), self.size(), rect).to_vec();
+        Self::from_vec(self.size, self.format, self.alpha_mode, data)
     }
 
     // TODO: https://github.com/servo/servo/issues/36594

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -1186,14 +1186,7 @@ impl CanvasState {
             let size = snapshot.size();
             Ok(Some(CanvasPattern::new(
                 global,
-                snapshot
-                    .to_vec(
-                        Some(SnapshotAlphaMode::Transparent {
-                            premultiplied: true,
-                        }),
-                        Some(SnapshotPixelFormat::BGRA),
-                    )
-                    .0, // TODO: send snapshot
+                snapshot,
                 size.cast(),
                 rep,
                 self.is_origin_clean(image),

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -1696,10 +1696,8 @@ impl CanvasState {
         };
 
         // Step 7.
-        let (sender, receiver) = ipc::bytes_channel().unwrap();
-        let pixels = unsafe { &imagedata.get_rect(Rect::new(src_rect.origin, dst_rect.size)) };
-        self.send_canvas_2d_msg(Canvas2dMsg::PutImageData(dst_rect, receiver));
-        sender.send(pixels).unwrap();
+        let snapshot = imagedata.get_snapshot_rect(Rect::new(src_rect.origin, dst_rect.size));
+        self.send_canvas_2d_msg(Canvas2dMsg::PutImageData(dst_rect, snapshot.as_ipc()));
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-drawimage

--- a/components/script/dom/canvaspattern.rs
+++ b/components/script/dom/canvaspattern.rs
@@ -5,6 +5,7 @@
 use canvas_traits::canvas::{FillOrStrokeStyle, RepetitionStyle, SurfaceStyle};
 use dom_struct::dom_struct;
 use euclid::default::{Size2D, Transform2D};
+use pixels::{IpcSnapshot, Snapshot};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasPatternMethods;
@@ -21,7 +22,8 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct CanvasPattern {
     reflector_: Reflector,
-    surface_data: Vec<u8>,
+    #[no_trace]
+    surface_data: IpcSnapshot,
     #[no_trace]
     surface_size: Size2D<u32>,
     repeat_x: bool,
@@ -33,7 +35,7 @@ pub(crate) struct CanvasPattern {
 
 impl CanvasPattern {
     fn new_inherited(
-        surface_data: Vec<u8>,
+        surface_data: Snapshot,
         surface_size: Size2D<u32>,
         repeat: RepetitionStyle,
         origin_clean: bool,
@@ -47,7 +49,7 @@ impl CanvasPattern {
 
         CanvasPattern {
             reflector_: Reflector::new(),
-            surface_data,
+            surface_data: surface_data.as_ipc(),
             surface_size,
             repeat_x: x,
             repeat_y: y,
@@ -57,7 +59,7 @@ impl CanvasPattern {
     }
     pub(crate) fn new(
         global: &GlobalScope,
-        surface_data: Vec<u8>,
+        surface_data: Snapshot,
         surface_size: Size2D<u32>,
         repeat: RepetitionStyle,
         origin_clean: bool,

--- a/components/script/dom/imagedata.rs
+++ b/components/script/dom/imagedata.rs
@@ -12,6 +12,7 @@ use js::gc::CustomAutoRooterGuard;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use js::typedarray::{ClampedU8, Uint8ClampedArray};
+use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 
 use super::bindings::buffer_source::{HeapBufferSource, create_heap_buffer_source_with_length};
 use crate::dom::bindings::buffer_source::create_buffer_source;
@@ -181,6 +182,18 @@ impl ImageData {
     #[allow(unsafe_code)]
     pub(crate) unsafe fn get_rect(&self, rect: Rect<u32>) -> Cow<[u8]> {
         pixels::rgba8_get_rect(unsafe { self.as_slice() }, self.get_size().to_u32(), rect)
+    }
+
+    #[allow(unsafe_code)]
+    pub(crate) fn get_snapshot_rect(&self, rect: Rect<u32>) -> Snapshot {
+        Snapshot::from_vec(
+            rect.size,
+            SnapshotPixelFormat::RGBA,
+            SnapshotAlphaMode::Transparent {
+                premultiplied: false,
+            },
+            unsafe { self.get_rect(rect).into_owned() },
+        )
     }
 
     #[allow(unsafe_code)]

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -6,7 +6,7 @@ use std::default::Default;
 use std::str::FromStr;
 
 use euclid::default::{Point2D, Rect, Size2D, Transform2D};
-use ipc_channel::ipc::{IpcBytesReceiver, IpcSender};
+use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
 use pixels::IpcSnapshot;
 use serde::{Deserialize, Serialize};
@@ -109,7 +109,7 @@ pub enum Canvas2dMsg {
     LineTo(Point2D<f32>),
     MoveTo(Point2D<f32>),
     MeasureText(String, IpcSender<TextMetrics>),
-    PutImageData(Rect<u32>, IpcBytesReceiver),
+    PutImageData(Rect<u32>, IpcSnapshot),
     QuadraticCurveTo(Point2D<f32>, Point2D<f32>),
     Rect(Rect<f32>),
     RestoreContext,

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -10,7 +10,6 @@ use ipc_channel::ipc::{IpcBytesReceiver, IpcSender};
 use malloc_size_of_derive::MallocSizeOf;
 use pixels::IpcSnapshot;
 use serde::{Deserialize, Serialize};
-use serde_bytes::ByteBuf;
 use strum::{Display, EnumString};
 use style::color::AbsoluteColor;
 use style::properties::style_structs::Font as FontStyleStruct;
@@ -210,7 +209,7 @@ impl RadialGradientStyle {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SurfaceStyle {
-    pub surface_data: ByteBuf,
+    pub surface_data: IpcSnapshot,
     pub surface_size: Size2D<u32>,
     pub repeat_x: bool,
     pub repeat_y: bool,
@@ -219,14 +218,14 @@ pub struct SurfaceStyle {
 
 impl SurfaceStyle {
     pub fn new(
-        surface_data: Vec<u8>,
+        surface_data: IpcSnapshot,
         surface_size: Size2D<u32>,
         repeat_x: bool,
         repeat_y: bool,
         transform: Transform2D<f32>,
     ) -> Self {
         Self {
-            surface_data: ByteBuf::from(surface_data),
+            surface_data,
             surface_size,
             repeat_x,
             repeat_y,

--- a/tests/wpt/meta/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-pattern-image.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-pattern-image.html.ini
@@ -1,74 +1,32 @@
 [canvas-display-p3-pattern-image.html]
-  [sRGB-FF0000FF.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [sRGB-FF0000FF.png, Context srgb, ImageData display-p3]
-    expected: FAIL
-
-  [sRGB-FF0000FF.png, Context display-p3, ImageData srgb]
     expected: FAIL
 
   [sRGB-FF0000FF.png, Context display-p3, ImageData display-p3]
     expected: FAIL
 
-  [sRGB-FF0000CC.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [sRGB-FF0000CC.png, Context srgb, ImageData display-p3]
-    expected: FAIL
-
-  [sRGB-FF0000CC.png, Context display-p3, ImageData srgb]
     expected: FAIL
 
   [sRGB-FF0000CC.png, Context display-p3, ImageData display-p3]
     expected: FAIL
 
-  [sRGB-BB0000FF.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [sRGB-BB0000FF.png, Context srgb, ImageData display-p3]
-    expected: FAIL
-
-  [sRGB-BB0000FF.png, Context display-p3, ImageData srgb]
     expected: FAIL
 
   [sRGB-BB0000FF.png, Context display-p3, ImageData display-p3]
     expected: FAIL
 
-  [sRGB-BB0000CC.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [sRGB-BB0000CC.png, Context srgb, ImageData display-p3]
-    expected: FAIL
-
-  [sRGB-BB0000CC.png, Context display-p3, ImageData srgb]
     expected: FAIL
 
   [sRGB-BB0000CC.png, Context display-p3, ImageData display-p3]
     expected: FAIL
 
-  [Display-P3-FF0000FF.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [Display-P3-FF0000FF.png, Context srgb, ImageData display-p3]
     expected: FAIL
 
-  [Display-P3-FF0000FF.png, Context display-p3, ImageData srgb]
-    expected: FAIL
-
-  [Display-P3-FF0000FF.png, Context display-p3, ImageData display-p3]
-    expected: FAIL
-
-  [Display-P3-FF0000CC.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [Display-P3-FF0000CC.png, Context srgb, ImageData display-p3]
-    expected: FAIL
-
-  [Display-P3-FF0000CC.png, Context display-p3, ImageData srgb]
-    expected: FAIL
-
-  [Display-P3-FF0000CC.png, Context display-p3, ImageData display-p3]
     expected: FAIL
 
   [Display-P3-BB0000FF.png, Context srgb, ImageData srgb]
@@ -80,9 +38,6 @@
   [Display-P3-BB0000FF.png, Context display-p3, ImageData srgb]
     expected: FAIL
 
-  [Display-P3-BB0000FF.png, Context display-p3, ImageData display-p3]
-    expected: FAIL
-
   [Display-P3-BB0000CC.png, Context srgb, ImageData srgb]
     expected: FAIL
 
@@ -92,12 +47,6 @@
   [Display-P3-BB0000CC.png, Context display-p3, ImageData srgb]
     expected: FAIL
 
-  [Display-P3-BB0000CC.png, Context display-p3, ImageData display-p3]
-    expected: FAIL
-
-  [Adobe-RGB-FF0000FF.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [Adobe-RGB-FF0000FF.png, Context srgb, ImageData display-p3]
     expected: FAIL
 
@@ -105,9 +54,6 @@
     expected: FAIL
 
   [Adobe-RGB-FF0000FF.png, Context display-p3, ImageData display-p3]
-    expected: FAIL
-
-  [Adobe-RGB-FF0000CC.png, Context srgb, ImageData srgb]
     expected: FAIL
 
   [Adobe-RGB-FF0000CC.png, Context srgb, ImageData display-p3]
@@ -167,76 +113,34 @@
   [Generic-CMYK-BE000000.jpg, Context display-p3, ImageData display-p3]
     expected: FAIL
 
-  [sRGB-FFFF00000000FFFF.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [sRGB-FFFF00000000FFFF.png, Context srgb, ImageData display-p3]
-    expected: FAIL
-
-  [sRGB-FFFF00000000FFFF.png, Context display-p3, ImageData srgb]
     expected: FAIL
 
   [sRGB-FFFF00000000FFFF.png, Context display-p3, ImageData display-p3]
     expected: FAIL
 
-  [sRGB-FFFF00000000CCCC.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [sRGB-FFFF00000000CCCC.png, Context srgb, ImageData display-p3]
-    expected: FAIL
-
-  [sRGB-FFFF00000000CCCC.png, Context display-p3, ImageData srgb]
     expected: FAIL
 
   [sRGB-FFFF00000000CCCC.png, Context display-p3, ImageData display-p3]
     expected: FAIL
 
-  [sRGB-BBBC00000000FFFF.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [sRGB-BBBC00000000FFFF.png, Context srgb, ImageData display-p3]
-    expected: FAIL
-
-  [sRGB-BBBC00000000FFFF.png, Context display-p3, ImageData srgb]
     expected: FAIL
 
   [sRGB-BBBC00000000FFFF.png, Context display-p3, ImageData display-p3]
     expected: FAIL
 
-  [sRGB-BBBC00000000CCCC.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [sRGB-BBBC00000000CCCC.png, Context srgb, ImageData display-p3]
-    expected: FAIL
-
-  [sRGB-BBBC00000000CCCC.png, Context display-p3, ImageData srgb]
     expected: FAIL
 
   [sRGB-BBBC00000000CCCC.png, Context display-p3, ImageData display-p3]
     expected: FAIL
 
-  [Display-P3-FFFF00000000FFFF.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [Display-P3-FFFF00000000FFFF.png, Context srgb, ImageData display-p3]
     expected: FAIL
 
-  [Display-P3-FFFF00000000FFFF.png, Context display-p3, ImageData srgb]
-    expected: FAIL
-
-  [Display-P3-FFFF00000000FFFF.png, Context display-p3, ImageData display-p3]
-    expected: FAIL
-
-  [Display-P3-FFFF00000000CCCC.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [Display-P3-FFFF00000000CCCC.png, Context srgb, ImageData display-p3]
-    expected: FAIL
-
-  [Display-P3-FFFF00000000CCCC.png, Context display-p3, ImageData srgb]
-    expected: FAIL
-
-  [Display-P3-FFFF00000000CCCC.png, Context display-p3, ImageData display-p3]
     expected: FAIL
 
   [Display-P3-BBBC00000000FFFF.png, Context srgb, ImageData srgb]
@@ -248,9 +152,6 @@
   [Display-P3-BBBC00000000FFFF.png, Context display-p3, ImageData srgb]
     expected: FAIL
 
-  [Display-P3-BBBC00000000FFFF.png, Context display-p3, ImageData display-p3]
-    expected: FAIL
-
   [Display-P3-BBBC00000000CCCC.png, Context srgb, ImageData srgb]
     expected: FAIL
 
@@ -260,12 +161,6 @@
   [Display-P3-BBBC00000000CCCC.png, Context display-p3, ImageData srgb]
     expected: FAIL
 
-  [Display-P3-BBBC00000000CCCC.png, Context display-p3, ImageData display-p3]
-    expected: FAIL
-
-  [Adobe-RGB-FFFF00000000FFFF.png, Context srgb, ImageData srgb]
-    expected: FAIL
-
   [Adobe-RGB-FFFF00000000FFFF.png, Context srgb, ImageData display-p3]
     expected: FAIL
 
@@ -273,9 +168,6 @@
     expected: FAIL
 
   [Adobe-RGB-FFFF00000000FFFF.png, Context display-p3, ImageData display-p3]
-    expected: FAIL
-
-  [Adobe-RGB-FFFF00000000CCCC.png, Context srgb, ImageData srgb]
     expected: FAIL
 
   [Adobe-RGB-FFFF00000000CCCC.png, Context srgb, ImageData display-p3]


### PR DESCRIPTION
This removes assumption about pixel format from backend abstraction to actual backend implementation. This is important for vello.

Testing: WPT tests
