### PR TITLE
Update tungstenite and async-tungstenite and put them in dependabot group.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,10 @@ updates:
     servo-media-related:
       patterns:
         - "servo-media*"
+    tungstenite-related:
+      patterns:
+        - "async-tungstenite",
+        - "tungstenite"
   ignore:
   # Ignore all stylo crates as their upgrades are coordinated via companion PRs.
   - dependency-name: selectors


### PR DESCRIPTION
async-tungstenite depends on tungstenite, hence, they did not get upgrades
