### PR TITLE
constellation: join on script-threads

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2534,17 +2534,17 @@ where
         // In single process mode, join on script-threads
         // from webview which haven't been manually closed before.
         for (_, join_handle) in self.script_join_handles.drain() {
-            join_handle
-                .join()
-                .expect("Failed to join on a script-thread.");
+            if join_handle.join().is_err() {
+                error!("Failed to join on a script-thread.");
+            }
         }
 
         // In single process mode, join on the background hang monitor worker thread.
         drop(self.background_monitor_register.take());
         if let Some(join_handle) = self.background_monitor_register_join_handle.take() {
-            join_handle
-                .join()
-                .expect("Failed to join on the BHM background thread.");
+            if join_handle.join().is_err() {
+                error!("Failed to join on the bhm background thread.");
+            }
         }
 
         // At this point, there are no active pipelines,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -25,7 +25,7 @@ use std::rc::Rc;
 use std::result::Result;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, SystemTime};
 
 use background_hang_monitor_api::{
@@ -412,7 +412,7 @@ impl ScriptThreadFactory for ScriptThread {
         layout_factory: Arc<dyn LayoutFactory>,
         system_font_service: Arc<SystemFontServiceProxy>,
         load_data: LoadData,
-    ) {
+    ) -> JoinHandle<()> {
         thread::Builder::new()
             .name(format!("Script{:?}", state.id))
             .spawn(move || {
@@ -462,7 +462,7 @@ impl ScriptThreadFactory for ScriptThread {
                 // This must always be the very last operation performed before the thread completes
                 failsafe.neuter();
             })
-            .expect("Thread spawning failed");
+            .expect("Thread spawning failed")
     }
 }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1265,7 +1265,7 @@ pub fn run_content_process(token: String) {
 
             content.register_system_memory_reporter();
 
-            content.start_all::<script::ScriptThread>(
+            let script_join_handle = content.start_all::<script::ScriptThread>(
                 true,
                 layout_factory,
                 background_hang_monitor_register,
@@ -1274,7 +1274,10 @@ pub fn run_content_process(token: String) {
             // Since wait_for_completion is true,
             // here we know that the script-thread
             // will exit(or already has),
-            // and so we can join on the BHM worker thread.
+            // and so we can join first on the script, and then on the BHM worker, threads.
+            script_join_handle
+                .join()
+                .expect("Failed to join on the script thread.");
             join_handle
                 .join()
                 .expect("Failed to join on the BHM background thread.");

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -15,6 +15,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicIsize, AtomicU64, Ordering};
+use std::thread::JoinHandle;
 
 use app_units::Au;
 use atomic_refcell::AtomicRefCell;
@@ -301,7 +302,7 @@ pub trait ScriptThreadFactory {
         layout_factory: Arc<dyn LayoutFactory>,
         system_font_service: Arc<SystemFontServiceProxy>,
         load_data: LoadData,
-    );
+    ) -> JoinHandle<()>;
 }
 #[derive(Clone, Default)]
 pub struct OffsetParentResponse {


### PR DESCRIPTION
We currently send exit signals to script-threads, and we also join on the BHM worker. This ensure the constellation shuts-down only after script has dropped it's sender to the BHM worker. By joining on the script-threads, we have a guarantee that they have exited(which is stronger than having dropped their senders) by the time the constellation exits. 

Testing: Manually opened many tabs and closed the window, both in single- and multi-process modes. 
Fixes: Part of - https://github.com/servo/servo/issues/30849