### PR TITLE
remove test-wpt-android from mach command

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -374,22 +374,6 @@ class MachCommands(CommandBase):
     def test_wpt(self, servo_binary: str, **kwargs):
         return self._test_wpt(servo_binary, **kwargs)
 
-    @Command(
-        "test-wpt-android",
-        description="Run the web platform test suite in an Android emulator",
-        category="testing",
-        parser=wpt.create_parser,
-    )
-    @CommandBase.common_command_arguments(build_configuration=False, build_type=True)
-    def test_wpt_android(self, build_type: BuildType, binary_args=None, **kwargs):
-        kwargs.update(
-            product="servodriver",
-            processes=1,
-            binary_args=self.in_android_emulator(build_type) + (binary_args or []),
-            binary=sys.executable,
-        )
-        return self._test_wpt(sys.executable, android=True, **kwargs)
-
     @CommandBase.allow_target_configuration
     def _test_wpt(self, servo_binary: str, **kwargs):
         # TODO(mrobinson): Why do we pass the wrong binary path in when running WPT on Android?


### PR DESCRIPTION
This command is no longer work as we arleady remove `in_android_emulator` in this PR [37958](https://github.com/servo/servo/pull/37958) cause of `setup_configuration_for_android_target` is no longer exist in `python/servo` codebase

These commands are being removed in order to implement Python type checking the Servo repository.
Testing: This just removes some mach command so shouldn't need tests.