### PR TITLE
script: further use of safe to jsval

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -16,13 +16,12 @@ use js::jsval::UndefinedValue;
 use js::rust::wrappers::{JS_ErrorFromException, JS_GetPendingException, JS_SetPendingException};
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use libc::c_uint;
+use script_bindings::conversions::SafeToJSValConvertible;
 pub(crate) use script_bindings::error::*;
 
 #[cfg(feature = "js_backtrace")]
 use crate::dom::bindings::cell::DomRefCell;
-use crate::dom::bindings::conversions::{
-    ConversionResult, FromJSValConvertible, ToJSValConvertible, root_from_object,
-};
+use crate::dom::bindings::conversions::{ConversionResult, FromJSValConvertible, root_from_object};
 use crate::dom::bindings::str::USVString;
 use crate::dom::domexception::{DOMErrorName, DOMException};
 use crate::dom::globalscope::GlobalScope;
@@ -80,7 +79,7 @@ pub(crate) fn throw_dom_exception(
                     can_gc,
                 );
                 rooted!(in(*cx) let mut thrown = UndefinedValue());
-                exception.to_jsval(*cx, thrown.handle_mut());
+                exception.safe_to_jsval(cx, thrown.handle_mut());
                 JS_SetPendingException(*cx, thrown.handle(), ExceptionStackBehavior::Capture);
                 return;
             },
@@ -119,7 +118,7 @@ pub(crate) fn throw_dom_exception(
         assert!(!JS_IsExceptionPending(*cx));
         let exception = DOMException::new(global, code, can_gc);
         rooted!(in(*cx) let mut thrown = UndefinedValue());
-        exception.to_jsval(*cx, thrown.handle_mut());
+        exception.safe_to_jsval(cx, thrown.handle_mut());
         JS_SetPendingException(*cx, thrown.handle(), ExceptionStackBehavior::Capture);
     }
 }

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -32,10 +32,10 @@ use js::jsapi::{
 use js::jsval::UndefinedValue;
 use js::rust::wrappers::{JS_ReadStructuredClone, JS_WriteStructuredClone};
 use js::rust::{CustomAutoRooterGuard, HandleValue, MutableHandleValue};
-use script_bindings::conversions::IDLInterface;
+use script_bindings::conversions::{IDLInterface, SafeToJSValConvertible};
 use strum::IntoEnumIterator;
 
-use crate::dom::bindings::conversions::{ToJSValConvertible, root_from_object};
+use crate::dom::bindings::conversions::root_from_object;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::serializable::{Serializable, StorageKey};
@@ -594,7 +594,7 @@ pub(crate) fn write(
     unsafe {
         rooted!(in(*cx) let mut val = UndefinedValue());
         if let Some(transfer) = transfer {
-            transfer.to_jsval(*cx, val.handle_mut());
+            transfer.safe_to_jsval(cx, val.handle_mut());
         }
         let mut sc_writer = StructuredDataWriter::default();
         let sc_writer_ptr = &mut sc_writer as *mut _;

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -13,6 +13,7 @@ use js::jsapi::{
     CallArgs, DOMCallbacks, HandleObject as RawHandleObject, JS_FreezeObject, JSContext, JSObject,
 };
 use js::rust::{HandleObject, MutableHandleValue, get_object_class, is_dom_class};
+use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::interfaces::{DomHelpers, Interface};
 use script_bindings::settings_stack::StackEntry;
 
@@ -59,7 +60,7 @@ pub(crate) fn to_frozen_array<T: ToJSValConvertible>(
     mut rval: MutableHandleValue,
     _can_gc: CanGc,
 ) {
-    unsafe { convertibles.to_jsval(*cx, rval.reborrow()) };
+    convertibles.safe_to_jsval(cx, rval.reborrow());
 
     rooted!(in(*cx) let obj = rval.to_object());
     unsafe { JS_FreezeObject(*cx, RawHandleObject::from(obj.handle())) };

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -13,6 +13,7 @@ use dom_struct::dom_struct;
 use js::jsapi::{Heap, JS_NewObject, JSObject};
 use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue};
+use script_bindings::conversions::SafeToJSValConvertible;
 
 use crate::dom::bindings::codegen::Bindings::EventHandlerBinding::EventHandlerNonNull;
 use crate::dom::bindings::codegen::Bindings::MessagePortBinding::{
@@ -29,7 +30,6 @@ use crate::dom::bindings::transferable::Transferable;
 use crate::dom::bindings::utils::set_dictionary_property;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
-use crate::js::conversions::ToJSValConvertible;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 #[dom_struct]
@@ -219,9 +219,7 @@ impl MessagePort {
         // Let message be OrdinaryObjectCreate(null).
         rooted!(in(*cx) let mut message = unsafe { JS_NewObject(*cx, ptr::null()) });
         rooted!(in(*cx) let mut type_string = UndefinedValue());
-        unsafe {
-            type_.to_jsval(*cx, type_string.handle_mut());
-        }
+        type_.safe_to_jsval(cx, type_string.handle_mut());
 
         // Perform ! CreateDataProperty(message, "type", type).
         unsafe {
@@ -244,9 +242,7 @@ impl MessagePort {
 
         // Run the message port post message steps providing targetPort, message, and options.
         rooted!(in(*cx) let mut message_val = UndefinedValue());
-        unsafe {
-            message.to_jsval(*cx, message_val.handle_mut());
-        }
+        message.safe_to_jsval(cx, message_val.handle_mut());
         self.post_message_impl(cx, message_val.handle(), transfer)
     }
 }

--- a/components/script/dom/webglrenderingcontext.rs
+++ b/components/script/dom/webglrenderingcontext.rs
@@ -30,6 +30,7 @@ use js::typedarray::{
     TypedArrayElementCreator, Uint32Array,
 };
 use pixels::{self, Alpha, PixelFormat, Snapshot, SnapshotPixelFormat};
+use script_bindings::conversions::SafeToJSValConvertible;
 use serde::{Deserialize, Serialize};
 use servo_config::pref;
 use webrender_api::ImageKey;
@@ -48,7 +49,7 @@ use crate::dom::bindings::codegen::UnionTypes::{
     ArrayBufferViewOrArrayBuffer, Float32ArrayOrUnrestrictedFloatSequence,
     HTMLCanvasElementOrOffscreenCanvas, Int32ArrayOrLongSequence,
 };
-use crate::dom::bindings::conversions::{DerivedFrom, ToJSValConvertible};
+use crate::dom::bindings::conversions::DerivedFrom;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{DomGlobal, DomObject, Reflector, reflect_dom_object};
@@ -2128,37 +2129,37 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         }
 
         match parameter {
-            constants::ARRAY_BUFFER_BINDING => unsafe {
-                self.bound_buffer_array.get().to_jsval(*cx, retval);
+            constants::ARRAY_BUFFER_BINDING => {
+                self.bound_buffer_array.get().safe_to_jsval(cx, retval);
                 return;
             },
-            constants::CURRENT_PROGRAM => unsafe {
-                self.current_program.get().to_jsval(*cx, retval);
+            constants::CURRENT_PROGRAM => {
+                self.current_program.get().safe_to_jsval(cx, retval);
                 return;
             },
-            constants::ELEMENT_ARRAY_BUFFER_BINDING => unsafe {
+            constants::ELEMENT_ARRAY_BUFFER_BINDING => {
                 let buffer = self.current_vao().element_array_buffer().get();
-                buffer.to_jsval(*cx, retval);
+                buffer.safe_to_jsval(cx, retval);
                 return;
             },
-            constants::FRAMEBUFFER_BINDING => unsafe {
-                self.bound_draw_framebuffer.get().to_jsval(*cx, retval);
+            constants::FRAMEBUFFER_BINDING => {
+                self.bound_draw_framebuffer.get().safe_to_jsval(cx, retval);
                 return;
             },
-            constants::RENDERBUFFER_BINDING => unsafe {
-                self.bound_renderbuffer.get().to_jsval(*cx, retval);
+            constants::RENDERBUFFER_BINDING => {
+                self.bound_renderbuffer.get().safe_to_jsval(cx, retval);
                 return;
             },
-            constants::TEXTURE_BINDING_2D => unsafe {
+            constants::TEXTURE_BINDING_2D => {
                 let texture = self
                     .textures
                     .active_texture_slot(constants::TEXTURE_2D, self.webgl_version())
                     .unwrap()
                     .get();
-                texture.to_jsval(*cx, retval);
+                texture.safe_to_jsval(cx, retval);
                 return;
             },
-            WebGL2RenderingContextConstants::TEXTURE_BINDING_2D_ARRAY => unsafe {
+            WebGL2RenderingContextConstants::TEXTURE_BINDING_2D_ARRAY => {
                 let texture = self
                     .textures
                     .active_texture_slot(
@@ -2167,10 +2168,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     )
                     .unwrap()
                     .get();
-                texture.to_jsval(*cx, retval);
+                texture.safe_to_jsval(cx, retval);
                 return;
             },
-            WebGL2RenderingContextConstants::TEXTURE_BINDING_3D => unsafe {
+            WebGL2RenderingContextConstants::TEXTURE_BINDING_3D => {
                 let texture = self
                     .textures
                     .active_texture_slot(
@@ -2179,21 +2180,21 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     )
                     .unwrap()
                     .get();
-                texture.to_jsval(*cx, retval);
+                texture.safe_to_jsval(cx, retval);
                 return;
             },
-            constants::TEXTURE_BINDING_CUBE_MAP => unsafe {
+            constants::TEXTURE_BINDING_CUBE_MAP => {
                 let texture = self
                     .textures
                     .active_texture_slot(constants::TEXTURE_CUBE_MAP, self.webgl_version())
                     .unwrap()
                     .get();
-                texture.to_jsval(*cx, retval);
+                texture.safe_to_jsval(cx, retval);
                 return;
             },
-            OESVertexArrayObjectConstants::VERTEX_ARRAY_BINDING_OES => unsafe {
+            OESVertexArrayObjectConstants::VERTEX_ARRAY_BINDING_OES => {
                 let vao = self.current_vao.get().filter(|vao| vao.id().is_some());
-                vao.to_jsval(*cx, retval);
+                vao.safe_to_jsval(cx, retval);
                 return;
             },
             // In readPixels we currently support RGBA/UBYTE only.  If
@@ -2223,16 +2224,16 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     .unwrap();
                 return retval.set(ObjectValue(rval.get()));
             },
-            constants::VERSION => unsafe {
-                "WebGL 1.0".to_jsval(*cx, retval);
+            constants::VERSION => {
+                "WebGL 1.0".safe_to_jsval(cx, retval);
                 return;
             },
-            constants::RENDERER | constants::VENDOR => unsafe {
-                "Mozilla/Servo".to_jsval(*cx, retval);
+            constants::RENDERER | constants::VENDOR => {
+                "Mozilla/Servo".safe_to_jsval(cx, retval);
                 return;
             },
-            constants::SHADING_LANGUAGE_VERSION => unsafe {
-                "WebGL GLSL ES 1.0".to_jsval(*cx, retval);
+            constants::SHADING_LANGUAGE_VERSION => {
+                "WebGL GLSL ES 1.0".safe_to_jsval(cx, retval);
                 return;
             },
             constants::UNPACK_FLIP_Y_WEBGL => {
@@ -2310,10 +2311,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 self.send_command(WebGLCommand::GetParameterBool(param, sender));
                 retval.set(BooleanValue(receiver.recv().unwrap()))
             },
-            Parameter::Bool4(param) => unsafe {
+            Parameter::Bool4(param) => {
                 let (sender, receiver) = webgl_channel().unwrap();
                 self.send_command(WebGLCommand::GetParameterBool4(param, sender));
-                receiver.recv().unwrap().to_jsval(*cx, retval);
+                receiver.recv().unwrap().safe_to_jsval(cx, retval);
             },
             Parameter::Int(param) => {
                 let (sender, receiver) = webgl_channel().unwrap();
@@ -3255,7 +3256,6 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         handle_potential_webgl_error!(self, program.get_attrib_location(name), -1)
     }
 
-    #[allow(unsafe_code)]
     // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.6
     fn GetFramebufferAttachmentParameter(
         &self,
@@ -3352,12 +3352,12 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             let fb = self.bound_draw_framebuffer.get().unwrap();
             if let Some(webgl_attachment) = fb.attachment(attachment) {
                 match webgl_attachment {
-                    WebGLFramebufferAttachmentRoot::Renderbuffer(rb) => unsafe {
-                        rb.to_jsval(*cx, retval);
+                    WebGLFramebufferAttachmentRoot::Renderbuffer(rb) => {
+                        rb.safe_to_jsval(cx, retval);
                         return;
                     },
-                    WebGLFramebufferAttachmentRoot::Texture(texture) => unsafe {
-                        texture.to_jsval(*cx, retval);
+                    WebGLFramebufferAttachmentRoot::Texture(texture) => {
+                        texture.safe_to_jsval(cx, retval);
                         return;
                     },
                 }
@@ -3640,9 +3640,9 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     retval.set(BooleanValue(data.normalized))
                 },
                 constants::VERTEX_ATTRIB_ARRAY_STRIDE => retval.set(Int32Value(data.stride as i32)),
-                constants::VERTEX_ATTRIB_ARRAY_BUFFER_BINDING => unsafe {
+                constants::VERTEX_ATTRIB_ARRAY_BUFFER_BINDING => {
                     if let Some(buffer) = data.buffer() {
-                        buffer.to_jsval(*cx, retval.reborrow());
+                        buffer.safe_to_jsval(cx, retval.reborrow());
                     } else {
                         retval.set(NullValue());
                     }
@@ -4264,14 +4264,14 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 triple,
                 WebGLCommand::GetUniformBool,
             ))),
-            constants::BOOL_VEC2 => unsafe {
-                uniform_get(triple, WebGLCommand::GetUniformBool2).to_jsval(*cx, rval);
+            constants::BOOL_VEC2 => {
+                uniform_get(triple, WebGLCommand::GetUniformBool2).safe_to_jsval(cx, rval)
             },
-            constants::BOOL_VEC3 => unsafe {
-                uniform_get(triple, WebGLCommand::GetUniformBool3).to_jsval(*cx, rval);
+            constants::BOOL_VEC3 => {
+                uniform_get(triple, WebGLCommand::GetUniformBool3).safe_to_jsval(cx, rval)
             },
-            constants::BOOL_VEC4 => unsafe {
-                uniform_get(triple, WebGLCommand::GetUniformBool4).to_jsval(*cx, rval);
+            constants::BOOL_VEC4 => {
+                uniform_get(triple, WebGLCommand::GetUniformBool4).safe_to_jsval(cx, rval)
             },
             constants::INT |
             constants::SAMPLER_2D |

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -41,7 +41,7 @@ pub trait SafeToJSValConvertible {
     fn safe_to_jsval(&self, cx: SafeJSContext, rval: MutableHandleValue);
 }
 
-impl<T: ToJSValConvertible> SafeToJSValConvertible for T {
+impl<T: ToJSValConvertible + ?Sized> SafeToJSValConvertible for T {
     fn safe_to_jsval(&self, cx: SafeJSContext, rval: MutableHandleValue) {
         unsafe { self.to_jsval(*cx, rval) };
     }


### PR DESCRIPTION
Remove size bound from safe to jsval trait, apply to script/dom, with the exception of windowproxy.

Second part of https://github.com/servo/servo/issues/37951

Signed-off-by: gterzian <2792687+gterzian@users.noreply.github.com>

*Describe the changes that this pull request makes here. This will be the commit message.*

Testing: *Describe how this pull request is tested or why it doesn't require tests*
Fixes: *Link to an issue this pull requests fixes or remove this line if there is no issue*
