### PR TITLE
layout: remove the finished animations to avoid to mark their dom nodes dirty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7249,7 +7249,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.30.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#673d9632edcec46250cfea9094eaa841f5dc8526"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -7555,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#673d9632edcec46250cfea9094eaa841f5dc8526"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8017,7 +8017,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#673d9632edcec46250cfea9094eaa841f5dc8526"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8074,7 +8074,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#673d9632edcec46250cfea9094eaa841f5dc8526"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8083,12 +8083,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#673d9632edcec46250cfea9094eaa841f5dc8526"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 
 [[package]]
 name = "stylo_derive"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#673d9632edcec46250cfea9094eaa841f5dc8526"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8100,7 +8100,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#673d9632edcec46250cfea9094eaa841f5dc8526"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -8109,7 +8109,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#673d9632edcec46250cfea9094eaa841f5dc8526"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8126,12 +8126,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#673d9632edcec46250cfea9094eaa841f5dc8526"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 
 [[package]]
 name = "stylo_traits"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#673d9632edcec46250cfea9094eaa841f5dc8526"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -8548,7 +8548,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#673d9632edcec46250cfea9094eaa841f5dc8526"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8561,7 +8561,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#673d9632edcec46250cfea9094eaa841f5dc8526"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
Remove the finished animations to avoid marking their dom nodes dirty. The mainly change happens at [stylo PR 216](https://github.com/servo/stylo/pull/216).

In Servo's current animation implementation, the finished animations are retained and continue to mark their corresponding DOM nodes as dirty. This can lead to a significant number of unnecessary and expensive reflow operations. For example, during page scrolling, the dirtied state from finished animations forces the whole reflow process on every update_the_rendering cycle, severely impacting scroll performance.

The [code comments in stylo repo](https://github.com/servo/stylo/blob/main/style/matching.rs#L752-L755) stated  that retaining finished animations was necessary to correctly compute the final frame state for [animation-fill-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-fill-mode). However, test results—including those from WPT test cases and manual verification—indicate that this functionality is already guaranteed without this overhead.