### PR TITLE
layout: Remove clearance parameter from `BoxFragment::new()`

### DIFF
--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -298,7 +298,6 @@ impl FlexLineItem<'_> {
             flex_context
                 .sides_to_flow_relative(item_margin)
                 .to_physical(container_writing_mode),
-            None, /* clearance */
             self.layout_result.specific_layout_info,
         );
 

--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -459,7 +459,6 @@ impl LineItemLayout<'_, '_> {
             padding.to_physical(ifc_writing_mode),
             border.to_physical(ifc_writing_mode),
             margin.to_physical(ifc_writing_mode),
-            None, /* clearance */
             None, /* specific_layout_info */
         );
 

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -407,7 +407,6 @@ impl OutsideMarker {
             PhysicalSides::zero(),
             PhysicalSides::zero(),
             PhysicalSides::zero(),
-            None,
             flow_layout.specific_layout_info,
         )))
     }
@@ -1173,11 +1172,11 @@ fn layout_in_flow_non_replaced_block_level_same_formatting_context(
         pbm.padding.to_physical(containing_block_writing_mode),
         pbm.border.to_physical(containing_block_writing_mode),
         margin.to_physical(containing_block_writing_mode),
-        clearance,
         flow_layout.specific_layout_info,
     )
     .with_baselines(flow_layout.baselines)
     .with_block_margins_collapsed_with_children(block_margins_collapsed_with_children)
+    .with_clearance(clearance)
 }
 
 impl IndependentFormattingContext {
@@ -1286,7 +1285,6 @@ impl IndependentFormattingContext {
             pbm.padding.to_physical(containing_block_writing_mode),
             pbm.border.to_physical(containing_block_writing_mode),
             margin.to_physical(containing_block_writing_mode),
-            None, /* clearance */
             layout.specific_layout_info,
         )
         .with_baselines(layout.baselines)
@@ -1604,11 +1602,11 @@ impl IndependentFormattingContext {
             pbm.padding.to_physical(containing_block_writing_mode),
             pbm.border.to_physical(containing_block_writing_mode),
             margin.to_physical(containing_block_writing_mode),
-            clearance,
             layout.specific_layout_info,
         )
         .with_baselines(layout.baselines)
         .with_block_margins_collapsed_with_children(CollapsedBlockMargins::from_margin(&margin))
+        .with_clearance(clearance)
     }
 }
 
@@ -2358,6 +2356,9 @@ impl IndependentFormattingContext {
             );
         }
 
+        // Floats can have clearance, but it's handled internally by the float placement logic,
+        // so there's no need to store it explicitly in the fragment.
+        // And atomic inlines don't have clearance.
         let fragment = BoxFragment::new(
             base_fragment_info,
             self.style().clone(),
@@ -2366,10 +2367,6 @@ impl IndependentFormattingContext {
             pbm.padding.to_physical(container_writing_mode),
             pbm.border.to_physical(container_writing_mode),
             margin.to_physical(container_writing_mode),
-            // Floats can have clearance, but it's handled internally by the float placement logic,
-            // so there's no need to store it explicitly in the fragment.
-            // And atomic inlines don't have clearance.
-            None, /* clearance */
             specific_layout_info,
         );
 

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -115,7 +115,6 @@ impl BoxFragment {
         padding: PhysicalSides<Au>,
         border: PhysicalSides<Au>,
         margin: PhysicalSides<Au>,
-        clearance: Option<Au>,
         specific_layout_info: Option<SpecificLayoutInfo>,
     ) -> BoxFragment {
         BoxFragment {
@@ -127,7 +126,7 @@ impl BoxFragment {
             padding,
             border,
             margin,
-            clearance,
+            clearance: None,
             baselines: Baselines::default(),
             block_margins_collapsed_with_children: None,
             scrollable_overflow: None,
@@ -191,6 +190,11 @@ impl BoxFragment {
         collapsed_margins: CollapsedBlockMargins,
     ) -> Self {
         self.block_margins_collapsed_with_children = Some(collapsed_margins.into());
+        self
+    }
+
+    pub fn with_clearance(mut self, clearance: Option<Au>) -> Self {
+        self.clearance = clearance;
         self
     }
 

--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -672,7 +672,6 @@ impl HoistedAbsolutelyPositionedBox {
                 pbm.padding.to_physical(containing_block_writing_mode),
                 pbm.border.to_physical(containing_block_writing_mode),
                 margin.to_physical(containing_block_writing_mode),
-                None, /* clearance */
                 specific_layout_info,
             )
         };

--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -1787,7 +1787,6 @@ impl<'a> TableLayout<'a> {
                 self.pbm.padding.to_physical(table_writing_mode),
                 self.pbm.border.to_physical(table_writing_mode),
                 PhysicalSides::zero(),
-                None, /* clearance */
                 self.specific_layout_info_for_grid(),
             );
         }
@@ -1912,7 +1911,6 @@ impl<'a> TableLayout<'a> {
             self.pbm.padding.to_physical(table_writing_mode),
             self.pbm.border.to_physical(table_writing_mode),
             PhysicalSides::zero(),
-            None, /* clearance */
             self.specific_layout_info_for_grid(),
         )
         .with_baselines(baselines)
@@ -2358,7 +2356,6 @@ impl<'a> RowFragmentLayout<'a> {
             PhysicalSides::zero(), /* padding */
             PhysicalSides::zero(), /* border */
             PhysicalSides::zero(), /* margin */
-            None,                  /* clearance */
             None,                  /* specific_layout_info */
         );
         row_fragment.set_does_not_paint_background();
@@ -2431,7 +2428,6 @@ impl RowGroupFragmentLayout {
             PhysicalSides::zero(), /* padding */
             PhysicalSides::zero(), /* border */
             PhysicalSides::zero(), /* margin */
-            None,                  /* clearance */
             None,                  /* specific_layout_info */
         );
         row_group_fragment.set_does_not_paint_background();
@@ -2911,7 +2907,6 @@ impl TableSlotCell {
             layout.padding.to_physical(table_style.writing_mode),
             layout.border.to_physical(table_style.writing_mode),
             PhysicalSides::zero(), /* margin */
-            None,                  /* clearance */
             specific_layout_info,
         )
         .with_baselines(layout.layout.baselines)

--- a/components/layout/taffy/layout.rs
+++ b/components/layout/taffy/layout.rs
@@ -551,7 +551,6 @@ impl TaffyContainer {
                             padding,
                             border,
                             margin,
-                            None, /* clearance */
                             child_specific_layout_info,
                         )
                         .with_baselines(Baselines {


### PR DESCRIPTION
Clearance only applies to block-level boxes, so it was unnecessary to require it as a parameter. Instead, in block layout we can set it using the new `.with_clearance()` method.

Testing: Unnecessary (no behavior change)
