### PR TITLE
WebDriver: Set current browsing context for NavigateTo and Refresh command

### DIFF
--- a/tests/wpt/meta/webdriver/tests/classic/refresh/refresh.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/refresh/refresh.py.ini
@@ -13,6 +13,3 @@
 
   [test_history_pushstate]
     expected: FAIL
-
-  [test_refresh_switches_to_parent_browsing_context]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/screenshot.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/screenshot.py.ini
@@ -1,7 +1,4 @@
 [screenshot.py]
-  [test_no_browsing_context]
-    expected: FAIL
-
   [test_no_such_element_with_invalid_value]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/take_screenshot/screenshot.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/take_screenshot/screenshot.py.ini
@@ -1,3 +1,0 @@
-[screenshot.py]
-  [test_no_browsing_context]
-    expected: FAIL


### PR DESCRIPTION
Previously we didn't change the current browsing context id in our WebDriver Session after the commands `Navigate To` and `Refresh`