### PR TITLE
script: implement IDBKeyRange

### DIFF
--- a/components/script/dom/idbkeyrange.rs
+++ b/components/script/dom/idbkeyrange.rs
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+use js::gc::MutableHandleValue;
+use js::rust::HandleValue;
+use net_traits::indexeddb_thread::IndexedDBKeyRange;
+use script_bindings::codegen::GenericBindings::IDBKeyRangeBinding::IDBKeyRangeMethods;
+use script_bindings::root::DomRoot;
+use script_bindings::script_runtime::CanGc;
+
+use crate::dom::bindings::error::Fallible;
+use crate::dom::bindings::import::module::SafeJSContext;
+use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
+use crate::dom::globalscope::GlobalScope;
+use crate::indexed_db::{convert_value_to_key, key_type_to_jsval};
+
+#[dom_struct]
+pub struct IDBKeyRange {
+    reflector_: Reflector,
+    #[no_trace]
+    inner: IndexedDBKeyRange,
+}
+
+impl IDBKeyRange {
+    pub fn new_inherited(inner: IndexedDBKeyRange) -> Self {
+        IDBKeyRange {
+            reflector_: Reflector::new(),
+            inner,
+        }
+    }
+
+    pub fn new(global: &GlobalScope, inner: IndexedDBKeyRange, can_gc: CanGc) -> DomRoot<Self> {
+        reflect_dom_object(Box::new(IDBKeyRange::new_inherited(inner)), global, can_gc)
+    }
+
+    #[expect(unused)]
+    pub fn inner(&self) -> &IndexedDBKeyRange {
+        &self.inner
+    }
+}
+
+impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
+    // https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-lower
+    fn Lower(&self, cx: SafeJSContext, answer: MutableHandleValue) {
+        if let Some(lower) = self.inner.lower.as_ref() {
+            key_type_to_jsval(cx, lower, answer);
+        }
+    }
+
+    // https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-upper
+    fn Upper(&self, cx: SafeJSContext, answer: MutableHandleValue) {
+        if let Some(upper) = self.inner.upper.as_ref() {
+            key_type_to_jsval(cx, upper, answer);
+        }
+    }
+
+    // https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-loweropen
+    fn LowerOpen(&self) -> bool {
+        self.inner.lower_open
+    }
+
+    // https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-upperopen
+    fn UpperOpen(&self) -> bool {
+        self.inner.upper_open
+    }
+
+    // https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-only
+    fn Only(
+        cx: SafeJSContext,
+        global: &GlobalScope,
+        value: HandleValue,
+    ) -> Fallible<DomRoot<IDBKeyRange>> {
+        let key = convert_value_to_key(cx, value, None)?;
+        let inner = IndexedDBKeyRange::only(key);
+        Ok(IDBKeyRange::new(global, inner, CanGc::note()))
+    }
+
+    // https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-lowerbound
+    fn LowerBound(
+        cx: SafeJSContext,
+        global: &GlobalScope,
+        lower: HandleValue,
+        open: bool,
+    ) -> Fallible<DomRoot<IDBKeyRange>> {
+        let key = convert_value_to_key(cx, lower, None)?;
+        let inner = IndexedDBKeyRange::lower_bound(key, open);
+        Ok(IDBKeyRange::new(global, inner, CanGc::note()))
+    }
+
+    // https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-upperbound
+    fn UpperBound(
+        cx: SafeJSContext,
+        global: &GlobalScope,
+        upper: HandleValue,
+        open: bool,
+    ) -> Fallible<DomRoot<IDBKeyRange>> {
+        let key = convert_value_to_key(cx, upper, None)?;
+        let inner = IndexedDBKeyRange::upper_bound(key, open);
+        Ok(IDBKeyRange::new(global, inner, CanGc::note()))
+    }
+
+    // https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-bound
+    fn Bound(
+        cx: SafeJSContext,
+        global: &GlobalScope,
+        lower: HandleValue,
+        upper: HandleValue,
+        lower_open: bool,
+        upper_open: bool,
+    ) -> Fallible<DomRoot<IDBKeyRange>> {
+        let lower_key = convert_value_to_key(cx, lower, None)?;
+        let upper_key = convert_value_to_key(cx, upper, None)?;
+        let inner =
+            IndexedDBKeyRange::new(Some(lower_key), Some(upper_key), lower_open, upper_open);
+        Ok(IDBKeyRange::new(global, inner, CanGc::note()))
+    }
+
+    // https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-_includes
+    fn Includes(&self, cx: SafeJSContext, value: HandleValue) -> Fallible<bool> {
+        let key = convert_value_to_key(cx, value, None)?;
+        if self.inner.contains(&key) {
+            return Ok(true);
+        }
+        Ok(false)
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -422,6 +422,7 @@ pub(crate) mod htmlunknownelement;
 pub(crate) mod htmlvideoelement;
 pub(crate) mod idbdatabase;
 pub(crate) mod idbfactory;
+pub(crate) mod idbkeyrange;
 pub(crate) mod idbobjectstore;
 pub(crate) mod idbopendbrequest;
 pub(crate) mod idbrequest;

--- a/components/script_bindings/webidls/IDBKeyRange.webidl
+++ b/components/script_bindings/webidls/IDBKeyRange.webidl
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/*
+ * The origin of this IDL file is
+ * https://w3c.github.io/IndexedDB/#keyrange
+ *
+ */
+
+// https://w3c.github.io/IndexedDB/#keyrange
+[Pref="dom_indexeddb_enabled", Exposed=(Window,Worker)]
+interface IDBKeyRange {
+  readonly attribute any lower;
+  readonly attribute any upper;
+  readonly attribute boolean lowerOpen;
+  readonly attribute boolean upperOpen;
+
+  // Static construction methods:
+  [Throws, NewObject] static IDBKeyRange only(any value);
+  [Throws, NewObject] static IDBKeyRange lowerBound(any lower, optional boolean open = false);
+  [Throws, NewObject] static IDBKeyRange upperBound(any upper, optional boolean open = false);
+  [Throws, NewObject] static IDBKeyRange bound(any lower,
+                                       any upper,
+                                       optional boolean lowerOpen = false,
+                                       optional boolean upperOpen = false);
+
+  [Throws] boolean _includes(any key);
+};

--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -5,6 +5,7 @@
 use std::cmp::{PartialEq, PartialOrd};
 
 use ipc_channel::ipc::IpcSender;
+use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use servo_url::origin::ImmutableOrigin;
 
@@ -17,7 +18,7 @@ pub enum IndexedDBTxnMode {
 }
 
 /// <https://www.w3.org/TR/IndexedDB-2/#key-type>
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub enum IndexedDBKeyType {
     Number(f64),
     String(String),
@@ -114,7 +115,7 @@ impl PartialEq for IndexedDBKeyType {
 }
 
 // <https://www.w3.org/TR/IndexedDB-2/#key-range>
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, Serialize)]
 #[allow(unused)]
 pub struct IndexedDBKeyRange {
     pub lower: Option<IndexedDBKeyType>,
@@ -134,6 +135,42 @@ impl From<IndexedDBKeyType> for IndexedDBKeyRange {
 }
 
 impl IndexedDBKeyRange {
+    pub fn only(key: IndexedDBKeyType) -> Self {
+        Self::from(key)
+    }
+
+    pub fn new(
+        lower: Option<IndexedDBKeyType>,
+        upper: Option<IndexedDBKeyType>,
+        lower_open: bool,
+        upper_open: bool,
+    ) -> Self {
+        IndexedDBKeyRange {
+            lower,
+            upper,
+            lower_open,
+            upper_open,
+        }
+    }
+
+    pub fn lower_bound(key: IndexedDBKeyType, open: bool) -> Self {
+        IndexedDBKeyRange {
+            lower: Some(key),
+            upper: None,
+            lower_open: open,
+            upper_open: false,
+        }
+    }
+
+    pub fn upper_bound(key: IndexedDBKeyType, open: bool) -> Self {
+        IndexedDBKeyRange {
+            lower: None,
+            upper: Some(key),
+            lower_open: false,
+            upper_open: open,
+        }
+    }
+
     // <https://www.w3.org/TR/IndexedDB-2/#in>
     pub fn contains(&self, key: &IndexedDBKeyType) -> bool {
         // A key is in a key range if both of the following conditions are fulfilled:
@@ -150,6 +187,17 @@ impl IndexedDBKeyRange {
             .as_ref()
             .is_none_or(|upper| key < upper || (!self.upper_open && key == upper));
         lower_bound_condition && upper_bound_condition
+    }
+
+    pub fn is_singleton(&self) -> bool {
+        self.lower == self.upper && !self.lower_open && !self.upper_open
+    }
+
+    pub fn as_singleton(&self) -> Option<&IndexedDBKeyType> {
+        if self.is_singleton() {
+            return Some(self.lower.as_ref().unwrap());
+        }
+        None
     }
 }
 

--- a/tests/wpt/meta/IndexedDB/idb-partitioned-coverage.sub.html.ini
+++ b/tests/wpt/meta/IndexedDB/idb-partitioned-coverage.sub.html.ini
@@ -1,5 +1,4 @@
 [idb-partitioned-coverage.sub.html]
-  expected: ERROR
   [Deletes are processed in order]
     expected: FAIL
 
@@ -46,4 +45,43 @@
     expected: FAIL
 
   [IDBObjectStore.openKeyCursor() - invalid inputs]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [maxCount=0]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Retrieve multiEntry key]
+    expected: FAIL
+
+  [Retrieve one key multiple values]
+    expected: FAIL
+
+  [Get all values with invalid query keys]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idb_binary_key_conversion.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idb_binary_key_conversion.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [idb_binary_key_conversion.any.worker.html]
+  expected: CRASH
   [Empty ArrayBuffer]
     expected: FAIL
 
@@ -19,6 +20,7 @@
 
 
 [idb_binary_key_conversion.any.html]
+  expected: CRASH
   [Empty ArrayBuffer]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbindex-cross-realm-methods.html.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-cross-realm-methods.html.ini
@@ -1,2 +1,21 @@
 [idbindex-cross-realm-methods.html]
-  expected: ERROR
+  [Cross-realm IDBIndex::get() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBIndex::getKey() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBIndex::getAll() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBIndex::getAllKeys() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBIndex::count() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBIndex::openCursor() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBIndex::openKeyCursor() method from detached <iframe> works as expected]
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbindex_getAll-options.tentative.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_getAll-options.tentative.any.js.ini
@@ -1,5 +1,4 @@
 [idbindex_getAll-options.tentative.any.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -16,6 +15,66 @@
     expected: FAIL
 
   [maxCount=10]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [maxCount=0]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Retrieve multiEntry key]
+    expected: FAIL
+
+  [Retrieve one key multiple values]
+    expected: FAIL
+
+  [Direction: next]
+    expected: FAIL
+
+  [Direction: prev]
+    expected: FAIL
+
+  [Direction: nextunique]
+    expected: FAIL
+
+  [Direction: prevunique]
+    expected: FAIL
+
+  [Direction and query]
+    expected: FAIL
+
+  [Direction, query and count]
+    expected: FAIL
+
+  [Get all values with both options and count]
+    expected: FAIL
+
+  [Get all values with invalid query keys]
     expected: FAIL
 
 
@@ -23,7 +82,6 @@
   expected: ERROR
 
 [idbindex_getAll-options.tentative.any.worker.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -40,6 +98,66 @@
     expected: FAIL
 
   [maxCount=10]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [maxCount=0]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Retrieve multiEntry key]
+    expected: FAIL
+
+  [Retrieve one key multiple values]
+    expected: FAIL
+
+  [Direction: next]
+    expected: FAIL
+
+  [Direction: prev]
+    expected: FAIL
+
+  [Direction: nextunique]
+    expected: FAIL
+
+  [Direction: prevunique]
+    expected: FAIL
+
+  [Direction and query]
+    expected: FAIL
+
+  [Direction, query and count]
+    expected: FAIL
+
+  [Get all values with both options and count]
+    expected: FAIL
+
+  [Get all values with invalid query keys]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbindex_getAll.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_getAll.any.js.ini
@@ -2,7 +2,6 @@
   expected: ERROR
 
 [idbindex_getAll.any.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -19,6 +18,45 @@
     expected: FAIL
 
   [maxCount=10]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [maxCount=0]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Retrieve multiEntry key]
+    expected: FAIL
+
+  [Retrieve one key multiple values]
+    expected: FAIL
+
+  [Get all values with invalid query keys]
     expected: FAIL
 
 
@@ -26,7 +64,6 @@
   expected: ERROR
 
 [idbindex_getAll.any.worker.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -43,4 +80,43 @@
     expected: FAIL
 
   [maxCount=10]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [maxCount=0]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Retrieve multiEntry key]
+    expected: FAIL
+
+  [Retrieve one key multiple values]
+    expected: FAIL
+
+  [Get all values with invalid query keys]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbindex_getAllKeys-options.tentative.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_getAllKeys-options.tentative.any.js.ini
@@ -5,7 +5,6 @@
   expected: ERROR
 
 [idbindex_getAllKeys-options.tentative.any.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -19,11 +18,70 @@
     expected: FAIL
 
   [maxCount=10]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [maxCount=0]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Retrieve multiEntry key]
+    expected: FAIL
+
+  [Retrieve one key multiple values]
+    expected: FAIL
+
+  [Direction: next]
+    expected: FAIL
+
+  [Direction: prev]
+    expected: FAIL
+
+  [Direction: nextunique]
+    expected: FAIL
+
+  [Direction: prevunique]
+    expected: FAIL
+
+  [Direction and query]
+    expected: FAIL
+
+  [Direction, query and count]
+    expected: FAIL
+
+  [Get all keys with both options and count]
+    expected: FAIL
+
+  [Get all keys with invalid query keys]
     expected: FAIL
 
 
 [idbindex_getAllKeys-options.tentative.any.worker.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -37,4 +95,64 @@
     expected: FAIL
 
   [maxCount=10]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [maxCount=0]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Retrieve multiEntry key]
+    expected: FAIL
+
+  [Retrieve one key multiple values]
+    expected: FAIL
+
+  [Direction: next]
+    expected: FAIL
+
+  [Direction: prev]
+    expected: FAIL
+
+  [Direction: nextunique]
+    expected: FAIL
+
+  [Direction: prevunique]
+    expected: FAIL
+
+  [Direction and query]
+    expected: FAIL
+
+  [Direction, query and count]
+    expected: FAIL
+
+  [Get all keys with both options and count]
+    expected: FAIL
+
+  [Get all keys with invalid query keys]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbindex_getAllKeys.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_getAllKeys.any.js.ini
@@ -2,7 +2,6 @@
   expected: ERROR
 
 [idbindex_getAllKeys.any.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -16,11 +15,49 @@
     expected: FAIL
 
   [maxCount=10]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [maxCount=0]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Retrieve multiEntry key]
+    expected: FAIL
+
+  [Retrieve one key multiple values]
+    expected: FAIL
+
+  [Get all keys with invalid query keys]
     expected: FAIL
 
 
 [idbindex_getAllKeys.any.worker.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -34,6 +71,45 @@
     expected: FAIL
 
   [maxCount=10]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [maxCount=0]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Retrieve multiEntry key]
+    expected: FAIL
+
+  [Retrieve one key multiple values]
+    expected: FAIL
+
+  [Get all keys with invalid query keys]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbindex_getAllRecords.tentative.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex_getAllRecords.tentative.any.js.ini
@@ -1,5 +1,4 @@
 [idbindex_getAllRecords.tentative.any.html]
-  expected: ERROR
   [Single item]
     expected: FAIL
 
@@ -16,6 +15,63 @@
     expected: FAIL
 
   [Count]
+    expected: FAIL
+
+  [Query with bound range]
+    expected: FAIL
+
+  [Query with bound range and count]
+    expected: FAIL
+
+  [Query with upper excluded bound range]
+    expected: FAIL
+
+  [Query with lower excluded bound range]
+    expected: FAIL
+
+  [Query with bound range and count for generated keys]
+    expected: FAIL
+
+  [Query with Nonexistent key]
+    expected: FAIL
+
+  [Zero count]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Query index key that matches multiple records]
+    expected: FAIL
+
+  [Query with multiEntry index]
+    expected: FAIL
+
+  [Direction: next]
+    expected: FAIL
+
+  [Direction: prev]
+    expected: FAIL
+
+  [Direction: nextunique]
+    expected: FAIL
+
+  [Direction: prevunique]
+    expected: FAIL
+
+  [Direction and query]
+    expected: FAIL
+
+  [Direction, query and count]
+    expected: FAIL
+
+  [Get all records with invalid query keys]
     expected: FAIL
 
 
@@ -26,7 +82,6 @@
   expected: ERROR
 
 [idbindex_getAllRecords.tentative.any.worker.html]
-  expected: ERROR
   [Single item]
     expected: FAIL
 
@@ -43,4 +98,61 @@
     expected: FAIL
 
   [Count]
+    expected: FAIL
+
+  [Query with bound range]
+    expected: FAIL
+
+  [Query with bound range and count]
+    expected: FAIL
+
+  [Query with upper excluded bound range]
+    expected: FAIL
+
+  [Query with lower excluded bound range]
+    expected: FAIL
+
+  [Query with bound range and count for generated keys]
+    expected: FAIL
+
+  [Query with Nonexistent key]
+    expected: FAIL
+
+  [Zero count]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Query index key that matches multiple records]
+    expected: FAIL
+
+  [Query with multiEntry index]
+    expected: FAIL
+
+  [Direction: next]
+    expected: FAIL
+
+  [Direction: prev]
+    expected: FAIL
+
+  [Direction: nextunique]
+    expected: FAIL
+
+  [Direction: prevunique]
+    expected: FAIL
+
+  [Direction and query]
+    expected: FAIL
+
+  [Direction, query and count]
+    expected: FAIL
+
+  [Get all records with invalid query keys]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbkeyrange-includes.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbkeyrange-includes.any.js.ini
@@ -1,4 +1,5 @@
 [idbkeyrange-includes.any.html]
+  expected: CRASH
   [IDBKeyRange.includes() with invalid input]
     expected: FAIL
 
@@ -40,6 +41,7 @@
   expected: ERROR
 
 [idbkeyrange-includes.any.worker.html]
+  expected: CRASH
   [IDBKeyRange.includes() with invalid input]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbkeyrange.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbkeyrange.any.js.ini
@@ -5,64 +5,16 @@
   expected: ERROR
 
 [idbkeyrange.any.html]
-  [IDBKeyRange.only() - returns an IDBKeyRange and the properties are set correctly]
-    expected: FAIL
-
-  [IDBKeyRange.only() - throws on invalid keys]
-    expected: FAIL
-
   [IDBKeyRange.lowerBound() - returns an IDBKeyRange and the properties are set correctly]
     expected: FAIL
 
-  [IDBKeyRange.lowerBound() - 'open' parameter has correct default set]
-    expected: FAIL
-
-  [IDBKeyRange.lowerBound() - throws on invalid keys]
-    expected: FAIL
-
   [IDBKeyRange.upperBound() - returns an IDBKeyRange and the properties are set correctly]
-    expected: FAIL
-
-  [IDBKeyRange.upperBound() - 'open' parameter has correct default set]
-    expected: FAIL
-
-  [IDBKeyRange.upperBound() - throws on invalid keys]
-    expected: FAIL
-
-  [IDBKeyRange.bound() - returns an IDBKeyRange and the properties are set correctly]
-    expected: FAIL
-
-  [IDBKeyRange.bound() - 'lowerOpen' and 'upperOpen' parameters have correct defaults set]
     expected: FAIL
 
 
 [idbkeyrange.any.worker.html]
-  [IDBKeyRange.only() - returns an IDBKeyRange and the properties are set correctly]
-    expected: FAIL
-
-  [IDBKeyRange.only() - throws on invalid keys]
-    expected: FAIL
-
   [IDBKeyRange.lowerBound() - returns an IDBKeyRange and the properties are set correctly]
     expected: FAIL
 
-  [IDBKeyRange.lowerBound() - 'open' parameter has correct default set]
-    expected: FAIL
-
-  [IDBKeyRange.lowerBound() - throws on invalid keys]
-    expected: FAIL
-
   [IDBKeyRange.upperBound() - returns an IDBKeyRange and the properties are set correctly]
-    expected: FAIL
-
-  [IDBKeyRange.upperBound() - 'open' parameter has correct default set]
-    expected: FAIL
-
-  [IDBKeyRange.upperBound() - throws on invalid keys]
-    expected: FAIL
-
-  [IDBKeyRange.bound() - returns an IDBKeyRange and the properties are set correctly]
-    expected: FAIL
-
-  [IDBKeyRange.bound() - 'lowerOpen' and 'upperOpen' parameters have correct defaults set]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbkeyrange_incorrect.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbkeyrange_incorrect.any.js.ini
@@ -1,40 +1,16 @@
 [idbkeyrange_incorrect.any.html]
-  [IDBKeyRange.bound() - bound requires more than 0 arguments.]
-    expected: FAIL
-
-  [IDBKeyRange.bound(null, null) - null parameters are incorrect.]
-    expected: FAIL
-
-  [IDBKeyRange.bound(1, null / null, 1) - null parameter is incorrect.]
-    expected: FAIL
-
   [IDBKeyRange.bound(lower, upper / lower > upper) - lower' is greater than 'upper'.]
     expected: FAIL
 
   [IDBKeyRange.bound(DOMString/Date/Array, 1) - A DOMString, Date and Array are greater than a float.]
-    expected: FAIL
-
-  [IDBKeyRange.bound(true, 1) - boolean is not a valid key type.]
     expected: FAIL
 
 
 [idbkeyrange_incorrect.any.worker.html]
-  [IDBKeyRange.bound() - bound requires more than 0 arguments.]
-    expected: FAIL
-
-  [IDBKeyRange.bound(null, null) - null parameters are incorrect.]
-    expected: FAIL
-
-  [IDBKeyRange.bound(1, null / null, 1) - null parameter is incorrect.]
-    expected: FAIL
-
   [IDBKeyRange.bound(lower, upper / lower > upper) - lower' is greater than 'upper'.]
     expected: FAIL
 
   [IDBKeyRange.bound(DOMString/Date/Array, 1) - A DOMString, Date and Array are greater than a float.]
-    expected: FAIL
-
-  [IDBKeyRange.bound(true, 1) - boolean is not a valid key type.]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-clear-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-clear-exception-order.any.js.ini
@@ -1,11 +1,23 @@
 [idbobjectstore-clear-exception-order.any.worker.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [IDBObjectStore.clear exception order: InvalidStateError vs. TransactionInactiveError]
+    expected: TIMEOUT
+
+  [IDBObjectStore.clear exception order: TransactionInactiveError vs. ReadOnlyError]
+    expected: FAIL
+
 
 [idbobjectstore-clear-exception-order.any.sharedworker.html]
   expected: ERROR
 
 [idbobjectstore-clear-exception-order.any.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [IDBObjectStore.clear exception order: InvalidStateError vs. TransactionInactiveError]
+    expected: TIMEOUT
+
+  [IDBObjectStore.clear exception order: TransactionInactiveError vs. ReadOnlyError]
+    expected: FAIL
+
 
 [idbobjectstore-clear-exception-order.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-cross-realm-methods.html.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-cross-realm-methods.html.ini
@@ -1,2 +1,31 @@
 [idbobjectstore-cross-realm-methods.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [Cross-realm IDBObjectStore::put() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBObjectStore::add() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBObjectStore::delete() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBObjectStore::clear() method from detached <iframe> works as expected]
+    expected: TIMEOUT
+
+  [Cross-realm IDBObjectStore::getKey() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBObjectStore::getAll() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBObjectStore::getAllKeys() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBObjectStore::count() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBObjectStore::openCursor() method from detached <iframe> works as expected]
+    expected: FAIL
+
+  [Cross-realm IDBObjectStore::openKeyCursor() method from detached <iframe> works as expected]
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-delete-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-delete-exception-order.any.js.ini
@@ -2,10 +2,21 @@
   expected: ERROR
 
 [idbobjectstore-delete-exception-order.any.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [IDBObjectStore.delete exception order: InvalidStateError vs. TransactionInactiveError]
+    expected: TIMEOUT
+
+  [IDBObjectStore.delete exception order: TransactionInactiveError vs. ReadOnlyError]
+    expected: FAIL
+
 
 [idbobjectstore-delete-exception-order.any.sharedworker.html]
   expected: ERROR
 
 [idbobjectstore-delete-exception-order.any.worker.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [IDBObjectStore.delete exception order: InvalidStateError vs. TransactionInactiveError]
+    expected: TIMEOUT
+
+  [IDBObjectStore.delete exception order: TransactionInactiveError vs. ReadOnlyError]
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAll-options.tentative.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAll-options.tentative.any.js.ini
@@ -1,5 +1,4 @@
 [idbobjectstore_getAll-options.tentative.any.worker.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -16,6 +15,60 @@
     expected: FAIL
 
   [Test maxCount]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [zero maxCount]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Direction: next]
+    expected: FAIL
+
+  [Direction: prev]
+    expected: FAIL
+
+  [Direction: nextunique]
+    expected: FAIL
+
+  [Direction: prevunique]
+    expected: FAIL
+
+  [Direction and query]
+    expected: FAIL
+
+  [Direction, query and count]
+    expected: FAIL
+
+  [Get all values with both options and count]
+    expected: FAIL
+
+  [Get all values with invalid query keys]
     expected: FAIL
 
 
@@ -26,7 +79,6 @@
   expected: ERROR
 
 [idbobjectstore_getAll-options.tentative.any.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -43,4 +95,58 @@
     expected: FAIL
 
   [Test maxCount]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [zero maxCount]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Direction: next]
+    expected: FAIL
+
+  [Direction: prev]
+    expected: FAIL
+
+  [Direction: nextunique]
+    expected: FAIL
+
+  [Direction: prevunique]
+    expected: FAIL
+
+  [Direction and query]
+    expected: FAIL
+
+  [Direction, query and count]
+    expected: FAIL
+
+  [Get all values with both options and count]
+    expected: FAIL
+
+  [Get all values with invalid query keys]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAll.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAll.any.js.ini
@@ -1,5 +1,4 @@
 [idbobjectstore_getAll.any.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -16,6 +15,42 @@
     expected: FAIL
 
   [Test maxCount]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [zero maxCount]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Get all values with transaction.commit()]
+    expected: FAIL
+
+  [Get all values with invalid query keys]
     expected: FAIL
 
 
@@ -23,7 +58,6 @@
   expected: ERROR
 
 [idbobjectstore_getAll.any.worker.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -40,6 +74,42 @@
     expected: FAIL
 
   [Test maxCount]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [zero maxCount]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Get all values with transaction.commit()]
+    expected: FAIL
+
+  [Get all values with invalid query keys]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys-options.tentative.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys-options.tentative.any.js.ini
@@ -1,5 +1,4 @@
 [idbobjectstore_getAllKeys-options.tentative.any.worker.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -13,6 +12,60 @@
     expected: FAIL
 
   [Test maxCount]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [zero maxCount]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Direction: next]
+    expected: FAIL
+
+  [Direction: prev]
+    expected: FAIL
+
+  [Direction: nextunique]
+    expected: FAIL
+
+  [Direction: prevunique]
+    expected: FAIL
+
+  [Direction and query]
+    expected: FAIL
+
+  [Direction, query and count]
+    expected: FAIL
+
+  [Get all keys with both options and count]
+    expected: FAIL
+
+  [Get all keys with invalid query keys]
     expected: FAIL
 
 
@@ -20,7 +73,6 @@
   expected: ERROR
 
 [idbobjectstore_getAllKeys-options.tentative.any.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -34,6 +86,60 @@
     expected: FAIL
 
   [Test maxCount]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [zero maxCount]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Direction: next]
+    expected: FAIL
+
+  [Direction: prev]
+    expected: FAIL
+
+  [Direction: nextunique]
+    expected: FAIL
+
+  [Direction: prevunique]
+    expected: FAIL
+
+  [Direction and query]
+    expected: FAIL
+
+  [Direction, query and count]
+    expected: FAIL
+
+  [Get all keys with both options and count]
+    expected: FAIL
+
+  [Get all keys with invalid query keys]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys.any.js.ini
@@ -5,7 +5,6 @@
   expected: ERROR
 
 [idbobjectstore_getAllKeys.any.worker.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -19,11 +18,43 @@
     expected: FAIL
 
   [Test maxCount]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [zero maxCount]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Get all keys with invalid query keys]
     expected: FAIL
 
 
 [idbobjectstore_getAllKeys.any.html]
-  expected: ERROR
   [Single item get]
     expected: FAIL
 
@@ -37,4 +68,37 @@
     expected: FAIL
 
   [Test maxCount]
+    expected: FAIL
+
+  [Get bound range]
+    expected: FAIL
+
+  [Get bound range with maxCount]
+    expected: FAIL
+
+  [Get upper excluded]
+    expected: FAIL
+
+  [Get lower excluded]
+    expected: FAIL
+
+  [Get bound range (generated) with maxCount]
+    expected: FAIL
+
+  [Non existent key]
+    expected: FAIL
+
+  [zero maxCount]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where  first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Get all keys with invalid query keys]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAllRecords.tentative.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAllRecords.tentative.any.js.ini
@@ -1,5 +1,4 @@
 [idbobjectstore_getAllRecords.tentative.any.worker.html]
-  expected: ERROR
   [Single item]
     expected: FAIL
 
@@ -19,11 +18,64 @@
     expected: FAIL
 
   [Count]
+    expected: FAIL
+
+  [Query with bound range]
+    expected: FAIL
+
+  [Query with bound range and count]
+    expected: FAIL
+
+  [Query with upper excluded bound range]
+    expected: FAIL
+
+  [Query with lower excluded bound range]
+    expected: FAIL
+
+  [Query with bound range and count for generated keys]
+    expected: FAIL
+
+  [Query with nonexistent key]
+    expected: FAIL
+
+  [Zero count]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Direction: next]
+    expected: FAIL
+
+  [Direction: prev]
+    expected: FAIL
+
+  [Direction: nextunique]
+    expected: FAIL
+
+  [Direction: prevunique]
+    expected: FAIL
+
+  [Direction and query]
+    expected: FAIL
+
+  [Direction, query and count]
+    expected: FAIL
+
+  [Get all records with transaction.commit()]
+    expected: FAIL
+
+  [Get all records with invalid query keys]
     expected: FAIL
 
 
 [idbobjectstore_getAllRecords.tentative.any.html]
-  expected: ERROR
   [Single item]
     expected: FAIL
 
@@ -43,6 +95,60 @@
     expected: FAIL
 
   [Count]
+    expected: FAIL
+
+  [Query with bound range]
+    expected: FAIL
+
+  [Query with bound range and count]
+    expected: FAIL
+
+  [Query with upper excluded bound range]
+    expected: FAIL
+
+  [Query with lower excluded bound range]
+    expected: FAIL
+
+  [Query with bound range and count for generated keys]
+    expected: FAIL
+
+  [Query with nonexistent key]
+    expected: FAIL
+
+  [Zero count]
+    expected: FAIL
+
+  [Max value count]
+    expected: FAIL
+
+  [Query with empty range where first key < upperBound]
+    expected: FAIL
+
+  [Query with empty range where lowerBound < last key]
+    expected: FAIL
+
+  [Direction: next]
+    expected: FAIL
+
+  [Direction: prev]
+    expected: FAIL
+
+  [Direction: nextunique]
+    expected: FAIL
+
+  [Direction: prevunique]
+    expected: FAIL
+
+  [Direction and query]
+    expected: FAIL
+
+  [Direction, query and count]
+    expected: FAIL
+
+  [Get all records with transaction.commit()]
+    expected: FAIL
+
+  [Get all records with invalid query keys]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
@@ -2,9 +2,6 @@
   expected: ERROR
 
 [idlharness.any.html]
-  [idl_test setup]
-    expected: FAIL
-
   [IDBFactory interface: operation databases()]
     expected: FAIL
 
@@ -95,51 +92,6 @@
   [IDBIndex interface: operation openKeyCursor(optional any, optional IDBCursorDirection)]
     expected: FAIL
 
-  [IDBKeyRange interface: existence and properties of interface object]
-    expected: FAIL
-
-  [IDBKeyRange interface object length]
-    expected: FAIL
-
-  [IDBKeyRange interface object name]
-    expected: FAIL
-
-  [IDBKeyRange interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [IDBKeyRange interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [IDBKeyRange interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [IDBKeyRange interface: attribute lower]
-    expected: FAIL
-
-  [IDBKeyRange interface: attribute upper]
-    expected: FAIL
-
-  [IDBKeyRange interface: attribute lowerOpen]
-    expected: FAIL
-
-  [IDBKeyRange interface: attribute upperOpen]
-    expected: FAIL
-
-  [IDBKeyRange interface: operation only(any)]
-    expected: FAIL
-
-  [IDBKeyRange interface: operation lowerBound(any, optional boolean)]
-    expected: FAIL
-
-  [IDBKeyRange interface: operation upperBound(any, optional boolean)]
-    expected: FAIL
-
-  [IDBKeyRange interface: operation bound(any, any, optional boolean, optional boolean)]
-    expected: FAIL
-
-  [IDBKeyRange interface: operation includes(any)]
-    expected: FAIL
-
   [IDBCursor interface: existence and properties of interface object]
     expected: FAIL
 
@@ -210,6 +162,9 @@
     expected: FAIL
 
   [IDBTransaction interface: attribute durability]
+    expected: FAIL
+
+  [IDBFactory interface: [object IDBFactory\] must inherit property "databases()" with the proper type]
     expected: FAIL
 
 
@@ -217,9 +172,6 @@
   expected: ERROR
 
 [idlharness.any.worker.html]
-  [idl_test setup]
-    expected: FAIL
-
   [IDBFactory interface: operation databases()]
     expected: FAIL
 
@@ -310,51 +262,6 @@
   [IDBIndex interface: operation openKeyCursor(optional any, optional IDBCursorDirection)]
     expected: FAIL
 
-  [IDBKeyRange interface: existence and properties of interface object]
-    expected: FAIL
-
-  [IDBKeyRange interface object length]
-    expected: FAIL
-
-  [IDBKeyRange interface object name]
-    expected: FAIL
-
-  [IDBKeyRange interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [IDBKeyRange interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [IDBKeyRange interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [IDBKeyRange interface: attribute lower]
-    expected: FAIL
-
-  [IDBKeyRange interface: attribute upper]
-    expected: FAIL
-
-  [IDBKeyRange interface: attribute lowerOpen]
-    expected: FAIL
-
-  [IDBKeyRange interface: attribute upperOpen]
-    expected: FAIL
-
-  [IDBKeyRange interface: operation only(any)]
-    expected: FAIL
-
-  [IDBKeyRange interface: operation lowerBound(any, optional boolean)]
-    expected: FAIL
-
-  [IDBKeyRange interface: operation upperBound(any, optional boolean)]
-    expected: FAIL
-
-  [IDBKeyRange interface: operation bound(any, any, optional boolean, optional boolean)]
-    expected: FAIL
-
-  [IDBKeyRange interface: operation includes(any)]
-    expected: FAIL
-
   [IDBCursor interface: existence and properties of interface object]
     expected: FAIL
 
@@ -425,4 +332,7 @@
     expected: FAIL
 
   [IDBTransaction interface: attribute durability]
+    expected: FAIL
+
+  [IDBFactory interface: [object IDBFactory\] must inherit property "databases()" with the proper type]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/value.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/value.any.js.ini
@@ -1,11 +1,5 @@
 [value.any.html]
   expected: TIMEOUT
-  [BigInts as keys in IndexedDB - primitive BigInt]
-    expected: FAIL
-
-  [BigInts as keys in IndexedDB - BigInt object]
-    expected: FAIL
-
   [Values - Array]
     expected: TIMEOUT
 
@@ -15,12 +9,6 @@
 
 [value.any.worker.html]
   expected: TIMEOUT
-  [BigInts as keys in IndexedDB - primitive BigInt]
-    expected: FAIL
-
-  [BigInts as keys in IndexedDB - BigInt object]
-    expected: FAIL
-
   [Values - Array]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/IndexedDB/value_recursive.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/value_recursive.any.js.ini
@@ -6,6 +6,9 @@
   [Recursive value - array member contains self]
     expected: TIMEOUT
 
+  [Recursive value - array indirectly contains self]
+    expected: TIMEOUT
+
 
 [value_recursive.any.worker.html]
   expected: TIMEOUT

--- a/tests/wpt/meta/workers/semantics/interface-objects/001.worker.js.ini
+++ b/tests/wpt/meta/workers/semantics/interface-objects/001.worker.js.ini
@@ -8,9 +8,6 @@
   [The IDBIndex interface object should be exposed.]
     expected: FAIL
 
-  [The IDBKeyRange interface object should be exposed.]
-    expected: FAIL
-
   [The IDBCursor interface object should be exposed.]
     expected: FAIL
 


### PR DESCRIPTION
#37684 provided the backend for this change. The key range interface just wraps a `IndexedDBKeyRange` and exposes the methods from it as per the spec.

Spec: https://www.w3.org/TR/IndexedDB-2/#keyrange
Testing: WPT tests (some regressions have been exposed, but that's fine)
