### PR TITLE
The simple implemention of Largest Contentful Paint

### DIFF
--- a/components/compositing/largest_contentful_paint.rs
+++ b/components/compositing/largest_contentful_paint.rs
@@ -1,0 +1,188 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashMap;
+
+use base::cross_process_instant::CrossProcessInstant;
+use compositing_traits::largest_contentful_paint_record::{
+    IMAGE_ENTROPY_THEAHOLD, ImageRecord, LCPCandidateRecord, LargestContentfulPaint, TextRecord,
+};
+use webrender_api::{Epoch, PipelineId};
+
+#[derive(Default)]
+pub struct LargestContentfulPaintDetector {
+    lcp_calculators: HashMap<PipelineId, LargestContentfulPaintCalculator>,
+}
+
+impl LargestContentfulPaintDetector {
+    pub fn new() -> Self {
+        Self {
+            lcp_calculators: HashMap::new(),
+        }
+    }
+
+    fn ensure_lcp_calculator(
+        &mut self,
+        pipeline_id: PipelineId,
+    ) -> &mut LargestContentfulPaintCalculator {
+        self.lcp_calculators
+            .entry(pipeline_id)
+            .or_insert(LargestContentfulPaintCalculator {
+                image_calculator: Default::default(),
+                text_calculator: Default::default(),
+                lcp: None,
+            })
+    }
+
+    pub fn appen_lcp_candidate_records(
+        &mut self,
+        pipeline_id: PipelineId,
+        mut records: LCPCandidateRecord,
+    ) {
+        let lcp_calculator = self.ensure_lcp_calculator(pipeline_id);
+        lcp_calculator
+            .image_calculator
+            .record_list
+            .append(&mut records.image_records);
+        let mut text_records: Vec<TextRecord> = records.text_records.into_values().collect();
+        lcp_calculator
+            .text_calculator
+            .record_list
+            .append(&mut text_records);
+    }
+
+    pub fn calculate_largest_contentful_paint(
+        &mut self,
+        paint_time: CrossProcessInstant,
+        epoch: Epoch,
+        pipeline_id: PipelineId,
+    ) -> Option<LargestContentfulPaint> {
+        let lcp_calculator = self.ensure_lcp_calculator(pipeline_id);
+        let image_candidate = lcp_calculator
+            .image_calculator
+            .calculate_largest_contentful_paint(paint_time, epoch);
+        let text_candidate = lcp_calculator
+            .text_calculator
+            .calculate_largest_contentful_paint(paint_time, epoch);
+
+        let mut candidate = Self::pick_largest_contentful_paint(image_candidate, text_candidate);
+        candidate = Self::pick_largest_contentful_paint(lcp_calculator.lcp, candidate);
+
+        if candidate == lcp_calculator.lcp {
+            return None;
+        }
+
+        lcp_calculator.lcp = candidate;
+        lcp_calculator.lcp
+    }
+
+    fn pick_largest_contentful_paint(
+        candidate1: Option<LargestContentfulPaint>,
+        candidate2: Option<LargestContentfulPaint>,
+    ) -> Option<LargestContentfulPaint> {
+        match (candidate1, candidate2) {
+            (_, None) => candidate1,
+            (None, _) => candidate2,
+            (Some(c1), Some(c2)) => {
+                if (c1.size > c2.size) || (c1.size == c2.size && c1.paint_time <= c2.paint_time) {
+                    Some(c1)
+                } else {
+                    Some(c2)
+                }
+            },
+        }
+    }
+}
+
+struct LargestContentfulPaintCalculator {
+    image_calculator: ImageLargestContentfulPaintCalculator,
+    text_calculator: TextLargestContentfulPaintCalculator,
+    lcp: Option<LargestContentfulPaint>,
+}
+
+#[derive(Default)]
+pub struct ImageLargestContentfulPaintCalculator {
+    record_list: Vec<ImageRecord>,
+    largest_image: Option<ImageRecord>,
+}
+
+impl ImageLargestContentfulPaintCalculator {
+    fn calculate_largest_contentful_paint(
+        &mut self,
+        paint_time: CrossProcessInstant,
+        cur_epoch: Epoch,
+    ) -> Option<LargestContentfulPaint> {
+        if self.record_list.is_empty() {
+            return self.largest_image.as_ref().map(|record| record.into());
+        }
+
+        let candidate_records = std::mem::take(&mut self.record_list);
+        for mut candidate_record in candidate_records {
+            if candidate_record.epoch() > cur_epoch {
+                self.record_list.push(candidate_record);
+                continue;
+            }
+
+            if candidate_record.image_entropy() < IMAGE_ENTROPY_THEAHOLD {
+                continue;
+            }
+
+            candidate_record.paint_time = Some(paint_time);
+            match self.largest_image {
+                None => self.largest_image = Some(candidate_record),
+                Some(ref largest_image) => {
+                    if largest_image.size() < candidate_record.size() ||
+                        (largest_image.size() == candidate_record.size() &&
+                            largest_image.paint_time() > candidate_record.paint_time())
+                    {
+                        self.largest_image = Some(candidate_record)
+                    }
+                },
+            }
+        }
+
+        self.largest_image.as_ref().map(|record| record.into())
+    }
+}
+
+#[derive(Default)]
+pub struct TextLargestContentfulPaintCalculator {
+    record_list: Vec<TextRecord>,
+    largest_text: Option<TextRecord>,
+}
+
+impl TextLargestContentfulPaintCalculator {
+    fn calculate_largest_contentful_paint(
+        &mut self,
+        paint_time: CrossProcessInstant,
+        cur_epoch: Epoch,
+    ) -> Option<LargestContentfulPaint> {
+        if self.record_list.is_empty() {
+            return self.largest_text.as_ref().map(|record| record.into());
+        }
+
+        let candidate_records = std::mem::take(&mut self.record_list);
+        for mut candidate_record in candidate_records {
+            if candidate_record.epoch() > cur_epoch {
+                self.record_list.push(candidate_record);
+                continue;
+            }
+
+            candidate_record.paint_time = Some(paint_time);
+            match self.largest_text {
+                None => self.largest_text = Some(candidate_record),
+                Some(ref largest_text) => {
+                    if largest_text.size() < candidate_record.size() ||
+                        (largest_text.size() == candidate_record.size() &&
+                            largest_text.paint_time() > candidate_record.paint_time())
+                    {
+                        self.largest_text = Some(candidate_record)
+                    }
+                },
+            }
+        }
+
+        self.largest_text.as_ref().map(|record| record.into())
+    }
+}

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -22,6 +22,7 @@ pub use crate::compositor::{IOCompositor, WebRenderDebugOption};
 mod tracing;
 
 mod compositor;
+mod largest_contentful_paint;
 mod refresh_driver;
 mod touch;
 mod webview_manager;

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -57,6 +57,7 @@ mod from_constellation {
                 Self::CollectMemoryReport(..) => target!("CollectMemoryReport"),
                 Self::Viewport(..) => target!("Viewport"),
                 Self::GenerateImageKeysForPipeline(..) => target!("GenerateImageKeysForPipeline"),
+                Self::LCPCandidate(..) => target!("LCPCandidate"),
             }
         }
     }

--- a/components/layout/display_list/effect.rs
+++ b/components/layout/display_list/effect.rs
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::fmt::Debug;
+use std::usize;
+
+use base::id::ScrollTreeNodeId;
+use servo_arc::Arc as ServoArc;
+use style::properties::ComputedValues;
+
+/// Similar to clip tree and scroll tree, it is used to track the
+/// effect css on the DOM tree. This is because blur and drop-shadow
+/// can affect the size of the visual area of elements.
+// #[derive(Debug)]
+pub(crate) struct EffectNode {
+    pub parent_id: EffectNodeId,
+    /// Similar to a clip node, it is the currently associated scroll node.
+    pub scroll_tree_node_id: ScrollTreeNodeId,
+    pub style: ServoArc<ComputedValues>,
+}
+
+impl Debug for EffectNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(
+            format!(
+                "EffectNode [parent_id: {:?}, scroll_id: {:?}]",
+                self.parent_id, self.scroll_tree_node_id
+            )
+            .as_str(),
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct EffectNodeId(usize);
+
+impl EffectNodeId {
+    pub(crate) const INVALID: EffectNodeId = EffectNodeId(usize::MAX);
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct StackingContextTreeEffectStore(pub Vec<EffectNode>);
+
+impl StackingContextTreeEffectStore {
+    pub fn add_effect(
+        &mut self,
+        parent_id: EffectNodeId,
+        scroll_tree_node_id: ScrollTreeNodeId,
+        style: ServoArc<ComputedValues>,
+    ) -> Option<EffectNodeId> {
+        let effects = style.get_effects();
+        if effects.opacity == 1.0 && effects.filter.0.is_empty() {
+            return None;
+        }
+
+        let id = self.0.len();
+        self.0.push(EffectNode {
+            parent_id,
+            scroll_tree_node_id,
+            style,
+        });
+
+        Some(EffectNodeId(id))
+    }
+
+    pub fn get(&self, id: EffectNodeId) -> Option<&EffectNode> {
+        self.0.get(id.0)
+    }
+}

--- a/components/layout/display_list/largest_contenful_paint_helper.rs
+++ b/components/layout/display_list/largest_contenful_paint_helper.rs
@@ -1,0 +1,244 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use base::id::ScrollTreeNodeId;
+use compositing_traits::display_list::{ScrollTree, SpatialTreeNodeInfo};
+use compositing_traits::largest_contentful_paint_record::LCPCandidateRecord;
+use style::values::computed::Filter;
+use webrender_api::units::{
+    LayoutPoint, LayoutRect, LayoutSideOffsets, LayoutSize, LayoutVector2D,
+};
+use webrender_api::{Epoch, ImageKey};
+
+use crate::display_list::clip::{ClipId, StackingContextTreeClipStore};
+use crate::display_list::effect::{EffectNodeId, StackingContextTreeEffectStore};
+
+pub(crate) struct LargestContentfulPaintHelper<'a> {
+    pub clip_tree: &'a StackingContextTreeClipStore,
+
+    pub effect_tree: &'a StackingContextTreeEffectStore,
+
+    pub current_scroll_node_id: ScrollTreeNodeId,
+
+    pub current_clip_id: ClipId,
+
+    pub current_effect_id: EffectNodeId,
+
+    pub lcp_record: &'a mut LCPCandidateRecord,
+}
+
+impl<'a> LargestContentfulPaintHelper<'a> {
+    pub fn update_current_node_id(
+        &mut self,
+        next_effect_id: EffectNodeId,
+        next_scroll_node_id: ScrollTreeNodeId,
+        next_clip_id: ClipId,
+    ) {
+        self.current_effect_id = next_effect_id;
+        self.current_scroll_node_id = next_scroll_node_id;
+        self.current_clip_id = next_clip_id;
+    }
+
+    pub fn record_image(
+        &mut self,
+        tag: usize,
+        visual_rect: &LayoutRect,
+        image_key: &ImageKey,
+        epoch: Epoch,
+    ) {
+        self.lcp_record
+            .record_image(tag, visual_rect, image_key, epoch);
+    }
+
+    pub fn record_text(
+        &mut self,
+        tag: usize,
+        text_block_parent: usize,
+        visual_rect: &LayoutRect,
+        epoch: Epoch,
+    ) {
+        self.lcp_record
+            .record_text(tag, text_block_parent, visual_rect, epoch);
+    }
+
+    /// Calculate the size of visual area in viewport. Because the parent elements will affect children,
+    /// We need track these css up to the root node.
+    pub fn compute_visual_rect(
+        &self,
+        rect: LayoutRect,
+        scroll_tree: &ScrollTree,
+        viewport_size: LayoutSize,
+    ) -> LayoutRect {
+        let visual_rect = self.compute_visual_rect_with_effect_scroll_clip(
+            rect,
+            self.current_effect_id,
+            Some(self.current_scroll_node_id),
+            self.current_clip_id,
+            scroll_tree,
+        );
+        let viewport = LayoutRect::from_size(viewport_size);
+
+        visual_rect
+            .intersection(&viewport)
+            .unwrap_or(LayoutRect::zero())
+    }
+    fn compute_visual_rect_with_effect_scroll_clip(
+        &self,
+        rect: LayoutRect,
+        effect_id: EffectNodeId,
+        scroll_id: Option<ScrollTreeNodeId>,
+        clip_id: ClipId,
+        scroll_tree: &ScrollTree,
+    ) -> LayoutRect {
+        if scroll_id.is_none() {
+            return rect;
+        }
+
+        let scroll_id = scroll_id.unwrap();
+        let mut next_effect_id = EffectNodeId::INVALID;
+        let mut next_scroll_id = None;
+        let mut next_clip_id = ClipId::INVALID;
+
+        // The size of visual area is affected by transform, filter and clip.
+        let visual_rect =
+            self.apply_effect_to_visual_rect(rect, effect_id, scroll_id, &mut next_effect_id);
+        let (visual_rect, origin) = self.apply_transform_to_visual_rect(
+            visual_rect,
+            scroll_id,
+            &mut next_scroll_id,
+            scroll_tree,
+        );
+        let visual_rect = self.apply_clip_to_visual_rect(
+            visual_rect,
+            origin,
+            clip_id,
+            scroll_id,
+            &mut next_clip_id,
+        );
+
+        if visual_rect.is_empty() {
+            visual_rect
+        } else {
+            self.compute_visual_rect_with_effect_scroll_clip(
+                rect,
+                next_effect_id,
+                next_scroll_id,
+                next_clip_id,
+                scroll_tree,
+            )
+        }
+    }
+
+    fn apply_clip_to_visual_rect(
+        &self,
+        rect: LayoutRect,
+        origin: LayoutPoint,
+        clip_id: ClipId,
+        scroll_id: ScrollTreeNodeId,
+        next_clip_id: &mut ClipId,
+    ) -> LayoutRect {
+        if clip_id == ClipId::INVALID {
+            *next_clip_id = clip_id;
+            return rect;
+        }
+
+        let clip_node = &self.clip_tree.0[clip_id.0];
+        if clip_node.parent_scroll_node_id == scroll_id {
+            *next_clip_id = clip_node.parent_clip_id;
+            let clip_rect = clip_node.rect.translate(origin.to_vector());
+            clip_rect.intersection(&rect).unwrap_or(LayoutRect::zero())
+        } else {
+            *next_clip_id = clip_id;
+            rect
+        }
+    }
+
+    fn apply_transform_to_visual_rect(
+        &self,
+        rect: LayoutRect,
+        scroll_id: ScrollTreeNodeId,
+        next_scroll_id: &mut Option<ScrollTreeNodeId>,
+        scroll_tree: &ScrollTree,
+    ) -> (LayoutRect, LayoutPoint) {
+        let scroll_node = scroll_tree.get_node(&scroll_id);
+        let mut origin = LayoutPoint::zero();
+        let visual_rect = match &scroll_node.info {
+            SpatialTreeNodeInfo::ReferenceFrame(frame_node_info) => {
+                origin = frame_node_info.origin;
+                let transform = &frame_node_info.transform;
+                let outer_rect = transform.outer_transformed_box2d(&rect);
+                if let Some(rect) = outer_rect {
+                    rect.translate(origin.to_vector())
+                } else {
+                    LayoutRect::zero()
+                }
+            },
+            _ => rect,
+        };
+        *next_scroll_id = scroll_node.parent;
+
+        (visual_rect, origin)
+    }
+
+    fn apply_effect_to_visual_rect(
+        &self,
+        rect: LayoutRect,
+        effect_id: EffectNodeId,
+        scroll_id: ScrollTreeNodeId,
+        next_effect_id: &mut EffectNodeId,
+    ) -> LayoutRect {
+        if effect_id == EffectNodeId::INVALID {
+            return rect;
+        }
+
+        let effect_node = self.effect_tree.get(effect_id).unwrap();
+        // The place where the effect is actually applied.
+        if effect_node.scroll_tree_node_id != scroll_id {
+            return rect;
+        }
+
+        let effects = effect_node.style.get_effects();
+        // If the opacity of the element is zero, it will be seen in viewport.
+        if effects.opacity == 0.0 {
+            return LayoutRect::zero();
+        }
+
+        let mut current_rect = rect;
+        for filter in effects.filter.0.iter() {
+            current_rect = match filter {
+                Filter::Blur(radius) => {
+                    let (spread_x, spread_y) = compute_spread(radius.px());
+                    let offsets = LayoutSideOffsets::new(spread_y, spread_x, spread_y, spread_x);
+                    current_rect.outer_box(offsets)
+                },
+                Filter::DropShadow(shadow) => {
+                    let (spread_x, spread_y) = compute_spread(shadow.blur.px());
+                    let offsets = LayoutSideOffsets::new(spread_y, spread_x, spread_y, spread_x);
+                    let result = rect.inner_box(offsets).translate(LayoutVector2D::new(
+                        shadow.horizontal.px(),
+                        shadow.vertical.px(),
+                    ));
+                    result.union(&current_rect)
+                },
+                Filter::Opacity(opacity) if opacity.0 == 0.0 => {
+                    return LayoutRect::zero();
+                },
+                _ => current_rect,
+            };
+        }
+        *next_effect_id = effect_node.parent_id;
+
+        current_rect
+    }
+}
+
+fn map_std_deviation(std_deviation: f32) -> LayoutVector2D {
+    let sigma = LayoutVector2D::new(std_deviation, std_deviation);
+    sigma * 3.0
+}
+
+fn compute_spread(std_deviation: f32) -> (f32, f32) {
+    let spread = map_std_deviation(std_deviation);
+    (spread.x.abs(), spread.y.abs())
+}

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -17,6 +17,7 @@ use base::id::{PipelineId, WebViewId};
 use bitflags::bitflags;
 use compositing_traits::CrossProcessCompositorApi;
 use compositing_traits::display_list::ScrollType;
+use compositing_traits::largest_contentful_paint_record::LCPCandidateRecord;
 use embedder_traits::{Theme, UntrustedNodeAddress, ViewportDetails};
 use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect};
 use euclid::{Point2D, Scale, Size2D};
@@ -1040,6 +1041,7 @@ impl LayoutThread {
         self.epoch.set(epoch);
         stacking_context_tree.compositor_info.epoch = epoch.into();
 
+        let mut lcp_record = LCPCandidateRecord::new();
         let built_display_list = DisplayListBuilder::build(
             reflow_request,
             stacking_context_tree,
@@ -1047,11 +1049,16 @@ impl LayoutThread {
             image_resolver.clone(),
             self.device().device_pixel_ratio(),
             &self.debug,
+            &mut lcp_record,
         );
         self.compositor_api.send_display_list(
             self.webview_id,
             &stacking_context_tree.compositor_info,
             built_display_list,
+        );
+        self.compositor_api.send_lcp_candidate(
+            lcp_record,
+            stacking_context_tree.compositor_info.pipeline_id,
         );
 
         let (keys, instance_keys) = self

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -281,6 +281,7 @@ pub struct RasterImage {
     pub cors_status: CorsStatus,
     pub bytes: IpcSharedMemory,
     pub frames: Vec<ImageFrame>,
+    pub raw_size: usize,
 }
 
 #[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
@@ -374,6 +375,7 @@ pub fn load_from_memory(buffer: &[u8], cors_status: CorsStatus) -> Option<Raster
                         bytes: IpcSharedMemory::from_bytes(&rgba),
                         id: None,
                         cors_status,
+                        raw_size: buffer.len(),
                     })
                 },
                 Err(e) => {
@@ -591,6 +593,7 @@ fn decode_gif(buffer: &[u8], cors_status: CorsStatus) -> Option<RasterImage> {
         id: None,
         format: PixelFormat::BGRA8,
         bytes: IpcSharedMemory::from_bytes(&bytes),
+        raw_size: buffer.len(),
     })
 }
 

--- a/components/shared/compositing/largest_contentful_paint_record.rs
+++ b/components/shared/compositing/largest_contentful_paint_record.rs
@@ -1,0 +1,234 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+use base::cross_process_instant::CrossProcessInstant;
+use serde::{Deserialize, Serialize};
+use webrender_api::units::LayoutRect;
+use webrender_api::{Epoch, ImageKey};
+
+pub const IMAGE_ENTROPY_THEAHOLD: f64 = 0.05;
+
+/// For images, if they have large visual area and very small number of bytes,
+/// they are typically low-content background and the like, and are not considered
+/// as largest-contentful-paint candidate. So we need record the file size of the
+/// image.
+static IMAGE_RAW_SIZE: LazyLock<Mutex<HashMap<ImageKey, usize>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub fn record_image_raw_size(key: ImageKey, raw_size: usize) {
+    IMAGE_RAW_SIZE
+        .lock()
+        .unwrap()
+        .entry(key)
+        .or_insert(raw_size);
+}
+
+pub fn get_image_raw_size(key: &ImageKey) -> usize {
+    IMAGE_RAW_SIZE
+        .lock()
+        .unwrap()
+        .get(key)
+        .copied()
+        .unwrap_or(0)
+}
+
+pub fn reset_all_image_raw_size() {
+    IMAGE_RAW_SIZE.lock().unwrap().clear();
+}
+
+#[derive(Default, Deserialize, Serialize)]
+pub struct LCPCandidateRecord {
+    pub image_records: Vec<ImageRecord>,
+    pub text_records: HashMap<LCPRecordTag, TextRecord>,
+}
+
+impl LCPCandidateRecord {
+    pub fn new() -> Self {
+        Self {
+            image_records: Vec::new(),
+            text_records: HashMap::new(),
+        }
+    }
+
+    pub fn record_image(
+        &mut self,
+        tag: usize,
+        rect: &LayoutRect,
+        image_key: &ImageKey,
+        epoch: Epoch,
+    ) {
+        let size = rect.area() as usize;
+        if size == 0 {
+            return;
+        }
+
+        let raw_size = get_image_raw_size(image_key);
+        self.image_records.push(ImageRecord {
+            tag: LCPRecordTag(tag),
+            size,
+            raw_size,
+            epoch,
+            paint_time: None,
+        });
+    }
+
+    pub fn record_text(
+        &mut self,
+        tag: usize,
+        block_parent: usize,
+        rect: &LayoutRect,
+        epoch: Epoch,
+    ) {
+        if rect.area() == 0.0 {
+            return;
+        }
+
+        let text_block_parent = LCPRecordTag(block_parent);
+        // Because a block node may contains many text node, we need union their visual area.
+        self.text_records
+            .entry(text_block_parent)
+            .and_modify(|record| {
+                if epoch == record.epoch {
+                    let union_rect = record.rect.union(rect);
+                    record.rect = union_rect;
+                }
+            })
+            .or_insert(TextRecord {
+                tag: LCPRecordTag(tag),
+                text_block_parent,
+                rect: *rect,
+                epoch,
+                paint_time: None,
+            });
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct LCPRecordTag(usize);
+
+impl LCPRecordTag {
+    pub const INVALID: LCPRecordTag = LCPRecordTag(0);
+}
+
+/// The LCP candidate Image.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ImageRecord {
+    /// The identity of the element.
+    tag: LCPRecordTag,
+    /// The size of the visual area
+    size: usize,
+    /// The file size of the image in bytes.
+    raw_size: usize,
+    epoch: Epoch,
+    pub paint_time: Option<CrossProcessInstant>,
+}
+
+impl ImageRecord {
+    pub fn tag(&self) -> LCPRecordTag {
+        self.tag
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    /// Used to judge if the image is low-content.
+    pub fn image_entropy(&self) -> f64 {
+        (self.raw_size as f64 * 8.0) / (self.size() as f64)
+    }
+
+    pub fn paint_time(&self) -> CrossProcessInstant {
+        self.paint_time.unwrap_or(CrossProcessInstant::now())
+    }
+
+    pub fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+}
+
+impl Default for ImageRecord {
+    fn default() -> Self {
+        Self {
+            tag: LCPRecordTag::INVALID,
+            size: 0,
+            raw_size: 0,
+            epoch: Epoch::invalid(),
+            paint_time: None,
+        }
+    }
+}
+
+/// The LCP candidate text. For text LCP, we record the block-level elements containing
+/// text nodes or other inline-level text element children.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TextRecord {
+    /// The tag of text element
+    tag: LCPRecordTag,
+    /// The block parent contains current text.
+    text_block_parent: LCPRecordTag,
+    /// The LayoutRect of the text node. It will be union.
+    rect: LayoutRect,
+    epoch: Epoch,
+    pub paint_time: Option<CrossProcessInstant>,
+}
+
+impl TextRecord {
+    pub fn parent_tag(&self) -> LCPRecordTag {
+        self.text_block_parent
+    }
+
+    pub fn size(&self) -> usize {
+        self.rect.area() as usize
+    }
+
+    pub fn paint_time(&self) -> CrossProcessInstant {
+        self.paint_time.unwrap_or(CrossProcessInstant::now())
+    }
+
+    pub fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+}
+
+impl Default for TextRecord {
+    fn default() -> Self {
+        Self {
+            tag: LCPRecordTag::INVALID,
+            text_block_parent: LCPRecordTag::INVALID,
+            rect: LayoutRect::zero(),
+            epoch: Epoch::invalid(),
+            paint_time: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LargestContentfulPaint {
+    pub tag: LCPRecordTag,
+    pub size: usize,
+    pub paint_time: CrossProcessInstant,
+}
+
+impl From<&ImageRecord> for LargestContentfulPaint {
+    fn from(record: &ImageRecord) -> Self {
+        Self {
+            tag: record.tag(),
+            size: record.size(),
+            paint_time: record.paint_time(),
+        }
+    }
+}
+
+impl From<&TextRecord> for LargestContentfulPaint {
+    fn from(record: &TextRecord) -> Self {
+        Self {
+            tag: record.parent_tag(),
+            size: record.size(),
+            paint_time: record.paint_time(),
+        }
+    }
+}

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -614,6 +614,7 @@ mod test {
             bytes: IpcSharedMemory::from_byte(1, 1),
             frames: image_frames,
             cors_status: CorsStatus::Unsafe,
+            raw_size: 1,
         };
         let mut image_animation_state = ImageAnimationState::new(Arc::new(image), 0.0);
 

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -40,6 +40,7 @@ pub struct VectorImage {
     pub id: VectorImageId,
     pub metadata: ImageMetadata,
     pub cors_status: CorsStatus,
+    pub raw_size: usize,
 }
 
 impl Image {
@@ -61,6 +62,13 @@ impl Image {
         match self {
             Image::Raster(image) => Some(image.clone()),
             Image::Vector(..) => None,
+        }
+    }
+
+    pub fn raw_size(&self) -> usize {
+        match self {
+            Image::Raster(image) => image.raw_size,
+            Image::Vector(image) => image.raw_size,
         }
     }
 }


### PR DESCRIPTION
Implement a simplified LCP (Largest Contentful Paint). LCP is a web performance metric introduced by Google, used to measure the render time of the largest content element within the viewport. Currently, it only tracks images and text content within block-level elements. The key enhancements include:

1. Image Resource Size Tracking: Record the file size of image resources to identify low-quality images.

2. Visual Area Calculation: Compute the visible area of elements, accounting for CSS styles such as transform and filter applied by parent DOM nodes. A new EffectNode is introduced, working in conjunction with existing ClipNode and ScrollNode, to track how these styles affect the element's visual dimensions.

3. Text Content Measurement: To determine the size of text nodes within block-level elements, a text_block_parent flag is added during the building the display list to identify these block elements. It's used to indicate which block-level element the text belong to.