### PR TITLE
Add LargestContentfulPaintCollector to calculate the actual visual size of a element,

### DIFF
--- a/components/compositing/largest_contentful_paint.rs
+++ b/components/compositing/largest_contentful_paint.rs
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use base::cross_process_instant::CrossProcessInstant;
+use compositing_traits::largest_contentful_paint_candidate::{
+    LCPCandidate, LargestContentfulPaint,
+};
+use fnv::{FnvBuildHasher, FnvHashMap};
+use webrender_api::{Epoch, PipelineId};
+
+/// Holds the [`LargestContentfulPaintCalculator`] for each pipeline.
+#[derive(Default)]
+pub(crate) struct LargestContentfulPaintDetector {
+    lcp_calculators: FnvHashMap<PipelineId, LargestContentfulPaintCalculator>,
+}
+
+impl LargestContentfulPaintDetector {
+    pub const fn new() -> Self {
+        Self {
+            lcp_calculators: FnvHashMap::with_hasher(FnvBuildHasher::new()),
+        }
+    }
+
+    pub fn append_lcp_candidate(&mut self, pipeline_id: PipelineId, candidate: LCPCandidate) {
+        self.lcp_calculators
+            .entry(pipeline_id)
+            .and_modify(|calculator| calculator.lcp_candidates.push(candidate))
+            .or_insert(LargestContentfulPaintCalculator {
+                lcp_candidates: vec![candidate],
+                latest_lcp: None,
+            });
+    }
+
+    pub fn calculate_largest_contentful_paint(
+        &mut self,
+        paint_time: CrossProcessInstant,
+        cur_epoch: Epoch,
+        pipeline_id: PipelineId,
+    ) -> Option<LargestContentfulPaint> {
+        match self.lcp_calculators.get_mut(&pipeline_id) {
+            Some(lcp_calculator) => {
+                lcp_calculator.calculate_largest_contentful_paint(paint_time, cur_epoch)
+            },
+
+            None => None,
+        }
+    }
+}
+
+#[derive(Default)]
+struct LargestContentfulPaintCalculator {
+    lcp_candidates: Vec<LCPCandidate>,
+    latest_lcp: Option<LargestContentfulPaint>,
+}
+
+impl LargestContentfulPaintCalculator {
+    fn calculate_largest_contentful_paint(
+        &mut self,
+        paint_time: CrossProcessInstant,
+        cur_epoch: Epoch,
+    ) -> Option<LargestContentfulPaint> {
+        if self.lcp_candidates.is_empty() {
+            return self.latest_lcp;
+        }
+
+        let candidates = std::mem::take(&mut self.lcp_candidates);
+        for candidate in candidates {
+            if candidate.epoch > cur_epoch {
+                self.lcp_candidates.push(candidate);
+                continue;
+            }
+
+            match self.latest_lcp {
+                None => {
+                    self.latest_lcp = Some(LargestContentfulPaint::from(candidate, paint_time));
+                },
+                Some(ref latest_lcp) => {
+                    if latest_lcp.area < candidate.area {
+                        self.latest_lcp = Some(LargestContentfulPaint::from(candidate, paint_time));
+                    }
+                },
+            };
+        }
+
+        self.latest_lcp
+    }
+}

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -22,6 +22,7 @@ pub use crate::compositor::{IOCompositor, WebRenderDebugOption};
 mod tracing;
 
 mod compositor;
+mod largest_contentful_paint;
 mod refresh_driver;
 mod touch;
 mod webview_manager;

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -53,6 +53,7 @@ mod from_constellation {
                 Self::CollectMemoryReport(..) => target!("CollectMemoryReport"),
                 Self::Viewport(..) => target!("Viewport"),
                 Self::GenerateImageKeysForPipeline(..) => target!("GenerateImageKeysForPipeline"),
+                Self::LCPCandidate(..) => target!("LCPCandidate"),
             }
         }
     }

--- a/components/layout/display_list/clip.rs
+++ b/components/layout/display_list/clip.rs
@@ -247,6 +247,10 @@ impl StackingContextTreeClipStore {
             _ => None,
         }
     }
+
+    pub fn get_node(&self, id: &ClipId) -> Option<&Clip> {
+        self.0.get(id.0)
+    }
 }
 
 fn compute_shape_radius(

--- a/components/layout/display_list/largest_contenful_paint_collector.rs
+++ b/components/layout/display_list/largest_contenful_paint_collector.rs
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use base::id::ScrollTreeNodeId;
+use compositing_traits::display_list::{ScrollTree, ScrollTreeNode, SpatialTreeNodeInfo};
+use compositing_traits::largest_contentful_paint_candidate::{LCPCandidate, LCPCandidateID};
+use webrender_api::Epoch;
+use webrender_api::units::{LayoutRect, LayoutSize};
+
+use crate::display_list::clip::{ClipId, StackingContextTreeClipStore};
+
+pub(crate) struct LargestContentfulPaintCandidateCollector<'a> {
+    /// Used to track CSS like overflow from current element to root element.
+    pub clip_tree: &'a StackingContextTreeClipStore,
+    /// The scroll node id, used to get [`ScrollTreeNode`] from scroll tree and
+    /// resolve transform CSS
+    pub current_scroll_node_id: ScrollTreeNodeId,
+    /// The ClipId, used to get [`Clip`] from ClipTree.
+    pub current_clip_id: ClipId,
+    /// The LCP candidate, it may be a image or text.
+    pub lcp_candidate: Option<LCPCandidate>,
+    /// Whether is recording LCP.
+    /// TODO(boluochoufeng): Set it to false for now, and add the corresponding handling later.
+    pub is_recording_lcp: bool,
+    /// The rect of viewport.
+    pub viewport_rect: LayoutRect,
+    /// The current [`Epoch`]
+    pub cur_epoch: Epoch,
+}
+
+impl<'a> LargestContentfulPaintCandidateCollector<'a> {
+    pub fn new(
+        clip_tree: &'a StackingContextTreeClipStore,
+        current_scroll_node_id: ScrollTreeNodeId,
+        is_recording_lcp: bool,
+        viewport_size: LayoutSize,
+        cur_epoch: Epoch,
+    ) -> Self {
+        Self {
+            clip_tree,
+            current_scroll_node_id,
+            current_clip_id: ClipId::INVALID,
+            lcp_candidate: None,
+            is_recording_lcp,
+            viewport_rect: LayoutRect::from_size(viewport_size),
+            cur_epoch,
+        }
+    }
+
+    pub fn update_current_node_id(
+        &mut self,
+        next_scroll_node_id: ScrollTreeNodeId,
+        next_clip_id: ClipId,
+    ) {
+        self.current_scroll_node_id = next_scroll_node_id;
+        self.current_clip_id = next_clip_id;
+    }
+
+    pub fn update_image_candidate(
+        &mut self,
+        id: LCPCandidateID,
+        rect: LayoutRect,
+        scroll_tree: &ScrollTree,
+    ) {
+        if !self.is_recording_lcp {
+            return;
+        }
+
+        let visual_rect = self.compute_visual_rect(rect, scroll_tree);
+        let area = visual_rect.area() as usize;
+        if area == 0 {
+            return;
+        }
+
+        // TODO(boluochoufeng): need to filter low-content image
+
+        self.update_candidate(LCPCandidate::new(id, area, self.cur_epoch));
+    }
+
+    fn update_candidate(&mut self, candidate: LCPCandidate) {
+        if let Some(ref mut latest_candidate) = self.lcp_candidate {
+            if candidate.area > latest_candidate.area {
+                *latest_candidate = candidate;
+            }
+        } else {
+            self.lcp_candidate = Some(candidate);
+        }
+    }
+
+    /// Calculate the size of visual area in viewport. Because the parent elements will affect children,
+    /// We need track these css up to the root node.
+    fn compute_visual_rect(&self, rect: LayoutRect, scroll_tree: &ScrollTree) -> LayoutRect {
+        let visual_rect = self.compute_visual_rect_with_scroll_clip(
+            rect,
+            Some(self.current_scroll_node_id),
+            self.current_clip_id,
+            scroll_tree,
+        );
+
+        visual_rect
+            .intersection(&self.viewport_rect)
+            .unwrap_or(LayoutRect::zero())
+    }
+
+    fn compute_visual_rect_with_scroll_clip(
+        &self,
+        rect: LayoutRect,
+        scroll_id: Option<ScrollTreeNodeId>,
+        clip_id: ClipId,
+        scroll_tree: &ScrollTree,
+    ) -> LayoutRect {
+        let mut visual_rect = rect;
+        let mut parent_clip_id = clip_id;
+        let mut parent_scroll_id = scroll_id;
+
+        while let Some(scroll_id) = parent_scroll_id {
+            // 1.If there is clip CSS in the stacking context created by transform, apply it.
+            while let Some(clip_node) = &self
+                .clip_tree
+                .get_node(&parent_clip_id)
+                .filter(|node| node.parent_scroll_node_id == scroll_id)
+            {
+                if clip_node.id == ClipId::INVALID {
+                    parent_clip_id = clip_node.id;
+                } else {
+                    visual_rect = clip_node
+                        .rect
+                        .intersection(&rect)
+                        .unwrap_or(LayoutRect::zero());
+                    parent_clip_id = clip_node.parent_clip_id;
+                }
+            }
+
+            // 2.Apply transform CSS.
+            let scroll_node = scroll_tree.get_node(&scroll_id);
+            visual_rect = self.apply_transform_to_visual_rect(visual_rect, scroll_node);
+            parent_scroll_id = scroll_node.parent;
+        }
+
+        visual_rect
+    }
+
+    fn apply_transform_to_visual_rect(
+        &self,
+        rect: LayoutRect,
+        scroll_node: &ScrollTreeNode,
+    ) -> LayoutRect {
+        match &scroll_node.info {
+            SpatialTreeNodeInfo::ReferenceFrame(frame_node_info) => {
+                let origin = frame_node_info.origin;
+                let transform = &frame_node_info.transform;
+                let outer_rect = transform.outer_transformed_box2d(&rect);
+                if let Some(rect) = outer_rect {
+                    rect.translate(origin.to_vector())
+                } else {
+                    LayoutRect::zero()
+                }
+            },
+            _ => rect,
+        }
+    }
+}

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -319,6 +319,9 @@ impl StackingContextContent {
                 builder.current_scroll_node_id = *scroll_node_id;
                 builder.current_reference_frame_scroll_node_id = *reference_frame_scroll_node_id;
                 builder.current_clip_id = *clip_id;
+                builder
+                    .lcp_candidate_collector
+                    .update_current_node_id(*scroll_node_id, *clip_id);
                 fragment.build_display_list(
                     builder,
                     containing_block,

--- a/components/shared/compositing/largest_contentful_paint_candidate.rs
+++ b/components/shared/compositing/largest_contentful_paint_candidate.rs
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use base::cross_process_instant::CrossProcessInstant;
+use serde::{Deserialize, Serialize};
+use webrender_api::Epoch;
+
+/// Largest Contentful Paint Candidate, include image and block-level element containing text
+#[derive(Clone, Copy, Deserialize, Serialize)]
+pub struct LCPCandidate {
+    /// The identity of the element.
+    pub id: LCPCandidateID,
+    /// The size of the visual area
+    pub area: usize,
+    /// The epoch when the image is drawn.
+    pub epoch: Epoch,
+}
+
+impl LCPCandidate {
+    pub fn new(id: LCPCandidateID, area: usize, epoch: Epoch) -> Self {
+        Self { id, area, epoch }
+    }
+}
+
+impl Default for LCPCandidate {
+    fn default() -> Self {
+        Self {
+            id: LCPCandidateID::INVALID,
+            area: 0,
+            epoch: Epoch::invalid(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct LCPCandidateID(pub usize);
+
+impl LCPCandidateID {
+    pub const INVALID: LCPCandidateID = LCPCandidateID(0);
+}
+
+impl Default for LCPCandidateID {
+    fn default() -> Self {
+        Self::INVALID
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LargestContentfulPaint {
+    pub id: LCPCandidateID,
+    pub area: usize,
+    pub paint_time: CrossProcessInstant,
+}
+
+impl LargestContentfulPaint {
+    pub fn from(lcp_candidate: LCPCandidate, paint_time: CrossProcessInstant) -> Self {
+        Self {
+            id: lcp_candidate.id,
+            area: lcp_candidate.area,
+            paint_time,
+        }
+    }
+}


### PR DESCRIPTION
Add a LargestContentfutCollector to implement a simplified LCP (Largest Contentful Paint). LCP is a web performance metric introduced by Google, used to measure the render time of the largest content element within the viewport (It's affected by transform, filter, overflow etc.). I will split code to several PRs. The key enhancement currently include:

1. Add the `LargestContentfulPaintDetector`, which is used to pick and save LargestContentfulPaint value. Currently, only the  elements with background-image are recorded.

2. Add the `LargestContentfulPaintCollector`, which is used to calculate the visual size of a element in viewport. It holds references to `StackingContextTreeClipStore`. Based on the  `ScrollTreeNode`, and `Clip` that an element belongs to, as well as the IDs of their corresponding parent nodes, it can trace up to the root node, accumulate all relevant CSS along the path, and thereby calculate the visible area size of the element.

TODO: In the future, an EffectNodeTree may be added to track the usage of CSS such as filter, because blur and drop-shadow will also affect the size of the visible area of elements.

For example: for the following code segment:
```
<div id="1" style="transform: translate(20px)"> 
    <div id="2" style="width: 100px; height: 100px; overflow: hidden;">
        <div id="3" style="width: 200px; height: 200px; background-image: url(example.jpg)">
        </div>
    </div>
</div>
```
For the element with the id "3", its initial size is 200x200 and because of overflow and blur, it's clipped to 100x100. Then, affected by overflow CSS belongs to the element "2",  it's will continue to change. Finally, because element "1" has a translate style, its visible area may extend beyond the viewport. Therefore, the visible area of the element "3" will be further clipped to fit within the viewport.
