### PR TITLE
script: join `compositor_requested_update_the_rendering` into `should_trigger_script_thread_animation_tick`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6752,7 +6752,7 @@ pub(crate) struct ImageAnimationUpdateCallback {
 impl ImageAnimationUpdateCallback {
     pub(crate) fn invoke(self, can_gc: CanGc) {
         with_script_thread(|script_thread| {
-            script_thread.set_animation_tick();
+            script_thread.set_has_pending_animation_tick();
             script_thread.update_the_rendering(can_gc);
         })
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6751,7 +6751,10 @@ pub(crate) struct ImageAnimationUpdateCallback {
 
 impl ImageAnimationUpdateCallback {
     pub(crate) fn invoke(self, can_gc: CanGc) {
-        with_script_thread(|script_thread| script_thread.update_the_rendering(true, can_gc))
+        with_script_thread(|script_thread| {
+            script_thread.set_animation_tick();
+            script_thread.update_the_rendering(can_gc);
+        })
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -342,7 +342,7 @@ pub struct ScriptThread {
     #[no_trace]
     scheduled_script_thread_animation_timer: RefCell<Option<TimerId>>,
 
-    /// A flag that lets the [`ScriptThread`]'s main loop know that the
+    /// A flag that lets the [`ScriptThread`]'s main loop know that
     /// it should trigger an animation tick "update the rendering" call.
     ///
     /// This can be set by receiving [`ScriptThreadMessage::TickAllAnimations`]


### PR DESCRIPTION
This will help us make "update the rendering" a proper task.

Testing: Existing WPT tests.

try run: https://github.com/sagudev/servo/actions/runs/16085256131