### PR TITLE
chore: Update kurbo to 0.11.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,11 +4651,12 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kurbo"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1077d333efea6170d9ccb96d3c3026f300ca0773da4938cc4c811daa6df68b0c"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
 dependencies = [
  "arrayvec",
+ "euclid",
  "serde",
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ ipc-channel = "0.20"
 itertools = "0.14"
 js = { package = "mozjs", git = "https://github.com/servo/mozjs" }
 keyboard-types = "0.7"
-kurbo = { version = "0.11", features = ["euclid"] }
+kurbo = { version = "0.11.3", features = ["euclid"] }
 libc = "0.2"
 log = "0.4"
 mach2 = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ ipc-channel = "0.20"
 itertools = "0.14"
 js = { package = "mozjs", git = "https://github.com/servo/mozjs" }
 keyboard-types = "0.7"
-kurbo = "0.11"
+kurbo = { version = "0.11", features = ["euclid"] }
 libc = "0.2"
 log = "0.4"
 mach2 = "0.4"

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -9,7 +9,7 @@ use euclid::Angle;
 use euclid::approxeq::ApproxEq;
 use euclid::default::{Point2D, Rect, Size2D, Transform2D};
 use ipc_channel::ipc::IpcSender;
-use kurbo::{Affine, BezPath, ParamCurveNearest as _, PathEl, Point, Shape, Triangle};
+use kurbo::{BezPath, ParamCurveNearest as _, PathEl, Point, Shape, Triangle};
 use malloc_size_of::MallocSizeOf;
 use malloc_size_of_derive::MallocSizeOf;
 use pixels::IpcSnapshot;
@@ -39,7 +39,7 @@ impl Path {
     }
 
     pub fn transform(&mut self, transform: Transform2D<f64>) {
-        self.0.apply_affine(Affine::new(transform.to_array()));
+        self.0.apply_affine(transform.into());
     }
 
     /// <https://html.spec.whatwg.org/multipage/#ensure-there-is-a-subpath>
@@ -222,19 +222,7 @@ impl Path {
     }
 
     pub fn last_point(&mut self) -> Option<Point> {
-        // https://github.com/linebender/kurbo/pull/462
-        match self.0.elements().last()? {
-            PathEl::ClosePath => self
-                .0
-                .elements()
-                .iter()
-                .rev()
-                .skip(1)
-                .take_while(|el| !matches!(el, PathEl::ClosePath))
-                .last()
-                .and_then(|el| el.end_point()),
-            other => other.end_point(),
-        }
+        self.0.current_position()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -399,11 +387,7 @@ impl Path {
     }
 
     pub fn bounding_box(&self) -> Rect<f64> {
-        let rect = self.0.control_box();
-        Rect::new(
-            Point2D::new(rect.origin().x, rect.origin().y),
-            Size2D::new(rect.width(), rect.height()),
-        )
+        self.0.control_box().into()
     }
 }
 


### PR DESCRIPTION
Some of the code we wrote is now also in upstream, mainly `BezPath.current_position` and euclid types conversions.

Testing: Code is covered by existing WPT tests.