### PR TITLE
webdriver: Fix "element in view" by correctly computing resolved `PointerEvents` style

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1902,9 +1902,9 @@ fn is_element_in_view(element: &Element, document: &Document, can_gc: CanGc) -> 
     // https://w3c.github.io/webdriver/#dfn-pointer-events-are-not-disabled
     // An element is said to have pointer events disabled
     // if the resolved value of its "pointer-events" style property is "none".
-    let pointer_events_enabled = element.style(can_gc).map_or(true, |style| {
-        style.get_inherited_ui().pointer_events != PointerEvents::None
-    });
+    let pointer_events_enabled = element
+        .style(can_gc)
+        .is_none_or(|style| style.get_inherited_ui().pointer_events != PointerEvents::None);
 
     // An element is in view if it is a member of its own pointer-interactable paint tree,
     // given the pretense that its pointer events are not disabled.

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/interactability.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/interactability.py.ini
@@ -4,12 +4,3 @@
 
   [test_element_intercepted_no_pointer_events]
     expected: FAIL
-
-  [test_disabled]
-    expected: FAIL
-
-  [test_element_interactable_css_transform[translate(100px, 100px)\]]
-    expected: FAIL
-
-  [test_element_interactable_css_transform[rotate(50deg)\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/select.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/select.py.ini
@@ -13,3 +13,21 @@
 
   [test_out_of_view_dropdown]
     expected: FAIL
+
+  [test_click_multiple_option]
+    expected: FAIL
+
+  [test_click_preselected_multiple_option]
+    expected: FAIL
+
+  [test_click_multiple_does_not_deselect_others]
+    expected: FAIL
+
+  [test_click_selected_multiple_option]
+    expected: FAIL
+
+  [test_out_of_view_multiple]
+    expected: FAIL
+
+  [test_option_disabled]
+    expected: FAIL


### PR DESCRIPTION
Testing: `element_click/interactability.py`. For some other tests in headed window, even tho the target is in view it falsely claim not in view previously.
