### PR TITLE
layout: Implement hit testing in script / layout

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -768,8 +768,6 @@ impl IOCompositor {
                     return warn!("Could not find WebView for incoming display list");
                 };
 
-                // WebRender is not ready until we receive "NewWebRenderFrameReady"
-                webview_renderer.webrender_frame_ready.set(false);
                 let old_scale = webview_renderer.device_pixels_per_page_pixel();
 
                 let pipeline_id = display_list_info.pipeline_id;
@@ -1566,15 +1564,8 @@ impl IOCompositor {
                 },
                 CompositorMsg::NewWebRenderFrameReady(..) => {
                     found_recomposite_msg = true;
-
-                    // Process all pending events
                     // FIXME: Shouldn't `webview_frame_ready` be stored globally and why can't `pending_frames`
                     // be used here?
-                    self.webview_renderers.iter().for_each(|webview| {
-                        webview.dispatch_pending_point_input_events();
-                        webview.webrender_frame_ready.set(true);
-                    });
-
                     true
                 },
                 _ => true,

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -18,7 +18,7 @@ use compositing_traits::display_list::{
 use embedder_traits::ViewportDetails;
 use euclid::SideOffsets2D;
 use euclid::default::{Point2D, Rect, Size2D};
-use layout_api::HitTestResult;
+use layout_api::{HitTestFlags, HitTestResult};
 use log::{debug, warn};
 use servo_config::opts::DebugOptions;
 use style::Zero;
@@ -74,6 +74,8 @@ pub(crate) struct ContainingBlock {
 pub(crate) struct HitTestData<'a> {
     /// hit test location
     client_point: LayoutPoint,
+    /// hit test flags
+    flags: HitTestFlags,
     /// we need scroll_tree and clip_store in StackingContextTree
     stacking_context_tree: &'a StackingContextTree,
 }
@@ -81,10 +83,12 @@ pub(crate) struct HitTestData<'a> {
 impl<'a> HitTestData<'a> {
     pub(crate) fn new(
         client_point: LayoutPoint,
+        flags: HitTestFlags,
         stacking_context_tree: &'a StackingContextTree,
     ) -> Self {
         HitTestData {
             client_point,
+            flags,
             stacking_context_tree,
         }
     }
@@ -512,6 +516,7 @@ impl StackingContextContent {
                     let hit_test_location = handle_spatial_node(hit_test_data, scroll_node_id);
                     fragment.hit_test_fragment(
                         hit_test_location,
+                        &hit_test_data.flags,
                         hit_test_result,
                         containing_block,
                         *is_hit_test_for_scrollable_overflow,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -51,9 +51,9 @@ use js::rust::{
     MutableHandleValue,
 };
 use layout_api::{
-    FragmentType, Layout, PendingImage, PendingImageState, PendingRasterizationImage, QueryMsg,
-    ReflowGoal, ReflowRequest, ReflowRequestRestyle, RestyleReason, TrustedNodeAddress,
-    combine_id_with_fragment_type,
+    FragmentType, HitTestResult, Layout, PendingImage, PendingImageState,
+    PendingRasterizationImage, QueryMsg, ReflowGoal, ReflowRequest, ReflowRequestRestyle,
+    RestyleReason, TrustedNodeAddress, combine_id_with_fragment_type,
 };
 use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
@@ -88,7 +88,7 @@ use style_traits::CSSPixel;
 use stylo_atoms::Atom;
 use url::Position;
 use webrender_api::ExternalScrollId;
-use webrender_api::units::{DeviceIntSize, DevicePixel, LayoutPixel};
+use webrender_api::units::{DeviceIntSize, DevicePixel, DevicePoint, LayoutPixel, LayoutPoint};
 
 use super::bindings::codegen::Bindings::MessagePortBinding::StructuredSerializeOptions;
 use super::bindings::trace::HashMapTracedValues;
@@ -3060,6 +3060,14 @@ impl Window {
                 nodes.push(Dom::from_ref(&*node));
             }
         }
+    }
+
+    pub(crate) fn hit_test(&self, hit_test_location: DevicePoint) -> HitTestResult {
+        // div device_pixel_ratio.
+        let dpr = self.device_pixel_ratio();
+        let hit_test_css_point = hit_test_location / dpr;
+        let hit_test_layout_point = LayoutPoint::from_untyped(hit_test_css_point.to_untyped());
+        self.layout.borrow().hit_test(hit_test_layout_point)
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -32,9 +32,9 @@ use devtools_traits::{ScriptToDevtoolsControlMsg, TimelineMarker, TimelineMarker
 use dom_struct::dom_struct;
 use embedder_traits::user_content_manager::{UserContentManager, UserScript};
 use embedder_traits::{
-    AlertResponse, ConfirmResponse, EmbedderMsg, GamepadEvent, GamepadSupportedHapticEffects,
-    GamepadUpdateType, PromptResponse, SimpleDialog, Theme, ViewportDetails, WebDriverJSError,
-    WebDriverJSResult, WebDriverLoadStatus,
+    AlertResponse, CompositorHitTestResult, ConfirmResponse, EmbedderMsg, GamepadEvent,
+    GamepadSupportedHapticEffects, GamepadUpdateType, PromptResponse, SimpleDialog, Theme,
+    ViewportDetails, WebDriverJSError, WebDriverJSResult, WebDriverLoadStatus,
 };
 use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect, Size2D as UntypedSize2D};
 use euclid::{Point2D, Scale, Size2D, Vector2D};
@@ -51,9 +51,9 @@ use js::rust::{
     MutableHandleValue,
 };
 use layout_api::{
-    FragmentType, HitTestResult, Layout, PendingImage, PendingImageState,
-    PendingRasterizationImage, QueryMsg, ReflowGoal, ReflowRequest, ReflowRequestRestyle,
-    RestyleReason, TrustedNodeAddress, combine_id_with_fragment_type,
+    FragmentType, HitTestFlags, Layout, PendingImage, PendingImageState, PendingRasterizationImage,
+    QueryMsg, ReflowGoal, ReflowRequest, ReflowRequestRestyle, RestyleReason, TrustedNodeAddress,
+    combine_id_with_fragment_type,
 };
 use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
@@ -3062,12 +3062,16 @@ impl Window {
         }
     }
 
-    pub(crate) fn hit_test(&self, hit_test_location: DevicePoint) -> HitTestResult {
+    pub(crate) fn hit_test(
+        &self,
+        hit_test_location: DevicePoint,
+        flags: HitTestFlags,
+    ) -> Vec<CompositorHitTestResult> {
         // div device_pixel_ratio.
         let dpr = self.device_pixel_ratio();
         let hit_test_css_point = hit_test_location / dpr;
         let hit_test_layout_point = LayoutPoint::from_untyped(hit_test_css_point.to_untyped());
-        self.layout.borrow().hit_test(hit_test_layout_point)
+        self.layout.borrow().hit_test(hit_test_layout_point, flags)
     }
 }
 

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -480,7 +480,6 @@ impl WebView {
             .send(EmbedderToConstellationMessage::ForwardInputEvent(
                 self.id(),
                 event,
-                None, /* hit_test */
             ))
     }
 

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -19,9 +19,8 @@ use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{MessagePortId, PipelineId, WebViewId};
 use embedder_traits::{
-    CompositorHitTestResult, Cursor, FocusId, InputEvent, JavaScriptEvaluationId,
-    MediaSessionActionType, Theme, TraversalId, ViewportDetails, WebDriverCommandMsg,
-    WebDriverCommandResponse,
+    Cursor, FocusId, InputEvent, JavaScriptEvaluationId, MediaSessionActionType, Theme,
+    TraversalId, ViewportDetails, WebDriverCommandMsg, WebDriverCommandResponse,
 };
 pub use from_script_message::*;
 use ipc_channel::ipc::IpcSender;
@@ -75,7 +74,7 @@ pub enum EmbedderToConstellationMessage {
     /// Make none of the webviews focused.
     BlurWebView,
     /// Forward an input event to an appropriate ScriptTask.
-    ForwardInputEvent(WebViewId, InputEvent, Option<CompositorHitTestResult>),
+    ForwardInputEvent(WebViewId, InputEvent),
     /// Requesting a change to the onscreen cursor.
     SetCursor(WebViewId, Cursor),
     /// Enable the sampling profiler, with a given sampling rate and max total sampling duration.

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -53,7 +53,7 @@ use style::properties::PropertyId;
 use style::properties::style_structs::Font;
 use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
 use style::stylesheets::Stylesheet;
-use webrender_api::units::{DeviceIntSize, LayoutVector2D};
+use webrender_api::units::{DeviceIntSize, LayoutPoint, LayoutVector2D};
 use webrender_api::{ExternalScrollId, ImageKey};
 
 pub trait GenericLayoutDataTrait: Any + MallocSizeOfTrait {
@@ -200,6 +200,18 @@ pub struct LayoutConfig {
     pub theme: Theme,
 }
 
+#[derive(Debug, Default)]
+pub struct HitTestResult {
+    /// hit test target node
+    pub node: Option<OpaqueNode>,
+    /// point in html page
+    pub page_point: LayoutPoint,
+    /// point in window client
+    pub client_point: LayoutPoint,
+    /// point in the target item.
+    pub point_in_target: LayoutPoint,
+}
+
 pub trait LayoutFactory: Send + Sync {
     fn create(&self, config: LayoutConfig) -> Box<dyn Layout>;
 }
@@ -286,6 +298,7 @@ pub trait Layout {
     ) -> Option<ServoArc<Font>>;
     fn query_scrolling_area(&self, node: Option<TrustedNodeAddress>) -> Rect<i32>;
     fn query_text_indext(&self, node: OpaqueNode, point: Point2D<f32>) -> Option<usize>;
+    fn hit_test(&self, hit_test_location: LayoutPoint) -> HitTestResult;
 }
 
 /// This trait is part of `layout_api` because it depends on both `script_traits`

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -28,8 +28,8 @@ use crossbeam_channel::{RecvTimeoutError, Sender};
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use embedder_traits::user_content_manager::UserContentManager;
 use embedder_traits::{
-    CompositorHitTestResult, FocusSequenceNumber, InputEvent, JavaScriptEvaluationId,
-    MediaSessionActionType, Theme, ViewportDetails, WebDriverScriptCommand,
+    FocusSequenceNumber, InputEvent, JavaScriptEvaluationId, MediaSessionActionType, Theme,
+    ViewportDetails, WebDriverScriptCommand,
 };
 use euclid::{Rect, Scale, Size2D, UnknownUnit};
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
@@ -274,8 +274,6 @@ pub enum DocumentState {
 /// Input events from the embedder that are sent via the `Constellation`` to the `ScriptThread`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ConstellationInputEvent {
-    /// The hit test result of this input event, if any.
-    pub hit_test_result: Option<CompositorHitTestResult>,
     /// The pressed mouse button state of the constellation when this input
     /// event was triggered.
     pub pressed_mouse_buttons: u16,


### PR DESCRIPTION
The main steps are:
1. Obtain the currently focused document in the constellation.
2. Retrieve the corresponding layout object and traverse the StackingContext and StackingContextContent.
3. Perform the hit test within the StackingContextContent::Fragment. 
  3.1. Process the current clip information and its parent clip information. 
  3.2. Process the current spatial information and its parent spatial. 
  3.3. Determine whether the point to be hit is within the border rect of the Fragment.

Testing: The test hit the target normally, with no issues.
Fixes: a part of #37932 
