### PR TITLE
Check crash in `WebDriverBrowser` for servo(driver) and restart browser when `check_crash` is true in `testrunner.py`

### DIFF
--- a/tests/wpt/meta/webdriver/tests/classic/close_window/close.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/close_window/close.py.ini
@@ -1,4 +1,5 @@
 [close.py]
+  expected: CRASH
   [test_close_last_browsing_context]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/node.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/node.py.ini
@@ -1,4 +1,5 @@
 [node.py]
+  expected: CRASH
   [test_detached_shadow_root[top_context\]]
     expected: FAIL
 

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servo.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servo.py
@@ -120,3 +120,6 @@ class ServoWdspecBrowser(WebDriverBrowser):
         if self.binary_args:
             command += self.binary_args
         return command
+
+    def check_crash(self, process, test):
+        return not super().is_alive()

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -123,3 +123,6 @@ class ServoWebDriverBrowser(WebDriverBrowser):
     def cleanup(self):
         super().cleanup()
         os.remove(self.hosts_path)
+
+    def check_crash(self, process, test):
+        return not super().is_alive()

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/testrunner.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/testrunner.py
@@ -850,14 +850,14 @@ class TestRunnerManager(threading.Thread):
                              stack=file_result.stack,
                              subsuite=self.state.subsuite)
 
-        restart_before_next = (self.retry_index > 0 or test.restart_after or
+        restart_before_next = (self.retry_index > 0 or test.restart_after or status == "CRASH" or
                                file_result.status in ("CRASH", "EXTERNAL-TIMEOUT", "INTERNAL-ERROR") or
                                ((subtest_unexpected or is_unexpected) and
                                 self.restart_on_unexpected))
         force_stop = test.test_type == "wdspec" and file_result.status == "EXTERNAL-TIMEOUT"
 
         self.recording.set(["testrunner", "after-test"])
-        if (not file_result.status == "CRASH" and
+        if (not status == "CRASH" and
             self.pause_after_test or
             (self.pause_on_unexpected and (subtest_unexpected or is_unexpected))):
             self.logger.info("Pausing until the browser exits")


### PR DESCRIPTION
- Make sure servo is not crashed by previous test by making sure it's still alive at the end of the test for `wdspec` test.
- In `testrunner.py`, use the result of `check_crash` to determine whether we should restart browser before next test.

Testing: Will restart servo if previously killed for `wdspec` test.
Fixes: https://github.com/servo/servo/issues/38226
