### PR TITLE
Use `scrollable_overflow` directly for the child fragment if available.

### DIFF
--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -255,6 +255,13 @@ impl BoxFragment {
                     .calculate_scrollable_overflow_for_parent()
                     .translate(content_origin);
 
+                let scrollable_overflow_from_child = match child {
+                    Fragment::Box(fragment) | Fragment::Float(fragment) => {
+                        fragment.borrow().scrollable_overflow()
+                    },
+                    _ => scrollable_overflow_from_child,
+                };
+
                 // Note that this doesn't just exclude scrollable overflow outside the
                 // wholly unrechable scrollable overflow area, but also clips it. This
                 // makes the resulting value more like the "scroll area" rather than the


### PR DESCRIPTION
For the blocks having property `overflow:hidden`, their scroll overflow is not added to parent's scroll overflow.
Causing unable to scroll the parent block aka Root block in our Issue https://github.com/servo/servo/issues/38248 .

This PR uses the `scrollable_overflow` of child directly if available.

Testing: Tested Manually
Fixes: #38248 
