### PR TITLE
script: Implement jsglue trap for runJobs()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5240,7 +5240,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#b23161580b082e1ccfa3273d94f43f6168aedc3d"
+source = "git+https://github.com/servo/mozjs#4035b0c4e9e2df5cacc68c4b71e7375a48605902"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -5251,8 +5251,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.13-2"
-source = "git+https://github.com/servo/mozjs#b23161580b082e1ccfa3273d94f43f6168aedc3d"
+version = "0.128.13-3"
+source = "git+https://github.com/servo/mozjs#4035b0c4e9e2df5cacc68c4b71e7375a48605902"
 dependencies = [
  "bindgen 0.71.1",
  "cc",


### PR DESCRIPTION
in the [SpiderMonkey Debugger API](https://firefox-source-docs.mozilla.org/js/Debugger/), hooks like [onNewGlobalObject()](https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.html#onnewglobalobject-global) use an AutoDebuggerJobQueueInterruption to [switch to a new microtask queue](https://github.com/servo/mozjs/blob/b14aebff23ac4d5b0652060ef949334bda08b22f/mozjs-sys/mozjs/js/src/debugger/Debugger.cpp#L2834-L2841) and avoid clobbering the debuggee’s microtask queue. this in turn relies on JobQueue::runJobs(), which is [not yet implemented in RustJobQueue](https://github.com/servo/mozjs/blob/b14aebff23ac4d5b0652060ef949334bda08b22f/mozjs-sys/src/jsglue.cpp#L76-L78).

this patch bumps mozjs to servo/mozjs#597, which implements [runJobs()](https://github.com/servo/mozjs/blob/b14aebff23ac4d5b0652060ef949334bda08b22f/mozjs-sys/mozjs/js/public/Promise.h#L61-L76) for RustJobQueue by calling into Servo’s MicrotaskQueue::checkpoint() via a new function in JobQueueTraps.

SpiderMonkey [does not own external job queues](https://github.com/servo/mozjs/blob/b14aebff23ac4d5b0652060ef949334bda08b22f/mozjs-sys/mozjs/js/public/Promise.h#L117-L123), so the lifetime of these queues is managed in Servo, where they are stored in a Vec-based stack. stack-like behaviour is adequate for SpiderMonkey’s save and restore patterns, as far as we can tell, but we’ve added an assertion just in case.

Testing: manually tested working in devtools debugger patch (#37667), where it will undergo automated tests