### PR TITLE
compositor: Add more doc for size of different `RenderingContext` implementation

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -150,7 +150,7 @@ pub struct IOCompositor {
     /// The webrender renderer.
     webrender: Option<webrender::Renderer>,
 
-    /// The surfman instance that webrender targets, which is the viewport.
+    /// The [`RenderingContext`] instance that webrender targets, which is the viewport.
     rendering_context: Rc<dyn RenderingContext>,
 
     /// The number of frames pending to receive from WebRender.

--- a/components/shared/compositing/rendering_context.rs
+++ b/components/shared/compositing/rendering_context.rs
@@ -381,6 +381,7 @@ impl RenderingContext for SoftwareRenderingContext {
 /// If you would like to paint to only a portion of the window, consider using
 /// [`OffscreenRenderingContext`] by calling [`WindowRenderingContext::offscreen_context`].
 pub struct WindowRenderingContext {
+    /// The inner size of the window in physical pixels which excludes OS decorations.
     size: Cell<PhysicalSize<u32>>,
     surfman_context: SurfmanRenderingContext,
 }

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -687,7 +687,8 @@ impl WindowPortsMethods for Window {
             },
             WindowEvent::Resized(new_inner_size) => {
                 if self.inner_size.get() != new_inner_size {
-                    // This should always be set to inner size.
+                    // This should always be set to inner size
+                    // because we are resizing `SurfmanRenderingContext`.
                     // See https://github.com/servo/servo/issues/38369#issuecomment-3138378527
                     self.window_rendering_context.resize(new_inner_size);
                 }


### PR DESCRIPTION
For more details, see https://github.com/servo/servo/issues/38369#issuecomment-3138378527.

Fixes: https://github.com/servo/servo/issues/38369#issuecomment-3138458772
Testing: Just adding docs. 