### PR TITLE
servo: Track async webview focus operations

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2755,11 +2755,7 @@ where
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn handle_focus_web_view(
-        &mut self,
-        webview_id: WebViewId,
-        focus_id: FocusId,
-    ) {
+    fn handle_focus_web_view(&mut self, webview_id: WebViewId, focus_id: FocusId) {
         let focused = self.webviews.focus(webview_id).is_ok();
         if !focused {
             warn!("{webview_id}: FocusWebView on unknown top-level browsing context");
@@ -4119,8 +4115,11 @@ where
 
         // Focus the top-level browsing context.
         let focused = self.webviews.focus(webview_id);
-        self.embedder_proxy
-            .send(EmbedderMsg::WebViewFocused(webview_id, FocusId::new(), focused.is_ok()));
+        self.embedder_proxy.send(EmbedderMsg::WebViewFocused(
+            webview_id,
+            FocusId::new(),
+            focused.is_ok(),
+        ));
 
         // If a container with a non-null nested browsing context is focused,
         // the nested browsing context's active document becomes the focused

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -129,7 +129,7 @@ use devtools_traits::{
 use embedder_traits::resources::{self, Resource};
 use embedder_traits::user_content_manager::UserContentManager;
 use embedder_traits::{
-    AnimationState, CompositorHitTestResult, Cursor, EmbedderMsg, EmbedderProxy,
+    AnimationState, CompositorHitTestResult, Cursor, EmbedderMsg, EmbedderProxy, FocusId,
     FocusSequenceNumber, InputEvent, JSValue, JavaScriptEvaluationError, JavaScriptEvaluationId,
     KeyboardEvent, MediaSessionActionType, MediaSessionEvent, MediaSessionPlaybackState,
     MouseButton, MouseButtonAction, MouseButtonEvent, Theme, ViewportDetails, WebDriverCommandMsg,
@@ -1347,8 +1347,8 @@ where
                 }
                 self.handle_panic(webview_id, error, None);
             },
-            EmbedderToConstellationMessage::FocusWebView(webview_id, response_sender) => {
-                self.handle_focus_web_view(webview_id, response_sender);
+            EmbedderToConstellationMessage::FocusWebView(webview_id, focus_id) => {
+                self.handle_focus_web_view(webview_id, focus_id);
             },
             EmbedderToConstellationMessage::BlurWebView => {
                 self.webviews.unfocus();
@@ -2758,17 +2758,14 @@ where
     fn handle_focus_web_view(
         &mut self,
         webview_id: WebViewId,
-        response_sender: Option<IpcSender<bool>>,
+        focus_id: FocusId,
     ) {
-        if self.webviews.get(webview_id).is_none() {
-            if let Some(response_sender) = response_sender {
-                let _ = response_sender.send(false);
-            }
-            return warn!("{webview_id}: FocusWebView on unknown top-level browsing context");
+        let focused = self.webviews.focus(webview_id).is_ok();
+        if !focused {
+            warn!("{webview_id}: FocusWebView on unknown top-level browsing context");
         }
-        self.webviews.focus(webview_id);
         self.embedder_proxy
-            .send(EmbedderMsg::WebViewFocused(webview_id, response_sender));
+            .send(EmbedderMsg::WebViewFocused(webview_id, focus_id, focused));
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -4121,9 +4118,9 @@ where
         }
 
         // Focus the top-level browsing context.
-        self.webviews.focus(webview_id);
+        let focused = self.webviews.focus(webview_id);
         self.embedder_proxy
-            .send(EmbedderMsg::WebViewFocused(webview_id, None));
+            .send(EmbedderMsg::WebViewFocused(webview_id, FocusId::new(), focused.is_ok()));
 
         // If a container with a non-null nested browsing context is focused,
         // the nested browsing context's active document becomes the focused

--- a/components/constellation/webview_manager.rs
+++ b/components/constellation/webview_manager.rs
@@ -67,11 +67,14 @@ impl<WebView> WebViewManager<WebView> {
         }
     }
 
-    pub fn focus(&mut self, webview_id: WebViewId) {
-        debug_assert!(self.webviews.contains_key(&webview_id));
+    pub fn focus(&mut self, webview_id: WebViewId) -> Result<(), ()> {
+        if !self.webviews.contains_key(&webview_id) {
+            return Err(());
+        }
         self.focus_order.retain(|b| *b != webview_id);
         self.focus_order.push(webview_id);
         self.is_focused = true;
+        Ok(())
     }
 
     pub fn unfocus(&mut self) {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -732,15 +732,17 @@ impl Servo {
                     webview.delegate().notify_closed(webview);
                 }
             },
-            EmbedderMsg::WebViewFocused(webview_id, response_sender) => {
-                for id in self.webviews.borrow().keys() {
-                    if let Some(webview) = self.get_webview_handle(*id) {
-                        let focused = webview.id() == webview_id;
-                        webview.set_focused(focused);
+            EmbedderMsg::WebViewFocused(webview_id, focus_id, focus_result) => {
+                if focus_result {
+                    for id in self.webviews.borrow().keys() {
+                        if let Some(webview) = self.get_webview_handle(*id) {
+                            let focused = webview.id() == webview_id;
+                            webview.set_focused(focused);
+                        }
                     }
                 }
-                if let Some(response_sender) = response_sender {
-                    let _ = response_sender.send(true);
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    webview.complete_focus(focus_id);
                 }
             },
             EmbedderMsg::WebViewBlurred => {

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -13,8 +13,8 @@ use compositing_traits::WebViewTrait;
 use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use dpi::PhysicalSize;
 use embedder_traits::{
-    Cursor, InputEvent, FocusId, JSValue, JavaScriptEvaluationError, LoadStatus, MediaSessionActionType,
-    ScreenGeometry, Theme, TraversalId, ViewportDetails,
+    Cursor, FocusId, InputEvent, JSValue, JavaScriptEvaluationError, LoadStatus,
+    MediaSessionActionType, ScreenGeometry, Theme, TraversalId, ViewportDetails,
 };
 use euclid::{Point2D, Scale, Size2D};
 use servo_geometry::DeviceIndependentPixel;

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -8,7 +8,7 @@ use base::id::PipelineId;
 use constellation_traits::EmbedderToConstellationMessage;
 use embedder_traits::{
     AllowOrDeny, AuthenticationResponse, ContextMenuResult, Cursor, FilterPattern,
-    GamepadHapticEffectType, InputMethodType, KeyboardEvent, LoadStatus, MediaSessionEvent,
+    FocusId, GamepadHapticEffectType, InputMethodType, KeyboardEvent, LoadStatus, MediaSessionEvent,
     Notification, PermissionFeature, RgbColor, ScreenGeometry, SelectElementOptionOrOptgroup,
     SimpleDialog, TraversalId, WebResourceRequest, WebResourceResponse, WebResourceResponseMsg,
 };
@@ -418,6 +418,9 @@ pub trait WebViewDelegate {
     /// This [`WebView`] has either become focused or lost focus. Whether or not the
     /// [`WebView`] is focused can be accessed via [`WebView::focused`].
     fn notify_focus_changed(&self, _webview: WebView, _focused: bool) {}
+    /// A focus operation that was initiated by this webview has completed.
+    /// The current focus status of this [`WebView`] can be accessed via [`WebView::focused`].
+    fn notify_focus_complete(&self, _webview: WebView, _focus_id: FocusId) {}
     /// This [`WebView`] has either started to animate or stopped animating. When a
     /// [`WebView`] is animating, it is up to the embedding application ensure that
     /// `Servo::spin_event_loop` is called at regular intervals in order to update the

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 use base::id::PipelineId;
 use constellation_traits::EmbedderToConstellationMessage;
 use embedder_traits::{
-    AllowOrDeny, AuthenticationResponse, ContextMenuResult, Cursor, FilterPattern,
-    FocusId, GamepadHapticEffectType, InputMethodType, KeyboardEvent, LoadStatus, MediaSessionEvent,
+    AllowOrDeny, AuthenticationResponse, ContextMenuResult, Cursor, FilterPattern, FocusId,
+    GamepadHapticEffectType, InputMethodType, KeyboardEvent, LoadStatus, MediaSessionEvent,
     Notification, PermissionFeature, RgbColor, ScreenGeometry, SelectElementOptionOrOptgroup,
     SimpleDialog, TraversalId, WebResourceRequest, WebResourceResponse, WebResourceResponseMsg,
 };

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -19,7 +19,7 @@ use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{MessagePortId, PipelineId, WebViewId};
 use embedder_traits::{
-    CompositorHitTestResult, Cursor, InputEvent, JavaScriptEvaluationId, MediaSessionActionType,
+    CompositorHitTestResult, Cursor, FocusId, InputEvent, JavaScriptEvaluationId, MediaSessionActionType,
     Theme, TraversalId, ViewportDetails, WebDriverCommandMsg, WebDriverCommandResponse,
 };
 pub use from_script_message::*;
@@ -70,7 +70,7 @@ pub enum EmbedderToConstellationMessage {
     SendError(Option<WebViewId>, String),
     /// Make a webview focused. If sender is provided, it will be used to send back a
     /// bool indicating whether the focus was successfully set in EmbedderMsg::WebViewFocused.
-    FocusWebView(WebViewId, Option<IpcSender<bool>>),
+    FocusWebView(WebViewId, FocusId),
     /// Make none of the webviews focused.
     BlurWebView,
     /// Forward an input event to an appropriate ScriptTask.

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -69,8 +69,8 @@ pub enum EmbedderToConstellationMessage {
     CloseWebView(WebViewId),
     /// Panic a top level browsing context.
     SendError(Option<WebViewId>, String),
-    /// Make a webview focused. If sender is provided, it will be used to send back a
-    /// bool indicating whether the focus was successfully set in EmbedderMsg::WebViewFocused.
+    /// Make a webview focused. [EmbedderMsg::WebViewFocused] will be sent with
+    /// the result of this operation.
     FocusWebView(WebViewId, FocusId),
     /// Make none of the webviews focused.
     BlurWebView,

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -19,8 +19,9 @@ use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{MessagePortId, PipelineId, WebViewId};
 use embedder_traits::{
-    CompositorHitTestResult, Cursor, FocusId, InputEvent, JavaScriptEvaluationId, MediaSessionActionType,
-    Theme, TraversalId, ViewportDetails, WebDriverCommandMsg, WebDriverCommandResponse,
+    CompositorHitTestResult, Cursor, FocusId, InputEvent, JavaScriptEvaluationId,
+    MediaSessionActionType, Theme, TraversalId, ViewportDetails, WebDriverCommandMsg,
+    WebDriverCommandResponse,
 };
 pub use from_script_message::*;
 use ipc_channel::ipc::IpcSender;

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -328,7 +328,7 @@ pub struct ScreenMetrics {
 }
 
 /// An opaque identifier for a single webview focus operation.
-#[derive(Clone, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct FocusId(String);
 
 impl FocusId {
@@ -339,7 +339,7 @@ impl FocusId {
 }
 
 /// An opaque identifier for a single history traversal operation.
-#[derive(Clone, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct TraversalId(String);
 
 impl TraversalId {

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -327,6 +327,17 @@ pub struct ScreenMetrics {
     pub available_size: DeviceIndependentIntSize,
 }
 
+/// An opaque identifier for a single webview focus operation.
+#[derive(Clone, Deserialize, PartialEq, Serialize)]
+pub struct FocusId(String);
+
+impl FocusId {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self(Uuid::new_v4().to_string())
+    }
+}
+
 /// An opaque identifier for a single history traversal operation.
 #[derive(Clone, Deserialize, PartialEq, Serialize)]
 pub struct TraversalId(String);
@@ -372,10 +383,10 @@ pub enum EmbedderMsg {
     AllowOpeningWebView(WebViewId, IpcSender<Option<(WebViewId, ViewportDetails)>>),
     /// A webview was destroyed.
     WebViewClosed(WebViewId),
-    /// A webview gained focus for keyboard events
-    /// If sender is provided, it will be used to send back a
-    /// bool indicating whether the focus was successfully set.
-    WebViewFocused(WebViewId, Option<IpcSender<bool>>),
+    /// A webview potentially gained focus for keyboard events, as initiated
+    /// by the provided focus id. If the boolean value is false, the webiew
+    /// could not be focused.
+    WebViewFocused(WebViewId, FocusId, bool),
     /// All webviews lost focus for keyboard events.
     WebViewBlurred,
     /// Wether or not to unload a document

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -479,19 +479,13 @@ impl App {
                 WebDriverCommandMsg::GoBack(webview_id, load_status_sender) => {
                     if let Some(webview) = running_state.webview_by_id(webview_id) {
                         let traversal_id = webview.go_back(1);
-                        running_state.set_pending_traversal(
-                            traversal_id,
-                            load_status_sender,
-                        );
+                        running_state.set_pending_traversal(traversal_id, load_status_sender);
                     }
                 },
                 WebDriverCommandMsg::GoForward(webview_id, load_status_sender) => {
                     if let Some(webview) = running_state.webview_by_id(webview_id) {
                         let traversal_id = webview.go_forward(1);
-                        running_state.set_pending_traversal(
-                            traversal_id,
-                            load_status_sender,
-                        );
+                        running_state.set_pending_traversal(traversal_id, load_status_sender);
                     }
                 },
                 // Key events don't need hit test so can be forwarded to constellation for now

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -381,11 +381,7 @@ impl App {
                 WebDriverCommandMsg::FocusWebView(webview_id, response_sender) => {
                     if let Some(webview) = running_state.webview_by_id(webview_id) {
                         let focus_id = webview.focus();
-                        running_state.set_pending_focus(
-                            webview_id,
-                            focus_id,
-                            response_sender,
-                        );
+                        running_state.set_pending_focus(webview_id, focus_id, response_sender);
                     }
                 },
                 WebDriverCommandMsg::GetWindowRect(_webview_id, response_sender) => {

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -381,7 +381,7 @@ impl App {
                 WebDriverCommandMsg::FocusWebView(webview_id, response_sender) => {
                     if let Some(webview) = running_state.webview_by_id(webview_id) {
                         let focus_id = webview.focus();
-                        running_state.set_pending_focus(webview_id, focus_id, response_sender);
+                        running_state.set_pending_focus(focus_id, response_sender);
                     }
                 },
                 WebDriverCommandMsg::GetWindowRect(_webview_id, response_sender) => {
@@ -480,7 +480,6 @@ impl App {
                     if let Some(webview) = running_state.webview_by_id(webview_id) {
                         let traversal_id = webview.go_back(1);
                         running_state.set_pending_traversal(
-                            webview_id,
                             traversal_id,
                             load_status_sender,
                         );
@@ -490,7 +489,6 @@ impl App {
                     if let Some(webview) = running_state.webview_by_id(webview_id) {
                         let traversal_id = webview.go_forward(1);
                         running_state.set_pending_traversal(
-                            webview_id,
                             traversal_id,
                             load_status_sender,
                         );

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -380,7 +380,12 @@ impl App {
                 },
                 WebDriverCommandMsg::FocusWebView(webview_id, response_sender) => {
                     if let Some(webview) = running_state.webview_by_id(webview_id) {
-                        webview.focus_from_webdriver(response_sender);
+                        let focus_id = webview.focus();
+                        running_state.set_pending_focus(
+                            webview_id,
+                            focus_id,
+                            response_sender,
+                        );
                     }
                 },
                 WebDriverCommandMsg::GetWindowRect(_webview_id, response_sender) => {

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -18,10 +18,11 @@ use servo::ipc_channel::ipc::IpcSender;
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 use servo::{
-    AllowOrDenyRequest, AuthenticationRequest, FilterPattern, FocusId, FormControl, GamepadHapticEffectType,
-    KeyboardEvent, LoadStatus, PermissionRequest, Servo, ServoDelegate, ServoError, SimpleDialog,
-    TraversalId, WebDriverCommandMsg, WebDriverJSResult, WebDriverJSValue, WebDriverLoadStatus,
-    WebDriverUserPrompt, WebView, WebViewBuilder, WebViewDelegate,
+    AllowOrDenyRequest, AuthenticationRequest, FilterPattern, FocusId, FormControl,
+    GamepadHapticEffectType, KeyboardEvent, LoadStatus, PermissionRequest, Servo, ServoDelegate,
+    ServoError, SimpleDialog, TraversalId, WebDriverCommandMsg, WebDriverJSResult,
+    WebDriverJSValue, WebDriverLoadStatus, WebDriverUserPrompt, WebView, WebViewBuilder,
+    WebViewDelegate,
 };
 use url::Url;
 
@@ -274,7 +275,7 @@ impl RunningAppState {
         match last_created {
             Some(last_created_webview) => {
                 last_created_webview.focus();
-            }
+            },
             None => self.servo.start_shutting_down(),
         }
     }

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -454,11 +454,7 @@ impl RunningAppState {
             });
     }
 
-    pub(crate) fn set_pending_focus(
-        &self,
-        focus_id: FocusId,
-        sender: IpcSender<bool>,
-    ) {
+    pub(crate) fn set_pending_focus(&self, focus_id: FocusId, sender: IpcSender<bool>) {
         self.webdriver_senders
             .borrow_mut()
             .pending_focus

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -18,7 +18,7 @@ use servo::ipc_channel::ipc::IpcSender;
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 use servo::{
-    AllowOrDenyRequest, AuthenticationRequest, FilterPattern, FormControl, GamepadHapticEffectType,
+    AllowOrDenyRequest, AuthenticationRequest, FilterPattern, FocusId, FormControl, GamepadHapticEffectType,
     KeyboardEvent, LoadStatus, PermissionRequest, Servo, ServoDelegate, ServoError, SimpleDialog,
     TraversalId, WebDriverCommandMsg, WebDriverJSResult, WebDriverJSValue, WebDriverLoadStatus,
     WebDriverUserPrompt, WebView, WebViewBuilder, WebViewDelegate,
@@ -46,6 +46,7 @@ struct WebDriverSenders {
     pub load_status_senders: HashMap<WebViewId, IpcSender<WebDriverLoadStatus>>,
     pub script_evaluation_interrupt_sender: Option<IpcSender<WebDriverJSResult>>,
     pub pending_traversals: HashMap<WebViewId, (TraversalId, IpcSender<WebDriverLoadStatus>)>,
+    pub pending_focus: HashMap<WebViewId, (FocusId, IpcSender<bool>)>,
 }
 
 pub(crate) struct RunningAppState {
@@ -271,7 +272,9 @@ impl RunningAppState {
             .and_then(|id| inner.webviews.get(id));
 
         match last_created {
-            Some(last_created_webview) => last_created_webview.focus(),
+            Some(last_created_webview) => {
+                last_created_webview.focus();
+            }
             None => self.servo.start_shutting_down(),
         }
     }
@@ -448,6 +451,18 @@ impl RunningAppState {
                 let location = ScrollLocation::Delta(Vector2D::new(LINE_WIDTH, 0.0));
                 webview.notify_scroll_event(location, origin);
             });
+    }
+
+    pub(crate) fn set_pending_focus(
+        &self,
+        webview_id: WebViewId,
+        focus_id: FocusId,
+        sender: IpcSender<bool>,
+    ) {
+        self.webdriver_senders
+            .borrow_mut()
+            .pending_focus
+            .insert(webview_id, (focus_id, sender));
     }
 
     pub(crate) fn set_pending_traversal(
@@ -640,6 +655,16 @@ impl WebViewDelegate for RunningAppState {
 
     fn notify_closed(&self, webview: servo::WebView) {
         self.close_webview(webview.id());
+    }
+
+    fn notify_focus_complete(&self, webview: servo::WebView, focus_id: FocusId) {
+        let mut webdriver_state = self.webdriver_senders.borrow_mut();
+        if let Entry::Occupied(entry) = webdriver_state.pending_focus.entry(webview.id()) {
+            if entry.get().0 == focus_id {
+                let (_, sender) = entry.remove();
+                let _ = sender.send(webview.focused());
+            }
+        }
     }
 
     fn notify_focus_changed(&self, webview: servo::WebView, focused: bool) {

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -46,8 +46,8 @@ pub(crate) enum AppState {
 struct WebDriverSenders {
     pub load_status_senders: HashMap<WebViewId, IpcSender<WebDriverLoadStatus>>,
     pub script_evaluation_interrupt_sender: Option<IpcSender<WebDriverJSResult>>,
-    pub pending_traversals: HashMap<WebViewId, (TraversalId, IpcSender<WebDriverLoadStatus>)>,
-    pub pending_focus: HashMap<WebViewId, (FocusId, IpcSender<bool>)>,
+    pub pending_traversals: HashMap<TraversalId, IpcSender<WebDriverLoadStatus>>,
+    pub pending_focus: HashMap<FocusId, IpcSender<bool>>,
 }
 
 pub(crate) struct RunningAppState {
@@ -456,26 +456,24 @@ impl RunningAppState {
 
     pub(crate) fn set_pending_focus(
         &self,
-        webview_id: WebViewId,
         focus_id: FocusId,
         sender: IpcSender<bool>,
     ) {
         self.webdriver_senders
             .borrow_mut()
             .pending_focus
-            .insert(webview_id, (focus_id, sender));
+            .insert(focus_id, sender);
     }
 
     pub(crate) fn set_pending_traversal(
         &self,
-        webview_id: WebViewId,
         traversal_id: TraversalId,
         sender: IpcSender<WebDriverLoadStatus>,
     ) {
         self.webdriver_senders
             .borrow_mut()
             .pending_traversals
-            .insert(webview_id, (traversal_id, sender));
+            .insert(traversal_id, sender);
     }
 
     pub(crate) fn set_load_status_sender(
@@ -559,13 +557,11 @@ impl WebViewDelegate for RunningAppState {
         }
     }
 
-    fn notify_traversal_complete(&self, webview: servo::WebView, traversal_id: TraversalId) {
+    fn notify_traversal_complete(&self, _webview: servo::WebView, traversal_id: TraversalId) {
         let mut webdriver_state = self.webdriver_senders.borrow_mut();
-        if let Entry::Occupied(entry) = webdriver_state.pending_traversals.entry(webview.id()) {
-            if entry.get().0 == traversal_id {
-                let (_, sender) = entry.remove();
-                let _ = sender.send(WebDriverLoadStatus::Complete);
-            }
+        if let Entry::Occupied(entry) = webdriver_state.pending_traversals.entry(traversal_id) {
+            let sender = entry.remove();
+            let _ = sender.send(WebDriverLoadStatus::Complete);
         }
     }
 
@@ -660,11 +656,9 @@ impl WebViewDelegate for RunningAppState {
 
     fn notify_focus_complete(&self, webview: servo::WebView, focus_id: FocusId) {
         let mut webdriver_state = self.webdriver_senders.borrow_mut();
-        if let Entry::Occupied(entry) = webdriver_state.pending_focus.entry(webview.id()) {
-            if entry.get().0 == focus_id {
-                let (_, sender) = entry.remove();
-                let _ = sender.send(webview.focused());
-            }
+        if let Entry::Occupied(entry) = webdriver_state.pending_focus.entry(focus_id) {
+            let sender = entry.remove();
+            let _ = sender.send(webview.focused());
         }
     }
 


### PR DESCRIPTION
https://github.com/servo/servo/pull/38160 added a webdriver-specific API to support waiting on focus operations to complete. These changes replace that with a generalized pattern, where a unique ID is created for each focus operation and the embedder can receive notifications about each focus operation when it is complete, regardless of whether the focus was actually changed.

Testing: Existing test coverage from https://github.com/servo/servo/pull/38160/ is unchanged.
