### PR TITLE
canvas: Clear bitmap without transform

### DIFF
--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -354,7 +354,7 @@ impl CanvasState {
 
         self.send_canvas_2d_msg(Canvas2dMsg::ClearRect(
             self.size.get().to_f32().into(),
-            self.state.borrow().transform,
+            Transform2D::identity(),
         ));
     }
 


### PR DESCRIPTION
We only need to clear the viewport and with wrong transform this will not do.

Testing: Existing WPT tests
