### PR TITLE
dom: Optimize IFrameCollection::validate

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3349,6 +3349,10 @@ impl Document {
         self.iframes.borrow_mut()
     }
 
+    pub(crate) fn invalidate_iframes_collection(&self) {
+        self.iframes.borrow_mut().invalidate();
+    }
+
     pub(crate) fn get_dom_interactive(&self) -> Option<CrossProcessInstant> {
         self.dom_interactive.get()
     }
@@ -4145,7 +4149,7 @@ impl Document {
             scripts: Default::default(),
             anchors: Default::default(),
             applets: Default::default(),
-            iframes: Default::default(),
+            iframes: RefCell::new(IFrameCollection::new()),
             style_shared_lock: {
                 /// Per-process shared lock for author-origin stylesheets
                 ///

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -43,7 +43,7 @@ use crate::dom::element::{
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlelement::HTMLElement;
-use crate::dom::node::{Node, NodeDamage, NodeTraits, UnbindContext};
+use crate::dom::node::{BindContext, Node, NodeDamage, NodeTraits, UnbindContext};
 use crate::dom::trustedhtml::TrustedHTML;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::windowproxy::WindowProxy;
@@ -813,6 +813,13 @@ impl VirtualMethods for HTMLIFrameElement {
         }
     }
 
+    fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
+        if let Some(s) = self.super_type() {
+            s.bind_to_tree(context, can_gc);
+        }
+        self.owner_document().invalidate_iframes_collection();
+    }
+
     fn unbind_from_tree(&self, context: &UnbindContext, can_gc: CanGc) {
         self.super_type().unwrap().unbind_from_tree(context, can_gc);
 
@@ -865,5 +872,7 @@ impl VirtualMethods for HTMLIFrameElement {
         // a new iframe. Without this, the constellation gets very
         // confused.
         self.destroy_nested_browsing_context();
+
+        self.owner_document().invalidate_iframes_collection();
     }
 }

--- a/tests/wpt/meta/css/selectors/invalidation/has-complexity.html.ini
+++ b/tests/wpt/meta/css/selectors/invalidation/has-complexity.html.ini
@@ -1,4 +1,18 @@
 [has-complexity.html]
-  expected: TIMEOUT
   [Before appending 25000 elements]
+    expected: FAIL
+
+  [After appending 25000 elements. This should not time out.]
+    expected: FAIL
+
+  [After appending another 25000 elements. This should not time out.]
+    expected: FAIL
+
+  [After appending div with 25000 elements. This should not time out.]
+    expected: FAIL
+
+  [After removing div with 25000 elements. This should not time out.]
+    expected: FAIL
+
+  [After removing 25000 elements one-by-one. This should not time out.]
     expected: FAIL


### PR DESCRIPTION
The `IFrameCollection` was previously rebuilt too often. This PR tries to address the todo, to only rebuild the IFrameCollection when necessary.

Testing: `CSS Selector Invalidation: :has() invalidation should not be O(n^2)` wpt-test changed status from timeout to failed.
Fixes: #38131 (IFrameCollection::validate accounts for 30% of script time in DOM heavy scenarios)


Co-authored-by: sharpshooter_pt <ibluegalaxy_taoj@163.com>