### PR TITLE
canvas: Make 2D context state creation failable and use `dom_canvas_backend` pref for backend selection

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -85,8 +85,7 @@ impl CanvasPaintThread {
                         recv(create_receiver) -> msg => {
                             match msg {
                                 Ok(ConstellationCanvasMsg::Create { sender: creator, size }) => {
-                                    let canvas_data = canvas_paint_thread.create_canvas(size);
-                                    creator.send(canvas_data).unwrap();
+                                    creator.send(canvas_paint_thread.create_canvas(size)).unwrap();
                                 },
                                 Ok(ConstellationCanvasMsg::Exit(exit_sender)) => {
                                     let _ = exit_sender.send(());
@@ -106,7 +105,7 @@ impl CanvasPaintThread {
         (create_sender, ipc_sender)
     }
 
-    pub fn create_canvas(&mut self, size: Size2D<u64>) -> (CanvasId, ImageKey) {
+    pub fn create_canvas(&mut self, size: Size2D<u64>) -> Option<(CanvasId, ImageKey)> {
         let canvas_id = self.next_canvas_id;
         self.next_canvas_id.0 += 1;
 
@@ -114,7 +113,7 @@ impl CanvasPaintThread {
         let image_key = canvas.image_key();
         self.canvases.insert(canvas_id, canvas);
 
-        (canvas_id, image_key)
+        Some((canvas_id, image_key))
     }
 
     fn process_canvas_2d_message(&mut self, message: Canvas2dMsg, canvas_id: CanvasId) {

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -76,10 +76,14 @@ pub struct Preferences {
     pub dom_allow_scripts_to_close_windows: bool,
     pub dom_canvas_capture_enabled: bool,
     pub dom_canvas_text_enabled: bool,
-    /// Uses vello as canvas backend
-    pub dom_canvas_vello_enabled: bool,
-    /// Uses vello_cpu as canvas backend
-    pub dom_canvas_vello_cpu_enabled: bool,
+    /// Selects canvas backend
+    ///
+    /// Available values:
+    /// - ` `/`auto`
+    /// - raqote
+    /// - vello
+    /// - vello_cpu
+    pub dom_canvas_backend: String,
     pub dom_clipboardevent_enabled: bool,
     pub dom_composition_event_enabled: bool,
     pub dom_cookiestore_enabled: bool,
@@ -259,8 +263,7 @@ impl Preferences {
             dom_bluetooth_testing_enabled: false,
             dom_canvas_capture_enabled: false,
             dom_canvas_text_enabled: true,
-            dom_canvas_vello_enabled: false,
-            dom_canvas_vello_cpu_enabled: false,
+            dom_canvas_backend: String::new(),
             dom_clipboardevent_enabled: true,
             dom_composition_event_enabled: false,
             dom_cookiestore_enabled: false,

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -68,12 +68,12 @@ impl CanvasRenderingContext2D {
         global: &GlobalScope,
         canvas: HTMLCanvasElementOrOffscreenCanvas,
         size: Size2D<u32>,
-    ) -> CanvasRenderingContext2D {
+    ) -> Option<CanvasRenderingContext2D> {
         let canvas_state =
-            CanvasState::new(global, Size2D::new(size.width as u64, size.height as u64));
+            CanvasState::new(global, Size2D::new(size.width as u64, size.height as u64))?;
         let ipc_sender = canvas_state.get_ipc_renderer().clone();
         let canvas_id = canvas_state.get_canvas_id();
-        CanvasRenderingContext2D {
+        Some(CanvasRenderingContext2D {
             reflector_: Reflector::new(),
             canvas,
             canvas_state,
@@ -81,21 +81,22 @@ impl CanvasRenderingContext2D {
                 ipc_sender,
                 canvas_id,
             },
-        }
+        })
     }
 
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn new(
         global: &GlobalScope,
         canvas: &HTMLCanvasElement,
         size: Size2D<u32>,
         can_gc: CanGc,
-    ) -> DomRoot<CanvasRenderingContext2D> {
+    ) -> Option<DomRoot<CanvasRenderingContext2D>> {
         let boxed = Box::new(CanvasRenderingContext2D::new_inherited(
             global,
             HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(DomRoot::from_ref(canvas)),
             size,
-        ));
-        reflect_dom_object(boxed, global, can_gc)
+        )?);
+        Some(reflect_dom_object(boxed, global, can_gc))
     }
 
     // https://html.spec.whatwg.org/multipage/#reset-the-rendering-context-to-its-default-state

--- a/components/script/dom/htmlcanvaselement.rs
+++ b/components/script/dom/htmlcanvaselement.rs
@@ -205,7 +205,7 @@ impl HTMLCanvasElement {
 
         let window = self.owner_window();
         let size = self.get_size();
-        let context = CanvasRenderingContext2D::new(window.as_global_scope(), self, size, can_gc);
+        let context = CanvasRenderingContext2D::new(window.as_global_scope(), self, size, can_gc)?;
         *self.context_mode.borrow_mut() =
             Some(RenderingContext::Context2d(Dom::from_ref(&*context)));
         Some(context)

--- a/components/script/dom/offscreencanvas.rs
+++ b/components/script/dom/offscreencanvas.rs
@@ -135,7 +135,7 @@ impl OffscreenCanvas {
                 _ => None,
             };
         }
-        let context = OffscreenCanvasRenderingContext2D::new(&self.global(), self, can_gc);
+        let context = OffscreenCanvasRenderingContext2D::new(&self.global(), self, can_gc)?;
         *self.context.borrow_mut() = Some(OffscreenRenderingContext::Context2d(Dom::from_ref(
             &*context,
         )));

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -39,29 +39,31 @@ pub(crate) struct OffscreenCanvasRenderingContext2D {
 }
 
 impl OffscreenCanvasRenderingContext2D {
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     fn new_inherited(
         global: &GlobalScope,
         canvas: &OffscreenCanvas,
-    ) -> OffscreenCanvasRenderingContext2D {
+    ) -> Option<OffscreenCanvasRenderingContext2D> {
         let size = canvas.get_size().cast();
-        OffscreenCanvasRenderingContext2D {
+        Some(OffscreenCanvasRenderingContext2D {
             context: CanvasRenderingContext2D::new_inherited(
                 global,
                 HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(DomRoot::from_ref(canvas)),
                 size,
-            ),
-        }
+            )?,
+        })
     }
 
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn new(
         global: &GlobalScope,
         canvas: &OffscreenCanvas,
         can_gc: CanGc,
-    ) -> DomRoot<OffscreenCanvasRenderingContext2D> {
+    ) -> Option<DomRoot<OffscreenCanvasRenderingContext2D>> {
         let boxed = Box::new(OffscreenCanvasRenderingContext2D::new_inherited(
             global, canvas,
-        ));
-        reflect_dom_object(boxed, global, can_gc)
+        )?);
+        Some(reflect_dom_object(boxed, global, can_gc))
     }
 
     pub(crate) fn send_canvas_2d_msg(&self, msg: Canvas2dMsg) {

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -42,23 +42,25 @@ pub(crate) struct PaintRenderingContext2D {
 }
 
 impl PaintRenderingContext2D {
-    fn new_inherited(global: &PaintWorkletGlobalScope) -> PaintRenderingContext2D {
-        PaintRenderingContext2D {
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
+    fn new_inherited(global: &PaintWorkletGlobalScope) -> Option<PaintRenderingContext2D> {
+        Some(PaintRenderingContext2D {
             reflector_: Reflector::new(),
-            canvas_state: CanvasState::new(global.upcast(), Size2D::zero()),
+            canvas_state: CanvasState::new(global.upcast(), Size2D::zero())?,
             device_pixel_ratio: Cell::new(Scale::new(1.0)),
-        }
+        })
     }
 
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn new(
         global: &PaintWorkletGlobalScope,
         can_gc: CanGc,
-    ) -> DomRoot<PaintRenderingContext2D> {
-        reflect_dom_object(
-            Box::new(PaintRenderingContext2D::new_inherited(global)),
+    ) -> Option<DomRoot<PaintRenderingContext2D>> {
+        Some(reflect_dom_object(
+            Box::new(PaintRenderingContext2D::new_inherited(global)?),
             global,
             can_gc,
-        )
+        ))
     }
 
     /// Send update to canvas paint thread and returns [`ImageKey`]

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -563,7 +563,9 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
         }
 
         // Step 19.
-        let context = PaintRenderingContext2D::new(self, CanGc::note());
+        let Some(context) = PaintRenderingContext2D::new(self, CanGc::note()) else {
+            return Err(Error::Operation);
+        };
         let definition = PaintDefinition::new(
             paint_val.handle(),
             paint_function.handle(),

--- a/components/shared/canvas/lib.rs
+++ b/components/shared/canvas/lib.rs
@@ -18,7 +18,7 @@ pub mod webgl;
 
 pub enum ConstellationCanvasMsg {
     Create {
-        sender: Sender<(CanvasId, ImageKey)>,
+        sender: Sender<Option<(CanvasId, ImageKey)>>,
         size: Size2D<u64>,
     },
     Exit(Sender<()>),

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -535,7 +535,7 @@ pub enum ScriptToConstellationMessage {
     /// 2D canvases may use the GPU and we don't want to give untrusted content access to the GPU.)
     CreateCanvasPaintThread(
         UntypedSize2D<u64>,
-        IpcSender<(IpcSender<CanvasMsg>, CanvasId, ImageKey)>,
+        IpcSender<Option<(IpcSender<CanvasMsg>, CanvasId, ImageKey)>>,
     ),
     /// Notifies the constellation that this pipeline is requesting focus.
     ///

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12970,6 +12970,13 @@
        null,
        {}
       ]
+     ],
+     "invalid.html": [
+      "d50ff1030c48794dfc92083b6fecde3f97524b7e",
+      [
+       null,
+       {}
+      ]
      ]
     },
     "canvas-oversize-serialization.html": [

--- a/tests/wpt/mozilla/meta/mozilla/canvas/invalid.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/canvas/invalid.html.ini
@@ -1,0 +1,3 @@
+[invalid.html]
+  prefs: ["dom_canvas_backend:none"]
+

--- a/tests/wpt/mozilla/tests/mozilla/canvas/invalid.html
+++ b/tests/wpt/mozilla/tests/mozilla/canvas/invalid.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>empty canvas context with invalid backend pref</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<canvas id="c">
+<script>
+    test(function() {
+        assert_equals(document.getElementById('c').getContext('2d'), null);
+    }, "Invalid canvas backend returns null context");
+</script>

--- a/tests/wpt/vello_canvas_subsuite.json
+++ b/tests/wpt/vello_canvas_subsuite.json
@@ -1,7 +1,7 @@
 {
   "vello_canvas": {
      "config": {
-        "binary_args": ["--pref", "dom_canvas_vello_enabled"]
+        "binary_args": ["--pref", "dom_canvas_backend=vello"]
      },
      "include": ["/html/canvas/element"]
   }

--- a/tests/wpt/vello_cpu_canvas_subsuite.json
+++ b/tests/wpt/vello_cpu_canvas_subsuite.json
@@ -1,7 +1,7 @@
 {
   "vello_cpu_canvas": {
      "config": {
-        "binary_args": ["--pref", "dom_canvas_vello_cpu_enabled"]
+        "binary_args": ["--pref", "dom_canvas_backend=vello_cpu"]
      },
      "include": ["/html/canvas/element"]
   }


### PR DESCRIPTION
Before script just crashed in those cases because IPCSender was dropped, now we send `None` to tell script about the failure and fail getContext or registerPainter accordingly.
This PR also unifies `dom_canvas_{backends}_enabled` prefs into `dom_canvas_backend` which is more flexible in multi-backends scenarios.

Reviewable per commit.

Testing: Added servo specific WPT test.