### PR TITLE
CI: Run webdriver tests using one process and 2 chunks

### DIFF
--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -119,10 +119,11 @@ def handle_preset(s: str) -> Optional[JobConfig]:
                     "./tests/wpt/tests/webdriver/tests/classic/",
                     "--product servodriver",
                     "--headless",
+                    "--processes 1",
                 ]
             ),
             unit_tests=False,
-            number_of_wpt_chunks=1,
+            number_of_wpt_chunks=2,
         )
     elif any(word in s for word in ["lint", "tidy"]):
         return JobConfig("Lint", Workflow.LINT)


### PR DESCRIPTION
- Make the test more stable with setting one process only for each chunk, while still running it concurrently with different machine for each chunk.
- Previously, there is an issue where the log files is too big to be uploaded to intermittent tracker. Now the log file should be smaller even if we have many errors, since we have multiple chunk.
