### PR TITLE
layout: Add BoxFragment rare data

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1362,7 +1362,7 @@ impl<'a> BuilderForBoxFragment<'a> {
 
     fn build_collapsed_table_borders(&mut self, builder: &mut DisplayListBuilder) {
         let Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(table_info)) =
-            &self.fragment.specific_layout_info
+            self.fragment.specific_layout_info()
         else {
             return;
         };

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -1321,7 +1321,7 @@ impl BoxFragment {
         }
 
         if matches!(&fragment, Fragment::Box(box_fragment) if matches!(
-            box_fragment.borrow().specific_layout_info,
+            box_fragment.borrow().specific_layout_info(),
             Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_))
         )) {
             stacking_context

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -68,6 +68,24 @@ pub(crate) struct BlockLevelLayoutInfo {
 }
 
 #[derive(MallocSizeOf)]
+pub(crate) struct BoxFragmentRareData {
+    /// Information that is specific to a layout system (e.g., grid, table, etc.).
+    pub specific_layout_info: Option<SpecificLayoutInfo>,
+}
+
+impl BoxFragmentRareData {
+    /// Create a new rare data based on information given to the fragment. Ideally, We should
+    /// avoid creating rare data as much as possible to reduce the memory cost.
+    fn try_boxed_from(specific_layout_info: Option<SpecificLayoutInfo>) -> Option<Box<Self>> {
+        specific_layout_info.map(|info| {
+            Box::new(BoxFragmentRareData {
+                specific_layout_info: Some(info),
+            })
+        })
+    }
+}
+
+#[derive(MallocSizeOf)]
 pub(crate) struct BoxFragment {
     pub base: BaseFragment,
 
@@ -104,8 +122,8 @@ pub(crate) struct BoxFragment {
 
     pub background_mode: BackgroundMode,
 
-    /// Additional information of from layout that could be used by Javascripts and devtools.
-    pub specific_layout_info: Option<SpecificLayoutInfo>,
+    /// Rare data that not all kinds of [`BoxFragment`] would have.
+    pub rare_data: Option<Box<BoxFragmentRareData>>,
 
     /// Additional information for block-level boxes.
     pub block_level_layout_info: Option<Box<BlockLevelLayoutInfo>>,
@@ -123,6 +141,8 @@ impl BoxFragment {
         margin: PhysicalSides<Au>,
         specific_layout_info: Option<SpecificLayoutInfo>,
     ) -> BoxFragment {
+        let rare_data = BoxFragmentRareData::try_boxed_from(specific_layout_info);
+
         BoxFragment {
             base: base_fragment_info.into(),
             style,
@@ -136,7 +156,7 @@ impl BoxFragment {
             scrollable_overflow: None,
             resolved_sticky_insets: AtomicRefCell::default(),
             background_mode: BackgroundMode::Normal,
-            specific_layout_info,
+            rare_data,
             block_level_layout_info: None,
         }
     }
@@ -188,6 +208,10 @@ impl BoxFragment {
 
     pub fn set_does_not_paint_background(&mut self) {
         self.background_mode = BackgroundMode::None;
+    }
+
+    pub fn specific_layout_info(&self) -> Option<&SpecificLayoutInfo> {
+        self.rare_data.as_ref()?.specific_layout_info.as_ref()
     }
 
     pub fn with_block_level_layout_info(
@@ -500,13 +524,13 @@ impl BoxFragment {
     /// <https://www.w3.org/TR/css-tables-3/#table-wrapper-box>
     pub(crate) fn is_table_wrapper(&self) -> bool {
         matches!(
-            self.specific_layout_info,
+            self.specific_layout_info(),
             Some(SpecificLayoutInfo::TableWrapper)
         )
     }
 
     pub(crate) fn has_collapsed_borders(&self) -> bool {
-        match &self.specific_layout_info {
+        match self.specific_layout_info() {
             Some(SpecificLayoutInfo::TableCellWithCollapsedBorders) => true,
             Some(SpecificLayoutInfo::TableGridWithCollapsedBorders(_)) => true,
             Some(SpecificLayoutInfo::TableWrapper) => {

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -212,7 +212,7 @@ pub fn process_resolved_style_request(
                 let content_rect = box_fragment.content_rect;
                 let margins = box_fragment.margin;
                 let padding = box_fragment.padding;
-                let specific_layout_info = box_fragment.specific_layout_info.clone();
+                let specific_layout_info = box_fragment.specific_layout_info().cloned();
                 (content_rect, margins, padding, specific_layout_info)
             },
             Fragment::Positioning(positioning_fragment) => {


### PR DESCRIPTION
Introduce `BoxFragmentRareData`, rare data for `BoxFragment`, which would store the specific data that is relevant to several fragments. This would reduce the `BoxFragment` size to 256 from 264 and add 8 bytes for fragment that have rare data (due to the additional pointer to the rare data).

Testing: Existing WPT coverage