### PR TITLE
Rename `viewport_zoom` to `pinch_zoom`

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -88,8 +88,8 @@ pub(crate) struct WebViewRenderer {
     touch_handler: TouchHandler,
     /// "Desktop-style" zoom that resizes the viewport to fit the window.
     pub page_zoom: Scale<f32, CSSPixel, DeviceIndependentPixel>,
-    /// "Mobile-style" zoom that does not reflow the page.
-    viewport_zoom: PinchZoomFactor,
+    /// "Mobile-style" zoom that does not reflow the page, i.e. pinch zoom.
+    pinch_zoom: PinchZoomFactor,
     /// The HiDPI scale factor for the `WebView` associated with this renderer. This is controlled
     /// by the embedding layer.
     hidpi_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
@@ -130,8 +130,8 @@ impl WebViewRenderer {
             touch_handler: TouchHandler::new(),
             global,
             pending_scroll_zoom_events: Default::default(),
-            page_zoom: Scale::new(1.0),
-            viewport_zoom: PinchZoomFactor::new(DEFAULT_ZOOM),
+            page_zoom: Scale::new(DEFAULT_ZOOM),
+            pinch_zoom: PinchZoomFactor::new(DEFAULT_ZOOM),
             hidpi_scale_factor: Scale::new(hidpi_scale_factor.0),
             animating: false,
             pending_point_input_events: Default::default(),
@@ -952,7 +952,7 @@ impl WebViewRenderer {
     }
 
     pub(crate) fn pinch_zoom_level(&self) -> Scale<f32, DevicePixel, DevicePixel> {
-        Scale::new(self.viewport_zoom.get())
+        Scale::new(self.pinch_zoom.get())
     }
 
     fn set_pinch_zoom_level(&mut self, mut zoom: f32) -> bool {
@@ -960,8 +960,8 @@ impl WebViewRenderer {
             zoom = viewport.clamp_zoom(zoom);
         }
 
-        let old_zoom = std::mem::replace(&mut self.viewport_zoom, PinchZoomFactor::new(zoom));
-        old_zoom != self.viewport_zoom
+        let old_zoom = std::mem::replace(&mut self.pinch_zoom, PinchZoomFactor::new(zoom));
+        old_zoom != self.pinch_zoom
     }
 
     pub(crate) fn set_page_zoom(&mut self, magnification: f32) {

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -88,7 +88,7 @@ pub(crate) struct WebViewRenderer {
     touch_handler: TouchHandler,
     /// "Desktop-style" zoom that resizes the viewport to fit the window.
     pub page_zoom: Scale<f32, CSSPixel, DeviceIndependentPixel>,
-    /// "Mobile-style" zoom that does not reflow the page, i.e. pinch zoom.
+    /// "Mobile-style" zoom that does not reflow the page.
     pinch_zoom: PinchZoomFactor,
     /// The HiDPI scale factor for the `WebView` associated with this renderer. This is controlled
     /// by the embedding layer.


### PR DESCRIPTION
This change is in accordance with highlighting the usage of various zoom options.

`pinch_zoom`: `Mobile-style` zoom using pinch gesture
 `page_zoom`: `Desktop-style` zoom (`Ctrl` + `+`/`-`)

It just renames the variable `viewport_zoom` to `pinch_zoom` for better clarity

Testing: Testing not required, as it's just renaming of variable .

