### PR TITLE
layout: dirty parent node with NodeDamage::ContentOrHeritage when text content changed

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -817,7 +817,13 @@ impl Node {
 
         match self.type_id() {
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text)) => {
-                self.parent_node.get().unwrap().dirty(damage)
+                // For content changes in text nodes, we should accurately use
+                // [`NodeDamage::ContentOrHeritage`] to mark the parent node, thereby
+                // reducing the scope of incremental box tree construction.
+                self.parent_node
+                    .get()
+                    .unwrap()
+                    .dirty(NodeDamage::ContentOrHeritage)
             },
             NodeTypeId::Element(_) => self.downcast::<Element>().unwrap().restyle(damage),
             NodeTypeId::DocumentFragment(DocumentFragmentTypeId::ShadowRoot) => self


### PR DESCRIPTION
This change aims to reduce the scope of incremental box tree construction. Previously, when text content changed, the parent node would always be marked as requiring box tree reconstruction; now, it is adjusted to only mark the parent node as needing to recollect its box tree children.

Testing: This should not change observable behavior and is thus covered by existing WPT tests.