### PR TITLE
servoshell: Enable headless event loop for Windows

### DIFF
--- a/ports/servoshell/desktop/events_loop.rs
+++ b/ports/servoshell/desktop/events_loop.rs
@@ -47,13 +47,13 @@ pub struct EventsLoop(EventLoop);
 impl EventsLoop {
     // Ideally, we could use the winit event loop in both modes,
     // but on Linux, the event loop requires a X11 server.
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
     pub fn new(_headless: bool, _has_output_file: bool) -> Result<EventsLoop, EventLoopError> {
         Ok(EventsLoop(EventLoop::Winit(
             WinitEventLoop::with_user_event().build()?,
         )))
     }
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     pub fn new(headless: bool, _has_output_file: bool) -> Result<EventsLoop, EventLoopError> {
         Ok(EventsLoop(if headless {
             EventLoop::Headless(Arc::new((Mutex::new(false), Condvar::new())))


### PR DESCRIPTION
Testing: For windows, it now passes `/_mozilla/mozilla/window_resizeTo.html` in headless mode but fails in headed window as expected in https://github.com/servo/servo/pull/37899#issuecomment-3052566865.

Fixes: #37973 
Fixes: #26431 
Fixes: #20365

Signed-off-by: Euclid Ye yezhizhenjiakang@gmail.com 
Co-authored-by: Josh Matthews josh@joshmatthews.net