### PR TITLE
canvas: Make GetImageData simple and only IPC message to obtain pixels

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -723,12 +723,8 @@ impl<DrawTarget: GenericDrawTarget> CanvasData<DrawTarget> {
     /// canvas_size: The size of the canvas we're reading from
     /// read_rect: The area of the canvas we want to read from
     #[allow(unsafe_code)]
-    pub(crate) fn read_pixels(
-        &mut self,
-        read_rect: Option<Rect<u32>>,
-        canvas_size: Option<Size2D<u32>>,
-    ) -> Snapshot {
-        let canvas_size = canvas_size.unwrap_or(self.drawtarget.get_size().cast());
+    pub(crate) fn read_pixels(&mut self, read_rect: Option<Rect<u32>>) -> Snapshot {
+        let canvas_size = self.drawtarget.get_size().cast();
 
         if let Some(read_rect) = read_rect {
             let canvas_rect = Rect::from_size(canvas_size);

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use canvas_traits::canvas::{Canvas2dMsg, CanvasId, CanvasMsg, FromScriptMsg};
+use canvas_traits::canvas::{Canvas2dMsg, CanvasId, CanvasMsg};
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
-use ipc_channel::ipc::IpcSender;
+use ipc_channel::ipc::{self, IpcSender};
 use pixels::Snapshot;
-use profile_traits::ipc;
 use script_bindings::inheritance::Castable;
 use servo_url::ServoUrl;
 use webrender_api::ImageKey;
@@ -162,10 +161,9 @@ impl CanvasContext for CanvasRenderingContext2D {
             return None;
         }
 
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
-        let msg = CanvasMsg::FromScript(FromScriptMsg::SendPixels(sender), self.get_canvas_id());
-        self.canvas_state.get_ipc_renderer().send(msg).unwrap();
-
+        let (sender, receiver) = ipc::channel().unwrap();
+        self.canvas_state
+            .send_canvas_2d_msg(Canvas2dMsg::GetImageData(None, sender));
         Some(receiver.recv().unwrap().to_owned())
     }
 

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -449,7 +449,6 @@ pub struct TextOptions {
 #[derive(Debug, Deserialize, Serialize)]
 pub enum CanvasMsg {
     Canvas2d(Canvas2dMsg, CanvasId),
-    FromScript(FromScriptMsg, CanvasId),
     Recreate(Option<Size2D<u64>>, CanvasId),
     Close(CanvasId),
 }
@@ -475,7 +474,6 @@ pub enum Canvas2dMsg {
     ),
     DrawImageInOther(
         CanvasId,
-        Size2D<u32>,
         Rect<f64>,
         Rect<f64>,
         bool,
@@ -512,7 +510,7 @@ pub enum Canvas2dMsg {
         CompositionOptions,
         Transform2D<f32>,
     ),
-    GetImageData(Rect<u32>, Size2D<u32>, IpcSender<IpcSnapshot>),
+    GetImageData(Option<Rect<u32>>, IpcSender<IpcSnapshot>),
     MeasureText(String, IpcSender<TextMetrics>, TextOptions),
     PutImageData(Rect<u32>, IpcSnapshot),
     StrokeRect(
@@ -532,11 +530,6 @@ pub enum Canvas2dMsg {
         Transform2D<f32>,
     ),
     UpdateImage(IpcSender<()>),
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum FromScriptMsg {
-    SendPixels(IpcSender<IpcSnapshot>),
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]


### PR DESCRIPTION
Currently we had `GetImageData` and `SendPixels` to obtain pixels from script thread. This PR unifies those into single `GetImageData` that does not need canvas size and has optional rect (for obtaining sub image).

Testing: Existing WPT tests

