### PR TITLE
layout: optimize the propagation and cleanup of RestyleDamage

### DIFF
--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -21,12 +21,11 @@ bitflags! {
 
 impl LayoutDamage {
     pub fn recollect_box_tree_children() -> RestyleDamage {
-        RestyleDamage::from_bits_retain(LayoutDamage::RECOLLECT_BOX_TREE_CHILDREN.bits()) |
-            RestyleDamage::RELAYOUT
+        RestyleDamage::from_bits_retain(LayoutDamage::RECOLLECT_BOX_TREE_CHILDREN.bits())
     }
 
     pub fn rebuild_box_tree() -> RestyleDamage {
-        RestyleDamage::from_bits_retain(LayoutDamage::REBUILD_BOX.bits()) | RestyleDamage::RELAYOUT
+        RestyleDamage::from_bits_retain(LayoutDamage::REBUILD_BOX.bits())
     }
 
     pub fn has_box_damage(&self) -> bool {


### PR DESCRIPTION
This change optimizes `RestyleDamage` propagation and cleanup to reduce unnecessary box reconstruction and relayouts, while preventing damage from the current reflow affecting subsequent ones. Improvements include:
- For box damage caused by `NodeDamage`, `RestyleDamage::RELAYOUT` is no longer marked immediately—avoiding erroneous propagation of `LayoutDamage::RECOLLECT_BOX_TREE_CHILDREN` to descendants during `RestyleDamage` propagation.
- Clearing damage for nodes whose boxes will be preserved, preventing it from carrying over to the next reflow and increasing its workload.

Testing: This should not change observable behavior and is thus covered by existing WPT tests. Although Servo lacks performance test cases, manual testing shows that this modification reduces reflow time by nearly 250ms, representing a decrease of approximately 25%.
