### PR TITLE
layout: respect `image-rendering` on border images

### DIFF
--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -1501,8 +1501,8 @@ impl<'a> BuilderForBoxFragment<'a> {
 
                 width = size.width;
                 height = size.height;
-                let rendering = self.fragment.style.clone_image_rendering().to_webrender();
-                NinePatchBorderSource::Image(key, rendering)
+                let image_rendering = self.fragment.style.clone_image_rendering().to_webrender();
+                NinePatchBorderSource::Image(key, image_rendering)
             },
             Ok(ResolvedImage::Gradient(gradient)) => {
                 match gradient::build(&self.fragment.style, gradient, border_image_size, builder) {

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -42,8 +42,8 @@ use style_traits::{CSSPixel as StyloCSSPixel, DevicePixel as StyloDevicePixel};
 use webrender_api::units::{DeviceIntSize, DevicePixel, LayoutPixel, LayoutRect, LayoutSize};
 use webrender_api::{
     self as wr, BorderDetails, BoxShadowClipMode, BuiltDisplayList, ClipChainId, ClipMode,
-    CommonItemProperties, ComplexClipRegion, ImageRendering, NinePatchBorder,
-    NinePatchBorderSource, PropertyBinding, SpatialId, SpatialTreeItemKey, units,
+    CommonItemProperties, ComplexClipRegion, NinePatchBorder, NinePatchBorderSource,
+    PropertyBinding, SpatialId, SpatialTreeItemKey, units,
 };
 use wr::units::LayoutVector2D;
 
@@ -1501,7 +1501,8 @@ impl<'a> BuilderForBoxFragment<'a> {
 
                 width = size.width;
                 height = size.height;
-                NinePatchBorderSource::Image(key, ImageRendering::Auto)
+                let rendering = self.fragment.style.clone_image_rendering().to_webrender();
+                NinePatchBorderSource::Image(key, rendering)
             },
             Ok(ResolvedImage::Gradient(gradient)) => {
                 match gradient::build(&self.fragment.style, gradient, border_image_size, builder) {

--- a/tests/wpt/meta/css/css-backgrounds/border-image-repeat-round-003.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-image-repeat-round-003.html.ini
@@ -1,2 +1,0 @@
-[border-image-repeat-round-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/border-image-repeat-round-stretch-001.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-image-repeat-round-stretch-001.html.ini
@@ -1,2 +1,0 @@
-[border-image-repeat-round-stretch-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/border-image-repeat-stretch-round-001.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/border-image-repeat-stretch-round-001.html.ini
@@ -1,2 +1,0 @@
-[border-image-repeat-stretch-round-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-images/image-rendering-border-image.html.ini
+++ b/tests/wpt/meta/css/css-images/image-rendering-border-image.html.ini
@@ -1,2 +1,0 @@
-[image-rendering-border-image.html]
-  expected: FAIL


### PR DESCRIPTION
Properly passes `image-rendering` down to border images.

Testing: Covered by WPT tests.
