### PR TITLE
canvas: Send surface patterns only once (on creation)

### DIFF
--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -15,7 +15,9 @@ use crate::canvas_data::{Filter, TextRun};
 // This defines required methods for a DrawTarget (currently only implemented for raqote).  The
 // prototypes are derived from the now-removed Azure backend's methods.
 pub(crate) trait GenericDrawTarget {
-    type SourceSurface;
+    /// surfaces are expected to have cheap clone,
+    /// likely by using ref counting or similar methods
+    type SourceSurface: Clone;
 
     fn new(size: Size2D<u32>) -> Self;
     fn create_similar_draw_target(&self, size: &Size2D<i32>) -> Self;
@@ -48,7 +50,7 @@ pub(crate) trait GenericDrawTarget {
         &mut self,
         path: &Path,
         fill_rule: FillRule,
-        style: FillOrStrokeStyle,
+        style: FillOrStrokeStyle<Self::SourceSurface>,
         composition_options: CompositionOptions,
         transform: Transform2D<f32>,
     );
@@ -56,14 +58,14 @@ pub(crate) trait GenericDrawTarget {
         &mut self,
         text_runs: Vec<TextRun>,
         start: Point2D<f32>,
-        style: FillOrStrokeStyle,
+        style: FillOrStrokeStyle<Self::SourceSurface>,
         composition_options: CompositionOptions,
         transform: Transform2D<f32>,
     );
     fn fill_rect(
         &mut self,
         rect: &Rect<f32>,
-        style: FillOrStrokeStyle,
+        style: FillOrStrokeStyle<Self::SourceSurface>,
         composition_options: CompositionOptions,
         transform: Transform2D<f32>,
     );
@@ -74,7 +76,7 @@ pub(crate) trait GenericDrawTarget {
     fn stroke(
         &mut self,
         path: &Path,
-        style: FillOrStrokeStyle,
+        style: FillOrStrokeStyle<Self::SourceSurface>,
         line_options: LineOptions,
         composition_options: CompositionOptions,
         transform: Transform2D<f32>,
@@ -82,7 +84,7 @@ pub(crate) trait GenericDrawTarget {
     fn stroke_rect(
         &mut self,
         rect: &Rect<f32>,
-        style: FillOrStrokeStyle,
+        style: FillOrStrokeStyle<Self::SourceSurface>,
         line_options: LineOptions,
         composition_options: CompositionOptions,
         transform: Transform2D<f32>,

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -283,6 +283,12 @@ impl CanvasPaintThread {
                 sender.send(()).unwrap();
             },
             Canvas2dMsg::PopClip => self.canvas(canvas_id).pop_clip(),
+            Canvas2dMsg::CreateSurfacePattern(surface_id, snapshot) => self
+                .canvas(canvas_id)
+                .create_surface_pattern(surface_id, snapshot),
+            Canvas2dMsg::DropSurfacePattern(surface_id) => {
+                self.canvas(canvas_id).drop_surface(surface_id)
+            },
         }
     }
 
@@ -691,6 +697,34 @@ impl Canvas {
             #[cfg(feature = "vello_cpu")]
             Canvas::VelloCPU(canvas_data) => canvas_data.recreate(size),
             _ => unreachable!(),
+        }
+    }
+
+    fn create_surface_pattern(
+        &mut self,
+        surface_id: SurfaceId,
+        snapshot: Snapshot<ipc::IpcSharedMemory>,
+    ) {
+        match self {
+            #[cfg(feature = "raqote")]
+            Canvas::Raqote(canvas_data) => canvas_data.create_surface_pattern(surface_id, snapshot),
+            #[cfg(feature = "vello")]
+            Canvas::Vello(canvas_data) => canvas_data.create_surface_pattern(surface_id, snapshot),
+            #[cfg(feature = "vello_cpu")]
+            Canvas::VelloCPU(canvas_data) => {
+                canvas_data.create_surface_pattern(surface_id, snapshot)
+            },
+        }
+    }
+
+    fn drop_surface(&mut self, surface_id: SurfaceId) {
+        match self {
+            #[cfg(feature = "raqote")]
+            Canvas::Raqote(canvas_data) => canvas_data.drop_surface(surface_id),
+            #[cfg(feature = "vello")]
+            Canvas::Vello(canvas_data) => canvas_data.drop_surface(surface_id),
+            #[cfg(feature = "vello_cpu")]
+            Canvas::VelloCPU(canvas_data) => canvas_data.drop_surface(surface_id),
         }
     }
 }

--- a/components/canvas/peniko_conversions.rs
+++ b/components/canvas/peniko_conversions.rs
@@ -115,7 +115,7 @@ impl Convert<kurbo::Stroke> for LineOptions {
     }
 }
 
-impl Convert<peniko::Brush> for FillOrStrokeStyle {
+impl Convert<peniko::Brush> for FillOrStrokeStyle<peniko::Blob<u8>> {
     fn convert(self) -> peniko::Brush {
         use canvas_traits::canvas::FillOrStrokeStyle::*;
         match self {
@@ -139,7 +139,25 @@ impl Convert<peniko::Brush> for FillOrStrokeStyle {
                 gradient.stops = style.stops.convert();
                 peniko::Brush::Gradient(gradient)
             },
-            Surface(surface_style) => {
+            Surface(surface_style) => peniko::Brush::Image(peniko::Image {
+                data: surface_style.surface_data,
+                format: peniko::ImageFormat::Rgba8,
+                width: surface_style.surface_size.width,
+                height: surface_style.surface_size.height,
+                x_extend: if surface_style.repeat_x {
+                    peniko::Extend::Repeat
+                } else {
+                    peniko::Extend::Pad
+                },
+                y_extend: if surface_style.repeat_y {
+                    peniko::Extend::Repeat
+                } else {
+                    peniko::Extend::Pad
+                },
+                quality: peniko::ImageQuality::Low,
+                alpha: 1.0,
+            }),
+            InPlaceSurface(surface_style) => {
                 let data = surface_style
                     .surface_data
                     .to_owned()


### PR DESCRIPTION
Even before #38214, styles were already stateless, meaning that they were send on each command using them. This is problematic for surface patterns, as they can be big (they are images or Snapshots in the code). This PR makes surfaces patterns somehow stateful, on `createPattern` we create `surface_id` and upload snapshot to canvas paint thread (and do pixel format conversions), then store this surface in hashmap. When any command with uses this pattern it will just send `surface_id` and `CanvasData` will resolve it to the backend surface. So we do not avoid only sending but also converting to appropriate image format.

For this to work, we expect surfaces to have "cheap" clones, so the are (a)rc-ed. This makes sense for vello where it already expects Arced surfaces, wgpu also has internally arecd texture, so it's only matter of adapting raqote to use rced drawtarget (raqote works natively with references, but it's harder to deal with them in the rest of the code and they do not work for other backends).

Testing: Code is covered by existing WPT tests and I plan to do bunnymark to show perf improvement.
