### PR TITLE
refactor(webdriver): move `webdriver_port` option to servoshell pref

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -44,10 +44,6 @@ pub struct Opts {
     /// behavior for debugging purposes.
     pub debug: DebugOptions,
 
-    /// `None` to disable WebDriver or `Some` with a port number to start a server to listen to
-    /// remote WebDriver commands.
-    pub webdriver_port: Option<u16>,
-
     /// Whether we're running in multiprocess mode.
     pub multiprocess: bool,
 
@@ -192,7 +188,6 @@ impl Default for Opts {
             nonincremental_layout: false,
             user_stylesheets: Vec::new(),
             hard_fail: true,
-            webdriver_port: None,
             multiprocess: false,
             background_hang_monitor: false,
             random_pipeline_closure_probability: None,

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -160,7 +160,7 @@ impl App {
         servo.setup_logging();
 
         // Initialize WebDriver server here before `servo` is moved.
-        let webdriver_receiver = self.opts.webdriver_port.map(|port| {
+        let webdriver_receiver = self.servoshell_preferences.webdriver_port.map(|port| {
             let (embedder_sender, embedder_receiver) = unbounded();
 
             // TODO: WebDriver will no longer need this channel once all WebDriver

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -12,7 +12,7 @@ use euclid::Vector2D;
 use keyboard_types::{Key, Modifiers, ShortcutMatcher};
 use log::{error, info};
 use servo::base::id::WebViewId;
-use servo::config::{opts, pref};
+use servo::config::pref;
 use servo::ipc_channel::ipc::IpcSender;
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
@@ -500,7 +500,7 @@ impl WebViewDelegate for RunningAppState {
         // When WebDriver is enabled, do not focus and raise the WebView to the top,
         // as that is what the specification expects. Otherwise, we would like `window.open()`
         // to create a new foreground tab
-        if opts::get().webdriver_port.is_none() {
+        if self.servoshell_preferences.webdriver_port.is_none() {
             webview.focus();
             webview.raise_to_top(true);
         }

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -57,6 +57,9 @@ pub(crate) struct ServoShellPreferences {
     /// Where to load userscripts from, if any.
     /// and if the option isn't passed userscripts won't be loaded.
     pub userscripts_directory: Option<PathBuf>,
+    /// `None` to disable WebDriver or `Some` with a port number to start a server to listen to
+    /// remote WebDriver commands.
+    pub webdriver_port: Option<u16>,
 
     /// Log filter given in the `log_filter` spec as a String, if any.
     /// If a filter is passed, the logger should adjust accordingly.
@@ -84,6 +87,7 @@ impl Default for ServoShellPreferences {
             output_image_path: None,
             exit_after_stable_image: false,
             userscripts_directory: None,
+            webdriver_port: None,
             #[cfg(target_env = "ohos")]
             log_filter: None,
             #[cfg(target_env = "ohos")]
@@ -535,12 +539,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         preferences.devtools_server_port = port;
     }
 
-    let webdriver_port = opt_match.opt_default("webdriver", "7000").map(|port| {
-        port.parse().unwrap_or_else(|err| {
-            args_fail(&format!("Error parsing option: --webdriver ({})", err))
-        })
-    });
-
     let parse_resolution_string = |string: String| {
         let components: Vec<u32> = string
             .split('x')
@@ -646,6 +644,12 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         preferences.js_ion_enabled = false;
     }
 
+    let webdriver_port = opt_match.opt_default("webdriver", "7000").map(|port| {
+        port.parse().unwrap_or_else(|err| {
+            args_fail(&format!("Error parsing option: --webdriver ({})", err))
+        })
+    });
+
     let exit_after_load = opt_match.opt_present("x") || output_image_path.is_some();
     let wait_for_stable_image = exit_after_load;
     let servoshell_preferences = ServoShellPreferences {
@@ -662,6 +666,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         userscripts_directory: opt_match
             .opt_default("userscripts", "resources/user-agent-js")
             .map(PathBuf::from),
+        webdriver_port,
         #[cfg(target_env = "ohos")]
         log_filter,
         #[cfg(target_env = "ohos")]
@@ -686,7 +691,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         nonincremental_layout,
         user_stylesheets,
         hard_fail: opt_match.opt_present("f") && !opt_match.opt_present("F"),
-        webdriver_port,
         multiprocess: opt_match.opt_present("M"),
         background_hang_monitor: opt_match.opt_present("B"),
         sandbox: opt_match.opt_present("S"),


### PR DESCRIPTION
Move `webdriver_port` option from servo config options to servoshell preference.

Testing: run `./mach run` with/without `--webdriver` option and see if the webdriver server runs on the port (default: 7000)
Fixes: https://github.com/servo/servo/issues/37843
