### PR TITLE
script: Fire `scroll` event whenever JS scrolled 

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -699,6 +699,7 @@ impl LayoutThread {
             pending_rasterization_images,
             iframe_sizes: Some(iframe_sizes),
             update_scroll_reflow_target_scrolled,
+            processed_relayout: true,
         })
     }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -633,18 +633,30 @@ impl LayoutThread {
         );
     }
 
+    /// Checks whether we need to update the scroll node, and report whether the
+    /// node is scrolled. We need to update the scroll node whenever it is requested.
+    fn handle_update_scroll_node_request(&self, reflow_request: &ReflowRequest) -> bool {
+        if let ReflowGoal::UpdateScrollNode(external_scroll_id, offset) = reflow_request.reflow_goal
+        {
+            self.set_scroll_offset_from_script(external_scroll_id, offset)
+        } else {
+            false
+        }
+    }
+
     /// The high-level routine that performs layout.
     #[servo_tracing::instrument(skip_all)]
     fn handle_reflow(&mut self, mut reflow_request: ReflowRequest) -> Option<ReflowResult> {
         self.maybe_print_reflow_event(&reflow_request);
 
         if self.can_skip_reflow_request_entirely(&reflow_request) {
-            if let ReflowGoal::UpdateScrollNode(external_scroll_id, offset) =
-                reflow_request.reflow_goal
-            {
-                self.set_scroll_offset_from_script(external_scroll_id, offset);
-            }
-            return None;
+            // We could skip the layout, but we might need to update the scroll node.
+            let update_scroll_reflow_target_scrolled =
+                self.handle_update_scroll_node_request(&reflow_request);
+
+            return Some(ReflowResult::new_without_relayout(
+                update_scroll_reflow_target_scrolled,
+            ));
         }
 
         let document = unsafe { ServoLayoutNode::new(&reflow_request.document) };
@@ -674,10 +686,8 @@ impl LayoutThread {
         self.build_stacking_context_tree(&reflow_request, damage);
         let built_display_list = self.build_display_list(&reflow_request, damage, &image_resolver);
 
-        if let ReflowGoal::UpdateScrollNode(external_scroll_id, offset) = reflow_request.reflow_goal
-        {
-            self.set_scroll_offset_from_script(external_scroll_id, offset);
-        }
+        let update_scroll_reflow_target_scrolled =
+            self.handle_update_scroll_node_request(&reflow_request);
 
         let pending_images = std::mem::take(&mut *image_resolver.pending_images.lock());
         let pending_rasterization_images =
@@ -687,7 +697,8 @@ impl LayoutThread {
             built_display_list,
             pending_images,
             pending_rasterization_images,
-            iframe_sizes,
+            iframe_sizes: Some(iframe_sizes),
+            update_scroll_reflow_target_scrolled,
         })
     }
 
@@ -1081,10 +1092,10 @@ impl LayoutThread {
         &self,
         external_scroll_id: ExternalScrollId,
         offset: LayoutVector2D,
-    ) {
+    ) -> bool {
         let mut stacking_context_tree = self.stacking_context_tree.borrow_mut();
         let Some(stacking_context_tree) = stacking_context_tree.as_mut() else {
-            return;
+            return false;
         };
 
         if let Some(offset) = stacking_context_tree
@@ -1102,6 +1113,9 @@ impl LayoutThread {
                 offset,
                 external_scroll_id,
             );
+            true
+        } else {
+            false
         }
     }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2417,11 +2417,11 @@ impl Document {
         // > Empty doc’s pending scroll event targets.
         // Since the scroll event callback could trigger another scroll event, we are taking all of the
         // current scroll event to avoid borrow checking error.
-        rooted_vec!(let notify_list <- self.pending_scroll_event_targets.clone().take().into_iter());
+        rooted_vec!(let notify_list <- self.pending_scroll_event_targets.take().into_iter());
         for target in notify_list.iter() {
-            // Step 2.1
-            // > If target is a Document, fire an event named scroll that bubbles at target.
             if target.downcast::<Document>().is_some() {
+                // Step 2.1
+                // > If target is a Document, fire an event named scroll that bubbles at target.
                 target.fire_bubbling_event(Atom::from("scroll"), can_gc);
             } else if target.downcast::<Element>().is_some() {
                 // Step 2.2

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3699,7 +3699,9 @@ impl Document {
             receiver.recv().unwrap();
         }
 
-        self.window().reflow(ReflowGoal::UpdateTheRendering, can_gc)
+        self.window()
+            .reflow(ReflowGoal::UpdateTheRendering, can_gc)
+            .reflow_issued
     }
 
     pub(crate) fn id_map(&self) -> Ref<HashMapTracedValues<Atom, Vec<Dom<Element>>>> {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2413,23 +2413,22 @@ impl Document {
         // Step 2
         // > For each item target in doc’s pending scroll event targets, in the order they
         // > were added to the list, run these substeps:
-        for target in self.pending_scroll_event_targets.borrow().iter() {
+        // Step 3.
+        // > Empty doc’s pending scroll event targets.
+        // Since the scroll event callback could trigger another scroll event, we are taking all of the
+        // current scroll event to avoid borrow checking error.
+        rooted_vec!(let notify_list <- self.pending_scroll_event_targets.clone().take().into_iter());
+        for target in notify_list.iter() {
             // Step 2.1
             // > If target is a Document, fire an event named scroll that bubbles at target.
             if target.downcast::<Document>().is_some() {
                 target.fire_bubbling_event(Atom::from("scroll"), can_gc);
-            }
-
-            // Step 2.2
-            // > Otherwise, fire an event named scroll at target.
-            if target.downcast::<Element>().is_some() {
+            } else if target.downcast::<Element>().is_some() {
+                // Step 2.2
+                // > Otherwise, fire an event named scroll at target.
                 target.fire_event(Atom::from("scroll"), can_gc);
             }
         }
-
-        // Step 3.
-        // > Empty doc’s pending scroll event targets.
-        self.pending_scroll_event_targets.borrow_mut().clear();
 
         // Step 4.
         // > Run the steps to dispatch pending scrollsnapchange events for doc.

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2476,6 +2476,7 @@ impl Element {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scroll
+    // TODO(stevennovaryo): Need to update the scroll API to follow the spec since it is quite outdated.
     pub(crate) fn scroll(&self, x_: f64, y_: f64, behavior: ScrollBehavior, can_gc: CanGc) {
         // Step 1.2 or 2.3
         let x = if x_.is_finite() { x_ } else { 0.0f64 };
@@ -2524,7 +2525,7 @@ impl Element {
         }
 
         // Step 11
-        win.scroll_node(node, x, y, behavior, can_gc);
+        win.scroll_an_element(self, x, y, behavior, can_gc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#fragment-parsing-algorithm-steps>
@@ -3180,6 +3181,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
+    // TODO(stevennovaryo): Need to update the scroll API to follow the spec since it is quite outdated.
     fn SetScrollTop(&self, y_: f64, can_gc: CanGc) {
         let behavior = ScrollBehavior::Auto;
 
@@ -3229,7 +3231,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 11
-        win.scroll_node(node, self.ScrollLeft(can_gc), y, behavior, can_gc);
+        win.scroll_an_element(self, self.ScrollLeft(can_gc), y, behavior, can_gc);
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
@@ -3329,7 +3331,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         }
 
         // Step 11
-        win.scroll_node(node, x, self.ScrollTop(can_gc), behavior, can_gc);
+        win.scroll_an_element(self, x, self.ScrollTop(can_gc), behavior, can_gc);
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1255,8 +1255,14 @@ impl ScriptThread {
             self.process_pending_input_events(*pipeline_id, can_gc);
 
             // > 8. For each doc of docs, run the resize steps for doc. [CSSOMVIEW]
-            if document.window().run_the_resize_steps(can_gc) {
-                // Evaluate media queries and report changes.
+            let resized = document.window().run_the_resize_steps(can_gc);
+
+            // > 9. For each doc of docs, run the scroll steps for doc.
+            document.run_the_scroll_steps(can_gc);
+
+            // Media queries is only relevant when there are resizing.
+            if resized {
+                // 10. For each doc of docs, evaluate media queries and report changes for doc.
                 document
                     .window()
                     .evaluate_media_queries_and_report_changes(can_gc);
@@ -1265,9 +1271,6 @@ impl ScriptThread {
                 // As per the spec, this can be run at any time.
                 document.react_to_environment_changes()
             }
-
-            // > 9. For each doc of docs, run the scroll steps for doc.
-            document.run_the_scroll_steps(can_gc);
 
             // > 11. For each doc of docs, update animations and send events for doc, passing
             // > in relative high resolution time given frameTimestamp and doc's relevant

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -393,6 +393,8 @@ pub struct ReflowResult {
     /// to communicate them with the Constellation and also the `Window`
     /// element of their content pages.
     pub iframe_sizes: IFrameSizes,
+    /// Whether the reflow target for a [ReflowGoal::UpdateScrollNode] is scrolled.
+    pub reflow_target_scrolled: bool,
 }
 
 /// Information needed for a script-initiated reflow that requires a restyle

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -399,6 +399,10 @@ pub struct ReflowResult {
     /// Whether the reflow is for [ReflowGoal::UpdateScrollNode] and the target is scrolled.
     /// Specifically, a node is scrolled whenever the scroll position of it changes.
     pub update_scroll_reflow_target_scrolled: bool,
+    /// Do the reflow results in a new component within layout. Incremental layout could be
+    /// skipped if it is deemed unnecessary or the required component is not ready to be
+    /// processed.
+    pub processed_relayout: bool,
 }
 
 impl ReflowResult {
@@ -406,11 +410,8 @@ impl ReflowResult {
     /// unecessary. In those cases, many of the [ReflowResult] would be irrelevant.
     pub fn new_without_relayout(update_scroll_reflow_target_scrolled: bool) -> Self {
         ReflowResult {
-            built_display_list: Default::default(),
-            pending_images: Default::default(),
-            pending_rasterization_images: Default::default(),
-            iframe_sizes: Default::default(),
             update_scroll_reflow_target_scrolled,
+            ..Default::default()
         }
     }
 }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -344,7 +344,7 @@ pub enum ReflowGoal {
     LayoutQuery(QueryMsg),
 
     /// Tells layout about a single new scrolling offset from the script. The rest will
-    /// remain untouched. Layout will forward whether the element is scrolled thru
+    /// remain untouched. Layout will forward whether the element is scrolled through
     /// [ReflowResult].
     UpdateScrollNode(ExternalScrollId, LayoutVector2D),
 }

--- a/tests/wpt/meta/html/webappapis/scripting/event-loops/new-scroll-event-dispatched-at-next-updating-rendering-time.html.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/event-loops/new-scroll-event-dispatched-at-next-updating-rendering-time.html.ini
@@ -1,4 +1,0 @@
-[new-scroll-event-dispatched-at-next-updating-rendering-time.html]
-  expected: TIMEOUT
-  [new-scroll-event-dispatched-at-next-updating-rendering-time]
-    expected: TIMEOUT

--- a/tests/wpt/tests/dom/events/resources/large-dimension-document.sub.html
+++ b/tests/wpt/tests/dom/events/resources/large-dimension-document.sub.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<body>
+    <div style="width: 10000px; height: 10000px;"></div>
+</body>

--- a/tests/wpt/tests/dom/events/scrolling/scroll-event-fired-to-element.html
+++ b/tests/wpt/tests/dom/events/scrolling/scroll-event-fired-to-element.html
@@ -3,6 +3,8 @@
 <title>Scroll event should behave correctly for Element.offsetTop and Element.offsetLeft</title>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src="scroll_support.js"></script>
+<link rel="author" title="Jo Steven Novaryo" href="mailto:jo.steven.novaryo@huawei.com">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-events">
 <div id=log></div>
@@ -24,41 +26,20 @@ function setupTarget() {
   return target;
 }
 
-function triggerReflow(target) {
-  // These should trigger reflow
-  target.style.display = "inline-block";
-}
-
-// Create a promise, returning scrollTop whenever it receive a "scroll" event.
-function promiseForScrollTop(target) {
-  return new Promise(
-    resolve =>
-      target.addEventListener("scroll", () => resolve(target.scrollTop)),
-    { once: true },
-  );
-}
-
-// Create a promise, returning scrollLeft whenever it receive a "scroll" event.
-function promiseForScrollLeft(target) {
-  return new Promise(
-    resolve =>
-      target.addEventListener("scroll", () => resolve(target.scrollLeft)),
-    { once: true },
-  );
-}
-
 promise_test(async (t) => {
   var target = setupTarget();
 
   assert_equals(target.scrollTop, 0);
-  var updatedOffsetTop = promiseForScrollTop(target);
+  var promiseForScrollTop = waitForEvent("scroll", t, target);
   target.scrollTop = 10;
-  assert_equals(await updatedOffsetTop, 10);
+  await promiseForScrollTop;
+  assert_equals(target.scrollTop, 10);
 
   assert_equals(target.scrollLeft, 0);
-  var updatedOffsetLeft = promiseForScrollLeft(target);
+  var promiseForScrollLeft = waitForEvent("scroll", t, target);
   target.scrollLeft = 10;
-  assert_equals(await updatedOffsetLeft, 10);
+  await promiseForScrollLeft;
+  assert_equals(target.scrollLeft, 10);
 
 }, "scrollTop and scrollLeft should fire scroll event.");
 
@@ -73,7 +54,9 @@ promise_test(async (t) => {
   assert_equals(target.scrollLeft, 0);
   target.scrollLeft = 0;
 
-  triggerReflow(target); // Ensure that all event is flushed.
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
 }, "scrollTop and scrollLeft being set with the same value.");
 
 promise_test(async (t) => {
@@ -84,28 +67,34 @@ promise_test(async (t) => {
   target.scrollTop = -100;
   target.scrollLeft = -100;
 
-  triggerReflow(target); // Ensure that all event is flushed.
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
 }, "scrollTop and scrollLeft being set with invalid scroll offset.");
 
 promise_test(async (t) => {
   var target = setupTarget();
 
   assert_equals(target.scrollTop, 0);
-  var updatedOffsetTop = promiseForScrollTop(target);
+  var promiseForScrollTop = waitForEvent("scroll", t, target);
   target.scrollTop = 1000;
-  assert_equals(await updatedOffsetTop, 100);
+  await promiseForScrollTop;
+  assert_equals(target.scrollTop, 100);
 
   assert_equals(target.scrollLeft, 0);
-  var updatedOffsetLeft = promiseForScrollLeft(target);
+  var promiseForScrollLeft = waitForEvent("scroll", t, target);
   target.scrollLeft = 1000;
-  assert_equals(await updatedOffsetLeft, 100);
+  await promiseForScrollLeft;
+  assert_equals(target.scrollLeft, 100);
 
   target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
 
   target.scrollTop = 1000;
   target.scrollLeft = 1000;
 
-  triggerReflow(target); // Ensure that all event is flushed.
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
 }, "scrollTop and scrollLeft when scrolling above maximum offset.");
 
 </script>

--- a/tests/wpt/tests/dom/events/scrolling/scroll-event-fired-to-element.html
+++ b/tests/wpt/tests/dom/events/scrolling/scroll-event-fired-to-element.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Scroll event should behave correctly for Element.offsetTop and Element.offsetLeft</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-events">
+<div id=log></div>
+<div id="container">
+</div>
+<script>
+
+function setupTarget() {
+  var container = document.getElementById("container");
+  container.innerHTML = "";
+
+  var target = document.createElement("div");
+  var overflowing_child = document.createElement("div");
+
+  target.style = "overflow:scroll; height: 100px; width: 100px; scrollbar-width: none";
+  overflowing_child.style = "height: 200px; width: 200px;";
+  target.appendChild(overflowing_child);
+  container.appendChild(target);
+  return target;
+}
+
+function triggerReflow(target) {
+  // These should trigger reflow
+  target.style.display = "inline-block";
+}
+
+// Create a promise, returning scrollTop whenever it receive a "scroll" event.
+function promiseForScrollTop(target) {
+  return new Promise(
+    resolve =>
+      target.addEventListener("scroll", () => resolve(target.scrollTop)),
+    { once: true },
+  );
+}
+
+// Create a promise, returning scrollLeft whenever it receive a "scroll" event.
+function promiseForScrollLeft(target) {
+  return new Promise(
+    resolve =>
+      target.addEventListener("scroll", () => resolve(target.scrollLeft)),
+    { once: true },
+  );
+}
+
+promise_test(async (t) => {
+  var target = setupTarget();
+
+  assert_equals(target.scrollTop, 0);
+  var updatedOffsetTop = promiseForScrollTop(target);
+  target.scrollTop = 10;
+  assert_equals(await updatedOffsetTop, 10);
+
+  assert_equals(target.scrollLeft, 0);
+  var updatedOffsetLeft = promiseForScrollLeft(target);
+  target.scrollLeft = 10;
+  assert_equals(await updatedOffsetLeft, 10);
+
+}, "scrollTop and scrollLeft should fire scroll event.");
+
+promise_test(async (t) => {
+  var target = setupTarget();
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  assert_equals(target.scrollTop, 0);
+  target.scrollTop = 0;
+
+  assert_equals(target.scrollLeft, 0);
+  target.scrollLeft = 0;
+
+  triggerReflow(target); // Ensure that all event is flushed.
+}, "scrollTop and scrollLeft being set with the same value.");
+
+promise_test(async (t) => {
+  var target = setupTarget();
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  target.scrollTop = -100;
+  target.scrollLeft = -100;
+
+  triggerReflow(target); // Ensure that all event is flushed.
+}, "scrollTop and scrollLeft being set with invalid scroll offset.");
+
+promise_test(async (t) => {
+  var target = setupTarget();
+
+  assert_equals(target.scrollTop, 0);
+  var updatedOffsetTop = promiseForScrollTop(target);
+  target.scrollTop = 1000;
+  assert_equals(await updatedOffsetTop, 100);
+
+  assert_equals(target.scrollLeft, 0);
+  var updatedOffsetLeft = promiseForScrollLeft(target);
+  target.scrollLeft = 1000;
+  assert_equals(await updatedOffsetLeft, 100);
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  target.scrollTop = 1000;
+  target.scrollLeft = 1000;
+
+  triggerReflow(target); // Ensure that all event is flushed.
+}, "scrollTop and scrollLeft when scrolling above maximum offset.");
+
+</script>

--- a/tests/wpt/tests/dom/events/scrolling/scroll-event-fired-to-iframe.html
+++ b/tests/wpt/tests/dom/events/scrolling/scroll-event-fired-to-iframe.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Scroll event should behave correctly for Element.ScrollX and Element.ScrollLeft</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-events">
+<div id=log></div>
+<div id="container">
+</div>
+<script>
+
+
+function promiseForFrameLoad(frame) {
+  return new Promise(async (resolve) => {
+    frame.addEventListener("load", () => resolve(frame), { once: true });
+  });
+}
+
+async function promiseForSetupTargetFrame() {
+  const target = document.createElement("iframe");
+  target.src = "../resources/large-dimension-document.sub.html";
+  target.width = "200";
+  target.height = "200";
+
+  var container = document.getElementById("container");
+  container.innerHTML = "";
+  container.appendChild(target);
+
+  return promiseForFrameLoad(target);
+}
+
+function triggerReflow() {
+  // These should trigger reflow
+  var container = document.getElementById("container");
+  container.style.display = "inline-block";
+  container.style.display = "block";
+}
+
+// Create a promise, returning scrollX whenever it receive a "scroll" event.
+function promiseForScrollX(target) {
+  return new Promise(
+    resolve =>
+      target.addEventListener("scroll", () => resolve(target.scrollX)),
+    { once: true },
+  );
+}
+
+// Create a promise, returning scrollY whenever it receive a "scroll" event.
+function promiseForScrollY(target) {
+  return new Promise(
+    resolve =>
+      target.addEventListener("scroll", () => resolve(target.scrollY)),
+    { once: true },
+  );
+}
+
+promise_test(async (t) => {
+  var frame = await promiseForSetupTargetFrame();
+  var target = frame.contentWindow;
+
+  assert_equals(target.scrollX, 0);
+  var updatedScrollX = promiseForScrollX(target);
+  target.scrollTo({left: 10});
+  assert_equals(await updatedScrollX, 10);
+
+  assert_equals(target.scrollY, 0);
+  var updatedScrollY = promiseForScrollY(target);
+  target.scrollTo({top: 10});
+  assert_equals(await updatedScrollY, 10);
+
+}, "scrollX and scrollY should fire scroll event.");
+
+promise_test(async (t) => {
+  var frame = await promiseForSetupTargetFrame();
+  var target = frame.contentWindow;
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  assert_equals(target.scrollX, 0);
+  target.scrollTo({left: 0});
+
+  assert_equals(target.scrollY, 0);
+  target.scrollTo({top: 0});
+
+  triggerReflow(); // Ensure that all event is flushed.
+}, "scrollX and scrollY being set with the same value.");
+
+promise_test(async (t) => {
+  var frame = await promiseForSetupTargetFrame();
+  var target = frame.contentWindow;
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  target.scrollTo({left: -100});
+  target.scrollTo({top: -100});
+
+  triggerReflow(); // Ensure that all event is flushed.
+}, "scrollX and scrollY being set with invalid scroll Scroll.");
+
+promise_test(async (t) => {
+  var frame = await promiseForSetupTargetFrame();
+  var target = frame.contentWindow;
+  var frameDocEl = frame.contentDocument.documentElement;
+
+  assert_equals(target.scrollX, 0);
+  var updatedScrollX = promiseForScrollX(target);
+  target.scrollTo({left: frameDocEl.scrollWidth});
+  assert_greater_than(await updatedScrollX, 0);
+
+  assert_equals(target.scrollY, 0);
+  var updatedScrollY = promiseForScrollY(target);
+  target.scrollTo({top: frameDocEl.scrollHeight});
+  assert_greater_than(await updatedScrollY, 0);
+
+  target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
+
+  target.scrollTo({left: updatedScrollX + 10});
+  target.scrollTo({top: updatedScrollY + 10});
+
+  triggerReflow(); // Ensure that all event is flushed.
+}, "scrollX and scrollY when scrolling above maximum Scroll.");
+
+</script>

--- a/tests/wpt/tests/dom/events/scrolling/scroll-event-fired-to-iframe.html
+++ b/tests/wpt/tests/dom/events/scrolling/scroll-event-fired-to-iframe.html
@@ -3,6 +3,8 @@
 <title>Scroll event should behave correctly for Element.ScrollX and Element.ScrollLeft</title>
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script src="scroll_support.js"></script>
+<link rel="author" title="Jo Steven Novaryo" href="mailto:jo.steven.novaryo@huawei.com">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface">
 <link rel="help" href="https://drafts.csswg.org/cssom-view/#scrolling-events">
 <div id=log></div>
@@ -30,44 +32,21 @@ async function promiseForSetupTargetFrame() {
   return promiseForFrameLoad(target);
 }
 
-function triggerReflow() {
-  // These should trigger reflow
-  var container = document.getElementById("container");
-  container.style.display = "inline-block";
-  container.style.display = "block";
-}
-
-// Create a promise, returning scrollX whenever it receive a "scroll" event.
-function promiseForScrollX(target) {
-  return new Promise(
-    resolve =>
-      target.addEventListener("scroll", () => resolve(target.scrollX)),
-    { once: true },
-  );
-}
-
-// Create a promise, returning scrollY whenever it receive a "scroll" event.
-function promiseForScrollY(target) {
-  return new Promise(
-    resolve =>
-      target.addEventListener("scroll", () => resolve(target.scrollY)),
-    { once: true },
-  );
-}
-
 promise_test(async (t) => {
   var frame = await promiseForSetupTargetFrame();
   var target = frame.contentWindow;
 
   assert_equals(target.scrollX, 0);
-  var updatedScrollX = promiseForScrollX(target);
+  var promiseForScrollX = waitForEvent("scroll", t, target);
   target.scrollTo({left: 10});
-  assert_equals(await updatedScrollX, 10);
+  await promiseForScrollX;
+  assert_equals(target.scrollX, 10);
 
   assert_equals(target.scrollY, 0);
-  var updatedScrollY = promiseForScrollY(target);
+  var promiseForScrollY = waitForEvent("scroll", t, target);
   target.scrollTo({top: 10});
-  assert_equals(await updatedScrollY, 10);
+  await promiseForScrollY;
+  assert_equals(target.scrollY, 10);
 
 }, "scrollX and scrollY should fire scroll event.");
 
@@ -83,7 +62,9 @@ promise_test(async (t) => {
   assert_equals(target.scrollY, 0);
   target.scrollTo({top: 0});
 
-  triggerReflow(); // Ensure that all event is flushed.
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
 }, "scrollX and scrollY being set with the same value.");
 
 promise_test(async (t) => {
@@ -95,7 +76,9 @@ promise_test(async (t) => {
   target.scrollTo({left: -100});
   target.scrollTo({top: -100});
 
-  triggerReflow(); // Ensure that all event is flushed.
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
 }, "scrollX and scrollY being set with invalid scroll Scroll.");
 
 promise_test(async (t) => {
@@ -104,21 +87,30 @@ promise_test(async (t) => {
   var frameDocEl = frame.contentDocument.documentElement;
 
   assert_equals(target.scrollX, 0);
-  var updatedScrollX = promiseForScrollX(target);
+  var promiseForScrollX = waitForEvent("scroll", t, target);
   target.scrollTo({left: frameDocEl.scrollWidth});
-  assert_greater_than(await updatedScrollX, 0);
+  await promiseForScrollX;
+  assert_greater_than(target.scrollX, 0);
 
   assert_equals(target.scrollY, 0);
-  var updatedScrollY = promiseForScrollY(target);
-  target.scrollTo({top: frameDocEl.scrollHeight});
-  assert_greater_than(await updatedScrollY, 0);
+  var promiseForScrollY = waitForEvent("scroll", t, target);
+  target.scrollTo({
+    top: frameDocEl.scrollHeight,
+    left: target.scrollX
+  });
+  await promiseForScrollY;
+  assert_greater_than(target.scrollY, 0);
 
   target.addEventListener("scroll", () => assert_unreached("Any scroll event should not be observed"));
 
-  target.scrollTo({left: updatedScrollX + 10});
-  target.scrollTo({top: updatedScrollY + 10});
+  target.scrollTo({
+    left: target.scrollX + 10,
+    top: target.scrollY + 10,
+  });
 
-  triggerReflow(); // Ensure that all event is flushed.
+  // Ensure all scroll event is flushed
+  await waitForNextFrame();
+  await waitForNextFrame();
 }, "scrollX and scrollY when scrolling above maximum Scroll.");
 
 </script>


### PR DESCRIPTION
Implement JS scroll event firing compliant to https://drafts.csswg.org/cssom-view/#scrolling-events. Basically whenever, the an element or the viewport is scrolled, we will fire a scroll event. The changes push a scroll event whenever an API causes a scroll position to change.

Testing: New WPT tests for basic APIs.
Part of: https://github.com/servo/servo/issues/31665
