### PR TITLE
canvas: Use bytemuck to remove unsafe from raqote backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,6 +1064,7 @@ name = "canvas"
 version = "0.0.1"
 dependencies = [
  "app_units",
+ "bytemuck",
  "canvas_traits",
  "compositing_traits",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ base64 = "0.22.1"
 bincode = "1"
 bitflags = "2.9"
 bluetooth_traits = { path = "components/shared/bluetooth" }
+bytemuck = "1"
 byteorder = "1.5"
 canvas_traits = { path = "components/shared/canvas" }
 cbc = "0.1.2"

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -16,6 +16,7 @@ vello = ["dep:vello", "dep:pollster", "dep:futures-intrusive"]
 
 [dependencies]
 app_units = { workspace = true }
+bytemuck = { workspace = true, features = ["extern_crate_alloc"] }
 canvas_traits = { workspace = true }
 compositing_traits = { workspace = true }
 crossbeam-channel = { workspace = true }


### PR DESCRIPTION
This PR changes surface type from `Vec<u8>` to `Vec<u32>` as this is native type of raqote's backend. We used unsafe for `Vec<u8>` <-> `Vec<u32>` casting that is replaced with bytemuck. Bytemuck is already in cargo lock.

Testing: Existing WPT tests.
