### PR TITLE
servoshell: Do handle prompts and other requests in headless mode when WebDriver is active

### DIFF
--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -452,7 +452,9 @@ impl WebViewDelegate for RunningAppState {
     }
 
     fn show_simple_dialog(&self, webview: servo::WebView, dialog: SimpleDialog) {
-        if self.servoshell_preferences.headless {
+        if self.servoshell_preferences.headless &&
+            self.servoshell_preferences.webdriver_port.is_none()
+        {
             // TODO: Avoid copying this from the default trait impl?
             // Return the DOM-specified default value for when we **cannot show simple dialogs**.
             let _ = match dialog {
@@ -477,7 +479,9 @@ impl WebViewDelegate for RunningAppState {
         webview: WebView,
         authentication_request: AuthenticationRequest,
     ) {
-        if self.servoshell_preferences.headless {
+        if self.servoshell_preferences.headless &&
+            self.servoshell_preferences.webdriver_port.is_none()
+        {
             return;
         }
 
@@ -575,7 +579,9 @@ impl WebViewDelegate for RunningAppState {
     }
 
     fn request_permission(&self, webview: servo::WebView, permission_request: PermissionRequest) {
-        if self.servoshell_preferences.headless {
+        if self.servoshell_preferences.headless &&
+            self.servoshell_preferences.webdriver_port.is_none()
+        {
             permission_request.deny();
             return;
         }
@@ -635,7 +641,9 @@ impl WebViewDelegate for RunningAppState {
     }
 
     fn show_form_control(&self, webview: WebView, form_control: FormControl) {
-        if self.servoshell_preferences.headless {
+        if self.servoshell_preferences.headless &&
+            self.servoshell_preferences.webdriver_port.is_none()
+        {
             return;
         }
 

--- a/tests/wpt/meta/webdriver/tests/classic/delete_session/delete.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/delete_session/delete.py.ini
@@ -1,5 +1,4 @@
 [delete.py]
-  expected: ERROR
   [test_null_response_value]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/element_clear/clear.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_clear/clear.py.ini
@@ -208,3 +208,12 @@
 
   [test_scroll_into_view]
     expected: FAIL
+
+  [test_resettable_element_does_not_satisfy_validation_constraints[range-foo\]]
+    expected: FAIL
+
+  [test_resettable_element_does_not_satisfy_validation_constraints[color-foo\]]
+    expected: FAIL
+
+  [test_resettable_element_does_not_satisfy_validation_constraints[datetime-foo\]]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/interactability.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/interactability.py.ini
@@ -1,5 +1,4 @@
 [interactability.py]
-  expected: TIMEOUT
   [test_display_none]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/events.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/events.py.ini
@@ -4,3 +4,12 @@
 
   [test_form_control_send_text[textarea\]]
     expected: FAIL
+
+  [test_file_upload]
+    expected: FAIL
+
+  [test_not_blurred[input\]]
+    expected: FAIL
+
+  [test_not_blurred[textarea\]]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/file_upload.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/file_upload.py.ini
@@ -22,3 +22,33 @@
 
   [test_strict_display_none]
     expected: ERROR
+
+  [test_multiple_files]
+    expected: FAIL
+
+  [test_multiple_files_without_multiple_attribute]
+    expected: FAIL
+
+  [test_single_file]
+    expected: FAIL
+
+  [test_single_file_replaces_without_multiple_attribute]
+    expected: FAIL
+
+  [test_transparent]
+    expected: FAIL
+
+  [test_obscured]
+    expected: FAIL
+
+  [test_outside_viewport]
+    expected: FAIL
+
+  [test_hidden]
+    expected: FAIL
+
+  [test_display_none]
+    expected: FAIL
+
+  [test_not_focused]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/form_controls.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/form_controls.py.ini
@@ -4,3 +4,18 @@
 
   [test_textarea_append]
     expected: FAIL
+
+  [test_input]
+    expected: FAIL
+
+  [test_textarea]
+    expected: FAIL
+
+  [test_input_insert_when_focused]
+    expected: FAIL
+
+  [test_textarea_insert_when_focused]
+    expected: FAIL
+
+  [test_date]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/interactability.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/interactability.py.ini
@@ -22,3 +22,12 @@
 
   [test_readonly_element]
     expected: FAIL
+
+  [test_body_is_interactable]
+    expected: FAIL
+
+  [test_transparent_element]
+    expected: FAIL
+
+  [test_obscured_element]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/scroll_into_view.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/scroll_into_view.py.ini
@@ -22,3 +22,6 @@
 
   [test_element_just_outside_viewport[Just below viewport\]]
     expected: FAIL
+
+  [test_element_outside_of_not_scrollable_viewport]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/send_keys.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/send_keys.py.ini
@@ -1,3 +1,33 @@
 [send_keys.py]
-  [test_no_browsing_context]
+  [test_null_response_value]
+    expected: FAIL
+
+  [test_no_top_browsing_context]
+    expected: FAIL
+
+  [test_no_such_element_with_invalid_value]
+    expected: FAIL
+
+  [test_no_such_element_with_shadow_root]
+    expected: FAIL
+
+  [test_no_such_element_from_other_window_handle[open\]]
+    expected: FAIL
+
+  [test_no_such_element_from_other_window_handle[closed\]]
+    expected: FAIL
+
+  [test_no_such_element_from_other_frame[open\]]
+    expected: FAIL
+
+  [test_no_such_element_from_other_frame[closed\]]
+    expected: FAIL
+
+  [test_stale_element_reference[top_context\]]
+    expected: FAIL
+
+  [test_stale_element_reference[child_context\]]
+    expected: FAIL
+
+  [test_surrogates]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/key_events.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/key_events.py.ini
@@ -10,3 +10,264 @@
 
   [test_special_key_sends_keydown[PAUSE-expected45\]]
     expected: FAIL
+
+  [test_modifier_key_sends_correct_events[\\ue00a-ALT\]]
+    expected: FAIL
+
+  [test_modifier_key_sends_correct_events[\\ue009-CONTROL\]]
+    expected: FAIL
+
+  [test_modifier_key_sends_correct_events[\\ue03d-META\]]
+    expected: FAIL
+
+  [test_modifier_key_sends_correct_events[\\ue052-R_ALT\]]
+    expected: FAIL
+
+  [test_modifier_key_sends_correct_events[\\ue051-R_CONTROL\]]
+    expected: FAIL
+
+  [test_modifier_key_sends_correct_events[\\ue053-R_META\]]
+    expected: FAIL
+
+  [test_modifier_key_sends_correct_events[\\ue050-R_SHIFT\]]
+    expected: FAIL
+
+  [test_non_printable_key_sends_events[\\ue014-RIGHT\]]
+    expected: FAIL
+
+  [test_printable_key_sends_correct_events[a-KeyA0\]]
+    expected: FAIL
+
+  [test_printable_key_sends_correct_events[a-KeyA1\]]
+    expected: FAIL
+
+  [test_printable_key_sends_correct_events["-Quote\]]
+    expected: FAIL
+
+  [test_printable_key_sends_correct_events[,-Comma\]]
+    expected: FAIL
+
+  [test_printable_key_sends_correct_events[\\xe0-\]]
+    expected: FAIL
+
+  [test_printable_key_sends_correct_events[\\u0416-\]]
+    expected: FAIL
+
+  [test_printable_key_sends_correct_events[@-Digit2\]]
+    expected: FAIL
+
+  [test_printable_key_sends_correct_events[\\u2603-\]]
+    expected: FAIL
+
+  [test_printable_key_sends_correct_events[\\uf6c2-\]]
+    expected: FAIL
+
+  [test_sequence_of_keydown_printable_keys_sends_events]
+    expected: FAIL
+
+  [test_sequence_of_keydown_printable_characters_sends_events]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[ADD-expected0\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[ALT-expected1\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[BACKSPACE-expected2\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[CANCEL-expected3\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[CLEAR-expected4\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[CONTROL-expected5\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[DECIMAL-expected6\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[DELETE-expected7\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[DIVIDE-expected8\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[DOWN-expected9\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[END-expected10\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[ENTER-expected11\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[ESCAPE-expected13\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[F1-expected14\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[F10-expected15\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[F11-expected16\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[F12-expected17\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[F2-expected18\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[F3-expected19\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[F4-expected20\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[F5-expected21\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[F6-expected22\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[F7-expected23\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[F8-expected24\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[F9-expected25\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[HELP-expected26\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[HOME-expected27\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[INSERT-expected28\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[LEFT-expected29\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[META-expected30\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[MULTIPLY-expected31\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[NULL-expected32\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[NUMPAD0-expected33\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[NUMPAD1-expected34\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[NUMPAD2-expected35\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[NUMPAD3-expected36\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[NUMPAD4-expected37\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[NUMPAD5-expected38\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[NUMPAD6-expected39\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[NUMPAD7-expected40\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[NUMPAD8-expected41\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[NUMPAD9-expected42\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[PAGE_DOWN-expected43\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[PAGE_UP-expected44\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[RETURN-expected46\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[RIGHT-expected47\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_ALT-expected48\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_ARROWDOWN-expected49\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_ARROWLEFT-expected50\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_ARROWRIGHT-expected51\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_ARROWUP-expected52\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_CONTROL-expected53\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_DELETE-expected54\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_END-expected55\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_HOME-expected56\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_INSERT-expected57\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_META-expected58\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_PAGEDOWN-expected59\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_PAGEUP-expected60\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[R_SHIFT-expected61\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[SEMICOLON-expected62\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[SEPARATOR-expected63\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[SHIFT-expected64\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[SPACE-expected65\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[SUBTRACT-expected66\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[TAB-expected67\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[UP-expected68\]]
+    expected: FAIL
+
+  [test_special_key_sends_keydown[ZENKAKUHANKAKU-expected69\]]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/key_shortcuts.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/key_shortcuts.py.ini
@@ -1,0 +1,3 @@
+[key_shortcuts.py]
+  [test_mod_a_mod_c_right_mod_v_pastes_text]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/navigation.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/navigation.py.ini
@@ -1,7 +1,3 @@
 [navigation.py]
-  expected: TIMEOUT
-  [test_key]
-    expected: FAIL
-
   [test_pointer]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_contextmenu.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_contextmenu.py.ini
@@ -4,3 +4,6 @@
 
   [test_control_click[\\ue051-ctrlKey\]]
     expected: FAIL
+
+  [test_release_control_click]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_mouse.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_mouse.py.ini
@@ -1,8 +1,4 @@
 [pointer_mouse.py]
-  expected: TIMEOUT
-  [test_no_top_browsing_context]
-    expected: FAIL
-
   [test_no_browsing_context]
     expected: FAIL
 
@@ -33,12 +29,6 @@
   [test_click_element_in_shadow_tree[inner-closed\]]
     expected: FAIL
 
-  [test_move_to_position_in_viewport[x\]]
-    expected: FAIL
-
-  [test_move_to_position_in_viewport[y\]]
-    expected: FAIL
-
   [test_move_to_fractional_position]
     expected: FAIL
 
@@ -52,4 +42,7 @@
     expected: FAIL
 
   [test_params_actions_origin_outside_viewport[element\]]
+    expected: FAIL
+
+  [test_move_to_position_in_viewport[default value\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_touch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_touch.py.ini
@@ -1,8 +1,4 @@
 [pointer_touch.py]
-  expected: TIMEOUT
-  [test_no_top_browsing_context]
-    expected: FAIL
-
   [test_no_browsing_context]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/wheel.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/wheel.py.ini
@@ -7,3 +7,18 @@
 
   [test_scroll_with_key_pressed]
     expected: FAIL
+
+  [test_scroll_not_scrollable]
+    expected: FAIL
+
+  [test_scroll_scrollable_overflow]
+    expected: FAIL
+
+  [test_scroll_iframe]
+    expected: FAIL
+
+  [test_scroll_shadow_tree[outer-open\]]
+    expected: FAIL
+
+  [test_scroll_shadow_tree[inner-open\]]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/release_actions/sequence_tentative.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/release_actions/sequence_tentative.py.ini
@@ -1,5 +1,4 @@
 [sequence_tentative.py]
-  expected: TIMEOUT
   [test_release_mouse_sequence_resets_dblclick_state[with release actions\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/set_window_rect/set.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/set_window_rect/set.py.ini
@@ -58,3 +58,6 @@
 
   [test_set_larger_than_screen_size]
     expected: FAIL
+
+  [test_height_width_as_current]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/switch_to_frame/switch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/switch_to_frame/switch.py.ini
@@ -4,3 +4,6 @@
 
   [test_no_browsing_context[id2\]]
     expected: FAIL
+
+  [test_find_element_while_frame_is_still_loading]
+    expected: FAIL


### PR DESCRIPTION
Webdriver CI uses headless window, which skips the handling for alert box.
It leads to unexpected `OK` in test results, which should be still timeout.
This PR removes the skip, so test result in local and CI are synchronized.  

Testing:
7 unexpected `OK` are removed
https://github.com/longvatrong111/servo/actions/runs/16079192271
compared to CI on main:
https://github.com/longvatrong111/servo/actions/runs/16078898742

Fixes: https://github.com/servo/servo/issues/37875
Partially fixes: https://github.com/servo/servo/issues/37387