### PR TITLE
compositor: Request reflow when doing a page zooming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,6 +1426,7 @@ dependencies = [
  "profile_traits",
  "raw-window-handle",
  "serde",
+ "servo_geometry",
  "servo_malloc_size_of",
  "smallvec",
  "strum_macros",

--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -65,7 +65,11 @@ impl<'a> BackgroundPainter<'a> {
         if &BackgroundAttachment::Fixed ==
             get_cyclic(&background.background_attachment.0, layer_index)
         {
-            return builder.compositor_info.viewport_size.into();
+            return builder
+                .compositor_info
+                .viewport_details
+                .layout_size()
+                .into();
         }
 
         match get_cyclic(&background.background_clip.0, layer_index) {
@@ -149,7 +153,11 @@ impl<'a> BackgroundPainter<'a> {
                 Origin::PaddingBox => *fragment_builder.padding_rect(),
                 Origin::BorderBox => fragment_builder.border_rect,
             },
-            BackgroundAttachment::Fixed => builder.compositor_info.viewport_size.into(),
+            BackgroundAttachment::Fixed => builder
+                .compositor_info
+                .viewport_details
+                .layout_size()
+                .into(),
         }
     }
 }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -75,7 +75,7 @@ use style::{Zero, driver};
 use style_traits::{CSSPixel, SpeculativePainter};
 use stylo_atoms::Atom;
 use url::Url;
-use webrender_api::units::{DevicePixel, DevicePoint, LayoutSize, LayoutVector2D};
+use webrender_api::units::{DevicePixel, DevicePoint, LayoutVector2D};
 use webrender_api::{ExternalScrollId, HitTestFlags};
 
 use crate::context::{CachedImageOrError, ImageResolver, LayoutContext};
@@ -960,12 +960,6 @@ impl LayoutThread {
             return;
         }
 
-        let viewport_size = self.stylist.device().au_viewport_size();
-        let viewport_size = LayoutSize::new(
-            viewport_size.width.to_f32_px(),
-            viewport_size.height.to_f32_px(),
-        );
-
         let mut stacking_context_tree = self.stacking_context_tree.borrow_mut();
         let old_scroll_offsets = stacking_context_tree
             .as_ref()
@@ -976,7 +970,7 @@ impl LayoutThread {
         // applicable spatial and clip nodes.
         let mut new_stacking_context_tree = StackingContextTree::new(
             fragment_tree,
-            viewport_size,
+            reflow_request.viewport_details,
             self.id.into(),
             !self.have_ever_generated_display_list.get(),
             &self.debug,

--- a/components/shared/compositing/Cargo.toml
+++ b/components/shared/compositing/Cargo.toml
@@ -32,6 +32,7 @@ malloc_size_of_derive = { workspace = true }
 profile_traits = { path = '../profile' }
 raw-window-handle = { version = "0.6" }
 serde = { workspace = true }
+servo_geometry = { path = "../../geometry" }
 smallvec = { workspace = true }
 strum_macros = { workspace = true }
 stylo = { workspace = true }

--- a/components/shared/compositing/display_list.rs
+++ b/components/shared/compositing/display_list.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
 use bitflags::bitflags;
-use embedder_traits::Cursor;
+use embedder_traits::{Cursor, ViewportDetails};
 use euclid::SideOffsets2D;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
@@ -486,8 +486,9 @@ pub struct CompositorDisplayListInfo {
     /// The WebRender [PipelineId] of this display list.
     pub pipeline_id: PipelineId,
 
-    /// The size of the viewport that this display list renders into.
-    pub viewport_size: LayoutSize,
+    /// The [`ViewportDetails`] that describe the viewport in the script/layout thread at
+    /// the time this display list was created.
+    pub viewport_details: ViewportDetails,
 
     /// The size of this display list's content.
     pub content_size: LayoutSize,
@@ -526,7 +527,7 @@ impl CompositorDisplayListInfo {
     /// Create a new CompositorDisplayListInfo with the root reference frame
     /// and scroll frame already added to the scroll tree.
     pub fn new(
-        viewport_size: LayoutSize,
+        viewport_details: ViewportDetails,
         content_size: LayoutSize,
         pipeline_id: PipelineId,
         epoch: Epoch,
@@ -548,7 +549,10 @@ impl CompositorDisplayListInfo {
             SpatialTreeNodeInfo::Scroll(ScrollableNodeInfo {
                 external_id: ExternalScrollId(0, pipeline_id),
                 content_rect: LayoutRect::from_origin_and_size(LayoutPoint::zero(), content_size),
-                clip_rect: LayoutRect::from_origin_and_size(LayoutPoint::zero(), viewport_size),
+                clip_rect: LayoutRect::from_origin_and_size(
+                    LayoutPoint::zero(),
+                    viewport_details.layout_size(),
+                ),
                 scroll_sensitivity: viewport_scroll_sensitivity,
                 offset: LayoutVector2D::zero(),
             }),
@@ -556,7 +560,7 @@ impl CompositorDisplayListInfo {
 
         CompositorDisplayListInfo {
             pipeline_id,
-            viewport_size,
+            viewport_details,
             content_size,
             epoch,
             hit_test_info: Default::default(),

--- a/components/shared/compositing/viewport_description.rs
+++ b/components/shared/compositing/viewport_description.rs
@@ -7,17 +7,19 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use euclid::default::Scale;
+use euclid::Scale;
 use serde::{Deserialize, Serialize};
+use servo_geometry::DeviceIndependentPixel;
+use style_traits::CSSPixel;
 
 /// Default viewport constraints
 ///
 /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#initial-scale>
-pub const MIN_ZOOM: f32 = 0.1;
+pub const MIN_PAGE_ZOOM: Scale<f32, CSSPixel, DeviceIndependentPixel> = Scale::new(0.1);
 /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#initial-scale>
-pub const MAX_ZOOM: f32 = 10.0;
+pub const MAX_PAGE_ZOOM: Scale<f32, CSSPixel, DeviceIndependentPixel> = Scale::new(10.0);
 /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#initial-scale>
-pub const DEFAULT_ZOOM: f32 = 1.0;
+pub const DEFAULT_PAGE_ZOOM: Scale<f32, CSSPixel, DeviceIndependentPixel> = Scale::new(1.0);
 
 /// <https://drafts.csswg.org/css-viewport/#parsing-algorithm>
 const SEPARATORS: [char; 2] = [',', ';']; // Comma (0x2c) and Semicolon (0x3b)
@@ -35,15 +37,15 @@ pub struct ViewportDescription {
     // TODO: height Needs to be implemented
     /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#initial-scale>
     /// the zoom level when the page is first loaded
-    pub initial_scale: Scale<f32>,
+    pub initial_scale: Scale<f32, CSSPixel, DeviceIndependentPixel>,
 
     /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#minimum_scale>
     /// how much zoom out is allowed on the page.
-    pub minimum_scale: Scale<f32>,
+    pub minimum_scale: Scale<f32, CSSPixel, DeviceIndependentPixel>,
 
     /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#maximum_scale>
     /// how much zoom in is allowed on the page
-    pub maximum_scale: Scale<f32>,
+    pub maximum_scale: Scale<f32, CSSPixel, DeviceIndependentPixel>,
 
     /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#user_scalable>
     /// whether zoom in and zoom out actions are allowed on the page
@@ -85,9 +87,9 @@ impl TryFrom<&str> for UserScalable {
 impl Default for ViewportDescription {
     fn default() -> Self {
         ViewportDescription {
-            initial_scale: Scale::new(DEFAULT_ZOOM),
-            minimum_scale: Scale::new(MIN_ZOOM),
-            maximum_scale: Scale::new(MAX_ZOOM),
+            initial_scale: DEFAULT_PAGE_ZOOM,
+            minimum_scale: MIN_PAGE_ZOOM,
+            maximum_scale: MAX_PAGE_ZOOM,
             user_scalable: UserScalable::Yes,
         }
     }
@@ -126,7 +128,9 @@ impl ViewportDescription {
     }
 
     /// Parses a viewport zoom value.
-    fn parse_viewport_value_as_zoom(value: &str) -> Option<Scale<f32>> {
+    fn parse_viewport_value_as_zoom(
+        value: &str,
+    ) -> Option<Scale<f32, CSSPixel, DeviceIndependentPixel>> {
         value
             .to_lowercase()
             .as_str()

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -38,7 +38,7 @@ use style::queries::values::PrefersColorScheme;
 use style_traits::CSSPixel;
 use url::Url;
 use uuid::Uuid;
-use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel};
+use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, LayoutSize};
 
 pub use crate::input_events::*;
 pub use crate::webdriver::*;
@@ -317,6 +317,14 @@ pub struct ViewportDetails {
     /// The scale factor to use to account for HiDPI scaling. This does not take into account
     /// any page or pinch zoom applied by the compositor to the contents.
     pub hidpi_scale_factor: Scale<f32, CSSPixel, DevicePixel>,
+}
+
+impl ViewportDetails {
+    /// Convert this [`ViewportDetails`] size to a [`LayoutSize`]. This is the same numerical
+    /// value as [`Self::size`], because a `LayoutPixel` is the same as a `CSSPixel`.
+    pub fn layout_size(&self) -> LayoutSize {
+        Size2D::from_untyped(self.size.to_untyped())
+    }
 }
 
 /// Unlike [`ScreenGeometry`], the data is in device-independent pixels


### PR DESCRIPTION
Request a reflow when doing page zoom and only modify the scaling of the
WebView scene after the first root pipeline display list with the new
zoom is ready. In addition:

  - store zoom limits in `Scale` types
  - send `ViewportDetails` along with the display list so that we can
    detect when the root pipeline scale is ready.

Testing: This is quite hard to test as it requires verification that
contents are zoomed appropriately at the right time.
Fixes: #38091.
