### PR TITLE
Timers: remove send bound on boxed timer callback

### DIFF
--- a/components/timers/lib.rs
+++ b/components/timers/lib.rs
@@ -18,7 +18,7 @@ use malloc_size_of_derive::MallocSizeOf;
 /// dispatched.
 pub type BoxedTimerCallback = Box<dyn Fn() + 'static>;
 
-///
+/// A sendable version of the timer callback.
 pub type SendableBoxedTimerCallback = Box<dyn Fn() + Send + 'static>;
 
 /// Requests a TimerEvent-Message be sent after the given duration.

--- a/components/timers/lib.rs
+++ b/components/timers/lib.rs
@@ -16,7 +16,10 @@ use malloc_size_of_derive::MallocSizeOf;
 
 /// A callback to pass to the [`TimerScheduler`] to be called when the timer is
 /// dispatched.
-pub type BoxedTimerCallback = Box<dyn Fn() + Send + 'static>;
+pub type BoxedTimerCallback = Box<dyn Fn() + 'static>;
+
+///
+pub type SendableBoxedTimerCallback = Box<dyn Fn() + Send + 'static>;
 
 /// Requests a TimerEvent-Message be sent after the given duration.
 #[derive(MallocSizeOf)]


### PR DESCRIPTION
But introduce a new send-able callback for use in refresh driver.

This then enables switching to an cell for `has_pending_animation_tick` in the script-thread, which uses no threading to schedule timers.

Fix https://github.com/servo/servo/issues/37946