### PR TITLE
Fix unused import `TouchEventType` warning

### DIFF
--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -1,5 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::cell::RefCell;
 use std::error::Error;
@@ -7,8 +8,7 @@ use std::rc::Rc;
 
 use euclid::{Scale, Size2D};
 use servo::{
-    RenderingContext, Servo, ServoBuilder, TouchEventType, WebView, WebViewBuilder,
-    WindowRenderingContext,
+    RenderingContext, Servo, ServoBuilder, WebView, WebViewBuilder, WindowRenderingContext,
 };
 use tracing::warn;
 use url::Url;


### PR DESCRIPTION
I'm getting an unused import warning when I use Rust-Analyzer in VS Code. I also fixed the license text which I think had gotten changed by accident.

Testing:  I built and ran the example with `cargo build --example winit_minimal` in the `components/servo` folder. There were some unused code warnings but they don't show up in Rust-Analyzer's output and I suspect they are used by other code. 
