### PR TITLE
ci: Automatically cancel parallel workflow on pr

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ on:
     types: [checks_requested]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   decision:
     name: Generate Try Configuration


### PR DESCRIPTION
This cancels any old workflow still running when a new commit is pushed to the PR, using concurrency control based on this [docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-using-a-fallback-value).

> The following concurrency group cancels in-progress jobs or runs on pull_request events only; if github.head_ref is undefined, the concurrency group will fallback to the run ID, which is guaranteed to be both unique and defined for the run.

Testing: I have test the second scenario on my repo [here](https://github.com/jerensl/servo/pull/14)