### PR TITLE
layout: Add incremental box tree construction for inline floats and abspos

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -136,6 +136,20 @@ impl LayoutBox {
                 .repair_style(context, node, new_style),
         }
     }
+
+    /// If this [`LayoutBox`] represents an unsplit (due to inline-block splits) inline
+    /// level item, unwrap and return it. If not, return `None`.
+    pub(crate) fn unsplit_inline_level_layout_box(self) -> Option<ArcRefCell<InlineItem>> {
+        let LayoutBox::InlineLevel(inline_level_boxes) = self else {
+            return None;
+        };
+        // If this element box has been subject to inline-block splitting, ignore it. It's
+        // not useful currently for incremental box tree construction.
+        if inline_level_boxes.len() != 1 {
+            return None;
+        }
+        inline_level_boxes.into_iter().next()
+    }
 }
 
 /// A wrapper for [`InnerDOMLayoutData`]. This is necessary to give the entire data

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -604,13 +604,17 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
     ) {
         if let Some(builder) = self.inline_formatting_context_builder.as_mut() {
             if !builder.is_empty() {
-                let inline_level_box =
-                    builder.push_absolutely_positioned_box(AbsolutelyPositionedBox::construct(
+                let constructor = || {
+                    ArcRefCell::new(AbsolutelyPositionedBox::construct(
                         self.context,
                         info,
                         display_inside,
                         contents,
-                    ));
+                    ))
+                };
+                let old_layout_box = box_slot.take_layout_box_if_undamaged(info.damage);
+                let inline_level_box =
+                    builder.push_absolutely_positioned_box(constructor, old_layout_box);
                 box_slot.set(LayoutBox::InlineLevel(vec![inline_level_box]));
                 return;
             }
@@ -637,13 +641,17 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
     ) {
         if let Some(builder) = self.inline_formatting_context_builder.as_mut() {
             if !builder.is_empty() {
-                let inline_level_box = builder.push_float_box(FloatBox::construct(
-                    self.context,
-                    info,
-                    display_inside,
-                    contents,
-                    self.propagated_data,
-                ));
+                let constructor = || {
+                    ArcRefCell::new(FloatBox::construct(
+                        self.context,
+                        info,
+                        display_inside,
+                        contents,
+                        self.propagated_data,
+                    ))
+                };
+                let old_layout_box = box_slot.take_layout_box_if_undamaged(info.damage);
+                let inline_level_box = builder.push_float_box(constructor, old_layout_box);
                 box_slot.set(LayoutBox::InlineLevel(vec![inline_level_box]));
                 return;
             }


### PR DESCRIPTION
Layout: Add incremental box tree construction for inline floats and abspos

Due to false positives in the memory benchmark on CI, the previous PR [37868](https://github.com/servo/servo/pull/37868) reverted. Now it is resubmitted.