### PR TITLE
build(deps): bump Stylo to servo/stylo#215

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7242,7 +7242,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.30.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#14c096bd61af12a7c9bd4e48d6696cc8b16feb8b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -7548,7 +7548,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#14c096bd61af12a7c9bd4e48d6696cc8b16feb8b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8010,7 +8010,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#14c096bd61af12a7c9bd4e48d6696cc8b16feb8b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8067,7 +8067,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#14c096bd61af12a7c9bd4e48d6696cc8b16feb8b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8076,12 +8076,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#14c096bd61af12a7c9bd4e48d6696cc8b16feb8b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 
 [[package]]
 name = "stylo_derive"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#14c096bd61af12a7c9bd4e48d6696cc8b16feb8b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8093,7 +8093,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#14c096bd61af12a7c9bd4e48d6696cc8b16feb8b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -8102,7 +8102,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#14c096bd61af12a7c9bd4e48d6696cc8b16feb8b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8119,12 +8119,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#14c096bd61af12a7c9bd4e48d6696cc8b16feb8b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 
 [[package]]
 name = "stylo_traits"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#14c096bd61af12a7c9bd4e48d6696cc8b16feb8b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -8539,7 +8539,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#14c096bd61af12a7c9bd4e48d6696cc8b16feb8b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8552,7 +8552,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#14c096bd61af12a7c9bd4e48d6696cc8b16feb8b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
Bumps Stylo to "Vendor markupsafe; Add macOS and Windows CI jobs".

Testing: Not needed (no behavior change).
