### PR TITLE
canvas: Make pixel obtaining methods take &mut GenericDrawTarget

### DIFF
--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -86,7 +86,9 @@ pub(crate) trait GenericDrawTarget {
         composition_options: CompositionOptions,
         transform: Transform2D<f32>,
     );
-    fn surface(&self) -> Self::SourceSurface;
-    fn image_descriptor_and_serializable_data(&self) -> (ImageDescriptor, SerializableImageData);
-    fn snapshot(&self) -> Snapshot;
+    fn surface(&mut self) -> Self::SourceSurface;
+    fn image_descriptor_and_serializable_data(
+        &mut self,
+    ) -> (ImageDescriptor, SerializableImageData);
+    fn snapshot(&mut self) -> Snapshot;
 }

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -116,7 +116,7 @@ impl<DrawTarget: GenericDrawTarget> CanvasData<DrawTarget> {
         font_context: Arc<FontContext>,
     ) -> CanvasData<DrawTarget> {
         let size = size.max(MIN_WR_IMAGE_SIZE);
-        let draw_target = DrawTarget::new(size.cast());
+        let mut draw_target = DrawTarget::new(size.cast());
         let image_key = compositor_api.generate_image_key_blocking().unwrap();
         let (descriptor, data) = draw_target.image_descriptor_and_serializable_data();
         compositor_api.add_image(image_key, descriptor, data);
@@ -724,7 +724,7 @@ impl<DrawTarget: GenericDrawTarget> CanvasData<DrawTarget> {
     /// read_rect: The area of the canvas we want to read from
     #[allow(unsafe_code)]
     pub(crate) fn read_pixels(
-        &self,
+        &mut self,
         read_rect: Option<Rect<u32>>,
         canvas_size: Option<Size2D<u32>>,
     ) -> Snapshot {

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -401,7 +401,7 @@ impl GenericDrawTarget for raqote::DrawTarget {
     fn push_clip_rect(&mut self, rect: &Rect<i32>) {
         self.push_clip_rect(rect.to_box2d());
     }
-    fn surface(&self) -> Self::SourceSurface {
+    fn surface(&mut self) -> Self::SourceSurface {
         self.get_data_u8().to_vec()
     }
     fn stroke(
@@ -450,7 +450,7 @@ impl GenericDrawTarget for raqote::DrawTarget {
     }
 
     fn image_descriptor_and_serializable_data(
-        &self,
+        &mut self,
     ) -> (
         webrender_api::ImageDescriptor,
         compositing_traits::SerializableImageData,
@@ -466,7 +466,7 @@ impl GenericDrawTarget for raqote::DrawTarget {
         (descriptor, data)
     }
 
-    fn snapshot(&self) -> Snapshot {
+    fn snapshot(&mut self) -> Snapshot {
         Snapshot::from_vec(
             self.get_size().cast(),
             SnapshotPixelFormat::BGRA,


### PR DESCRIPTION
This will be needed for vello_cpu. While we could wrap it in RefCell for inner mut, but that would be less ergonomic and performant.

Testing: Just refactoring, but the code is covered by WPT tests.
