### PR TITLE
script: Tell SpiderMonkey whether scripts are inline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5240,7 +5240,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#b6d7bce2bc165fb555ce3f254404aecc89627388"
+source = "git+https://github.com/servo/mozjs#eb4268a973f2334a18f97be0c6def8b1a7143431"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -5252,7 +5252,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.128.13-3"
-source = "git+https://github.com/servo/mozjs#b6d7bce2bc165fb555ce3f254404aecc89627388"
+source = "git+https://github.com/servo/mozjs#eb4268a973f2334a18f97be0c6def8b1a7143431"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5240,7 +5240,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#903a158b36c10902a40c7fda766406d698f98bf4"
+source = "git+https://github.com/servo/mozjs#b6d7bce2bc165fb555ce3f254404aecc89627388"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -5252,7 +5252,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.128.13-3"
-source = "git+https://github.com/servo/mozjs#903a158b36c10902a40c7fda766406d698f98bf4"
+source = "git+https://github.com/servo/mozjs#b6d7bce2bc165fb555ce3f254404aecc89627388"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -65,6 +65,7 @@ pub(crate) fn handle_evaluate_js(
             ScriptFetchOptions::default_classic_script(global),
             global.api_base_url(),
             can_gc,
+            None,
         );
 
         if rval.is_undefined() {

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -81,7 +81,7 @@ use crate::script_module::{
     ImportMap, ModuleOwner, ScriptFetchOptions, fetch_external_module_script,
     fetch_inline_module_script, parse_an_import_map_string, register_import_map,
 };
-use crate::script_runtime::CanGc;
+use crate::script_runtime::{CanGc, IntroductionType};
 use crate::task_source::{SendableTaskSource, TaskSourceName};
 use crate::unminify::{ScriptSource, unminify_js};
 
@@ -1146,7 +1146,7 @@ impl HTMLScriptElement {
         // Step 6.
         let document = self.owner_document();
         let old_script = document.GetCurrentScript();
-        let introduction_type = (!script.external).then_some(c"inlineScript");
+        let introduction_type = (!script.external).then_some(IntroductionType::INLINE_SCRIPT);
 
         match script.type_ {
             ScriptType::Classic => {

--- a/components/script/dom/userscripts.rs
+++ b/components/script/dom/userscripts.rs
@@ -39,6 +39,7 @@ pub(crate) fn load_script(head: &HTMLHeadElement) {
                 ScriptFetchOptions::default_classic_script(global_scope),
                 global_scope.api_base_url(),
                 CanGc::note(),
+                None,
             );
         }
     }));

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -427,12 +427,17 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
                 Ok((metadata, bytes)) => (metadata.final_url, String::from_utf8(bytes).unwrap()),
             };
 
+            let options = self
+                .runtime
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .new_compile_options(url.as_str(), 1);
             let result = self.runtime.borrow().as_ref().unwrap().evaluate_script(
                 self.reflector().get_jsobject(),
                 &source,
-                url.as_str(),
-                1,
                 rval.handle_mut(),
+                options,
             );
 
             maybe_resume_unwind();
@@ -639,12 +644,17 @@ impl WorkerGlobalScope {
         let _aes = AutoEntryScript::new(self.upcast());
         let cx = self.runtime.borrow().as_ref().unwrap().cx();
         rooted!(in(cx) let mut rval = UndefinedValue());
+        let options = self
+            .runtime
+            .borrow()
+            .as_ref()
+            .unwrap()
+            .new_compile_options(self.worker_url.borrow().as_str(), 1);
         match self.runtime.borrow().as_ref().unwrap().evaluate_script(
             self.reflector().get_jsobject(),
             &source,
-            self.worker_url.borrow().as_str(),
-            1,
             rval.handle_mut(),
+            options,
         ) {
             Ok(_) => (),
             Err(_) => {

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -78,7 +78,7 @@ use crate::dom::window::Window;
 use crate::dom::worker::TrustedWorkerAddress;
 use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_runtime::{CanGc, IntroductionType, JSContext as SafeJSContext};
 use crate::task::TaskBox;
 
 fn gen_type_error(global: &GlobalScope, string: String, can_gc: CanGc) -> RethrowError {
@@ -1901,7 +1901,7 @@ pub(crate) fn fetch_inline_module_script(
         compiled_module.handle_mut(),
         true,
         can_gc,
-        Some(c"inlineScript"),
+        Some(IntroductionType::INLINE_SCRIPT),
     );
 
     match compiled_module_result {

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -9,7 +9,7 @@
 
 use core::ffi::c_char;
 use std::cell::Cell;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::io::{Write, stdout};
 use std::ops::Deref;
 use std::os::raw::c_void;
@@ -1194,3 +1194,9 @@ impl Runnable {
 }
 
 pub(crate) use script_bindings::script_runtime::CanGc;
+
+/// `introductionType` values in SpiderMonkey TransitiveCompileOptions.
+pub(crate) struct IntroductionType;
+impl IntroductionType {
+    pub const INLINE_SCRIPT: &'static CStr = c"inlineScript";
+}


### PR DESCRIPTION
to use the [SpiderMonkey Debugger API](https://firefox-source-docs.mozilla.org/js/Debugger/) as the single source of truth about scripts and their sources for devtools purposes (servo/servo#38334), the debugger script needs to be able to distinguish inline scripts from other scripts, because inline scripts are a special case where the source contents need to come from the Servo parser.

the mechanism for this is [Debugger.Script.prototype.**introductionType**](https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Source.html#introductiontype), which is `inlineScript` for inline scripts or a variety of other values for other kinds of scripts, but only the embedder can provide this information.

this patch bumps mozjs to servo/mozjs#603, which expands on CompileOptionsWrapper, making it a safe wrapper around CompileOptions. to construct one from safe code, use Runtime::new_compile_options(). then you can call `set_introduction_type(&'static CStr)` on the new instance. we also make Runtime::evaluate_script() take a CompileOptionsWrapper from the caller, instead of constructing one internally.

in this patch, we set the introductionType to `c"inlineScript"` when calling run_a_classic_script() and compile_module_script() for inline scripts, and leave it unset all other cases.

Testing: will undergo automated tests in #38334
Fixes: part of #36027, part of servo/servo#38378
