### PR TITLE
script: Update indexeddb serialization

### DIFF
--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -22,8 +22,7 @@ pub enum IndexedDBKeyType {
     Number(f64),
     String(String),
     Binary(Vec<u8>),
-    // FIXME:(arihant2math) Date should not be stored as a Vec<u8>
-    Date(Vec<u8>),
+    Date(f64),
     Array(Vec<IndexedDBKeyType>),
     // FIXME:(arihant2math) implment ArrayBuffer
 }

--- a/tests/wpt/meta/IndexedDB/idb-binary-key-roundtrip.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idb-binary-key-roundtrip.any.js.ini
@@ -1,4 +1,5 @@
 [idb-binary-key-roundtrip.any.worker.html]
+  expected: CRASH
   [Binary keys can be supplied using the view type Uint8Array]
     expected: FAIL
 
@@ -49,6 +50,7 @@
 
 
 [idb-binary-key-roundtrip.any.html]
+  expected: CRASH
   [Binary keys can be supplied using the view type Uint8Array]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbcursor-key.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbcursor-key.any.js.ini
@@ -2,10 +2,26 @@
   expected: ERROR
 
 [idbcursor-key.any.worker.html]
-  expected: CRASH
+  [IDBCursor.key]
+    expected: FAIL
+
+  [IDBCursor.key 1]
+    expected: FAIL
+
+  [IDBCursor.key 2]
+    expected: FAIL
+
 
 [idbcursor-key.any.html]
-  expected: CRASH
+  [IDBCursor.key]
+    expected: FAIL
+
+  [IDBCursor.key 1]
+    expected: FAIL
+
+  [IDBCursor.key 2]
+    expected: FAIL
+
 
 [idbcursor-key.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbfactory_cmp.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory_cmp.any.js.ini
@@ -2,74 +2,24 @@
   expected: ERROR
 
 [idbfactory_cmp.any.html]
-  expected: CRASH
-  [IDBFactory.cmp() - compared keys return correct value]
-    expected: FAIL
-
-  [IDBFactory.cmp() - null]
-    expected: FAIL
-
-  [IDBFactory.cmp() - NaN]
-    expected: FAIL
-
   [Array vs. Binary]
-    expected: FAIL
-
-  [Binary vs. String]
-    expected: FAIL
-
-  [String vs. Date]
-    expected: FAIL
-
-  [Date vs. Number]
     expected: FAIL
 
   [Compare in unsigned octet values (in the range [0, 255\])]
     expected: FAIL
 
-  [Compare values of the same length]
-    expected: FAIL
-
   [Compare values of different lengths]
-    expected: FAIL
-
-  [Compare when values in the range of their minimal length are the same]
     expected: FAIL
 
 
 [idbfactory_cmp.any.worker.html]
-  expected: CRASH
-  [IDBFactory.cmp() - compared keys return correct value]
-    expected: FAIL
-
-  [IDBFactory.cmp() - null]
-    expected: FAIL
-
-  [IDBFactory.cmp() - NaN]
-    expected: FAIL
-
   [Array vs. Binary]
-    expected: FAIL
-
-  [Binary vs. String]
-    expected: FAIL
-
-  [String vs. Date]
-    expected: FAIL
-
-  [Date vs. Number]
     expected: FAIL
 
   [Compare in unsigned octet values (in the range [0, 255\])]
     expected: FAIL
 
-  [Compare values of the same length]
-    expected: FAIL
-
   [Compare values of different lengths]
-    expected: FAIL
-
-  [Compare when values in the range of their minimal length are the same]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-clear-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-clear-exception-order.any.js.ini
@@ -1,11 +1,23 @@
 [idbobjectstore-clear-exception-order.any.worker.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [IDBObjectStore.clear exception order: InvalidStateError vs. TransactionInactiveError]
+    expected: TIMEOUT
+
+  [IDBObjectStore.clear exception order: TransactionInactiveError vs. ReadOnlyError]
+    expected: FAIL
+
 
 [idbobjectstore-clear-exception-order.any.sharedworker.html]
   expected: ERROR
 
 [idbobjectstore-clear-exception-order.any.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [IDBObjectStore.clear exception order: InvalidStateError vs. TransactionInactiveError]
+    expected: TIMEOUT
+
+  [IDBObjectStore.clear exception order: TransactionInactiveError vs. ReadOnlyError]
+    expected: FAIL
+
 
 [idbobjectstore-clear-exception-order.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-delete-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-delete-exception-order.any.js.ini
@@ -2,10 +2,21 @@
   expected: ERROR
 
 [idbobjectstore-delete-exception-order.any.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [IDBObjectStore.delete exception order: InvalidStateError vs. TransactionInactiveError]
+    expected: TIMEOUT
+
+  [IDBObjectStore.delete exception order: TransactionInactiveError vs. ReadOnlyError]
+    expected: FAIL
+
 
 [idbobjectstore-delete-exception-order.any.sharedworker.html]
   expected: ERROR
 
 [idbobjectstore-delete-exception-order.any.worker.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [IDBObjectStore.delete exception order: InvalidStateError vs. TransactionInactiveError]
+    expected: TIMEOUT
+
+  [IDBObjectStore.delete exception order: TransactionInactiveError vs. ReadOnlyError]
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/key-conversion-exceptions.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/key-conversion-exceptions.any.js.ini
@@ -2,7 +2,6 @@
   expected: ERROR
 
 [key-conversion-exceptions.any.worker.html]
-  expected: CRASH
   [IDBFactory cmp() static with throwing/invalid keys]
     expected: FAIL
 
@@ -20,7 +19,6 @@
 
 
 [key-conversion-exceptions.any.html]
-  expected: CRASH
   [IDBFactory cmp() static with throwing/invalid keys]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/key_invalid.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/key_invalid.any.js.ini
@@ -2,10 +2,73 @@
   expected: ERROR
 
 [key_invalid.any.worker.html]
-  expected: CRASH
+  [Invalid key - [{}\]]
+    expected: FAIL
+
+  [Invalid key - [[\], [\], [\], [[ Date \]\]\]]
+    expected: FAIL
+
+  [Invalid key - [undefined\]]
+    expected: FAIL
+
+  [Invalid key - [,1\]]
+    expected: FAIL
+
+  [Invalid key - sparse array]
+    expected: FAIL
+
+  [Invalid key - sparse array 2]
+    expected: FAIL
+
+  [Invalid key - [[1\], [3\], [7\], [[ sparse array \]\]\]]
+    expected: FAIL
+
+  [Invalid key - [1,2,3,,\]]
+    expected: FAIL
+
+  [Invalid key - array directly contains self]
+    expected: FAIL
+
+  [Invalid key - array indirectly contains self]
+    expected: FAIL
+
+  [Invalid key - array member contains self]
+    expected: FAIL
+
 
 [key_invalid.any.sharedworker.html]
   expected: ERROR
 
 [key_invalid.any.html]
-  expected: CRASH
+  [Invalid key - [{}\]]
+    expected: FAIL
+
+  [Invalid key - [[\], [\], [\], [[ Date \]\]\]]
+    expected: FAIL
+
+  [Invalid key - [undefined\]]
+    expected: FAIL
+
+  [Invalid key - [,1\]]
+    expected: FAIL
+
+  [Invalid key - sparse array]
+    expected: FAIL
+
+  [Invalid key - sparse array 2]
+    expected: FAIL
+
+  [Invalid key - [[1\], [3\], [7\], [[ sparse array \]\]\]]
+    expected: FAIL
+
+  [Invalid key - [1,2,3,,\]]
+    expected: FAIL
+
+  [Invalid key - array directly contains self]
+    expected: FAIL
+
+  [Invalid key - array indirectly contains self]
+    expected: FAIL
+
+  [Invalid key - array member contains self]
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/keyorder.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/keyorder.any.js.ini
@@ -2,10 +2,152 @@
   expected: ERROR
 
 [keyorder.any.worker.html]
-  expected: CRASH
+  [Database readback sort - String < Array]
+    expected: FAIL
+
+  [IDBKey.cmp sort - String < Array]
+    expected: FAIL
+
+  [Database readback sort - float < String]
+    expected: FAIL
+
+  [IDBKey.cmp sort - float < String]
+    expected: FAIL
+
+  [Database readback sort - float < Date]
+    expected: FAIL
+
+  [IDBKey.cmp sort - float < Date]
+    expected: FAIL
+
+  [Database readback sort - float < Date < String < Array]
+    expected: FAIL
+
+  [IDBKey.cmp sort - float < Date < String < Array]
+    expected: FAIL
+
+  [Database readback sort - Date(1 sec ago) < Date(now) < Date(1 minute in future)]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Date(1 sec ago) < Date(now) < Date(1 minute in future)]
+    expected: FAIL
+
+  [Database readback sort - -1.1 < 1 < 1.01337 < 1.013373 < 2]
+    expected: FAIL
+
+  [IDBKey.cmp sort - -1.1 < 1 < 1.01337 < 1.013373 < 2]
+    expected: FAIL
+
+  [Database readback sort - -Infinity < -0.01 < 0 < Infinity]
+    expected: FAIL
+
+  [IDBKey.cmp sort - -Infinity < -0.01 < 0 < Infinity]
+    expected: FAIL
+
+  [Database readback sort - "" < "a" < "ab" < "b" < "ba"]
+    expected: FAIL
+
+  [IDBKey.cmp sort - "" < "a" < "ab" < "b" < "ba"]
+    expected: FAIL
+
+  [Database readback sort - Arrays]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Arrays]
+    expected: FAIL
+
+  [Database readback sort - Array.length: 10,000 < Array.length: 10,001]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Array.length: 10,000 < Array.length: 10,001]
+    expected: FAIL
+
+  [Database readback sort - Infinity inside arrays]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Infinity inside arrays]
+    expected: FAIL
+
+  [Database readback sort - Test different stuff at once]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Test different stuff at once]
+    expected: FAIL
+
 
 [keyorder.any.html]
-  expected: CRASH
+  [Database readback sort - String < Array]
+    expected: FAIL
+
+  [IDBKey.cmp sort - String < Array]
+    expected: FAIL
+
+  [Database readback sort - float < String]
+    expected: FAIL
+
+  [IDBKey.cmp sort - float < String]
+    expected: FAIL
+
+  [Database readback sort - float < Date]
+    expected: FAIL
+
+  [IDBKey.cmp sort - float < Date]
+    expected: FAIL
+
+  [Database readback sort - float < Date < String < Array]
+    expected: FAIL
+
+  [IDBKey.cmp sort - float < Date < String < Array]
+    expected: FAIL
+
+  [Database readback sort - Date(1 sec ago) < Date(now) < Date(1 minute in future)]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Date(1 sec ago) < Date(now) < Date(1 minute in future)]
+    expected: FAIL
+
+  [Database readback sort - -1.1 < 1 < 1.01337 < 1.013373 < 2]
+    expected: FAIL
+
+  [IDBKey.cmp sort - -1.1 < 1 < 1.01337 < 1.013373 < 2]
+    expected: FAIL
+
+  [Database readback sort - -Infinity < -0.01 < 0 < Infinity]
+    expected: FAIL
+
+  [IDBKey.cmp sort - -Infinity < -0.01 < 0 < Infinity]
+    expected: FAIL
+
+  [Database readback sort - "" < "a" < "ab" < "b" < "ba"]
+    expected: FAIL
+
+  [IDBKey.cmp sort - "" < "a" < "ab" < "b" < "ba"]
+    expected: FAIL
+
+  [Database readback sort - Arrays]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Arrays]
+    expected: FAIL
+
+  [Database readback sort - Array.length: 10,000 < Array.length: 10,001]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Array.length: 10,000 < Array.length: 10,001]
+    expected: FAIL
+
+  [Database readback sort - Infinity inside arrays]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Infinity inside arrays]
+    expected: FAIL
+
+  [Database readback sort - Test different stuff at once]
+    expected: FAIL
+
+  [IDBKey.cmp sort - Test different stuff at once]
+    expected: FAIL
+
 
 [keyorder.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/value.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/value.any.js.ini
@@ -1,11 +1,5 @@
 [value.any.html]
   expected: TIMEOUT
-  [BigInts as keys in IndexedDB - primitive BigInt]
-    expected: FAIL
-
-  [BigInts as keys in IndexedDB - BigInt object]
-    expected: FAIL
-
   [Values - Array]
     expected: TIMEOUT
 
@@ -15,12 +9,6 @@
 
 [value.any.worker.html]
   expected: TIMEOUT
-  [BigInts as keys in IndexedDB - primitive BigInt]
-    expected: FAIL
-
-  [BigInts as keys in IndexedDB - BigInt object]
-    expected: FAIL
-
   [Values - Array]
     expected: TIMEOUT
 


### PR DESCRIPTION
- Dates are now serialized as f64s (like how firefox does it)
- Array buffers are serialized with structured cloning (this is not the most correct/efficent way to serialize them, however it is currently better than not supporting array buffers at all)
- Array types are still unimplemented.

Testing: WPT
Fixes: Some panicking
