### PR TITLE
Implement webdriver extract script arguments

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2388,6 +2388,22 @@ impl ScriptThread {
                     can_gc,
                 )
             },
+            WebDriverScriptCommand::GetKnownElement(element_id, reply) => {
+                webdriver_handlers::handle_get_known_element(
+                    &documents,
+                    pipeline_id,
+                    element_id,
+                    reply,
+                )
+            },
+            WebDriverScriptCommand::GetKnownShadowRoot(element_id, reply) => {
+                webdriver_handlers::handle_get_known_shadow_root(
+                    &documents,
+                    pipeline_id,
+                    element_id,
+                    reply,
+                )
+            },
             WebDriverScriptCommand::GetActiveElement(reply) => {
                 webdriver_handlers::handle_get_active_element(&documents, pipeline_id, reply)
             },

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -122,6 +122,18 @@ fn is_disabled(element: &Element) -> bool {
     element.is_actually_disabled()
 }
 
+pub(crate) fn handle_get_known_shadow_root(
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    shadow_root_id: String,
+    reply: IpcSender<Result<(), ErrorStatus>>,
+) {
+    let result = get_known_shadow_root(documents, pipeline, shadow_root_id).map(|_| ());
+    if reply.send(result).is_err() {
+        error!("Webdriver get known shadow root reply failed");
+    }
+}
+
 /// <https://w3c.github.io/webdriver/#dfn-get-a-known-shadow-root>
 fn get_known_shadow_root(
     documents: &DocumentCollection,
@@ -168,6 +180,18 @@ fn get_known_shadow_root(
     }
     // Step 5. Return success with data node.
     Ok(shadow_root)
+}
+
+pub(crate) fn handle_get_known_element(
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    element_id: String,
+    reply: IpcSender<Result<(), ErrorStatus>>,
+) {
+    let result = get_known_element(documents, pipeline, element_id).map(|_| ());
+    if reply.send(result).is_err() {
+        error!("Webdriver get known element reply failed");
+    }
 }
 
 /// <https://w3c.github.io/webdriver/#dfn-get-a-known-element>

--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -152,7 +152,7 @@ partial interface Window {
   undefined webdriverTimeout();
   Element? webdriverElement(DOMString id);
   Element? webdriverFrame(DOMString id);
-  Window? webdriverWindow(DOMString id);
+  WindowProxy? webdriverWindow(DOMString id);
   ShadowRoot? webdriverShadowRoot(DOMString id);
 };
 

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -210,6 +210,8 @@ pub enum WebDriverScriptCommand {
     FindShadowElementsXPathSelector(String, String, IpcSender<Result<Vec<String>, ErrorStatus>>),
     GetElementShadowRoot(String, IpcSender<Result<Option<String>, ErrorStatus>>),
     ElementClick(String, IpcSender<Result<Option<String>, ErrorStatus>>),
+    GetKnownElement(String, IpcSender<Result<(), ErrorStatus>>),
+    GetKnownShadowRoot(String, IpcSender<Result<(), ErrorStatus>>),
     GetActiveElement(IpcSender<Option<String>>),
     GetComputedRole(String, IpcSender<Result<Option<String>, ErrorStatus>>),
     GetCookie(

--- a/components/webdriver_server/elements.rs
+++ b/components/webdriver_server/elements.rs
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use embedder_traits::{WebDriverCommandMsg, WebDriverScriptCommand};
+use ipc_channel::ipc;
+use serde_json::Value;
+use webdriver::command::JavascriptCommandParameters;
+use webdriver::error::{ErrorStatus, WebDriverError, WebDriverResult};
+
+use crate::{Handler, wait_for_script_response};
+
+/// <https://w3c.github.io/webdriver/#dfn-web-element-identifier>
+const ELEMENT_IDENTIFIER: &str = "element-6066-11e4-a52e-4f735466cecf";
+/// <https://w3c.github.io/webdriver/#dfn-web-frame-identifier>
+const FRAME_IDENTIFIER: &str = "frame-075b-4da1-b6ba-e579c2d3230a";
+/// <https://w3c.github.io/webdriver/#dfn-web-window-identifier>
+const WINDOW_IDENTIFIER: &str = "window-fcc6-11e5-b4f8-330a88ab9d7f";
+/// <https://w3c.github.io/webdriver/#dfn-shadow-root-identifier>
+const SHADOW_ROOT_IDENTIFIER: &str = "shadow-6066-11e4-a52e-4f735466cecf";
+
+impl Handler {
+    /// <https://w3c.github.io/webdriver/#dfn-extract-the-script-arguments-from-a-request>
+    pub(crate) fn extract_script_arguments(
+        &self,
+        parameters: JavascriptCommandParameters,
+    ) -> WebDriverResult<(String, Vec<String>)> {
+        // Step 1. Let script be the result of getting a property named "script" from parameters
+        // Step 2. (Skip) If script is not a String, return error with error code invalid argument.
+        let script = parameters.script;
+
+        // Step 3. Let args be the result of getting a property named "args" from parameters.
+        // Step 4. (Skip) If args is not an Array return error with error code invalid argument.
+        let args: Vec<String> = parameters
+            .args
+            .as_deref()
+            .unwrap_or(&[])
+            .iter()
+            .map(|value| self.webdriver_value_to_js_argument(value))
+            .collect::<WebDriverResult<Vec<_>>>()?;
+
+        Ok((script, args))
+    }
+
+    /// <https://w3c.github.io/webdriver/#dfn-deserialize-a-web-element>
+    pub(crate) fn deserialize_web_element(&self, element: &Value) -> WebDriverResult<String> {
+        // Step 2. Let reference be the result of getting the web element identifier property from object.
+        let element_ref: String = match element {
+            Value::String(s) => s.clone(),
+            _ => element.to_string(),
+        };
+
+        // Step 3. Let element be the result of trying to get a known element with session and reference.
+        let browsing_context_id = self.session()?.browsing_context_id;
+        let (sender, receiver) = ipc::channel().unwrap();
+        self.send_message_to_embedder(WebDriverCommandMsg::ScriptCommand(
+            browsing_context_id,
+            WebDriverScriptCommand::GetKnownElement(element_ref.clone(), sender),
+        ))?;
+
+        match wait_for_script_response(receiver)? {
+            // Step 4. Return success with data element.
+            Ok(_) => Ok(format!("window.webdriverElement(\"{}\")", element_ref)),
+            Err(_) => Err(WebDriverError::new(
+                ErrorStatus::NoSuchElement,
+                "No such element",
+            )),
+        }
+    }
+
+    /// <https://w3c.github.io/webdriver/#dfn-deserialize-a-shadow-root>
+    pub(crate) fn deserialize_shadow_root(&self, shadow_root: &Value) -> WebDriverResult<String> {
+        // Step 2. Let reference be the result of getting the shadow root identifier property from object.
+        let shadow_root_ref = match shadow_root {
+            Value::String(s) => s.clone(),
+            _ => shadow_root.to_string(),
+        };
+
+        // Step 3. Let element be the result of trying to get a known element with session and reference.
+        let browsing_context_id = self.session()?.browsing_context_id;
+        let (sender, receiver) = ipc::channel().unwrap();
+        self.send_message_to_embedder(WebDriverCommandMsg::ScriptCommand(
+            browsing_context_id,
+            WebDriverScriptCommand::GetKnownShadowRoot(shadow_root_ref.clone(), sender),
+        ))?;
+
+        match wait_for_script_response(receiver)? {
+            // Step 4. Return success with data element.
+            Ok(_) => Ok(format!(
+                "window.webdriverShadowRoot(\"{}\")",
+                shadow_root_ref
+            )),
+            Err(_) => Err(WebDriverError::new(
+                ErrorStatus::NoSuchShadowRoot,
+                "No such shadow root",
+            )),
+        }
+    }
+
+    /// This function is equivalent to step 5 of
+    /// <https://w3c.github.io/webdriver/#dfn-extract-the-script-arguments-from-a-request>
+    fn webdriver_value_to_js_argument(&self, v: &Value) -> WebDriverResult<String> {
+        let res = match v {
+            Value::String(s) => format!("\"{}\"", s),
+            Value::Null => "null".to_string(),
+            Value::Bool(b) => b.to_string(),
+            Value::Number(n) => n.to_string(),
+            Value::Array(list) => {
+                let elems = list
+                    .iter()
+                    .map(|v| self.webdriver_value_to_js_argument(v))
+                    .collect::<WebDriverResult<Vec<_>>>()?;
+                format!("[{}]", elems.join(", "))
+            },
+            Value::Object(map) => {
+                let key = map.keys().next().map(String::as_str);
+                match (key, map.values().next()) {
+                    (Some(ELEMENT_IDENTIFIER), Some(id)) => {
+                        return self.deserialize_web_element(id);
+                    },
+                    (Some(FRAME_IDENTIFIER), Some(id)) => {
+                        return Ok(format!("window.webdriverFrame(\"{}\")", id));
+                    },
+                    (Some(WINDOW_IDENTIFIER), Some(id)) => {
+                        return Ok(format!("window.webdriverWindow(\"{}\")", id));
+                    },
+                    (Some(SHADOW_ROOT_IDENTIFIER), Some(id)) => {
+                        return self.deserialize_shadow_root(id);
+                    },
+                    _ => {},
+                }
+                let elems = map
+                    .iter()
+                    .map(|(k, v)| {
+                        let arg = self.webdriver_value_to_js_argument(v)?;
+                        Ok(format!("{}: {}", k, arg))
+                    })
+                    .collect::<WebDriverResult<Vec<String>>>()?;
+                format!("{{{}}}", elems.join(", "))
+            },
+        };
+
+        Ok(res)
+    }
+}

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1977,6 +1977,7 @@ impl Handler {
             args_string.join(", ")
         );
         debug!("{}", script);
+        dbg!("Run script: {}", &script);
 
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::ExecuteScript(script, sender);
@@ -2434,6 +2435,7 @@ impl WebDriverHandler<ServoExtensionRoute> for Handler {
         msg: WebDriverMessage<ServoExtensionRoute>,
     ) -> WebDriverResult<WebDriverResponse> {
         info!("{:?}", msg.command);
+        dbg!("WebDriver command: {:?}", &msg.command);
 
         // Unless we are trying to create a new session, we need to ensure that a
         // session has previously been created

--- a/tests/wpt/meta/webdriver/tests/classic/execute_async_script/arguments.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_async_script/arguments.py.ini
@@ -37,6 +37,3 @@
 
   [test_element_reference[shadow-root\]]
     expected: FAIL
-
-  [test_element_reference[window\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/execute_async_script/arguments.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_async_script/arguments.py.ini
@@ -1,16 +1,4 @@
 [arguments.py]
-  [test_no_such_element_from_other_frame[closed\]]
-    expected: FAIL
-
-  [test_no_such_shadow_root_from_other_frame[closed\]]
-    expected: FAIL
-
-  [test_stale_element_reference[top_context\]]
-    expected: FAIL
-
-  [test_stale_element_reference[child_context\]]
-    expected: FAIL
-
   [test_invalid_argument_for_window_with_invalid_type[None-frame\]]
     expected: FAIL
 
@@ -51,7 +39,4 @@
     expected: FAIL
 
   [test_element_reference[window\]]
-    expected: FAIL
-
-  [test_element_reference[node\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/execute_async_script/arguments.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_async_script/arguments.py.ini
@@ -1,29 +1,5 @@
 [arguments.py]
-  [test_no_such_element_with_unknown_id]
-    expected: FAIL
-
-  [test_no_such_element_from_other_window_handle[open\]]
-    expected: FAIL
-
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL
-
-  [test_no_such_element_from_other_frame[open\]]
-    expected: FAIL
-
   [test_no_such_element_from_other_frame[closed\]]
-    expected: FAIL
-
-  [test_no_such_shadow_root_with_unknown_id]
-    expected: FAIL
-
-  [test_no_such_shadow_root_from_other_window_handle[open\]]
-    expected: FAIL
-
-  [test_no_such_shadow_root_from_other_window_handle[closed\]]
-    expected: FAIL
-
-  [test_no_such_shadow_root_from_other_frame[open\]]
     expected: FAIL
 
   [test_no_such_shadow_root_from_other_frame[closed\]]
@@ -75,4 +51,7 @@
     expected: FAIL
 
   [test_element_reference[window\]]
+    expected: FAIL
+
+  [test_element_reference[node\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/execute_async_script/collections.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_async_script/collections.py.ini
@@ -4,6 +4,3 @@
 
   [test_html_all_collection]
     expected: FAIL
-
-  [test_dom_token_list]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/execute_async_script/collections.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_async_script/collections.py.ini
@@ -4,3 +4,6 @@
 
   [test_html_all_collection]
     expected: FAIL
+
+  [test_dom_token_list]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/arguments.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/arguments.py.ini
@@ -37,6 +37,3 @@
 
   [test_element_reference[shadow-root\]]
     expected: FAIL
-
-  [test_element_reference[window\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/arguments.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/arguments.py.ini
@@ -1,16 +1,4 @@
 [arguments.py]
-  [test_detached_shadow_root_reference[top_context\]]
-    expected: FAIL
-
-  [test_detached_shadow_root_reference[child_context\]]
-    expected: FAIL
-
-  [test_stale_element_reference[top_context\]]
-    expected: FAIL
-
-  [test_stale_element_reference[child_context\]]
-    expected: FAIL
-
   [test_invalid_argument_for_window_with_invalid_type[None-frame\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/arguments.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/arguments.py.ini
@@ -1,34 +1,4 @@
 [arguments.py]
-  [test_no_such_element_with_unknown_id]
-    expected: FAIL
-
-  [test_no_such_element_from_other_window_handle[open\]]
-    expected: FAIL
-
-  [test_no_such_element_from_other_window_handle[closed\]]
-    expected: FAIL
-
-  [test_no_such_element_from_other_frame[open\]]
-    expected: FAIL
-
-  [test_no_such_element_from_other_frame[closed\]]
-    expected: FAIL
-
-  [test_no_such_shadow_root_with_unknown_id]
-    expected: FAIL
-
-  [test_no_such_shadow_root_from_other_window_handle[open\]]
-    expected: FAIL
-
-  [test_no_such_shadow_root_from_other_window_handle[closed\]]
-    expected: FAIL
-
-  [test_no_such_shadow_root_from_other_frame[open\]]
-    expected: FAIL
-
-  [test_no_such_shadow_root_from_other_frame[closed\]]
-    expected: FAIL
-
   [test_detached_shadow_root_reference[top_context\]]
     expected: FAIL
 


### PR DESCRIPTION
Fix script parsing step.
Implement webdriver `extract script arguments`.
Implement `deserialize_web_element` and `deserialize_shadow_root` from script command argument.

Testing:
`/tests/wpt/tests/webdriver/tests/classic/execute_script/`
`/tests/wpt/tests/webdriver/tests/classic/execute_async_script/`

cc: @xiaochengh 
