### PR TITLE
Webdriver: Allow error when selecting file at ElementSendKeys

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1114,11 +1114,12 @@ pub(crate) fn handle_will_send_keys(
                     }
 
                     // Step 8.5
-                    // TODO: Should return invalid argument error if file doesn't exist
-
+                    // InvalidArgument Error is returned if the files are not valid.
                     // Step 8.6 - 8.7
                     // Input and change event already fired in `htmlinputelement.rs`.
-                    file_input.SelectFiles(files, can_gc);
+                    if let Err(_) = file_input.select_files(Some(files), can_gc) {
+                        return Err(ErrorStatus::InvalidArgument);
+                    }
 
                     // Step 8.8
                     return Ok(false);

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1117,7 +1117,7 @@ pub(crate) fn handle_will_send_keys(
                     // InvalidArgument Error is returned if the files are not valid.
                     // Step 8.6 - 8.7
                     // Input and change event already fired in `htmlinputelement.rs`.
-                    if let Err(_) = file_input.select_files(Some(files), can_gc) {
+                    if file_input.select_files(Some(files), can_gc).is_err() {
                         return Err(ErrorStatus::InvalidArgument);
                     }
 

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/file_upload.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/file_upload.py.ini
@@ -1,10 +1,4 @@
 [file_upload.py]
-  [test_empty_text]
-    expected: FAIL
-
-  [test_multiple_files_last_path_not_found]
-    expected: FAIL
-
   [test_multiple_files_send_twice]
     expected: FAIL
 


### PR DESCRIPTION
Based on [spec](https://w3c.github.io/webdriver/#element-send-keys),

> 5. Verify that each file given by the user exists. If any do not, return [error](https://w3c.github.io/webdriver/#dfn-error) with [error code](https://w3c.github.io/webdriver/#dfn-error-code) [invalid argument](https://w3c.github.io/webdriver/#dfn-invalid-argument).