### PR TITLE
cargo: Remove unused dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,7 +1074,6 @@ dependencies = [
  "ipc-channel",
  "kurbo",
  "log",
- "lyon_geom",
  "net_traits",
  "pixels",
  "range",
@@ -1098,7 +1097,6 @@ dependencies = [
  "malloc_size_of_derive",
  "pixels",
  "serde",
- "serde_bytes",
  "servo_config",
  "servo_malloc_size_of",
  "strum",
@@ -1409,11 +1407,9 @@ dependencies = [
  "ipc-channel",
  "log",
  "malloc_size_of_derive",
- "pixels",
  "profile_traits",
  "raw-window-handle",
  "serde",
- "servo_geometry",
  "servo_malloc_size_of",
  "smallvec",
  "strum_macros",
@@ -4669,7 +4665,6 @@ dependencies = [
  "base",
  "bitflags 2.9.1",
  "compositing_traits",
- "constellation_traits",
  "data-url",
  "embedder_traits",
  "euclid",
@@ -7087,7 +7082,6 @@ dependencies = [
  "itertools 0.14.0",
  "jstraceable_derive",
  "keyboard-types",
- "kurbo",
  "layout_api",
  "libc",
  "log",
@@ -7116,7 +7110,6 @@ dependencies = [
  "serde",
  "serde_json",
  "servo-media",
- "servo_allocator",
  "servo_arc",
  "servo_config",
  "servo_geometry",
@@ -8477,10 +8470,8 @@ checksum = "06535c958d6abe68dc4b4ef9e6845f758fc42fe463d0093d0aca40254f03fb14"
 name = "timers"
 version = "0.0.1"
 dependencies = [
- "base",
  "crossbeam-channel",
  "malloc_size_of_derive",
- "serde",
  "servo_malloc_size_of",
 ]
 
@@ -9407,7 +9398,6 @@ version = "0.0.1"
 dependencies = [
  "base",
  "base64 0.22.1",
- "constellation_traits",
  "cookie 0.18.1",
  "crossbeam-channel",
  "embedder_traits",
@@ -9466,7 +9456,6 @@ dependencies = [
  "serde",
  "servo_config",
  "webgpu_traits",
- "webrender",
  "webrender_api",
  "wgpu-core",
  "wgpu-types",

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -23,7 +23,6 @@ fonts = { path = "../fonts" }
 ipc-channel = { workspace = true }
 kurbo = { workspace = true }
 log = { workspace = true }
-lyon_geom = "1.0.4"
 net_traits = { workspace = true }
 pixels = { path = "../pixels" }
 range = { path = "../range" }

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -22,7 +22,6 @@ atomic_refcell = { workspace = true }
 base = { workspace = true }
 bitflags = { workspace = true }
 compositing_traits = { workspace = true }
-constellation_traits = { workspace = true }
 data-url = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -81,7 +81,6 @@ itertools = { workspace = true }
 js = { workspace = true }
 jstraceable_derive = { path = "../jstraceable_derive" }
 keyboard-types = { workspace = true }
-kurbo = { workspace = true }
 layout_api = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
@@ -109,7 +108,6 @@ selectors = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 servo-media = { workspace = true }
-servo_allocator = { path = "../allocator" }
 servo_arc = { workspace = true }
 servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }

--- a/components/shared/canvas/Cargo.toml
+++ b/components/shared/canvas/Cargo.toml
@@ -25,7 +25,6 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 pixels = { path = "../../pixels" }
 serde = { workspace = true }
-serde_bytes = { workspace = true }
 servo_config = { path = "../../config" }
 strum = { workspace = true }
 stylo = { workspace = true }

--- a/components/shared/compositing/Cargo.toml
+++ b/components/shared/compositing/Cargo.toml
@@ -29,11 +29,9 @@ ipc-channel = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-pixels = { path = '../../pixels' }
 profile_traits = { path = '../profile' }
 raw-window-handle = { version = "0.6" }
 serde = { workspace = true }
-servo_geometry = { path = "../../geometry" }
 smallvec = { workspace = true }
 strum_macros = { workspace = true }
 stylo = { workspace = true }

--- a/components/timers/Cargo.toml
+++ b/components/timers/Cargo.toml
@@ -12,8 +12,6 @@ name = "timers"
 path = "lib.rs"
 
 [dependencies]
-base = { workspace = true }
 crossbeam-channel = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-serde = { workspace = true }

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -14,7 +14,6 @@ path = "lib.rs"
 [dependencies]
 base = { workspace = true }
 base64 = { workspace = true }
-constellation_traits = { workspace = true }
 cookie = { workspace = true }
 crossbeam-channel = { workspace = true }
 embedder_traits = { workspace = true }

--- a/components/webgpu/Cargo.toml
+++ b/components/webgpu/Cargo.toml
@@ -22,7 +22,6 @@ pixels = { path = "../pixels" }
 serde = { workspace = true, features = ["serde_derive"] }
 servo_config = { path = "../config" }
 webgpu_traits = { workspace = true }
-webrender = { workspace = true }
 webrender_api = { workspace = true }
 wgpu-core = { workspace = true, features = ["serde", "wgsl"] }
 wgpu-types = { workspace = true }


### PR DESCRIPTION
Remove unused `Cargo.toml` dependency to reduce binary size.

Testing: Can still compile in different platforms.
