### PR TITLE
webdriver: Implement element send keys command for non-typeable form control

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -492,6 +492,24 @@ impl HTMLInputElement {
     }
 
     #[inline]
+    /// <https://w3c.github.io/webdriver/#dfn-non-typeable-form-control>
+    pub(crate) fn is_nontypeable(&self) -> bool {
+        matches!(
+            self.input_type(),
+            InputType::Button |
+                InputType::Checkbox |
+                InputType::Color |
+                InputType::File |
+                InputType::Hidden |
+                InputType::Image |
+                InputType::Radio |
+                InputType::Range |
+                InputType::Reset |
+                InputType::Submit
+        )
+    }
+
+    #[inline]
     pub(crate) fn is_submit_button(&self) -> bool {
         let input_type = self.input_type.get();
         input_type == InputType::Submit || input_type == InputType::Image

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -491,7 +491,6 @@ impl HTMLInputElement {
         self.input_type.get()
     }
 
-    #[inline]
     /// <https://w3c.github.io/webdriver/#dfn-non-typeable-form-control>
     pub(crate) fn is_nontypeable(&self) -> bool {
         matches!(

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -212,7 +212,7 @@ impl InputType {
         )
     }
 
-    pub(crate) fn is_textual_or_password(&self) -> bool {
+    fn is_textual_or_password(&self) -> bool {
         self.is_textual() || *self == InputType::Password
     }
 

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -212,7 +212,7 @@ impl InputType {
         )
     }
 
-    fn is_textual_or_password(&self) -> bool {
+    pub(crate) fn is_textual_or_password(&self) -> bool {
         self.is_textual() || *self == InputType::Password
     }
 
@@ -1990,7 +1990,7 @@ impl HTMLInputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#concept-fe-mutable
-    fn is_mutable(&self) -> bool {
+    pub(crate) fn is_mutable(&self) -> bool {
         // https://html.spec.whatwg.org/multipage/#the-input-element:concept-fe-mutable
         // https://html.spec.whatwg.org/multipage/#the-readonly-attribute:concept-fe-mutable
         !(self.upcast::<Element>().disabled_state() || self.ReadOnly())

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -70,7 +70,6 @@ use crate::dom::htmloptionelement::HTMLOptionElement;
 use crate::dom::htmlselectelement::HTMLSelectElement;
 use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::nodelist::NodeList;
-use crate::dom::textcontrol::TextControlElement;
 use crate::dom::types::ShadowRoot;
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::window::Window;

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -70,6 +70,7 @@ use crate::dom::htmloptionelement::HTMLOptionElement;
 use crate::dom::htmlselectelement::HTMLSelectElement;
 use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::nodelist::NodeList;
+use crate::dom::textcontrol::TextControlElement;
 use crate::dom::types::ShadowRoot;
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::window::Window;
@@ -1184,7 +1185,7 @@ pub(crate) fn handle_will_send_keys(
 
                 // Step 8 (non-typeable form control)
                 if let Some(input_element) = input_element {
-                    if !input_element.input_type().is_textual_or_password() {
+                    if !input_element.has_selectable_text() {
                         return handle_send_keys_non_typeable(input_element, &text, can_gc);
                     }
                 }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1185,7 +1185,7 @@ pub(crate) fn handle_will_send_keys(
 
                 // Step 8 (non-typeable form control)
                 if let Some(input_element) = input_element {
-                    if !input_element.has_selectable_text() {
+                    if input_element.is_nontypeable() {
                         return handle_send_keys_non_typeable(input_element, &text, can_gc);
                     }
                 }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1184,7 +1184,7 @@ pub(crate) fn handle_will_send_keys(
                 // Step 8 (non-typeable form control)
                 if let Some(input_element) = input_element {
                     if !input_element.input_type().is_textual_or_password() {
-                        return handle_send_keys_non_typeable(&input_element, &text, can_gc);
+                        return handle_send_keys_non_typeable(input_element, &text, can_gc);
                     } 
                 }
 

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1121,6 +1121,7 @@ fn handle_send_keys_non_typeable(
 
     // Step 3. Set a property value to text on element.
     if input_element.SetValue(text.into(), can_gc).is_err() {
+        info!("Failed to set value on non-typeable input element");
         return Err(ErrorStatus::UnknownError);
     }
 

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1110,7 +1110,7 @@ fn handle_send_keys_non_typeable(
     can_gc: CanGc,
 ) -> Result<bool, ErrorStatus> {
     // Step 1. If element does not have an own property named value,
-    // Return ErrorStatus::ElementNotInteractable. 
+    // Return ErrorStatus::ElementNotInteractable.
     // Currently, we only support HTMLInputElement for non-typeable
     // form controls. Hence, it should always have value property.
 
@@ -1121,13 +1121,15 @@ fn handle_send_keys_non_typeable(
 
     // Step 3. Set a property value to text on element.
     if input_element.SetValue(text.into(), can_gc).is_err() {
-        return Err(ErrorStatus::UnknownError)
+        return Err(ErrorStatus::UnknownError);
     }
 
     // Step 4. If element is suffering from bad input, return ErrorStatus::InvalidArgument.
-    if input_element.Validity()
+    if input_element
+        .Validity()
         .invalid_flags()
-        .contains(ValidationFlags::BAD_INPUT) {
+        .contains(ValidationFlags::BAD_INPUT)
+    {
         return Err(ErrorStatus::InvalidArgument);
     }
 
@@ -1152,8 +1154,7 @@ pub(crate) fn handle_will_send_keys(
         .send(
             // Set 5. Let element be the result of trying to get a known element.
             get_known_element(documents, pipeline, element_id).and_then(|element| {
-                let input_element = element
-                    .downcast::<HTMLInputElement>();
+                let input_element = element.downcast::<HTMLInputElement>();
 
                 // Step 6: Let file be true if element is input element
                 // in the file upload state, or false otherwise
@@ -1185,7 +1186,7 @@ pub(crate) fn handle_will_send_keys(
                 if let Some(input_element) = input_element {
                     if !input_element.input_type().is_textual_or_password() {
                         return handle_send_keys_non_typeable(input_element, &text, can_gc);
-                    } 
+                    }
                 }
 
                 // TODO: Check content editable


### PR DESCRIPTION
Implement Step 8 of remote end steps of [Element Send keys](https://w3c.github.io/webdriver/#element-send-keys), specifically for non-typeable form control.