### PR TITLE
ohos CI: Simplify getting the model name

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -295,8 +295,9 @@ jobs:
         run: touch speedometer.json
         if: ${{ steps.BencherRun.outcome == 'failure' }}
       - name: Getting model name
+        # awk is used to remove trailing spaces
         run: |
-          echo "MODEL_NAME=$(hdc bugreport | head -n 20 | grep MarketName | awk '{for (i=2; i<NF; i++) printf $i " "; print $NF}' -)" >> $GITHUB_ENV
+          echo "MODEL_NAME=$(hdc shell param get const.product.name | awk '{$1=$1;print}' )" >> $GITHUB_ENV
       - name: Combining bencher files
         run: jq --compact-output --slurp add speedometer.json bench.json > combined-bencher.json
       - uses: bencherdev/bencher@main


### PR DESCRIPTION
Same output, but much easier and faster than sifting through the whole output of hdc bugreport.

Testing: CI change: `./mach try` [run](https://github.com/servo/servo/actions/runs/16460283107)