### PR TITLE
webdriver: configure Expires and SameSite in handle_add_cookie

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9520,6 +9520,7 @@ dependencies = [
  "servo_geometry",
  "servo_url",
  "stylo_traits",
+ "time",
  "uuid",
  "webdriver",
 ]

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -30,5 +30,6 @@ servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
 stylo_traits = { workspace = true }
+time = { workspace = true }
 uuid = { workspace = true }
 webdriver = { workspace = true }

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -21,7 +21,7 @@ use std::{env, fmt, process, thread};
 use base::id::{BrowsingContextId, WebViewId};
 use base64::Engine;
 use capabilities::ServoCapabilities;
-use cookie::{CookieBuilder, Expiration};
+use cookie::{CookieBuilder, Expiration, SameSite};
 use crossbeam_channel::{Receiver, Sender, after, select, unbounded};
 use embedder_traits::{
     EventLoopWaker, MouseButton, WebDriverCommandMsg, WebDriverCommandResponse, WebDriverFrameId,
@@ -44,6 +44,7 @@ use servo_config::prefs::{self, PrefValue, Preferences};
 use servo_geometry::DeviceIndependentIntRect;
 use servo_url::ServoUrl;
 use style_traits::CSSPixel;
+use time::OffsetDateTime;
 use uuid::Uuid;
 use webdriver::actions::{
     ActionSequence, ActionsType, PointerAction, PointerActionItem, PointerActionParameters,
@@ -1780,17 +1781,32 @@ impl Handler {
         self.handle_any_user_prompts(self.session()?.webview_id)?;
         let (sender, receiver) = ipc::channel().unwrap();
 
-        let cookie_builder = CookieBuilder::new(params.name.to_owned(), params.value.to_owned())
-            .secure(params.secure)
-            .http_only(params.httpOnly);
-        let cookie_builder = match params.domain {
-            Some(ref domain) => cookie_builder.domain(domain.to_owned()),
-            _ => cookie_builder,
-        };
-        let cookie_builder = match params.path {
-            Some(ref path) => cookie_builder.path(path.to_owned()),
-            _ => cookie_builder,
-        };
+        let mut cookie_builder =
+            CookieBuilder::new(params.name.to_owned(), params.value.to_owned())
+                .secure(params.secure)
+                .http_only(params.httpOnly);
+        if let Some(ref domain) = params.domain {
+            cookie_builder = cookie_builder.domain(domain.clone());
+        }
+        if let Some(ref path) = params.path {
+            cookie_builder = cookie_builder.path(path.clone());
+        }
+        if let Some(ref expiry) = params.expiry {
+            if let Ok(datetime) = OffsetDateTime::from_unix_timestamp(expiry.0 as i64) {
+                cookie_builder = cookie_builder.expires(datetime);
+            }
+        }
+        if let Some(ref same_site) = params.sameSite {
+            cookie_builder = match same_site.as_str() {
+                "None" => Ok(cookie_builder.same_site(SameSite::None)),
+                "Lax" => Ok(cookie_builder.same_site(SameSite::Lax)),
+                "Strict" => Ok(cookie_builder.same_site(SameSite::Strict)),
+                _ => Err(WebDriverError::new(
+                    ErrorStatus::InvalidArgument,
+                    "invalid argument",
+                )),
+            }?;
+        }
 
         let cmd = WebDriverScriptCommand::AddCookie(cookie_builder.build(), sender);
         self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;

--- a/tests/wpt/meta/webdriver/tests/classic/add_cookie/add.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/add_cookie/add.py.ini
@@ -25,21 +25,3 @@
 
   [test_cookie_unsupported_scheme[secure websocket\]]
     expected: FAIL
-
-  [test_add_non_session_cookie]
-    expected: FAIL
-
-  [test_add_cookie_with_expiry_in_the_future]
-    expected: FAIL
-
-  [test_add_cookie_with_valid_samesite_flag[None\]]
-    expected: FAIL
-
-  [test_add_cookie_with_valid_samesite_flag[Lax\]]
-    expected: FAIL
-
-  [test_add_cookie_with_valid_samesite_flag[Strict\]]
-    expected: FAIL
-
-  [test_add_cookie_with_invalid_samesite_flag]
-    expected: FAIL


### PR DESCRIPTION
Handler::handle_add_cookie did not configure the attributes "Expires" and "SameSite". This patch adds them.

Testing: Passing WPT tests that were expected to fail.
Fixes: https://github.com/servo/servo/pull/37715#issuecomment-3069734014
