### PR TITLE
servoshell: make the color picker and select picker closeable

### DIFF
--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -540,6 +540,7 @@ impl Dialog {
                     })
                     .backdrop_response;
 
+                //FIXME: Doesn't update until you move your mouse or press a key - why?
                 if backdrop_response.clicked() {
                     is_open = false;
                 }
@@ -598,6 +599,7 @@ impl Dialog {
                     })
                     .backdrop_response;
 
+                //FIXME: Doesn't update until you move your mouse or press a key - why?
                 if backdrop_response.clicked() {
                     is_open = false;
                 }

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -507,36 +507,38 @@ impl Dialog {
                 }
 
                 let modal = Modal::new("select_element_picker".into()).area(area);
-                let backdrop_response = modal.show(ctx, |ui| {
-                    egui::ScrollArea::vertical().show(ui, |ui| {
-                        for option_or_optgroup in prompt.options() {
-                            match &option_or_optgroup {
-                                SelectElementOptionOrOptgroup::Option(option) => {
-                                    display_option(
-                                        ui,
-                                        option,
-                                        &mut selected_option,
-                                        &mut is_open,
-                                        false,
-                                    );
-                                },
-                                SelectElementOptionOrOptgroup::Optgroup { label, options } => {
-                                    ui.label(egui::RichText::new(label).strong());
-
-                                    for option in options {
+                let backdrop_response = modal
+                    .show(ctx, |ui| {
+                        egui::ScrollArea::vertical().show(ui, |ui| {
+                            for option_or_optgroup in prompt.options() {
+                                match &option_or_optgroup {
+                                    SelectElementOptionOrOptgroup::Option(option) => {
                                         display_option(
                                             ui,
                                             option,
                                             &mut selected_option,
                                             &mut is_open,
-                                            true,
+                                            false,
                                         );
-                                    }
-                                },
+                                    },
+                                    SelectElementOptionOrOptgroup::Optgroup { label, options } => {
+                                        ui.label(egui::RichText::new(label).strong());
+
+                                        for option in options {
+                                            display_option(
+                                                ui,
+                                                option,
+                                                &mut selected_option,
+                                                &mut is_open,
+                                                true,
+                                            );
+                                        }
+                                    },
+                                }
                             }
-                        }
-                    });
-                }).backdrop_response;
+                        });
+                    })
+                    .backdrop_response;
 
                 if backdrop_response.clicked() {
                     is_open = false;
@@ -568,31 +570,33 @@ impl Dialog {
                     .fixed_pos(egui::pos2(position.min.x as f32, position.max.y as f32));
 
                 let modal = Modal::new("select_element_picker".into()).area(area);
-                let backdrop_response = modal.show(ctx, |ui| {
-                    egui::widgets::color_picker::color_picker_color32(
-                        ui,
-                        current_color,
-                        egui::widgets::color_picker::Alpha::Opaque,
-                    );
+                let backdrop_response = modal
+                    .show(ctx, |ui| {
+                        egui::widgets::color_picker::color_picker_color32(
+                            ui,
+                            current_color,
+                            egui::widgets::color_picker::Alpha::Opaque,
+                        );
 
-                    ui.add_space(10.);
+                        ui.add_space(10.);
 
-                    if ui.button("Dismiss").clicked() ||
-                        ui.input(|i| i.key_pressed(egui::Key::Escape))
-                    {
-                        is_open = false;
-                        prompt.select(None);
-                    }
-                    if ui.button("Select").clicked() {
-                        is_open = false;
-                        let selected_color = RgbColor {
-                            red: current_color.r(),
-                            green: current_color.g(),
-                            blue: current_color.b(),
-                        };
-                        prompt.select(Some(selected_color));
-                    }
-                }).backdrop_response;
+                        if ui.button("Dismiss").clicked() ||
+                            ui.input(|i| i.key_pressed(egui::Key::Escape))
+                        {
+                            is_open = false;
+                            prompt.select(None);
+                        }
+                        if ui.button("Select").clicked() {
+                            is_open = false;
+                            let selected_color = RgbColor {
+                                red: current_color.r(),
+                                green: current_color.g(),
+                                blue: current_color.b(),
+                            };
+                            prompt.select(Some(selected_color));
+                        }
+                    })
+                    .backdrop_response;
 
                 if backdrop_response.clicked() {
                     is_open = false;

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -500,6 +500,10 @@ impl Dialog {
                     if clickable_area.hovered() && option.is_disabled {
                         ui.ctx().set_cursor_icon(egui::CursorIcon::NotAllowed);
                     }
+
+                    if ui.ctx().input(|i| i.key_pressed(egui::Key::Escape)) {
+                        *is_open = false;
+                    }
                 }
 
                 let modal = Modal::new("select_element_picker".into()).area(area);
@@ -569,7 +573,9 @@ impl Dialog {
 
                     ui.add_space(10.);
 
-                    if ui.button("Dismiss").clicked() {
+                    if ui.button("Dismiss").clicked() ||
+                        ui.input(|i| i.key_pressed(egui::Key::Escape))
+                    {
                         is_open = false;
                         prompt.select(None);
                     }

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -507,7 +507,7 @@ impl Dialog {
                 }
 
                 let modal = Modal::new("select_element_picker".into()).area(area);
-                modal.show(ctx, |ui| {
+                let backdrop_response = modal.show(ctx, |ui| {
                     egui::ScrollArea::vertical().show(ui, |ui| {
                         for option_or_optgroup in prompt.options() {
                             match &option_or_optgroup {
@@ -536,7 +536,11 @@ impl Dialog {
                             }
                         }
                     });
-                });
+                }).backdrop_response;
+
+                if backdrop_response.clicked() {
+                    is_open = false;
+                }
 
                 prompt.select(selected_option);
 
@@ -564,7 +568,7 @@ impl Dialog {
                     .fixed_pos(egui::pos2(position.min.x as f32, position.max.y as f32));
 
                 let modal = Modal::new("select_element_picker".into()).area(area);
-                modal.show(ctx, |ui| {
+                let backdrop_response = modal.show(ctx, |ui| {
                     egui::widgets::color_picker::color_picker_color32(
                         ui,
                         current_color,
@@ -588,7 +592,11 @@ impl Dialog {
                         };
                         prompt.select(Some(selected_color));
                     }
-                });
+                }).backdrop_response;
+
+                if backdrop_response.clicked() {
+                    is_open = false;
+                }
 
                 is_open
             },


### PR DESCRIPTION
Addresses the first half of #38347 by making it possible to close the select picker and the color picker by pressing ESC or clicking off the modal. Marking this as draft since I need some help with squashing a bug - the "clicking off" part only triggers after moving the mouse or pressing any key, and I'm not sure why.

Testing: Manual.
Fixes: First half of #38347.
