### PR TITLE
Reduce redundancy in servoshell webdriver message forwarding and add log for script::`handle_send_keys_non_typeable`

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -520,7 +520,6 @@ impl HTMLInputElement {
         self.input_type.get()
     }
 
-    #[inline]
     /// <https://w3c.github.io/webdriver/#dfn-non-typeable-form-control>
     pub(crate) fn is_nontypeable(&self) -> bool {
         matches!(

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -532,7 +532,7 @@ pub(crate) fn handle_execute_script(
             };
 
             if reply.send(result).is_err() {
-                info!("Webdriver might already be released by embedder before reply is sent");
+                error!("Webdriver might already be released by embedder before reply is sent");
             };
         },
         None => {
@@ -540,7 +540,7 @@ pub(crate) fn handle_execute_script(
                 .send(Err(WebDriverJSError::BrowsingContextNotFound))
                 .is_err()
             {
-                info!("Webdriver might already be released by embedder before reply is sent");
+                error!("Webdriver might already be released by embedder before reply is sent");
             };
         },
     }
@@ -1120,7 +1120,11 @@ fn handle_send_keys_non_typeable(
     }
 
     // Step 3. Set a property value to text on element.
-    if input_element.SetValue(text.into(), can_gc).is_err() {
+    if let Err(error) = input_element.SetValue(text.into(), can_gc) {
+        error!(
+            "Failed to set value on non-typeable input element: {:?}",
+            error
+        );
         return Err(ErrorStatus::UnknownError);
     }
 

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -353,7 +353,7 @@ impl App {
         while let Ok(msg) = webdriver_receiver.try_recv() {
             match msg {
                 WebDriverCommandMsg::SetWebDriverResponseSender(..) => {
-                    running_state.forward_webdriver_command(msg);
+                    running_state.servo().execute_webdriver_command(msg);
                 },
                 WebDriverCommandMsg::IsWebViewOpen(webview_id, sender) => {
                     let context = running_state.webview_by_id(webview_id);
@@ -363,7 +363,7 @@ impl App {
                     }
                 },
                 WebDriverCommandMsg::IsBrowsingContextOpen(..) => {
-                    running_state.forward_webdriver_command(msg);
+                    running_state.servo().execute_webdriver_command(msg);
                 },
                 WebDriverCommandMsg::NewWebView(response_sender, load_status_sender) => {
                     let new_webview =
@@ -580,15 +580,9 @@ impl App {
                         webview.notify_scroll_event(scroll_location, point.to_i32());
                     }
                 },
-                WebDriverCommandMsg::ScriptCommand(
-                    browsing_context_id,
-                    webdriver_script_command,
-                ) => {
-                    self.handle_webdriver_script_commnd(&webdriver_script_command, running_state);
-                    running_state.forward_webdriver_command(WebDriverCommandMsg::ScriptCommand(
-                        browsing_context_id,
-                        webdriver_script_command,
-                    ));
+                WebDriverCommandMsg::ScriptCommand(_, ref webdriver_script_command) => {
+                    self.handle_webdriver_script_commnd(webdriver_script_command, running_state);
+                    running_state.servo().execute_webdriver_command(msg);
                 },
                 WebDriverCommandMsg::CurrentUserPrompt(webview_id, response_sender) => {
                     let current_dialog =
@@ -637,7 +631,7 @@ impl App {
                     running_state.set_alert_text_of_newest_dialog(webview_id, text);
                 },
                 WebDriverCommandMsg::TakeScreenshot(..) => {
-                    running_state.forward_webdriver_command(msg);
+                    running_state.servo().execute_webdriver_command(msg);
                 },
             };
         }

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -159,10 +159,6 @@ impl RunningAppState {
         self.webdriver_receiver.as_ref()
     }
 
-    pub(crate) fn forward_webdriver_command(&self, command: WebDriverCommandMsg) {
-        self.servo().execute_webdriver_command(command);
-    }
-
     pub(crate) fn hidpi_scale_factor_changed(&self) {
         let inner = self.inner();
         let new_scale_factor = inner.window.hidpi_scale_factor();

--- a/tests/wpt/meta/webdriver/tests/classic/element_clear/clear.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_clear/clear.py.ini
@@ -167,9 +167,6 @@
   [test_resettable_element_does_not_satisfy_validation_constraints[number-foo\]]
     expected: FAIL
 
-  [test_resettable_element_does_not_satisfy_validation_constraints[range-foo\]]
-    expected: FAIL
-
   [test_resettable_element_does_not_satisfy_validation_constraints[email-foo\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/form_controls.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/form_controls.py.ini
@@ -4,6 +4,3 @@
 
   [test_textarea_append]
     expected: FAIL
-
-  [test_date]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/send_keys.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/send_keys.py.ini
@@ -1,6 +1,3 @@
 [send_keys.py]
   [test_no_browsing_context]
     expected: FAIL
-
-  [test_surrogates]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/send_alert_text/send.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/send_alert_text/send.py.ini
@@ -1,7 +1,4 @@
 [send.py]
-  [test_alert_element_not_interactable[confirm\]]
-    expected: FAIL
-
   [test_chained_alert_element_not_interactable[alert\]]
     expected: FAIL
 
@@ -18,7 +15,4 @@
     expected: FAIL
 
   [test_send_alert_text[Fed\\terer\]]
-    expected: FAIL
-
-  [test_unexpected_alert]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/set_window_rect/set.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/set_window_rect/set.py.ini
@@ -43,3 +43,6 @@
 
   [test_negative_x_y]
     expected: FAIL
+
+  [test_response_payload]
+    expected: FAIL


### PR DESCRIPTION
There was a new commit for after https://github.com/servo/servo/pull/38189#discussion_r2224805172, but that does not seem to update/stop MQ.
Also removed `forward_webdriver_command` in servoshell according to https://github.com/servo/servo/pull/38212#discussion_r2221854327.