### PR TITLE
Implemented DeviceMemory API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5489,6 +5489,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7125,6 +7134,7 @@ dependencies = [
  "stylo_malloc_size_of",
  "stylo_traits",
  "swapper",
+ "sysinfo",
  "tempfile",
  "tendril",
  "time",
@@ -8243,6 +8253,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
 dependencies = [
  "libc",
+ "memchr",
+ "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows 0.61.3",

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -140,6 +140,7 @@ webxr-api = { workspace = true, features = ["ipc"], optional = true }
 wgpu-core = { workspace = true }
 wgpu-types = { workspace = true }
 xml5ever = { workspace = true }
+sysinfo = {version = "0.36.1", default-features = false, features = ["system"]}
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]
 mozangle = { workspace = true }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -140,7 +140,7 @@ webxr-api = { workspace = true, features = ["ipc"], optional = true }
 wgpu-core = { workspace = true }
 wgpu-types = { workspace = true }
 xml5ever = { workspace = true }
-sysinfo = {version = "0.36.1", default-features = false, features = ["system"]}
+sysinfo = { version = "0.36.1", default-features = false, features = ["system"] }
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]
 mozangle = { workspace = true }

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -346,7 +346,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
             .or_init(|| ServoInternals::new(&self.global(), CanGc::note()))
     }
 
-    /// https://www.w3.org/TR/device-memory/
+    /// <https://www.w3.org/TR/device-memory/>
     fn DeviceMemory(&self) -> Finite<f64> {
         device_memory()
     }

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use js::rust::MutableHandleValue;
+use script_bindings::num::Finite;
 use servo_config::pref;
 
 use crate::dom::bindings::codegen::Bindings::WorkerNavigatorBinding::WorkerNavigatorMethods;
@@ -18,6 +19,8 @@ use crate::dom::permissions::Permissions;
 use crate::dom::webgpu::gpu::GPU;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::script_runtime::{CanGc, JSContext};
+
+use super::navigator::device_memory;
 
 // https://html.spec.whatwg.org/multipage/#workernavigator
 #[dom_struct]
@@ -125,5 +128,10 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator-hardwareconcurrency>
     fn HardwareConcurrency(&self) -> u64 {
         hardware_concurrency()
+    }
+
+    /// https://www.w3.org/TR/device-memory/
+    fn DeviceMemory(&self) -> Finite<f64> {
+        device_memory()
     }
 }

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -129,7 +129,7 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
         hardware_concurrency()
     }
 
-    /// https://www.w3.org/TR/device-memory/
+    /// <https://www.w3.org/TR/device-memory/>
     fn DeviceMemory(&self) -> Finite<f64> {
         device_memory()
     }

--- a/components/script/dom/workernavigator.rs
+++ b/components/script/dom/workernavigator.rs
@@ -7,6 +7,7 @@ use js::rust::MutableHandleValue;
 use script_bindings::num::Finite;
 use servo_config::pref;
 
+use super::navigator::device_memory;
 use crate::dom::bindings::codegen::Bindings::WorkerNavigatorBinding::WorkerNavigatorMethods;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
@@ -19,8 +20,6 @@ use crate::dom::permissions::Permissions;
 use crate::dom::webgpu::gpu::GPU;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::script_runtime::{CanGc, JSContext};
-
-use super::navigator::device_memory;
 
 // https://html.spec.whatwg.org/multipage/#workernavigator
 #[dom_struct]

--- a/components/script_bindings/webidls/DeviceMemory.webidl
+++ b/components/script_bindings/webidls/DeviceMemory.webidl
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://www.w3.org/TR/device-memory/
+
+[
+    SecureContext,
+    Exposed=(Window,Worker)
+] interface mixin NavigatorDeviceMemory {
+    readonly attribute double deviceMemory
+;
+};
+
+Navigator includes NavigatorDeviceMemory;
+WorkerNavigator includes NavigatorDeviceMemory;

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -124,6 +124,8 @@ skip: true
     skip: true
 [custom-elements]
   skip: false
+[device-memory]
+  skip: false
 [dom]
   skip: false
 [domparsing]


### PR DESCRIPTION
I've implemented the DeviceMemory API from https://www.w3.org/TR/device-memory
I've enabled the `device-memory` WPT tests and they look like they all pass. I'm using the [sysinfo](https://crates.io/crates/sysinfo) crate to get the memory values, which looks like it supports everything that Servo does aside from OpenHarmony. 

I haven't been able to test what the behaviour is like on unsupported devices, the crate docs say it'll return 0, which isn't ideal so I'll add in platform flags to disable the API on unsupported devices but I'm unsure how to do that since the traits are defined from webidl files and I'm not sure how to conditionally disable those

Testing:  `device-memory` WPT tests

