### PR TITLE
Run IndexedDB tests by default.

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -181,7 +181,7 @@ skip: true
 [import-maps]
   skip: false
 [IndexedDB]
-  skip: true
+  skip: false
 [intersection-observer]
   skip: false
 [js]


### PR DESCRIPTION
Recent fixes have addressed all the previously-observed widespread intermittency. Try runs with the tests enabled do not show any new flaky results or Stanley intermittent failures. Let's keep it that way!