### PR TITLE
ci: Automatically cancel bootstrap step after 1 hour in wpt linux/mach

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -42,6 +42,7 @@ jobs:
   linux-wpt:
     name: WPT
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     needs: chunks
     strategy:
       fail-fast: false

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -42,7 +42,6 @@ jobs:
   linux-wpt:
     name: WPT
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
     needs: chunks
     strategy:
       fail-fast: false
@@ -66,6 +65,7 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-python
       - name: Bootstrap dependencies
+        timeout-minutes: 30
         run: |
           sudo apt update
           sudo apt install -qy --no-install-recommends mesa-vulkan-drivers fonts-noto-cjk

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-python
       - name: Bootstrap dependencies
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           sudo apt update
           sudo apt install -qy --no-install-recommends mesa-vulkan-drivers fonts-noto-cjk

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -19,6 +19,7 @@ jobs:
   mac-wpt:
     name: WPT
     runs-on: macos-13
+    timeout-minutes: 60
     env:
       max_chunk_id: 5
     strategy:

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-python
       - name: Prep test environment
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           gtar -xzf target.tar.gz
           ./mach bootstrap --skip-lints

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -19,7 +19,6 @@ jobs:
   mac-wpt:
     name: WPT
     runs-on: macos-13
-    timeout-minutes: 60
     env:
       max_chunk_id: 5
     strategy:
@@ -41,6 +40,7 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-python
       - name: Prep test environment
+        timeout-minutes: 30
         run: |
           gtar -xzf target.tar.gz
           ./mach bootstrap --skip-lints


### PR DESCRIPTION
Introduces a timeout for each WPT run chunk job, set to 1 hour, after which it will be automatically canceled.

Testing: 
Fixes: #38348
