### PR TITLE
script: Implement `DocumentOrShadowDOM.adoptedStylesheet` with `FrozenArray`

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -69,6 +69,7 @@ pub struct Preferences {
     /// List of comma-separated backends to be used by wgpu.
     pub dom_webgpu_wgpu_backend: String,
     pub dom_abort_controller_enabled: bool,
+    pub dom_adoptedstylesheet_enabled: bool,
     pub dom_async_clipboard_enabled: bool,
     pub dom_bluetooth_enabled: bool,
     pub dom_bluetooth_testing_enabled: bool,
@@ -247,6 +248,7 @@ impl Preferences {
             devtools_server_enabled: false,
             devtools_server_port: 0,
             dom_abort_controller_enabled: false,
+            dom_adoptedstylesheet_enabled: false,
             dom_allow_scripts_to_close_windows: false,
             dom_async_clipboard_enabled: false,
             dom_bluetooth_enabled: false,

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -120,7 +120,7 @@ impl CSSRuleList {
         let parent_stylesheet = self.parent_stylesheet.style_stylesheet();
         let owner = self
             .parent_stylesheet
-            .get_owner()
+            .owner_node()
             .and_then(DomRoot::downcast::<HTMLElement>);
         let loader = owner
             .as_ref()

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -127,9 +127,7 @@ impl CSSStyleOwner {
                 if changed {
                     // If this is changed, see also
                     // CSSStyleRule::SetSelectorText, which does the same thing.
-                    if let Some(owner) = rule.parent_stylesheet().get_owner() {
-                        owner.stylesheet_list_owner().invalidate_stylesheets();
-                    }
+                    rule.parent_stylesheet().notify_invalidations();
                 }
                 result
             },

--- a/components/script/dom/cssstylerule.rs
+++ b/components/script/dom/cssstylerule.rs
@@ -21,7 +21,6 @@ use crate::dom::cssgroupingrule::CSSGroupingRule;
 use crate::dom::cssrule::SpecificCSSRule;
 use crate::dom::cssstyledeclaration::{CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner};
 use crate::dom::cssstylesheet::CSSStyleSheet;
-use crate::dom::node::NodeTraits;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 
@@ -136,9 +135,9 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
             let mut guard = self.cssgroupingrule.shared_lock().write();
             let stylerule = self.stylerule.write_with(&mut guard);
             mem::swap(&mut stylerule.selectors, &mut s);
-            if let Some(owner) = self.cssgroupingrule.parent_stylesheet().get_owner() {
-                owner.stylesheet_list_owner().invalidate_stylesheets();
-            }
+            self.cssgroupingrule
+                .parent_stylesheet()
+                .notify_invalidations();
         }
     }
 }

--- a/components/script/dom/cssstylesheet.rs
+++ b/components/script/dom/cssstylesheet.rs
@@ -42,7 +42,7 @@ pub(crate) struct CSSStyleSheet {
     stylesheet: StyleSheet,
 
     /// <https://drafts.csswg.org/cssom/#concept-css-style-sheet-owner-node>
-    owner: MutNullableDom<Element>,
+    owner_node: MutNullableDom<Element>,
 
     /// <https://drafts.csswg.org/cssom/#ref-for-concept-css-style-sheet-css-rules>
     rulelist: MutNullableDom<CSSRuleList>,
@@ -76,7 +76,7 @@ impl CSSStyleSheet {
     ) -> CSSStyleSheet {
         CSSStyleSheet {
             stylesheet: StyleSheet::new_inherited(type_, href, title),
-            owner: MutNullableDom::new(owner),
+            owner_node: MutNullableDom::new(owner),
             rulelist: MutNullableDom::new(None),
             style_stylesheet: stylesheet,
             origin_clean: Cell::new(true),
@@ -155,8 +155,8 @@ impl CSSStyleSheet {
         self.style_stylesheet.disabled()
     }
 
-    pub(crate) fn get_owner(&self) -> Option<DomRoot<Element>> {
-        self.owner.get()
+    pub(crate) fn owner_node(&self) -> Option<DomRoot<Element>> {
+        self.owner_node.get()
     }
 
     pub(crate) fn set_disabled(&self, disabled: bool) {
@@ -165,8 +165,8 @@ impl CSSStyleSheet {
         }
     }
 
-    pub(crate) fn set_owner(&self, value: Option<&Element>) {
-        self.owner.set(value);
+    pub(crate) fn set_owner_node(&self, value: Option<&Element>) {
+        self.owner_node.set(value);
     }
 
     pub(crate) fn shared_lock(&self) -> &SharedRwLock {
@@ -224,7 +224,7 @@ impl CSSStyleSheet {
 
     /// Invalidate all stylesheet set this stylesheet is a part on.
     pub(crate) fn notify_invalidations(&self) {
-        if let Some(owner) = self.get_owner() {
+        if let Some(owner) = self.owner_node() {
             owner.stylesheet_list_owner().invalidate_stylesheets();
         }
         for adopter in self.adopters.borrow().iter() {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4904,13 +4904,13 @@ impl Document {
             .and_then(|s| s.owner.get_cssom_object())
     }
 
-    /// Add a stylesheet owned by `owning_node` to the list of document sheets, in the
+    /// Add a stylesheet owned by `owner_node` to the list of document sheets, in the
     /// correct tree position. Additionally, the owned stylesheet is inserted before any
     /// constructed ones.
     ///
     /// <https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets>
     #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Owner needs to be rooted already necessarily.
-    pub(crate) fn add_owned_stylesheet(&self, owning_node: &Element, sheet: Arc<Stylesheet>) {
+    pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
         let stylesheets = &mut *self.stylesheets.borrow_mut();
 
         // FIXME(stevennovaryo): This is almost identical with the one in ShadowRoot::add_stylesheet.
@@ -4919,8 +4919,8 @@ impl Document {
             .map(|(sheet, _origin)| sheet)
             .find(|sheet_in_doc| {
                 match &sheet_in_doc.owner {
-                    StylesheetSource::Element(el) => {
-                        owning_node.upcast::<Node>().is_before(el.upcast())
+                    StylesheetSource::Element(other_node) => {
+                        owner_node.upcast::<Node>().is_before(other_node.upcast())
                     },
                     // Non-constructed stylesheet should be ordered before owned ones.
                     StylesheetSource::Constructed(_) => true,
@@ -4936,7 +4936,7 @@ impl Document {
         }
 
         DocumentOrShadowRoot::add_stylesheet(
-            StylesheetSource::Element(Dom::from_ref(owning_node)),
+            StylesheetSource::Element(Dom::from_ref(owner_node)),
             StylesheetSetRef::Document(stylesheets),
             sheet,
             insertion_point,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4905,8 +4905,8 @@ impl Document {
     }
 
     /// Add a stylesheet owned by `owner_node` to the list of document sheets, in the
-    /// correct tree position. Additionally, the owned stylesheet is inserted before any
-    /// constructed ones.
+    /// correct tree position. Additionally, ensure that the owned stylesheet is inserted
+    /// before any constructed stylesheet.
     ///
     /// <https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets>
     #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Owner needs to be rooted already necessarily.
@@ -4922,7 +4922,8 @@ impl Document {
                     StylesheetSource::Element(other_node) => {
                         owner_node.upcast::<Node>().is_before(other_node.upcast())
                     },
-                    // Non-constructed stylesheet should be ordered before owned ones.
+                    // Non-constructed stylesheet should be ordered before the
+                    // constructed ones.
                     StylesheetSource::Constructed(_) => true,
                 }
             })

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6737,7 +6737,6 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn AdoptedStyleSheets(&self, context: JSContext, can_gc: CanGc, retval: MutableHandleValue) {
         self.adopted_stylesheets_frozen_types.get_or_init(
             || {
-                dbg!(self.adopted_stylesheets.borrow().len());
                 self.adopted_stylesheets
                     .borrow()
                     .clone()

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -369,8 +369,8 @@ impl DocumentOrShadowRoot {
     /// In case of duplicates, the setter will respect the last duplicates.
     ///
     /// <https://drafts.csswg.org/cssom/#dom-documentorshadowroot-adoptedstylesheets>
-    // TODO(stevennovaryo): Handle duplicated adoptedstylesheet correctly, Stylo is preventing
-    //                      duplicates inside a Stylesheet Set. But this is not ideal.
+    // TODO: Handle duplicated adoptedstylesheet correctly, Stylo is preventing duplicates inside a
+    //       Stylesheet Set. But this is not ideal. https://bugzilla.mozilla.org/show_bug.cgi?id=1978755
     fn set_adopted_stylesheet(
         adopted_stylesheets: &mut Vec<Dom<CSSStyleSheet>>,
         incoming_stylesheets: &[Dom<CSSStyleSheet>],

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -369,6 +369,8 @@ impl DocumentOrShadowRoot {
     /// In case of duplicates, the setter will respect the last duplicates.
     ///
     /// <https://drafts.csswg.org/cssom/#dom-documentorshadowroot-adoptedstylesheets>
+    // TODO(stevennovaryo): Handle duplicated adoptedstylesheet correctly, Stylo is preventing
+    //                      duplicates inside a Stylesheet Set. But this is not ideal.
     fn set_adopted_stylesheet(
         adopted_stylesheets: &mut Vec<Dom<CSSStyleSheet>>,
         incoming_stylesheets: &[Dom<CSSStyleSheet>],
@@ -428,10 +430,7 @@ impl DocumentOrShadowRoot {
                 sheet.add_adopter(owner.clone());
             }
 
-            owner.add_stylesheet(
-                StylesheetSource::Constructed(sheet.clone()),
-                sheet.style_stylesheet_arc().clone(),
-            );
+            owner.append_constructed_stylesheet(sheet);
         }
 
         *adopted_stylesheets = incoming_stylesheets.to_vec();

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -185,8 +185,7 @@ impl HTMLLinkElement {
         }
         *self.stylesheet.borrow_mut() = Some(s.clone());
         self.clean_stylesheet_ownership();
-        stylesheets_owner
-            .add_stylesheet(StylesheetSource::Element(Dom::from_ref(self.upcast())), s);
+        stylesheets_owner.add_owned_stylesheet(self.upcast(), s);
     }
 
     pub(crate) fn get_stylesheet(&self) -> Option<Arc<Stylesheet>> {

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -221,7 +221,7 @@ impl HTMLLinkElement {
 
     fn clean_stylesheet_ownership(&self) {
         if let Some(cssom_stylesheet) = self.cssom_stylesheet.get() {
-            cssom_stylesheet.set_owner(None);
+            cssom_stylesheet.set_owner_node(None);
         }
         self.cssom_stylesheet.set(None);
     }

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -203,7 +203,7 @@ impl HTMLLinkElement {
                     None, // todo handle location
                     None, // todo handle title
                     sheet,
-                    false, // is_constructed
+                    None, // constructor_document
                     can_gc,
                 )
             })

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -178,7 +178,7 @@ impl HTMLStyleElement {
                     None, // todo handle location
                     None, // todo handle title
                     sheet,
-                    false, // is_constructed
+                    None, // constructor_document
                     CanGc::note(),
                 )
             })

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -160,8 +160,7 @@ impl HTMLStyleElement {
         }
         *self.stylesheet.borrow_mut() = Some(s.clone());
         self.clean_stylesheet_ownership();
-        stylesheets_owner
-            .add_stylesheet(StylesheetSource::Element(Dom::from_ref(self.upcast())), s);
+        stylesheets_owner.add_owned_stylesheet(self.upcast(), s);
     }
 
     pub(crate) fn get_stylesheet(&self) -> Option<Arc<Stylesheet>> {

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -186,7 +186,7 @@ impl HTMLStyleElement {
 
     fn clean_stylesheet_ownership(&self) {
         if let Some(cssom_stylesheet) = self.cssom_stylesheet.get() {
-            cssom_stylesheet.set_owner(None);
+            cssom_stylesheet.set_owner_node(None);
         }
         self.cssom_stylesheet.set(None);
     }

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -198,10 +198,10 @@ impl ShadowRoot {
             .and_then(|s| s.owner.get_cssom_object())
     }
 
-    /// Add a stylesheet owned by `owning_node` to the list of shadow root sheets, in the
+    /// Add a stylesheet owned by `owner_node` to the list of shadow root sheets, in the
     /// correct tree position.
     #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Owner needs to be rooted already necessarily.
-    pub(crate) fn add_owned_stylesheet(&self, owning_node: &Element, sheet: Arc<Stylesheet>) {
+    pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
         let stylesheets = &mut self.author_styles.borrow_mut().stylesheets;
 
         // FIXME(stevennovaryo): This is almost identical with the one in Document::add_stylesheet.
@@ -209,8 +209,8 @@ impl ShadowRoot {
             .iter()
             .find(|sheet_in_shadow| {
                 match &sheet_in_shadow.owner {
-                    StylesheetSource::Element(el) => {
-                        owning_node.upcast::<Node>().is_before(el.upcast())
+                    StylesheetSource::Element(other_node) => {
+                        owner_node.upcast::<Node>().is_before(other_node.upcast())
                     },
                     // Non-constructed stylesheet should be ordered before owned ones.
                     StylesheetSource::Constructed(_) => true,
@@ -219,7 +219,7 @@ impl ShadowRoot {
             .cloned();
 
         DocumentOrShadowRoot::add_stylesheet(
-            StylesheetSource::Element(Dom::from_ref(owning_node)),
+            StylesheetSource::Element(Dom::from_ref(owner_node)),
             StylesheetSetRef::Author(stylesheets),
             sheet,
             insertion_point,

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -178,6 +178,10 @@ impl ShadowRoot {
         self.host.set(None);
     }
 
+    pub(crate) fn owner_doc(&self) -> &Document {
+        &self.document
+    }
+
     pub(crate) fn get_focused_element(&self) -> Option<DomRoot<Element>> {
         //XXX get retargeted focused element
         None

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -199,7 +199,10 @@ impl ShadowRoot {
     }
 
     /// Add a stylesheet owned by `owner_node` to the list of shadow root sheets, in the
-    /// correct tree position.
+    /// correct tree position. Additionally, ensure that owned stylesheet is inserted before
+    /// any constructed stylesheet.
+    ///
+    /// <https://drafts.csswg.org/cssom/#documentorshadowroot-final-css-style-sheets>
     #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Owner needs to be rooted already necessarily.
     pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
         let stylesheets = &mut self.author_styles.borrow_mut().stylesheets;
@@ -212,7 +215,8 @@ impl ShadowRoot {
                     StylesheetSource::Element(other_node) => {
                         owner_node.upcast::<Node>().is_before(other_node.upcast())
                     },
-                    // Non-constructed stylesheet should be ordered before owned ones.
+                    // Non-constructed stylesheet should be ordered before the
+                    // constructed ones.
                     StylesheetSource::Constructed(_) => true,
                 }
             })

--- a/components/script/dom/stylesheet.rs
+++ b/components/script/dom/stylesheet.rs
@@ -51,7 +51,8 @@ impl StyleSheetMethods<crate::DomTypeHolder> for StyleSheet {
 
     // https://drafts.csswg.org/cssom/#dom-stylesheet-ownernode
     fn GetOwnerNode(&self) -> Option<DomRoot<Element>> {
-        self.downcast::<CSSStyleSheet>().and_then(|s| s.get_owner())
+        self.downcast::<CSSStyleSheet>()
+            .and_then(|s| s.owner_node())
     }
 
     // https://drafts.csswg.org/cssom/#dom-stylesheet-media

--- a/components/script/dom/stylesheetlist.rs
+++ b/components/script/dom/stylesheetlist.rs
@@ -40,11 +40,11 @@ impl StyleSheetListOwner {
         }
     }
 
-    pub(crate) fn add_owned_stylesheet(&self, owning_node: &Element, sheet: Arc<Stylesheet>) {
+    pub(crate) fn add_owned_stylesheet(&self, owner_node: &Element, sheet: Arc<Stylesheet>) {
         match *self {
-            StyleSheetListOwner::Document(ref doc) => doc.add_owned_stylesheet(owning_node, sheet),
+            StyleSheetListOwner::Document(ref doc) => doc.add_owned_stylesheet(owner_node, sheet),
             StyleSheetListOwner::ShadowRoot(ref shadow_root) => {
-                shadow_root.add_owned_stylesheet(owning_node, sheet)
+                shadow_root.add_owned_stylesheet(owner_node, sheet)
             },
         }
     }

--- a/components/script/dom/stylesheetlist.rs
+++ b/components/script/dom/stylesheetlist.rs
@@ -18,7 +18,7 @@ use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
-#[derive(JSTraceable, MallocSizeOf)]
+#[derive(Clone, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) enum StyleSheetListOwner {
     Document(Dom<Document>),
     ShadowRoot(Dom<ShadowRoot>),

--- a/components/script/dom/stylesheetlist.rs
+++ b/components/script/dom/stylesheetlist.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::document::Document;
 use crate::dom::documentorshadowroot::StylesheetSource;
+use crate::dom::element::Element;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::stylesheet::StyleSheet;
 use crate::dom::window::Window;
@@ -39,12 +40,23 @@ impl StyleSheetListOwner {
         }
     }
 
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))] // Owner needs to be rooted already necessarily.
-    pub(crate) fn add_stylesheet(&self, owner: StylesheetSource, sheet: Arc<Stylesheet>) {
+    pub(crate) fn add_owned_stylesheet(&self, owning_node: &Element, sheet: Arc<Stylesheet>) {
         match *self {
-            StyleSheetListOwner::Document(ref doc) => doc.add_stylesheet(owner, sheet),
+            StyleSheetListOwner::Document(ref doc) => doc.add_owned_stylesheet(owning_node, sheet),
             StyleSheetListOwner::ShadowRoot(ref shadow_root) => {
-                shadow_root.add_stylesheet(owner, sheet)
+                shadow_root.add_owned_stylesheet(owning_node, sheet)
+            },
+        }
+    }
+
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
+    pub(crate) fn append_constructed_stylesheet(&self, cssom_stylesheet: &CSSStyleSheet) {
+        match *self {
+            StyleSheetListOwner::Document(ref doc) => {
+                doc.append_constructed_stylesheet(cssom_stylesheet)
+            },
+            StyleSheetListOwner::ShadowRoot(ref shadow_root) => {
+                shadow_root.append_constructed_stylesheet(cssom_stylesheet)
             },
         }
     }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -167,7 +167,7 @@ DOMInterfaces = {
 
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
-    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'GetScrollingElement', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter'],
+    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'GetScrollingElement', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets'],
 },
 
 'DissimilarOriginWindow': {
@@ -586,7 +586,7 @@ DOMInterfaces = {
 },
 
 'ShadowRoot': {
-    'canGc': ['SetHTMLUnsafe', 'ElementFromPoint', 'ElementsFromPoint', 'SetInnerHTML', 'GetHTML', 'InnerHTML'],
+    'canGc': ['SetHTMLUnsafe', 'ElementFromPoint', 'ElementsFromPoint', 'SetInnerHTML', 'GetHTML', 'InnerHTML', 'AdoptedStyleSheets'],
 },
 
 'StaticRange': {

--- a/components/script_bindings/webidls/DocumentOrShadowRoot.webidl
+++ b/components/script_bindings/webidls/DocumentOrShadowRoot.webidl
@@ -15,3 +15,9 @@ interface mixin DocumentOrShadowRoot {
   readonly attribute Element? activeElement;
   readonly attribute StyleSheetList styleSheets;
 };
+
+partial interface mixin DocumentOrShadowRoot {
+  // TODO(37902): Use ObservableArray Array when available
+  [SetterThrows]
+  attribute /* ObservableArray<CSSStyleSheet> */ any adoptedStyleSheets;
+};

--- a/components/script_bindings/webidls/DocumentOrShadowRoot.webidl
+++ b/components/script_bindings/webidls/DocumentOrShadowRoot.webidl
@@ -18,6 +18,6 @@ interface mixin DocumentOrShadowRoot {
 
 partial interface mixin DocumentOrShadowRoot {
   // TODO(37902): Use ObservableArray Array when available
-  [SetterThrows]
+  [Pref="dom_adoptedstylesheet_enabled", SetterThrows]
   attribute /* ObservableArray<CSSStyleSheet> */ any adoptedStyleSheets;
 };

--- a/resources/wpt-prefs.json
+++ b/resources/wpt-prefs.json
@@ -1,4 +1,5 @@
 {
+  "dom_adoptedstylesheet_enabled": true,
   "dom_webxr_test": true,
   "gfx_text_antialiasing_enabled": false,
   "dom_testutils_enabled": true

--- a/tests/wpt/meta/__dir__.ini
+++ b/tests/wpt/meta/__dir__.ini
@@ -1,4 +1,5 @@
 prefs: [
+  "dom_adoptedstylesheet_enabled:true",
   "dom_indexeddb_enabled:true",
   "dom_serviceworker_enabled:true",
   "dom_testutils_enabled:true",

--- a/tests/wpt/meta/css/css-cascade/layer-replaceSync-clears-stale.html.ini
+++ b/tests/wpt/meta/css/css-cascade/layer-replaceSync-clears-stale.html.ini
@@ -1,3 +1,0 @@
-[layer-replaceSync-clears-stale.html]
-  [replaceSync clears stale layer statements]
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-concat.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-concat.html.ini
@@ -1,4 +1,0 @@
-[CSSStyleSheet-constructable-concat.html]
-  expected: TIMEOUT
-  [adoptedStyleSheets should allow .concat on empty starting values]
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-invalidation.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-invalidation.html.ini
@@ -1,9 +1,0 @@
-[CSSStyleSheet-constructable-invalidation.html]
-  [mutating constructed CSSStyleSheet applied to root invalidates styles]
-    expected: FAIL
-
-  [mutating constructed CSSStyleSheet applied to shadowdom invalidates styles]
-    expected: FAIL
-
-  [mutating dependent constructed CSSStyleSheet applied to shadowdom invalidates styles]
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable.html.ini
@@ -1,7 +1,4 @@
 [CSSStyleSheet-constructable.html]
-  [document.adoptedStyleSheets should initially have length 0.]
-    expected: FAIL
-
   [new CSSStyleSheet produces empty CSSStyleSheet]
     expected: FAIL
 
@@ -17,12 +14,6 @@
   [Re-attaching shadow host with adopted stylesheets work]
     expected: FAIL
 
-  [Attaching a shadow root that already has adopted stylesheets work]
-    expected: FAIL
-
-  [Re-attaching shadow host and updating attributes work]
-    expected: FAIL
-
   [Changes to constructed stylesheets through CSSOM is reflected]
     expected: FAIL
 
@@ -33,12 +24,6 @@
     expected: FAIL
 
   [Stylesheet constructed on iframe cannot be used in the main Document]
-    expected: FAIL
-
-  [Adding non-constructed stylesheet to AdoptedStyleSheets is not allowed when the owner document of the stylesheet is in the same document tree as the AdoptedStyleSheets]
-    expected: FAIL
-
-  [Adding non-constructed stylesheet to AdoptedStyleSheets is not allowed when the owner document of the stylesheet and the AdoptedStyleSheets are in different document trees]
     expected: FAIL
 
   [CSSStyleSheet.replaceSync correctly updates the style of its adopters synchronously]

--- a/tests/wpt/meta/css/cssom/adoptedstylesheets-modify-array-and-sheet.html.ini
+++ b/tests/wpt/meta/css/cssom/adoptedstylesheets-modify-array-and-sheet.html.ini
@@ -1,9 +1,0 @@
-[adoptedstylesheets-modify-array-and-sheet.html]
-  [Add the two sheets. Text should be red.]
-    expected: FAIL
-
-  [Flip the two sheet. Still red.]
-    expected: FAIL
-
-  [Modify the color declaration. Should now be green.]
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom/adoptedstylesheets-observablearray.html.ini
+++ b/tests/wpt/meta/css/cssom/adoptedstylesheets-observablearray.html.ini
@@ -4,6 +4,3 @@
 
   [shadowRoot.adoptedStyleSheets should allow mutation in-place]
     expected: FAIL
-
-  [adoptedStyleSheets should return true for isArray()]
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom/idlharness.html.ini
+++ b/tests/wpt/meta/css/cssom/idlharness.html.ini
@@ -395,18 +395,6 @@
   [CSSStyleSheet interface: calling replace(USVString) on sheet with too few arguments must throw TypeError]
     expected: FAIL
 
-  [Document interface: attribute adoptedStyleSheets]
-    expected: FAIL
-
-  [Document interface: document must inherit property "adoptedStyleSheets" with the proper type]
-    expected: FAIL
-
-  [Document interface: new Document() must inherit property "adoptedStyleSheets" with the proper type]
-    expected: FAIL
-
-  [ShadowRoot interface: attribute adoptedStyleSheets]
-    expected: FAIL
-
   [CSSImportRule interface: attribute supportsText]
     expected: FAIL
 

--- a/tests/wpt/meta/webidl/ecmascript-binding/observable-array-no-leak-of-internals.window.js.ini
+++ b/tests/wpt/meta/webidl/ecmascript-binding/observable-array-no-leak-of-internals.window.js.ini
@@ -1,3 +1,0 @@
-[observable-array-no-leak-of-internals.window.html]
-  [ObservableArray's internals won't leak]
-    expected: FAIL


### PR DESCRIPTION
Spec: https://drafts.csswg.org/cssom/#dom-documentorshadowroot-adoptedstylesheets

Implement `DocumentOrShadowDOM.adoptedStylesheet`. Due to `ObservableArray` being a massive issue on its own, it will be as it was a `FrozenArray` at first. This approach is similar to how Gecko implement adopted stylesheet.  See https://phabricator.services.mozilla.com/D144547#change-IXyOzxxFn8sU.

All of the changes will be gated behind a preference `dom_adoptedstylesheet_enabled`. 

Adopted stylesheet is implemented by adding the setter and getter of it. While the getter works like a normal attribute getter, the setter need to consider the inner working of document and shadow root StylesheetSet, specifically the ordering and the invalidations. Particularly for setter, we will clear all of the adopted stylesheet within the StylesheetSet and readd them. Possible optimization exist, but the focus should be directed to implementing `ObservableArray`.

More context about the implementations https://hackmd.io/vtJAn4UyS_O0Idvk5dCO_w.

Testing: Existing WPT Coverage
Fixes: https://github.com/servo/servo/issues/37561
