### PR TITLE
Use consistent spacing and alphabetize `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,31 +9,31 @@ updates:
   - dependency-type: direct
   - dependency-type: indirect
   groups:
-    gstreamer-related:
-       patterns:
-         - "gio*"
-         - "glib*"
-         - "gobject*"
-         - "gstreamer*"
     egui-related:
-       patterns:
-         - "ecolor"
-         - "egui"
-         - "egui-winit"
-         - "egui_glow"
-         - "emath"
-         - "epaint"
-         - "epaint_default_fonts"
+      patterns:
+        - "ecolor"
+        - "egui"
+        - "egui-winit"
+        - "egui_glow"
+        - "emath"
+        - "epaint"
+        - "epaint_default_fonts"
+    gstreamer-related:
+      patterns:
+        - "gio*"
+        - "glib*"
+        - "gobject*"
+        - "gstreamer*"
     napi-ohos-related:
       patterns:
         - "napi-ohos*"
         - "napi-*-ohos*"
-    servo-media-related:
-      patterns:
-        - "servo-media*"
     objc2-related:
       patterns:
         - "objc2*"
+    servo-media-related:
+      patterns:
+        - "servo-media*"
   ignore:
   # Ignore all stylo crates as their upgrades are coordinated via companion PRs.
   - dependency-name: selectors


### PR DESCRIPTION
This uses consistent spacing for indentation. I'm not sure if it was causing any issues but it has been a problem before (#36642). Also reorder categories to be in alphabetical order. 

Testing: No testing for Dependabot file.
