### PR TITLE
Suppress warning in `webview` unit test

### DIFF
--- a/components/constellation/webview_manager.rs
+++ b/components/constellation/webview_manager.rs
@@ -131,13 +131,13 @@ mod test {
         assert_eq!(webviews.is_focused, false);
 
         // focus() makes the given webview the latest in focus order.
-        webviews.focus(id(0, 2));
+        let _ = webviews.focus(id(0, 2));
         assert_eq!(webviews.focus_order, vec![id(0, 2)]);
         assert_eq!(webviews.is_focused, true);
-        webviews.focus(id(0, 1));
+        let _ = webviews.focus(id(0, 1));
         assert_eq!(webviews.focus_order, vec![id(0, 2), id(0, 1)]);
         assert_eq!(webviews.is_focused, true);
-        webviews.focus(id(0, 3));
+        let _ = webviews.focus(id(0, 3));
         assert_eq!(webviews.focus_order, vec![id(0, 2), id(0, 1), id(0, 3)]);
         assert_eq!(webviews.is_focused, true);
 
@@ -147,7 +147,7 @@ mod test {
         assert_eq!(webviews.is_focused, false);
 
         // focus() avoids duplicates in focus order, when the given webview has been focused before.
-        webviews.focus(id(0, 1));
+        let _ = webviews.focus(id(0, 1));
         assert_eq!(webviews.focus_order, vec![id(0, 2), id(0, 3), id(0, 1)]);
         assert_eq!(webviews.is_focused, true);
 


### PR DESCRIPTION
`webview.focus` return `Result<(),()>`, hence it gives warning if the result is not handled.