### PR TITLE
script: Add new Window globals as debuggees

### DIFF
--- a/components/script/dom/debuggerevent.rs
+++ b/components/script/dom/debuggerevent.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::default::Default;
 use std::ptr::NonNull;
 
 use dom_struct::dom_struct;
@@ -13,7 +12,7 @@ use script_bindings::reflector::DomObject;
 use crate::dom::bindings::codegen::Bindings::DebuggerEventBinding::DebuggerEventMethods;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::reflector::reflect_dom_object;
-use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::event::Event;
 use crate::dom::types::GlobalScope;
 use crate::script_runtime::CanGc;
@@ -22,7 +21,7 @@ use crate::script_runtime::CanGc;
 /// Event for Rust → JS calls in [`crate::dom::DebuggerGlobalScope`].
 pub(crate) struct DebuggerEvent {
     event: Event,
-    global: MutNullableDom<GlobalScope>,
+    global: Dom<GlobalScope>,
 }
 
 impl DebuggerEvent {
@@ -33,10 +32,8 @@ impl DebuggerEvent {
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
-            global: Default::default(),
+            global: Dom::from_ref(global),
         });
-        // TODO: make these fields not optional somehow?
-        result.global.set(Some(global));
 
         result.event.init_event("addDebuggee".into(), false, false);
 
@@ -51,8 +48,6 @@ impl DebuggerEventMethods<crate::DomTypeHolder> for DebuggerEvent {
         // into the active realm (debugger realm) so that it can be passed across compartments.
         rooted!(in(*cx) let mut result: Value);
         self.global
-            .get()
-            .expect("Guaranteed by new")
             .reflector()
             .safe_to_jsval(cx, result.handle_mut());
         NonNull::new(result.to_object()).unwrap()

--- a/components/script/dom/debuggerevent.rs
+++ b/components/script/dom/debuggerevent.rs
@@ -34,10 +34,10 @@ impl DebuggerEvent {
             event: Event::new_inherited(),
             global: Dom::from_ref(global),
         });
-
+        let result = reflect_dom_object(result, debugger_global, can_gc);
         result.event.init_event("addDebuggee".into(), false, false);
 
-        reflect_dom_object(result, debugger_global, can_gc)
+        result
     }
 }
 

--- a/components/script/dom/debuggerevent.rs
+++ b/components/script/dom/debuggerevent.rs
@@ -43,7 +43,7 @@ impl DebuggerEvent {
 
 impl DebuggerEventMethods<crate::DomTypeHolder> for DebuggerEvent {
     // check-tidy: no specs after this line
-    fn Global(&self, r#cx: script_bindings::script_runtime::JSContext) -> NonNull<JSObject> {
+    fn Global(&self, cx: script_bindings::script_runtime::JSContext) -> NonNull<JSObject> {
         // Convert the debuggee global’s reflector to a Value, wrapping it from its originating realm (debuggee realm)
         // into the active realm (debugger realm) so that it can be passed across compartments.
         rooted!(in(*cx) let mut result: Value);

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -124,9 +124,9 @@ impl DebuggerGlobalScope {
 
     #[allow(unsafe_code)]
     pub(crate) fn fire_add_debuggee(&self, can_gc: CanGc, global: &GlobalScope) {
-        let event = DomRoot::upcast::<Event>(DebuggerEvent::new(self.upcast(), global, can_gc));
         assert_eq!(
-            event.fire(self.upcast(), can_gc),
+            DomRoot::upcast::<Event>(DebuggerEvent::new(self.upcast(), global, can_gc))
+                .fire(self.upcast(), can_gc),
             EventStatus::NotCanceled,
             "Guaranteed by DebuggerEvent::new"
         );

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -122,7 +122,6 @@ impl DebuggerGlobalScope {
         }
     }
 
-    #[allow(unsafe_code)]
     pub(crate) fn fire_add_debuggee(&self, can_gc: CanGc, global: &GlobalScope) {
         assert_eq!(
             DomRoot::upcast::<Event>(DebuggerEvent::new(self.upcast(), global, can_gc))

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -24,7 +24,9 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::CustomTraceable;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
+use crate::dom::event::EventStatus;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::types::{DebuggerEvent, Event};
 #[cfg(feature = "testbinding")]
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
@@ -118,5 +120,15 @@ impl DebuggerGlobalScope {
             let ar = enter_realm(self);
             report_pending_exception(Self::get_cx(), true, InRealm::Entered(&ar), can_gc);
         }
+    }
+
+    #[allow(unsafe_code)]
+    pub(crate) fn fire_add_debuggee(&self, can_gc: CanGc, global: &GlobalScope) {
+        let event = DomRoot::upcast::<Event>(DebuggerEvent::new(self.upcast(), global, can_gc));
+        assert_eq!(
+            event.fire(self.upcast(), can_gc),
+            EventStatus::NotCanceled,
+            "Guaranteed by DebuggerEvent::new"
+        );
     }
 }

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -1105,7 +1105,7 @@ pub(crate) enum EventDefault {
     Handled,
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum EventStatus {
     Canceled,
     NotCanceled,

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -289,6 +289,7 @@ pub(crate) mod customevent;
 pub(crate) mod datatransfer;
 pub(crate) mod datatransferitem;
 pub(crate) mod datatransferitemlist;
+pub(crate) mod debuggerevent;
 pub(crate) mod debuggerglobalscope;
 pub(crate) mod dedicatedworkerglobalscope;
 pub(crate) mod defaultteereadrequest;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3449,6 +3449,8 @@ impl ScriptThread {
             incomplete.load_data.inherited_secure_context,
             incomplete.theme,
         );
+        self.debugger_global
+            .fire_add_debuggee(can_gc, window.upcast());
 
         let _realm = enter_realm(&*window);
 

--- a/components/script_bindings/webidls/DebuggerEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvent.webidl
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+[Exposed=DebuggerGlobalScope]
+interface DebuggerEvent : Event {
+    readonly attribute object global;
+};

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -1,3 +1,20 @@
 if (!("dbg" in this)) {
     dbg = new Debugger;
+
+    dbg.onNewGlobalObject = function(global) {
+        console.log("[debugger] onNewGlobalObject");
+        console.log(this, global);
+    };
+
+    dbg.onNewScript = function(script, global) {
+        console.log("[debugger] onNewScript");
+        console.log(this, script, global);
+    };
 }
+
+addEventListener("addDebuggee", event => {
+    const {global} = event;
+    console.log("[debugger] Adding debuggee");
+    dbg.addDebuggee(global);
+    console.log("[debugger] getDebuggees().length =", dbg.getDebuggees().length);
+});


### PR DESCRIPTION
to debug the scripts in a page with the [SpiderMonkey Debugger API](https://firefox-source-docs.mozilla.org/js/Debugger/), we need to pass the page’s global object to [Debugger.prototype.**addDebuggee()**](https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.html#adddebuggee-global). we could pick up the global via the [onNewGlobalObject() hook](https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.html#onnewglobalobject-global), but if our script system passes the global to the debugger script instead, we can later add details like the PipelineId that will help servo identify debuggees that the API is notifying us about (#38334).

this patch plumbs new Window globals from script into addDebuggee() via the debugger script. to call into the debugger script with structured input, we create a new DOM event type, DebuggerEvent, that the debugger script listens for as the “addDebuggee” event.

Testing: no testable effects yet, but will be used in #37667
Fixes: part of #36027