### PR TITLE
IndexedDB: Handle missing object stores in object store operations

### DIFF
--- a/components/script/dom/idbdatabase.rs
+++ b/components/script/dom/idbdatabase.rs
@@ -92,6 +92,13 @@ impl IDBDatabase {
         )
     }
 
+    pub(crate) fn object_store_exists(&self, name: &DOMString) -> bool {
+        self.object_store_names
+            .borrow()
+            .iter()
+            .any(|store_name| store_name == name)
+    }
+
     pub fn version(&self) -> u64 {
         let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
         let operation = SyncOperation::Version(

--- a/components/script_bindings/webidls/IDBObjectStore.webidl
+++ b/components/script_bindings/webidls/IDBObjectStore.webidl
@@ -10,7 +10,7 @@
 // https://w3c.github.io/IndexedDB/#idbobjectstore
 [Pref="dom_indexeddb_enabled", Exposed=(Window,Worker)]
 interface IDBObjectStore {
-  attribute DOMString name;
+  [SetterThrows] attribute DOMString name;
   // readonly attribute any keyPath;
   // readonly attribute DOMStringList indexNames;
   [SameObject] readonly attribute IDBTransaction transaction;

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-add-put-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-add-put-exception-order.any.js.ini
@@ -5,13 +5,7 @@
   expected: ERROR
 
 [idbobjectstore-add-put-exception-order.any.html]
-  [IDBObjectStore.put exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
   [IDBObjectStore.put exception order: TransactionInactiveError vs. ReadOnlyError]
-    expected: FAIL
-
-  [IDBObjectStore.add exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBObjectStore.add exception order: TransactionInactiveError vs. ReadOnlyError]
@@ -19,13 +13,7 @@
 
 
 [idbobjectstore-add-put-exception-order.any.worker.html]
-  [IDBObjectStore.put exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
   [IDBObjectStore.put exception order: TransactionInactiveError vs. ReadOnlyError]
-    expected: FAIL
-
-  [IDBObjectStore.add exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBObjectStore.add exception order: TransactionInactiveError vs. ReadOnlyError]

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-clear-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-clear-exception-order.any.js.ini
@@ -1,7 +1,4 @@
 [idbobjectstore-clear-exception-order.any.worker.html]
-  [IDBObjectStore.clear exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
   [IDBObjectStore.clear exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
 
@@ -10,9 +7,6 @@
   expected: ERROR
 
 [idbobjectstore-clear-exception-order.any.html]
-  [IDBObjectStore.clear exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
   [IDBObjectStore.clear exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-delete-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-delete-exception-order.any.js.ini
@@ -2,9 +2,6 @@
   expected: ERROR
 
 [idbobjectstore-delete-exception-order.any.html]
-  [IDBObjectStore.delete exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
   [IDBObjectStore.delete exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
 
@@ -13,8 +10,5 @@
   expected: ERROR
 
 [idbobjectstore-delete-exception-order.any.worker.html]
-  [IDBObjectStore.delete exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
   [IDBObjectStore.delete exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-query-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-query-exception-order.any.js.ini
@@ -1,7 +1,4 @@
 [idbobjectstore-query-exception-order.any.html]
-  [IDBObjectStore.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
   [IDBObjectStore.get exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
@@ -15,9 +12,6 @@
     expected: FAIL
 
   [IDBObjectStore.getAllKeys exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
-  [IDBObjectStore.count exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBObjectStore.count exception order: TransactionInactiveError vs. DataError]
@@ -40,9 +34,6 @@
   expected: ERROR
 
 [idbobjectstore-query-exception-order.any.worker.html]
-  [IDBObjectStore.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
   [IDBObjectStore.get exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
@@ -56,9 +47,6 @@
     expected: FAIL
 
   [IDBObjectStore.getAllKeys exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
-  [IDBObjectStore.count exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBObjectStore.count exception order: TransactionInactiveError vs. DataError]

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_clear.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_clear.any.js.ini
@@ -5,9 +5,6 @@
   [Clear removes all records from an index ]
     expected: FAIL
 
-  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError ]
-    expected: FAIL
-
 
 [idbobjectstore_clear.any.sharedworker.html]
   expected: ERROR
@@ -20,7 +17,4 @@
     expected: FAIL
 
   [Clear removes all records from an index ]
-    expected: FAIL
-
-  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError ]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_count.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_count.any.js.ini
@@ -5,9 +5,6 @@
   [Returns the number of records that have keys with the key]
     expected: FAIL
 
-  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError ]
-    expected: FAIL
-
 
 [idbobjectstore_count.any.sharedworker.html]
   expected: ERROR
@@ -17,9 +14,6 @@
     expected: FAIL
 
   [Returns the number of records that have keys with the key]
-    expected: FAIL
-
-  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError ]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_delete.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_delete.any.js.ini
@@ -12,9 +12,6 @@
   [delete() removes all of the records in the range]
     expected: FAIL
 
-  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError]
-    expected: FAIL
-
 
 [idbobjectstore_delete.any.serviceworker.html]
   expected: ERROR
@@ -31,9 +28,6 @@
     expected: TIMEOUT
 
   [delete() removes all of the records in the range]
-    expected: FAIL
-
-  [If the object store has been deleted, the implementation must throw a DOMException of type InvalidStateError]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/nested-cloning-basic.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/nested-cloning-basic.any.js.ini
@@ -2,7 +2,6 @@
   expected: ERROR
 
 [nested-cloning-basic.any.worker.html]
-  expected: CRASH
   [small typed array]
     expected: FAIL
 


### PR DESCRIPTION
These changes fix a large number of panics that can manifest as intermittent test failures. They also add more specification text to various IDBObjectStore methods and implement missing steps that check for whether an object store is deleted.

Testing: Existing test coverage.