### PR TITLE
Chore: cleanup unused `EmbedderMsg::WebDriverCommand`

### DIFF
--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -246,7 +246,6 @@ mod from_script {
                 Self::FinishJavaScriptEvaluation(..) => {
                     target_variant!("FinishJavaScriptEvaluation")
                 },
-                Self::WebDriverCommand(..) => target_variant!("WebDriverCommand"),
             }
         }
     }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -998,7 +998,6 @@ impl Servo {
                     webview.delegate().show_form_control(webview, form_control);
                 }
             },
-            _ => {},
         }
     }
 

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -425,7 +425,6 @@ pub enum EmbedderMsg {
         JavaScriptEvaluationId,
         Result<JSValue, JavaScriptEvaluationError>,
     ),
-    WebDriverCommand(WebDriverCommandMsg),
 }
 
 impl Debug for EmbedderMsg {

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -40,7 +40,7 @@ pub enum WebDriverCommandMsg {
     /// Used in the initialization of the WebDriver server to set the sender for sending responses
     /// back to the WebDriver client. It is set to constellation for now
     SetWebDriverResponseSender(IpcSender<WebDriverCommandResponse>),
-    /// Get the window size.
+    /// Get the window rectangle.
     GetWindowRect(WebViewId, IpcSender<DeviceIndependentIntRect>),
     /// Get the viewport size.
     GetViewportSize(WebViewId, IpcSender<Size2D<u32, DevicePixel>>),


### PR DESCRIPTION
Also fix doc for `WebDriverCommandMsg::GetWindowRect`.

Testing: No behaviour change.
