### PR TITLE
servoshell: Set `dom_testing_html_input_element_select_files_enabled` when WebDriver is enabled

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -539,6 +539,10 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         preferences.devtools_server_port = port;
     }
 
+    if opt_match.opt_present("webdriver") {
+        preferences.dom_testing_html_input_element_select_files_enabled = true;
+    }
+
     let parse_resolution_string = |string: String| {
         let components: Vec<u32> = string
             .split('x')

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -117,7 +117,6 @@ def handle_preset(s: str) -> Optional[JobConfig]:
             wpt_args=" ".join(
                 [
                     "./tests/wpt/tests/webdriver/tests/classic/",
-                    "--pref=dom_testing_html_input_element_select_files_enabled",
                     "--product servodriver",
                     "--headless",
                 ]


### PR DESCRIPTION
Testing: `.\tests\wpt\tests\webdriver\tests\classic\execute_script\collections.py` can now run to the end when running either locally or `try`.
Fixes: #37870
