### PR TITLE
canvas: Send CanvasClose to canvas thread from canvas state

### DIFF
--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -259,10 +259,6 @@ impl CanvasState {
         })
     }
 
-    pub(crate) fn get_ipc_renderer(&self) -> &IpcSender<CanvasMsg> {
-        &self.ipc_renderer
-    }
-
     pub(crate) fn image_key(&self) -> ImageKey {
         self.image_key
     }
@@ -2199,7 +2195,7 @@ impl CanvasState {
 
 impl Drop for CanvasState {
     fn drop(&mut self) {
-        if let Err(err) = self.ipc_sender.send(CanvasMsg::Close(self.canvas_id)) {
+        if let Err(err) = self.ipc_renderer.send(CanvasMsg::Close(self.canvas_id)) {
             warn!("Could not close canvas: {}", err)
         }
     }

--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -2197,6 +2197,14 @@ impl CanvasState {
     }
 }
 
+impl Drop for CanvasState {
+    fn drop(&mut self) {
+        if let Err(err) = self.ipc_sender.send(CanvasMsg::Close(self.canvas_id)) {
+            warn!("Could not close canvas: {}", err)
+        }
+    }
+}
+
 pub(crate) fn parse_color(
     canvas: Option<&HTMLCanvasElement>,
     string: &str,


### PR DESCRIPTION
Currently we only closed `CanvasRenderingContext2D` (and `OffscreenCanvasRenderingContext2D` because it wraps `CanvasRenderingContext2D`), but we didn't close last consumer of `CanvasState` which is `PaintRenderingContext`. To prevent any future leaks, let's just send `CanvasClose` in `CanvasState` drop.

Testing: Existing WPT tests
