### PR TITLE
Don't increment node revision twice when attaching shadow root to element

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -683,7 +683,6 @@ impl Element {
 
         let node = self.upcast::<Node>();
         node.dirty(NodeDamage::Other);
-        node.rev_version();
 
         Ok(shadow_root)
     }


### PR DESCRIPTION
`Node::dirty` already increments the version. `Node::rev_version` traverses all ancestors, so it can end up being fairly expensive. 

Testing: I'm not sure about WPT coverage but I think this change is trivial enough to merge without tests.
