### PR TITLE
servoshell: Respond resize with authentic result and Adjust minimum window size

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -48,7 +48,10 @@ use {
 use super::app_state::RunningAppState;
 use super::geometry::{winit_position_to_euclid_point, winit_size_to_euclid_size};
 use super::keyutils::{CMD_OR_ALT, keyboard_event_from_winit};
-use super::window_trait::{LINE_HEIGHT, LINE_WIDTH, PIXEL_DELTA_FACTOR, WindowPortsMethods};
+use super::window_trait::{
+    LINE_HEIGHT, LINE_WIDTH, MIN_INNER_HEIGHT, MIN_INNER_WIDTH, PIXEL_DELTA_FACTOR,
+    WindowPortsMethods,
+};
 use crate::desktop::accelerated_gl_media::setup_gl_accelerated_media;
 use crate::desktop::keyutils::CMD_OR_CONTROL;
 use crate::prefs::ServoShellPreferences;
@@ -97,7 +100,7 @@ impl Window {
             .with_decorations(!no_native_titlebar)
             .with_transparent(no_native_titlebar)
             .with_inner_size(LogicalSize::new(inner_size.width, inner_size.height))
-            .with_min_inner_size(LogicalSize::new(1, 1))
+            .with_min_inner_size(LogicalSize::new(MIN_INNER_WIDTH, MIN_INNER_HEIGHT))
             // Must be invisible at startup; accesskit_winit setup needs to
             // happen before the window is shown for the first time.
             .with_visible(false);
@@ -772,8 +775,11 @@ impl WindowPortsMethods for Window {
         // Prevent the inner area from being 0 pixels wide or tall
         // this prevents a crash in the compositor due to invalid surface size
         self.winit_window.set_min_inner_size(Some(PhysicalSize::new(
-            1.0,
-            1.0 + (self.toolbar_height() * self.hidpi_scale_factor()).0,
+            MIN_INNER_WIDTH,
+            i32::max(
+                MIN_INNER_HEIGHT,
+                (self.toolbar_height() * self.hidpi_scale_factor()).0 as i32,
+            ),
         )));
     }
 

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -17,7 +17,7 @@ use servo::{RenderingContext, ScreenGeometry, SoftwareRenderingContext};
 use winit::dpi::PhysicalSize;
 
 use super::app_state::RunningAppState;
-use crate::desktop::window_trait::WindowPortsMethods;
+use crate::desktop::window_trait::{MIN_INNER_HEIGHT, MIN_INNER_WIDTH, WindowPortsMethods};
 use crate::prefs::ServoShellPreferences;
 
 pub struct Window {
@@ -89,8 +89,10 @@ impl WindowPortsMethods for Window {
         webview: &::servo::WebView,
         outer_size: DeviceIntSize,
     ) -> Option<DeviceIntSize> {
-        // Surfman doesn't support zero-sized surfaces.
-        let new_size = DeviceIntSize::new(outer_size.width.max(1), outer_size.height.max(1));
+        let new_size = DeviceIntSize::new(
+            outer_size.width.max(MIN_INNER_WIDTH),
+            outer_size.height.max(MIN_INNER_HEIGHT),
+        );
         if self.inner_size.get() == new_size {
             return Some(new_size);
         }

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -22,6 +22,11 @@ pub const LINE_WIDTH: f32 = 76.0;
 // See https://github.com/servo/servo/pull/34063#discussion_r2197729507
 pub const PIXEL_DELTA_FACTOR: f64 = 4.0;
 
+/// <https://github.com/web-platform-tests/wpt/blob/9320b1f724632c52929a3fdb11bdaf65eafc7611/webdriver/tests/classic/set_window_rect/set.py#L287-L290>
+/// "A window size of 10x10px shouldn't be supported by any browser."
+pub(crate) const MIN_INNER_WIDTH: i32 = 20;
+pub(crate) const MIN_INNER_HEIGHT: i32 = 20;
+
 pub trait WindowPortsMethods {
     fn id(&self) -> winit::window::WindowId;
     fn screen_geometry(&self) -> ScreenGeometry;

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -15,12 +15,12 @@ use servo::{Cursor, RenderingContext, ScreenGeometry, WebView};
 use super::app_state::RunningAppState;
 
 // This should vary by zoom level and maybe actual text size (focused or under cursor)
-pub const LINE_HEIGHT: f32 = 76.0;
-pub const LINE_WIDTH: f32 = 76.0;
+pub(crate) const LINE_HEIGHT: f32 = 76.0;
+pub(crate) const LINE_WIDTH: f32 = 76.0;
 // MouseScrollDelta::PixelDelta is default for MacOS, which is high precision and very slow
 // in winit. Therefore we use a factor of 4.0 to make it more usable.
 // See https://github.com/servo/servo/pull/34063#discussion_r2197729507
-pub const PIXEL_DELTA_FACTOR: f64 = 4.0;
+pub(crate) const PIXEL_DELTA_FACTOR: f64 = 4.0;
 
 /// <https://github.com/web-platform-tests/wpt/blob/9320b1f724632c52929a3fdb11bdaf65eafc7611/webdriver/tests/classic/set_window_rect/set.py#L287-L290>
 /// "A window size of 10x10px shouldn't be supported by any browser."

--- a/tests/wpt/meta/webdriver/tests/classic/set_window_rect/set.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/set_window_rect/set.py.ini
@@ -7,6 +7,3 @@
 
   [test_set_to_available_size]
     expected: FAIL
-
-  [test_set_smaller_than_minimum_browser_size]
-    expected: FAIL


### PR DESCRIPTION
- We no longer pretend that resize is always successful and simplify the result computation. 
- Adjust minimum window size to match other browsers and the test expectation.
- Restrict some unnecessary access specifier.

Testing: ` ./mach test-wpt -r "tests\wpt\tests\webdriver\tests\classic\set_window_rect\set.py" --log-raw "D:\servo test log\set.txt" --product servodriver  {--headless}`
Fixes: #37804 as Task 8 is last task.
