### PR TITLE
Remove Webdriver Server's access to Constellation

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -60,12 +60,12 @@ use crate::webview_manager::WebViewManager;
 use crate::webview_renderer::{PinchZoomResult, UnknownWebView, WebViewRenderer};
 
 #[derive(Debug, PartialEq)]
-enum UnableToComposite {
+pub enum UnableToComposite {
     NotReadyToPaintImage(NotReadyToPaint),
 }
 
 #[derive(Debug, PartialEq)]
-enum NotReadyToPaint {
+pub enum NotReadyToPaint {
     JustNotifiedConstellation,
     WaitingOnConstellation,
 }
@@ -591,18 +591,6 @@ impl IOCompositor {
                 };
                 webview_renderer.on_touch_event_processed(result);
             },
-
-            CompositorMsg::CreatePng(webview_id, page_rect, reply) => {
-                let res = self.render_to_shared_memory(webview_id, page_rect);
-                if let Err(ref e) = res {
-                    info!("Error retrieving PNG: {:?}", e);
-                }
-                let img = res.unwrap_or(None);
-                if let Err(e) = reply.send(img) {
-                    warn!("Sending reply to create png failed ({:?}).", e);
-                }
-            },
-
             CompositorMsg::IsReadyToSaveImageReply(is_ready) => {
                 assert_eq!(
                     self.ready_to_save_state,
@@ -1351,7 +1339,7 @@ impl IOCompositor {
 
     /// Render the WebRender scene to the shared memory, without updating other state of this
     /// [`IOCompositor`]. If succesful return the output image in shared memory.
-    fn render_to_shared_memory(
+    pub fn render_to_shared_memory(
         &mut self,
         webview_id: WebViewId,
         page_rect: Option<Rect<f32, CSSPixel>>,

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -34,7 +34,6 @@ mod from_constellation {
                 Self::CreateOrUpdateWebView(..) => target!("CreateOrUpdateWebView"),
                 Self::RemoveWebView(..) => target!("RemoveWebView"),
                 Self::TouchEventProcessed(..) => target!("TouchEventProcessed"),
-                Self::CreatePng(..) => target!("CreatePng"),
                 Self::IsReadyToSaveImageReply(..) => target!("IsReadyToSaveImageReply"),
                 Self::SetThrottled(..) => target!("SetThrottled"),
                 Self::NewWebRenderFrameReady(..) => target!("NewWebRenderFrameReady"),

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4455,13 +4455,6 @@ where
                     self.handle_send_error(pipeline_id, e);
                 }
             },
-            WebDriverCommandMsg::TakeScreenshot(webview_id, rect, response_sender) => {
-                self.compositor_proxy.send(CompositorMsg::CreatePng(
-                    webview_id,
-                    rect,
-                    response_sender,
-                ));
-            },
             WebDriverCommandMsg::CloseWebView(..) |
             WebDriverCommandMsg::NewWebView(..) |
             WebDriverCommandMsg::FocusWebView(..) |
@@ -4475,7 +4468,8 @@ where
             WebDriverCommandMsg::KeyboardAction(..) |
             WebDriverCommandMsg::MouseButtonAction(..) |
             WebDriverCommandMsg::MouseMoveAction(..) |
-            WebDriverCommandMsg::WheelScrollAction(..) => {
+            WebDriverCommandMsg::WheelScrollAction(..) |
+            WebDriverCommandMsg::TakeScreenshot(..) => {
                 unreachable!("This command should be send directly to the embedder.");
             },
             _ => {

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -9,14 +9,11 @@ use std::fmt::{Debug, Error, Formatter};
 use base::id::{PipelineId, WebViewId};
 use crossbeam_channel::Sender;
 use embedder_traits::{AnimationState, EventLoopWaker, TouchEventResult};
-use euclid::Rect;
 use ipc_channel::ipc::IpcSender;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
-use pixels::RasterImage;
 use smallvec::SmallVec;
 use strum_macros::IntoStaticStr;
-use style_traits::CSSPixel;
 use webrender_api::DocumentId;
 
 pub mod display_list;
@@ -80,12 +77,6 @@ pub enum CompositorMsg {
     RemoveWebView(WebViewId),
     /// Script has handled a touch event, and either prevented or allowed default actions.
     TouchEventProcessed(WebViewId, TouchEventResult),
-    /// Composite to a PNG file and return the Image over a passed channel.
-    CreatePng(
-        WebViewId,
-        Option<Rect<f32, CSSPixel>>,
-        IpcSender<Option<RasterImage>>,
-    ),
     /// A reply to the compositor asking if the output image is stable.
     IsReadyToSaveImageReply(bool),
     /// Set whether to use less resources by stopping animations.

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -138,7 +138,7 @@ pub enum WebDriverCommandMsg {
         DeviceIndependentIntSize,
         IpcSender<Size2D<i32, DeviceIndependentPixel>>,
     ),
-    /// Take a screenshot of the window.
+    /// Take a screenshot of the viewport.
     TakeScreenshot(
         WebViewId,
         Option<Rect<f32, CSSPixel>>,

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -187,7 +187,6 @@ impl App {
 
             webdriver_server::start_server(
                 port,
-                servo.constellation_sender(),
                 embedder_sender,
                 self.waker.clone(),
                 webdriver_response_receiver,
@@ -621,10 +620,7 @@ impl App {
                     running_state.set_alert_text_of_newest_dialog(webview_id, text);
                 },
                 WebDriverCommandMsg::TakeScreenshot(..) => {
-                    warn!(
-                        "WebDriverCommand {:?} is still not moved from constellation to embedder",
-                        msg
-                    );
+                    running_state.forward_webdriver_command(msg);
                 },
             };
         }


### PR DESCRIPTION
`WebDriverCommandMsg::TakeScreenshot` was the last thing blocking us from removing constellation access in webdriver server. Now we can happily remove it.

Surprisingly, this reduces binary size by 185KB for release profile in Windows. #37737 removes a net total of 300 lines, but only reduced 98KB.

Testing: No regression after testing.
