### PR TITLE
webdriver: Wait until last events dispatched in element send keys 

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -29,7 +29,7 @@ use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
 use embedder_traits::{
     AllowOrDeny, AnimationState, CompositorHitTestResult, ContextMenuResult, EditingActionEvent,
-    EmbedderMsg, FocusSequenceNumber, ImeEvent, InputEvent, LoadStatus, MouseButton,
+    EmbedderMsg, FocusSequenceNumber, ImeEvent, ImeType, InputEvent, LoadStatus, MouseButton,
     MouseButtonAction, MouseButtonEvent, ScrollEvent, TouchEvent, TouchEventType, TouchId,
     UntrustedNodeAddress, WheelEvent,
 };
@@ -2620,8 +2620,8 @@ impl Document {
     }
 
     pub(crate) fn dispatch_ime_event(&self, event: ImeEvent, can_gc: CanGc) {
-        let composition_event = match event {
-            ImeEvent::Dismissed => {
+        let composition_event = match event.event {
+            ImeType::Dismissed => {
                 self.request_focus(
                     self.GetBody().as_ref().map(|e| e.upcast()),
                     FocusInitiator::Local,
@@ -2629,7 +2629,7 @@ impl Document {
                 );
                 return;
             },
-            ImeEvent::Composition(composition_event) => composition_event,
+            ImeType::Composition(composition_event) => composition_event,
         };
 
         // spec: https://w3c.github.io/uievents/#compositionstart

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -54,7 +54,7 @@ impl InputEvent {
         match self {
             InputEvent::EditingAction(..) => None,
             InputEvent::Gamepad(..) => None,
-            InputEvent::Ime(..) => None,
+            InputEvent::Ime(event) => event.webdriver_id,
             InputEvent::Keyboard(event) => event.webdriver_id,
             InputEvent::MouseButton(event) => event.webdriver_id,
             InputEvent::MouseMove(event) => event.webdriver_id,
@@ -69,7 +69,9 @@ impl InputEvent {
         match self {
             InputEvent::EditingAction(..) => {},
             InputEvent::Gamepad(..) => {},
-            InputEvent::Ime(..) => {},
+            InputEvent::Ime(ref mut event) => {
+                event.webdriver_id = webdriver_id;
+            },
             InputEvent::Keyboard(ref mut event) => {
                 event.webdriver_id = webdriver_id;
             },
@@ -364,9 +366,24 @@ pub struct ScrollEvent {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum ImeEvent {
+pub enum ImeType {
     Composition(CompositionEvent),
     Dismissed,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ImeEvent {
+    pub event: ImeType,
+    webdriver_id: Option<WebDriverMessageId>,
+}
+
+impl ImeEvent {
+    pub fn new(event: ImeType) -> Self {
+        Self {
+            event,
+            webdriver_id: None,
+        }
+    }
 }
 
 #[derive(

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -21,7 +21,7 @@ use servo::servo_geometry::{
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel};
 use servo::{
-    Cursor, ImeEvent, InputEvent, Key, KeyState, KeyboardEvent, Modifiers,
+    Cursor, ImeEvent, ImeType, InputEvent, Key, KeyState, KeyboardEvent, Modifiers,
     MouseButton as ServoMouseButton, MouseButtonAction, MouseButtonEvent, MouseLeaveEvent,
     MouseMoveEvent, NamedKey, OffscreenRenderingContext, RenderingContext, ScreenGeometry, Theme,
     TouchEvent, TouchEventType, TouchId, WebRenderDebugOption, WebView, WheelDelta, WheelEvent,
@@ -694,31 +694,31 @@ impl WindowPortsMethods for Window {
             },
             WindowEvent::Ime(ime) => match ime {
                 Ime::Enabled => {
-                    webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
-                        servo::CompositionEvent {
+                    webview.notify_input_event(InputEvent::Ime(ImeEvent::new(
+                        ImeType::Composition(servo::CompositionEvent {
                             state: servo::CompositionState::Start,
                             data: String::new(),
-                        },
+                        }),
                     )));
                 },
                 Ime::Preedit(text, _) => {
-                    webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
-                        servo::CompositionEvent {
+                    webview.notify_input_event(InputEvent::Ime(ImeEvent::new(
+                        ImeType::Composition(servo::CompositionEvent {
                             state: servo::CompositionState::Update,
                             data: text,
-                        },
+                        }),
                     )));
                 },
                 Ime::Commit(text) => {
-                    webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
-                        servo::CompositionEvent {
+                    webview.notify_input_event(InputEvent::Ime(ImeEvent::new(
+                        ImeType::Composition(servo::CompositionEvent {
                             state: servo::CompositionState::End,
                             data: text,
-                        },
+                        }),
                     )));
                 },
                 Ime::Disabled => {
-                    webview.notify_input_event(InputEvent::Ime(ImeEvent::Dismissed));
+                    webview.notify_input_event(InputEvent::Ime(ImeEvent::new(ImeType::Dismissed)));
                 },
             },
             _ => {},

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -15,7 +15,7 @@ use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntRect, DeviceIntSize, DevicePixel};
 use servo::{
-    AllowOrDenyRequest, CompositionEvent, CompositionState, ContextMenuResult, ImeEvent,
+    AllowOrDenyRequest, CompositionEvent, CompositionState, ContextMenuResult, ImeEvent, ImeType,
     InputEvent, InputMethodType, Key, KeyState, KeyboardEvent, LoadStatus, MediaSessionActionType,
     MediaSessionEvent, MouseButton, MouseButtonAction, MouseButtonEvent, MouseMoveEvent, NamedKey,
     NavigationRequest, PermissionRequest, RenderingContext, ScreenGeometry, Servo, ServoDelegate,
@@ -615,12 +615,12 @@ impl RunningAppState {
             KeyState::Down,
             Key::Named(NamedKey::Process),
         )));
-        active_webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
+        active_webview.notify_input_event(InputEvent::Ime(ImeEvent::new(ImeType::Composition(
             CompositionEvent {
                 state: CompositionState::End,
                 data: text,
             },
-        )));
+        ))));
         active_webview.notify_input_event(InputEvent::Keyboard(KeyboardEvent::from_state_and_key(
             KeyState::Up,
             Key::Named(NamedKey::Process),
@@ -668,7 +668,7 @@ impl RunningAppState {
     pub fn ime_dismissed(&self) {
         info!("ime_dismissed");
         self.active_webview()
-            .notify_input_event(InputEvent::Ime(ImeEvent::Dismissed));
+            .notify_input_event(InputEvent::Ime(ImeEvent::new(ImeType::Dismissed)));
         self.perform_updates();
     }
 


### PR DESCRIPTION
Improve stability for element send keys by waiting until the last event dispatched before moving on.

As mentioned in https://github.com/servo/servo/issues/38354, it's hard for us to use `dispatch action` as required by spec, because we generate the required event (based on [dispatch action for string](https://w3c.github.io/webdriver/#dfn-dispatch-actions-for-a-string)) from `keyboard_types:webdriver:send_keys`. This function will return `KeyEvent` which does not contains the raw character needed for `dispatch_actions`

Testing: Improve stability for wdspec tests that use `send_keys`
Addresses: https://github.com/servo/servo/issues/38354