### PR TITLE
OHOS CI: Allow benchmarking of files and show smaps

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -165,6 +165,8 @@ jobs:
       - run: |
           git switch --detach
           git reset --hard FETCH_HEAD
+      - name: Adding test files to directory
+        run: cp -r support/hitrace-bencher/* support/openharmony/AppScope/resources/resfile/
       - name: Build for aarch64 HarmonyOS
         run: |
           ./mach build --locked --target aarch64-unknown-linux-ohos --profile=${{ inputs.profile }} --flavor=harmonyos --no-default-features --features tracing,tracing-hitrace

--- a/support/hitrace-bencher/parse_from_string.html
+++ b/support/hitrace-bencher/parse_from_string.html
@@ -1,0 +1,37 @@
+<html>
+<script>
+    function generateHTML(count) {
+        let html = '';
+        for (let i = 0; i < count; i++) {
+            html += `<div>
+                    <h2>Item ${i}</h2>
+                    <p>This is paragraph number ${i}</p>
+                    <ul>
+                    <li>A</li><li>B</li><li>C</li>
+                    </ul>
+                    </div>`;
+        }
+        return html;
+    }
+
+    function run() {
+        const result = document.getElementById("result");
+        const html = generateHTML(15000);
+        const parser = new DOMParser();
+
+        const start = performance.now();
+        const doc = parser.parseFromString(html, "text/html");
+        const end = performance.now();
+
+        const result_text = (end - start).toFixed(0);
+        result.textContent = `Total: ${result_text} ms`;
+        alert("TESTCASE_PROFILING: parsefromstring:" + result_text);
+    };
+</script>
+
+<body onload="run()">
+    <button id="run">Run Script</button>
+    <div id="result"></div>
+</body>
+
+</html>

--- a/support/hitrace-bencher/runs.json
+++ b/support/hitrace-bencher/runs.json
@@ -11,6 +11,7 @@
             //"sleep": 10,  // how long should we wait for servo to load the page
             //"bundle_name": "org.servo.servo", // the bundle name to start
             //"commands": ["--ps=--tracing-filter", "info"] // arbitrary additional arguments
+            //"is_rooted": true  // Allows files to be pushed to the device instead of relying them being already packaged
         },
         "filters": [
             // Filters are currently given via the simple serialize of `filters::JsonValueFilter`.
@@ -46,6 +47,11 @@
             {
                 "name": "JS",
                 "match_str": "js"
+            },
+            {
+                "name": "resident-smaps",
+                "match_str": "resident-according-to-smaps",
+                "combined": true,
             }
         ]
     },
@@ -82,6 +88,27 @@
             {
                 "name": "JS",
                 "match_str": "js"
+            },
+            {
+                "name": "resident-smaps",
+                "match_str": "resident-according-to-smaps",
+                "combined": true
+            }
+        ]
+    },
+    {
+        "args": {
+            "bencher": true,
+            "url": "file:///parse_from_string.html",
+            "tries": 5
+        },
+        "filters": [
+        ],
+        "point_filters": [
+            {
+                "name": "",
+                "match_str": "parsefromstring",
+                "no_unit_conversion": true
             }
         ]
     }


### PR DESCRIPTION
OHOS CI: Now we can benchmark specific files. These files need to be in
the runs.json and in the supprt/hitrace-bench folder.
A simple testcase of parsing html from string is included (taken from https://github.com/servo/servo/issues/37223). 
We copy all files in
support/hitrace-bench into the hap of the phone.
These files can use the console.log javascript command to get their
measured output.

Additionally, this now supports reporting resident-accordings-to-smaps which is a slightly different memory than resident.

This needs update to hitrace-bench 0.7 which will be completed once the
PR is marked ready.

Testing: On action runner here: https://github.com/Narfinger/servo/actions/runs/16118101025/job/45477031813
