### PR TITLE
canvas: Make OffscreenCanvas transferable (without placeholder)

### DIFF
--- a/components/script/canvas_context.rs
+++ b/components/script/canvas_context.rs
@@ -258,6 +258,7 @@ pub(crate) enum OffscreenRenderingContext {
     //WebGL2(Dom<WebGL2RenderingContext>),
     //#[cfg(feature = "webgpu")]
     //WebGPU(Dom<GPUCanvasContext>),
+    Detached,
 }
 
 impl CanvasContext for OffscreenRenderingContext {
@@ -268,54 +269,63 @@ impl CanvasContext for OffscreenRenderingContext {
     fn canvas(&self) -> Option<HTMLCanvasElementOrOffscreenCanvas> {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.canvas(),
+            OffscreenRenderingContext::Detached => None,
         }
     }
 
     fn resize(&self) {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.resize(),
+            OffscreenRenderingContext::Detached => {},
         }
     }
 
     fn reset_bitmap(&self) {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.reset_bitmap(),
+            OffscreenRenderingContext::Detached => {},
         }
     }
 
     fn get_image_data(&self) -> Option<Snapshot> {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.get_image_data(),
+            OffscreenRenderingContext::Detached => None,
         }
     }
 
     fn origin_is_clean(&self) -> bool {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.origin_is_clean(),
+            OffscreenRenderingContext::Detached => true,
         }
     }
 
     fn size(&self) -> Size2D<u32> {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.size(),
+            OffscreenRenderingContext::Detached => Size2D::default(),
         }
     }
 
     fn mark_as_dirty(&self) {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.mark_as_dirty(),
+            OffscreenRenderingContext::Detached => {},
         }
     }
 
     fn update_rendering(&self) {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.update_rendering(),
+            OffscreenRenderingContext::Detached => {},
         }
     }
 
     fn onscreen(&self) -> bool {
         match self {
             OffscreenRenderingContext::Context2d(context) => context.onscreen(),
+            OffscreenRenderingContext::Detached => false,
         }
     }
 }

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -651,6 +651,7 @@ impl CanvasState {
                         smoothing_enabled,
                     ));
                 },
+                OffscreenRenderingContext::Detached => return Err(Error::InvalidState),
             }
         } else {
             self.send_canvas_2d_msg(Canvas2dMsg::DrawEmptyImage(
@@ -719,6 +720,7 @@ impl CanvasState {
                                 source_rect,
                                 smoothing_enabled,
                             )),
+                        OffscreenRenderingContext::Detached => return Err(Error::InvalidState),
                     }
                 },
                 _ => return Err(Error::InvalidState),

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -3,9 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::Cell;
+use std::collections::HashMap;
 use std::rc::Rc;
 
-use constellation_traits::BlobImpl;
+use base::id::{OffscreenCanvasId, OffscreenCanvasIndex};
+use constellation_traits::{BlobImpl, TransferableOffscreenCanvas};
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use js::rust::{HandleObject, HandleValue};
@@ -23,6 +25,8 @@ use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::structuredclone::StructuredData;
+use crate::dom::bindings::transferable::Transferable;
 use crate::dom::blob::Blob;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -126,6 +130,7 @@ impl OffscreenCanvas {
         if let Some(ctx) = self.context() {
             return match *ctx {
                 OffscreenRenderingContext::Context2d(ref ctx) => Some(DomRoot::from_ref(ctx)),
+                _ => None,
             };
         }
         let context = OffscreenCanvasRenderingContext2D::new(&self.global(), self, can_gc);
@@ -142,6 +147,86 @@ impl OffscreenCanvas {
     }
 }
 
+impl Transferable for OffscreenCanvas {
+    type Index = OffscreenCanvasIndex;
+    type Data = TransferableOffscreenCanvas;
+
+    /// <https://html.spec.whatwg.org/multipage/#the-offscreencanvas-interface:transfer-steps>
+    fn transfer(&self) -> Result<(OffscreenCanvasId, TransferableOffscreenCanvas), ()> {
+        // TODO(#37919) Step 1. If value's context mode is not equal to none,
+        // then throw an "InvalidStateError" DOMException.
+        if !self.context.borrow().is_none() {
+            return Err(());
+        }
+
+        // TODO(#37882): Allow to transfer with a placeholder canvas element.
+        if self.placeholder.is_some() {
+            return Err(());
+        }
+
+        // Step 2. Set value's context mode to detached.
+        *self.context.borrow_mut() = Some(OffscreenRenderingContext::Detached);
+
+        // Step 3. Let width and height be the dimensions of value's bitmap.
+        // Step 5. Unset value's bitmap.
+        let width = self.width.replace(0);
+        let height = self.height.replace(0);
+
+        // TODO(#37918) Step 4. Let language and direction be the values of
+        // value's inherited language and inherited direction.
+
+        // Step 6. Set dataHolder.[[Width]] to width and dataHolder.[[Height]]
+        // to height.
+
+        // TODO(#37918) Step 7. Set dataHolder.[[Language]] to language and
+        // dataHolder.[[Direction]] to direction.
+
+        // TODO(#37882) Step 8. Set dataHolder.[[PlaceholderCanvas]] to be a
+        // weak reference to value's placeholder canvas element, if value has
+        // one, or null if it does not.
+        let transferred = TransferableOffscreenCanvas { width, height };
+
+        Ok((OffscreenCanvasId::new(), transferred))
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#the-offscreencanvas-interface:transfer-receiving-steps>
+    fn transfer_receive(
+        owner: &GlobalScope,
+        _: OffscreenCanvasId,
+        transferred: TransferableOffscreenCanvas,
+    ) -> Result<DomRoot<Self>, ()> {
+        // Step 1. Initialize value's bitmap to a rectangular array of
+        // transparent black pixels with width given by dataHolder.[[Width]] and
+        // height given by dataHolder.[[Height]].
+
+        // TODO(#37918) Step 2. Set value's inherited language to
+        // dataHolder.[[Language]] and its inherited direction to
+        // dataHolder.[[Direction]].
+
+        // TODO(#37882) Step 3. If dataHolder.[[PlaceholderCanvas]] is not null,
+        // set value's placeholder canvas element to
+        // dataHolder.[[PlaceholderCanvas]] (while maintaining the weak
+        // reference semantics).
+        Ok(OffscreenCanvas::new(
+            owner,
+            None,
+            transferred.width,
+            transferred.height,
+            None,
+            CanGc::note(),
+        ))
+    }
+
+    fn serialized_storage<'a>(
+        data: StructuredData<'a, '_>,
+    ) -> &'a mut Option<HashMap<OffscreenCanvasId, Self::Data>> {
+        match data {
+            StructuredData::Reader(r) => &mut r.offscreen_canvases,
+            StructuredData::Writer(w) => &mut w.offscreen_canvases,
+        }
+    }
+}
+
 impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
     /// <https://html.spec.whatwg.org/multipage/#dom-offscreencanvas>
     fn Constructor(
@@ -151,8 +236,9 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         width: u64,
         height: u64,
     ) -> Fallible<DomRoot<OffscreenCanvas>> {
-        let offscreencanvas = OffscreenCanvas::new(global, proto, width, height, None, can_gc);
-        Ok(offscreencanvas)
+        Ok(OffscreenCanvas::new(
+            global, proto, width, height, None, can_gc,
+        ))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-offscreencanvas-getcontext>
@@ -163,6 +249,12 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         _options: HandleValue,
         can_gc: CanGc,
     ) -> Fallible<Option<RootedOffscreenRenderingContext>> {
+        // Step 3. Throw an "InvalidStateError" DOMException if the
+        // OffscreenCanvas object's context mode is detached.
+        if let Some(OffscreenRenderingContext::Detached) = *self.context.borrow() {
+            return Err(Error::InvalidState);
+        }
+
         match &*id {
             "2d" => Ok(self
                 .get_or_init_2d_context(can_gc)
@@ -217,9 +309,12 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-offscreencanvas-transfertoimagebitmap>
     fn TransferToImageBitmap(&self, can_gc: CanGc) -> Fallible<DomRoot<ImageBitmap>> {
-        // TODO Step 1. If the value of this OffscreenCanvas object's
-        // [[Detached]] internal slot is set to true, then throw an
-        // "InvalidStateError" DOMException.
+        // Step 1. If the value of this OffscreenCanvas object's [[Detached]]
+        // internal slot is set to true, then throw an "InvalidStateError"
+        // DOMException.
+        if let Some(OffscreenRenderingContext::Detached) = *self.context.borrow() {
+            return Err(Error::InvalidState);
+        }
 
         // Step 2. If this OffscreenCanvas object's context mode is set to none,
         // then throw an "InvalidStateError" DOMException.
@@ -254,6 +349,14 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         // Step 5. Let result be a new promise object.
         let in_realm_proof = AlreadyInRealm::assert::<crate::DomTypeHolder>();
         let promise = Promise::new_in_current_realm(InRealm::Already(&in_realm_proof), can_gc);
+
+        // Step 1. If the value of this's [[Detached]] internal slot is true,
+        // then return a promise rejected with an "InvalidStateError"
+        // DOMException.
+        if let Some(OffscreenRenderingContext::Detached) = *self.context.borrow() {
+            promise.reject_error(Error::InvalidState, can_gc);
+            return promise;
+        }
 
         // Step 2. If this's context mode is 2d and the rendering context's
         // output bitmap's origin-clean flag is set to false, then return a

--- a/components/script_bindings/webidls/OffscreenCanvas.webidl
+++ b/components/script_bindings/webidls/OffscreenCanvas.webidl
@@ -13,7 +13,7 @@ dictionary ImageEncodeOptions {
 
 //enum OffscreenRenderingContextId { "2d", "webgl", "webgl2" };
 
-[Exposed=(Window,Worker)/*, Transferable*/, Pref="dom_offscreen_canvas_enabled"]
+[Exposed=(Window,Worker), Transferable, Pref="dom_offscreen_canvas_enabled"]
 interface OffscreenCanvas : EventTarget {
   [Throws] constructor([EnforceRange] unsigned long long width, [EnforceRange] unsigned long long height);
   attribute [EnforceRange] unsigned long long width;

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -373,6 +373,8 @@ namespace_id! {HistoryStateId, HistoryStateIndex, "HistoryState"}
 
 namespace_id! {ImageBitmapId, ImageBitmapIndex, "ImageBitmap"}
 
+namespace_id! {OffscreenCanvasId, OffscreenCanvasIndex, "OffscreenCanvas"}
+
 // We provide ids just for unit testing.
 pub const TEST_NAMESPACE: PipelineNamespaceId = PipelineNamespaceId(1234);
 #[allow(unsafe_code)]

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -214,6 +214,7 @@ pub struct SWManagerSenders {
 
 /// Messages sent to Service Worker Manager thread
 #[derive(Debug, Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum ServiceWorkerMsg {
     /// Timeout message sent by active service workers
     Timeout(ServoUrl),

--- a/components/shared/constellation/structured_data/mod.rs
+++ b/components/shared/constellation/structured_data/mod.rs
@@ -10,7 +10,9 @@ mod transferable;
 
 use std::collections::HashMap;
 
-use base::id::{BlobId, DomExceptionId, DomPointId, ImageBitmapId, MessagePortId};
+use base::id::{
+    BlobId, DomExceptionId, DomPointId, ImageBitmapId, MessagePortId, OffscreenCanvasId,
+};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
@@ -38,6 +40,8 @@ pub struct StructuredSerializedData {
     pub image_bitmaps: Option<HashMap<ImageBitmapId, SerializableImageBitmap>>,
     /// Transferred image bitmap objects.
     pub transferred_image_bitmaps: Option<HashMap<ImageBitmapId, SerializableImageBitmap>>,
+    /// Transferred offscreen canvas objects.
+    pub offscreen_canvases: Option<HashMap<OffscreenCanvasId, TransferableOffscreenCanvas>>,
 }
 
 impl StructuredSerializedData {
@@ -48,6 +52,7 @@ impl StructuredSerializedData {
         match val {
             Transferrable::ImageBitmap => is_field_empty(&self.transferred_image_bitmaps),
             Transferrable::MessagePort => is_field_empty(&self.ports),
+            Transferrable::OffscreenCanvas => is_field_empty(&self.offscreen_canvases),
             Transferrable::ReadableStream => is_field_empty(&self.ports),
             Transferrable::WritableStream => is_field_empty(&self.ports),
             Transferrable::TransformStream => is_field_empty(&self.ports),

--- a/components/shared/constellation/structured_data/transferable.rs
+++ b/components/shared/constellation/structured_data/transferable.rs
@@ -28,6 +28,8 @@ pub enum Transferrable {
     ImageBitmap,
     /// The `MessagePort` interface.
     MessagePort,
+    /// The `OffscreenCanvas` interface.
+    OffscreenCanvas,
     /// The `ReadableStream` interface.
     ReadableStream,
     /// The `WritableStream` interface.
@@ -184,4 +186,13 @@ impl MessagePortImpl {
         // Step 1
         self.state = MessagePortState::Detached;
     }
+}
+
+#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
+/// A struct supporting the transfer of OffscreenCanvas, which loosely
+/// corresponds to the dataHolder in
+/// <https://html.spec.whatwg.org/multipage/#the-offscreencanvas-interface:offscreencanvas-16>
+pub struct TransferableOffscreenCanvas {
+    pub width: u64,
+    pub height: u64,
 }

--- a/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.detachedcanvas.html.ini
+++ b/tests/wpt/meta/html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.detachedcanvas.html.ini
@@ -1,3 +1,0 @@
-[2d.drawImage.detachedcanvas.html]
-  [drawImage with detached OffscreenCanvas as the source should throw exception]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/manual/convert-to-blob/offscreencanvas.convert.to.blob.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/convert-to-blob/offscreencanvas.convert.to.blob.html.ini
@@ -1,3 +1,0 @@
-[offscreencanvas.convert.to.blob.html]
-  [Test that call convertToBlob on a detached OffscreenCanvas throws exception]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/manual/convert-to-blob/offscreencanvas.convert.to.blob.w.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/convert-to-blob/offscreencanvas.convert.to.blob.w.html.ini
@@ -1,4 +1,0 @@
-[offscreencanvas.convert.to.blob.w.html]
-  expected: ERROR
-  [Test that call convertToBlob on a detached OffscreenCanvas throws exception in a worker]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.html.ini
@@ -4,6 +4,3 @@
 
   [Test that transferToImageBitmap returns an ImageBitmap with correct width and height]
     expected: FAIL
-
-  [Test that call transferToImageBitmap on a detached OffscreenCanvas throws an exception]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.w.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer.to.imagebitmap.w.html.ini
@@ -3,8 +3,5 @@
   [Test that transferToImageBitmap returns an ImageBitmap with correct width and height in a worker]
     expected: FAIL
 
-  [Test that call transferToImageBitmap on a detached OffscreenCanvas throws an exception in a worker]
-    expected: FAIL
-
   [Test that call transferToImageBitmap twice on a alpha-disabled context returns an ImageBitmap with correct color in a worker]
     expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.html.ini
@@ -1,18 +1,3 @@
 [offscreencanvas.transferrable.html]
-  [Test that offscreenCanvas's size is correct after being transferred to a worker.]
-    expected: FAIL
-
-  [Test that calling getContext('webgl') on a detached OffscreenCanvas throws exception.]
-    expected: FAIL
-
-  [Test that transfer an OffscreenCanvas that has a context throws exception.]
-    expected: FAIL
-
-  [Test that transfer an OffscreenCanvas twice throws exception.]
-    expected: FAIL
-
-  [Test that calling getContext('2d') on a detached OffscreenCanvas throws exception.]
-    expected: FAIL
-
   [Test that transfer an OffscreenCanvas that already have a 2d context throws exception.]
     expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.w.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.w.html.ini
@@ -1,20 +1,10 @@
 [offscreencanvas.transferrable.w.html]
   expected: ERROR
-  [Test that calling getContext('webgl') on a detached OffscreenCanvas throws exception in a worker.]
-    expected: FAIL
-
   [Test that transfer an OffscreenCanvas that has a webgl context throws exception in a worker.]
-    expected: FAIL
-
-  [Test that transfer an OffscreenCanvas twice throws exception in a worker.]
-    expected: FAIL
-
-  [Test that calling getContext('2d') on a detached OffscreenCanvas throws exception in a worker.]
-    expected: FAIL
-
-  [Test that OffscreenCanvas's size is correct after being transferred from a worker.]
     expected: FAIL
 
   [Test that transfer an OffscreenCanvas that has a 2d context throws exception in a worker.]
     expected: FAIL
 
+  [Test that transfer an OffscreenCanvas twice throws exception in a worker.]
+    expected: FAIL

--- a/tests/wpt/meta/html/infrastructure/safe-passing-of-structured-data/transfer-errors.window.js.ini
+++ b/tests/wpt/meta/html/infrastructure/safe-passing-of-structured-data/transfer-errors.window.js.ini
@@ -8,11 +8,5 @@
   [Serialize should throw before a detached ImageBitmap is found]
     expected: FAIL
 
-  [Serialize should make the OffscreenCanvas detached, so it cannot be transferred again]
-    expected: FAIL
-
   [Serialize should throw before a detached OffscreenCanvas is found]
-    expected: FAIL
-
-  [Cannot transfer OffscreenCanvas detached while the message was serialized]
     expected: FAIL


### PR DESCRIPTION
Follow the specification and make OffscreenCanvas objects are transferable,
but not in case if there are a weak reference to placeholder canvas element.
To handle it properly need to implement dedicated frame provider/dispatcher
between canvas element (script thread) and offscreen canvas (dedicated worker thread).
https://html.spec.whatwg.org/multipage/#the-offscreencanvas-interface:transferable-objects

Testing: Improvements in the following tests
- html/canvas/element/drawing-images-to-the-canvas/2d.drawImage.detachedcanvas.html
- html/canvas/offscreen/manual/convert-to-blob/offscreencanvas.convert.to.blob*
- html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transfer*
- html/infrastructure/safe-passing-of-structured-data/transfer-errors.window.js

Part of #24276