### PR TITLE
script_thread: handle_unfocus_msg ignores unfocus request of top-level document

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1216,10 +1216,10 @@ impl Document {
     /// document's container is removed from the top-level browsing context's
     /// focus chain (not considering system focus).
     pub(crate) fn handle_container_unfocus(&self, can_gc: CanGc) {
-        assert!(
-            self.window().parent_info().is_some(),
-            "top-level document cannot be unfocused",
-        );
+        if self.window().parent_info().is_none() {
+            warn!("Top-level document cannot be unfocused");
+            return;
+        }
 
         // Since this method is called from an event loop, there mustn't be
         // an in-progress focus transaction


### PR DESCRIPTION
`ScriptThread::handle_unfocus_msg` ignores unfocus request of top-level document
Fix errors in webdriver navigation commands, which may request unfocus on top-level documents. 

Testing: 
`tests/wpt/meta/webdriver/tests/classic/back/back.py`
`tests/wpt/meta/webdriver/tests/classic/forward/forward.py`