### PR TITLE
Replace all sort with unstable sort

### DIFF
--- a/components/compositing/webview_manager.rs
+++ b/components/compositing/webview_manager.rs
@@ -127,7 +127,7 @@ mod test {
         webviews: &WebViewManager<WebView>,
     ) -> Vec<(WebViewId, WebView)> {
         let mut keys = webviews.webviews.keys().collect::<Vec<_>>();
-        keys.sort();
+        keys.sort_unstable();
         keys.iter()
             .map(|&id| (*id, webviews.webviews.get(id).cloned().unwrap()))
             .collect()

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -5401,7 +5401,7 @@ where
         };
         // In order to get repeatability, we sort the pipeline ids.
         let mut pipeline_ids: Vec<&PipelineId> = self.pipelines.keys().collect();
-        pipeline_ids.sort();
+        pipeline_ids.sort_unstable();
         if let Some((ref mut rng, probability)) = self.random_pipeline_closure {
             if let Some(pipeline_id) = pipeline_ids.choose(rng) {
                 if let Some(pipeline) = self.pipelines.get(pipeline_id) {

--- a/components/constellation/webview_manager.rs
+++ b/components/constellation/webview_manager.rs
@@ -99,7 +99,7 @@ mod test {
         webviews: &WebViewManager<WebView>,
     ) -> Vec<(WebViewId, WebView)> {
         let mut keys = webviews.webviews.keys().collect::<Vec<_>>();
-        keys.sort();
+        keys.sort_unstable();
         keys.iter()
             .map(|&id| {
                 (

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -814,7 +814,7 @@ fn load_userscripts(userscripts_directory: Option<&Path>) -> std::io::Result<Vec
         let mut files = std::fs::read_dir(userscripts_directory)?
             .map(|e| e.map(|entry| entry.path()))
             .collect::<Result<Vec<_>, _>>()?;
-        files.sort();
+        files.sort_unstable();
         for file in files {
             userscripts.push(UserScript {
                 script: std::fs::read_to_string(&file)?,


### PR DESCRIPTION
["When applicable, unstable sorting is preferred because it is generally faster than stable sorting and it doesn’t allocate auxiliary memory."](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.sort)

Binary also reduced by 1KB in Release.

Testing: No behaviour change as semantically all current usage does not have any pair with `std::cmp::Ordering::Equal`. 