### PR TITLE
webdriver: Properly insert the user agent into the capabilities data structure

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -681,6 +681,10 @@ impl Handler {
                         "setWindowRect".to_string(),
                         json!(servo_capabilities.set_window_rect),
                     );
+                    processed.insert(
+                        "userAgent".to_string(),
+                        servo_config::pref!(user_agent).into(),
+                    );
 
                     let response =
                         NewSessionResponse::new(session.id.to_string(), Value::Object(processed));

--- a/tests/wpt/meta/webdriver/tests/classic/new_session/response.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/new_session/response.py.ini
@@ -1,3 +1,0 @@
-[response.py]
-  [test_capability_user_agent]
-    expected: FAIL


### PR DESCRIPTION
Add user agent into webdriver capabilities.

Testing:
`/mach test-wpt -r --product servodriver ./tests/wpt/tests/webdriver/tests/classic/new_session/response.py`
