### PR TITLE
script: Use `NodeDamage::ContentOrHeritage` for slot changes

### DIFF
--- a/components/script/dom/htmlslotelement.rs
+++ b/components/script/dom/htmlslotelement.rs
@@ -346,7 +346,7 @@ impl HTMLSlotElement {
 
     /// <https://dom.spec.whatwg.org/#signal-a-slot-change>
     pub(crate) fn signal_a_slot_change(&self) {
-        self.upcast::<Node>().dirty(NodeDamage::Other);
+        self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
 
         if self.is_in_agents_signal_slots.get() {
             return;


### PR DESCRIPTION
This change aims to reduce the scope of incremental box tree construction. Previously, when children of slot node changed, the slot would always be marked as requiring box tree reconstruction; now, it is adjusted to only mark the slot node as needing to recollect its box tree children.

Testing: This should not change observable behavior and is thus covered by existing WPT tests.
