### PR TITLE
net: Fix possible indexeddb key range singleton related panic

### DIFF
--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -189,7 +189,7 @@ impl IndexedDBKeyRange {
     }
 
     pub fn is_singleton(&self) -> bool {
-        self.lower == self.upper && !self.lower_open && !self.upper_open
+        self.lower.is_some() && self.lower == self.upper && !self.lower_open && !self.upper_open
     }
 
     pub fn as_singleton(&self) -> Option<&IndexedDBKeyType> {

--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -200,6 +200,21 @@ impl IndexedDBKeyRange {
     }
 }
 
+#[test]
+fn test_as_singleton() {
+    let key = IndexedDBKeyType::Number(1.0);
+    let key2 = IndexedDBKeyType::Number(2.0);
+    let range = IndexedDBKeyRange::only(key.clone());
+    assert!(range.is_singleton());
+    assert!(range.as_singleton().is_some());
+    let range = IndexedDBKeyRange::new(Some(key), Some(key2.clone()), false, false);
+    assert!(!range.is_singleton());
+    assert!(range.as_singleton().is_none());
+    let full_range = IndexedDBKeyRange::new(None, None, false, false);
+    assert!(!full_range.is_singleton());
+    assert!(full_range.as_singleton().is_none());
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub enum AsyncReadOnlyOperation {
     /// Gets the value associated with the given key in the associated idb data


### PR DESCRIPTION
If `.as_singleton()` was called on a range that had both lower and upper set as `None`, it would have panicked.

Testing: Nothing seems to have changed
Fixes: #37647 
