### PR TITLE
dependabot: Add egui-file-dialog and accesskit_winit to egui group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
         - "emath"
         - "epaint"
         - "epaint_default_fonts"
+        - "accesskit_winit"
+        - "egui-file-dialog"
     gstreamer-related:
       patterns:
         - "gio*"


### PR DESCRIPTION
https://github.com/servo/servo/pull/38119#issuecomment-3079653012

Testing: None, just dependabot config.
