### PR TITLE
servoshell: Consider window decorations when handling resize requests from web content

### DIFF
--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -349,6 +349,7 @@ impl WebView {
         self.inner().rect
     }
 
+    /// Update Compositor's [`WebViewRenderer`] rect and notify repaint.
     pub fn move_resize(&self, rect: DeviceRect) {
         if self.inner().rect == rect {
             return;
@@ -359,6 +360,14 @@ impl WebView {
             .compositor
             .borrow_mut()
             .move_resize_webview(self.id(), rect);
+    }
+
+    /// Update Compositor's [`RenderingContext`] size and notify repaint.
+    pub fn resize(&self, new_size: PhysicalSize<u32>) {
+        self.inner()
+            .compositor
+            .borrow_mut()
+            .resize_rendering_context(new_size);
     }
 
     pub fn hidpi_scale_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
@@ -488,13 +497,6 @@ impl WebView {
 
     pub fn notify_vsync(&self) {
         self.inner().compositor.borrow_mut().on_vsync(self.id());
-    }
-
-    pub fn resize(&self, new_size: PhysicalSize<u32>) {
-        self.inner()
-            .compositor
-            .borrow_mut()
-            .resize_rendering_context(new_size);
     }
 
     pub fn set_zoom(&self, new_zoom: f32) {

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -349,7 +349,6 @@ impl WebView {
         self.inner().rect
     }
 
-    /// Update Compositor's [`WebViewRenderer`] rect and notify repaint.
     pub fn move_resize(&self, rect: DeviceRect) {
         if self.inner().rect == rect {
             return;
@@ -362,7 +361,6 @@ impl WebView {
             .move_resize_webview(self.id(), rect);
     }
 
-    /// Update Compositor's [`RenderingContext`] size and notify repaint.
     pub fn resize(&self, new_size: PhysicalSize<u32>) {
         self.inner()
             .compositor

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -468,10 +468,10 @@ pub trait WebViewDelegate {
     /// Whether or not to allow a [`WebView`]  to unload a `Document` in its main frame or one
     /// of its nested `<iframe>`s. By default, unloads are allowed.
     fn request_unload(&self, _webview: WebView, _unload_request: AllowOrDenyRequest) {}
-    /// Move the window to a point
+    /// Move the window to a point.
     fn request_move_to(&self, _webview: WebView, _: DeviceIntPoint) {}
-    /// Resize the window to size
-    fn request_resize_to(&self, _webview: WebView, _: DeviceIntSize) {}
+    /// Try to resize the window to outer size.
+    fn request_resize_to(&self, _webview: WebView, _requested_outer_size: DeviceIntSize) {}
     /// Whether or not to allow script to open a new `WebView`. If not handled by the
     /// embedder, these requests are automatically denied.
     fn request_open_auxiliary_webview(&self, _parent_webview: WebView) -> Option<WebView> {

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -470,7 +470,7 @@ pub trait WebViewDelegate {
     fn request_unload(&self, _webview: WebView, _unload_request: AllowOrDenyRequest) {}
     /// Move the window to a point.
     fn request_move_to(&self, _webview: WebView, _: DeviceIntPoint) {}
-    /// Try to resize the window to outer size.
+    /// Try to resize the window that contains this [`WebView`] to the provided outer size.
     fn request_resize_to(&self, _webview: WebView, _requested_outer_size: DeviceIntSize) {}
     /// Whether or not to allow script to open a new `WebView`. If not handled by the
     /// embedder, these requests are automatically denied.

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -557,11 +557,11 @@ impl WebViewDelegate for RunningAppState {
         self.inner().window.set_position(new_position);
     }
 
-    fn request_resize_to(&self, webview: servo::WebView, new_outer_size: DeviceIntSize) {
-        let mut rect = webview.rect();
-        rect.set_size(new_outer_size.to_f32());
-        webview.move_resize(rect);
-        self.inner().window.request_resize(&webview, new_outer_size);
+    fn request_resize_to(&self, webview: servo::WebView, requested_outer_size: DeviceIntSize) {
+        // We need to update compositor's view later as we not sure about resizing result.
+        self.inner()
+            .window
+            .request_resize(&webview, requested_outer_size);
     }
 
     fn show_simple_dialog(&self, webview: servo::WebView, dialog: SimpleDialog) {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -432,14 +432,11 @@ impl Window {
     }
 
     /// Update [`WindowRenderingContext`] after a resize.
-    fn update_window_rendering_context_after_resize(
-        &self,
-        res_inner_width: f32,
-        res_inner_height: f32,
-    ) {
+    fn update_window_rendering_context_after_resize(&self, inner_size: PhysicalSize<u32>) {
         self.window_rendering_context.resize(PhysicalSize::new(
-            res_inner_width as u32,
-            (res_inner_height - (self.toolbar_height() * self.hidpi_scale_factor()).0) as u32,
+            inner_size.width,
+            (inner_size.height as f32 - (self.toolbar_height() * self.hidpi_scale_factor()).0)
+                as u32,
         ));
     }
 }
@@ -507,10 +504,10 @@ impl WindowPortsMethods for Window {
                 new_outer_size.width - decoration_width as i32,
                 new_outer_size.height - decoration_height as i32,
             ))
-            .map(|res_inner_size| {
+            .map(|resulting_size| {
                 DeviceIntSize::new(
-                    (res_inner_size.width + decoration_width) as i32,
-                    (res_inner_size.height + decoration_height) as i32,
+                    (resulting_size.width + decoration_width) as i32,
+                    (resulting_size.height + decoration_height) as i32,
                 )
             })
     }
@@ -693,11 +690,8 @@ impl WindowPortsMethods for Window {
             WindowEvent::Resized(new_inner_size) => {
                 if self.inner_size.get() != new_inner_size {
                     self.inner_size.set(new_inner_size);
-                    // webview related compositor rect was updated in minibrowser::update
-                    self.update_window_rendering_context_after_resize(
-                        new_inner_size.width as f32,
-                        new_inner_size.height as f32,
-                    );
+                    // `WebView::move_resize` was already called in `Minibrowser::update`.
+                    self.update_window_rendering_context_after_resize(new_inner_size);
                 }
             },
             WindowEvent::ThemeChanged(theme) => {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -91,12 +91,12 @@ impl Window {
         event_loop: &ActiveEventLoop,
     ) -> Window {
         let no_native_titlebar = servoshell_preferences.no_native_titlebar;
-        let window_size = servoshell_preferences.initial_window_size;
+        let inner_size = servoshell_preferences.initial_window_size;
         let window_attr = winit::window::Window::default_attributes()
             .with_title("Servo".to_string())
             .with_decorations(!no_native_titlebar)
             .with_transparent(no_native_titlebar)
-            .with_inner_size(LogicalSize::new(window_size.width, window_size.height))
+            .with_inner_size(LogicalSize::new(inner_size.width, inner_size.height))
             .with_min_inner_size(LogicalSize::new(1, 1))
             // Must be invisible at startup; accesskit_winit setup needs to
             // happen before the window is shown for the first time.
@@ -430,6 +430,18 @@ impl Window {
             }
         }
     }
+
+    /// Update [`WindowRenderingContext`] after a resize.
+    fn update_window_rendering_context_after_resize(
+        &self,
+        res_inner_width: f32,
+        res_inner_height: f32,
+    ) {
+        self.window_rendering_context.resize(PhysicalSize::new(
+            res_inner_width as u32,
+            (res_inner_height - (self.toolbar_height() * self.hidpi_scale_factor()).0) as u32,
+        ));
+    }
 }
 
 impl WindowPortsMethods for Window {
@@ -495,11 +507,11 @@ impl WindowPortsMethods for Window {
                 new_outer_size.width - decoration_width as i32,
                 new_outer_size.height - decoration_height as i32,
             ))
-            .and_then(|size| {
-                Some(DeviceIntSize::new(
-                    size.width.try_into().ok()?,
-                    size.height.try_into().ok()?,
-                ))
+            .map(|res_inner_size| {
+                DeviceIntSize::new(
+                    (res_inner_size.width + decoration_width) as i32,
+                    (res_inner_size.height + decoration_height) as i32,
+                )
             })
     }
 
@@ -678,10 +690,14 @@ impl WindowPortsMethods for Window {
             WindowEvent::CloseRequested => {
                 state.servo().start_shutting_down();
             },
-            WindowEvent::Resized(new_size) => {
-                if self.inner_size.get() != new_size {
-                    self.window_rendering_context.resize(new_size);
-                    self.inner_size.set(new_size);
+            WindowEvent::Resized(new_inner_size) => {
+                if self.inner_size.get() != new_inner_size {
+                    self.inner_size.set(new_inner_size);
+                    // webview related compositor rect was updated in minibrowser::update
+                    self.update_window_rendering_context_after_resize(
+                        new_inner_size.width as f32,
+                        new_inner_size.height as f32,
+                    );
                 }
             },
             WindowEvent::ThemeChanged(theme) => {
@@ -755,6 +771,9 @@ impl WindowPortsMethods for Window {
     }
 
     fn set_toolbar_height(&self, height: Length<f32, DeviceIndependentPixel>) {
+        if self.toolbar_height() == height {
+            return;
+        }
         self.toolbar_height.set(height);
         // Prevent the inner area from being 0 pixels wide or tall
         // this prevents a crash in the compositor due to invalid surface size

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -77,10 +77,10 @@ impl WindowPortsMethods for Window {
     fn request_resize(
         &self,
         webview: &::servo::WebView,
-        size: DeviceIntSize,
+        outer_size: DeviceIntSize,
     ) -> Option<DeviceIntSize> {
         // Surfman doesn't support zero-sized surfaces.
-        let new_size = DeviceIntSize::new(size.width.max(1), size.height.max(1));
+        let new_size = DeviceIntSize::new(outer_size.width.max(1), outer_size.height.max(1));
         if self.inner_size.get() == new_size {
             return Some(new_size);
         }
@@ -90,7 +90,13 @@ impl WindowPortsMethods for Window {
         // Because we are managing the rendering surface ourselves, there will be no other
         // notification (such as from the display manager) that it has changed size, so we
         // must notify the compositor here.
-        webview.resize(PhysicalSize::new(size.width as u32, size.height as u32));
+        let mut rect = webview.rect();
+        rect.set_size(outer_size.to_f32());
+        webview.move_resize(rect);
+        webview.resize(PhysicalSize::new(
+            outer_size.width as u32,
+            outer_size.height as u32,
+        ));
 
         Some(new_size)
     }

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -90,9 +90,7 @@ impl WindowPortsMethods for Window {
         // Because we are managing the rendering surface ourselves, there will be no other
         // notification (such as from the display manager) that it has changed size, so we
         // must notify the compositor here.
-        let mut rect = webview.rect();
-        rect.set_size(outer_size.to_f32());
-        webview.move_resize(rect);
+        webview.move_resize(outer_size.to_f32().into());
         webview.resize(PhysicalSize::new(
             outer_size.width as u32,
             outer_size.height as u32,

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -44,7 +44,7 @@ pub(crate) struct ServoShellPreferences {
     /// Overrides directives specified via `SERVO_TRACING` if set.
     /// See: <https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/filter/struct.EnvFilter.html#directives>
     pub tracing_filter: Option<String>,
-    /// The initial requested size of the window.
+    /// The initial requested inner size of the window.
     pub initial_window_size: Size2D<u32, DeviceIndependentPixel>,
     /// An override for the screen resolution. This is useful for testing behavior on different screen sizes,
     /// such as the screen of a mobile device.


### PR DESCRIPTION
Also fix some docs. This is used by JS `resizeTo`, `resizeBy` and webdriver [set window rect](https://w3c.github.io/webdriver/#set-window-rect).

Testing: Can now pass more tests for headed window.
Fixes: Well.. Originally the attempt is to address https://github.com/servo/servo/issues/38093#issuecomment-3092284104. But it turns out as a more general problem to be fixed in another PR.