### PR TITLE
webdriver: improve session commands

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -623,8 +623,12 @@ impl Handler {
         Ok(WebDriverResponse::NewSession(response))
     }
 
+    /// <https://w3c.github.io/webdriver/#dfn-delete-session>
     fn handle_delete_session(&mut self) -> WebDriverResult<WebDriverResponse> {
+        // Step 1. If session is http, close the session
         self.session = None;
+
+        // Step 2. Return success with data null
         Ok(WebDriverResponse::DeleteSession)
     }
 
@@ -2445,7 +2449,9 @@ impl WebDriverHandler<ServoExtensionRoute> for Handler {
         // Unless we are trying to create a new session, we need to ensure that a
         // session has previously been created
         match msg.command {
-            WebDriverCommand::NewSession(_) | WebDriverCommand::Status => {},
+            WebDriverCommand::NewSession(_) |
+            WebDriverCommand::Status |
+            WebDriverCommand::DeleteSession => {},
             _ => {
                 self.session()?;
             },

--- a/components/webdriver_server/session.rs
+++ b/components/webdriver_server/session.rs
@@ -119,6 +119,8 @@ impl Handler {
             capabilities.get("strictFileInteractability")
         {
             session.strict_file_interactability = *strict_file_interactability;
+        } else {
+            capabilities.insert(String::from("strictFileInteractability"), json!(false));
         }
 
         // Step 9.3. Let timeouts be the result of getting a property "timeouts" from capabilities.

--- a/components/webdriver_server/timeout.rs
+++ b/components/webdriver_server/timeout.rs
@@ -46,9 +46,15 @@ pub(crate) fn deserialize_as_timeouts_configuration(
                     })? as u64;
                 },
                 "script" => {
-                    config.script = Some(value.as_f64().ok_or_else(|| {
-                        WebDriverError::new(ErrorStatus::InvalidArgument, "Invalid script timeout")
-                    })? as u64);
+                    config.script = match value {
+                        Value::Null => None,
+                        _ => Some(value.as_f64().ok_or_else(|| {
+                            WebDriverError::new(
+                                ErrorStatus::InvalidArgument,
+                                "Invalid script timeout",
+                            )
+                        })? as u64),
+                    };
                 },
                 _ => {
                     return Err(WebDriverError::new(
@@ -69,9 +75,7 @@ pub(crate) fn deserialize_as_timeouts_configuration(
 
 pub(crate) fn serialize_timeouts_configuration(timeouts: &TimeoutsConfiguration) -> Value {
     let mut map = serde_json::Map::new();
-    if let Some(script_timeout) = timeouts.script {
-        map.insert("script".to_string(), Value::from(script_timeout));
-    }
+    map.insert("script".to_string(), Value::from(timeouts.script));
     map.insert("pageLoad".to_string(), Value::from(timeouts.page_load));
     map.insert("implicit".to_string(), Value::from(timeouts.implicit_wait));
     Value::Object(map)

--- a/tests/wpt/meta/webdriver/tests/classic/delete_session/delete.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/delete_session/delete.py.ini
@@ -1,7 +1,3 @@
 [delete.py]
-  expected: ERROR
-  [test_null_response_value]
-    expected: FAIL
-
   [test_accepted_beforeunload_prompt]
     expected: FAIL


### PR DESCRIPTION
Add timeout and strictFileInteractability capabilities to response of new session command.
Allow delete session command to run without a session.

Testing: Clear some unexpected results of session tests in webdriver CI and 
`tests/wpt/meta/webdriver/tests/classic/delete_session/delete.py.ini`
