### PR TITLE
Webdriver: Send Keys use `webview::notify_input_event`

### DIFF
--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -56,7 +56,7 @@ pub enum WebDriverCommandMsg {
     /// of a browsing context.
     ScriptCommand(BrowsingContextId, WebDriverScriptCommand),
     /// Act as if keys were pressed in the browsing context with the given ID.
-    SendKeys(BrowsingContextId, Vec<WebDriverInputEvent>),
+    SendKeys(WebViewId, Vec<WebDriverInputEvent>),
     /// Act as if keys were pressed or release in the browsing context with the given ID.
     KeyboardAction(
         WebViewId,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1850,7 +1850,7 @@ impl Handler {
             self.session()?.strict_file_interactability,
             sender,
         );
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
 
         // TODO: distinguish the not found and not focusable cases
         // File input and non-typeable form control should have

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1842,20 +1842,15 @@ impl Handler {
         element: &WebElement,
         keys: &SendKeysParameters,
     ) -> WebDriverResult<WebDriverResponse> {
-        let browsing_context_id = self.session()?.browsing_context_id;
-        // Step 3. If session's current browsing context is no longer open,
-        // return error with error code no such window.
-        self.verify_browsing_context_is_open(browsing_context_id)?;
+        // Step 3-8
         let (sender, receiver) = ipc::channel().unwrap();
-
         let cmd = WebDriverScriptCommand::WillSendKeys(
             element.to_string(),
             keys.text.to_string(),
             self.session()?.strict_file_interactability,
             sender,
         );
-        let cmd_msg = WebDriverCommandMsg::ScriptCommand(browsing_context_id, cmd);
-        self.send_message_to_embedder(cmd_msg)?;
+        self.browsing_context_script_command::<true>(cmd)?;
 
         // TODO: distinguish the not found and not focusable cases
         // File input and non-typeable form control should have
@@ -1869,7 +1864,8 @@ impl Handler {
         // TODO: there's a race condition caused by the focus command and the
         // send keys command being two separate messages,
         // so the constellation may have changed state between them.
-        let cmd_msg = WebDriverCommandMsg::SendKeys(browsing_context_id, input_events);
+        // TODO: We should use `dispatch_action` to send the keys.
+        let cmd_msg = WebDriverCommandMsg::SendKeys(self.session()?.webview_id, input_events);
         self.send_message_to_embedder(cmd_msg)?;
 
         Ok(WebDriverResponse::Void)

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -477,22 +477,24 @@ impl App {
                     }
                 },
                 // Key events don't need hit test so can be forwarded to constellation for now
-                WebDriverCommandMsg::SendKeys(webview_id, cmd) => {
-                    for event in cmd {
-                        if let Some(webview) = running_state.webview_by_id(webview_id) {
-                            match event {
-                                WebDriverInputEvent::Keyboard(event) => {
-                                    webview.notify_input_event(InputEvent::Keyboard(
-                                        KeyboardEvent::new(event),
-                                    ));
-                                },
-                                WebDriverInputEvent::Composition(event) => {
-                                    webview.notify_input_event(InputEvent::Ime(
-                                        ImeEvent::Composition(event),
-                                    ));
-                                },
-                            }
-                        };
+                WebDriverCommandMsg::SendKeys(webview_id, webdriver_input_events) => {
+                    let Some(webview) = running_state.webview_by_id(webview_id) else {
+                        continue;
+                    };
+
+                    for event in webdriver_input_events {
+                        match event {
+                            WebDriverInputEvent::Keyboard(event) => {
+                                webview.notify_input_event(InputEvent::Keyboard(
+                                    KeyboardEvent::new(event),
+                                ));
+                            },
+                            WebDriverInputEvent::Composition(event) => {
+                                webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
+                                    event,
+                                )));
+                            },
+                        }
                     }
                 },
                 WebDriverCommandMsg::KeyboardAction(webview_id, key_event, msg_id) => {


### PR DESCRIPTION
Previously, we SendKeys will be forwarded to constellation by the embedder. Now we use webview.notify_input_event, which will send WebDriverCommandMsg::ForwardInputEvent for the KeyboardEvent and CompositionEvent.

Fixes: part of https://github.com/servo/servo/issues/37370 