### PR TITLE
background_hang_monitor: ensure workers run until monitored components do

### DIFF
--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -24,17 +24,13 @@ pub struct HangMonitorRegister {
 }
 
 impl HangMonitorRegister {
-    /// Start a new hang monitor worker, and return a handle to register components for monitoring.
+    /// Start a new hang monitor worker, and return a handle to register components for monitoring,
+    /// as well as a join handle on the worker thread.
     pub fn init(
         constellation_chan: IpcSender<HangMonitorAlert>,
         control_port: IpcReceiver<BackgroundHangMonitorControlMsg>,
         monitoring_enabled: bool,
     ) -> (Box<dyn BackgroundHangMonitorRegister>, JoinHandle<()>) {
-        // Create a channel to pass messages of type `MonitoredComponentMsg`.
-        // See the discussion in `<HangMonitorRegister as
-        // BackgroundHangMonitorRegister>::register_component` for why we wrap
-        // the sender with `Arc` and why `HangMonitorRegister` only maintains
-        // a weak reference to it.
         let (sender, port) = unbounded();
         let sender_clone = sender.clone();
 

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -336,7 +336,9 @@ impl BackgroundHangMonitorWorker {
                         }
 
                         // Note the start of shutdown,
-                        // to prevent registration from this point on.
+                        // to ensure exit propagates, 
+                        // even to components that have yet to register themselves,
+                        // from this point on.
                         self.shutting_down = true;
 
                         // Keep running; this worker thread will shutdown
@@ -385,10 +387,10 @@ impl BackgroundHangMonitorWorker {
             ) => {
                 // If we are shutting down,
                 // propagate it to the component,
-                // and do not register it.
+                // and register it(the component will unregister itself
+                // as part of handling the exit).
                 if self.shutting_down {
                     exit_signal.signal_to_exit();
-                    return;
                 }
 
                 let component = MonitoredComponent {

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -345,7 +345,7 @@ impl BackgroundHangMonitorWorker {
 
                         // Keep running; this worker thread will shutdown
                         // when the monitored components have shutdown,
-                        // which we know has happened when the tether chan disconnects.
+                        // which we know has happened when `self.port` disconnects.
                         None
                     },
                     Err(_) => return false,

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -336,7 +336,7 @@ impl BackgroundHangMonitorWorker {
                         }
 
                         // Note the start of shutdown,
-                        // to ensure exit propagates, 
+                        // to ensure exit propagates,
                         // even to components that have yet to register themselves,
                         // from this point on.
                         self.shutting_down = true;

--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -444,16 +444,15 @@ impl BackgroundHangMonitorWorker {
                         }
                         None
                     },
-                    Ok(BackgroundHangMonitorControlMsg::Exit(sender)) => {
+                    Ok(BackgroundHangMonitorControlMsg::Exit) => {
                         for component in self.monitored_components.values_mut() {
                             component.exit_signal.signal_to_exit();
                         }
 
-                        // Confirm exit with to the constellation.
-                        let _ = sender.send(());
-
-                        // Also exit the BHM.
-                        return false;
+                        // Keep running; this worker thread will shutdown
+                        // when the monitored components have shutdown, 
+                        // which we know has happened when the tether chan disconnects.
+                        None
                     },
                     Err(_) => return false,
                 }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2430,14 +2430,9 @@ where
         // even when currently hanging(on JS or sync XHR).
         // This must be done before starting the process of closing all pipelines.
         for chan in &self.background_monitor_control_senders {
-            let (exit_ipc_sender, exit_ipc_receiver) =
-                ipc::channel().expect("Failed to create IPC channel!");
-            if let Err(e) = chan.send(BackgroundHangMonitorControlMsg::Exit(exit_ipc_sender)) {
+            if let Err(e) = chan.send(BackgroundHangMonitorControlMsg::Exit) {
                 warn!("error communicating with bhm: {}", e);
                 continue;
-            }
-            if exit_ipc_receiver.recv().is_err() {
-                warn!("Failed to receive exit confirmation from BHM.");
             }
         }
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2440,6 +2440,9 @@ where
         // even when currently hanging(on JS or sync XHR).
         // This must be done before starting the process of closing all pipelines.
         for chan in &self.background_monitor_control_senders {
+            // Note: the bhm worker thread will continue to run 
+            // until all monitored components have exited,
+            // at which point we can join on the thread(done in `handle_shutdown`).
             if let Err(e) = chan.send(BackgroundHangMonitorControlMsg::Exit) {
                 warn!("error communicating with bhm: {}", e);
                 continue;

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2440,7 +2440,7 @@ where
         // even when currently hanging(on JS or sync XHR).
         // This must be done before starting the process of closing all pipelines.
         for chan in &self.background_monitor_control_senders {
-            // Note: the bhm worker thread will continue to run 
+            // Note: the bhm worker thread will continue to run
             // until all monitored components have exited,
             // at which point we can join on the thread(done in `handle_shutdown`).
             if let Err(e) = chan.send(BackgroundHangMonitorControlMsg::Exit) {

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -5,6 +5,7 @@
 use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::thread::JoinHandle;
 
 use background_hang_monitor::HangMonitorRegister;
 use background_hang_monitor_api::{
@@ -558,7 +559,7 @@ impl UnprivilegedPipelineContent {
 
     pub fn register_with_background_hang_monitor(
         &mut self,
-    ) -> Box<dyn BackgroundHangMonitorRegister> {
+    ) -> (Box<dyn BackgroundHangMonitorRegister>, JoinHandle<()>) {
         HangMonitorRegister::init(
             self.background_hang_monitor_to_constellation_chan.clone(),
             self.bhm_control_port.take().expect("no sampling profiler?"),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3060,6 +3060,8 @@ impl ScriptThread {
 
     /// Handles a request to exit the script thread and shut down layout.
     fn handle_exit_script_thread_msg(&self, can_gc: CanGc) {
+        debug!("Exiting script thread.");
+
         let mut webview_and_pipeline_ids = Vec::new();
         webview_and_pipeline_ids.extend(
             self.incomplete_loads

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3060,8 +3060,6 @@ impl ScriptThread {
 
     /// Handles a request to exit the script thread and shut down layout.
     fn handle_exit_script_thread_msg(&self, can_gc: CanGc) {
-        debug!("Exiting script thread.");
-
         let mut webview_and_pipeline_ids = Vec::new();
         webview_and_pipeline_ids.extend(
             self.incomplete_loads

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -892,7 +892,7 @@ impl ScriptThread {
             MonitoredComponentId(state.id, MonitoredComponentType::Script),
             Duration::from_millis(1000),
             Duration::from_millis(5000),
-            Some(Box::new(background_hang_monitor_exit_signal)),
+            Box::new(background_hang_monitor_exit_signal),
         );
 
         let (image_cache_sender, image_cache_receiver) = unbounded();

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1271,10 +1271,9 @@ pub fn run_content_process(token: String) {
             );
 
             // Since wait_for_completion is true,
-            // here we "sort of" know that the script-thread
-            // has exited,
+            // here we know that the script-thread
+            // will exit(or already has),
             // and so we can join on the BHM worker thread.
-            // TODO: remove "sort of", by joining on the script-thread.
             join_handle
                 .join()
                 .expect("Failed to join on the BHM background thread.");

--- a/components/shared/background_hang_monitor/lib.rs
+++ b/components/shared/background_hang_monitor/lib.rs
@@ -208,6 +208,6 @@ pub trait BackgroundHangMonitorExitSignal: Send {
 pub enum BackgroundHangMonitorControlMsg {
     /// Toggle the sampler, with a given sampling rate and max total sampling duration.
     ToggleSampler(Duration, Duration),
-    /// Exit, and propagate the signal to monitored components.
-    Exit(IpcSender<()>),
+    /// Propaget exit signal to monitored components, and shutdown when they have.
+    Exit,
 }

--- a/components/shared/background_hang_monitor/lib.rs
+++ b/components/shared/background_hang_monitor/lib.rs
@@ -170,7 +170,7 @@ pub trait BackgroundHangMonitorRegister: BackgroundHangMonitorClone + Send {
         component: MonitoredComponentId,
         transient_hang_timeout: Duration,
         permanent_hang_timeout: Duration,
-        exit_signal: Option<Box<dyn BackgroundHangMonitorExitSignal>>,
+        exit_signal: Box<dyn BackgroundHangMonitorExitSignal>,
     ) -> Box<dyn BackgroundHangMonitor>;
 }
 

--- a/components/shared/background_hang_monitor/lib.rs
+++ b/components/shared/background_hang_monitor/lib.rs
@@ -207,6 +207,6 @@ pub trait BackgroundHangMonitorExitSignal: Send {
 pub enum BackgroundHangMonitorControlMsg {
     /// Toggle the sampler, with a given sampling rate and max total sampling duration.
     ToggleSampler(Duration, Duration),
-    /// Propaget exit signal to monitored components, and shutdown when they have.
+    /// Propagate exit signal to monitored components, and shutdown when they have.
     Exit,
 }

--- a/components/shared/background_hang_monitor/lib.rs
+++ b/components/shared/background_hang_monitor/lib.rs
@@ -10,7 +10,6 @@ use std::time::Duration;
 use std::{fmt, mem};
 
 use base::id::PipelineId;
-use ipc_channel::ipc::IpcSender;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Shut-down of the background hang monitor(bhm) is currently  problematic:

- it does not always run until the monitored script-thread does(see "BackgroundHangMonitor has gone away" mentioned in https://github.com/servo/servo/issues/34158).
- it shuts-down before the constellation(good, so actually https://github.com/servo/servo/issues/24850 was "fixed" but in a way that introduced a new problem), but using a mechanism that allows it to shutdown before script(the problem above). 
- there are various mechanism(see the doc comments removed by this PR) in place which are meant to ensure a clean shutdown despite the above problems; those are complicated, and become unnecessary once those problems are fixed.

All of the above is fixed by the changes in this PR, which ensure the bhm does not shut-down before script, and also maintains the invariant that it must shut-down before the constellation(in single-process mode) or before the main thread(in multi-process mode), but using a mechanism which allows it to keep running until script shuts-down. 

An unnecessary option around the exit signal is also removed.

As a positive side-effect, it also ensures that any script-thread is shut-down before the constellation(because for the bhm worker to exit, the monitored script must have exited first), so this should also fix a host of other problems noted in https://github.com/servo/servo/issues/30849, but each should be confirmed independently(and various other improvements seem possible in their specific contexts, such as joining on script threads, and removing the `ScriptThreadMessage::ExitScriptThread`). 

Fixes: https://github.com/servo/servo/issues/24850 and part of https://github.com/servo/servo/issues/34158

Testing: Unit tests in `component/background_hang_monitor/tests`. Also manually tested loading "about-blank" in single- and multi-process mode. 