### PR TITLE
layout: Add incremental box tree construction for inline boxes

### DIFF
--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -114,8 +114,8 @@ impl InlineBoxes {
 
     pub(super) fn start_inline_box(
         &mut self,
-        mut inline_box: InlineBox,
-    ) -> (InlineBoxIdentifier, ArcRefCell<InlineBox>) {
+        inline_box: ArcRefCell<InlineBox>,
+    ) -> InlineBoxIdentifier {
         assert!(self.inline_boxes.len() <= u32::MAX as usize);
         assert!(self.inline_box_tree.len() <= u32::MAX as usize);
 
@@ -126,14 +126,13 @@ impl InlineBoxes {
             index_of_start_in_tree,
             index_in_inline_boxes,
         };
-        inline_box.identifier = identifier;
-        let inline_box = ArcRefCell::new(inline_box);
+        inline_box.borrow_mut().identifier = identifier;
 
-        self.inline_boxes.push(inline_box.clone());
+        self.inline_boxes.push(inline_box);
         self.inline_box_tree
             .push(InlineBoxTreePathToken::Start(identifier));
 
-        (identifier, inline_box)
+        identifier
     }
 
     pub(super) fn get_path(


### PR DESCRIPTION
This changes extend the incremental box tree construction for inline boxes.  Since an `InlineItem` can be split into multiple `InlineItem`s by a block element, the reason such an inline item is marked as damaged may simply be the removal of the block element or the need to reconstruct its box tree. Therefore, under the current LayoutDamage design, theoretically, even damaged inline items might still have some of their splits reusable. However, based on the principle of simplicity and effectiveness, this PR only considers reusing undamaged inline boxes.

Testing: This should not change observable behavior and is thus covered by existing WPT tests.