### PR TITLE
Add AsHandleValue trait to Heap<Value> and make Heap values rooted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5240,7 +5240,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#4035b0c4e9e2df5cacc68c4b71e7375a48605902"
+source = "git+https://github.com/servo/mozjs#903a158b36c10902a40c7fda766406d698f98bf4"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -5252,7 +5252,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.128.13-3"
-source = "git+https://github.com/servo/mozjs#4035b0c4e9e2df5cacc68c4b71e7375a48605902"
+source = "git+https://github.com/servo/mozjs#903a158b36c10902a40c7fda766406d698f98bf4"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/components/script/dom/bindings/frozenarray.rs
+++ b/components/script/dom/bindings/frozenarray.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::utils::to_frozen_array;
 use crate::script_runtime::{CanGc, JSContext};
 
 #[derive(JSTraceable)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct CachedFrozenArray {
     frozen_value: DomRefCell<Option<Heap<JSVal>>>,
 }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -422,6 +422,7 @@ impl Element {
         self.ensure_rare_data().custom_element_definition = None;
     }
 
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn push_callback_reaction(&self, function: Rc<Function>, args: Box<[Heap<JSVal>]>) {
         self.ensure_rare_data()
             .custom_element_reaction_queue

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -115,7 +115,7 @@ pub(crate) enum FileReaderReadyState {
 
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) enum FileReaderResult {
-    ArrayBuffer(#[ignore_malloc_size_of = "mozjs"] Heap<JSVal>),
+    ArrayBuffer(#[ignore_malloc_size_of = "mozjs"] RootedTraceableBox<Heap<JSVal>>),
     String(DOMString),
 }
 
@@ -354,7 +354,8 @@ impl FileReader {
                     .is_ok()
             );
 
-            *result.borrow_mut() = Some(FileReaderResult::ArrayBuffer(Heap::default()));
+            *result.borrow_mut() =
+                Some(FileReaderResult::ArrayBuffer(RootedTraceableBox::default()));
 
             if let Some(FileReaderResult::ArrayBuffer(ref mut heap)) = *result.borrow_mut() {
                 heap.set(jsval::ObjectValue(array_buffer.get()));

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -166,7 +166,6 @@ impl Notification {
     ) -> Self {
         // TODO: missing call to https://html.spec.whatwg.org/multipage/#structuredserializeforstorage
         // may be find in `dom/bindings/structuredclone.rs`
-        let data = Heap::default();
 
         let title = title.clone();
         let dir = options.dir;
@@ -234,7 +233,7 @@ impl Notification {
             serviceworker_registration: None,
             title,
             body,
-            data,
+            data: Heap::default(),
             dir,
             image,
             icon,

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -154,7 +154,7 @@ pub(crate) struct PipeTo {
     /// The error potentially passed to shutdown,
     /// stored here because we must keep it across a microtask.
     #[ignore_malloc_size_of = "mozjs"]
-    shutdown_error: Rc<RefCell<Option<Heap<JSVal>>>>,
+    shutdown_error: Rc<RefCell<Option<RootedTraceableBox<Heap<JSVal>>>>>,
 
     /// The promise returned by a shutdown action.
     /// We keep it to only continue when it is not pending anymore.
@@ -376,7 +376,7 @@ impl PipeTo {
     /// Setting shutdown error in a way that ensures it isn't
     /// moved after it has been set.
     fn set_shutdown_error(&self, error: SafeHandleValue) {
-        *self.shutdown_error.borrow_mut() = Some(Heap::default());
+        *self.shutdown_error.borrow_mut() = Some(RootedTraceableBox::new(Heap::default()));
         let Some(ref heap) = *self.shutdown_error.borrow() else {
             unreachable!("Option set to Some(heap) above.");
         };

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use constellation_traits::ScriptToConstellationMessage;
 use dom_struct::dom_struct;
-use js::jsapi::Heap;
+use js::jsapi::HandleObject;
 use webgpu_traits::WebGPUAdapterResponse;
 use wgpu_types::PowerPreference;
 
@@ -117,7 +117,7 @@ impl RoutedPromiseListener<WebGPUAdapterResponse> for GPU {
                         "{} ({:?})",
                         adapter.adapter_info.name, adapter.adapter_id.0
                     )),
-                    Heap::default(),
+                    HandleObject::null(),
                     adapter.features,
                     adapter.limits,
                     adapter.adapter_info,

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -9,7 +9,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use js::jsapi::{Heap, JSObject};
+use js::jsapi::{HandleObject, Heap, JSObject};
 use webgpu_traits::{
     PopError, WebGPU, WebGPUComputePipeline, WebGPUComputePipelineResponse, WebGPUDevice,
     WebGPUPoppedErrorScopeResponse, WebGPUQueue, WebGPURenderPipeline,
@@ -114,7 +114,6 @@ impl GPUDevice {
     fn new_inherited(
         channel: WebGPU,
         adapter: &GPUAdapter,
-        extensions: Heap<*mut JSObject>,
         features: &GPUSupportedFeatures,
         limits: &GPUSupportedLimits,
         device: WebGPUDevice,
@@ -126,7 +125,7 @@ impl GPUDevice {
             eventtarget: EventTarget::new_inherited(),
             channel,
             adapter: Dom::from_ref(adapter),
-            extensions,
+            extensions: Heap::default(),
             features: Dom::from_ref(features),
             limits: Dom::from_ref(limits),
             label: DomRefCell::new(USVString::from(label)),
@@ -142,7 +141,7 @@ impl GPUDevice {
         global: &GlobalScope,
         channel: WebGPU,
         adapter: &GPUAdapter,
-        extensions: Heap<*mut JSObject>,
+        extensions: HandleObject,
         features: wgpu_types::Features,
         limits: wgpu_types::Limits,
         device: WebGPUDevice,
@@ -158,7 +157,6 @@ impl GPUDevice {
             Box::new(GPUDevice::new_inherited(
                 channel,
                 adapter,
-                extensions,
                 &features,
                 &limits,
                 device,
@@ -170,6 +168,7 @@ impl GPUDevice {
             can_gc,
         );
         queue.set_device(&device);
+        device.extensions.set(*extensions);
         device
     }
 }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -88,16 +88,15 @@ fn gen_type_error(global: &GlobalScope, string: String, can_gc: CanGc) -> Rethro
 }
 
 #[derive(JSTraceable)]
-pub(crate) struct ModuleObject(Box<Heap<*mut JSObject>>);
+pub(crate) struct ModuleObject(RootedTraceableBox<Heap<*mut JSObject>>);
 
 impl ModuleObject {
     fn new(obj: RustHandleObject) -> ModuleObject {
-        ModuleObject(Heap::boxed(obj.get()))
+        ModuleObject(RootedTraceableBox::from_box(Heap::boxed(obj.get())))
     }
 
-    #[allow(unsafe_code)]
     pub(crate) fn handle(&self) -> HandleObject {
-        unsafe { self.0.handle() }
+        self.0.handle().into()
     }
 }
 


### PR DESCRIPTION
Encapsulates the unsafe conversion from Heap<Value> to HandleValue<'a>, and reducing repetitive unsafe code at call.

fix #37258