### PR TITLE
net: clean shutdown of fetch thread

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -35,8 +35,8 @@ use layout_api::{LayoutFactory, ScriptThreadFactory};
 use log::{debug, error, warn};
 use media::WindowGLContext;
 use net::image_cache::ImageCacheImpl;
-use net_traits::ResourceThreads;
 use net_traits::image_cache::ImageCache;
+use net_traits::{CoreResourceThread, ResourceThreads};
 use profile::system_reporter;
 use profile_traits::mem::{ProfilerMsg, Reporter};
 use profile_traits::{mem as profile_mem, time};
@@ -569,6 +569,10 @@ impl UnprivilegedPipelineContent {
 
     pub fn script_to_constellation_chan(&self) -> &ScriptToConstellationChan {
         &self.script_to_constellation_chan
+    }
+
+    pub fn core_resource_thread(&self) -> &CoreResourceThread {
+        &self.resource_threads.core_thread
     }
 
     pub fn opts(&self) -> Opts {

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -11,7 +11,7 @@ mod font_context {
     use std::path::PathBuf;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicI32, Ordering};
-    use std::thread::{self, ThreadHandle};
+    use std::thread::{self, JoinHandle};
 
     use app_units::Au;
     use compositing_traits::CrossProcessCompositorApi;
@@ -40,7 +40,7 @@ mod font_context {
         context: FontContext,
         system_font_service: Arc<MockSystemFontService>,
         system_font_service_proxy: SystemFontServiceProxy,
-        fetch_thread_join_handle: Option<ThreadHandle<()>>,
+        fetch_thread_join_handle: Option<JoinHandle<()>>,
     }
 
     impl TestContext {
@@ -54,7 +54,7 @@ mod font_context {
             let mock_compositor_api = CrossProcessCompositorApi::dummy();
 
             let proxy_clone = Arc::new(system_font_service_proxy.to_sender().to_proxy());
-            let fetch_thread_join_handle = start_fetch_thread(mock_resource_threads);
+            let fetch_thread_join_handle = start_fetch_thread(&mock_resource_threads.core_thread);
             Self {
                 context: FontContext::new(proxy_clone, mock_compositor_api, mock_resource_threads),
                 system_font_service,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1258,7 +1258,7 @@ pub fn run_content_process(token: String) {
         UnprivilegedContent::Pipeline(mut content) => {
             media_platform::init();
 
-            // Start a fetch thread.
+            // Start the fetch thread for this content process.
             let fetch_thread_join_handle = start_fetch_thread(content.core_resource_thread());
 
             set_logger(content.script_to_constellation_chan().clone());

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -692,7 +692,7 @@ pub fn exit_fetch_thread() {
 
 /// Instruct the resource thread to make a new fetch request.
 pub fn fetch_async(
-    core_resource_thread: &CoreResourceThread,
+    _core_resource_thread: &CoreResourceThread,
     request: RequestBuilder,
     response_init: Option<ResponseInit>,
     callback: BoxedFetchCallback,

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -682,7 +682,9 @@ pub fn start_fetch_thread(core_resource_thread: &CoreResourceThread) -> JoinHand
 }
 
 /// Send the exit message to the background thread,
-/// after which it can be joined on.
+/// after which the caller can,
+/// and should,
+/// join on the thread.
 pub fn exit_fetch_thread() {
     let _ = FETCH_THREAD
         .get()

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::sync::{LazyLock, OnceLock};
-use std::thread;
+use std::thread::{self, JoinHandle};
 
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::HistoryStateId;
@@ -563,6 +563,8 @@ enum ToFetchThreadMessage {
         /* callback  */ BoxedFetchCallback,
     ),
     FetchResponse(FetchResponseMsg),
+    /// Stop the background thread.
+    Exit,
 }
 
 pub type BoxedFetchCallback = Box<dyn FnMut(FetchResponseMsg) + Send + 'static>;
@@ -586,7 +588,9 @@ struct FetchThread {
 }
 
 impl FetchThread {
-    fn spawn(core_resource_thread: &CoreResourceThread) -> Sender<ToFetchThreadMessage> {
+    fn spawn(
+        core_resource_thread: &CoreResourceThread,
+    ) -> (Sender<ToFetchThreadMessage>, JoinHandle<()>) {
         let (sender, receiver) = unbounded();
         let (to_fetch_sender, from_fetch_sender) = ipc::channel().unwrap();
 
@@ -600,7 +604,7 @@ impl FetchThread {
         );
 
         let core_resource_thread = core_resource_thread.clone();
-        thread::Builder::new()
+        let join_handle = thread::Builder::new()
             .name("FetchThread".to_owned())
             .spawn(move || {
                 let mut fetch_thread = FetchThread {
@@ -612,7 +616,7 @@ impl FetchThread {
                 fetch_thread.run();
             })
             .expect("Thread spawning failed");
-        sender
+        (sender, join_handle)
     }
 
     fn run(&mut self) {
@@ -659,12 +663,32 @@ impl FetchThread {
                         .core_resource_thread
                         .send(CoreResourceMsg::Cancel(request_ids));
                 },
+                ToFetchThreadMessage::Exit => break,
             }
         }
     }
 }
 
 static FETCH_THREAD: OnceLock<Sender<ToFetchThreadMessage>> = OnceLock::new();
+
+/// Start the fetch thread,
+/// and returns the join handle to the background thread.
+pub fn start_fetch_thread(core_resource_thread: &CoreResourceThread) -> JoinHandle<()> {
+    let (sender, join_handle) = FetchThread::spawn(core_resource_thread);
+    FETCH_THREAD
+        .set(sender)
+        .expect("Fetch thread should be set only once on start-up");
+    join_handle
+}
+
+/// Send the exit message to the background thread,
+/// after which it can be joined on.
+pub fn exit_fetch_thread() {
+    let _ = FETCH_THREAD
+        .get()
+        .expect("Fetch thread should always be initialized on start-up")
+        .send(ToFetchThreadMessage::Exit);
+}
 
 /// Instruct the resource thread to make a new fetch request.
 pub fn fetch_async(
@@ -674,7 +698,8 @@ pub fn fetch_async(
     callback: BoxedFetchCallback,
 ) {
     let _ = FETCH_THREAD
-        .get_or_init(|| FetchThread::spawn(core_resource_thread))
+        .get()
+        .expect("Fetch thread should always be initialized on start-up")
         .send(ToFetchThreadMessage::StartFetch(
             request,
             response_init,
@@ -687,7 +712,7 @@ pub fn fetch_async(
 pub fn cancel_async_fetch(request_ids: Vec<RequestId>) {
     let _ = FETCH_THREAD
         .get()
-        .expect("Tried to cancel request in process that hasn't started one.")
+        .expect("Fetch thread should always be initialized on start-up")
         .send(ToFetchThreadMessage::Cancel(request_ids));
 }
 

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -671,8 +671,8 @@ impl FetchThread {
 
 static FETCH_THREAD: OnceLock<Sender<ToFetchThreadMessage>> = OnceLock::new();
 
-/// Start the fetch thread,
-/// and returns the join handle to the background thread.
+/// Starts a fetch thread,
+/// and returns the join handle to it.
 pub fn start_fetch_thread(core_resource_thread: &CoreResourceThread) -> JoinHandle<()> {
     let (sender, join_handle) = FetchThread::spawn(core_resource_thread);
     FETCH_THREAD


### PR DESCRIPTION
The fetch thread is currently not shut down, meaning it is one of the threads counted in the "threads are still running after shutdown (bad)" counter shown when Servo has shut-down. 

This PR introduces a mechanism to start, and shut-down, one fetch thread per process that requires one.

Testing: WPT tests and unit tests(for font context). Also manually tested loading and closing "about:blank": this change indeed brings down the count of threads still running after shutdown by one.

Fixes: https://github.com/servo/servo/issues/34887