### PR TITLE
Fix element in view check for webdriver

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1898,7 +1898,7 @@ pub(crate) fn handle_element_click(
 
 /// <https://w3c.github.io/webdriver/#dfn-in-view>
 fn is_element_in_view(element: &Element, document: &Document, can_gc: CanGc) -> bool {
-    element.enabled_state() &&
+    !element.disabled_state() &&
         get_element_pointer_interactable_paint_tree(element, document, can_gc)
             .contains(&DomRoot::from_ref(element))
 }

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/interactability.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/interactability.py.ini
@@ -7,9 +7,3 @@
 
   [test_disabled]
     expected: FAIL
-
-  [test_element_interactable_css_transform[translate(100px, 100px)\]]
-    expected: FAIL
-
-  [test_element_interactable_css_transform[rotate(50deg)\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/navigate.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/navigate.py.ini
@@ -1,7 +1,4 @@
 [navigate.py]
-  [test_link_hash]
-    expected: FAIL
-
   [test_link_from_toplevel_context_with_target[_blank\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/select.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/select.py.ini
@@ -13,3 +13,21 @@
 
   [test_out_of_view_dropdown]
     expected: FAIL
+
+  [test_click_multiple_option]
+    expected: FAIL
+
+  [test_click_preselected_multiple_option]
+    expected: FAIL
+
+  [test_click_multiple_does_not_deselect_others]
+    expected: FAIL
+
+  [test_click_selected_multiple_option]
+    expected: FAIL
+
+  [test_out_of_view_multiple]
+    expected: FAIL
+
+  [test_option_disabled]
+    expected: FAIL


### PR DESCRIPTION
Fix according to the [spec](https://w3c.github.io/webdriver/#dfn-in-view):

> An [element](https://dom.spec.whatwg.org/#concept-element) is in view if it is a member of its own [pointer-interactable paint tree](https://w3c.github.io/webdriver/#dfn-pointer-interactable-paint-tree), given the pretense that its [pointer events are not disabled](https://w3c.github.io/webdriver/#dfn-pointer-events-are-not-disabled).

Current implementation uses `enabled` instead of `not disabled`.

Testing: this PR clears regression in: https://github.com/longvatrong111/servo/actions/runs/16641287175

cc: @xiaochengh 
