### PR TITLE
script: Create a debugger script for the SpiderMonkey Debugger API

### DIFF
--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::sync::Arc;
+
+use base::id::PipelineId;
+use constellation_traits::ScriptToConstellationChan;
+use crossbeam_channel::Sender;
+use devtools_traits::ScriptToDevtoolsControlMsg;
+use dom_struct::dom_struct;
+use embedder_traits::resources::{self, Resource};
+use ipc_channel::ipc::IpcSender;
+use js::jsval::UndefinedValue;
+use js::rust::Runtime;
+use js::rust::wrappers::JS_DefineDebuggerObject;
+use net_traits::ResourceThreads;
+use profile_traits::{mem, time};
+use script_bindings::realms::InRealm;
+use script_bindings::reflector::DomObject;
+use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
+
+use crate::dom::bindings::codegen::Bindings::DebuggerGlobalScopeBinding;
+use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::trace::CustomTraceable;
+use crate::dom::bindings::utils::define_all_exposed_interfaces;
+use crate::dom::globalscope::GlobalScope;
+#[cfg(feature = "testbinding")]
+#[cfg(feature = "webgpu")]
+use crate::dom::webgpu::identityhub::IdentityHub;
+use crate::messaging::MainThreadScriptMsg;
+use crate::realms::enter_realm;
+use crate::script_module::ScriptFetchOptions;
+use crate::script_runtime::{CanGc, JSContext};
+
+#[dom_struct]
+/// Global scope for interacting with the devtools Debugger API.
+///
+/// <https://firefox-source-docs.mozilla.org/js/Debugger/>
+pub(crate) struct DebuggerGlobalScope {
+    global_scope: GlobalScope,
+    script_chan: Sender<MainThreadScriptMsg>,
+}
+
+impl DebuggerGlobalScope {
+    /// Create a new heap-allocated `DebuggerGlobalScope`.
+    #[allow(unsafe_code)]
+    pub(crate) fn new(
+        runtime: &Runtime,
+        script_chan: Sender<MainThreadScriptMsg>,
+        devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
+        mem_profiler_chan: mem::ProfilerChan,
+        time_profiler_chan: time::ProfilerChan,
+        script_to_constellation_chan: ScriptToConstellationChan,
+        resource_threads: ResourceThreads,
+        #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
+    ) -> DomRoot<Self> {
+        let global = Box::new(Self {
+            global_scope: GlobalScope::new_inherited(
+                PipelineId::new(),
+                devtools_chan,
+                mem_profiler_chan,
+                time_profiler_chan,
+                script_to_constellation_chan,
+                resource_threads,
+                MutableOrigin::new(ImmutableOrigin::new_opaque()),
+                ServoUrl::parse_with_base(None, "about:internal/debugger")
+                    .expect("Guaranteed by argument"),
+                None,
+                Default::default(),
+                gpu_id_hub,
+                None,
+                false,
+            ),
+            script_chan,
+        });
+        let global = unsafe {
+            DebuggerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(
+                JSContext::from_ptr(runtime.cx()),
+                global,
+            )
+        };
+
+        let realm = enter_realm(&*global);
+        define_all_exposed_interfaces(global.upcast(), InRealm::entered(&realm), CanGc::note());
+        // TODO: what invariants do we need to uphold for the unsafe call?
+        assert!(unsafe {
+            JS_DefineDebuggerObject(
+                *Self::get_cx(),
+                global.global_scope.reflector().get_jsobject(),
+            )
+        });
+
+        global
+    }
+
+    /// Get the JS context.
+    pub(crate) fn get_cx() -> JSContext {
+        GlobalScope::get_cx()
+    }
+
+    fn evaluate_js(&self, script: &str, can_gc: CanGc) -> bool {
+        rooted!(in (*Self::get_cx()) let mut rval = UndefinedValue());
+        self.global_scope.evaluate_js_on_global_with_result(
+            script,
+            rval.handle_mut(),
+            ScriptFetchOptions::default_classic_script(&self.global_scope),
+            self.global_scope.api_base_url(),
+            can_gc,
+        )
+    }
+
+    pub(crate) fn execute(&self, can_gc: CanGc) {
+        if !self.evaluate_js(&resources::read_string(Resource::DebuggerJS), can_gc) {
+            warn!("Failed to execute debugger request");
+        }
+    }
+}

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::sync::Arc;
-
 use base::id::PipelineId;
 use constellation_traits::ScriptToConstellationChan;
 use crossbeam_channel::Sender;
@@ -55,7 +53,7 @@ impl DebuggerGlobalScope {
         time_profiler_chan: time::ProfilerChan,
         script_to_constellation_chan: ScriptToConstellationChan,
         resource_threads: ResourceThreads,
-        #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
+        #[cfg(feature = "webgpu")] gpu_id_hub: std::sync::Arc<IdentityHub>,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
         let global = Box::new(Self {
@@ -71,6 +69,7 @@ impl DebuggerGlobalScope {
                     .expect("Guaranteed by argument"),
                 None,
                 Default::default(),
+                #[cfg(feature = "webgpu")]
                 gpu_id_hub,
                 None,
                 false,

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -46,7 +46,7 @@ pub(crate) struct DebuggerGlobalScope {
 
 impl DebuggerGlobalScope {
     /// Create a new heap-allocated `DebuggerGlobalScope`.
-    #[allow(unsafe_code)]
+    #[allow(unsafe_code, clippy::too_many_arguments)]
     pub(crate) fn new(
         runtime: &Runtime,
         script_chan: Sender<MainThreadScriptMsg>,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -114,7 +114,7 @@ use crate::dom::reportingobserver::ReportingObserver;
 use crate::dom::serviceworker::ServiceWorker;
 use crate::dom::serviceworkerregistration::ServiceWorkerRegistration;
 use crate::dom::trustedtypepolicyfactory::TrustedTypePolicyFactory;
-use crate::dom::types::MessageEvent;
+use crate::dom::types::{DebuggerGlobalScope, MessageEvent};
 use crate::dom::underlyingsourcecontainer::UnderlyingSourceType;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::gpudevice::GPUDevice;
@@ -2530,6 +2530,9 @@ impl GlobalScope {
             // https://drafts.css-houdini.org/worklets/#script-settings-for-worklets
             return worklet.base_url();
         }
+        if let Some(_debugger_global) = self.downcast::<DebuggerGlobalScope>() {
+            return self.creation_url.clone();
+        }
         unreachable!();
     }
 
@@ -2544,6 +2547,9 @@ impl GlobalScope {
         if let Some(worklet) = self.downcast::<WorkletGlobalScope>() {
             // TODO: is this the right URL to return?
             return worklet.base_url();
+        }
+        if let Some(_debugger_global) = self.downcast::<DebuggerGlobalScope>() {
+            return self.creation_url.clone();
         }
         unreachable!();
     }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -289,6 +289,7 @@ pub(crate) mod customevent;
 pub(crate) mod datatransfer;
 pub(crate) mod datatransferitem;
 pub(crate) mod datatransferitemlist;
+pub(crate) mod debuggerglobalscope;
 pub(crate) mod dedicatedworkerglobalscope;
 pub(crate) mod defaultteereadrequest;
 pub(crate) mod defaultteeunderlyingsource;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -951,6 +951,7 @@ impl ScriptThread {
             state.resource_threads.clone(),
             #[cfg(feature = "webgpu")]
             gpu_id_hub.clone(),
+            CanGc::note(),
         );
         debugger_global.execute(CanGc::note());
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -166,6 +166,10 @@ DOMInterfaces = {
     'canGc': ['IndexedGetter', 'Add', 'Add_']
 },
 
+'DebuggerGlobalScope': {
+    'useSystemCompartment': True,
+},
+
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
     'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'GetScrollingElement', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets'],

--- a/components/script_bindings/webidls/DebuggerGlobalScope.webidl
+++ b/components/script_bindings/webidls/DebuggerGlobalScope.webidl
@@ -4,7 +4,6 @@
 
 // This interface is entirely internal to Servo, and should not be accessible to
 // web pages.
-
-[Exposed=(Window,Worker,Worklet,DissimilarOriginWindow,DebuggerGlobalScope),
- Inline]
-interface GlobalScope : EventTarget {};
+[Global=DebuggerGlobalScope, Exposed=DebuggerGlobalScope]
+interface DebuggerGlobalScope: GlobalScope {
+};

--- a/components/script_bindings/webidls/EventTarget.webidl
+++ b/components/script_bindings/webidls/EventTarget.webidl
@@ -5,7 +5,7 @@
  * https://dom.spec.whatwg.org/#interface-eventtarget
  */
 
-[Exposed=(Window,Worker,Worklet,DissimilarOriginWindow)]
+[Exposed=(Window,Worker,Worklet,DissimilarOriginWindow,DebuggerGlobalScope)]
 interface EventTarget {
   [Throws] constructor();
   undefined addEventListener(

--- a/components/shared/embedder/resources.rs
+++ b/components/shared/embedder/resources.rs
@@ -109,6 +109,8 @@ pub enum Resource {
     DirectoryListingHTML,
     /// A HTML page that is used for the about:memory url.
     AboutMemoryHTML,
+    /// RPC script for the Debugger API on behalf of devtools.
+    DebuggerJS,
 }
 
 impl Resource {
@@ -123,6 +125,7 @@ impl Resource {
             Resource::CrashHTML => "crash.html",
             Resource::DirectoryListingHTML => "directory-listing.html",
             Resource::AboutMemoryHTML => "about-memory.html",
+            Resource::DebuggerJS => "debugger.js",
         }
     }
 }
@@ -167,6 +170,7 @@ fn resources_for_tests() -> Box<dyn ResourceReaderMethods + Sync + Send> {
                 Resource::AboutMemoryHTML => {
                     &include_bytes!("../../../resources/about-memory.html")[..]
                 },
+                Resource::DebuggerJS => &include_bytes!("../../../resources/debugger.js")[..],
             }
             .to_owned()
         }

--- a/ports/servoshell/egl/android/resources.rs
+++ b/ports/servoshell/egl/android/resources.rs
@@ -33,6 +33,7 @@ impl ResourceReaderMethods for ResourceReaderInstance {
             Resource::AboutMemoryHTML => {
                 &include_bytes!("../../../../resources/about-memory.html")[..]
             },
+            Resource::DebuggerJS => &include_bytes!("../../../../resources/debugger.js")[..],
         })
     }
 

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -1,0 +1,3 @@
+if (!("dbg" in this)) {
+    dbg = new Debugger;
+}


### PR DESCRIPTION
to use the [SpiderMonkey Debugger API](https://firefox-source-docs.mozilla.org/js/Debugger/), we need to call it from an internal debugger script that we will supply. this script must run in the same runtime as the debuggee(s), but in a separate [compartment](https://udn.realityripple.com/docs/Mozilla/Projects/SpiderMonkey/Compartments) ([more details](https://hacks.mozilla.org/2020/03/future-proofing-firefoxs-javascript-debugger-implementation/)).

this patch defines a new DebuggerGlobalScope type and a new debugger script resource. when creating each script thread, we create a debugger global, load the debugger script from resources/debugger.js, and run that script in the global to initialise the Debugger API.

subsequent patches will use the debugger script as an RPC mechanism for the Debugger API.

Testing: no testable effects yet, but will be used in #37667
Fixes: part of #36027 