### PR TITLE
script: Allow to throw a custom exception on structured cloning

### DIFF
--- a/components/script/dom/bindings/transferable.rs
+++ b/components/script/dom/bindings/transferable.rs
@@ -10,10 +10,12 @@ use std::hash::Hash;
 
 use base::id::NamespaceIndex;
 
+use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::structuredclone::StructuredData;
 use crate::dom::globalscope::GlobalScope;
+
 pub(crate) trait Transferable: DomObject
 where
     Self: Sized,
@@ -25,7 +27,10 @@ where
         true
     }
 
-    fn transfer(&self) -> Result<(NamespaceIndex<Self::Index>, Self::Data), ()>;
+    /// <https://html.spec.whatwg.org/multipage/#transfer-steps>
+    fn transfer(&self) -> Fallible<(NamespaceIndex<Self::Index>, Self::Data)>;
+
+    /// <https://html.spec.whatwg.org/multipage/#transfer-receiving-steps>
     fn transfer_receive(
         owner: &GlobalScope,
         id: NamespaceIndex<Self::Index>,

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -19,7 +19,7 @@ use crate::dom::bindings::codegen::Bindings::MessagePortBinding::{
     MessagePortMethods, StructuredSerializeOptions,
 };
 use crate::dom::bindings::conversions::root_from_object;
-use crate::dom::bindings::error::{Error, ErrorResult, ErrorToJsval};
+use crate::dom::bindings::error::{Error, ErrorResult, ErrorToJsval, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
@@ -256,9 +256,13 @@ impl Transferable for MessagePort {
     type Data = MessagePortImpl;
 
     /// <https://html.spec.whatwg.org/multipage/#message-ports:transfer-steps>
-    fn transfer(&self) -> Result<(MessagePortId, MessagePortImpl), ()> {
+    fn transfer(&self) -> Fallible<(MessagePortId, MessagePortImpl)> {
+        // <https://html.spec.whatwg.org/multipage/#structuredserializewithtransfer>
+        // Step 5.2. If transferable has a [[Detached]] internal slot and
+        // transferable.[[Detached]] is true, then throw a "DataCloneError"
+        // DOMException.
         if self.detached.get() {
-            return Err(());
+            return Err(Error::DataClone(None));
         }
 
         self.detached.set(true);

--- a/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.html.ini
@@ -1,3 +1,0 @@
-[offscreencanvas.transferrable.html]
-  [Test that transfer an OffscreenCanvas that already have a 2d context throws exception.]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.w.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable.w.html.ini
@@ -3,8 +3,5 @@
   [Test that transfer an OffscreenCanvas that has a webgl context throws exception in a worker.]
     expected: FAIL
 
-  [Test that transfer an OffscreenCanvas that has a 2d context throws exception in a worker.]
-    expected: FAIL
-
   [Test that transfer an OffscreenCanvas twice throws exception in a worker.]
     expected: FAIL


### PR DESCRIPTION
The structured cloning with transfer list
https://html.spec.whatwg.org/multipage/#structuredserializewithtransfer
throws a "DataCloneError" DOM expection by default if serialization/transferral
is not possible, but a platform object can throw a custom excepton on its serialization/transfer steps.

One example is OffscreenCanvas, which can throw
an "InvalidStateError" exception if the context mode is not none on transfer steps.
https://html.spec.whatwg.org/multipage/#the-offscreencanvas-interface:transfer-steps

Testing: Improvements in the following tests
- html/canvas/offscreen/manual/the-offscreen-canvas/offscreencanvas.transferrable*

Fixes: #37919
