### PR TITLE
Webdriver: limit tick action duration to ECMA maximum safe integer

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -26,6 +26,9 @@ use crate::{Handler, VerifyBrowsingContextIsOpen, WebElement, wait_for_script_re
 static POINTERMOVE_INTERVAL: u64 = 17;
 static WHEELSCROLL_INTERVAL: u64 = 17;
 
+// https://262.ecma-international.org/6.0/#sec-number.max_safe_integer
+static MAXIMUM_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
 // A single action, corresponding to an `action object` in the spec.
 // In the spec, `action item` refers to a plain JSON object.
 // However, we use the name ActionItem here
@@ -148,6 +151,13 @@ impl Handler {
             // Step 1.2. Let tick duration be the result of
             // computing the tick duration with argument tick actions.
             let tick_duration = compute_tick_duration(tick_actions);
+
+            // FIXME: This is out of spec, but the test `perform_actions/invalid.py` requires
+            // that duration more than `MAXIMUM_SAFE_INTEGER` is considered invalid.
+            if tick_duration > MAXIMUM_SAFE_INTEGER {
+                return Err(ErrorStatus::InvalidArgument);
+            }
+
             let now = Instant::now();
 
             // Step 1.3. Try to dispatch tick actions

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/invalid.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/invalid.py.ini
@@ -1,17 +1,4 @@
 [invalid.py]
-  expected: TIMEOUT
-  [test_input_source_action_sequence_actions_pause_duration_invalid_value[9007199254740992-none\]]
-    expected: FAIL
-
-  [test_input_source_action_sequence_actions_pause_duration_invalid_value[9007199254740992-key\]]
-    expected: FAIL
-
-  [test_input_source_action_sequence_actions_pause_duration_invalid_value[9007199254740992-pointer\]]
-    expected: FAIL
-
-  [test_input_source_action_sequence_actions_pause_duration_invalid_value[9007199254740992-wheel\]]
-    expected: FAIL
-
   [test_pointer_action_up_down_button_invalid_value[9007199254740992-pointerDown\]]
     expected: FAIL
 
@@ -36,12 +23,6 @@
   [test_pointer_action_common_properties_dimensions_invalid_value[9007199254740992-height-pointerUp\]]
     expected: FAIL
 
-  [test_wheel_action_scroll_coordinate_invalid_type[None-x\]]
-    expected: FAIL
-
-  [test_wheel_action_scroll_coordinate_invalid_type[None-y\]]
-    expected: FAIL
-
   [test_wheel_action_scroll_coordinate_invalid_value[-9007199254740992-x\]]
     expected: FAIL
 
@@ -52,40 +33,4 @@
     expected: FAIL
 
   [test_wheel_action_scroll_coordinate_invalid_value[9007199254740992-y\]]
-    expected: FAIL
-
-  [test_wheel_action_scroll_delta_invalid_type[None-x\]]
-    expected: FAIL
-
-  [test_wheel_action_scroll_delta_invalid_type[None-y\]]
-    expected: FAIL
-
-  [test_wheel_action_scroll_delta_invalid_value[-9007199254740992-x\]]
-    expected: FAIL
-
-  [test_wheel_action_scroll_delta_invalid_value[-9007199254740992-y\]]
-    expected: FAIL
-
-  [test_wheel_action_scroll_delta_invalid_value[9007199254740992-x\]]
-    expected: FAIL
-
-  [test_wheel_action_scroll_delta_invalid_value[9007199254740992-y\]]
-    expected: FAIL
-
-  [test_wheel_action_scroll_origin_pointer_not_supported]
-    expected: FAIL
-
-  [test_wheel_action_scroll_origin_element_invalid_value]
-    expected: FAIL
-
-  [test_wheel_action_scroll_missing_property[x\]]
-    expected: FAIL
-
-  [test_wheel_action_scroll_missing_property[y\]]
-    expected: FAIL
-
-  [test_wheel_action_scroll_missing_property[deltaX\]]
-    expected: FAIL
-
-  [test_wheel_action_scroll_missing_property[deltaY\]]
     expected: FAIL


### PR DESCRIPTION
Workaround to prevent `webdriver/tests/classic/perform_actions/invalid.py` from TIMEOUT. I don't see the spec telling us to limit this number, so I assume the correct fix is to handle it on parsing.

Testing: `webdriver/tests/classic/perform_actions/invalid.py`.