### PR TITLE
script_binding: wrapper of JSAutoStructuredCloneBuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5226,7 +5226,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#128e1e230a0155ed9395c718184f34bddc045860"
+source = "git+https://github.com/servo/mozjs#9c017973a4bf9186df2335d8c96ed3554b84434e"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -5237,8 +5237,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.13-0"
-source = "git+https://github.com/servo/mozjs#128e1e230a0155ed9395c718184f34bddc045860"
+version = "0.128.13-1"
+source = "git+https://github.com/servo/mozjs#9c017973a4bf9186df2335d8c96ed3554b84434e"
 dependencies = [
  "bindgen 0.71.1",
  "cc",


### PR DESCRIPTION
Instead of using raw pointer of JSAutoStructuredCloneBuffer, use its wrapper JSAutoStructuredCloneBufferWrapper, which implements the Drop trait that can prevent leakage when structured cloning fails.

Testing: Refactoring. Existing tests should be enough.
Fixes: #37966 
