### PR TITLE
Add Linux .desktop file

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -33,7 +33,8 @@ use winit::event::{
 };
 use winit::event_loop::ActiveEventLoop;
 use winit::keyboard::{Key as LogicalKey, ModifiersState, NamedKey};
-use winit::platform::x11::WindowAttributesExtX11;
+#[cfg(target_os = "linux")]
+use winit::platform::wayland::WindowAttributesExtWayland;
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 use winit::window::Icon;
 #[cfg(target_os = "macos")]
@@ -95,9 +96,11 @@ impl Window {
             .with_min_inner_size(LogicalSize::new(1, 1))
             // Must be invisible at startup; accesskit_winit setup needs to
             // happen before the window is shown for the first time.
-            .with_visible(false)
-            // Set a name so it can be pinned to taskbars in Linux.
-            .with_name("org.servo.Servo", "Servo");
+            .with_visible(false);
+
+        // Set a name so it can be pinned to taskbars in Linux.
+        #[cfg(target_os = "linux")]
+        let window_attr = window_attr.with_name("org.servo.Servo", "Servo");
 
         #[allow(deprecated)]
         let winit_window = event_loop

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -33,6 +33,7 @@ use winit::event::{
 };
 use winit::event_loop::ActiveEventLoop;
 use winit::keyboard::{Key as LogicalKey, ModifiersState, NamedKey};
+use winit::platform::x11::WindowAttributesExtX11;
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 use winit::window::Icon;
 #[cfg(target_os = "macos")]
@@ -94,7 +95,9 @@ impl Window {
             .with_min_inner_size(LogicalSize::new(1, 1))
             // Must be invisible at startup; accesskit_winit setup needs to
             // happen before the window is shown for the first time.
-            .with_visible(false);
+            .with_visible(false)
+            // Set a name so it can be pinned to taskbars in Linux.
+            .with_name("org.servo.Servo", "Servo");
 
         #[allow(deprecated)]
         let winit_window = event_loop

--- a/resources/org.servo.Servo.desktop
+++ b/resources/org.servo.Servo.desktop
@@ -1,0 +1,33 @@
+# You can use this file to get a menu entry on Linux and so you can pin Servo to your taskbar.
+#
+# Steps:
+#   1. Create the applications folder if it doesn't exist:
+#           mkdir -p ~/.local/share/applications/
+#   2. Copy this file:
+#           cp org.servo.Servo.desktop ~/.local/share/applications
+#   3. Edit the copied file and replace the two SERVO_SRC_PATH occurrences
+#      with the path to the Servo sources.
+#   4. Create the icons folder if it doesn't exist:
+#          mkdir -p ~/.local/share/icons/hicolor/scalable/apps
+#   5. Create a link for the icon:
+#          ln -s servo.svg ~/.local/share/icons/hicolor/scalable/apps/servo.svg
+[Desktop Entry]
+Version=1.0
+Name=Servo
+GenericName=Web Browser
+Comment=Browse the Web
+# TODO: Replace SERVO_SRC_PATH with the path to the Servo sources
+Exec=SERVO_SRC_PATH/target/release/servo %u
+Icon=servo
+Terminal=false
+Type=Application
+MimeType=text/html;text/xml;application/xhtml+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;
+StartupNotify=true
+Categories=Network;WebBrowser;
+Keywords=web;browser;internet;
+Actions=new-window;
+
+[Desktop Action new-window]
+Name=Open a New Window
+# TODO: Replace SERVO_SRC_PATH with the path to the Servo sources
+Exec=SERVO_SRC_PATH/target/release/servo %u


### PR DESCRIPTION
I'm trying to use Servo as a daily driver. I like to pin the most often used apps to the my taskbar (Dash to Panel in Gnome). I also launch apps from the menu (Arc Menu). Adding a .desktop file make it show up in the menu. I could not get pinning to work until I set the name with `winit`. This is because the name is used to match it with the icon. I used the Gnome Looking Glass (lg) command to determine that the name was not set.

Testing: I followed the instructions that I put in the .desktop file. I copied the .desktop file to the right folder, set up a link to the svg icon, and adjusted the paths to point to the compiled executable.
