### PR TITLE
OHOS: Fix speedometer hang sometimes.

### DIFF
--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -167,7 +167,10 @@ impl ServoAction {
     fn do_action(&self, servo: &Rc<RunningAppState>) {
         use ServoAction::*;
         match self {
-            WakeUp => servo.perform_updates(),
+            WakeUp => {
+                servo.perform_updates();
+                servo.present_if_needed();
+            },
             LoadUrl(url) => servo.load_uri(url.as_str()),
             GoBack => servo.go_back(),
             GoForward => servo.go_forward(),

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -684,8 +684,6 @@ class MachCommands(CommandBase):
         whole_file: str = ""
         for i in range(10):
             sleep(30)
-            subprocess.call([hdc_path, "shell", "uinput", "-T", "-d", "100", "100"])
-            subprocess.call([hdc_path, "shell", "uinput", "-T", "-u", "105", "105"])
             whole_file = read_log_file()
             if "[INFO script::dom::console]" in whole_file:
                 # technically the file could not have been written completely yet


### PR DESCRIPTION
This fixes the speedometer hang on CI.
Sometimes on CI we have the servoshell app not being in the foreground (because popups have higher priority). Then, for some reason the eventloop does not get pumped after some time.
This fixes this and is consistent with the current code in android.

Here is a succesful run https://github.com/Narfinger/servo/actions/runs/16214904687/job/45782241427. This needs also https://github.com/servo/servo/pull/37994 to be successful but these two PR are independent.

Testing: Having the usb popup on the screen while running speedometer without this changes hangs consistently (until input which calls present_if_needed). With this change the hang does not occur anymore.
Fixes: I think https://github.com/servo/servo/issues/37727 is the same issue and I confirmed that in the above case testinput does nothing useful. We will see if this occurs again.
