### PR TITLE
canvas: Use `create_similar_draw_target` for recreate

### DIFF
--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -632,7 +632,9 @@ impl<DrawTarget: GenericDrawTarget> CanvasData<DrawTarget> {
             .max(MIN_WR_IMAGE_SIZE);
 
         // Step 1. Clear canvas's bitmap to transparent black.
-        self.drawtarget = DrawTarget::new(Size2D::new(size.width, size.height).cast());
+        self.drawtarget = self
+            .drawtarget
+            .create_similar_draw_target(&Size2D::new(size.width, size.height).cast());
 
         self.update_image_rendering();
     }


### PR DESCRIPTION
`create_similar_draw_target` is more performant then creating completely new target (this creates new wgpu device in vello backend).

Testing: This change does not modify test results, but should increase performance.