### PR TITLE
webdriver: Element click waits for navigation complete

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2499,6 +2499,13 @@ impl ScriptThread {
                 reply,
                 can_gc,
             ),
+            WebDriverScriptCommand::IsDocumentReadyStateComplete(response_sender) => {
+                webdriver_handlers::handle_try_wait_for_document_navigation(
+                    &documents,
+                    pipeline_id,
+                    response_sender,
+                )
+            },
             _ => (),
         }
     }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -33,7 +33,9 @@ use webdriver::error::ErrorStatus;
 use crate::document_collection::DocumentCollection;
 use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyleDeclarationMethods;
 use crate::dom::bindings::codegen::Bindings::DOMRectBinding::DOMRectMethods;
-use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
+use crate::dom::bindings::codegen::Bindings::DocumentBinding::{
+    DocumentMethods, DocumentReadyState,
+};
 use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLInputElementBinding::HTMLInputElementMethods;
@@ -1716,4 +1718,21 @@ pub(crate) fn handle_is_selected(
             }),
         )
         .unwrap();
+}
+
+pub(crate) fn handle_try_wait_for_document_navigation(
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    reply: IpcSender<bool>,
+) {
+    let document = match documents.find_document(pipeline) {
+        Some(document) => document,
+        None => {
+            return reply.send(false).unwrap();
+        },
+    };
+
+    let wait_for_document_ready = document.ReadyState() != DocumentReadyState::Complete;
+
+    reply.send(wait_for_document_ready).unwrap();
 }

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -127,6 +127,8 @@ pub enum WebDriverCommandMsg {
         IpcSender<Result<(), ()>>,
     ),
     GetAlertText(WebViewId, IpcSender<Result<String, ()>>),
+    AddLoadStatusSender(WebViewId, IpcSender<WebDriverLoadStatus>),
+    RemoveLoadStatusSender(WebViewId),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -202,6 +204,7 @@ pub enum WebDriverScriptCommand {
     GetTitle(IpcSender<String>),
     /// Match the element type before sending the event for webdriver `element send keys`.
     WillSendKeys(String, String, bool, IpcSender<Result<bool, ErrorStatus>>),
+    IsDocumentReadyStateComplete(IpcSender<bool>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -454,6 +454,12 @@ impl App {
                         warn!("Failed to send response of GetFocusedWebView: {error}");
                     };
                 },
+                WebDriverCommandMsg::AddLoadStatusSender(webview_id, load_status_sender) => {
+                    running_state.set_load_status_sender(webview_id, load_status_sender);
+                },
+                WebDriverCommandMsg::RemoveLoadStatusSender(webview_id) => {
+                    running_state.remove_load_status_sender(webview_id);
+                },
                 WebDriverCommandMsg::LoadUrl(webview_id, url, load_status_sender) => {
                     if let Some(webview) = running_state.webview_by_id(webview_id) {
                         webview.load(url.into_url());

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -470,6 +470,13 @@ impl RunningAppState {
             });
         }
     }
+
+    pub(crate) fn remove_load_status_sender(&self, webview_id: WebViewId) {
+        self.webdriver_senders
+            .borrow_mut()
+            .load_status_senders
+            .remove(&webview_id);
+    }
 }
 
 struct ServoShellServoDelegate;


### PR DESCRIPTION
Step 11 in https://w3c.github.io/webdriver/#dfn-element-click

> [Try](https://w3c.github.io/webdriver/#dfn-try) to [wait for navigation to complete](https://w3c.github.io/webdriver/#dfn-wait-for-navigation-to-complete) with session.

This fixes issue in which element_click triggers navigation, but incoming commands still interact with old page.

Testing:
https://github.com/longvatrong111/servo/actions/runs/16175767947
https://github.com/longvatrong111/servo/actions/runs/16175770044