### PR TITLE
Disable serde feature of taffy dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-07-01" }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
-taffy = { version = "0.8.3", default-features = false, features = ["detailed_layout_info", "grid", "serde", "std"] }
+taffy = { version = "0.8.3", default-features = false, features = ["detailed_layout_info", "grid", "std"] }
 tikv-jemalloc-sys = "0.6.0"
 tikv-jemallocator = "0.6.0"
 time = { package = "time", version = "0.3", features = ["large-dates", "local-offset", "serde"] }


### PR DESCRIPTION
Disables the serde of taffy. This feature doesn't seem to be actually being used.

Testing: This would cause build errors if it was required. So if it builds it should be fine.
