### PR TITLE
script: Lazy init and reuse const `BOOLEAN_ATTRIBUTES`

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -5,6 +5,7 @@
 use std::borrow::ToOwned;
 use std::cell::LazyCell;
 use std::mem;
+use std::sync::LazyLock;
 
 use devtools_traits::AttrInfo;
 use dom_struct::dom_struct;
@@ -298,38 +299,42 @@ pub(crate) fn is_boolean_attribute(name: &str) -> bool {
     // webdriver/tests/classic/get_element_attribute/get.py
     //
     // [1] <https://html.spec.whatwg.org/multipage/#attributes-3>
-    [
-        "allowfullscreen",
-        "alpha",
-        "async",
-        "autofocus",
-        "autoplay",
-        "checked",
-        "controls",
-        "default",
-        "defer",
-        "disabled",
-        "formnovalidate",
-        "hidden",
-        "inert",
-        "ismap",
-        "itemscope",
-        "loop",
-        "multiple",
-        "muted",
-        "nomodule",
-        "novalidate",
-        "open",
-        "playsinline",
-        "readonly",
-        "required",
-        "reversed",
-        "selected",
-        "shadowrootclonable",
-        "shadowrootcustomelementregistry",
-        "shadowrootdelegatesfocus",
-        "shadowrootserializable",
-    ]
-    .iter()
-    .any(|&boolean_attr| boolean_attr.eq_ignore_ascii_case(name))
+    static BOOLEAN_ATTRIBUTES: LazyLock<[&str; 30]> = LazyLock::new(|| {
+        [
+            "allowfullscreen",
+            "alpha",
+            "async",
+            "autofocus",
+            "autoplay",
+            "checked",
+            "controls",
+            "default",
+            "defer",
+            "disabled",
+            "formnovalidate",
+            "hidden",
+            "inert",
+            "ismap",
+            "itemscope",
+            "loop",
+            "multiple",
+            "muted",
+            "nomodule",
+            "novalidate",
+            "open",
+            "playsinline",
+            "readonly",
+            "required",
+            "reversed",
+            "selected",
+            "shadowrootclonable",
+            "shadowrootcustomelementregistry",
+            "shadowrootdelegatesfocus",
+            "shadowrootserializable",
+        ]
+    });
+
+    BOOLEAN_ATTRIBUTES
+        .iter()
+        .any(|&boolean_attr| boolean_attr.eq_ignore_ascii_case(name))
 }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1584,7 +1584,6 @@ pub(crate) fn handle_get_attribute(
         .send(
             get_known_element(documents, pipeline, node_id).map(|element| {
                 if is_boolean_attribute(&name) {
-                    // element.get_attribute_by_name(DOMString::from(name)).map(|_| String::from("true"))
                     if element.HasAttribute(DOMString::from(name)) {
                         Some(String::from("true"))
                     } else {


### PR DESCRIPTION
Follow up of  #38401.
- The constant String array was recreated for every invocation. Chromium store this as a global const. https://source.chromium.org/chromium/chromium/src/+/main:chrome/test/chromedriver/element_commands.cc;l=48-94?q=chrome%2Ftest%2Fchromedriver%2Felement_commands.cc
We now use static `LazyLock` to lazy init and avoid recreation.
- Clean up some comments

Testing: Just refactor.
