### PR TITLE
mach: Fail on invalid argument in try_parser

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -808,7 +808,11 @@ class MachCommands(CommandBase):
             return 1
 
         try_string = " ".join(try_strings)
-        config = servo.try_parser.Config(try_string)
+        try:
+            config = servo.try_parser.Config(try_string)
+        except ValueError as err:
+            print(f"Failed to parse `try` config because of {err}")
+            return 1
         print(f"Trying on {remote} ({remote_url}) with following configuration:")
         print()
         print(textwrap.indent(config.to_json(indent=2), prefix="  "))

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -197,6 +197,7 @@ class Config(object):
             input = "full"
 
         words: list[str] = input.split(" ")
+        invalid_words: list[str] = list()
 
         for word in words:
             # Handle keywords.
@@ -220,9 +221,13 @@ class Config(object):
             job = handle_preset(word)
             job = handle_modifier(job, word)
             if job is None:
+                invalid_words.append(word)
                 print(f"Ignoring unknown preset {word}")
             else:
                 self.add_or_merge_job_to_matrix(job)
+
+        if len(invalid_words) > 0:
+            raise ValueError(f"Invalid `try` argument: {', '.join(invalid_words)}")
 
     def add_or_merge_job_to_matrix(self, job: JobConfig) -> None:
         for existing_job in self.matrix:


### PR DESCRIPTION
This will block the command, print an error message about an invalid argument being passed to the ./mach try command, and return the exit code.

Testing: `./mach try test-wpt`
Fixes: #38193