### PR TITLE
script: Restore initial behavior of IntersectionObserver

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -269,6 +269,15 @@ impl Layout for LayoutThread {
         process_content_box_request(stacking_context_tree, node)
     }
 
+    /// Same as [Layout::query_content_box], but without any layout checking assert. Queries
+    /// without any layout will returns None.
+    #[servo_tracing::instrument(skip_all)]
+    fn query_content_box_unchecked(&self, node: TrustedNodeAddress) -> Option<UntypedRect<Au>> {
+        let node = unsafe { ServoLayoutNode::new(&node) };
+        let stacking_context_tree = self.stacking_context_tree.borrow();
+        process_content_box_request(stacking_context_tree.as_ref()?, node)
+    }
+
     /// Get a `Vec` of bounding boxes of this node's `Fragement`s in the coordinate space of the
     /// Document. This is used to implement `getClientRects()`.
     ///

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -260,6 +260,7 @@ pub trait Layout {
     fn scroll_offset(&self, id: ExternalScrollId) -> Option<LayoutVector2D>;
 
     fn query_content_box(&self, node: TrustedNodeAddress) -> Option<Rect<Au>>;
+    fn query_content_box_unchecked(&self, node: TrustedNodeAddress) -> Option<Rect<Au>>;
     fn query_content_boxes(&self, node: TrustedNodeAddress) -> Vec<Rect<Au>>;
     fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32>;
     fn query_element_inner_outer_text(&self, node: TrustedNodeAddress) -> String;


### PR DESCRIPTION
After #37871, we added an assert for checking whether the layout is ready when we are trying to get content box queries. But this made `IntersectionObserver` that queries content box "as is" (without any reflow) to crash. 

This PR restore the initial behavior for these kind of queries, where it would returns `None` if the layout is not ready, and elaborate this behavior more. Adding a more specific layout utilities that checks for the queries without doing some asserts.

In practice, this behavior querying layout that is not ready would not affect the `IntersectionObserver` since any failed observation would report the same as the first entry and would not results in different behavior (e.g., additional entries being observed, or different first entries).

Testing: Existing WPT Coverages
Fixes: #38390