### PR TITLE
Layout: minor optimizations and bugfix for non-functional details

### DIFF
--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -1179,7 +1179,11 @@ fn do_initial_flex_line_layout<'items>(
     // We didn't reach the end of the last line, so add all remaining items there.
     lines.push((items, line_size_so_far));
 
-    lines.par_drain(..).map(construct_line).collect()
+    if flex_context.layout_context.use_rayon {
+        lines.par_drain(..).map(construct_line).collect()
+    } else {
+        lines.drain(..).map(construct_line).collect()
+    }
 }
 
 /// The result of splitting the flex items into lines using their intrinsic sizes and doing an

--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -376,6 +376,7 @@ impl<'dom> IncrementalBoxTreeUpdate<'dom> {
         })
     }
 
+    #[servo_tracing::instrument(name = "Box Tree Construction", skip_all)]
     fn update_from_dirty_root(&self, context: &LayoutContext) {
         let contents = ReplacedContents::for_element(self.node, context)
             .map_or_else(|| NonReplacedContents::OfElement.into(), Contents::Replaced);

--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -376,7 +376,7 @@ impl<'dom> IncrementalBoxTreeUpdate<'dom> {
         })
     }
 
-    #[servo_tracing::instrument(name = "Box Tree Construction", skip_all)]
+    #[servo_tracing::instrument(name = "Box Tree Update From Dirty Root", skip_all)]
     fn update_from_dirty_root(&self, context: &LayoutContext) {
         let contents = ReplacedContents::for_element(self.node, context)
             .map_or_else(|| NonReplacedContents::OfElement.into(), Contents::Replaced);

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -589,7 +589,7 @@ impl LayoutThread {
             return false;
         }
         // We always need to at least build a fragment tree.
-        if !self.fragment_tree.borrow().is_none() {
+        if self.fragment_tree.borrow().is_none() {
             return false;
         }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -710,6 +710,7 @@ impl LayoutThread {
         (viewport_changed && had_used_viewport_units) || theme_changed
     }
 
+    #[servo_tracing::instrument(skip_all)]
     fn prepare_stylist_for_reflow<'dom>(
         &mut self,
         reflow_request: &ReflowRequest,


### PR DESCRIPTION
This change adds some minor optimizations and bugfix for non-functional details with seperated commits:
- fix the omission that stop use `Rayon` in single-thread mode
- add trace for incremental box tree construction
- fix the bug that failed to skip reflow entirely when there is no need for `restyle` and a fragment tree has already been built.
- add trace for stylist preparation during reflow. In certain scenarios, this phase might take up a significant amount of time, such as when there are a large number of shadow trees.

Testing: This should not change observable behavior and is thus covered by existing WPT tests.
