### PR TITLE
servoshell: Send all button events to the `WebView` regardless of what button is pressed

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -594,9 +594,7 @@ impl WindowPortsMethods for Window {
             WindowEvent::KeyboardInput { event, .. } => self.handle_keyboard_input(state, event),
             WindowEvent::ModifiersChanged(modifiers) => self.modifiers_state.set(modifiers.state()),
             WindowEvent::MouseInput { state, button, .. } => {
-                if button == MouseButton::Left || button == MouseButton::Right {
-                    self.handle_mouse(&webview, button, state);
-                }
+                self.handle_mouse(&webview, button, state);
             },
             WindowEvent::CursorMoved { position, .. } => {
                 let mut point = winit_position_to_euclid_point(position).to_f32();


### PR DESCRIPTION
Sending all mouse button events (Left, Right, Middle, Back, Forward) to the constellation for processing. Before, only left and right mouse buttons were handled.

Testing: There is no new test for this. Manually testing was done. We currently
do not have a good way to test user interaction in servoshell.
Fixes: #37996