### PR TITLE
Send early DevToolsHttpRequest and relocate response reporting to main_fetch

### DIFF
--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -493,6 +493,7 @@ impl DevtoolsInstance {
     ) {
         let browsing_context_id = match &network_event {
             NetworkEvent::HttpRequest(req) => req.browsing_context_id,
+            NetworkEvent::HttpRequestUpdate(req) => req.browsing_context_id,
             NetworkEvent::HttpResponse(resp) => resp.browsing_context_id,
         };
 

--- a/components/devtools/network_handler.rs
+++ b/components/devtools/network_handler.rs
@@ -55,6 +55,21 @@ pub(crate) fn handle_network_event(
                 );
             }
         },
+
+        NetworkEvent::HttpRequestUpdate(httprequest) => {
+            actor.add_request(httprequest);
+            let resource = actor.resource_updates();
+            let watcher_actor = actors.find::<WatcherActor>(&watcher_name);
+
+            for stream in &mut connections {
+                watcher_actor.resource_array(
+                    resource.clone(),
+                    "network-event".to_string(),
+                    ResourceArrayType::Updated,
+                    stream,
+                );
+            }
+        },
         NetworkEvent::HttpResponse(httpresponse) => {
             // Store the response information in the actor
             actor.add_response(httpresponse);

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -261,6 +261,7 @@ pub async fn main_fetch(
     // Step 1: Let request be fetchParam's request.
     let request = &mut fetch_params.request;
     // send early HTTP request to DevTools
+    #[allow(clippy::needless_borrow)]
     send_early_httprequest_to_devtools(request, &context);
     // Step 2: Let response be null.
     let mut response = None;
@@ -706,6 +707,7 @@ pub async fn main_fetch(
     // Step 22.
     target.process_response(request, &response);
     // Send Response to Devtools
+    #[allow(clippy::needless_borrow)]
     send_response_to_devtools(request, &context, &response);
 
     // Step 23.
@@ -718,6 +720,7 @@ pub async fn main_fetch(
     // Send Response to Devtools
     // This is done after process_response_eof to ensure that the body is fully
     // processed before sending the response to Devtools.
+    #[allow(clippy::needless_borrow)]
     send_response_to_devtools(request, &context, &response);
 
     if let Ok(http_cache) = context.state.http_cache.write() {

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -4,22 +4,17 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime};
 use std::{io, mem, str};
 
 use base64::Engine as _;
 use base64::engine::general_purpose;
 use content_security_policy as csp;
 use crossbeam_channel::Sender;
-use devtools_traits::{
-    ChromeToDevtoolsControlMsg, DevtoolsControlMsg, HttpRequest as DevtoolsHttpRequest,
-    NetworkEvent,
-};
+use devtools_traits::DevtoolsControlMsg;
 use embedder_traits::resources::{self, Resource};
 use headers::{AccessControlExposeHeaders, ContentType, HeaderMapExt};
 use http::header::{self, HeaderMap, HeaderName, RANGE};
 use http::{HeaderValue, Method, StatusCode};
-use hyper_serde::Serde;
 use ipc_channel::ipc;
 use log::{debug, trace, warn};
 use mime::{self, Mime};
@@ -34,8 +29,8 @@ use net_traits::request::{
 };
 use net_traits::response::{Response, ResponseBody, ResponseType};
 use net_traits::{
-    FetchMetadata, FetchTaskTarget, NetworkError, ReferrerPolicy, ResourceAttribute,
-    ResourceFetchTiming, ResourceTimeValue, ResourceTimingType, set_default_accept_language,
+    FetchTaskTarget, NetworkError, ReferrerPolicy, ResourceAttribute, ResourceFetchTiming,
+    ResourceTimeValue, ResourceTimingType, set_default_accept_language,
 };
 use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
@@ -48,7 +43,7 @@ use crate::fetch::cors_cache::CorsCache;
 use crate::fetch::headers::determine_nosniff;
 use crate::filemanager_thread::FileManager;
 use crate::http_loader::{
-    HttpState, determine_requests_referrer, http_fetch, send_request_to_devtools,
+    HttpState, determine_requests_referrer, http_fetch, send_early_httprequest_to_devtools,
     send_response_to_devtools, set_default_accept,
 };
 use crate::protocols::{ProtocolRegistry, is_url_potentially_trustworthy};
@@ -265,40 +260,8 @@ pub async fn main_fetch(
 ) -> Response {
     // Step 1: Let request be fetchParam's request.
     let request = &mut fetch_params.request;
-
-    let request_id = context
-        .devtools_chan
-        .as_ref()
-        .map(|_| uuid::Uuid::new_v4().simple().to_string());
-    // Send information about the request to devtools
-    if let (Some(devtools_chan), Some(browsing_context_id), Some(pipeline_id)) = (
-        context.devtools_chan.as_ref(),
-        request.target_webview_id.map(|id| id.0),
-        request.pipeline_id,
-    ) {
-        // Build the partial DevtoolsHttpRequest
-        let devtools_request = DevtoolsHttpRequest {
-            url: request.current_url().clone(),
-            method: request.method.clone(),
-            headers: request.headers.clone(),
-            body: None,
-            pipeline_id,
-            started_date_time: SystemTime::now(),
-            time_stamp: 0,
-            connect_time: Duration::from_millis(0),
-            send_time: Duration::from_millis(0),
-            is_xhr: false,
-            browsing_context_id,
-        };
-
-        let msg = ChromeToDevtoolsControlMsg::NetworkEvent(
-            request_id.clone().unwrap(),
-            NetworkEvent::HttpRequest(devtools_request),
-        );
-
-        send_request_to_devtools(msg, &devtools_chan.lock().unwrap());
-    }
-
+    // send early HTTP request to DevTools
+    send_early_httprequest_to_devtools(request, &context);
     // Step 2: Let response be null.
     let mut response = None;
 
@@ -743,31 +706,7 @@ pub async fn main_fetch(
     // Step 22.
     target.process_response(request, &response);
     // Send Response to Devtools
-    if let (Some(devtools_chan), Some(pipeline_id), Some(webview_id)) = (
-        context.devtools_chan.as_ref(),
-        request.pipeline_id,
-        request.target_webview_id,
-    ) {
-        let browsing_context_id = webview_id.0;
-        let meta = match response
-            .metadata()
-            .expect("Response metadata should exist at this stage")
-        {
-            FetchMetadata::Unfiltered(m) => m,
-            FetchMetadata::Filtered { unsafe_, .. } => unsafe_,
-        };
-        let status = meta.status;
-        let headers = meta.headers.map(Serde::into_inner);
-
-        send_response_to_devtools(
-            &devtools_chan.lock().unwrap(),
-            request_id.clone().unwrap(),
-            headers,
-            status,
-            pipeline_id,
-            browsing_context_id,
-        );
-    }
+    send_response_to_devtools(request, &context, &response);
 
     // Step 23.
     if !response_loaded {
@@ -779,31 +718,7 @@ pub async fn main_fetch(
     // Send Response to Devtools
     // This is done after process_response_eof to ensure that the body is fully
     // processed before sending the response to Devtools.
-    if let (Some(devtools_chan), Some(pipeline_id), Some(webview_id)) = (
-        context.devtools_chan.as_ref(),
-        request.pipeline_id,
-        request.target_webview_id,
-    ) {
-        let browsing_context_id = webview_id.0;
-        let meta = match response
-            .metadata()
-            .expect("Response metadata should exist at this stage")
-        {
-            FetchMetadata::Unfiltered(m) => m,
-            FetchMetadata::Filtered { unsafe_, .. } => unsafe_,
-        };
-        let status = meta.status;
-        let headers = meta.headers.map(Serde::into_inner);
-
-        send_response_to_devtools(
-            &devtools_chan.lock().unwrap(),
-            request_id.clone().unwrap(),
-            headers,
-            status,
-            pipeline_id,
-            browsing_context_id,
-        );
-    }
+    send_response_to_devtools(request, &context, &response);
 
     if let Ok(http_cache) = context.state.http_cache.write() {
         http_cache.update_awaiting_consumers(request, &response);

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -261,8 +261,7 @@ pub async fn main_fetch(
     // Step 1: Let request be fetchParam's request.
     let request = &mut fetch_params.request;
     // send early HTTP request to DevTools
-    #[allow(clippy::needless_borrow)]
-    send_early_httprequest_to_devtools(request, &context);
+    send_early_httprequest_to_devtools(request, context);
     // Step 2: Let response be null.
     let mut response = None;
 
@@ -707,7 +706,6 @@ pub async fn main_fetch(
     // Step 22.
     target.process_response(request, &response);
     // Send Response to Devtools
-    #[allow(clippy::needless_borrow)]
     send_response_to_devtools(request, &context, &response);
 
     // Step 23.
@@ -720,7 +718,6 @@ pub async fn main_fetch(
     // Send Response to Devtools
     // This is done after process_response_eof to ensure that the body is fully
     // processed before sending the response to Devtools.
-    #[allow(clippy::needless_borrow)]
     send_response_to_devtools(request, &context, &response);
 
     if let Ok(http_cache) = context.state.http_cache.write() {

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -706,7 +706,7 @@ pub async fn main_fetch(
     // Step 22.
     target.process_response(request, &response);
     // Send Response to Devtools
-    send_response_to_devtools(request, &context, &response);
+    send_response_to_devtools(request, context, &response);
 
     // Step 23.
     if !response_loaded {
@@ -718,7 +718,7 @@ pub async fn main_fetch(
     // Send Response to Devtools
     // This is done after process_response_eof to ensure that the body is fully
     // processed before sending the response to Devtools.
-    send_response_to_devtools(request, &context, &response);
+    send_response_to_devtools(request, context, &response);
 
     if let Ok(http_cache) = context.state.http_cache.write() {
         http_cache.update_awaiting_consumers(request, &response);

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -417,7 +417,7 @@ fn prepare_devtools_request(
         is_xhr,
         browsing_context_id,
     };
-    let net_event = NetworkEvent::HttpRequest(request);
+    let net_event = NetworkEvent::HttpRequestUpdate(request);
 
     ChromeToDevtoolsControlMsg::NetworkEvent(request_id, net_event)
 }
@@ -2052,16 +2052,8 @@ async fn http_network_fetch(
 
     if let Some(ref sender) = devtools_sender {
         let sender = sender.lock().unwrap();
-        if let Some(ChromeToDevtoolsControlMsg::NetworkEvent(
-            _,
-            NetworkEvent::HttpRequest(devtools_request),
-        )) = msg
-        {
-            let update_msg = ChromeToDevtoolsControlMsg::NetworkEvent(
-                request.id.0.to_string(),
-                NetworkEvent::HttpRequestUpdate(devtools_request),
-            );
-            send_request_to_devtools(update_msg, &sender);
+        if let Some(m) = msg {
+            send_request_to_devtools(m, &sender);
         }
     }
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -934,6 +934,8 @@ pub async fn http_fetch(
         .try_code()
         .is_some_and(is_redirect_status)
     {
+        // Notify devtools before handling redirect
+        send_response_to_devtools(request, context, &response);
         // Substep 1.
         if response.actual_response().status != StatusCode::SEE_OTHER {
             // TODO: send RST_STREAM frame

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1958,7 +1958,7 @@ async fn http_network_fetch(
             .map(|body| body.source_is_null())
             .unwrap_or(false),
         &request.pipeline_id,
-        Some(&request_id)  ,
+        Some(&request_id),
         is_xhr,
         context,
         fetch_terminated_sender,
@@ -2052,7 +2052,11 @@ async fn http_network_fetch(
 
     if let Some(ref sender) = devtools_sender {
         let sender = sender.lock().unwrap();
-        if let Some(ChromeToDevtoolsControlMsg::NetworkEvent(_, NetworkEvent::HttpRequest(devtools_request))) = msg {
+        if let Some(ChromeToDevtoolsControlMsg::NetworkEvent(
+            _,
+            NetworkEvent::HttpRequest(devtools_request),
+        )) = msg
+        {
             let update_msg = ChromeToDevtoolsControlMsg::NetworkEvent(
                 request.id.0.to_string(),
                 NetworkEvent::HttpRequestUpdate(devtools_request),
@@ -2060,8 +2064,6 @@ async fn http_network_fetch(
             send_request_to_devtools(update_msg, &sender);
         }
     }
-    
-
 
     let done_sender2 = done_sender.clone();
     let done_sender3 = done_sender.clone();

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -1295,7 +1295,7 @@ fn test_fetch_with_devtools() {
     let _ = server.close();
 
     // notification received from devtools
-    let devhttprequest = expect_devtools_http_request(&devtools_port);
+    let devhttprequests = expect_devtools_http_request(&devtools_port);
     let mut devhttpresponse = expect_devtools_http_response(&devtools_port);
 
     //Creating default headers for request
@@ -1335,10 +1335,10 @@ fn test_fetch_with_devtools() {
         headers: headers,
         body: Some(vec![]),
         pipeline_id: TEST_PIPELINE_ID,
-        started_date_time: devhttprequest.started_date_time,
-        time_stamp: devhttprequest.time_stamp,
-        connect_time: devhttprequest.connect_time,
-        send_time: devhttprequest.send_time,
+        started_date_time: devhttprequests.1.started_date_time,
+        time_stamp: devhttprequests.1.time_stamp,
+        connect_time: devhttprequests.1.connect_time,
+        send_time: devhttprequests.1.send_time,
         is_xhr: true,
         browsing_context_id: TEST_WEBVIEW_ID.0,
     };
@@ -1360,7 +1360,7 @@ fn test_fetch_with_devtools() {
         browsing_context_id: TEST_WEBVIEW_ID.0,
     };
 
-    assert_eq!(devhttprequest, httprequest);
+    assert_eq!(devhttprequests.1, httprequest);
     assert_eq!(devhttpresponse, httpresponse);
 }
 

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -72,6 +72,7 @@ fn recv_http_request(devtools_port: &Receiver<DevtoolsControlMsg>) -> DevtoolsHt
         DevtoolsControlMsg::FromChrome(ChromeToDevtoolsControlMsg::NetworkEvent(_, net_event)) => {
             match net_event {
                 NetworkEvent::HttpRequest(req) => req,
+                NetworkEvent::HttpRequestUpdate(req) => req,
                 other => panic!("Expected HttpRequest but got: {:?}", other),
             }
         },

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -432,7 +432,7 @@ pub enum CachedConsoleMessage {
     ConsoleLog(ConsoleLog),
 }
 
-#[derive(Debug, PartialEq,Clone)]
+#[derive(Debug, PartialEq)]
 pub struct HttpRequest {
     pub url: ServoUrl,
     pub method: Method,

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -432,7 +432,7 @@ pub enum CachedConsoleMessage {
     ConsoleLog(ConsoleLog),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct HttpRequest {
     pub url: ServoUrl,
     pub method: Method,
@@ -459,6 +459,7 @@ pub struct HttpResponse {
 #[derive(Debug)]
 pub enum NetworkEvent {
     HttpRequest(HttpRequest),
+    HttpRequestUpdate(HttpRequest),
     HttpResponse(HttpResponse),
 }
 

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -22,7 +22,7 @@ use crate::{ReferrerPolicy, ResourceTimingType};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 /// An id to differeniate one network request from another.
-pub struct RequestId(Uuid);
+pub struct RequestId(pub Uuid);
 
 impl Default for RequestId {
     fn default() -> Self {


### PR DESCRIPTION
This change refactors how we notify DevTools about network activity so that all fetches (even those served from cache) appear correctly in the Network panel, and so that DevTools sees request metadata as soon as possible rather than waiting until the end of a full HTTP cycle.
- Before, we only send DevTools events inside http_network_fetch, so cached responses (which skip that path) never show up. By emitting a minimal HttpRequest event at the very start of main_fetch (with URL, method, pipeline and browsing IDs), we guarantee every fetch shows up immediately. 
- Then, by moving HttpResponse notifications out of http_network_fetch into main_fetch (right after process_response and process_response_eof), we ensure DevTools gets status, header, and completion events for both network and cache hits. Leveraging nullable fields in NetworkEventActor lets us incrementally fill in timing, header, and body data later, improving DevTools’ visibility.
Testing: Ran servo with `--devtools=6080` flag, cached responses now appear in the network panel
Fixes: https://github.com/servo/servo/issues/37869
