### PR TITLE
Ohos: include build id in ohos built binary

### DIFF
--- a/python/servo/platform/build_target.py
+++ b/python/servo/platform/build_target.py
@@ -374,7 +374,12 @@ class OpenHarmonyTarget(CrossBuildTarget):
         # rustc linker
         env[f"CARGO_TARGET_{rust_target_triple.upper()}_LINKER"] = ndk_clang
 
-        link_args = ["-fuse-ld=lld", f"--target={clang_target_triple}", f"--sysroot={ohos_sysroot_posix}"]
+        link_args = [
+            "-fuse-ld=lld",
+            f"--target={clang_target_triple}",
+            f"--sysroot={ohos_sysroot_posix}",
+            "-Wl,--build-id",
+        ]
 
         env["HOST_CFLAGS"] = ""
         env["HOST_CXXFLAGS"] = ""


### PR DESCRIPTION
add link-arg for ohos to include build id in its ELF binary. This could enable us to do debugging and size checking more easily.

Testing: No test needed.
Fixes: N/A

cc @jschwe 