### PR TITLE
WPT upstreamer: Make all failed merge operations leave a comment.

### DIFF
--- a/python/wpt/exporter/step.py
+++ b/python/wpt/exporter/step.py
@@ -228,9 +228,9 @@ class MergePRStep(Step):
         self.labels_to_remove = labels_to_remove
 
     def run(self, run: SyncRun):
-        for label in self.labels_to_remove:
-            self.pull_request.remove_label(label)
         try:
+            for label in self.labels_to_remove:
+                self.pull_request.remove_label(label)
             self.pull_request.merge()
         except Exception as exception:
             logging.warning("Could not merge PR (%s).", self.pull_request)


### PR DESCRIPTION
The WPT exporter currently assumes that removing a label from a github PR will never fail. This is obviously false and the result is a silent failure. By moving the operation inside the existing try block we ensure that a comment will be posted if any part of the merge step fails.

Testing: Untested; did not feel worth the time investment to determine if the existing test harness can mock this particular situation.
Fixes: #37914
