### PR TITLE
OHOS: Clean up some compile warnings

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -914,7 +914,10 @@ pub struct FontBaseline {
 /// ];
 /// let mapped_weight = apply_font_config_to_style_mapping(&mapping, weight as f64);
 /// ```
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos"),
+    not(target_env = "ohos")
+))]
 pub(crate) fn map_platform_values_to_style_values(mapping: &[(f64, f64)], value: f64) -> f64 {
     if value < mapping[0].0 {
         return mapping[0].1;

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -4,7 +4,7 @@
 
 use std::convert::TryFrom;
 use std::ptr::{self, NonNull};
-use std::{io, slice};
+use std::slice;
 
 use devtools_traits::{
     ConsoleMessage, ConsoleMessageArgument, ConsoleMessageBuilder, LogLevel,
@@ -115,6 +115,7 @@ fn with_stderr_lock<F>(f: F)
 where
     F: FnOnce(),
 {
+    use std::io;
     let stderr = io::stderr();
     let _handle = stderr.lock();
     f()
@@ -343,6 +344,7 @@ fn stringify_handle_values(messages: &[HandleValue]) -> DOMString {
 /// to the logger. As `Console::method` and `Console::send_string_message`
 /// already forwards all messages to the logger with appropriate level
 /// this does not need to do anything for these targets.
+#[allow(unused)]
 fn console_message_to_stdout(global: &GlobalScope, message: &DOMString) {
     #[cfg(not(any(target_os = "android", target_env = "ohos")))]
     {

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -344,7 +344,7 @@ fn stringify_handle_values(messages: &[HandleValue]) -> DOMString {
 /// to the logger. As `Console::method` and `Console::send_string_message`
 /// already forwards all messages to the logger with appropriate level
 /// this does not need to do anything for these targets.
-#[allow(unused)]
+#[allow(unused_variables)]
 fn console_message_to_stdout(global: &GlobalScope, message: &DOMString) {
     #[cfg(not(any(target_os = "android", target_env = "ohos")))]
     {

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -696,11 +696,14 @@ impl RunningAppState {
     }
 }
 
+/// Currently the OHOS build does not use this.
+#[allow(unused)]
 #[cfg(feature = "webxr")]
 pub(crate) struct XrDiscoveryWebXrRegistry {
     xr_discovery: RefCell<Option<servo::webxr::Discovery>>,
 }
 
+#[allow(unused)]
 #[cfg(feature = "webxr")]
 impl XrDiscoveryWebXrRegistry {
     pub(crate) fn new(xr_discovery: Option<servo::webxr::Discovery>) -> Self {

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -696,15 +696,13 @@ impl RunningAppState {
     }
 }
 
-/// Currently the OHOS build does not use this.
-#[allow(unused)]
 #[cfg(feature = "webxr")]
 pub(crate) struct XrDiscoveryWebXrRegistry {
     xr_discovery: RefCell<Option<servo::webxr::Discovery>>,
 }
 
-#[allow(unused)]
 #[cfg(feature = "webxr")]
+#[cfg_attr(target_env = "ohos", allow(dead_code))]
 impl XrDiscoveryWebXrRegistry {
     pub(crate) fn new(xr_discovery: Option<servo::webxr::Discovery>) -> Self {
         Self {

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -818,6 +818,7 @@ struct HostCallbacks {
     ime_proxy: RefCell<Option<ohos_ime::ImeProxy>>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 enum ImeError {
     TextEditorProxy(CreateTextEditorProxyError),

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -1008,7 +1008,7 @@ impl HostTrait for HostCallbacks {
         if ime_proxy.is_none() {
             *ime_proxy = match self.try_create_ime_proxy(input_type, multiline) {
                 Err(ref e) => {
-                    error!("Couold not show keyboard because of {e:?}");
+                    error!("Could not show keyboard because of {e:?}");
                     None
                 },
                 Ok(proxy) => Some(proxy),


### PR DESCRIPTION
This cleans up some compile warnings about unused functions.

Testing: Does not change functionality, OHOS and Linux still compile (hopefully the other builds too).
