### PR TITLE
WebDriver Chore: use enum instead of compile time constant for `browsing_context_script_command`

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -20,7 +20,7 @@ use webdriver::actions::{
 use webdriver::command::ActionsParameters;
 use webdriver::error::{ErrorStatus, WebDriverError};
 
-use crate::{Handler, WebElement, wait_for_script_response};
+use crate::{Handler, VerifyBrowsingContextIsOpen, WebElement, wait_for_script_response};
 
 // Interval between wheelScroll and pointerMove increments in ms, based on common vsync
 static POINTERMOVE_INTERVAL: u64 = 17;
@@ -744,8 +744,9 @@ impl Handler {
         web_element: &WebElement,
     ) -> Result<(i64, i64), ErrorStatus> {
         let (sender, receiver) = ipc::channel().unwrap();
-        self.browsing_context_script_command::<false>(
+        self.browsing_context_script_command(
             WebDriverScriptCommand::GetElementInViewCenterPoint(web_element.to_string(), sender),
+            VerifyBrowsingContextIsOpen::No,
         )
         .unwrap();
         let response = match wait_for_script_response(receiver) {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -715,13 +715,14 @@ impl Handler {
     }
 
     /// Send command to Script Thread with session's current browsing context.
-    /// If CHECK_OPEN is true, it would verify the existence of browsing context before sending.
-    fn browsing_context_script_command<const CHECK_OPEN: bool>(
+    /// If verify is Yes, it would verify the existence of browsing context before sending.
+    fn browsing_context_script_command(
         &self,
         cmd_msg: WebDriverScriptCommand,
+        verify: VerifyBrowsingContextIsOpen,
     ) -> WebDriverResult<()> {
         let browsing_context_id = self.session()?.browsing_context_id;
-        if CHECK_OPEN {
+        if let VerifyBrowsingContextIsOpen::Yes = verify {
             self.verify_browsing_context_is_open(browsing_context_id)?;
         }
         let msg = EmbedderToConstellationMessage::WebDriverCommand(
@@ -732,14 +733,15 @@ impl Handler {
     }
 
     /// Send command to Script Thread with session's current top-level browsing context.
-    /// If CHECK_OPEN is true, it would verify the existence of top-level
+    /// If verify is Yes, it would verify the existence of top-level
     /// browsing context before sending.
-    fn top_level_script_command<const CHECK_OPEN: bool>(
+    fn top_level_script_command(
         &self,
         cmd_msg: WebDriverScriptCommand,
+        verify: VerifyBrowsingContextIsOpen,
     ) -> WebDriverResult<()> {
         let webview_id = self.session()?.webview_id;
-        if CHECK_OPEN {
+        if let VerifyBrowsingContextIsOpen::Yes = verify {
             self.verify_top_level_browsing_context_is_open(webview_id)?;
         }
         let browsing_context_id = BrowsingContextId::from(webview_id);
@@ -790,7 +792,10 @@ impl Handler {
 
     fn handle_current_url(&self) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
-        self.top_level_script_command::<true>(WebDriverScriptCommand::GetUrl(sender))?;
+        self.top_level_script_command(
+            WebDriverScriptCommand::GetUrl(sender),
+            VerifyBrowsingContextIsOpen::Yes,
+        )?;
 
         let url = wait_for_script_response(receiver)?;
 
@@ -887,10 +892,10 @@ impl Handler {
     fn handle_is_enabled(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
 
-        self.browsing_context_script_command::<true>(WebDriverScriptCommand::IsEnabled(
-            element.to_string(),
-            sender,
-        ))?;
+        self.browsing_context_script_command(
+            WebDriverScriptCommand::IsEnabled(element.to_string(), sender),
+            VerifyBrowsingContextIsOpen::Yes,
+        )?;
 
         match wait_for_script_response(receiver)? {
             Ok(is_enabled) => Ok(WebDriverResponse::Generic(ValueResponse(
@@ -903,10 +908,10 @@ impl Handler {
     fn handle_is_selected(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
 
-        self.browsing_context_script_command::<true>(WebDriverScriptCommand::IsSelected(
-            element.to_string(),
-            sender,
-        ))?;
+        self.browsing_context_script_command(
+            WebDriverScriptCommand::IsSelected(element.to_string(), sender),
+            VerifyBrowsingContextIsOpen::Yes,
+        )?;
 
         match wait_for_script_response(receiver)? {
             Ok(is_selected) => Ok(WebDriverResponse::Generic(ValueResponse(
@@ -951,7 +956,10 @@ impl Handler {
     fn handle_title(&self) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
 
-        self.top_level_script_command::<true>(WebDriverScriptCommand::GetTitle(sender))?;
+        self.top_level_script_command(
+            WebDriverScriptCommand::GetTitle(sender),
+            VerifyBrowsingContextIsOpen::Yes,
+        )?;
 
         let value = wait_for_script_response(receiver)?;
         Ok(WebDriverResponse::Generic(ValueResponse(
@@ -1106,7 +1114,7 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetParentFrameId(sender);
         // TODO: Track Parent Browsing Context directly in the session, as expected by Spec.
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         match wait_for_script_response(receiver)? {
             Ok(browsing_context_id) => {
                 self.session_mut()?.browsing_context_id = browsing_context_id;
@@ -1151,7 +1159,7 @@ impl Handler {
     ) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetBrowsingContextId(frame_id, sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
 
         match wait_for_script_response(receiver)? {
             Ok(browsing_context_id) => {
@@ -1178,7 +1186,7 @@ impl Handler {
                     parameters.value.clone(),
                     sender,
                 );
-                self.browsing_context_script_command::<true>(cmd)?;
+                self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
             },
             LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
                 let cmd = WebDriverScriptCommand::FindElementsLinkText(
@@ -1186,19 +1194,19 @@ impl Handler {
                     parameters.using == LocatorStrategy::PartialLinkText,
                     sender,
                 );
-                self.browsing_context_script_command::<true>(cmd)?;
+                self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
             },
             LocatorStrategy::TagName => {
                 let cmd =
                     WebDriverScriptCommand::FindElementsTagName(parameters.value.clone(), sender);
-                self.browsing_context_script_command::<true>(cmd)?;
+                self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
             },
             LocatorStrategy::XPath => {
                 let cmd = WebDriverScriptCommand::FindElementsXpathSelector(
                     parameters.value.clone(),
                     sender,
                 );
-                self.browsing_context_script_command::<true>(cmd)?;
+                self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
             },
         }
 
@@ -1245,7 +1253,7 @@ impl Handler {
                     element.to_string(),
                     sender,
                 );
-                self.browsing_context_script_command::<true>(cmd)?;
+                self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
             },
             LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
                 let cmd = WebDriverScriptCommand::FindElementElementsLinkText(
@@ -1254,7 +1262,7 @@ impl Handler {
                     parameters.using == LocatorStrategy::PartialLinkText,
                     sender,
                 );
-                self.browsing_context_script_command::<true>(cmd)?;
+                self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
             },
             LocatorStrategy::TagName => {
                 let cmd = WebDriverScriptCommand::FindElementElementsTagName(
@@ -1262,7 +1270,7 @@ impl Handler {
                     element.to_string(),
                     sender,
                 );
-                self.browsing_context_script_command::<true>(cmd)?;
+                self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
             },
             LocatorStrategy::XPath => {
                 let cmd = WebDriverScriptCommand::FindElementElementsXPathSelector(
@@ -1270,7 +1278,7 @@ impl Handler {
                     element.to_string(),
                     sender,
                 );
-                self.browsing_context_script_command::<true>(cmd)?;
+                self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
             },
         }
 
@@ -1307,7 +1315,7 @@ impl Handler {
                     shadow_root.to_string(),
                     sender,
                 );
-                self.browsing_context_script_command::<true>(cmd)?;
+                self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
             },
             LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
                 let cmd = WebDriverScriptCommand::FindShadowElementsLinkText(
@@ -1316,7 +1324,7 @@ impl Handler {
                     parameters.using == LocatorStrategy::PartialLinkText,
                     sender,
                 );
-                self.browsing_context_script_command::<true>(cmd)?;
+                self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
             },
             LocatorStrategy::TagName => {
                 let cmd = WebDriverScriptCommand::FindShadowElementsTagName(
@@ -1324,7 +1332,7 @@ impl Handler {
                     shadow_root.to_string(),
                     sender,
                 );
-                self.browsing_context_script_command::<true>(cmd)?;
+                self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
             },
             LocatorStrategy::XPath => {
                 let cmd = WebDriverScriptCommand::FindShadowElementsXPathSelector(
@@ -1332,7 +1340,7 @@ impl Handler {
                     shadow_root.to_string(),
                     sender,
                 );
-                self.browsing_context_script_command::<true>(cmd)?;
+                self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
             },
         }
 
@@ -1366,7 +1374,7 @@ impl Handler {
     fn handle_get_shadow_root(&self, element: WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetElementShadowRoot(element.to_string(), sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => {
                 let Some(value) = value else {
@@ -1384,7 +1392,7 @@ impl Handler {
     fn handle_element_rect(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetElementRect(element.to_string(), sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         match wait_for_script_response(receiver)? {
             Ok(rect) => {
                 let response = ElementRectResponse {
@@ -1403,7 +1411,7 @@ impl Handler {
     fn handle_element_text(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetElementText(element.to_string(), sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse(
                 serde_json::to_value(value)?,
@@ -1416,7 +1424,7 @@ impl Handler {
     fn handle_active_element(&self) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetActiveElement(sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         let value = wait_for_script_response(receiver)?
             .map(|x| serde_json::to_value(WebElement(x)).unwrap());
         // Step 4. If active element is a non-null element, return success
@@ -1437,7 +1445,7 @@ impl Handler {
     fn handle_computed_role(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetComputedRole(element.to_string(), sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse(
                 serde_json::to_value(value)?,
@@ -1449,7 +1457,7 @@ impl Handler {
     fn handle_element_tag_name(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetElementTagName(element.to_string(), sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse(
                 serde_json::to_value(value)?,
@@ -1469,7 +1477,7 @@ impl Handler {
             name.to_owned(),
             sender,
         );
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse(
                 serde_json::to_value(value)?,
@@ -1490,7 +1498,7 @@ impl Handler {
             name.to_owned(),
             sender,
         );
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
 
         match wait_for_script_response(receiver)? {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse(
@@ -1508,7 +1516,7 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd =
             WebDriverScriptCommand::GetElementCSS(element.to_string(), name.to_owned(), sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         match wait_for_script_response(receiver)? {
             Ok(value) => Ok(WebDriverResponse::Generic(ValueResponse(
                 serde_json::to_value(value)?,
@@ -1520,7 +1528,7 @@ impl Handler {
     fn handle_get_cookies(&self) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetCookies(sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         let cookies = match wait_for_script_response(receiver)? {
             Ok(cookies) => cookies,
             Err(error) => return Err(WebDriverError::new(error, "")),
@@ -1535,7 +1543,7 @@ impl Handler {
     fn handle_get_cookie(&self, name: String) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::GetCookie(name, sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         let cookies = match wait_for_script_response(receiver)? {
             Ok(cookies) => cookies,
             Err(error) => return Err(WebDriverError::new(error, "")),
@@ -1569,7 +1577,7 @@ impl Handler {
         };
 
         let cmd = WebDriverScriptCommand::AddCookie(cookie_builder.build(), sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         match wait_for_script_response(receiver)? {
             Ok(_) => Ok(WebDriverResponse::Void),
             Err(error) => Err(WebDriverError::new(error, "")),
@@ -1579,7 +1587,7 @@ impl Handler {
     fn handle_delete_cookie(&self, name: String) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::DeleteCookie(name, sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         match wait_for_script_response(receiver)? {
             Ok(_) => Ok(WebDriverResponse::Void),
             Err(error) => Err(WebDriverError::new(error, "")),
@@ -1589,7 +1597,7 @@ impl Handler {
     fn handle_delete_cookies(&self) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::DeleteCookies(sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         match wait_for_script_response(receiver)? {
             Ok(_) => Ok(WebDriverResponse::Void),
             Err(error) => Err(WebDriverError::new(error, "")),
@@ -1646,7 +1654,7 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
 
         let cmd = WebDriverScriptCommand::GetPageSource(sender);
-        self.browsing_context_script_command::<true>(cmd)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
 
         match wait_for_script_response(receiver)? {
             Ok(source) => Ok(WebDriverResponse::Generic(ValueResponse(
@@ -1735,8 +1743,8 @@ impl Handler {
         debug!("{}", script);
 
         let (sender, receiver) = ipc::channel().unwrap();
-        let command = WebDriverScriptCommand::ExecuteScript(script, sender);
-        self.browsing_context_script_command::<true>(command)?;
+        let cmd = WebDriverScriptCommand::ExecuteScript(script, sender);
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         let result = wait_for_script_response(receiver)?;
         self.postprocess_js_result(result)
     }
@@ -1779,8 +1787,8 @@ impl Handler {
         debug!("{}", script);
 
         let (sender, receiver) = ipc::channel().unwrap();
-        let command = WebDriverScriptCommand::ExecuteAsyncScript(script, sender);
-        self.browsing_context_script_command::<true>(command)?;
+        let cmd = WebDriverScriptCommand::ExecuteAsyncScript(script, sender);
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
         let result = wait_for_script_response(receiver)?;
         self.postprocess_js_result(result)
     }
@@ -1862,8 +1870,8 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
 
         // Steps 1 - 7
-        let command = WebDriverScriptCommand::ElementClick(element.to_string(), sender);
-        self.browsing_context_script_command::<true>(command)?;
+        let cmd = WebDriverScriptCommand::ElementClick(element.to_string(), sender);
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
 
         match wait_for_script_response(receiver)? {
             Ok(element_id) => match element_id {
@@ -2015,8 +2023,8 @@ impl Handler {
     ) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
 
-        let command = WebDriverScriptCommand::GetBoundingClientRect(element.to_string(), sender);
-        self.browsing_context_script_command::<true>(command)?;
+        let cmd = WebDriverScriptCommand::GetBoundingClientRect(element.to_string(), sender);
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
 
         match wait_for_script_response(receiver)? {
             Ok(rect) => {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -715,7 +715,8 @@ impl Handler {
     }
 
     /// Send command to Script Thread with session's current browsing context.
-    /// If verify is Yes, it would verify the existence of browsing context before sending.
+    /// If `verify` is [`VerifyBrowsingContextIsOpen::Yes`],
+    /// it would verify the existence of browsing context before sending.
     fn browsing_context_script_command(
         &self,
         cmd_msg: WebDriverScriptCommand,
@@ -733,8 +734,8 @@ impl Handler {
     }
 
     /// Send command to Script Thread with session's current top-level browsing context.
-    /// If verify is Yes, it would verify the existence of top-level
-    /// browsing context before sending.
+    /// If `verify` is [`VerifyBrowsingContextIsOpen::Yes`],
+    /// it would verify the existence of top-level browsing context before sending.
     fn top_level_script_command(
         &self,
         cmd_msg: WebDriverScriptCommand,


### PR DESCRIPTION
This reduces unnecessary generated code and binary size. See https://github.com/servo/servo/pull/37712#discussion_r2171957828

Testing: No Behaviour change
