### PR TITLE
layout: Unify layout logic for replaced and non-replaced floats&atomics

### DIFF
--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -2076,11 +2076,8 @@ impl IndependentFormattingContext {
             .content_rect
             .translate(pbm_physical_offset.to_vector());
 
-        // Apply baselines if necessary.
-        let mut fragment = match baselines {
-            Some(baselines) => fragment.with_baselines(baselines),
-            None => fragment,
-        };
+        // Apply baselines.
+        fragment = fragment.with_baselines(baselines);
 
         // Lay out absolutely positioned children if this new atomic establishes a containing block
         // for absolutes.

--- a/components/layout/geom.rs
+++ b/components/layout/geom.rs
@@ -85,13 +85,6 @@ impl<T: Copy> From<T> for LogicalVec2<T> {
 }
 
 impl<T> LogicalVec2<T> {
-    pub(crate) fn as_ref(&self) -> LogicalVec2<&T> {
-        LogicalVec2 {
-            inline: &self.inline,
-            block: &self.block,
-        }
-    }
-
     pub fn map_inline_and_block_axes<U>(
         &self,
         inline_f: impl FnOnce(&T) -> U,

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -29,12 +29,10 @@ use crate::dom::NodeExt;
 use crate::fragment_tree::{
     BaseFragmentInfo, CollapsedBlockMargins, Fragment, IFrameFragment, ImageFragment,
 };
-use crate::geom::{
-    LazySize, LogicalSides1D, LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSize, Size, Sizes,
-};
+use crate::geom::{LazySize, LogicalVec2, PhysicalPoint, PhysicalRect, PhysicalSize, Size, Sizes};
 use crate::layout_box_base::{CacheableLayoutResult, LayoutBoxBase};
 use crate::sizing::{ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult};
-use crate::style_ext::{AspectRatio, Clamp, ComputedValuesExt, ContentBoxSizesAndPBM, LayoutStyle};
+use crate::style_ext::{AspectRatio, Clamp, ComputedValuesExt, LayoutStyle};
 use crate::{ConstraintSpace, ContainingBlock, SizeConstraint};
 
 #[derive(Debug, MallocSizeOf)]
@@ -408,29 +406,6 @@ impl ReplacedContents {
             .or_else(|| {
                 matches!(self.kind, ReplacedContentKind::Video(_)).then(Self::default_aspect_ratio)
             })
-    }
-
-    /// <https://drafts.csswg.org/css2/visudet.html#inline-replaced-width>
-    /// <https://drafts.csswg.org/css2/visudet.html#inline-replaced-height>
-    ///
-    /// Also used in other cases, for example
-    /// <https://drafts.csswg.org/css2/visudet.html#block-replaced-width>
-    pub(crate) fn used_size_as_if_inline_element(
-        &self,
-        containing_block: &ContainingBlock,
-        style: &ComputedValues,
-        content_box_sizes_and_pbm: &ContentBoxSizesAndPBM,
-        ignore_block_margins_for_stretch: LogicalSides1D<bool>,
-    ) -> LogicalVec2<Au> {
-        let pbm = &content_box_sizes_and_pbm.pbm;
-        self.used_size_as_if_inline_element_from_content_box_sizes(
-            containing_block,
-            style,
-            self.preferred_aspect_ratio(style, &pbm.padding_border_sums),
-            content_box_sizes_and_pbm.content_box_sizes.as_ref(),
-            Size::FitContent.into(),
-            pbm.sums_auto_is_zero(ignore_block_margins_for_stretch),
-        )
     }
 
     /// The aspect ratio of the default object sizes.


### PR DESCRIPTION
Laying out a float or atomic inline will now use the same logic regardless of whether it's replaced or not.
This reduces the amount of code, and should have no observable effect.

Testing: Unneeded (no behavior change)
This part of #37942
