### PR TITLE
net: clean shutdown of the async runtime

### DIFF
--- a/components/net/async_runtime.rs
+++ b/components/net/async_runtime.rs
@@ -8,6 +8,9 @@ use futures::Future;
 use net_traits::AsyncRuntime;
 use tokio::runtime::{Handle, Runtime};
 
+
+/// The actual runtime,
+/// to be used as part of shut-down.
 pub struct AsyncRuntimeHolder {
     runtime: Option<Runtime>,
 }
@@ -29,8 +32,11 @@ impl AsyncRuntime for AsyncRuntimeHolder {
     }
 }
 
+/// A shared handle to the runtime,
+/// to be initialized on start-up.
 pub static HANDLE: OnceLock<Handle> = OnceLock::new();
 
+/// Spawn a task using the handle to the runtime.
 pub fn spawn_task<F>(task: F)
 where
     F: Future + 'static + std::marker::Send,

--- a/components/net/async_runtime.rs
+++ b/components/net/async_runtime.rs
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
 use std::time::Duration;
 
 use futures::Future;
 use net_traits::AsyncRuntime;
-use tokio::runtime::{Handle, Runtime};
-
+use tokio::runtime::{Builder, Handle, Runtime};
 
 /// The actual runtime,
 /// to be used as part of shut-down.
@@ -34,7 +35,35 @@ impl AsyncRuntime for AsyncRuntimeHolder {
 
 /// A shared handle to the runtime,
 /// to be initialized on start-up.
-pub static HANDLE: OnceLock<Handle> = OnceLock::new();
+static ASYNC_RUNTIME_HANDLE: OnceLock<Handle> = OnceLock::new();
+
+pub fn init_async_runtime() -> Box<dyn AsyncRuntime> {
+    // Initialize a tokio runtime.
+    let runtime = Builder::new_multi_thread()
+        .thread_name_fn(|| {
+            static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+            let id = ATOMIC_ID.fetch_add(1, Ordering::Relaxed);
+            format!("tokio-runtime-{}", id)
+        })
+        .worker_threads(
+            thread::available_parallelism()
+                .map(|i| i.get())
+                .unwrap_or(servo_config::pref!(threadpools_fallback_worker_num) as usize)
+                .min(servo_config::pref!(threadpools_async_runtime_workers_max).max(1) as usize),
+        )
+        .enable_io()
+        .enable_time()
+        .build()
+        .expect("Unable to build tokio-runtime runtime");
+
+    // Make the runtime available to users inside this crate.
+    ASYNC_RUNTIME_HANDLE
+        .set(runtime.handle().clone())
+        .expect("Runtime handle should be initialized once on start-up");
+
+    // Return an async runtime for use in shutdown.
+    Box::new(AsyncRuntimeHolder::new(runtime))
+}
 
 /// Spawn a task using the handle to the runtime.
 pub fn spawn_task<F>(task: F)
@@ -42,8 +71,19 @@ where
     F: Future + 'static + std::marker::Send,
     F::Output: Send + 'static,
 {
-    HANDLE
+    ASYNC_RUNTIME_HANDLE
         .get()
         .expect("Runtime handle should be initialized on start-up")
         .spawn(task);
+}
+
+/// Spawn a blocking task using the handle to the runtime.
+pub fn spawn_blocking_task<F, R>(task: F) -> F::Output
+where
+    F: Future,
+{
+    ASYNC_RUNTIME_HANDLE
+        .get()
+        .expect("Runtime handle should be initialized on start-up")
+        .block_on(task)
 }

--- a/components/net/async_runtime.rs
+++ b/components/net/async_runtime.rs
@@ -1,28 +1,43 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-use std::cmp::Ord;
-use std::sync::LazyLock;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::thread;
+use std::sync::OnceLock;
+use std::time::Duration;
 
-use tokio::runtime::{Builder, Runtime};
+use futures::Future;
+use net_traits::AsyncRuntime;
+use tokio::runtime::{Handle, Runtime};
 
-pub static HANDLE: LazyLock<Runtime> = LazyLock::new(|| {
-    Builder::new_multi_thread()
-        .thread_name_fn(|| {
-            static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-            let id = ATOMIC_ID.fetch_add(1, Ordering::Relaxed);
-            format!("tokio-runtime-{}", id)
-        })
-        .worker_threads(
-            thread::available_parallelism()
-                .map(|i| i.get())
-                .unwrap_or(servo_config::pref!(threadpools_fallback_worker_num) as usize)
-                .min(servo_config::pref!(threadpools_async_runtime_workers_max).max(1) as usize),
-        )
-        .enable_io()
-        .enable_time()
-        .build()
-        .expect("Unable to build tokio-runtime runtime")
-});
+pub struct AsyncRuntimeHolder {
+    runtime: Option<Runtime>,
+}
+
+impl AsyncRuntimeHolder {
+    pub(crate) fn new(runtime: Runtime) -> Self {
+        Self {
+            runtime: Some(runtime),
+        }
+    }
+}
+
+impl AsyncRuntime for AsyncRuntimeHolder {
+    fn shutdown(&mut self) {
+        self.runtime
+            .take()
+            .expect("Runtime should have been initialized on start-up.")
+            .shutdown_timeout(Duration::from_millis(100))
+    }
+}
+
+pub static HANDLE: OnceLock<Handle> = OnceLock::new();
+
+pub fn spawn_task<F>(task: F)
+where
+    F: Future + 'static + std::marker::Send,
+    F::Output: Send + 'static,
+{
+    HANDLE
+        .get()
+        .expect("Runtime handle should be initialized on start-up")
+        .spawn(task);
+}

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -21,7 +21,7 @@ use rustls::{ClientConfig, RootCertStore};
 use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
 use tower_service::Service;
 
-use crate::async_runtime::HANDLE;
+use crate::async_runtime::spawn_task;
 use crate::hosts::replace_host;
 
 pub const BUF_SIZE: usize = 32768;
@@ -165,7 +165,7 @@ where
     F: Future<Output = ()> + 'static + std::marker::Send,
 {
     fn execute(&self, fut: F) {
-        HANDLE.spawn(fut);
+        spawn_task(fut);
     }
 }
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -66,7 +66,7 @@ use tokio::sync::mpsc::{
 };
 use tokio_stream::wrappers::ReceiverStream;
 
-use crate::async_runtime::HANDLE;
+use crate::async_runtime::spawn_task;
 use crate::connector::{CertificateErrorOverrideManager, Connector};
 use crate::cookie::ServoCookie;
 use crate::cookie_storage::CookieStorage;
@@ -574,7 +574,7 @@ impl BodySink {
         match self {
             BodySink::Chunked(sender) => {
                 let sender = sender.clone();
-                HANDLE.spawn(async move {
+                spawn_task(async move {
                     let _ = sender
                         .send(Ok(Frame::data(Bytes::copy_from_slice(&bytes))))
                         .await;
@@ -2090,7 +2090,7 @@ async fn http_network_fetch(
     let headers = response.headers.clone();
     let devtools_chan = context.devtools_chan.clone();
 
-    HANDLE.spawn(
+    spawn_task(
         res.into_body()
             .map_err(|e| {
                 warn!("Error streaming response body: {:?}", e);

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -137,7 +137,6 @@ pub fn new_resource_threads(
     (
         ResourceThreads::new(public_core, storage.clone(), idb.clone()),
         ResourceThreads::new(private_core, storage, idb),
-        
         // Return the runtime for use in shutdown.
         Box::new(AsyncRuntimeHolder::new(runtime)),
     )

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -26,6 +26,7 @@ use http_body_util::combinators::BoxBody;
 use hyper::body::{Bytes, Incoming};
 use hyper::{Request as HyperRequest, Response as HyperResponse};
 use mime::{self, Mime};
+use net::async_runtime::spawn_blocking_task;
 use net::fetch::cors_cache::CorsCache;
 use net::fetch::methods::{self, FetchContext};
 use net::filemanager_thread::FileManager;
@@ -200,7 +201,7 @@ fn test_fetch_blob() {
         expected: bytes.to_vec(),
     };
 
-    crate::HANDLE.block_on(methods::fetch(request, &mut target, &context));
+    spawn_blocking_task::<_, Response>(methods::fetch(request, &mut target, &context));
 
     let fetch_response = receiver.recv().unwrap();
     assert!(!fetch_response.is_network_error());

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -49,7 +49,7 @@ use url::Url;
 
 use crate::{
     create_embedder_proxy_and_receiver, fetch, fetch_with_context, make_body, make_server,
-    new_fetch_context, receive_credential_prompt_msgs,
+    new_fetch_context, receive_credential_prompt_msgs, spawn_blocking_task,
 };
 
 fn mock_origin() -> ImmutableOrigin {
@@ -1611,7 +1611,7 @@ fn test_fetch_compressed_response_update_count() {
         sender: Some(sender),
         update_count: 0,
     };
-    let response_update_count = crate::HANDLE.block_on(async move {
+    let response_update_count = spawn_blocking_task::<_, Response>(async move {
         methods::fetch(
             request,
             &mut target,

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -39,7 +39,7 @@ use tungstenite::handshake::client::{Request, Response};
 use tungstenite::protocol::CloseFrame;
 use url::Url;
 
-use crate::async_runtime::HANDLE;
+use crate::async_runtime::spawn_task;
 use crate::connector::{CACertificates, TlsConfig, create_tls_config};
 use crate::cookie::ServoCookie;
 use crate::fetch::methods::{
@@ -423,7 +423,7 @@ fn connect(
     tls_config.alpn_protocols = vec!["http/1.1".to_string().into()];
 
     let resource_event_sender2 = resource_event_sender.clone();
-    HANDLE.spawn(
+    spawn_task(
         start_websocket(
             http_state,
             req_url.clone(),

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1141,7 +1141,7 @@ fn create_constellation(
     let bluetooth_thread: IpcSender<BluetoothRequest> =
         BluetoothThreadFactory::new(embedder_proxy.clone());
 
-    let (public_resource_threads, private_resource_threads) = new_resource_threads(
+    let (public_resource_threads, private_resource_threads, async_runtime) = new_resource_threads(
         devtools_sender.clone(),
         time_profiler_chan.clone(),
         mem_profiler_chan.clone(),
@@ -1182,6 +1182,7 @@ fn create_constellation(
         #[cfg(feature = "webgpu")]
         wgpu_image_map,
         user_content_manager,
+        async_runtime,
     };
 
     let layout_factory = Arc::new(LayoutFactoryImpl());

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -389,6 +389,12 @@ impl<T: FetchResponseListener> Action<T> for FetchResponseMsg {
     }
 }
 
+/// Handle to an async runtime,
+/// only used to shut it down for now.
+pub trait AsyncRuntime: Send {
+    fn shutdown(&mut self);
+}
+
 /// Handle to a resource thread
 pub type CoreResourceThread = IpcSender<CoreResourceMsg>;
 


### PR DESCRIPTION
The previous use of a static variable for the runtime prevented it from shutting down cleanly, because shutdown requires dropping or taking ownership of it. This PR switches the static variable to a handle only, and introduces a new trait to pass a handle to the async runtime to the constellation, where it can be shut-down along with other components and help reduce our count of still running threads after shutdown. 

Testing: manual testing, and covered by unit-test in net, and wpt tests.
Fixes: part of - https://github.com/servo/servo/issues/30849

