### PR TITLE
canvas: Clear vello scene if possible

### DIFF
--- a/components/canvas/vello_backend.rs
+++ b/components/canvas/vello_backend.rs
@@ -180,8 +180,8 @@ impl VelloDrawTarget {
             // clip makes no visible side effects
             return false;
         };
-        transformed_rect.cast().contains_rect(&viewport) // whole viewport is cleared
-        && clip.contains_rect(&viewport) // viewport is not clipped
+        transformed_rect.cast().contains_rect(&viewport) && // whole viewport is cleared
+            clip.contains_rect(&viewport) // viewport is not clipped
     }
 }
 

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -117,7 +117,7 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
     }
 
     fn clear_rect(&mut self, rect: &Rect<f32>, transform: Transform2D<f32>) {
-        // vello scene only ever grows,
+        // vello_cpu RenderingContext only ever grows,
         // so we need to use every opportunity to shrink it
         if self.is_viewport_cleared(rect, transform) {
             self.ctx.reset();

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -99,8 +99,8 @@ impl VelloCPUDrawTarget {
             // clip makes no visible side effects
             return false;
         };
-        transformed_rect.cast().contains_rect(&viewport) // whole viewport is cleared
-        && clip.contains_rect(&viewport) // viewport is not clipped
+        transformed_rect.cast().contains_rect(&viewport) && // whole viewport is cleared
+            clip.contains_rect(&viewport) // viewport is not clipped
     }
 }
 

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -86,6 +86,22 @@ impl VelloCPUDrawTarget {
     fn size(&self) -> Size2D<u32> {
         Size2D::new(self.ctx.width(), self.ctx.height()).cast()
     }
+
+    fn is_viewport_cleared(&mut self, rect: &Rect<f32>, transform: Transform2D<f32>) -> bool {
+        let transformed_rect = transform.outer_transformed_rect(rect);
+        if transformed_rect.is_empty() {
+            return false;
+        }
+        let viewport: Rect<f64> = Rect::from_size(self.get_size().cast());
+        let Some(clip) = self.clips.iter().try_fold(viewport, |acc, e| {
+            acc.intersection(&e.0.bounding_box().into())
+        }) else {
+            // clip makes no visible side effects
+            return false;
+        };
+        transformed_rect.cast().contains_rect(&viewport) // whole viewport is cleared
+        && clip.contains_rect(&viewport) // viewport is not clipped
+    }
 }
 
 impl GenericDrawTarget for VelloCPUDrawTarget {
@@ -101,6 +117,13 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
     }
 
     fn clear_rect(&mut self, rect: &Rect<f32>, transform: Transform2D<f32>) {
+        // vello scene only ever grows,
+        // so we need to use every opportunity to shrink it
+        if self.is_viewport_cleared(rect, transform) {
+            self.ctx.reset();
+            self.clips.clear(); // no clips are affecting rendering
+            return;
+        }
         let rect: kurbo::Rect = rect.cast().into();
         let mut clip_path = rect.to_path(0.1);
         clip_path.apply_affine(transform.cast().into());

--- a/tests/wpt/meta/html/canvas/element/path-objects/2d.path.clip.winding.evenodd.1.html.ini
+++ b/tests/wpt/meta/html/canvas/element/path-objects/2d.path.clip.winding.evenodd.1.html.ini
@@ -1,0 +1,4 @@
+[2d.path.clip.winding.evenodd.1.html]
+  [evenodd winding number rule works in clip]
+    expected:
+      if subsuite == "vello_canvas": FAIL

--- a/tests/wpt/meta/html/canvas/element/path-objects/2d.path.clip.winding.evenodd.2.html.ini
+++ b/tests/wpt/meta/html/canvas/element/path-objects/2d.path.clip.winding.evenodd.2.html.ini
@@ -1,0 +1,4 @@
+[2d.path.clip.winding.evenodd.2.html]
+  [evenodd winding number rule works in clip]
+    expected:
+      if subsuite == "vello_canvas": FAIL

--- a/tests/wpt/meta/html/canvas/element/pixel-manipulation/2d.imageData.put.clip.html.ini
+++ b/tests/wpt/meta/html/canvas/element/pixel-manipulation/2d.imageData.put.clip.html.ini
@@ -1,5 +1,0 @@
-[2d.imageData.put.clip.html]
-  [putImageData() is not affected by clipping regions]
-    bug: https://github.com/linebender/vello/issues/1088
-    expected:
-      if subsuite == "vello_canvas": FAIL

--- a/tests/wpt/meta/html/canvas/element/pixel-manipulation/2d.imageData.put.unchanged.html.ini
+++ b/tests/wpt/meta/html/canvas/element/pixel-manipulation/2d.imageData.put.unchanged.html.ini
@@ -1,3 +1,5 @@
 [2d.imageData.put.unchanged.html]
   [putImageData(getImageData(...), ...) has no effect]
-    expected: FAIL
+    expected:
+      if subsuite == "": FAIL
+      if subsuite == "vello_cpu": FAIL


### PR DESCRIPTION
Vello scene only ever grows, so we need to clear it as soon as it's possible (in clear rect). This PR also adds ignore_clips to vello_backend (already exists in vello_cpu_backend).

Testing: Behavior is verified by existing tests, as this is mainly a change for performance. There are currently no performance tests. This makes bunnymark actually playable (from 3 FPS to 20 FPS on vello_cpu).
