### PR TITLE
BroadcastChannel: cleanup routers when closing tabs

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2000,6 +2000,12 @@ where
         if self.broadcast_routers.remove(&router_id).is_none() {
             warn!("Attempt to remove unknown broadcast-channel router.");
         }
+        // Also remove the router_id from the broadcast_channels list.
+        for channels in self.broadcast_channels.values_mut() {
+            for routers in channels.values_mut() {
+                routers.retain(|router| router != &router_id);
+            }
+        }
     }
 
     /// Add a new broadcast router.

--- a/components/shared/constellation/structured_data/mod.rs
+++ b/components/shared/constellation/structured_data/mod.rs
@@ -47,7 +47,7 @@ pub struct StructuredSerializedData {
 impl StructuredSerializedData {
     fn is_empty(&self, val: Transferrable) -> bool {
         fn is_field_empty<K, V>(field: &Option<HashMap<K, V>>) -> bool {
-            field.as_ref().is_some_and(|h| h.is_empty())
+            field.as_ref().is_none_or(|h| h.is_empty())
         }
         match val {
             Transferrable::ImageBitmap => is_field_empty(&self.transferred_image_bitmaps),


### PR DESCRIPTION
BroadcastChannel uses 2 hash maps in the constellation and they were not kept properly in sync. Also fixed a logic error where `Option<HashMap<...>>` was not considered empty when being `None`.

Testing: These warnings should not happen anymore:
[2025-07-14T03:54:22Z WARN  constellation::constellation] No sender for broadcast router: (4,1)

[2025-07-14T03:33:59Z WARN  constellation_traits::structured_data] Attempt to broadcast structured serialized data including ImageBitmap (should never happen).
[2025-07-14T03:33:59Z WARN  constellation_traits::structured_data] Attempt to broadcast structured serialized data including MessagePort (should never happen).
[2025-07-14T03:33:59Z WARN  constellation_traits::structured_data] Attempt to broadcast structured serialized data including OffscreenCanvas (should never happen).
[2025-07-14T03:33:59Z WARN  constellation_traits::structured_data] Attempt to broadcast structured serialized data including ReadableStream (should never happen).
[2025-07-14T03:33:59Z WARN  constellation_traits::structured_data] Attempt to broadcast structured serialized data including WritableStream (should never happen).
[2025-07-14T03:33:59Z WARN  constellation_traits::structured_data] Attempt to broadcast structured serialized data including TransformStream (should never happen).


