### PR TITLE
constellation: Eliminate long-standing inactive code path for `WebDriverData`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,6 @@ dependencies = [
  "servo_config",
  "servo_rand",
  "servo_url",
- "stylo_traits",
  "tracing",
  "webgpu",
  "webgpu_traits",

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -47,7 +47,6 @@ serde = { workspace = true }
 servo_config = { path = "../config" }
 servo_rand = { path = "../rand" }
 servo_url = { path = "../url" }
-stylo_traits = { workspace = true }
 tracing = { workspace = true, optional = true }
 webgpu = { path = "../webgpu" }
 webgpu_traits = { workspace = true }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -397,7 +397,7 @@ pub struct Constellation<STF, SWF> {
     next_pipeline_namespace_id: PipelineNamespaceId,
 
     // Forward responses from the script thread to the webdriver server.
-    input_command_response_sender: Option<IpcSender<WebDriverCommandResponse>>,
+    webdriver_input_command_reponse_sender: Option<IpcSender<WebDriverCommandResponse>>,
 
     /// Document states for loaded pipelines (used only when writing screenshots).
     document_states: HashMap<PipelineId, DocumentState>,
@@ -666,7 +666,7 @@ where
                     time_profiler_chan: state.time_profiler_chan,
                     mem_profiler_chan: state.mem_profiler_chan.clone(),
                     phantom: PhantomData,
-                    input_command_response_sender: None,
+                    webdriver_input_command_reponse_sender: None,
                     document_states: HashMap::new(),
                     #[cfg(feature = "webgpu")]
                     webrender_wgpu,
@@ -1454,7 +1454,7 @@ where
                 }
             },
             EmbedderToConstellationMessage::SetWebDriverResponseSender(sender) => {
-                self.input_command_response_sender = Some(sender);
+                self.webdriver_input_command_reponse_sender = Some(sender);
             },
         }
     }
@@ -1855,14 +1855,14 @@ where
                 self.handle_finish_javascript_evaluation(evaluation_id, result)
             },
             ScriptToConstellationMessage::WebDriverInputComplete(msg_id) => {
-                if let Some(ref reply_sender) = self.input_command_response_sender {
+                if let Some(ref reply_sender) = self.webdriver_input_command_reponse_sender {
                     reply_sender
                         .send(WebDriverCommandResponse { id: msg_id })
                         .unwrap_or_else(|_| {
                             warn!("Failed to send WebDriverInputComplete {:?}", msg_id);
                         });
                 } else {
-                    warn!("No WebDriver input_command_response_sender");
+                    warn!("No webdriver_input_command_reponse_sender");
                 }
             },
         }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -396,7 +396,7 @@ pub struct Constellation<STF, SWF> {
     /// and the namespaces are allocated by the constellation.
     next_pipeline_namespace_id: PipelineNamespaceId,
 
-    // Forward responses from the script thread to the webdriver server.
+    /// Forward responses from the script thread to the webdriver server.
     webdriver_input_command_reponse_sender: Option<IpcSender<WebDriverCommandResponse>>,
 
     /// Document states for loaded pipelines (used only when writing screenshots).

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -159,7 +159,6 @@ use serde::{Deserialize, Serialize};
 use servo_config::{opts, pref};
 use servo_rand::{Rng, ServoRng, SliceRandom, random};
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
-use style_traits::CSSPixel;
 #[cfg(feature = "webgpu")]
 use webgpu::swapchain::WGPUImageMap;
 #[cfg(feature = "webgpu")]
@@ -509,7 +508,6 @@ pub struct InitialConstellationState {
 /// Data needed for webdriver
 struct WebDriverData {
     load_channel: Option<(PipelineId, IpcSender<WebDriverLoadStatus>)>,
-    resize_channel: Option<IpcSender<Size2D<f32, CSSPixel>>>,
     // Forward responses from the script thread to the webdriver server.
     input_command_response_sender: Option<IpcSender<WebDriverCommandResponse>>,
 }
@@ -518,7 +516,6 @@ impl WebDriverData {
     fn new() -> WebDriverData {
         WebDriverData {
             load_channel: None,
-            resize_channel: None,
             input_command_response_sender: None,
         }
     }
@@ -4930,10 +4927,6 @@ where
 
         let browsing_context_id = BrowsingContextId::from(webview_id);
         self.resize_browsing_context(new_viewport_details, size_type, browsing_context_id);
-
-        if let Some(response_sender) = self.webdriver.resize_channel.take() {
-            let _ = response_sender.send(new_viewport_details.size);
-        }
     }
 
     /// Called when the window exits from fullscreen mode

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -396,7 +396,7 @@ pub struct Constellation<STF, SWF> {
     /// and the namespaces are allocated by the constellation.
     next_pipeline_namespace_id: PipelineNamespaceId,
 
-    /// Forward responses from the script thread to the webdriver server.
+    /// An [`IpcSender`] to forward responses from the `ScriptThread` to the WebDriver server.
     webdriver_input_command_reponse_sender: Option<IpcSender<WebDriverCommandResponse>>,
 
     /// Document states for loaded pipelines (used only when writing screenshots).

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1103,7 +1103,7 @@ fn handle_send_keys_file(
     Ok(false)
 }
 
-/// Implementing step 5 - 7, plus step 8.file for Element Send Keys.
+/// Implementing step 5 - 7, plus file part of step 8 of "Element Send Keys".
 /// This function will send a boolean back to webdriver_server,
 /// indicating whether the dispatching of the key and
 /// composition event is still needed or not.

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1103,7 +1103,8 @@ fn handle_send_keys_file(
     Ok(false)
 }
 
-/// Implementing step 5 - 7, plus file part of step 8 of "Element Send Keys".
+/// Implementing step 5 - 7, plus part of step 8 of "Element Send Keys"
+/// where element is input element in the file upload state.
 /// This function will send a boolean back to webdriver_server,
 /// indicating whether the dispatching of the key and
 /// composition event is still needed or not.

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1103,8 +1103,9 @@ fn handle_send_keys_file(
     Ok(false)
 }
 
-/// Implementing step 5 - 8 of Element Send Keys. This function will send a boolean
-/// back to webdriver_server, indicating whether the dispatching of the key and
+/// Implementing step 5 - 7, plus step 8.file for Element Send Keys.
+/// This function will send a boolean back to webdriver_server,
+/// indicating whether the dispatching of the key and
 /// composition event is still needed or not.
 pub(crate) fn handle_will_send_keys(
     documents: &DocumentCollection,

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -243,7 +243,7 @@ pub enum WebDriverScriptCommand {
     IsEnabled(String, IpcSender<Result<bool, ErrorStatus>>),
     IsSelected(String, IpcSender<Result<bool, ErrorStatus>>),
     GetTitle(IpcSender<String>),
-    /// Match the element type before sending the event for webdriver `element send keys`.
+    /// Deal with the case of input element for Element Send Keys, which does not send keys.
     WillSendKeys(String, String, bool, IpcSender<Result<bool, ErrorStatus>>),
     IsDocumentReadyStateComplete(IpcSender<bool>),
 }


### PR DESCRIPTION
Cleaning up some dead code which has been here for 9 years. They are never detected by Lint because we still initialize them as `None` but never change afterwards.

Testing: No regression.