### PR TITLE
OHOS CI allow profile

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -36,7 +36,7 @@ env:
   SHELL: /bin/bash
   CARGO_INCREMENTAL: 0
   BENCHER_PROJECT: ${{ vars.BENCHER_PROJECT || 'servo' }}
-  HITRACE_BENCH_VERSION: 0.7.0
+  HITRACE_BENCH_VERSION: 0.8.2
 
 jobs:
   build:
@@ -285,7 +285,7 @@ jobs:
         run: cargo install --locked hitrace-bench --version $HITRACE_BENCH_VERSION
         if: ${{ env.INSTALLED_HITRACE_BENCH_VERSION != env.HITRACE_BENCH_VERSION }}
       - name: "Run benchmark"
-        run: hitrace-bench -r support/hitrace-bencher/runs.json
+        run: hitrace-bench -r support/hitrace-bencher/runs.json --bencher -p ${{ inputs.profile }}
         continue-on-error: true
       - name: Run speedometer
         id: BencherRun

--- a/support/hitrace-bencher/runs.json
+++ b/support/hitrace-bencher/runs.json
@@ -3,15 +3,12 @@
 // different filters and different arguments
 [
     {
-        "args": {
-            "bencher": true, // output in bencher format
+        "run_args": {
             "url": "https://www.google.com", // the url to test
             "tries": 5 // How many repeated tries we should have, we show the min,max,avg in the output
             //"trace_buffer": 524288,   // trace_buffer size of hitrace
             //"sleep": 10,  // how long should we wait for servo to load the page
-            //"bundle_name": "org.servo.servo", // the bundle name to start
             //"commands": ["--ps=--tracing-filter", "info"] // arbitrary additional arguments
-            //"is_rooted": true  // Allows files to be pushed to the device instead of relying them being already packaged
         },
         "filters": [
             // Filters are currently given via the simple serialize of `filters::JsonValueFilter`.
@@ -56,8 +53,7 @@
         ]
     },
     {
-        "args": {
-            "bencher": true,
+        "run_args": {
             "url": "https://www.servo.org",
             "tries": 5
         },
@@ -97,8 +93,7 @@
         ]
     },
     {
-        "args": {
-            "bencher": true,
+        "run_args": {
             "url": "file:///parse_from_string.html",
             "tries": 5
         },


### PR DESCRIPTION
OHOS CI: We now allow a profile flag. The profile name will be prepended to all measurements.
This allows us to distinguish different build profiles in bencher.
Additionally we are more robust on duplicated entries for some measurements.

Testing: Tested on CI with a run here: https://github.com/Narfinger/servo/actions/runs/16168150429/job/45635086884
Fixes: https://github.com/servo/servo/issues/37890
