### PR TITLE
Mach: add type check on python tidy folder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ search-path = [
 ]
 project-includes = [
     "python/wpt/**/*.py",
+    "python/tidy/**/*.py",
 ]
 project-excludes = [
     "**/venv/**",

--- a/python/tidy/linting_report.py
+++ b/python/tidy/linting_report.py
@@ -8,7 +8,7 @@
 # except according to those terms.
 
 from dataclasses import dataclass
-from typing import Any, Literal, NotRequired
+from typing import Any, Literal, Optional
 
 
 @dataclass
@@ -19,20 +19,20 @@ class GithubAnnotation:
     level: Literal["notice", "warning", "error"]
     title: str
     message: str
-    column_start: NotRequired[int]
-    column_end: NotRequired[int]
+    column_start: Optional[int] = None
+    column_end: Optional[int] = None
 
 
 class GitHubAnnotationManager:
-    def __init__(self, annotation_prefix: str, limit: int = 10):
+    def __init__(self, annotation_prefix: str, limit: int = 10) -> None:
         self.annotation_prefix: str = annotation_prefix
         self.limit: int = limit
         self.total_count: int = 0
 
-    def clean_path(self, path: str):
+    def clean_path(self, path: str) -> str:
         return path.removeprefix("./")
 
-    def escape(self, s: str):
+    def escape(self, s: str) -> str:
         return s.replace("\r", "%0D").replace("\n", "%0A")
 
     def emit_annotation(
@@ -42,42 +42,38 @@ class GitHubAnnotationManager:
         file_name: str,
         line_start: int,
         line_end: int | None = None,
-        annotation_level: str = "error",
+        annotation_level: Literal["notice", "warning", "error"] = "error",
         column_start: int | None = None,
         column_end: int | None = None,
-    ):
+    ) -> None:
         if self.total_count >= self.limit:
             return
 
         if line_end is None:
             line_end = line_start
 
-        annotation: GithubAnnotation = {
-            "title": f"{self.annotation_prefix}: {self.escape(title)}",
-            "message": self.escape(message),
-            "file_name": self.clean_path(file_name),
-            "line_start": line_start,
-            "line_end": line_end,
-            "level": annotation_level,
-        }
+        annotation = GithubAnnotation(
+            title=f"{self.annotation_prefix}: {self.escape(title)}",
+            message=self.escape(message),
+            file_name=self.clean_path(file_name),
+            line_start=line_start,
+            line_end=line_end,
+            level=annotation_level,
+            column_start=column_start if line_start == line_end and column_start is not None else None,
+            column_end=column_end if line_start == line_end and column_end is not None else None,
+        )
 
-        if line_start == line_end and column_start is not None and column_end is not None:
-            annotation["column_start"] = column_start
-            annotation["column_end"] = column_end
-
-        line_info = f"line={annotation['line_start']},endLine={annotation['line_end']},title={annotation['title']}"
+        line_info = f"line={annotation.line_start},endLine={annotation.line_end},title={annotation.title}"
 
         column_info = ""
-        if "column_end" in annotation and "column_start" in annotation:
-            column_info = f"col={annotation['column_start']},endColumn={annotation['column_end']},"
+        if annotation.column_end is not None and annotation.column_start is not None:
+            column_info = f"col={annotation.column_start},endColumn={annotation.column_end},"
 
-        print(
-            f"::{annotation['level']} file={annotation['file_name']},{column_info}{line_info}::{annotation['message']}"
-        )
+        print(f"::{annotation.level} file={annotation.file_name},{column_info}{line_info}::{annotation.message}")
 
         self.total_count += 1
 
-    def emit_annotations_for_clippy(self, data: list[dict[str, Any]]):
+    def emit_annotations_for_clippy(self, data: list[dict[str, Any]]) -> None:
         severenty_map: dict[str, Literal["notice", "warning", "error"]] = {
             "help": "notice",
             "note": "notice",

--- a/python/tidy/linting_report.py
+++ b/python/tidy/linting_report.py
@@ -59,14 +59,14 @@ class GitHubAnnotationManager:
             line_start=line_start,
             line_end=line_end,
             level=annotation_level,
-            column_start=column_start if line_start == line_end and column_start is not None else None,
-            column_end=column_end if line_start == line_end and column_end is not None else None,
+            column_start=column_start,
+            column_end=column_end,
         )
 
         line_info = f"line={annotation.line_start},endLine={annotation.line_end},title={annotation.title}"
 
         column_info = ""
-        if annotation.column_end is not None and annotation.column_start is not None:
+        if line_start == line_end and annotation.column_end is not None and annotation.column_start is not None:
             column_info = f"col={annotation.column_start},endColumn={annotation.column_end},"
 
         print(f"::{annotation.level} file={annotation.file_name},{column_info}{line_info}::{annotation.message}")

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -20,6 +20,7 @@ import sys
 from dataclasses import dataclass
 from typing import Any, Dict, List, TypedDict, LiteralString
 from collections.abc import Iterator, Callable
+import types
 
 import colorama
 import toml
@@ -832,9 +833,10 @@ def lint_wpt_test_files() -> Iterator[tuple[str, int, str]]:
     messages: List[str] = []
     assert lint.logger is not None
 
-    # HACK: Ignoring this since only Pyrefly raises an issue about ovveride argument name
-    # https://github.com/facebook/pyrefly/issues/643
-    lint.logger.error = lambda message: messages.append(message)  # pyrefly: ignore[bad-assignment]
+    def collect_messages(_, message):
+        messages.append(message)
+
+    lint.logger.error = types.MethodType(collect_messages, lint.logger)
 
     # We do not lint all WPT-like tests because they do not all currently have
     # lint.ignore files.
@@ -1005,7 +1007,7 @@ def parse_config(config_file: dict[str, Any]) -> None:
     dirs_to_check = config_file.get("check_ext", {})
     # Fix the paths (OS-dependent)
     for path, exts in dirs_to_check.items():
-        # FIXME: Temporarily ignoring this since only Pyrefly raises an issue about the dynamic key
+        # FIXME: Temporarily ignoring this since only Pyrefly raises an issue constrained type variable
         # pyrefly: ignore[bad-argument-type]
         config["check_ext"][normalize_paths(path)] = exts
 

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -1117,3 +1117,6 @@ class CargoDenyKrate:
         self.parents = [CargoDenyKrate(parent) for parent in data.get("parents", [])]
         self.version = crate["version"]
         self.parents = [CargoDenyKrate(parent) for parent in data.get("parents", [])]
+
+    def __str__(self):
+        return f"{self.name}@{self.version}"

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -832,6 +832,8 @@ def lint_wpt_test_files() -> Iterator[tuple[str, int, str]]:
     messages: List[str] = []
     assert lint.logger is not None
 
+    # HACK: Ignoring this since only Pyrefly raises an issue about ovveride argument name
+    # https://github.com/facebook/pyrefly/issues/643
     lint.logger.error = lambda message: messages.append(message)  # pyrefly: ignore[bad-assignment]
 
     # We do not lint all WPT-like tests because they do not all currently have
@@ -1003,6 +1005,7 @@ def parse_config(config_file: dict[str, Any]) -> None:
     dirs_to_check = config_file.get("check_ext", {})
     # Fix the paths (OS-dependent)
     for path, exts in dirs_to_check.items():
+        # FIXME: Temporarily ignoring this since only Pyrefly raises an issue about the dynamic key
         # pyrefly: ignore[bad-argument-type]
         config["check_ext"][normalize_paths(path)] = exts
 
@@ -1014,6 +1017,7 @@ def parse_config(config_file: dict[str, Any]) -> None:
 
     for pref in user_configs:
         if pref in config:
+            # FIXME: Temporarily ignoring this since only Pyrefly raises an issue about the dynamic key
             # pyrefly: ignore[missing-attribute]
             config[pref] = user_configs[pref]
 

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -1115,8 +1115,6 @@ class CargoDenyKrate:
         self.name = crate["name"]
         self.version = crate["version"]
         self.parents = [CargoDenyKrate(parent) for parent in data.get("parents", [])]
-        self.version = crate["version"]
-        self.parents = [CargoDenyKrate(parent) for parent in data.get("parents", [])]
 
     def __str__(self):
         return f"{self.name}@{self.version}"

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -155,7 +155,7 @@ def is_iter_empty(iterator: Iterator[str]) -> tuple[bool, Iterator[str]]:
         return False, iterator
 
 
-def normalize_path(path: str) -> str:
+def relative_path(path: str) -> str:
     return os.path.relpath(os.path.abspath(path), TOPDIR)
 
 
@@ -443,7 +443,7 @@ def run_python_type_checker() -> Iterator[tuple[str, int, str]]:
     else:
         for error in errors:
             diagnostic = PyreflyDiagnostic(**error)
-            yield normalize_path(diagnostic.path), diagnostic.line, diagnostic.concise_description
+            yield relative_path(diagnostic.path), diagnostic.line, diagnostic.concise_description
 
 
 def run_cargo_deny_lints():
@@ -1007,7 +1007,9 @@ def parse_config(config_file: dict[str, Any]) -> None:
     dirs_to_check = config_file.get("check_ext", {})
     # Fix the paths (OS-dependent)
     for path, exts in dirs_to_check.items():
-        # FIXME: Temporarily ignoring this since only Pyrefly raises an issue constrained type variable
+        # FIXME: Temporarily ignoring this since the type signature for
+        # `normalize_paths` must use a constrained type variable for this to
+        # typecheck but Pyrefly doesn't handle that correctly (but mypy does).
         # pyrefly: ignore[bad-argument-type]
         config["check_ext"][normalize_paths(path)] = exts
 
@@ -1120,5 +1122,5 @@ class CargoDenyKrate:
         self.version = crate["version"]
         self.parents = [CargoDenyKrate(parent) for parent in data.get("parents", [])]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.name}@{self.version}"

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -66,7 +66,6 @@ Config = TypedDict(
     },
 )
 
-# Default configs
 config: Config = {
     "skip-check-length": False,
     "skip-check-licenses": False,

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -168,7 +168,7 @@ def normalize_paths(paths: list[str] | str) -> list[str] | str:
 
 # A simple wrapper for iterators to show progress
 # (Note that it's inefficient for giant iterators, since it iterates once to get the upper bound)
-def progress_wrapper(iterator):
+def progress_wrapper(iterator: Iterator[str]) -> Iterator[str]:
     list_of_stuff = list(iterator)
     total_files, progress = len(list_of_stuff), 0
     for idx, thing in enumerate(list_of_stuff):
@@ -873,7 +873,7 @@ def run_wpt_lints(only_changed_files: bool) -> Iterator[tuple[str, int, str]]:
     yield from lint_wpt_test_files()
 
 
-def check_spec(file_name, lines) -> Iterator[tuple[int, str]]:
+def check_spec(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:
     if SPEC_BASE_PATH not in file_name:
         return
     file_name = os.path.relpath(os.path.splitext(file_name)[0], SPEC_BASE_PATH)
@@ -991,7 +991,7 @@ def check_config_file(config_file: LiteralString, print_text: bool = True) -> It
     parse_config(config_content)
 
 
-def parse_config(config_file: dict) -> None:
+def parse_config(config_file: dict[str, Any]) -> None:
     exclude = config_file.get("ignore", {})
     # Add list of ignored directories to config
     ignored_directories = [d for p in exclude.get("directories", []) for d in (glob.glob(p) or [p])]
@@ -1020,7 +1020,7 @@ def parse_config(config_file: dict) -> None:
             config[pref] = user_configs[pref]
 
 
-def check_directory_files(directories, print_text=True) -> Iterator[tuple[str, int, str]]:
+def check_directory_files(directories: dict[str, Any], print_text: bool = True) -> Iterator[tuple[str, int, str]]:
     if print_text:
         print("\r ➤  Checking directories for correct file extensions...")
     for directory, file_extensions in directories.items():
@@ -1037,7 +1037,7 @@ def collect_errors_for_files(
     files_to_check: Iterator[str],
     checking_functions: tuple[GenericCheckingFunction[bytes], ...],
     line_checking_functions: tuple[GenericCheckingFunction[list[bytes]], ...],
-    print_text=True,
+    print_text: bool = True,
 ) -> Iterator[tuple[str, int, str]]:
     (has_element, files_to_check) = is_iter_empty(files_to_check)
     if not has_element:


### PR DESCRIPTION
Introduce `python/tidy` folder in pyrefly type checker

Testing: Manual testing via `./mach test-tidy` command
