### PR TITLE
script: introduce safe wrappers for js val conversions 

### DIFF
--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -6,11 +6,11 @@ use std::ptr;
 
 use html5ever::interface::QualName;
 use html5ever::{LocalName, local_name, ns};
-use js::conversions::ToJSValConvertible;
 use js::glue::{UnwrapObjectDynamic, UnwrapObjectStatic};
 use js::jsapi::{CallArgs, CurrentGlobalOrNull, JSAutoRealm, JSObject};
 use js::rust::wrappers::{JS_SetPrototype, JS_WrapObject};
 use js::rust::{HandleObject, MutableHandleObject, MutableHandleValue};
+use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::interface::get_desired_proto;
 
 use super::utils::ProtoOrIfaceArray;
@@ -242,7 +242,7 @@ fn html_constructor(
 
         JS_SetPrototype(*cx, element.handle(), prototype.handle());
 
-        result.to_jsval(*cx, MutableHandleValue::from_raw(call_args.rval()));
+        result.safe_to_jsval(cx, MutableHandleValue::from_raw(call_args.rval()));
     }
     Ok(())
 }

--- a/components/script/dom/cryptokey.rs
+++ b/components/script/dom/cryptokey.rs
@@ -8,6 +8,7 @@ use std::ptr::NonNull;
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JSObject, Value};
 use js::rust::HandleObject;
+use script_bindings::conversions::SafeToJSValConvertible;
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, KeyType, KeyUsage,
@@ -16,7 +17,6 @@ use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::js::conversions::ToJSValConvertible;
 use crate::script_runtime::{CanGc, JSContext};
 
 /// The underlying cryptographic data this key represents
@@ -135,14 +135,11 @@ impl CryptoKeyMethods<crate::DomTypeHolder> for CryptoKey {
         NonNull::new(self.algorithm_object.get()).unwrap()
     }
 
-    #[allow(unsafe_code)]
     /// <https://w3c.github.io/webcrypto/#dom-cryptokey-usages>
     fn Usages(&self, cx: JSContext) -> NonNull<JSObject> {
-        unsafe {
-            rooted!(in(*cx) let mut usages: Value);
-            self.usages.to_jsval(*cx, usages.handle_mut());
-            NonNull::new(usages.to_object()).unwrap()
-        }
+        rooted!(in(*cx) let mut usages: Value);
+        self.usages.safe_to_jsval(cx, usages.handle_mut());
+        NonNull::new(usages.to_object()).unwrap()
     }
 }
 

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -5,7 +5,6 @@
 use std::ptr;
 
 use dom_struct::dom_struct;
-use js::conversions::ToJSValConvertible;
 use js::jsapi::{
     ESClass, GetBuiltinClass, IsArrayBufferObject, JS_DeleteUCProperty,
     JS_GetOwnUCPropertyDescriptor, JS_GetStringLength, JS_IsArrayBufferViewObject, JSObject,
@@ -18,6 +17,7 @@ use net_traits::indexeddb_thread::{
     AsyncOperation, IndexedDBKeyType, IndexedDBThreadMsg, SyncOperation,
 };
 use profile_traits::ipc;
+use script_bindings::conversions::SafeToJSValConvertible;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::IDBDatabaseBinding::IDBObjectStoreParameters;
@@ -235,7 +235,7 @@ impl IDBObjectStore {
                             rooted!(in(*cx) let input_val = current_val.to_string());
                             unsafe {
                                 let string_len = JS_GetStringLength(*input_val) as u64;
-                                string_len.to_jsval(*cx, return_val);
+                                string_len.safe_to_jsval(cx, return_val);
                             }
                             break;
                         }

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -16,7 +16,7 @@ use std::ptr;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use js::conversions::{ConversionResult, FromJSValConvertibleRc, ToJSValConvertible};
+use js::conversions::{ConversionResult, FromJSValConvertibleRc};
 use js::jsapi::{
     AddRawValueRoot, CallArgs, GetFunctionNativeReserved, Heap, JS_ClearPendingException,
     JS_GetFunctionObject, JS_NewFunction, JSAutoRealm, JSContext, JSObject,
@@ -157,7 +157,7 @@ impl Promise {
     pub(crate) fn new_resolved(
         global: &GlobalScope,
         cx: SafeJSContext,
-        value: impl ToJSValConvertible,
+        value: impl SafeToJSValConvertible,
         _can_gc: CanGc,
     ) -> Rc<Promise> {
         let _ac = JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
@@ -175,7 +175,7 @@ impl Promise {
     pub(crate) fn new_rejected(
         global: &GlobalScope,
         cx: SafeJSContext,
-        value: impl ToJSValConvertible,
+        value: impl SafeToJSValConvertible,
         _can_gc: CanGc,
     ) -> Rc<Promise> {
         let _ac = JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
@@ -190,7 +190,7 @@ impl Promise {
 
     pub(crate) fn resolve_native<T>(&self, val: &T, can_gc: CanGc)
     where
-        T: ToJSValConvertible,
+        T: SafeToJSValConvertible,
     {
         let cx = GlobalScope::get_cx();
         let _ac = enter_realm(self);
@@ -211,7 +211,7 @@ impl Promise {
 
     pub(crate) fn reject_native<T>(&self, val: &T, can_gc: CanGc)
     where
-        T: ToJSValConvertible,
+        T: SafeToJSValConvertible,
     {
         let cx = GlobalScope::get_cx();
         let _ac = enter_realm(self);

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -30,7 +30,7 @@ use js::rust::wrappers::{
     ResolvePromise, SetAnyPromiseIsHandled, SetPromiseUserInputEventHandlingState,
 };
 use js::rust::{HandleObject, HandleValue, MutableHandleObject, Runtime};
-use script_bindings::conversions::safe_to_jsval;
+use script_bindings::conversions::SafeToJSValConvertible;
 
 use crate::dom::bindings::conversions::root_from_object;
 use crate::dom::bindings::error::{Error, ErrorToJsval};
@@ -162,7 +162,7 @@ impl Promise {
     ) -> Rc<Promise> {
         let _ac = JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
         rooted!(in(*cx) let mut rval = UndefinedValue());
-        safe_to_jsval(cx, value, rval.handle_mut());
+        value.safe_to_jsval(cx, rval.handle_mut());
         unsafe {
             rooted!(in(*cx) let p = CallOriginalPromiseResolve(*cx, rval.handle()));
             assert!(!p.handle().is_null());
@@ -180,7 +180,7 @@ impl Promise {
     ) -> Rc<Promise> {
         let _ac = JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
         rooted!(in(*cx) let mut rval = UndefinedValue());
-        safe_to_jsval(cx, value, rval.handle_mut());
+        value.safe_to_jsval(cx, rval.handle_mut());
         unsafe {
             rooted!(in(*cx) let p = CallOriginalPromiseReject(*cx, rval.handle()));
             assert!(!p.handle().is_null());
@@ -195,7 +195,7 @@ impl Promise {
         let cx = GlobalScope::get_cx();
         let _ac = enter_realm(self);
         rooted!(in(*cx) let mut v = UndefinedValue());
-        safe_to_jsval(cx, val, v.handle_mut());
+        val.safe_to_jsval(cx, v.handle_mut());
         self.resolve(cx, v.handle(), can_gc);
     }
 
@@ -216,7 +216,7 @@ impl Promise {
         let cx = GlobalScope::get_cx();
         let _ac = enter_realm(self);
         rooted!(in(*cx) let mut v = UndefinedValue());
-        safe_to_jsval(cx, val, v.handle_mut());
+        val.safe_to_jsval(cx, v.handle_mut());
         self.reject(cx, v.handle(), can_gc);
     }
 

--- a/components/script/dom/rtcdatachannel.rs
+++ b/components/script/dom/rtcdatachannel.rs
@@ -7,11 +7,11 @@ use std::ptr;
 
 use constellation_traits::BlobImpl;
 use dom_struct::dom_struct;
-use js::conversions::ToJSValConvertible;
 use js::jsapi::{JSAutoRealm, JSObject};
 use js::jsval::UndefinedValue;
 use js::rust::CustomAutoRooterGuard;
 use js::typedarray::{ArrayBuffer, ArrayBufferView, CreateWith};
+use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::weakref::WeakRef;
 use servo_media::webrtc::{
     DataChannelId, DataChannelInit, DataChannelMessage, DataChannelState, WebRtcError,
@@ -203,7 +203,7 @@ impl RTCDataChannel {
 
             match channel_message {
                 DataChannelMessage::Text(text) => {
-                    text.to_jsval(*cx, message.handle_mut());
+                    text.safe_to_jsval(cx, message.handle_mut());
                 },
                 DataChannelMessage::Binary(data) => match &**self.binary_type.borrow() {
                     "blob" => {
@@ -212,7 +212,7 @@ impl RTCDataChannel {
                             BlobImpl::new_from_bytes(data, "".to_owned()),
                             can_gc,
                         );
-                        blob.to_jsval(*cx, message.handle_mut());
+                        blob.safe_to_jsval(cx, message.handle_mut());
                     },
                     "arraybuffer" => {
                         rooted!(in(*cx) let mut array_buffer = ptr::null_mut::<JSObject>());
@@ -225,7 +225,7 @@ impl RTCDataChannel {
                             .is_ok()
                         );
 
-                        (*array_buffer).to_jsval(*cx, message.handle_mut());
+                        (*array_buffer).safe_to_jsval(cx, message.handle_mut());
                     },
                     _ => unreachable!(),
                 },

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -590,24 +590,24 @@ impl TaskOnce for MessageReceivedTask {
 
         // Step 2-5.
         let global = ws.global();
-        // GlobalScope::get_cx() returns a valid `JSContext` pointer, so this is safe.
-        unsafe {
-            let cx = GlobalScope::get_cx();
-            let _ac = JSAutoRealm::new(*cx, ws.reflector().get_jsobject().get());
-            rooted!(in(*cx) let mut message = UndefinedValue());
-            match self.message {
-                MessageData::Text(text) => text.safe_to_jsval(cx, message.handle_mut()),
-                MessageData::Binary(data) => match ws.binary_type.get() {
-                    BinaryType::Blob => {
-                        let blob = Blob::new(
-                            &global,
-                            BlobImpl::new_from_bytes(data, "".to_owned()),
-                            CanGc::note(),
-                        );
-                        blob.safe_to_jsval(cx, message.handle_mut());
-                    },
-                    BinaryType::Arraybuffer => {
-                        rooted!(in(*cx) let mut array_buffer = ptr::null_mut::<JSObject>());
+        let cx = GlobalScope::get_cx();
+        let _ac = JSAutoRealm::new(*cx, ws.reflector().get_jsobject().get());
+        rooted!(in(*cx) let mut message = UndefinedValue());
+        match self.message {
+            MessageData::Text(text) => text.safe_to_jsval(cx, message.handle_mut()),
+            MessageData::Binary(data) => match ws.binary_type.get() {
+                BinaryType::Blob => {
+                    let blob = Blob::new(
+                        &global,
+                        BlobImpl::new_from_bytes(data, "".to_owned()),
+                        CanGc::note(),
+                    );
+                    blob.safe_to_jsval(cx, message.handle_mut());
+                },
+                BinaryType::Arraybuffer => {
+                    rooted!(in(*cx) let mut array_buffer = ptr::null_mut::<JSObject>());
+                    // GlobalScope::get_cx() returns a valid `JSContext` pointer, so this is safe.
+                    unsafe {
                         assert!(
                             ArrayBuffer::create(
                                 *cx,
@@ -615,21 +615,21 @@ impl TaskOnce for MessageReceivedTask {
                                 array_buffer.handle_mut()
                             )
                             .is_ok()
-                        );
+                        )
+                    };
 
-                        (*array_buffer).safe_to_jsval(cx, message.handle_mut());
-                    },
+                    (*array_buffer).safe_to_jsval(cx, message.handle_mut());
                 },
-            }
-            MessageEvent::dispatch_jsval(
-                ws.upcast(),
-                &global,
-                message.handle(),
-                Some(&ws.origin().ascii_serialization()),
-                None,
-                vec![],
-                CanGc::note(),
-            );
+            },
         }
+        MessageEvent::dispatch_jsval(
+            ws.upcast(),
+            &global,
+            message.handle(),
+            Some(&ws.origin().ascii_serialization()),
+            None,
+            vec![],
+            CanGc::note(),
+        );
     }
 }

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -22,13 +22,13 @@ use net_traits::{
     CoreResourceMsg, FetchChannels, MessageData, WebSocketDomAction, WebSocketNetworkEvent,
 };
 use profile_traits::ipc as ProfiledIpc;
+use script_bindings::conversions::SafeToJSValConvertible;
 use servo_url::{ImmutableOrigin, ServoUrl};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
 use crate::dom::bindings::codegen::Bindings::WebSocketBinding::{BinaryType, WebSocketMethods};
 use crate::dom::bindings::codegen::UnionTypes::StringOrStringSequence;
-use crate::dom::bindings::conversions::ToJSValConvertible;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
@@ -596,7 +596,7 @@ impl TaskOnce for MessageReceivedTask {
             let _ac = JSAutoRealm::new(*cx, ws.reflector().get_jsobject().get());
             rooted!(in(*cx) let mut message = UndefinedValue());
             match self.message {
-                MessageData::Text(text) => text.to_jsval(*cx, message.handle_mut()),
+                MessageData::Text(text) => text.safe_to_jsval(cx, message.handle_mut()),
                 MessageData::Binary(data) => match ws.binary_type.get() {
                     BinaryType::Blob => {
                         let blob = Blob::new(
@@ -604,7 +604,7 @@ impl TaskOnce for MessageReceivedTask {
                             BlobImpl::new_from_bytes(data, "".to_owned()),
                             CanGc::note(),
                         );
-                        blob.to_jsval(*cx, message.handle_mut());
+                        blob.safe_to_jsval(cx, message.handle_mut());
                     },
                     BinaryType::Arraybuffer => {
                         rooted!(in(*cx) let mut array_buffer = ptr::null_mut::<JSObject>());
@@ -617,7 +617,7 @@ impl TaskOnce for MessageReceivedTask {
                             .is_ok()
                         );
 
-                        (*array_buffer).to_jsval(*cx, message.handle_mut());
+                        (*array_buffer).safe_to_jsval(cx, message.handle_mut());
                     },
                 },
             }

--- a/components/script/dom/webxr/xrinputsource.rs
+++ b/components/script/dom/webxr/xrinputsource.rs
@@ -4,10 +4,10 @@
 
 use dom_struct::dom_struct;
 use embedder_traits::GamepadSupportedHapticEffects;
-use js::conversions::ToJSValConvertible;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::MutableHandleValue;
+use script_bindings::conversions::SafeToJSValConvertible;
 use webxr_api::{Handedness, InputFrame, InputId, InputSource, TargetRayMode};
 
 use crate::dom::bindings::codegen::Bindings::XRInputSourceBinding::{
@@ -73,7 +73,6 @@ impl XRInputSource {
         }
     }
 
-    #[allow(unsafe_code)]
     pub(crate) fn new(
         window: &Window,
         session: &XRSession,
@@ -88,11 +87,12 @@ impl XRInputSource {
 
         let _ac = enter_realm(window);
         let cx = GlobalScope::get_cx();
-        unsafe {
-            rooted!(in(*cx) let mut profiles = UndefinedValue());
-            source.info.profiles.to_jsval(*cx, profiles.handle_mut());
-            source.profiles.set(profiles.get());
-        }
+        rooted!(in(*cx) let mut profiles = UndefinedValue());
+        source
+            .info
+            .profiles
+            .safe_to_jsval(cx, profiles.handle_mut());
+        source.profiles.set(profiles.get());
         source
     }
 

--- a/components/script/dom/webxr/xrviewerpose.rs
+++ b/components/script/dom/webxr/xrviewerpose.rs
@@ -4,10 +4,10 @@
 
 use dom_struct::dom_struct;
 use euclid::RigidTransform3D;
-use js::conversions::ToJSValConvertible;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::MutableHandleValue;
+use script_bindings::conversions::SafeToJSValConvertible;
 use webxr_api::{Viewer, ViewerPose, Views};
 
 use crate::dom::bindings::codegen::Bindings::XRViewBinding::XREye;
@@ -38,7 +38,6 @@ impl XRViewerPose {
         }
     }
 
-    #[allow(unsafe_code)]
     pub(crate) fn new(
         window: &Window,
         session: &XRSession,
@@ -183,11 +182,9 @@ impl XRViewerPose {
         );
 
         let cx = GlobalScope::get_cx();
-        unsafe {
-            rooted!(in(*cx) let mut jsval = UndefinedValue());
-            views.to_jsval(*cx, jsval.handle_mut());
-            pose.views.set(jsval.get());
-        }
+        rooted!(in(*cx) let mut jsval = UndefinedValue());
+        views.safe_to_jsval(cx, jsval.handle_mut());
+        pose.views.set(jsval.get());
 
         pose
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -40,7 +40,6 @@ use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect, Size2D as 
 use euclid::{Point2D, Scale, Size2D, Vector2D};
 use fonts::FontContext;
 use ipc_channel::ipc::{self, IpcSender};
-use js::conversions::ToJSValConvertible;
 use js::glue::DumpJSStack;
 use js::jsapi::{
     GCReason, Heap, JS_GC, JSAutoRealm, JSContext as RawJSContext, JSObject, JSPROP_ENUMERATE,
@@ -70,6 +69,7 @@ use profile_traits::mem::ProfilerChan as MemProfilerChan;
 use profile_traits::time::ProfilerChan as TimeProfilerChan;
 use script_bindings::codegen::GenericBindings::NavigatorBinding::NavigatorMethods;
 use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMethods;
+use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::interfaces::WindowHelpers;
 use script_bindings::root::Root;
 use script_traits::ScriptThreadMessage;
@@ -1789,12 +1789,9 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     // https://dom.spec.whatwg.org/#dom-window-event
-    #[allow(unsafe_code)]
     fn Event(&self, cx: JSContext, rval: MutableHandleValue) {
         if let Some(ref event) = *self.current_event.borrow() {
-            unsafe {
-                event.reflector().get_jsobject().to_jsval(*cx, rval);
-            }
+            event.reflector().get_jsobject().safe_to_jsval(cx, rval);
         }
     }
 

--- a/components/script/dom/writablestream.rs
+++ b/components/script/dom/writablestream.rs
@@ -18,6 +18,7 @@ use js::rust::{
     MutableHandleValue as SafeMutableHandleValue,
 };
 use script_bindings::codegen::GenericBindings::MessagePortBinding::MessagePortMethods;
+use script_bindings::conversions::SafeToJSValConvertible;
 
 use super::bindings::codegen::Bindings::QueuingStrategyBinding::QueuingStrategySize;
 use crate::dom::bindings::cell::DomRefCell;
@@ -41,7 +42,6 @@ use crate::dom::writablestreamdefaultcontroller::{
     UnderlyingSinkType, WritableStreamDefaultController,
 };
 use crate::dom::writablestreamdefaultwriter::WritableStreamDefaultWriter;
-use crate::js::conversions::ToJSValConvertible;
 use crate::realms::{InRealm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
@@ -1191,7 +1191,6 @@ impl CrossRealmTransformWritable {
 
     /// <https://streams.spec.whatwg.org/#abstract-opdef-setupcrossrealmtransformwritable>
     /// Add a handler for port’s messageerror event with the following steps:
-    #[allow(unsafe_code)]
     pub(crate) fn handle_error(
         &self,
         cx: SafeJSContext,
@@ -1203,7 +1202,7 @@ impl CrossRealmTransformWritable {
         // Let error be a new "DataCloneError" DOMException.
         let error = DOMException::new(global, DOMErrorName::DataCloneError, can_gc);
         rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-        unsafe { error.to_jsval(*cx, rooted_error.handle_mut()) };
+        error.safe_to_jsval(cx, rooted_error.handle_mut());
 
         // Perform ! CrossRealmTransformSendError(port, error).
         port.cross_realm_transform_send_error(rooted_error.handle(), can_gc);

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -37,9 +37,14 @@ use crate::trace::RootedTraceableBox;
 use crate::utils::{DOMClass, DOMJSClass};
 
 /// A safe wrapper for `ToJSValConvertible`.
-#[allow(unsafe_code)]
-pub fn safe_to_jsval<T: ToJSValConvertible>(cx: SafeJSContext, val: T, rval: MutableHandleValue) {
-    unsafe { val.to_jsval(*cx, rval) };
+pub trait SafeToJSValConvertible {
+    fn safe_to_jsval(&self, cx: SafeJSContext, rval: MutableHandleValue);
+}
+
+impl<T: ToJSValConvertible> SafeToJSValConvertible for T {
+    fn safe_to_jsval(&self, cx: SafeJSContext, rval: MutableHandleValue) {
+        unsafe { self.to_jsval(*cx, rval) };
+    }
 }
 
 /// A trait to check whether a given `JSObject` implements an IDL interface.

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -31,9 +31,16 @@ use crate::inheritance::Castable;
 use crate::num::Finite;
 use crate::reflector::{DomObject, Reflector};
 use crate::root::DomRoot;
+use crate::script_runtime::JSContext as SafeJSContext;
 use crate::str::{ByteString, DOMString, USVString};
 use crate::trace::RootedTraceableBox;
 use crate::utils::{DOMClass, DOMJSClass};
+
+/// A safe wrapper for `ToJSValConvertible`.
+#[allow(unsafe_code)]
+pub fn safe_to_jsval<T: ToJSValConvertible>(cx: SafeJSContext, val: T, rval: MutableHandleValue) {
+    unsafe { val.to_jsval(*cx, rval) };
+}
 
 /// A trait to check whether a given `JSObject` implements an IDL interface.
 pub trait IDLInterface {


### PR DESCRIPTION
Introduce a safe wrapper trait for the unsafe `ToJSValConvertible`, and use it in `script/dom` where the default `T` implementation works.

Part of https://github.com/servo/servo/issues/37951