### PR TITLE
compositing: Remove unused dependency.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,7 +1377,6 @@ dependencies = [
  "ipc-channel",
  "libc",
  "log",
- "net",
  "pixels",
  "profile_traits",
  "servo-tracing",

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -31,12 +31,12 @@ gleam = { workspace = true }
 ipc-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
-net = { path = "../net" }
 pixels = { path = "../pixels" }
 profile_traits = { workspace = true }
 servo_allocator = { path = "../allocator" }
 servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
+servo-tracing = { workspace = true }
 stylo_traits = { workspace = true }
 timers = { path = "../timers" }
 tracing = { workspace = true, optional = true }
@@ -44,7 +44,6 @@ webrender = { workspace = true }
 webrender_api = { workspace = true }
 webxr = { path = "../webxr", optional = true }
 wr_malloc_size_of = { workspace = true }
-servo-tracing = { workspace = true }
 
 [dev-dependencies]
 surfman = { workspace = true }


### PR DESCRIPTION
There are no uses of `net` within the `compositing` crate.