### PR TITLE
servoshell: Fix `screen_geometry` for headed_window

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -438,14 +438,13 @@ impl WindowPortsMethods for Window {
 
         // Offset the WebView origin by the toolbar so that it reflects the actual viewport and
         // not the window origin.
-        let window_origin = self.winit_window.inner_position().unwrap_or_default();
-        let window_origin = winit_position_to_euclid_point(window_origin).to_f32();
-        let offset = window_origin + toolbar_size;
+        let window_origin = self.winit_window.outer_position().unwrap_or_default();
+        let offset = winit_position_to_euclid_point(window_origin);
 
         ScreenGeometry {
             size: screen_size.to_i32(),
             available_size: available_screen_size.to_i32(),
-            offset: offset.to_i32(),
+            offset,
         }
     }
 

--- a/tests/wpt/meta/webdriver/tests/classic/set_window_rect/set.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/set_window_rect/set.py.ini
@@ -26,18 +26,6 @@
   [test_negative_x_y]
     expected: FAIL
 
-  [test_set_to_screen_size]
-    expected: FAIL
-
-  [test_width_height_floats]
-    expected: FAIL
-
-  [test_height_as_current]
-    expected: FAIL
-
-  [test_width_as_current]
-    expected: FAIL
-
   [test_no_change[rect12\]]
     expected: FAIL
 
@@ -54,10 +42,4 @@
     expected: FAIL
 
   [test_no_change[rect19\]]
-    expected: FAIL
-
-  [test_set_larger_than_screen_size]
-    expected: FAIL
-
-  [test_height_width_as_current]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/switch_to_window/switch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/switch_to_window/switch.py.ini
@@ -1,8 +1,4 @@
 [switch.py]
-  expected: TIMEOUT
-  [test_no_top_browsing_context]
-    expected: FAIL
-
   [test_finds_exising_user_prompt_after_tab_switch[alert\]]
     expected: FAIL
 


### PR DESCRIPTION
This function is used to compute `screenLeft`, `screenTop`, `screenY`, `screenX`. Previously, it wrongly computes viewport position instead of window position, which didn't match https://github.com/servo/servo/blob/f7c86c439388c29be74161383241787e3f2fa5de/components/shared/embedder/lib.rs#L717-L720

Testing: More webdriver test would pass once #37893 is merged.
Fixes: the position part of #37824. 