### PR TITLE
compositor: Do not wait for animation termination to take screenshots

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -139,12 +139,6 @@ impl WebViewRenderer {
         }
     }
 
-    pub(crate) fn animations_or_animation_callbacks_running(&self) -> bool {
-        self.pipelines
-            .values()
-            .any(PipelineDetails::animations_or_animation_callbacks_running)
-    }
-
     pub(crate) fn animation_callbacks_running(&self) -> bool {
         self.pipelines
             .values()

--- a/tests/wpt/meta/css/css-animations/animation-delay-008.html.ini
+++ b/tests/wpt/meta/css/css-animations/animation-delay-008.html.ini
@@ -1,2 +1,2 @@
 [animation-delay-008.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/css/css-animations/animation-delay-009.html.ini
+++ b/tests/wpt/meta/css/css-animations/animation-delay-009.html.ini
@@ -1,2 +1,2 @@
 [animation-delay-009.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/css/css-animations/animation-important-002.html.ini
+++ b/tests/wpt/meta/css/css-animations/animation-important-002.html.ini
@@ -1,2 +1,2 @@
 [animation-important-002.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/css/css-animations/crashtests/chrome-bug-404743651.html.ini
+++ b/tests/wpt/meta/css/css-animations/crashtests/chrome-bug-404743651.html.ini
@@ -1,2 +1,0 @@
-[chrome-bug-404743651.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-animations/inheritance-pseudo-element.html.ini
+++ b/tests/wpt/meta/css/css-animations/inheritance-pseudo-element.html.ini
@@ -1,2 +1,2 @@
 [inheritance-pseudo-element.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/css/css-animations/transform-animation-under-large-scale.html.ini
+++ b/tests/wpt/meta/css/css-animations/transform-animation-under-large-scale.html.ini
@@ -1,2 +1,0 @@
-[transform-animation-under-large-scale.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-animations/translation-animation-on-important-property.html.ini
+++ b/tests/wpt/meta/css/css-animations/translation-animation-on-important-property.html.ini
@@ -1,2 +1,0 @@
-[translation-animation-on-important-property.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-animations/translation-animation-subpixel-offset.html.ini
+++ b/tests/wpt/meta/css/css-animations/translation-animation-subpixel-offset.html.ini
@@ -1,2 +1,0 @@
-[translation-animation-subpixel-offset.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-element-not-visible-at-current-viewport.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-element-not-visible-at-current-viewport.html.ini
@@ -1,2 +1,0 @@
-[background-color-animation-element-not-visible-at-current-viewport.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-fragmented.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-fragmented.html.ini
@@ -1,2 +1,0 @@
-[background-color-animation-fragmented.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-in-body.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-in-body.html.ini
@@ -1,2 +1,0 @@
-[background-color-animation-in-body.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-non-zero-size-element-change-to-zero.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-non-zero-size-element-change-to-zero.html.ini
@@ -1,2 +1,0 @@
-[background-color-animation-non-zero-size-element-change-to-zero.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-with-images.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-with-images.html.ini
@@ -1,2 +1,0 @@
-[background-color-animation-with-images.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-with-table2.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-with-table2.html.ini
@@ -1,2 +1,0 @@
-[background-color-animation-with-table2.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-with-table3.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-with-table3.html.ini
@@ -1,2 +1,0 @@
-[background-color-animation-with-table3.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-zero-size-element-change-to-non-zero.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/animations/background-color-animation-zero-size-element-change-to-non-zero.html.ini
@@ -1,2 +1,0 @@
-[background-color-animation-zero-size-element-change-to-non-zero.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/animations/background-color-transition.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/animations/background-color-transition.html.ini
@@ -1,2 +1,0 @@
-[background-color-transition.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/animations/background-color-transparent-animation-in-body.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/animations/background-color-transparent-animation-in-body.html.ini
@@ -1,2 +1,0 @@
-[background-color-transparent-animation-in-body.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/animations/invalidation/background-color-animation-with-zero-alpha.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/animations/invalidation/background-color-animation-with-zero-alpha.html.ini
@@ -1,2 +1,0 @@
-[background-color-animation-with-zero-alpha.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-cascade/important-prop.html.ini
+++ b/tests/wpt/meta/css/css-cascade/important-prop.html.ini
@@ -1,2 +1,0 @@
-[important-prop.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-conditional/container-queries/crashtests/size-change-during-transition-crash.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/crashtests/size-change-during-transition-crash.html.ini
@@ -1,2 +1,0 @@
-[size-change-during-transition-crash.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-fonts/font-size-monospace-adjust.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-size-monospace-adjust.html.ini
@@ -1,2 +1,0 @@
-[font-size-monospace-adjust.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-pseudo/first-line-inherited-with-transition.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/first-line-inherited-with-transition.html.ini
@@ -1,2 +1,2 @@
 [first-line-inherited-with-transition.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/css/css-shadow-parts/animation-part.html.ini
+++ b/tests/wpt/meta/css/css-shadow-parts/animation-part.html.ini
@@ -1,2 +1,0 @@
-[animation-part.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-transforms/animation/rotate-animation-with-will-change-transform-001.html.ini
+++ b/tests/wpt/meta/css/css-transforms/animation/rotate-animation-with-will-change-transform-001.html.ini
@@ -1,2 +1,0 @@
-[rotate-animation-with-will-change-transform-001.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-transforms/backface-visibility-hidden-animated-001.html.ini
+++ b/tests/wpt/meta/css/css-transforms/backface-visibility-hidden-animated-001.html.ini
@@ -1,2 +1,0 @@
-[backface-visibility-hidden-animated-001.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-transforms/backface-visibility-hidden-animated-002.html.ini
+++ b/tests/wpt/meta/css/css-transforms/backface-visibility-hidden-animated-002.html.ini
@@ -1,2 +1,0 @@
-[backface-visibility-hidden-animated-002.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-transforms/individual-transform/animation/individual-transform-combine.html.ini
+++ b/tests/wpt/meta/css/css-transforms/individual-transform/animation/individual-transform-combine.html.ini
@@ -1,2 +1,2 @@
 [individual-transform-combine.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/individual-transform/animation/individual-transform-ordering.html.ini
+++ b/tests/wpt/meta/css/css-transforms/individual-transform/animation/individual-transform-ordering.html.ini
@@ -1,2 +1,2 @@
 [individual-transform-ordering.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/individual-transform/stacking-context-001.html.ini
+++ b/tests/wpt/meta/css/css-transforms/individual-transform/stacking-context-001.html.ini
@@ -1,2 +1,2 @@
 [stacking-context-001.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transitions/allow-discrete-auto-inset.html.ini
+++ b/tests/wpt/meta/css/css-transitions/allow-discrete-auto-inset.html.ini
@@ -1,2 +1,0 @@
-[allow-discrete-auto-inset.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-values/vh-interpolate-pct.html.ini
+++ b/tests/wpt/meta/css/css-values/vh-interpolate-pct.html.ini
@@ -1,2 +1,0 @@
-[vh-interpolate-pct.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-values/vh-interpolate-px.html.ini
+++ b/tests/wpt/meta/css/css-values/vh-interpolate-px.html.ini
@@ -1,2 +1,0 @@
-[vh-interpolate-px.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-values/vh-interpolate-vh.html.ini
+++ b/tests/wpt/meta/css/css-values/vh-interpolate-vh.html.ini
@@ -1,2 +1,0 @@
-[vh-interpolate-vh.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/filter-effects/crashtests/broken-reference-crash-001.html.ini
+++ b/tests/wpt/meta/css/filter-effects/crashtests/broken-reference-crash-001.html.ini
@@ -1,2 +1,0 @@
-[broken-reference-crash-001.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/rendering/widgets/appearance/appearance-animation-001.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/appearance/appearance-animation-001.html.ini
@@ -1,2 +1,0 @@
-[appearance-animation-001.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/rendering/widgets/appearance/appearance-animation-002.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/appearance/appearance-animation-002.html.ini
@@ -1,2 +1,2 @@
 [appearance-animation-002.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/html/rendering/widgets/appearance/appearance-transition-001.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/appearance/appearance-transition-001.html.ini
@@ -1,2 +1,0 @@
-[appearance-transition-001.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/rendering/widgets/appearance/appearance-transition-002.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/appearance/appearance-transition-002.html.ini
@@ -1,2 +1,0 @@
-[appearance-transition-002.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/rendering/widgets/appearance/appearance-transition-003.html.ini
+++ b/tests/wpt/meta/html/rendering/widgets/appearance/appearance-transition-003.html.ini
@@ -1,2 +1,2 @@
 [appearance-transition-003.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2887,7 +2887,7 @@
      ]
     ],
     "incremental_trailing_whitespace_a.html": [
-     "f59bd91d9ea23effec2a888649e345937cf0addd",
+     "eca05c4f79fb786492e81aa7881aaa0d75899811",
      [
       null,
       [
@@ -3186,7 +3186,7 @@
      ]
     ],
     "inline_block_opacity_change.html": [
-     "aa51ab444cddb381b6ca76615a30573f49f6f6c3",
+     "6df5d7466d6569a7d1969d5c49a83a7a3564ef7b",
      [
       null,
       [

--- a/tests/wpt/mozilla/tests/css/incremental_trailing_whitespace_a.html
+++ b/tests/wpt/mozilla/tests/css/incremental_trailing_whitespace_a.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html class="reftest-wait">
   <head>
     <meta charset="utf-8">
     <title>incremental trailing whitespace test</title>
@@ -19,9 +19,13 @@
       <div id="a" style="transition: all .1s ease-out;">Hello</div>
     </div>
     <script>
+      let transitioningDiv = document.querySelector('#a');
+      transitioningDiv.addEventListener('transitionend', () => {
+        document.documentElement.classList.remove("reftest-wait");
+      });
+
       document.body.offsetWidth; // force layout
-      document.querySelector('#a').classList.add('go');
-      // FIXME (#10245): Wait for the "transitionend" event.
+      transitioningDiv.classList.add('go');
     </script>
   </body>
 </html>

--- a/tests/wpt/mozilla/tests/css/inline_block_opacity_change.html
+++ b/tests/wpt/mozilla/tests/css/inline_block_opacity_change.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="reftest-wait">
 <head>
     <link rel="match" href="inline_block_opacity_change_ref.html">
     <style>
@@ -19,8 +19,13 @@
 <body>
     <span style="transition: opacity .1s ease-out;" id="a">a</span>
     <script>
+            let transitioningSpan = document.querySelector('#a');
+            transitioningSpan.addEventListener("transitionend", () => {
+              document.documentElement.classList.remove("reftest-wait");
+            });
+
             document.body.offsetWidth; // force layout
-            document.querySelector('#a').classList.add('go');
+            transitioningSpan.classList.add('go');
     </script>
 </body>
 </html>


### PR DESCRIPTION
WPT tests are expected to create screenshots as soon as everything is
loaded. If an animation is happening adding the "reftest-wait" class to
the root element is appropriate way to delay the screenshot. Previously, the
test harness was waiting for all animations to finish, but that is just
leading to many timeouts. Removing that code fixes the timeouts.

Two Servo-specific tests are also updated as they were written with
Servo's previous behavior in mind.

Testing: There are test result updates for this change. Many TIMEOUTS now either correctly
PASS OR FAIL.
Fixes: #36931.
