### PR TITLE
Chore: Fix warnings for openxr

### DIFF
--- a/components/webxr/openxr/interaction_profiles.rs
+++ b/components/webxr/openxr/interaction_profiles.rs
@@ -47,6 +47,7 @@ pub enum InteractionProfileType {
 
 #[derive(Clone, Copy, Debug)]
 pub struct InteractionProfile<'a> {
+    #[allow(dead_code)]
     pub profile_type: InteractionProfileType,
     /// The interaction profile path
     pub path: &'static str,

--- a/components/webxr/openxr/mod.rs
+++ b/components/webxr/openxr/mod.rs
@@ -554,7 +554,7 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
                 let gl = contexts.bindings(device, context_id).unwrap();
                 unsafe { gl.delete_texture(depth_stencil_texture) };
             }
-            let mut context = contexts
+            let context = contexts
                 .context(device, context_id)
                 .expect("missing GL context");
             for surface_texture in mem::replace(&mut layer.surface_textures, vec![]) {


### PR DESCRIPTION
These warnings have been there for quite a while and annoying.

```
   Compiling webxr v0.0.1 (D:\servo\components\webxr)
warning: variable does not need to be mutable
   --> components\webxr\openxr\mod.rs:557:17
    |
557 |             let mut context = contexts
    |                 ----^^^^^^^
    |                 |
    |                 help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

warning: field `profile_type` is never read
  --> components\webxr\openxr\interaction_profiles.rs:50:9
   |
49 | pub struct InteractionProfile<'a> {
   |            ------------------ field in this struct
50 |     pub profile_type: InteractionProfileType,
   |         ^^^^^^^^^^^^
   |
   = note: `InteractionProfile` has derived impls for the traits `Debug` and `Clone`, but these are intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` on by default
```

Testing: No behaviour change.