### PR TITLE
indexeddb: Allow deleting unknown DBs.

### DIFF
--- a/components/net/indexeddb/idb_thread.rs
+++ b/components/net/indexeddb/idb_thread.rs
@@ -297,11 +297,17 @@ impl IndexedDBManager {
                 }
             },
             SyncOperation::DeleteDatabase(sender, origin, db_name) => {
+                // https://w3c.github.io/IndexedDB/#delete-a-database
+                // Step 4. Let db be the database named name in storageKey,
+                // if one exists. Otherwise, return 0 (zero).
                 let idb_description = IndexedDBDescription {
                     origin,
                     name: db_name,
                 };
-                self.databases.remove(&idb_description);
+                if self.databases.remove(&idb_description).is_none() {
+                    let _ = sender.send(Ok(()));
+                    return;
+                }
 
                 // FIXME:(rasviitanen) Possible security issue?
                 // FIXME:(arihant2math) using remove_dir_all with arbitrary input ...

--- a/tests/wpt/meta/IndexedDB/database-names-by-origin.html.ini
+++ b/tests/wpt/meta/IndexedDB/database-names-by-origin.html.ini
@@ -1,13 +1,12 @@
 [database-names-by-origin.html]
-  expected: TIMEOUT
   [open database names don't leak to cross-origin iframe]
-    expected: TIMEOUT
+    expected: FAIL
 
   [open database names don't leak to cross-origin window]
-    expected: NOTRUN
+    expected: FAIL
 
   [closed database names don't leak to cross-origin iframe]
-    expected: NOTRUN
+    expected: FAIL
 
   [closed database names don't leak to cross-origin window]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idb-binary-key-detached.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idb-binary-key-detached.any.js.ini
@@ -1,4 +1,5 @@
 [idb-binary-key-detached.any.html]
+  expected: CRASH
   [Detached ArrayBuffers must throw DataError when used as a key]
     expected: FAIL
 
@@ -7,6 +8,7 @@
 
 
 [idb-binary-key-detached.any.worker.html]
+  expected: CRASH
   [Detached ArrayBuffers must throw DataError when used as a key]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbdatabase_createObjectStore.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbdatabase_createObjectStore.any.js.ini
@@ -11,16 +11,10 @@
   [Empty name]
     expected: FAIL
 
-  [Attempting to create an existing object store with a different keyPath throw ConstraintError ]
-    expected: FAIL
-
   [Object store 'name' and 'keyPath' properties are correctly set ]
     expected: FAIL
 
   [Attempt to create an object store outside of a version change transaction ]
-    expected: FAIL
-
-  [Attempt to create an object store that already exists ]
     expected: FAIL
 
   [Attempt to create an object store with an invalid key path ]
@@ -40,16 +34,10 @@
   [Empty name]
     expected: FAIL
 
-  [Attempting to create an existing object store with a different keyPath throw ConstraintError ]
-    expected: FAIL
-
   [Object store 'name' and 'keyPath' properties are correctly set ]
     expected: FAIL
 
   [Attempt to create an object store outside of a version change transaction ]
-    expected: FAIL
-
-  [Attempt to create an object store that already exists ]
     expected: FAIL
 
   [Attempt to create an object store with an invalid key path ]

--- a/tests/wpt/meta/IndexedDB/idbfactory-deleteDatabase-request-success.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory-deleteDatabase-request-success.any.js.ini
@@ -1,15 +1,9 @@
 [idbfactory-deleteDatabase-request-success.any.worker.html]
-  [IDBFactory deleteDatabase() request properties on success]
-    expected: FAIL
-
 
 [idbfactory-deleteDatabase-request-success.any.serviceworker.html]
   expected: ERROR
 
 [idbfactory-deleteDatabase-request-success.any.html]
-  [IDBFactory deleteDatabase() request properties on success]
-    expected: FAIL
-
 
 [idbfactory-deleteDatabase-request-success.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbrequest-onupgradeneeded.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbrequest-onupgradeneeded.any.js.ini
@@ -1,4 +1,5 @@
 [idbrequest-onupgradeneeded.any.worker.html]
+  expected: TIMEOUT
   [indexedDB.delete called from upgradeneeded handler]
     expected: FAIL
 
@@ -9,10 +10,11 @@
     expected: FAIL
 
   [transaction oncomplete ordering relative to open request onsuccess]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [idbrequest-onupgradeneeded.any.html]
+  expected: TIMEOUT
   [indexedDB.delete called from upgradeneeded handler]
     expected: FAIL
 
@@ -23,7 +25,7 @@
     expected: FAIL
 
   [transaction oncomplete ordering relative to open request onsuccess]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [idbrequest-onupgradeneeded.any.serviceworker.html]

--- a/tests/wpt/meta/wasm/webapi/historical.any.js.ini
+++ b/tests/wpt/meta/wasm/webapi/historical.any.js.ini
@@ -5,10 +5,12 @@
   expected: ERROR
 
 [historical.any.worker.html]
+  expected: CRASH
   [historical]
     expected: FAIL
 
 
 [historical.any.html]
+  expected: CRASH
   [historical]
     expected: FAIL


### PR DESCRIPTION
The current behaviour is too strict according to the spec and is the cause of many intermittent test errors.

Testing: Existing coverage is sufficient.
Fixes: #37706
