### PR TITLE
canvas: Use stored transform instead of querying canvas paint thread

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -231,10 +231,6 @@ impl<'a> CanvasPaintThread<'a> {
             Canvas2dMsg::SetLineDashOffset(offset) => {
                 self.canvas(canvas_id).set_line_dash_offset(offset)
             },
-            Canvas2dMsg::GetTransform(sender) => {
-                let transform = self.canvas(canvas_id).get_transform();
-                sender.send(transform).unwrap();
-            },
             Canvas2dMsg::SetTransform(ref matrix) => self.canvas(canvas_id).set_transform(matrix),
             Canvas2dMsg::SetGlobalAlpha(alpha) => self.canvas(canvas_id).set_global_alpha(alpha),
             Canvas2dMsg::SetGlobalComposition(op) => {
@@ -567,12 +563,6 @@ impl Canvas<'_> {
     fn clip_path(&mut self, path: &Path) {
         match self {
             Canvas::Raqote(canvas_data) => canvas_data.clip_path(path),
-        }
-    }
-
-    fn get_transform(&self) -> Transform2D<f32> {
-        match self {
-            Canvas::Raqote(canvas_data) => canvas_data.get_transform(),
         }
     }
 

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -1965,10 +1965,7 @@ impl CanvasState {
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-gettransform
     pub(crate) fn get_transform(&self, global: &GlobalScope, can_gc: CanGc) -> DomRoot<DOMMatrix> {
-        let (sender, receiver) = ipc::channel::<Transform2D<f32>>().unwrap();
-        self.send_canvas_2d_msg(Canvas2dMsg::GetTransform(sender));
-        let transform = receiver.recv().unwrap();
-
+        let transform = self.state.borrow_mut().transform;
         DOMMatrix::new(global, true, transform.cast::<f64>().to_3d(), can_gc)
     }
 

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -436,7 +436,6 @@ pub enum Canvas2dMsg {
     FillText(String, f64, f64, Option<f64>, FillOrStrokeStyle, bool),
     FillRect(Rect<f32>, FillOrStrokeStyle),
     GetImageData(Rect<u32>, Size2D<u32>, IpcSender<IpcSnapshot>),
-    GetTransform(IpcSender<Transform2D<f32>>),
     IsPointInCurrentPath(f64, f64, FillRule, IpcSender<bool>),
     LineTo(Point2D<f32>),
     MoveTo(Point2D<f32>),


### PR DESCRIPTION
We already store transform in context state, so let's just use this when querying instead of using IPC to ask canvas paint thread.

Testing: Existing WPT tests
work towards #38022

try run: https://github.com/sagudev/servo/actions/runs/16299182583
