### PR TITLE
Remove `cargo-update`, `update-cargo`, `grep`, `ndk-stack`, and `ndk-gdb` mach commands

### DIFF
--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -8,11 +8,6 @@
 # except according to those terms.
 
 import json
-import signal
-import subprocess
-import sys
-import tempfile
-from os import getcwd, listdir, path
 
 from mach.decorators import (
     Command,
@@ -21,7 +16,7 @@ from mach.decorators import (
 )
 from tidy.linting_report import GitHubAnnotationManager
 
-from servo.command_base import CommandBase, call, cd
+from servo.command_base import CommandBase, call
 
 
 @CommandProvider
@@ -42,48 +37,6 @@ class MachCommands(CommandBase):
             print("Finished checking, binary NOT updated. Consider ./mach build before ./mach run")
 
         return status
-
-    @Command("cargo-update", description="Same as update-cargo", category="devenv")
-    @CommandArgument(
-        "params", default=None, nargs="...", help="Command-line arguments to be passed through to cargo update"
-    )
-    @CommandArgument("--package", "-p", default=None, help="Updates selected package")
-    @CommandArgument("--all-packages", "-a", action="store_true", help="Updates all packages")
-    @CommandArgument("--dry-run", "-d", action="store_true", help="Show outdated packages.")
-    def cargo_update(self, params=None, package=None, all_packages=None, dry_run=None):
-        self.update_cargo(params, package, all_packages, dry_run)
-
-    @Command("update-cargo", description="Update Cargo dependencies", category="devenv")
-    @CommandArgument(
-        "params", default=None, nargs="...", help="Command-line arguments to be passed through to cargo update"
-    )
-    @CommandArgument("--package", "-p", default=None, help="Updates the selected package")
-    @CommandArgument(
-        "--all-packages",
-        "-a",
-        action="store_true",
-        help="Updates all packages. NOTE! This is very likely to break your "
-        "working copy, making it impossible to build servo. Only do "
-        "this if you really know what you are doing.",
-    )
-    @CommandArgument("--dry-run", "-d", action="store_true", help="Show outdated packages.")
-    def update_cargo(self, params=None, package=None, all_packages=None, dry_run=None):
-        if not params:
-            params = []
-
-        if not package and not all_packages:
-            print("Please choose package to update with the --package (-p) ")
-            print("flag or update all packages with --all-packages (-a) flag")
-            sys.exit(1)
-
-        if package:
-            params += ["-p", package]
-        if dry_run:
-            params.append("--dry-run")
-
-        self.ensure_bootstrapped()
-        with cd(self.context.topdir):
-            call(["cargo", "update"] + params, env=self.build_env())
 
     @Command("rustc", description="Run the Rust compiler", category="devenv")
     @CommandArgument("params", default=None, nargs="...", help="Command-line arguments to be passed through to rustc")
@@ -143,109 +96,7 @@ class MachCommands(CommandBase):
             return results.returncode
         return self.run_cargo_build_like_command("clippy", params, env=env, **kwargs)
 
-    @Command("grep", description="`git grep` for selected directories.", category="devenv")
-    @CommandArgument(
-        "params", default=None, nargs="...", help="Command-line arguments to be passed through to `git grep`"
-    )
-    def grep(self, params):
-        if not params:
-            params = []
-        # get all directories under tests/
-        tests_dirs = listdir("tests")
-        # Directories to be excluded under tests/
-        excluded_tests_dirs = ["wpt", "jquery"]
-        tests_dirs = filter(lambda dir: dir not in excluded_tests_dirs, tests_dirs)
-        # Set of directories in project root
-        root_dirs = ["components", "ports", "python", "etc", "resources"]
-        # Generate absolute paths for directories in tests/ and project-root/
-        tests_dirs_abs = [path.join(self.context.topdir, "tests", s) for s in tests_dirs]
-        root_dirs_abs = [path.join(self.context.topdir, s) for s in root_dirs]
-        # Absolute paths for all directories to be considered
-        grep_paths = root_dirs_abs + tests_dirs_abs
-        return call(
-            ["git"] + ["grep"] + params + ["--"] + grep_paths + [":(exclude)*.min.js", ":(exclude)*.min.css"],
-            env=self.build_env(),
-        )
-
     @Command("fetch", description="Fetch Rust, Cargo and Cargo dependencies", category="devenv")
     def fetch(self):
         self.ensure_bootstrapped()
         return call(["cargo", "fetch"], env=self.build_env())
-
-    @Command("ndk-stack", description="Invoke the ndk-stack tool with the expected symbol paths", category="devenv")
-    @CommandArgument("--release", action="store_true", help="Use release build symbols")
-    @CommandArgument("--target", action="store", default="armv7-linux-androideabi", help="Build target")
-    @CommandArgument("logfile", action="store", help="Path to logcat output with crash report")
-    def stack(self, release, target, logfile):
-        if not path.isfile(logfile):
-            print(logfile + " doesn't exist")
-            return -1
-
-        env = self.build_env()
-        ndk_stack = path.join(env["ANDROID_NDK"], "ndk-stack")
-        self.setup_configuration_for_android_target(target)
-        sym_path = path.join(
-            "target", target, "release" if release else "debug", "apk", "obj", "local", self.config["android"]["lib"]
-        )
-        print(subprocess.check_output([ndk_stack, "-sym", sym_path, "-dump", logfile]))
-
-    @Command("ndk-gdb", description="Invoke ndk-gdb tool with the expected symbol paths", category="devenv")
-    @CommandArgument("--release", action="store_true", help="Use release build symbols")
-    @CommandArgument("--target", action="store", default="armv7-linux-androideabi", help="Build target")
-    def ndk_gdb(self, release, target):
-        env = self.build_env()
-        ndk_gdb = path.join(env["ANDROID_NDK"], "ndk-gdb")
-        adb_path = path.join(env["ANDROID_SDK"], "platform-tools", "adb")
-        sym_paths = [
-            path.join(
-                getcwd(),
-                "target",
-                target,
-                "release" if release else "debug",
-                "apk",
-                "obj",
-                "local",
-                self.config["android"]["lib"],
-            ),
-            path.join(
-                getcwd(),
-                "target",
-                target,
-                "release" if release else "debug",
-                "apk",
-                "libs",
-                self.config["android"]["lib"],
-            ),
-        ]
-        env["NDK_PROJECT_PATH"] = path.join(getcwd(), "support", "android", "apk")
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
-
-        with tempfile.NamedTemporaryFile(delete=False) as f:
-            f.write(
-                "\n".join(
-                    [
-                        "python",
-                        "param = gdb.parameter('solib-search-path')",
-                        "param += ':{}'".format(":".join(sym_paths)),
-                        "gdb.execute('set solib-search-path ' + param)",
-                        "end",
-                    ]
-                )
-            )
-
-        p = subprocess.Popen(
-            [
-                ndk_gdb,
-                "--adb",
-                adb_path,
-                "--project",
-                "support/android/apk/servoapp/src/main/",
-                "--launch",
-                "org.servo.servoshell.MainActivity",
-                "-x",
-                f.name,
-                "--verbose",
-            ],
-            env=env,
-        )
-        return p.wait()


### PR DESCRIPTION
Remove some seldomly used `mach commands:

- `ndk-stack` and `ndk-gdb`: These commands have bit rotted completely, so need to be reimplemented. Remove them for now to make them less confusing.
- `cargo-update` / `update-cargo`: This command just calls `cargo` directly so isn't really necessary.
- `grep`: There are much better grep tools now such as `rg` that make these kind of special-cases obsolete. In addition, we can improve the default behavior of `git grep` by using the git attributes feature.

These commands are being removed in order to implement Python type checking the Servo repository.

Testing: This just removes some mach command so shouldn't need tests.