### PR TITLE
script(webdriver): Check if element is keyboard interactable in element send keys

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1740,6 +1740,18 @@ impl Element {
         }
     }
 
+    pub(crate) fn is_keyboard_interactable(&self) -> bool {
+        self.is_focusable_area() || self.is::<HTMLBodyElement>() || self.is_document_element()
+    }
+
+    fn is_document_element(&self) -> bool {
+        if let Some(ref document_element) = self.upcast::<Node>().owner_doc().GetDocumentElement() {
+            **document_element == *self
+        } else {
+            false
+        }
+    }
+
     pub(crate) fn is_focusable_area(&self) -> bool {
         if self.is_actually_disabled() {
             return false;

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1740,12 +1740,9 @@ impl Element {
         }
     }
 
-    pub(crate) fn is_keyboard_interactable(&self) -> bool {
-        self.is_focusable_area() || self.is::<HTMLBodyElement>() || self.is_document_element()
-    }
-
-    fn is_document_element(&self) -> bool {
-        if let Some(ref document_element) = self.upcast::<Node>().owner_doc().GetDocumentElement() {
+    /// <https://dom.spec.whatwg.org/#document-element>
+    pub(crate) fn is_document_element(&self) -> bool {
+        if let Some(ref document_element) = self.owner_document().GetDocumentElement() {
             **document_element == *self
         } else {
             false

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1166,9 +1166,14 @@ pub(crate) fn handle_will_send_keys(
                 // Step 7. If file is false or the session's strict file interactability
                 if file_input.is_none() || strict_file_interactability {
                     // TODO: Step 7.1. Scroll Into View
-                    // TODO: Step 7.2 - 7.6
-                    // Wait until element become Keyboard-interactable
-                    // or return error with error code element not interactable.
+                    // TODO: Step 7.2 - 7.5
+                    // Wait until element become keyboard-interactable
+
+                    // Step 7.6. If element is not keyboard-interactable,
+                    // return ErrorStatus::ElementNotInteractable.
+                    if !element.is_keyboard_interactable() {
+                        return Err(ErrorStatus::ElementNotInteractable);
+                    }
 
                     match element.downcast::<HTMLElement>() {
                         Some(element) => {

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -61,6 +61,7 @@ use crate::dom::domrect::DOMRect;
 use crate::dom::element::Element;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::htmlbodyelement::HTMLBodyElement;
 use crate::dom::htmldatalistelement::HTMLDataListElement;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::htmliframeelement::HTMLIFrameElement;
@@ -1069,6 +1070,11 @@ pub(crate) fn handle_get_element_shadow_root(
         .unwrap();
 }
 
+/// <https://w3c.github.io/webdriver/#dfn-keyboard-interactable>
+fn is_keyboard_interactable(element: &Element) -> bool {
+    element.is_focusable_area() || element.is::<HTMLBodyElement>() || element.is_document_element()
+}
+
 fn handle_send_keys_file(
     file_input: &HTMLInputElement,
     text: &str,
@@ -1165,13 +1171,13 @@ pub(crate) fn handle_will_send_keys(
 
                 // Step 7. If file is false or the session's strict file interactability
                 if file_input.is_none() || strict_file_interactability {
-                    // TODO: Step 7.1. Scroll Into View
+                    // TODO(24059): Step 7.1. Scroll Into View
                     // TODO: Step 7.2 - 7.5
                     // Wait until element become keyboard-interactable
 
                     // Step 7.6. If element is not keyboard-interactable,
                     // return ErrorStatus::ElementNotInteractable.
-                    if !element.is_keyboard_interactable() {
+                    if !is_keyboard_interactable(&element) {
                         return Err(ErrorStatus::ElementNotInteractable);
                     }
 

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/interactability.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/interactability.py.ini
@@ -5,9 +5,6 @@
   [test_readonly_element]
     expected: FAIL
 
-  [test_not_a_focusable_element]
-    expected: FAIL
-
   [test_display_none]
     expected: FAIL
 
@@ -15,7 +12,4 @@
     expected: FAIL
 
   [test_hidden]
-    expected: FAIL
-
-  [test_disabled]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/send_keys.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/send_keys.py.ini
@@ -1,6 +1,3 @@
 [send_keys.py]
   [test_no_browsing_context]
     expected: FAIL
-
-  [test_surrogates]
-    expected: FAIL


### PR DESCRIPTION
Step 7.6 of remote end steps of [Element Send Keys](https://w3c.github.io/webdriver/#element-send-keys)
> If element is not [keyboard-interactable](https://w3c.github.io/webdriver/#dfn-keyboard-interactable), return [error](https://w3c.github.io/webdriver/#dfn-error) with [error code](https://w3c.github.io/webdriver/#dfn-error-code) [element not interactable](https://w3c.github.io/webdriver/#dfn-element-not-interactable).