### PR TITLE
devtools: Create source actors from Debugger API notifications

### DIFF
--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -56,6 +56,9 @@ pub struct SourceActor {
     pub content: Option<String>,
     pub content_type: Option<String>,
 
+    // TODO: use it in #37667, then remove this allow
+    #[allow(unused)]
+    pub spidermonkey_id: u32,
     /// `introductionType` in SpiderMonkey `CompileOptionsWrapper`.
     pub introduction_type: String,
 }
@@ -96,6 +99,7 @@ impl SourceActor {
         url: ServoUrl,
         content: Option<String>,
         content_type: Option<String>,
+        spidermonkey_id: u32,
         introduction_type: String,
     ) -> SourceActor {
         SourceActor {
@@ -104,6 +108,7 @@ impl SourceActor {
             content,
             content_type,
             is_black_boxed: false,
+            spidermonkey_id,
             introduction_type,
         }
     }
@@ -114,6 +119,7 @@ impl SourceActor {
         url: ServoUrl,
         content: Option<String>,
         content_type: Option<String>,
+        spidermonkey_id: u32,
         introduction_type: String,
     ) -> &SourceActor {
         let source_actor_name = actors.new_name("source");
@@ -123,6 +129,7 @@ impl SourceActor {
             url,
             content,
             content_type,
+            spidermonkey_id,
             introduction_type,
         );
         actors.register(Box::new(source_actor));
@@ -160,6 +167,10 @@ impl Actor for SourceActor {
                 let reply = SourceContentReply {
                     from: self.name(),
                     content_type: self.content_type.clone(),
+                    // TODO: if needed, fetch the page again, in the same way as in the original request.
+                    // Fetch it from cache, even if the original request was non-idempotent (e.g. POST).
+                    // If we can’t fetch it from cache, we should probably give up, because with a real
+                    // fetch, the server could return a different response.
                     // TODO: do we want to wait instead of giving up immediately, in cases where the content could
                     // become available later (e.g. after a fetch)?
                     source: self

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -552,6 +552,7 @@ impl DevtoolsInstance {
             source_info.url,
             source_content,
             source_info.content_type,
+            source_info.spidermonkey_id,
             source_info.introduction_type,
         );
         let source_actor_name = source_actor.name.clone();

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -9,7 +9,7 @@ use std::thread::{self, JoinHandle};
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use constellation_traits::{WorkerGlobalScopeInit, WorkerScriptLoadOrigin};
 use crossbeam_channel::{Receiver, Sender, unbounded};
-use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, SourceInfo};
+use devtools_traits::DevtoolScriptControlMsg;
 use dom_struct::dom_struct;
 use headers::{HeaderMapExt, ReferrerPolicy as ReferrerPolicyHeader};
 use ipc_channel::ipc::IpcReceiver;
@@ -60,9 +60,7 @@ use crate::fetch::{CspViolationsProcessor, load_whole_resource};
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
 use crate::script_runtime::ScriptThreadEventCategory::WorkerEvent;
-use crate::script_runtime::{
-    CanGc, IntroductionType, JSContext as SafeJSContext, Runtime, ThreadSafeJSContext,
-};
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext, Runtime, ThreadSafeJSContext};
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
 use crate::task_source::{SendableTaskSource, TaskSourceName};
 
@@ -536,24 +534,6 @@ impl DedicatedWorkerGlobalScope {
                 ));
                 global_scope.set_https_state(metadata.https_state);
                 let source = String::from_utf8_lossy(&bytes);
-                if let Some(chan) = global_scope.devtools_chan() {
-                    let pipeline_id = global_scope.pipeline_id();
-                    let source_info = SourceInfo {
-                        url: metadata.final_url,
-                        introduction_type: IntroductionType::WORKER
-                            .to_str()
-                            .expect("Guaranteed by definition")
-                            .to_owned(),
-                        external: true, // Worker scripts are always external.
-                        worker_id: Some(global.upcast::<WorkerGlobalScope>().get_worker_id()),
-                        content: Some(source.to_string()),
-                        content_type: metadata.content_type.map(|c_type| c_type.0.to_string()),
-                    };
-                    let _ = chan.send(ScriptToDevtoolsControlMsg::CreateSourceActor(
-                        pipeline_id,
-                        source_info,
-                    ));
-                }
 
                 unsafe {
                     // Handle interrupt requests

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -1254,20 +1254,36 @@ pub(crate) use script_bindings::script_runtime::CanGc;
 // TODO: squish `scriptElement` <https://searchfox.org/mozilla-central/rev/202069c4c5113a1a9052d84fa4679d4c1b22113e/devtools/server/actors/source.js#199-201>
 pub(crate) struct IntroductionType;
 impl IntroductionType {
+    /// `introductionType` for code passed to `eval`.
+    pub const EVAL: &CStr = c"eval";
+    pub const EVAL_STR: &str = "eval";
+
     /// `introductionType` for code evaluated by debugger.
     /// This includes code run via the devtools repl, even if the thread is not paused.
     pub const DEBUGGER_EVAL: &CStr = c"debugger eval";
+    pub const DEBUGGER_EVAL_STR: &str = "debugger eval";
+
+    /// `introductionType` for code passed to the `Function` constructor.
+    pub const FUNCTION: &CStr = c"Function";
+    pub const FUNCTION_STR: &str = "Function";
 
     /// `introductionType` for code loaded by worklet.
     pub const WORKLET: &CStr = c"Worklet";
+    pub const WORKLET_STR: &str = "Worklet";
+
+    /// `introductionType` for code assigned to DOM elements’ event handler IDL attributes as a string.
+    pub const EVENT_HANDLER: &CStr = c"eventHandler";
+    pub const EVENT_HANDLER_STR: &str = "eventHandler";
 
     /// `introductionType` for code belonging to `<script src="file.js">` elements.
     /// This includes `<script type="module" src="...">`.
     pub const SRC_SCRIPT: &CStr = c"srcScript";
+    pub const SRC_SCRIPT_STR: &str = "srcScript";
 
     /// `introductionType` for code belonging to `<script>code;</script>` elements.
     /// This includes `<script type="module" src="...">`.
     pub const INLINE_SCRIPT: &CStr = c"inlineScript";
+    pub const INLINE_SCRIPT_STR: &str = "inlineScript";
 
     /// `introductionType` for code belonging to scripts that *would* be `"inlineScript"` except that they were not
     /// part of the initial file itself.
@@ -1275,18 +1291,24 @@ impl IntroductionType {
     /// - `document.write("<script>code;</script>")`
     /// - `var s = document.createElement("script"); s.text = "code";`
     pub const INJECTED_SCRIPT: &CStr = c"injectedScript";
+    pub const INJECTED_SCRIPT_STR: &str = "injectedScript";
 
     /// `introductionType` for code that was loaded indirectly by being imported by another script
     /// using ESM static or dynamic imports.
     pub const IMPORTED_MODULE: &CStr = c"importedModule";
+    pub const IMPORTED_MODULE_STR: &str = "importedModule";
 
     /// `introductionType` for code presented in `javascript:` URLs.
     pub const JAVASCRIPT_URL: &CStr = c"javascriptURL";
+    pub const JAVASCRIPT_URL_STR: &str = "javascriptURL";
 
     /// `introductionType` for code passed to `setTimeout`/`setInterval` as a string.
     pub const DOM_TIMER: &CStr = c"domTimer";
+    pub const DOM_TIMER_STR: &str = "domTimer";
 
     /// `introductionType` for web workers.
-    /// <https://searchfox.org/mozilla-central/rev/202069c4c5113a1a9052d84fa4679d4c1b22113e/devtools/docs/user/debugger-api/debugger.source/index.rst#96>
+    /// FIXME: only documented in older(?) devtools user docs
+    /// <https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.source/index.html>
     pub const WORKER: &CStr = c"Worker";
+    pub const WORKER_STR: &str = "Worker";
 }

--- a/components/script_bindings/webidls/DebuggerGlobalScope.webidl
+++ b/components/script_bindings/webidls/DebuggerGlobalScope.webidl
@@ -6,4 +6,20 @@
 // web pages.
 [Global=DebuggerGlobalScope, Exposed=DebuggerGlobalScope]
 interface DebuggerGlobalScope: GlobalScope {
+    undefined notifyNewSource(NotifyNewSource args);
+};
+
+dictionary NotifyNewSource {
+    required PipelineIdInit pipelineId;
+    required DOMString? workerId;
+    required unsigned long spidermonkeyId;
+    required DOMString url;
+    required DOMString? urlOverride;
+    required DOMString text;
+    required DOMString? introductionType;
+};
+
+dictionary PipelineIdInit {
+    required unsigned long namespaceId;
+    required unsigned long index;
 };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -602,8 +602,9 @@ impl fmt::Display for ShadowRootMode {
 pub struct SourceInfo {
     pub url: ServoUrl,
     pub introduction_type: String,
-    pub external: bool,
+    pub inline: bool,
     pub worker_id: Option<WorkerId>,
     pub content: Option<String>,
     pub content_type: Option<String>,
+    pub spidermonkey_id: u32,
 }

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -13,6 +13,7 @@ import logging
 from geckordp.actors.root import RootActor
 from geckordp.actors.descriptors.tab import TabActor
 from geckordp.actors.watcher import WatcherActor
+from geckordp.actors.web_console import WebConsoleActor
 from geckordp.actors.resources import Resources
 from geckordp.actors.events import Events
 from geckordp.rdp_client import RDPClient
@@ -35,6 +36,13 @@ LOG_REQUESTS = False
 class Source:
     introduction_type: str
     url: str
+
+
+@dataclass
+class Devtools:
+    client: RDPClient
+    watcher: WatcherActor
+    targets: list
 
 
 class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
@@ -71,8 +79,9 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
                         [
                             Source("srcScript", f"{self.base_urls[0]}/classic.js"),
                             Source("inlineScript", f"{self.base_urls[0]}/test.html"),
-                            Source("srcScript", f"{self.base_urls[1]}/classic.js"),
                             Source("inlineScript", f"{self.base_urls[0]}/test.html"),
+                            Source("srcScript", f"{self.base_urls[1]}/classic.js"),
+                            Source("importedModule", f"{self.base_urls[0]}/module.js"),
                         ]
                     ),
                     tuple([Source("Worker", f"{self.base_urls[0]}/classic_worker.js")]),
@@ -116,7 +125,6 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
 
     # Sources list for `introductionType` = `importedModule`
 
-    @unittest.expectedFailure
     def test_sources_list_with_static_import_module(self):
         self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))
         self.run_servoshell(url=f"{self.base_urls[0]}/test_sources_list_with_static_import_module.html")
@@ -135,7 +143,6 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
             ),
         )
 
-    @unittest.expectedFailure
     def test_sources_list_with_dynamic_import_module(self):
         self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))
         self.run_servoshell(url=f"{self.base_urls[0]}/test_sources_list_with_dynamic_import_module.html")
@@ -194,6 +201,324 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
                     ),
                 ]
             ),
+        )
+
+    # Sources list for `introductionType` set to values that require `displayURL` (`//# sourceURL`)
+
+    def test_sources_list_with_injected_script_write_and_display_url(self):
+        self.run_servoshell(
+            url='data:text/html,<script>document.write("<script>//%23 sourceURL=http://test</scr"+"ipt>")</script>'
+        )
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source(
+                                "inlineScript",
+                                'data:text/html,<script>document.write("<script>//%23 sourceURL=http://test</scr"+"ipt>")</script>',
+                            ),
+                            Source("injectedScript", "http://test/"),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    def test_sources_list_with_injected_script_write_but_no_display_url(self):
+        self.run_servoshell(url='data:text/html,<script>document.write("<script>1</scr"+"ipt>")</script>')
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source(
+                                "inlineScript",
+                                'data:text/html,<script>document.write("<script>1</scr"+"ipt>")</script>',
+                            ),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    def test_sources_list_with_injected_script_append_and_display_url(self):
+        script = 's=document.createElement("script");s.append("//%23 sourceURL=http://test");document.body.append(s)'
+        self.run_servoshell(url=f"data:text/html,<body><script>{script}</script>")
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source(
+                                "inlineScript",
+                                f"data:text/html,<body><script>{script}</script>",
+                            ),
+                            Source("injectedScript", "http://test/"),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    def test_sources_list_with_injected_script_append_but_no_display_url(self):
+        script = 's=document.createElement("script");s.append("1");document.body.append(s)'
+        self.run_servoshell(url=f"data:text/html,<body><script>{script}</script>")
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source(
+                                "inlineScript",
+                                f"data:text/html,<body><script>{script}</script>",
+                            ),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    def test_sources_list_with_eval_and_display_url(self):
+        self.run_servoshell(url='data:text/html,<script>eval("//%23 sourceURL=http://test")</script>')
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source(
+                                "inlineScript", 'data:text/html,<script>eval("//%23 sourceURL=http://test")</script>'
+                            ),
+                            Source("eval", "http://test/"),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    def test_sources_list_with_eval_but_no_display_url(self):
+        self.run_servoshell(url='data:text/html,<script>eval("1")</script>')
+        self.assert_sources_list(set([tuple([Source("inlineScript", 'data:text/html,<script>eval("1")</script>')])]))
+
+    def test_sources_list_with_debugger_eval_and_display_url(self):
+        self.run_servoshell(url="data:text/html,")
+        devtools = self._setup_devtools_client()
+        console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+        evaluation_result = Future()
+
+        async def on_evaluation_result(data: dict):
+            evaluation_result.set_result(data)
+
+        devtools.client.add_event_listener(console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation_result)
+        console.evaluate_js_async("//# sourceURL=http://test")
+        evaluation_result.result(1)
+        self.assert_sources_list(set([tuple([Source("debugger eval", "http://test/")])]))
+
+    def test_sources_list_with_debugger_eval_but_no_display_url(self):
+        self.run_servoshell(url="data:text/html,")
+        devtools = self._setup_devtools_client()
+        console = WebConsoleActor(devtools.client, devtools.targets[0]["consoleActor"])
+        evaluation_result = Future()
+
+        async def on_evaluation_result(data: dict):
+            evaluation_result.set_result(data)
+
+        devtools.client.add_event_listener(console.actor_id, Events.WebConsole.EVALUATION_RESULT, on_evaluation_result)
+        console.evaluate_js_async("1")
+        evaluation_result.result(1)
+        self.assert_sources_list(set([tuple([])]))
+
+    def test_sources_list_with_function_and_display_url(self):
+        self.run_servoshell(url='data:text/html,<script>new Function("//%23 sourceURL=http://test")</script>')
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source(
+                                "inlineScript",
+                                'data:text/html,<script>new Function("//%23 sourceURL=http://test")</script>',
+                            ),
+                            Source("Function", "http://test/"),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    def test_sources_list_with_function_but_no_display_url(self):
+        self.run_servoshell(url='data:text/html,<script>new Function("1")</script>')
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source("inlineScript", 'data:text/html,<script>new Function("1")</script>'),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    def test_sources_list_with_javascript_url_and_display_url(self):
+        # “1” prefix is a workaround for <https://github.com/servo/servo/issues/38547>
+        self.run_servoshell(
+            url='data:text/html,<a href="javascript:1//%23 sourceURL=http://test"></a><script>document.querySelector("a").click()</script>'
+        )
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source(
+                                "inlineScript",
+                                'data:text/html,<a href="javascript:1//%23 sourceURL=http://test"></a><script>document.querySelector("a").click()</script>',
+                            ),
+                            Source("javascriptURL", "http://test/"),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    def test_sources_list_with_javascript_url_but_no_display_url(self):
+        self.run_servoshell(url='data:text/html,<a href="javascript:1"></a>')
+        self.assert_sources_list(set([tuple([])]))
+
+    @unittest.expectedFailure
+    def test_sources_list_with_event_handler_and_display_url(self):
+        self.run_servoshell(url='data:text/html,<a onclick="//%23 sourceURL=http://test"></a>')
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source("eventHandler", "http://test/"),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    def test_sources_list_with_event_handler_but_no_display_url(self):
+        self.run_servoshell(url='data:text/html,<a onclick="1"></a>')
+        self.assert_sources_list(set([tuple([])]))
+
+    @unittest.expectedFailure
+    def test_sources_list_with_dom_timer_and_display_url(self):
+        self.run_servoshell(url='data:text/html,<script>setTimeout("//%23 sourceURL=http://test",0)</script>')
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source("domTimer", "http://test/"),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    @unittest.expectedFailure
+    def test_sources_list_with_dom_timer_but_no_display_url(self):
+        self.run_servoshell(url='data:text/html,<script>setTimeout("1",0)</script>')
+        self.assert_sources_list(set([tuple([])]))
+
+    # Sources list for scripts with `displayURL` (`//# sourceURL`), despite not being required by `introductionType`
+
+    def test_sources_list_with_inline_script_and_display_url(self):
+        self.run_servoshell(url="data:text/html,<script>//%23 sourceURL=http://test</script>")
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source("inlineScript", "http://test/"),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    # Extra test case for situation where `//# sourceURL` can’t be parsed with page url as base.
+    def test_sources_list_with_inline_script_but_invalid_display_url(self):
+        self.run_servoshell(url="data:text/html,<script>//%23 sourceURL=test</script>")
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source("inlineScript", "data:text/html,<script>//%23 sourceURL=test</script>"),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    def test_sources_list_with_inline_script_but_no_display_url(self):
+        self.run_servoshell(url="data:text/html,<script>1</script>")
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source("inlineScript", "data:text/html,<script>1</script>"),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    # Sources list for inline scripts in `<iframe srcdoc>`
+
+    @unittest.expectedFailure
+    def test_sources_list_with_iframe_srcdoc_and_display_url(self):
+        self.run_servoshell(url='data:text/html,<iframe srcdoc="<script>//%23 sourceURL=http://test</script>">')
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source("inlineScript", "http://test/"),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    @unittest.expectedFailure
+    def test_sources_list_with_iframe_srcdoc_but_no_display_url(self):
+        self.run_servoshell(url='data:text/html,<iframe srcdoc="<script>1</script>">')
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            # FIXME: it’s not really gonna be 0
+                            Source("inlineScript", "about:srcdoc#0"),
+                        ]
+                    )
+                ]
+            )
+        )
+
+    @unittest.expectedFailure
+    def test_sources_list_with_iframe_srcdoc_multiple_inline_scripts(self):
+        self.run_servoshell(
+            url='data:text/html,<iframe srcdoc="<script>//%23 sourceURL=http://test</script><script>2</script>">'
+        )
+        self.assert_sources_list(
+            set(
+                [
+                    tuple(
+                        [
+                            Source("inlineScript", "http://test/"),
+                            # FIXME: it’s not really gonna be 0
+                            Source("inlineScript", "about:srcdoc#0"),
+                        ]
+                    )
+                ]
+            )
         )
 
     # Source contents
@@ -320,7 +645,7 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         if self.base_urls is not None:
             self.base_urls = None
 
-    def _setup_devtools_client(self, expected_targets=1):
+    def _setup_devtools_client(self, *, expected_targets=1) -> Devtools:
         client = RDPClient()
         client.connect("127.0.0.1", 6080)
         root = RootActor(client)
@@ -355,11 +680,14 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         if result:
             raise result
 
-        return client, watcher, targets
+        return Devtools(client, watcher, targets)
 
-    def assert_sources_list(self, expected_sources_by_target: set[tuple[Source]]):
+    def assert_sources_list(
+        self, expected_sources_by_target: set[tuple[Source]], *, devtools: Optional[Devtools] = None
+    ):
         expected_targets = len(expected_sources_by_target)
-        client, watcher, targets = self._setup_devtools_client(expected_targets)
+        if devtools is None:
+            devtools = self._setup_devtools_client(expected_targets=expected_targets)
         done = Future()
         # NOTE: breaks if two targets have the same list of source urls.
         # This should really be a multiset, but Python does not have multisets.
@@ -379,22 +707,25 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
                     # Send the exception back so it can be raised.
                     done.set_result(e)
 
-        for target in targets:
-            client.add_event_listener(
+        for target in devtools.targets:
+            devtools.client.add_event_listener(
                 target["actor"],
                 Events.Watcher.RESOURCES_AVAILABLE_ARRAY,
                 on_source_resource,
             )
-        watcher.watch_resources([Resources.SOURCE])
+        devtools.watcher.watch_resources([Resources.SOURCE])
 
         result: Optional[Exception] = done.result(1)
         if result:
             raise result
         self.assertEqual(actual_sources_by_target, expected_sources_by_target)
-        client.disconnect()
+        devtools.client.disconnect()
 
-    def assert_source_content(self, expected_source: Source, expected_content: str):
-        client, watcher, targets = self._setup_devtools_client()
+    def assert_source_content(
+        self, expected_source: Source, expected_content: str, *, devtools: Optional[Devtools] = None
+    ):
+        if devtools is None:
+            devtools = self._setup_devtools_client()
 
         done = Future()
         source_actors = {}
@@ -410,13 +741,13 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
                 except Exception as e:
                     done.set_result(e)
 
-        for target in targets:
-            client.add_event_listener(
+        for target in devtools.targets:
+            devtools.client.add_event_listener(
                 target["actor"],
                 Events.Watcher.RESOURCES_AVAILABLE_ARRAY,
                 on_source_resource,
             )
-        watcher.watch_resources([Resources.SOURCE])
+        devtools.watcher.watch_resources([Resources.SOURCE])
 
         result: Optional[Exception] = done.result(1)
         if result:
@@ -426,11 +757,11 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn(expected_source, source_actors)
         source_actor = source_actors[expected_source]
 
-        response = client.send_receive({"to": source_actor, "type": "source"})
+        response = devtools.client.send_receive({"to": source_actor, "type": "source"})
 
         self.assertEqual(response["source"], expected_content)
 
-        client.disconnect()
+        devtools.client.disconnect()
 
     def get_test_path(self, path: str) -> str:
         return os.path.join(DevtoolsTests.script_path, os.path.join("devtools_tests", path))


### PR DESCRIPTION
currently our devtools impl creates source actors in script, when executing scripts in HTMLScriptElement or DedicatedWorkerGlobalScope. this approach is cumbersome, and it means that many pathways to running scripts are missed, such as imported ES modules.

with the [SpiderMonkey Debugger API](https://firefox-source-docs.mozilla.org/js/Debugger/), we can pick up all of the scripts and all of their sources without any extra code, as long as we tell it about every global we create (#38333, #38551). this patch adds a [Debugger#onNewScript() hook](https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.html#onnewscript-script-global) to the debugger script, which calls DebuggerGlobalScope#notifyNewSource() to notify our script system when a new script runs. if the source is relevant to the file tree in the Sources tab, script tells devtools to create a source actor.

Testing: adds several new automated devtools tests
Fixes: part of #36027