### PR TITLE
Make request parameter immutable in send_response_to_devtools and send_early_httprequest_to_devtools

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -433,11 +433,7 @@ pub fn send_request_to_devtools(
         .unwrap();
 }
 
-pub fn send_response_to_devtools(
-    request: &mut Request,
-    context: &FetchContext,
-    response: &Response,
-) {
+pub fn send_response_to_devtools(request: &Request, context: &FetchContext, response: &Response) {
     if let (Some(devtools_chan), Some(pipeline_id), Some(webview_id)) = (
         context.devtools_chan.as_ref(),
         request.pipeline_id,
@@ -473,7 +469,7 @@ pub fn send_response_to_devtools(
     }
 }
 
-pub fn send_early_httprequest_to_devtools(request: &mut Request, context: &FetchContext) {
+pub fn send_early_httprequest_to_devtools(request: &Request, context: &FetchContext) {
     if let (Some(devtools_chan), Some(browsing_context_id), Some(pipeline_id)) = (
         context.devtools_chan.as_ref(),
         request.target_webview_id.map(|id| id.0),


### PR DESCRIPTION
- Changes request parameters to immutable borrow
Testing: 
Fixes: https://github.com/servo/servo/issues/38300
