### PR TITLE
devtools: Use request destination as cause_type in NetworkEventActor

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -397,6 +397,7 @@ fn prepare_devtools_request(
     pipeline_id: PipelineId,
     connect_time: Duration,
     send_time: Duration,
+    destination: Destination,
     is_xhr: bool,
     browsing_context_id: BrowsingContextId,
 ) -> ChromeToDevtoolsControlMsg {
@@ -414,6 +415,7 @@ fn prepare_devtools_request(
             .as_secs() as i64,
         connect_time,
         send_time,
+        destination,
         is_xhr,
         browsing_context_id,
     };
@@ -586,6 +588,7 @@ async fn obtain_response(
     source_is_null: bool,
     pipeline_id: &Option<PipelineId>,
     request_id: Option<&str>,
+    destination: Destination,
     is_xhr: bool,
     context: &FetchContext,
     fetch_terminated: UnboundedSender<bool>,
@@ -780,6 +783,7 @@ async fn obtain_response(
                                 pipeline_id,
                                 (connect_end - connect_start).unsigned_abs(),
                                 (send_end - send_start).unsigned_abs(),
+                                destination,
                                 is_xhr,
                                 browsing_context_id,
                             ))
@@ -1959,6 +1963,7 @@ async fn http_network_fetch(
             .unwrap_or(false),
         &request.pipeline_id,
         Some(&request_id),
+        request.destination,
         is_xhr,
         context,
         fetch_terminated_sender,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -490,6 +490,7 @@ pub fn send_early_httprequest_to_devtools(request: &mut Request, context: &Fetch
             time_stamp: 0,
             connect_time: Duration::from_millis(0),
             send_time: Duration::from_millis(0),
+            destination: request.destination,
             is_xhr: false,
             browsing_context_id,
         };

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -1339,6 +1339,7 @@ fn test_fetch_with_devtools() {
         time_stamp: devhttprequests.1.time_stamp,
         connect_time: devhttprequests.1.connect_time,
         send_time: devhttprequests.1.send_time,
+        destination: Destination::None,
         is_xhr: true,
         browsing_context_id: TEST_WEBVIEW_ID.0,
     };

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -333,6 +333,7 @@ fn test_request_and_response_data_with_network_messages() {
         time_stamp: devhttprequests.1.time_stamp,
         connect_time: devhttprequests.1.connect_time,
         send_time: devhttprequests.1.send_time,
+        destination: Destination::Document,
         is_xhr: false,
         browsing_context_id: TEST_WEBVIEW_ID.0,
     };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -23,6 +23,7 @@ use http::{HeaderMap, Method};
 use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::http_status::HttpStatus;
+use net_traits::request::Destination;
 use serde::{Deserialize, Serialize};
 use servo_url::ServoUrl;
 use uuid::Uuid;
@@ -443,6 +444,7 @@ pub struct HttpRequest {
     pub time_stamp: i64,
     pub connect_time: Duration,
     pub send_time: Duration,
+    pub destination: Destination,
     pub is_xhr: bool,
     pub browsing_context_id: BrowsingContextId,
 }


### PR DESCRIPTION
The cause_type in NetworkEventActor was derived from a hard-coded pattern match on the request URL file extension.

This patch replaces the hard-coded pattern matching with the Destination field of Request, to provide a better alignment with the Fetch specification.

Testing: Updated unit tests.
Fixes: #38151