### PR TITLE
WebDriver: Implement some missing steps of wait for navigation to complete

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -973,7 +973,7 @@ impl Handler {
             webview_id,
             self.load_status_sender.clone(),
         ))?;
-        self.wait_for_load()
+        self.wait_for_navigation_to_complete()
     }
 
     fn handle_go_forward(&self) -> WebDriverResult<WebDriverResponse> {
@@ -986,7 +986,7 @@ impl Handler {
             webview_id,
             self.load_status_sender.clone(),
         ))?;
-        self.wait_for_load()
+        self.wait_for_navigation_to_complete()
     }
 
     fn handle_refresh(&self) -> WebDriverResult<WebDriverResponse> {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -791,7 +791,7 @@ impl Handler {
         let session = self.session()?;
 
         // Step 1
-        if session.page_loading_strategy == "none".to_string() {
+        if session.page_loading_strategy == "none" {
             return Ok(WebDriverResponse::Void);
         }
 

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -790,12 +790,14 @@ impl Handler {
 
         let session = self.session()?;
 
-        // Step 1
+        // Step 1. If session's page loading strategy is "none",
+        // return success with data null.
         if session.page_loading_strategy == "none" {
             return Ok(WebDriverResponse::Void);
         }
 
-        // Step 2
+        // Step 2. If session's current browsing context is no longer open,
+        // return success with data null.
         if self
             .verify_browsing_context_is_open(session.browsing_context_id)
             .is_err()
@@ -803,8 +805,10 @@ impl Handler {
             return Ok(WebDriverResponse::Void);
         }
 
-        // Step 3
+        // Step 3. let timeout be the session's page load timeout.
         let timeout = self.session()?.load_timeout;
+
+        // TODO: Step 4. Implement timer parameter
 
         let result = select! {
             recv(self.load_status_receiver) -> res => {


### PR DESCRIPTION
Based on https://w3c.github.io/webdriver/#dfn-wait-for-navigation-to-complete. We still have not implement the timer parameter, but I think it makes sense to implement Step 8.4 of `Navigation To` first.