### PR TITLE
canvas: Use `Convert` instead of multiple to_raqote* traits

### DIFF
--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -94,7 +94,6 @@ pub(crate) trait GenericDrawTarget {
     fn snapshot(&mut self) -> Snapshot;
 }
 
-#[allow(dead_code)] // used by gated backends
 /// A version of the `Into<T>` trait from the standard library that can be used
 /// to convert between two types that are not defined in the canvas crate.
 pub(crate) trait Convert<T> {


### PR DESCRIPTION
We need such trait for other backends too.

Testing: Just refactor, but the code is covered by WPT tests.
