### PR TITLE
OHOS CI: Install the required hitrace-bench version

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -36,6 +36,7 @@ env:
   SHELL: /bin/bash
   CARGO_INCREMENTAL: 0
   BENCHER_PROJECT: ${{ vars.BENCHER_PROJECT || 'servo' }}
+  HITRACE_BENCH_VERSION: 0.7.0
 
 jobs:
   build:
@@ -276,6 +277,11 @@ jobs:
           fetch-depth: 2
       - name: Setup Python
         uses: ./.github/actions/setup-python
+      - name: Getting hitrace-bench version
+        run: echo "INSTALLED_HITRACE_BENCH_VERSION=$(hitrace-bench --version | awk '{print $2}')" >> $GITHUB_ENV
+      - name: Install hitrace-bench
+        run: cargo install --locked hitrace-bench --version $HITRACE_BENCH_VERSION
+        if: ${{ env.INSTALLED_HITRACE_BENCH_VERSION != env.HITRACE_BENCH_VERSION }}
       - name: "Run benchmark"
         run: hitrace-bench -r support/hitrace-bencher/runs.json
         continue-on-error: true


### PR DESCRIPTION
OHOS CI: Install the required hitrace-bench version if it is not already
installed. This allows us to see the hitrace-bench version in the commit
history without it being reinstalled on CI all the time.
This does not change the version of hitrace-bench in this PR.

This needs another update of the docker images to get the correct build tools installed.

Succesful run: https://github.com/Narfinger/servo/actions/runs/16115943664/job/45469959328
And here a run where it installs the given version: https://github.com/Narfinger/servo/actions/runs/16116949656/job/45473231784
Testing: Tested on CI.
