### PR TITLE
Use the `AxesOverflow` of parent to decide whether to include the scrollable overflow of a child box.

### DIFF
--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -15,6 +15,7 @@ use super::{BoxFragment, ContainingBlockManager, Fragment};
 use crate::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::geom::PhysicalRect;
+use crate::style_ext::{AxesOverflow, ComputedValuesExt};
 
 #[derive(MallocSizeOf)]
 pub struct FragmentTree {
@@ -117,8 +118,15 @@ impl FragmentTree {
             let scrollable_overflow = self.root_fragments.iter().fold(
                 self.initial_containing_block,
                 |overflow, fragment| {
+                    let overflow_style = match fragment {
+                        Fragment::Box(fragment) | Fragment::Float(fragment) => {
+                            let fragment_flags = fragment.borrow().base.flags;
+                            fragment.borrow().style.effective_overflow(fragment_flags)
+                        },
+                        _ => AxesOverflow::default(),
+                    };
                     fragment
-                        .calculate_scrollable_overflow_for_parent()
+                        .calculate_scrollable_overflow_for_parent(overflow_style)
                         .union(&overflow)
                 },
             );

--- a/components/layout/fragment_tree/positioning_fragment.rs
+++ b/components/layout/fragment_tree/positioning_fragment.rs
@@ -11,6 +11,7 @@ use style::properties::ComputedValues;
 use super::{BaseFragment, BaseFragmentInfo, Fragment};
 use crate::cell::ArcRefCell;
 use crate::geom::PhysicalRect;
+use crate::style_ext::AxesOverflow;
 
 /// Can contain child fragments with relative coordinates, but does not contribute to painting
 /// itself. [`PositioningFragment`]s may be completely anonymous, or just non-painting Fragments
@@ -79,7 +80,7 @@ impl PositioningFragment {
             |acc, child| {
                 acc.union(
                     &child
-                        .calculate_scrollable_overflow_for_parent()
+                        .calculate_scrollable_overflow_for_parent(AxesOverflow::default())
                         .translate(self.rect.origin.to_vector()),
                 )
             },

--- a/components/layout/style_ext.rs
+++ b/components/layout/style_ext.rs
@@ -63,6 +63,15 @@ pub struct AxesOverflow {
     pub y: Overflow,
 }
 
+impl Default for AxesOverflow {
+    fn default() -> Self {
+        AxesOverflow {
+            x: Overflow::Visible,
+            y: Overflow::Visible,
+        }
+    }
+}
+
 impl DisplayGeneratingBox {
     pub(crate) fn display_inside(&self) -> DisplayInside {
         match *self {


### PR DESCRIPTION
This PR uses the `AxesOverflow` of parent while calculating `scrollable_overflow_for_parent`. Both axes are handled separately.

For calculating the scrollable overflow of a child box, consider
1. if its parent has overflow: visible, or 
2. if the child's overflow style is not scrollable.

**Issue**: For the blocks having property `overflow:hidden`, their scroll overflow is not added to parent's scroll overflow.
Causing unable to scroll the parent block aka `Root` block in our Issue #38248 .

**Testing**: Tested Manually
**Fixes**: #38248 
