### PR TITLE
servoshell: Add window position for headless window

### DIFF
--- a/tests/wpt/meta/webdriver/tests/classic/set_window_rect/set.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/set_window_rect/set.py.ini
@@ -5,44 +5,8 @@
   [test_restore_from_maximized]
     expected: FAIL
 
-  [test_x_y_floats]
-    expected: FAIL
-
-  [test_partial_input[rect2\]]
-    expected: FAIL
-
-  [test_partial_input[rect3\]]
-    expected: FAIL
-
-  [test_partial_input[rect4\]]
-    expected: FAIL
-
-  [test_partial_input[rect5\]]
-    expected: FAIL
-
-  [test_partial_input[rect6\]]
-    expected: FAIL
-
-  [test_partial_input[rect7\]]
-    expected: FAIL
-
   [test_set_to_available_size]
     expected: FAIL
 
   [test_set_smaller_than_minimum_browser_size]
-    expected: FAIL
-
-  [test_x_y]
-    expected: FAIL
-
-  [test_x_as_current]
-    expected: FAIL
-
-  [test_y_as_current]
-    expected: FAIL
-
-  [test_negative_x_y]
-    expected: FAIL
-
-  [test_response_payload]
     expected: FAIL


### PR DESCRIPTION
Add virtual `window_position` to headless window so that `moveTo` and WebDriver window command can work properly.

Testing: `./mach test-wpt -r "tests\wpt\tests\webdriver\tests\classic\set_window_rect\set.py" --product servodriver --headless`
Fixes: Task 7 of #37804.
