### PR TITLE
Avoid rooting/unrooting in Node::rev_version

### DIFF
--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -291,6 +291,20 @@ impl<T: DomObject> MutNullableDom<T> {
         self.set(None);
         value
     }
+
+    /// Runs the given callback on the object if it's not null.
+    pub(crate) fn if_is_some<F, R>(&self, cb: F) -> Option<&R>
+    where
+        F: FnOnce(&T) -> &R,
+    {
+        unsafe {
+            if let Some(ref value) = *self.ptr.get() {
+                Some(cb(value))
+            } else {
+                None
+            }
+        }
+    }
 }
 
 impl<T: DomObject> PartialEq for MutNullableDom<T> {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -796,8 +796,15 @@ impl Node {
             self.inclusive_descendants_version(),
             doc.inclusive_descendants_version(),
         ) + 1;
-        for ancestor in self.inclusive_ancestors(ShadowIncluding::No) {
-            ancestor.inclusive_descendants_version.set(version);
+
+        // This `while` loop is equivalent to iterating over the non-shadow-inclusive ancestors
+        // without creating intermediate rooted DOM objects.
+        let mut node = &MutNullableDom::new(Some(self));
+        while let Some(p) = node.if_is_some(|p| {
+            p.inclusive_descendants_version.set(version);
+            &p.parent_node
+        }) {
+            node = p
         }
         doc.inclusive_descendants_version.set(version);
     }


### PR DESCRIPTION
The iterator produced by Node::inclusive_ancestors roots the items but rev_version just drop and unroot them right away. This patch makes it possible to work on the Node references instead to avoid rooting.

*Describe the changes that this pull request makes here. This will be the commit message.*

Testing: *Describe how this pull request is tested or why it doesn't require tests*
Fixes: *Link to an issue this pull requests fixes or remove this line if there is no issue*
