### PR TITLE
layout: Correctly marking box damage when text-related style changed

### DIFF
--- a/tests/wpt/tests/css/css-text/white-space/pre-001.html
+++ b/tests/wpt/tests/css/css-text/white-space/pre-001.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>CSS-white-space test: restore collapsed whitespace</title>
+<link rel="author" title="JoeDow" href="ibluegalaxy_taoj@163.com">
+<link rel="match" href="reference/pre-001-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#white-space-property">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+html {
+  font: 20px/1 Ahem;
+}
+.span {
+    background-color: blueviolet;
+}
+#target {
+    background-color: blue;
+}
+</style>
+<body>
+  <div>
+    <span class="span">aa bb </span><span id="target">     target </span><span class="span">bb aa</span>
+  </div>
+
+  <script>
+    window.onload = function() {
+        const target = document.getElementById("target");
+        // force layout
+        target.offsetLeft;
+        target.style.whiteSpace = "pre";
+    }
+  </script>
+</body>

--- a/tests/wpt/tests/css/css-text/white-space/reference/pre-001-ref.html
+++ b/tests/wpt/tests/css/css-text/white-space/reference/pre-001-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
+<style>
+html {
+  font: 20px/1 Ahem;
+}
+.span {
+    background-color: blueviolet;
+}
+#target {
+    background-color: blue;
+    white-space: pre;
+}
+</style>
+<body>
+  <div>
+    <span class="span">aa bb </span><span id="target">     target </span><span class="span">bb aa</span>
+  </div>
+</body>


### PR DESCRIPTION
This change aims to supplement the missing incremental box tree construction when text-related styles change. Since certain text style adjustments can alter visible text content and typography. Therefore, the parent nodes of such text are marked as needing to re-collect their box tree children to ensure the correct display of text.