### PR TITLE
devtools: Make contentType optional in source actor source responses

### DIFF
--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -52,14 +52,14 @@ pub struct SourceActor {
     pub is_black_boxed: bool,
 
     pub content: Option<String>,
-    pub content_type: String,
+    pub content_type: Option<String>,
 }
 
 #[derive(Serialize)]
 struct SourceContentReply {
     from: String,
     #[serde(rename = "contentType")]
-    content_type: String,
+    content_type: Option<String>,
     source: String,
 }
 
@@ -90,7 +90,7 @@ impl SourceActor {
         name: String,
         url: ServoUrl,
         content: Option<String>,
-        content_type: String,
+        content_type: Option<String>,
     ) -> SourceActor {
         SourceActor {
             name,
@@ -106,7 +106,7 @@ impl SourceActor {
         pipeline_id: PipelineId,
         url: ServoUrl,
         content: Option<String>,
-        content_type: String,
+        content_type: Option<String>,
     ) -> &SourceActor {
         let source_actor_name = actors.new_name("source");
 

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -548,7 +548,7 @@ impl DevtoolsInstance {
             pipeline_id,
             source_info.url,
             source_info.content,
-            source_info.content_type.unwrap(),
+            source_info.content_type,
         );
         let source_actor_name = source_actor.name.clone();
         let source_form = source_actor.source_form();


### PR DESCRIPTION
This is allowed by the [protocol docs](https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#loading-script-sources), and eliminates an unwrap().

Testing: does not get exercised yet, but will be used in #37667 
Fixes: part of #36027