### PR TITLE
webdriver: improve perform pointermove & wheel actions with more accurate coordinates

### DIFF
--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -86,8 +86,8 @@ pub enum WebDriverCommandMsg {
     /// Act as if the mouse wheel is scrolled in the browsing context given the given ID.
     WheelScrollAction(
         WebViewId,
-        f32,
-        f32,
+        f64,
+        f64,
         f64,
         f64,
         // None if it's not the last `perform_wheel_scroll` since we only

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -470,7 +470,7 @@ impl Handler {
                 // Steps 1 - 2: Check "no such element", covered in script thread handler.
 
                 // Step 3. Let x element and y element be the result of calculating the in-view center point of element.
-                let (x_element, y_element) = self.get_element_in_view_center_point(&web_element)?;
+                let (x_element, y_element) = self.get_element_in_view_center_point(web_element)?;
                 // Step 4. Let x equal x element + x offset, and y equal y element + y offset.
                 Ok((x_element as f64 + x_offset, y_element as f64 + y_offset))
             },

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -644,6 +644,13 @@ impl Handler {
         // Step 3. Let origin be equal to the origin property of action object.
         let origin = &action.origin;
 
+        // Pointer origin isn't currently supported for wheel input source
+        // See: https://github.com/w3c/webdriver/issues/1758
+
+        if origin == &PointerOrigin::Pointer {
+            return Err(ErrorStatus::InvalidArgument);
+        }
+
         // Step 4. Let (x, y) be the result of trying to get coordinates relative to an origin
         // with source, x offset, y offset, origin, browsing context, and actions options.
         let (x, y) =

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -560,7 +560,7 @@ impl App {
                             ScrollLocation::Delta(Vector2D::new(dx as f32, dy as f32));
 
                         webview.notify_input_event(
-                            InputEvent::Wheel(WheelEvent::new(delta, point))
+                            InputEvent::Wheel(WheelEvent::new(delta, point.to_f32()))
                                 .with_webdriver_message_id(webdriver_message_id),
                         );
 

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/key_shortcuts.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/key_shortcuts.py.ini
@@ -1,3 +1,0 @@
-[key_shortcuts.py]
-  [test_mod_a_mod_c_right_mod_v_pastes_text]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_mouse.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_mouse.py.ini
@@ -29,8 +29,5 @@
   [test_move_to_origin_position_within_frame[element\]]
     expected: FAIL
 
-  [test_params_actions_origin_outside_viewport[element\]]
-    expected: FAIL
-
   [test_move_to_position_in_viewport[default value\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_origin.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_origin.py.ini
@@ -1,3 +1,0 @@
-[pointer_origin.py]
-  [test_element_center_point_with_offset]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_pen.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_pen.py.ini
@@ -19,6 +19,3 @@
 
   [test_pen_pointer_properties]
     expected: FAIL
-
-  [test_params_actions_origin_outside_viewport[element\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_touch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_touch.py.ini
@@ -28,6 +28,3 @@
 
   [test_move_to_fractional_position]
     expected: FAIL
-
-  [test_params_actions_origin_outside_viewport[element\]]
-    expected: FAIL


### PR DESCRIPTION
1. Create `get_origin_relative_coordinates` according to [spec](https://w3c.github.io/webdriver/#dfn-get-coordinates-relative-to-an-origin) to be reused
2. Add previously missing offset for PointerOrigin::Element
3. Refactor code for perform pointermove/wheel to be closer to spec.
4. Handle some issues with spec: https://github.com/w3c/webdriver/issues/1758

Testing: Several new passing cases as we are more precise with coordinates now.
Fixes: Part of #38042.
