### PR TITLE
mach: macos: Don't let gstreamer override symbols

### DIFF
--- a/ports/servoshell/build.rs
+++ b/ports/servoshell/build.rs
@@ -11,9 +11,6 @@ use std::process::Command;
 fn git_sha() -> Result<String, String> {
     let output = Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
-        // on macos mach sets DYLD_LIBRARY_PATH since it is needed for unit-tests, but it
-        // causes git to fail, so we remove it for the git invocation.
-        .env_remove("DYLD_LIBRARY_PATH")
         .output()
         .map_err(|e| e.to_string())?;
     if output.status.success() {

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -466,7 +466,7 @@ class CommandBase(object):
                 # GStreamer distribution (such as harfbuzz), but we only modify the rpath of the
                 # target binary (servoshell / libsimpleservo).
                 if platform.is_macos:
-                    util.prepend_paths_to_env(env, "DYLD_LIBRARY_PATH", os.path.join(gstreamer_root, "lib"))
+                    util.prepend_paths_to_env(env, "DYLD_FALLBACK_LIBRARY_PATH", os.path.join(gstreamer_root, "lib"))
 
         if sys.platform != "win32":
             env.setdefault("CC", "clang")


### PR DESCRIPTION
Using DYLD_FALLBACK_LIBRARY_PATH means we first try to link to the normal libraries and only fallback to looking up symbols in gstreamer if the symbols were not found elsewhere.
This prevents some linking issues.

Testing: Covered by existing tests. Fix for issue #37811 manually verified by the reporter.