### PR TITLE
script: Also update canvas contents when laying out right after / during long parsing

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2341,7 +2341,7 @@ impl Window {
         // iframe size updates.
         //
         // See <https://github.com/servo/servo/issues/14719>
-        self.reflow(ReflowGoal::UpdateTheRendering, can_gc);
+        self.Document().update_the_rendering(can_gc);
     }
 
     pub(crate) fn layout_blocked(&self) -> bool {

--- a/tests/wpt/mozilla/meta/mozilla/window_resizeTo.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/window_resizeTo.html.ini
@@ -1,3 +1,0 @@
-[window_resizeTo.html]
-  [Correctly resize outerWidth and outerHeight]
-    expected: FAIL


### PR DESCRIPTION
Before #37703 we were actually doing update rendering of canvases/images as part of `allow_layout_if_necessary` so let's keep doing that until we fix this properly as this will be much more involved and we want usable canvases in the mean time.

Testing: Manual testing + WPT tests
Fixes: #37891