### PR TITLE
webdriver: Allow script thread to fail to send response for `ExecuteScript`

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -529,12 +529,17 @@ pub(crate) fn handle_execute_script(
                 Err(WebDriverJSError::JSError)
             };
 
-            reply.send(result).unwrap();
+            if reply.send(result).is_err() {
+                info!("Webdriver might already be released by embedder before reply is sent");
+            };
         },
         None => {
-            reply
+            if reply
                 .send(Err(WebDriverJSError::BrowsingContextNotFound))
-                .unwrap();
+                .is_err()
+            {
+                info!("Webdriver might already be released by embedder before reply is sent");
+            };
         },
     }
 }

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/execute.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/execute.py.ini
@@ -1,25 +1,6 @@
 [execute.py]
-  expected: TIMEOUT
   [test_no_browsing_context]
     expected: FAIL
 
   [test_opening_new_window_keeps_current_window_handle]
-    expected: FAIL
-
-  [test_abort_by_user_prompt[alert\]]
-    expected: FAIL
-
-  [test_abort_by_user_prompt[confirm\]]
-    expected: FAIL
-
-  [test_abort_by_user_prompt[prompt\]]
-    expected: FAIL
-
-  [test_abort_by_user_prompt_twice[alert\]]
-    expected: FAIL
-
-  [test_abort_by_user_prompt_twice[confirm\]]
-    expected: FAIL
-
-  [test_abort_by_user_prompt_twice[prompt\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/switch_to_window/switch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/switch_to_window/switch.py.ini
@@ -1,6 +1,0 @@
-[switch.py]
-  [test_finds_exising_user_prompt_after_tab_switch[confirm\]]
-    expected: ERROR
-
-  [test_finds_exising_user_prompt_after_tab_switch[prompt\]]
-    expected: ERROR


### PR DESCRIPTION
When script thread executes script sent from webdriver, if an alert appears, webdriver can stop waiting for the script response and process the next command.

This PR allows script thread to fail to send response for `ExecuteScript` if the channel is closed.

cc: @xiaochengh 
