### PR TITLE
Split devtools network event logic for creating/retrieving network event actors

### DIFF
--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -13,7 +13,6 @@
 
 use std::borrow::ToOwned;
 use std::collections::HashMap;
-use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::io::Read;
 use std::net::{Shutdown, TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
@@ -511,7 +510,10 @@ impl DevtoolsInstance {
             .watcher
             .clone();
 
-        let netevent_actor_name = self.find_network_event_actor(request_id, watcher_name);
+        let netevent_actor_name = match self.get_network_event_actor(&request_id) {
+            Some(name) => name,
+            None => self.create_network_event_actor(request_id, watcher_name),
+        };
 
         handle_network_event(
             Arc::clone(&self.actors),
@@ -521,25 +523,32 @@ impl DevtoolsInstance {
         )
     }
 
-    // Find the name of NetworkEventActor corresponding to request_id
-    // Create a new one if it does not exist, add it to the actor_requests hashmap
-    fn find_network_event_actor(&mut self, request_id: String, watcher_name: String) -> String {
-        let mut actors = self.actors.lock().unwrap();
-        match self.actor_requests.entry(request_id) {
-            Occupied(name) => {
-                // TODO: Delete from map like Firefox does?
-                name.into_mut().clone()
-            },
-            Vacant(entry) => {
-                let resource_id = self.next_resource_id;
-                self.next_resource_id += 1;
-                let actor_name = actors.new_name("netevent");
-                let actor = NetworkEventActor::new(actor_name.clone(), resource_id, watcher_name);
-                entry.insert(actor_name.clone());
-                actors.register(Box::new(actor));
-                actor_name
-            },
+    /// Get the NetworkEventActor name for a given request ID, if it exists.
+    fn get_network_event_actor(&self, request_id: &str) -> Option<String> {
+        self.actor_requests.get(request_id).cloned()
+    }
+
+    /// Create a new NetworkEventActor for a given request ID and watcher name.
+    /// Fails if one already exists.
+    fn create_network_event_actor(&mut self, request_id: String, watcher_name: String) -> String {
+        if self.actor_requests.contains_key(&request_id) {
+            panic!(
+                "NetworkEventActor for request_id `{}` already exists",
+                request_id
+            );
         }
+
+        let mut actors = self.actors.lock().unwrap();
+        let resource_id = self.next_resource_id;
+        self.next_resource_id += 1;
+
+        let actor_name = actors.new_name("netevent");
+        let actor = NetworkEventActor::new(actor_name.clone(), resource_id, watcher_name);
+
+        self.actor_requests.insert(request_id, actor_name.clone());
+        actors.register(Box::new(actor));
+
+        actor_name
     }
 
     fn handle_create_source_actor(

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -510,8 +510,8 @@ impl DevtoolsInstance {
             .watcher
             .clone();
 
-        let netevent_actor_name = match self.actor_requests.get(&request_id).cloned() {
-            Some(name) => name,
+        let netevent_actor_name = match self.actor_requests.get(&request_id) {
+            Some(name) => name.clone(),
             None => self.create_network_event_actor(request_id, watcher_name),
         };
 
@@ -524,7 +524,6 @@ impl DevtoolsInstance {
     }
 
     /// Create a new NetworkEventActor for a given request ID and watcher name.
-    /// Fails if one already exists.
     fn create_network_event_actor(&mut self, request_id: String, watcher_name: String) -> String {
         let mut actors = self.actors.lock().unwrap();
         let resource_id = self.next_resource_id;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -510,7 +510,7 @@ impl DevtoolsInstance {
             .watcher
             .clone();
 
-        let netevent_actor_name = match self.get_network_event_actor(&request_id) {
+        let netevent_actor_name = match self.actor_requests.get(&request_id).cloned() {
             Some(name) => name,
             None => self.create_network_event_actor(request_id, watcher_name),
         };
@@ -523,21 +523,9 @@ impl DevtoolsInstance {
         )
     }
 
-    /// Get the NetworkEventActor name for a given request ID, if it exists.
-    fn get_network_event_actor(&self, request_id: &str) -> Option<String> {
-        self.actor_requests.get(request_id).cloned()
-    }
-
     /// Create a new NetworkEventActor for a given request ID and watcher name.
     /// Fails if one already exists.
     fn create_network_event_actor(&mut self, request_id: String, watcher_name: String) -> String {
-        if self.actor_requests.contains_key(&request_id) {
-            panic!(
-                "NetworkEventActor for request_id `{}` already exists",
-                request_id
-            );
-        }
-
         let mut actors = self.actors.lock().unwrap();
         let resource_id = self.next_resource_id;
         self.next_resource_id += 1;


### PR DESCRIPTION
`DevtoolsInstance::find_network_event_actor` silently creates a new actor if there is not one already known for a given ID. This is confusing; this PR separates  logic for handling network requests (create a new actor) and network responses (retrieve an existing actor).

Fixes: (https://github.com/servo/servo/issues/37841)
