### PR TITLE
layout: Make `IndependentFormattingContext::contents` private (again)

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -69,10 +69,10 @@ impl<'dom> ModernContainerJob<'dom> {
                     BlockContainer::InlineFormattingContext(inline_formatting_context),
                 );
                 let info: &NodeAndStyleInfo = anonymous_info;
-                let formatting_context = IndependentFormattingContext {
-                    base: LayoutBoxBase::new(info.into(), info.style.clone()),
-                    contents: IndependentFormattingContextContents::Flow(block_formatting_context),
-                };
+                let formatting_context = IndependentFormattingContext::new(
+                    LayoutBoxBase::new(info.into(), info.style.clone()),
+                    IndependentFormattingContextContents::Flow(block_formatting_context),
+                );
 
                 Some(ModernItem {
                     kind: ModernItemKind::InFlow(formatting_context),

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -114,10 +114,7 @@ use webrender_api::FontInstanceKey;
 use xi_unicode::linebreak_property;
 
 use super::float::{Clear, PlacementAmongFloats};
-use super::{
-    CacheableLayoutResult, IndependentFloatOrAtomicLayoutResult,
-    IndependentFormattingContextContents,
-};
+use super::{CacheableLayoutResult, IndependentFloatOrAtomicLayoutResult};
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom_traversal::NodeAndStyleInfo;
@@ -2151,10 +2148,8 @@ impl IndependentFormattingContext {
         match self.style().clone_baseline_source() {
             BaselineSource::First => baselines.first,
             BaselineSource::Last => baselines.last,
-            BaselineSource::Auto => match &self.contents {
-                IndependentFormattingContextContents::Flow(_) => baselines.last,
-                _ => baselines.first,
-            },
+            BaselineSource::Auto if self.is_block_container() => baselines.last,
+            BaselineSource::Auto => baselines.first,
         }
     }
 

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -28,9 +28,7 @@ use crate::flow::float::{
     Clear, ContainingBlockPositionInfo, FloatBox, FloatSide, PlacementAmongFloats,
     SequentialLayoutState,
 };
-use crate::formatting_contexts::{
-    Baselines, IndependentFormattingContext, IndependentFormattingContextContents,
-};
+use crate::formatting_contexts::{Baselines, IndependentFormattingContext};
 use crate::fragment_tree::{
     BaseFragmentInfo, BlockLevelLayoutInfo, BoxFragment, CollapsedBlockMargins, CollapsedMargin,
     Fragment, FragmentFlags,

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -34,7 +34,9 @@ use crate::{
 #[derive(Debug, MallocSizeOf)]
 pub(crate) struct IndependentFormattingContext {
     pub base: LayoutBoxBase,
-    pub contents: IndependentFormattingContextContents,
+    // Private so that code outside of this module cannot match variants.
+    // It should go through methods instead.
+    contents: IndependentFormattingContextContents,
 }
 
 #[derive(Debug, MallocSizeOf)]
@@ -65,6 +67,10 @@ impl Baselines {
 }
 
 impl IndependentFormattingContext {
+    pub(crate) fn new(base: LayoutBoxBase, contents: IndependentFormattingContextContents) -> Self {
+        Self { base, contents }
+    }
+
     pub fn construct(
         context: &LayoutContext,
         node_and_style_info: &NodeAndStyleInfo,
@@ -137,13 +143,6 @@ impl IndependentFormattingContext {
                 }
             },
         }
-    }
-
-    pub fn is_replaced(&self) -> bool {
-        matches!(
-            self.contents,
-            IndependentFormattingContextContents::Replaced(_)
-        )
     }
 
     #[inline]
@@ -236,6 +235,19 @@ impl IndependentFormattingContext {
                 table.repair_style(context, new_style)
             },
         }
+    }
+
+    #[inline]
+    pub(crate) fn is_block_container(&self) -> bool {
+        matches!(self.contents, IndependentFormattingContextContents::Flow(_))
+    }
+
+    #[inline]
+    pub(crate) fn is_replaced(&self) -> bool {
+        matches!(
+            self.contents,
+            IndependentFormattingContextContents::Replaced(_)
+        )
     }
 
     #[inline]

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -118,10 +118,10 @@ impl Table {
         let mut table = table_builder.finish();
         table.anonymous = true;
 
-        let ifc = IndependentFormattingContext {
-            base: LayoutBoxBase::new((&table_info).into(), table_style),
-            contents: IndependentFormattingContextContents::Table(table),
-        };
+        let ifc = IndependentFormattingContext::new(
+            LayoutBoxBase::new((&table_info).into(), table_style),
+            IndependentFormattingContextContents::Table(table),
+        );
 
         (table_info, ifc)
     }
@@ -881,12 +881,9 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                                 false, /* is_list_item */
                             ),
                         );
-
+                        let base = LayoutBoxBase::new(info.into(), info.style.clone());
                         ArcRefCell::new(TableCaption {
-                            context: IndependentFormattingContext {
-                                base: LayoutBoxBase::new(info.into(), info.style.clone()),
-                                contents,
-                            },
+                            context: IndependentFormattingContext::new(base, contents),
                         })
                     });
 


### PR DESCRIPTION
This was done in #24871, but after some refactorings it became public. This makes it private again. As said in b2b3ea992c2f045a49d7264df18f5f85b2c913fb:

> Privacy forces the rest of the code to go through methods
> rather than matching on the enum,
> reducing accidental layout-mode-specific behavior.

It also avoids the risk of accidentally calling `layout()` on the inner layout-mode-specific struct, bypassing caching.

Testing: Not needed (no behavior change)
