### PR TITLE
mach (Windows): make `vswhere.exe` work properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For more detailed build instructions, see the Servo book under [Setting up your 
 - Download [`uv`](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer), [`choco`](https://chocolatey.org/install#individual), and [`rustup`](https://win.rustup.rs/)
   - Be sure to select *Quick install via the Visual Studio Community installer*
 - In the Visual Studio Installer, ensure the following components are installed:
-  - **Windows 10 SDK (10.0.19041.0)** (`Microsoft.VisualStudio.Component.Windows10SDK.19041`)
+  - **Windows 10/11 SDK (anything >= 10.0.19041.0)** (`Microsoft.VisualStudio.Component.Windows{10, 11}SDK.{>=19041}`)
   - **MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)** (`Microsoft.VisualStudio.Component.VC.Tools.x86.x64`)
   - **C++ ATL for latest v143 build tools (x86 & x64)** (`Microsoft.VisualStudio.Component.VC.ATL`)
   - **C++ MFC for latest v143 build tools (x86 & x64)** (`Microsoft.VisualStudio.Component.VC.ATLMFC`)

--- a/python/servo/visual_studio.py
+++ b/python/servo/visual_studio.py
@@ -51,7 +51,6 @@ def find_compatible_msvc_with_vswhere() -> Generator[VisualStudioInstallation, N
     vswhere = find_vswhere()
     if not vswhere:
         return
-
     output = subprocess.check_output(
         [
             vswhere,
@@ -62,7 +61,7 @@ def find_compatible_msvc_with_vswhere() -> Generator[VisualStudioInstallation, N
             "-requires",
             "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
             "-requires",
-            "Microsoft.VisualStudio.Component.Windows10SDK",
+            "Microsoft.VisualStudio.Component.Windows*SDK.*",
             "-utf8",
         ]
     ).decode(errors="ignore")


### PR DESCRIPTION
Previously, the args passed to `vswhere.exe` was wrong. There is no generic component ID called `Microsoft.VisualStudio.Component.Windows10SDK`, but always something like `Microsoft.VisualStudio.Component.Windows10SDK.19041` / `Microsoft.VisualStudio.Component.Windows11SDK.22621`. 
That's why users always had to manually setup environment variable `VSINSTALLDIR`, `VisualStudioVersion`.

This QoL PR also makes `mach` compatible with Windows 11 SDK, and update README.md to be consistent with https://github.com/servo/book/pull/92.

Testing: Tested locally and working fine after removing environment variables.
