### PR TITLE
script: Unify script-based "update the rendering" and throttle it to 60 FPS

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -495,6 +495,10 @@ impl Layout for LayoutThread {
             .as_mut()
             .and_then(|tree| tree.compositor_info.scroll_tree.scroll_offset(id))
     }
+
+    fn needs_new_display_list(&self) -> bool {
+        self.need_new_display_list.get()
+    }
 }
 
 impl LayoutThread {

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -216,7 +216,7 @@ pub(crate) fn handle_get_attribute_style(
             let name = style.Item(i);
             NodeStyle {
                 name: name.to_string(),
-                value: style.GetPropertyValue(name.clone(), can_gc).to_string(),
+                value: style.GetPropertyValue(name.clone()).to_string(),
                 priority: style.GetPropertyPriority(name).to_string(),
             }
         })
@@ -259,7 +259,7 @@ pub(crate) fn handle_get_stylesheet_style(
                     let name = style.Item(i);
                     NodeStyle {
                         name: name.to_string(),
-                        value: style.GetPropertyValue(name.clone(), can_gc).to_string(),
+                        value: style.GetPropertyValue(name.clone()).to_string(),
                         priority: style.GetPropertyPriority(name).to_string(),
                     }
                 })
@@ -315,7 +315,6 @@ pub(crate) fn handle_get_computed_style(
     pipeline: PipelineId,
     node_id: String,
     reply: IpcSender<Option<Vec<NodeStyle>>>,
-    can_gc: CanGc,
 ) {
     let node = match find_node_by_unique_id(documents, pipeline, &node_id) {
         None => return reply.send(None).unwrap(),
@@ -333,9 +332,7 @@ pub(crate) fn handle_get_computed_style(
             let name = computed_style.Item(i);
             NodeStyle {
                 name: name.to_string(),
-                value: computed_style
-                    .GetPropertyValue(name.clone(), can_gc)
-                    .to_string(),
+                value: computed_style.GetPropertyValue(name.clone()).to_string(),
                 priority: computed_style.GetPropertyPriority(name).to_string(),
             }
         })
@@ -375,7 +372,7 @@ pub(crate) fn handle_get_layout(
             position: String::from(computed_style.Position()),
             z_index: String::from(computed_style.ZIndex()),
             box_sizing: String::from(computed_style.BoxSizing()),
-            auto_margins: determine_auto_margins(&node, can_gc),
+            auto_margins: determine_auto_margins(&node),
             margin_top: String::from(computed_style.MarginTop()),
             margin_right: String::from(computed_style.MarginRight()),
             margin_bottom: String::from(computed_style.MarginBottom()),
@@ -394,8 +391,8 @@ pub(crate) fn handle_get_layout(
         .unwrap();
 }
 
-fn determine_auto_margins(node: &Node, can_gc: CanGc) -> AutoMargins {
-    let style = node.style(can_gc).unwrap();
+fn determine_auto_margins(node: &Node) -> AutoMargins {
+    let style = node.style().unwrap();
     let margin = style.get_margin();
     AutoMargins {
         top: margin.margin_top.is_auto(),

--- a/components/script/dom/canvasgradient.rs
+++ b/components/script/dom/canvasgradient.rs
@@ -57,12 +57,12 @@ impl CanvasGradient {
 
 impl CanvasGradientMethods<crate::DomTypeHolder> for CanvasGradient {
     // https://html.spec.whatwg.org/multipage/#dom-canvasgradient-addcolorstop
-    fn AddColorStop(&self, offset: Finite<f64>, color: DOMString, can_gc: CanGc) -> ErrorResult {
+    fn AddColorStop(&self, offset: Finite<f64>, color: DOMString) -> ErrorResult {
         if *offset < 0f64 || *offset > 1f64 {
             return Err(Error::IndexSize);
         }
 
-        let color = match parse_color(None, &color, can_gc) {
+        let color = match parse_color(None, &color) {
             Ok(color) => color,
             Err(_) => return Err(Error::Syntax),
         };

--- a/components/script/dom/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvasrenderingcontext2d.rs
@@ -327,15 +327,9 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-filltext
-    fn FillText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>, can_gc: CanGc) {
-        self.canvas_state.fill_text(
-            self.canvas.canvas().as_deref(),
-            text,
-            x,
-            y,
-            max_width,
-            can_gc,
-        );
+    fn FillText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>) {
+        self.canvas_state
+            .fill_text(self.canvas.canvas().as_deref(), text, x, y, max_width);
         self.mark_as_dirty();
     }
 
@@ -355,9 +349,9 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-font
-    fn SetFont(&self, value: DOMString, can_gc: CanGc) {
+    fn SetFont(&self, value: DOMString) {
         self.canvas_state
-            .set_font(self.canvas.canvas().as_deref(), value, can_gc)
+            .set_font(self.canvas.canvas().as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-textalign
@@ -504,9 +498,9 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
-    fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
+    fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
         self.canvas_state
-            .set_stroke_style(self.canvas.canvas().as_deref(), value, can_gc)
+            .set_stroke_style(self.canvas.canvas().as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
@@ -515,9 +509,9 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
-    fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
+    fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
         self.canvas_state
-            .set_fill_style(self.canvas.canvas().as_deref(), value, can_gc)
+            .set_fill_style(self.canvas.canvas().as_deref(), value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createimagedata
@@ -715,8 +709,8 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
-    fn SetShadowColor(&self, value: DOMString, can_gc: CanGc) {
+    fn SetShadowColor(&self, value: DOMString) {
         self.canvas_state
-            .set_shadow_color(self.canvas.canvas().as_deref(), value, can_gc)
+            .set_shadow_color(self.canvas.canvas().as_deref(), value)
     }
 }

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -204,7 +204,7 @@ macro_rules! css_properties(
                     $id.enabled_for_all_content(),
                     "Someone forgot a #[Pref] annotation"
                 );
-                self.get_property_value($id, CanGc::note())
+                self.get_property_value($id)
             }
             fn $setter(&self, value: DOMString) -> ErrorResult {
                 debug_assert!(
@@ -268,7 +268,7 @@ impl CSSStyleDeclaration {
         )
     }
 
-    fn get_computed_style(&self, property: PropertyId, can_gc: CanGc) -> DOMString {
+    fn get_computed_style(&self, property: PropertyId) -> DOMString {
         match self.owner {
             CSSStyleOwner::CSSRule(..) => {
                 panic!("get_computed_style called on CSSStyleDeclaration with a CSSRule owner")
@@ -280,20 +280,20 @@ impl CSSStyleDeclaration {
                 }
                 let addr = node.to_trusted_node_address();
                 node.owner_window()
-                    .resolved_style_query(addr, self.pseudo, property, can_gc)
+                    .resolved_style_query(addr, self.pseudo, property)
             },
             CSSStyleOwner::Null => DOMString::new(),
         }
     }
 
-    fn get_property_value(&self, id: PropertyId, can_gc: CanGc) -> DOMString {
+    fn get_property_value(&self, id: PropertyId) -> DOMString {
         if matches!(self.owner, CSSStyleOwner::Null) {
             return DOMString::new();
         }
 
         if self.readonly {
             // Readonly style declarations are used for getComputedStyle.
-            return self.get_computed_style(id, can_gc);
+            return self.get_computed_style(id);
         }
 
         let mut string = String::new();
@@ -431,12 +431,12 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
     }
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertyvalue
-    fn GetPropertyValue(&self, property: DOMString, can_gc: CanGc) -> DOMString {
+    fn GetPropertyValue(&self, property: DOMString) -> DOMString {
         let id = match PropertyId::parse_enabled_for_all_content(&property) {
             Ok(id) => id,
             Err(..) => return DOMString::new(),
         };
-        self.get_property_value(id, can_gc)
+        self.get_property_value(id)
     }
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertypriority
@@ -502,8 +502,8 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
     }
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-cssfloat
-    fn CssFloat(&self, can_gc: CanGc) -> DOMString {
-        self.get_property_value(PropertyId::NonCustom(LonghandId::Float.into()), can_gc)
+    fn CssFloat(&self) -> DOMString {
+        self.get_property_value(PropertyId::NonCustom(LonghandId::Float.into()))
     }
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-cssfloat

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -35,7 +35,6 @@ use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::stylesheetlist::StyleSheetListOwner;
 use crate::dom::types::CSSStyleSheet;
 use crate::dom::window::Window;
-use crate::script_runtime::CanGc;
 use crate::stylesheet_set::StylesheetSetRef;
 
 /// Stylesheet could be constructed by a CSSOM object CSSStylesheet or parsed
@@ -141,10 +140,8 @@ impl DocumentOrShadowRoot {
         &self,
         client_point: &Point2D<f32>,
         query_type: NodesFromPointQueryType,
-        can_gc: CanGc,
     ) -> Vec<UntrustedNodeAddress> {
-        self.window
-            .layout_reflow(QueryMsg::NodesFromPointQuery, can_gc);
+        self.window.layout_reflow(QueryMsg::NodesFromPointQuery);
         self.window
             .layout()
             .query_nodes_from_point(*client_point, query_type)
@@ -158,7 +155,6 @@ impl DocumentOrShadowRoot {
         y: Finite<f64>,
         document_element: Option<DomRoot<Element>>,
         has_browsing_context: bool,
-        can_gc: CanGc,
     ) -> Option<DomRoot<Element>> {
         let x = *x as f32;
         let y = *y as f32;
@@ -174,7 +170,7 @@ impl DocumentOrShadowRoot {
         }
 
         match self
-            .nodes_from_point(point, NodesFromPointQueryType::Topmost, can_gc)
+            .nodes_from_point(point, NodesFromPointQueryType::Topmost)
             .first()
         {
             Some(address) => {
@@ -206,7 +202,6 @@ impl DocumentOrShadowRoot {
         y: Finite<f64>,
         document_element: Option<DomRoot<Element>>,
         has_browsing_context: bool,
-        can_gc: CanGc,
     ) -> Vec<DomRoot<Element>> {
         let x = *x as f32;
         let y = *y as f32;
@@ -223,7 +218,7 @@ impl DocumentOrShadowRoot {
         }
 
         // Step 1 and Step 3
-        let nodes = self.nodes_from_point(point, NodesFromPointQueryType::All, can_gc);
+        let nodes = self.nodes_from_point(point, NodesFromPointQueryType::All);
         let mut elements: Vec<DomRoot<Element>> = nodes
             .iter()
             .flat_map(|&untrusted_node_address| {

--- a/components/script/dom/fontfaceset.rs
+++ b/components/script/dom/fontfaceset.rs
@@ -69,10 +69,17 @@ impl FontFaceSet {
         }
     }
 
-    pub(crate) fn fulfill_ready_promise_if_needed(&self, can_gc: CanGc) {
-        if !self.promise.is_fulfilled() {
-            self.promise.resolve_native(self, can_gc);
+    /// Fulfill the font ready promise, returning true if it was not already fulfilled beforehand.
+    pub(crate) fn fulfill_ready_promise_if_needed(&self, can_gc: CanGc) -> bool {
+        if self.promise.is_fulfilled() {
+            return false;
         }
+        self.promise.resolve_native(self, can_gc);
+        true
+    }
+
+    pub(crate) fn waiting_to_fullfill_promise(&self) -> bool {
+        !self.promise.is_fulfilled()
     }
 }
 

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -101,7 +101,7 @@ impl History {
 
         // Step 8
         if let Some(fragment) = url.fragment() {
-            document.check_and_scroll_fragment(fragment, can_gc);
+            document.check_and_scroll_fragment(fragment);
         }
 
         // Step 11

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -319,7 +319,7 @@ impl Activatable for HTMLAnchorElement {
     }
 
     //https://html.spec.whatwg.org/multipage/#the-a-element:activation-behaviour
-    fn activation_behavior(&self, event: &Event, target: &EventTarget, can_gc: CanGc) {
+    fn activation_behavior(&self, event: &Event, target: &EventTarget, _: CanGc) {
         let element = self.as_element();
         let mouse_event = event.downcast::<MouseEvent>().unwrap();
         let mut ismap_suffix = None;
@@ -329,7 +329,7 @@ impl Activatable for HTMLAnchorElement {
         if let Some(element) = target.downcast::<Element>() {
             if target.is::<HTMLImageElement>() && element.has_attribute(&local_name!("ismap")) {
                 let target_node = element.upcast::<Node>();
-                let rect = target_node.bounding_content_box_or_zero(can_gc);
+                let rect = target_node.bounding_content_box_or_zero();
                 ismap_suffix = Some(format!(
                     "?{},{}",
                     mouse_event.ClientX().to_f32().unwrap() - rect.origin.x.to_f32_px(),

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -116,18 +116,18 @@ impl HTMLElement {
     /// `.outerText` in JavaScript.`
     ///
     /// <https://html.spec.whatwg.org/multipage/#get-the-text-steps>
-    pub(crate) fn get_inner_outer_text(&self, can_gc: CanGc) -> DOMString {
+    pub(crate) fn get_inner_outer_text(&self) -> DOMString {
         let node = self.upcast::<Node>();
         let window = node.owner_window();
         let element = self.as_element();
 
         // Step 1.
-        let element_not_rendered = !node.is_connected() || !element.has_css_layout_box(can_gc);
+        let element_not_rendered = !node.is_connected() || !element.has_css_layout_box();
         if element_not_rendered {
             return node.GetTextContent().unwrap();
         }
 
-        window.layout_reflow(QueryMsg::ElementInnerOuterTextQuery, can_gc);
+        window.layout_reflow(QueryMsg::ElementInnerOuterTextQuery);
         let text = window
             .layout()
             .query_element_inner_outer_text(node.to_trusted_node_address());
@@ -438,65 +438,65 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent>
-    fn GetOffsetParent(&self, can_gc: CanGc) -> Option<DomRoot<Element>> {
+    fn GetOffsetParent(&self) -> Option<DomRoot<Element>> {
         if self.is_body_element() || self.is::<HTMLHtmlElement>() {
             return None;
         }
 
         let node = self.upcast::<Node>();
         let window = self.owner_window();
-        let (element, _) = window.offset_parent_query(node, can_gc);
+        let (element, _) = window.offset_parent_query(node);
 
         element
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsettop
-    fn OffsetTop(&self, can_gc: CanGc) -> i32 {
+    fn OffsetTop(&self) -> i32 {
         if self.is_body_element() {
             return 0;
         }
 
         let node = self.upcast::<Node>();
         let window = self.owner_window();
-        let (_, rect) = window.offset_parent_query(node, can_gc);
+        let (_, rect) = window.offset_parent_query(node);
 
         rect.origin.y.to_nearest_px()
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetleft
-    fn OffsetLeft(&self, can_gc: CanGc) -> i32 {
+    fn OffsetLeft(&self) -> i32 {
         if self.is_body_element() {
             return 0;
         }
 
         let node = self.upcast::<Node>();
         let window = self.owner_window();
-        let (_, rect) = window.offset_parent_query(node, can_gc);
+        let (_, rect) = window.offset_parent_query(node);
 
         rect.origin.x.to_nearest_px()
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetwidth
-    fn OffsetWidth(&self, can_gc: CanGc) -> i32 {
+    fn OffsetWidth(&self) -> i32 {
         let node = self.upcast::<Node>();
         let window = self.owner_window();
-        let (_, rect) = window.offset_parent_query(node, can_gc);
+        let (_, rect) = window.offset_parent_query(node);
 
         rect.size.width.to_nearest_px()
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetheight
-    fn OffsetHeight(&self, can_gc: CanGc) -> i32 {
+    fn OffsetHeight(&self) -> i32 {
         let node = self.upcast::<Node>();
         let window = self.owner_window();
-        let (_, rect) = window.offset_parent_query(node, can_gc);
+        let (_, rect) = window.offset_parent_query(node);
 
         rect.size.height.to_nearest_px()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-innertext-idl-attribute>
-    fn InnerText(&self, can_gc: CanGc) -> DOMString {
-        self.get_inner_outer_text(can_gc)
+    fn InnerText(&self) -> DOMString {
+        self.get_inner_outer_text()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#set-the-inner-text-steps>
@@ -505,8 +505,8 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-outertext>
-    fn GetOuterText(&self, can_gc: CanGc) -> Fallible<DOMString> {
-        Ok(self.get_inner_outer_text(can_gc))
+    fn GetOuterText(&self) -> Fallible<DOMString> {
+        Ok(self.get_inner_outer_text())
     }
 
     /// <https://html.spec.whatwg.org/multipage/#the-innertext-idl-attribute:dom-outertext-2>

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -210,7 +210,7 @@ impl HTMLIFrameElement {
         };
 
         let viewport_details = window
-            .get_iframe_viewport_details_if_known(browsing_context_id, can_gc)
+            .get_iframe_viewport_details_if_known(browsing_context_id)
             .unwrap_or_else(|| ViewportDetails {
                 hidpi_scale_factor: window.device_pixel_ratio(),
                 ..Default::default()

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -1655,9 +1655,9 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
     make_bool_setter!(SetIsMap, "ismap");
 
     // https://html.spec.whatwg.org/multipage/#dom-img-width
-    fn Width(&self, can_gc: CanGc) -> u32 {
+    fn Width(&self) -> u32 {
         let node = self.upcast::<Node>();
-        match node.bounding_content_box(can_gc) {
+        match node.bounding_content_box() {
             Some(rect) => rect.size.width.to_px() as u32,
             None => self.NaturalWidth(),
         }
@@ -1669,9 +1669,9 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-img-height
-    fn Height(&self, can_gc: CanGc) -> u32 {
+    fn Height(&self) -> u32 {
         let node = self.upcast::<Node>();
-        match node.bounding_content_box(can_gc) {
+        match node.bounding_content_box() {
             Some(rect) => rect.size.height.to_px() as u32,
             None => self.NaturalHeight(),
         }

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2736,7 +2736,7 @@ impl HTMLInputElement {
             let (ipc_sender, ipc_receiver) =
                 ipc::channel::<Option<RgbColor>>().expect("Failed to create IPC channel!");
             let document = self.owner_document();
-            let rect = self.upcast::<Node>().bounding_content_box_or_zero(can_gc);
+            let rect = self.upcast::<Node>().bounding_content_box_or_zero();
             let rect = Rect::new(
                 Point2D::new(rect.origin.x.to_px(), rect.origin.y.to_px()),
                 Size2D::new(rect.size.width.to_px(), rect.size.height.to_px()),
@@ -3074,11 +3074,8 @@ impl VirtualMethods for HTMLInputElement {
                     // now.
                     if let Some(point_in_target) = mouse_event.point_in_target() {
                         let window = self.owner_window();
-                        let index = window.text_index_query(
-                            self.upcast::<Node>(),
-                            point_in_target.to_untyped(),
-                            can_gc,
-                        );
+                        let index = window
+                            .text_index_query(self.upcast::<Node>(), point_in_target.to_untyped());
                         // Position the caret at the click position or at the end of the current
                         // value.
                         let edit_point_index = match index {

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1551,9 +1551,9 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
     make_setter!(SetReferrerPolicy, "referrerpolicy");
 
     /// <https://w3c.github.io/trusted-types/dist/spec/#dom-htmlscriptelement-innertext>
-    fn InnerText(&self, can_gc: CanGc) -> TrustedScriptOrString {
+    fn InnerText(&self) -> TrustedScriptOrString {
         // Step 1: Return the result of running get the text steps with this.
-        TrustedScriptOrString::String(self.upcast::<HTMLElement>().get_inner_outer_text(can_gc))
+        TrustedScriptOrString::String(self.upcast::<HTMLElement>().get_inner_outer_text())
     }
 
     /// <https://w3c.github.io/trusted-types/dist/spec/#the-innerText-idl-attribute>

--- a/components/script/dom/htmlselectelement.rs
+++ b/components/script/dom/htmlselectelement.rs
@@ -339,7 +339,7 @@ impl HTMLSelectElement {
             .or_else(|| self.list_of_options().next())
     }
 
-    pub(crate) fn show_menu(&self, can_gc: CanGc) -> Option<usize> {
+    pub(crate) fn show_menu(&self) -> Option<usize> {
         let (ipc_sender, ipc_receiver) = ipc::channel().expect("Failed to create IPC channel!");
 
         // Collect list of optgroups and options
@@ -377,7 +377,7 @@ impl HTMLSelectElement {
             })
             .collect();
 
-        let rect = self.upcast::<Node>().bounding_content_box_or_zero(can_gc);
+        let rect = self.upcast::<Node>().bounding_content_box_or_zero();
         let rect = Rect::new(
             Point2D::new(rect.origin.x.to_px(), rect.origin.y.to_px()),
             Size2D::new(rect.size.width.to_px(), rect.size.height.to_px()),
@@ -782,7 +782,7 @@ impl Activatable for HTMLSelectElement {
     }
 
     fn activation_behavior(&self, _event: &Event, _target: &EventTarget, can_gc: CanGc) {
-        let Some(selected_value) = self.show_menu(can_gc) else {
+        let Some(selected_value) = self.show_menu() else {
             // The user did not select a value
             return;
         };

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -278,7 +278,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
     ) -> Fallible<DomRoot<MouseEvent>> {
         let bubbles = EventBubbles::from(init.parent.parent.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.parent.parent.cancelable);
-        let scroll_offset = window.scroll_offset(can_gc);
+        let scroll_offset = window.scroll_offset();
         let page_point = Point2D::new(
             scroll_offset.x as i32 + init.clientX,
             scroll_offset.y as i32 + init.clientY,
@@ -370,7 +370,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsetx>
-    fn OffsetX(&self, can_gc: CanGc) -> i32 {
+    fn OffsetX(&self) -> i32 {
         // > The offsetX attribute must follow these steps:
         // > 1. If the event’s dispatch flag is set, return the x-coordinate of the position
         // >    where the event occurred relative to the origin of the padding edge of the
@@ -384,7 +384,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
             let Some(node) = target.downcast::<Node>() else {
                 return 0;
             };
-            return self.ClientX() - node.client_rect(can_gc).origin.x;
+            return self.ClientX() - node.client_rect().origin.x;
         }
 
         // > 2. Return the value of the event’s pageX attribute.
@@ -392,7 +392,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-mouseevent-offsety>
-    fn OffsetY(&self, can_gc: CanGc) -> i32 {
+    fn OffsetY(&self) -> i32 {
         // > The offsetY attribute must follow these steps:
         // > 1. If the event’s dispatch flag is set, return the y-coordinate of the
         // >    position where the event occurred relative to the origin of the padding edge of
@@ -406,7 +406,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
             let Some(node) = target.downcast::<Node>() else {
                 return 0;
             };
-            return self.ClientY() - node.client_rect(can_gc).origin.y;
+            return self.ClientY() - node.client_rect().origin.y;
         }
 
         // 2. Return the value of the event’s pageY attribute.
@@ -479,7 +479,6 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
         meta_key_arg: bool,
         button_arg: i16,
         related_target_arg: Option<&EventTarget>,
-        can_gc: CanGc,
     ) {
         if self.upcast::<Event>().dispatching() {
             return;
@@ -498,7 +497,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
             .set(Point2D::new(client_x_arg, client_y_arg));
 
         let global = self.global();
-        let scroll_offset = global.as_window().scroll_offset(can_gc);
+        let scroll_offset = global.as_window().scroll_offset();
         self.page_point.set(Point2D::new(
             scroll_offset.x as i32 + client_x_arg,
             scroll_offset.y as i32 + client_y_arg,

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -944,29 +944,29 @@ impl Node {
 
     /// Returns the rendered bounding content box if the element is rendered,
     /// and none otherwise.
-    pub(crate) fn bounding_content_box(&self, can_gc: CanGc) -> Option<Rect<Au>> {
-        self.owner_window().content_box_query(self, can_gc)
+    pub(crate) fn bounding_content_box(&self) -> Option<Rect<Au>> {
+        self.owner_window().content_box_query(self)
     }
 
-    pub(crate) fn bounding_content_box_or_zero(&self, can_gc: CanGc) -> Rect<Au> {
-        self.bounding_content_box(can_gc).unwrap_or_else(Rect::zero)
+    pub(crate) fn bounding_content_box_or_zero(&self) -> Rect<Au> {
+        self.bounding_content_box().unwrap_or_else(Rect::zero)
     }
 
     pub(crate) fn bounding_content_box_no_reflow(&self) -> Option<Rect<Au>> {
         self.owner_window().content_box_query_unchecked(self)
     }
 
-    pub(crate) fn content_boxes(&self, can_gc: CanGc) -> Vec<Rect<Au>> {
-        self.owner_window().content_boxes_query(self, can_gc)
+    pub(crate) fn content_boxes(&self) -> Vec<Rect<Au>> {
+        self.owner_window().content_boxes_query(self)
     }
 
-    pub(crate) fn client_rect(&self, can_gc: CanGc) -> Rect<i32> {
-        self.owner_window().client_rect_query(self, can_gc)
+    pub(crate) fn client_rect(&self) -> Rect<i32> {
+        self.owner_window().client_rect_query(self)
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-element-scrollwidth>
     /// <https://drafts.csswg.org/cssom-view/#dom-element-scrollheight>
-    pub(crate) fn scroll_area(&self, can_gc: CanGc) -> Rect<i32> {
+    pub(crate) fn scroll_area(&self) -> Rect<i32> {
         // "1. Let document be the element’s node document.""
         let document = self.owner_doc();
 
@@ -992,7 +992,7 @@ impl Node {
         // element is not potentially scrollable, return max(viewport scrolling area
         // width, viewport width)."
         if (is_root && !in_quirks_mode) || (is_body_element && in_quirks_mode) {
-            let viewport_scrolling_area = window.scrolling_area_query(None, can_gc);
+            let viewport_scrolling_area = window.scrolling_area_query(None);
             return Rect::new(
                 viewport_scrolling_area.origin,
                 viewport_scrolling_area.size.max(viewport),
@@ -1002,7 +1002,7 @@ impl Node {
         // "6. If the element does not have any associated box return zero and terminate
         // these steps."
         // "7. Return the width of the element’s scrolling area."
-        window.scrolling_area_query(Some(self), can_gc)
+        window.scrolling_area_query(Some(self))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-childnode-before>
@@ -1461,9 +1461,8 @@ impl Node {
         })
     }
 
-    pub(crate) fn style(&self, can_gc: CanGc) -> Option<Arc<ComputedValues>> {
-        self.owner_window()
-            .layout_reflow(QueryMsg::StyleQuery, can_gc);
+    pub(crate) fn style(&self) -> Option<Arc<ComputedValues>> {
+        self.owner_window().layout_reflow(QueryMsg::StyleQuery);
         self.style_data
             .borrow()
             .as_ref()

--- a/components/script/dom/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/offscreencanvasrenderingcontext2d.rs
@@ -161,8 +161,8 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
-    fn SetShadowColor(&self, value: DOMString, can_gc: CanGc) {
-        self.context.SetShadowColor(value, can_gc)
+    fn SetShadowColor(&self, value: DOMString) {
+        self.context.SetShadowColor(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
@@ -171,8 +171,8 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
-    fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
-        self.context.SetStrokeStyle(value, can_gc)
+    fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
+        self.context.SetStrokeStyle(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
@@ -181,8 +181,8 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
-    fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
-        self.context.SetFillStyle(value, can_gc)
+    fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
+        self.context.SetFillStyle(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createlineargradient
@@ -269,8 +269,8 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-filltext
-    fn FillText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>, can_gc: CanGc) {
-        self.context.FillText(text, x, y, max_width, can_gc)
+    fn FillText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>) {
+        self.context.FillText(text, x, y, max_width)
     }
 
     // https://html.spec.whatwg.org/multipage/#textmetrics
@@ -284,8 +284,8 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-font
-    fn SetFont(&self, value: DOMString, can_gc: CanGc) {
-        self.context.SetFont(value, can_gc)
+    fn SetFont(&self, value: DOMString) {
+        self.context.SetFont(value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-textalign

--- a/components/script/dom/paintrenderingcontext2d.rs
+++ b/components/script/dom/paintrenderingcontext2d.rs
@@ -343,8 +343,8 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
-    fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
-        self.canvas_state.set_stroke_style(None, value, can_gc)
+    fn SetStrokeStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
+        self.canvas_state.set_stroke_style(None, value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
@@ -353,8 +353,8 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-strokestyle
-    fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern, can_gc: CanGc) {
-        self.canvas_state.set_fill_style(None, value, can_gc)
+    fn SetFillStyle(&self, value: StringOrCanvasGradientOrCanvasPattern) {
+        self.canvas_state.set_fill_style(None, value)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createlineargradient
@@ -497,7 +497,7 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-shadowcolor
-    fn SetShadowColor(&self, value: DOMString, can_gc: CanGc) {
-        self.canvas_state.set_shadow_color(None, value, can_gc)
+    fn SetShadowColor(&self, value: DOMString) {
+        self.canvas_state.set_shadow_color(None, value)
     }
 }

--- a/components/script/dom/pointerevent.rs
+++ b/components/script/dom/pointerevent.rs
@@ -233,7 +233,7 @@ impl PointerEventMethods<crate::DomTypeHolder> for PointerEvent {
     ) -> DomRoot<PointerEvent> {
         let bubbles = EventBubbles::from(init.parent.parent.parent.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.parent.parent.parent.cancelable);
-        let scroll_offset = window.scroll_offset(can_gc);
+        let scroll_offset = window.scroll_offset();
         let page_point = Point2D::new(
             scroll_offset.x as i32 + init.parent.clientX,
             scroll_offset.y as i32 + init.parent.clientY,

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -329,7 +329,6 @@ impl Range {
 
     fn client_rects(
         &self,
-        can_gc: CanGc,
     ) -> impl Iterator<Item = euclid::Rect<app_units::Au, euclid::UnknownUnit>> {
         // FIXME: For text nodes that are only partially selected, this should return the client
         // rect of the selected part, not the whole text node.
@@ -341,7 +340,7 @@ impl Range {
             .following_nodes(document.upcast::<Node>())
             .take_while(move |node| node != &end)
             .chain(iter::once(end_clone))
-            .flat_map(move |node| node.content_boxes(can_gc))
+            .flat_map(move |node| node.content_boxes())
     }
 
     /// <https://dom.spec.whatwg.org/#concept-range-bp-set>
@@ -1153,7 +1152,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         let window = start.owner_window();
 
         let client_rects = self
-            .client_rects(can_gc)
+            .client_rects()
             .map(|rect| {
                 DOMRect::new(
                     window.upcast(),
@@ -1174,7 +1173,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         let window = self.start_container().owner_window();
 
         // Step 1. Let list be the result of invoking getClientRects() on the same range this method was invoked on.
-        let list = self.client_rects(can_gc);
+        let list = self.client_rects();
 
         // Step 2. If list is empty return a DOMRect object whose x, y, width and height members are zero.
         // Step 3. If all rectangles in list have zero width or height, return the first rectangle in list.

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -81,7 +81,6 @@ impl ResizeObserver {
         &self,
         depth: &ResizeObservationDepth,
         has_active: &mut bool,
-        can_gc: CanGc,
     ) {
         // Step 2.1 Clear observer’s [[activeTargets]], and [[skippedTargets]].
         // NOTE: This happens as part of Step 2.2
@@ -91,7 +90,7 @@ impl ResizeObserver {
             observation.state = Default::default();
 
             // Step 2.2.1 If observation.isActive() is true
-            if let Some(size) = observation.is_active(target, can_gc) {
+            if let Some(size) = observation.is_active(target) {
                 // Step 2.2.1.1 Let targetDepth be result of calculate depth for node for observation.target.
                 let target_depth = calculate_depth_for_node(target);
 
@@ -227,6 +226,10 @@ impl ResizeObserverMethods<crate::DomTypeHolder> for ResizeObserver {
         self.observation_targets
             .borrow_mut()
             .push((resize_observation, Dom::from_ref(target)));
+        target
+            .owner_window()
+            .Document()
+            .set_resize_observer_started_observing_target(true);
     }
 
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserver-unobserve>
@@ -284,9 +287,9 @@ impl ResizeObservation {
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobservation-isactive>
     /// Returning an optional calculated size, instead of a boolean,
     /// to avoid recalculating the size in the subsequent broadcast.
-    fn is_active(&self, target: &Element, can_gc: CanGc) -> Option<Rect<Au>> {
+    fn is_active(&self, target: &Element) -> Option<Rect<Au>> {
         let last_reported_size = self.last_reported_sizes[0];
-        let box_size = calculate_box_size(target, &self.observed_box, can_gc);
+        let box_size = calculate_box_size(target, &self.observed_box);
         let is_active = box_size.width().to_f64_px() != last_reported_size.inline_size() ||
             box_size.height().to_f64_px() != last_reported_size.block_size();
         if is_active { Some(box_size) } else { None }
@@ -301,18 +304,14 @@ fn calculate_depth_for_node(target: &Element) -> ResizeObservationDepth {
 }
 
 /// <https://drafts.csswg.org/resize-observer/#calculate-box-size>
-fn calculate_box_size(
-    target: &Element,
-    observed_box: &ResizeObserverBoxOptions,
-    can_gc: CanGc,
-) -> Rect<Au> {
+fn calculate_box_size(target: &Element, observed_box: &ResizeObserverBoxOptions) -> Rect<Au> {
     match observed_box {
         ResizeObserverBoxOptions::Content_box => {
             // Note: only taking first fragment,
             // but the spec will expand to cover all fragments.
             target
                 .upcast::<Node>()
-                .content_boxes(can_gc)
+                .content_boxes()
                 .pop()
                 .unwrap_or_else(Rect::zero)
         },

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -659,9 +659,7 @@ impl ServoParser {
             assert!(!self.suspended.get());
             assert!(!self.aborted.get());
 
-            self.document
-                .window()
-                .reflow_if_reflow_timer_expired(can_gc);
+            self.document.window().reflow_if_reflow_timer_expired();
             let script = match feed(&self.tokenizer) {
                 TokenizerResult::Done => return,
                 TokenizerResult::Script(script) => script,

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -370,12 +370,7 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint
-    fn ElementFromPoint(
-        &self,
-        x: Finite<f64>,
-        y: Finite<f64>,
-        can_gc: CanGc,
-    ) -> Option<DomRoot<Element>> {
+    fn ElementFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Option<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input.
         match self.document_or_shadow_root.element_from_point(
@@ -383,7 +378,6 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
             y,
             None,
             self.document.has_browsing_context(),
-            can_gc,
         ) {
             Some(e) => {
                 let retargeted_node = self
@@ -396,18 +390,13 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-document-elementsfrompoint
-    fn ElementsFromPoint(
-        &self,
-        x: Finite<f64>,
-        y: Finite<f64>,
-        can_gc: CanGc,
-    ) -> Vec<DomRoot<Element>> {
+    fn ElementsFromPoint(&self, x: Finite<f64>, y: Finite<f64>) -> Vec<DomRoot<Element>> {
         // Return the result of running the retargeting algorithm with context object
         // and the original result as input
         let mut elements = Vec::new();
         for e in self
             .document_or_shadow_root
-            .elements_from_point(x, y, None, self.document.has_browsing_context(), can_gc)
+            .elements_from_point(x, y, None, self.document.has_browsing_context())
             .iter()
         {
             let retargeted_node = self

--- a/components/script/dom/wheelevent.rs
+++ b/components/script/dom/wheelevent.rs
@@ -204,7 +204,7 @@ impl WheelEventMethods<crate::DomTypeHolder> for WheelEvent {
     ) -> Fallible<DomRoot<WheelEvent>> {
         let bubbles = EventBubbles::from(init.parent.parent.parent.parent.bubbles);
         let cancelable = EventCancelable::from(init.parent.parent.parent.parent.cancelable);
-        let scroll_offset = window.scroll_offset(can_gc);
+        let scroll_offset = window.scroll_offset();
 
         let page_point = Point2D::<i32, CSSPixel>::new(
             scroll_offset.x as i32 + init.parent.clientX,
@@ -269,7 +269,6 @@ impl WheelEventMethods<crate::DomTypeHolder> for WheelEvent {
         delta_y_arg: Finite<f64>,
         delta_z_arg: Finite<f64>,
         delta_mode_arg: u32,
-        can_gc: CanGc,
     ) {
         if self.upcast::<Event>().dispatching() {
             return;
@@ -291,7 +290,6 @@ impl WheelEventMethods<crate::DomTypeHolder> for WheelEvent {
             self.mouseevent.MetaKey(),
             self.mouseevent.Button(),
             self.mouseevent.GetRelatedTarget().as_deref(),
-            can_gc,
         );
         self.delta_x.set(delta_x_arg);
         self.delta_y.set(delta_y_arg);

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -145,7 +145,6 @@ impl TaskManager {
     task_source_functions!(self, performance_timeline_task_source, PerformanceTimeline);
     task_source_functions!(self, port_message_queue, PortMessage);
     task_source_functions!(self, remote_event_task_source, RemoteEvent);
-    task_source_functions!(self, rendering_task_source, Rendering);
     task_source_functions!(self, timer_task_source, Timer);
     task_source_functions!(self, user_interaction_task_source, UserInteraction);
     task_source_functions!(self, websocket_task_source, WebSocket);

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -80,12 +80,8 @@ DOMInterfaces = {
     'canGc': ['GetSize'],
 },
 
-'CanvasGradient': {
-    'canGc': ['AddColorStop'],
-},
-
 'CanvasRenderingContext2D': {
-    'canGc': ['GetTransform','GetImageData', 'CreateImageData', 'CreateImageData_', 'SetFont', 'FillText', 'MeasureText', 'SetStrokeStyle', 'SetFillStyle', 'SetShadowColor', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
+    'canGc': ['GetTransform','GetImageData', 'CreateImageData', 'CreateImageData_', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
 },
 
 'CharacterData': {
@@ -146,7 +142,7 @@ DOMInterfaces = {
 },
 
 'CSSStyleDeclaration': {
-    'canGc': ['RemoveProperty', 'SetCssText', 'GetPropertyValue', 'SetProperty', 'CssFloat', 'SetCssFloat']
+    'canGc': ['RemoveProperty', 'SetCssText', 'SetProperty', 'SetCssFloat']
 },
 
 'CustomElementRegistry': {
@@ -172,7 +168,7 @@ DOMInterfaces = {
 
 'Document': {
     'additionalTraits': ["crate::interfaces::DocumentHelpers"],
-    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ElementFromPoint', 'ElementsFromPoint', 'GetScrollingElement', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets'],
+    'canGc': ['Close', 'CreateElement', 'CreateElementNS', 'ImportNode', 'SetTitle', 'Write', 'Writeln', 'CreateEvent', 'CreateRange', 'Open', 'Open_', 'CreateComment', 'CreateAttribute', 'CreateAttributeNS', 'CreateDocumentFragment', 'CreateTextNode', 'CreateCDATASection', 'CreateProcessingInstruction', 'Prepend', 'Append', 'ReplaceChildren', 'SetBgColor', 'SetFgColor', 'Fonts', 'ExitFullscreen', 'CreateExpression', 'CreateNSResolver', 'Evaluate', 'StyleSheets', 'Implementation', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'AdoptNode', 'CreateNodeIterator', 'SetBody', 'GetElementsByName', 'Images', 'Embeds', 'Plugins', 'Links', 'Forms', 'Scripts', 'Anchors', 'Applets', 'Children', 'GetSelection', 'NamedGetter', 'AdoptedStyleSheets'],
 },
 
 'DissimilarOriginWindow': {
@@ -236,7 +232,7 @@ DOMInterfaces = {
 },
 
 'Element': {
-    'canGc': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetId','SetClassName','Prepend','Append','ReplaceChildren','Before','After','ReplaceWith', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'SetScrollTop', 'SetScrollLeft', 'Scroll', 'Scroll_', 'ScrollBy', 'ScrollBy_', 'ScrollWidth', 'ScrollHeight', 'ScrollTop', 'ScrollLeft', 'ClientTop', 'ClientLeft', 'ClientWidth', 'ClientHeight', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttribute', 'RemoveAttributeNS', 'RemoveAttributeNode', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'ScrollTo', 'ScrollTo_', 'Children', 'Remove', 'InsertAdjacentElement', 'AttachShadow'],
+    'canGc': ['SetHTMLUnsafe', 'SetInnerHTML', 'SetOuterHTML', 'InsertAdjacentHTML', 'GetClientRects', 'GetBoundingClientRect', 'InsertAdjacentText', 'ToggleAttribute', 'SetAttribute', 'SetAttributeNS', 'SetId','SetClassName','Prepend','Append','ReplaceChildren','Before','After','ReplaceWith', 'SetRole', 'SetAriaAtomic', 'SetAriaAutoComplete', 'SetAriaBrailleLabel', 'SetAriaBrailleRoleDescription', 'SetAriaBusy', 'SetAriaChecked', 'SetAriaColCount', 'SetAriaColIndex', 'SetAriaColIndexText', 'SetAriaColSpan', 'SetAriaCurrent', 'SetAriaDescription', 'SetAriaDisabled', 'SetAriaExpanded', 'SetAriaHasPopup', 'SetAriaHidden', 'SetAriaInvalid', 'SetAriaKeyShortcuts', 'SetAriaLabel', 'SetAriaLevel', 'SetAriaLive', 'SetAriaModal', 'SetAriaMultiLine', 'SetAriaMultiSelectable', 'SetAriaOrientation', 'SetAriaPlaceholder', 'SetAriaPosInSet', 'SetAriaPressed','SetAriaReadOnly', 'SetAriaRelevant', 'SetAriaRequired', 'SetAriaRoleDescription', 'SetAriaRowCount', 'SetAriaRowIndex', 'SetAriaRowIndexText', 'SetAriaRowSpan', 'SetAriaSelected', 'SetAriaSetSize','SetAriaSort', 'SetAriaValueMax', 'SetAriaValueMin', 'SetAriaValueNow', 'SetAriaValueText', 'RequestFullscreen', 'GetHTML', 'GetInnerHTML', 'GetOuterHTML', 'ClassList', 'Attributes', 'SetAttributeNode', 'SetAttributeNodeNS', 'RemoveAttribute', 'RemoveAttributeNS', 'RemoveAttributeNode', 'GetElementsByTagName', 'GetElementsByTagNameNS', 'GetElementsByClassName', 'Children', 'Remove', 'InsertAdjacentElement', 'AttachShadow'],
 },
 
 'ElementInternals': {
@@ -362,7 +358,7 @@ DOMInterfaces = {
 },
 
 'HTMLElement': {
-    'canGc': ['AttachInternals', 'Focus', 'Blur', 'Click', 'SetInnerText', 'SetOuterText', "SetTranslate", 'SetAutofocus', 'GetOffsetParent', 'OffsetTop', 'OffsetLeft', 'OffsetWidth', 'OffsetHeight', 'InnerText', 'GetOuterText', 'GetOnerror', 'GetOnload', 'GetOnblur', 'GetOnfocus', 'GetOnresize', 'GetOnscroll', 'Style', 'Dataset'],
+    'canGc': ['AttachInternals', 'Focus', 'Blur', 'Click', 'SetInnerText', 'SetOuterText', "SetTranslate", 'SetAutofocus', 'GetOnerror', 'GetOnload', 'GetOnblur', 'GetOnfocus', 'GetOnresize', 'GetOnscroll', 'Style', 'Dataset'],
 },
 
 'HTMLFieldSetElement': {
@@ -386,7 +382,7 @@ DOMInterfaces = {
 },
 
 'HTMLImageElement': {
-    'canGc': ['RequestSubmit', 'ReportValidity', 'Reset','SetRel', 'Width', 'Height', 'Decode', 'SetCrossOrigin', 'SetWidth', 'SetHeight', 'SetReferrerPolicy'],
+    'canGc': ['RequestSubmit', 'ReportValidity', 'Reset','SetRel', 'Decode', 'SetCrossOrigin', 'SetWidth', 'SetHeight', 'SetReferrerPolicy'],
 },
 
 'HTMLInputElement': {
@@ -427,7 +423,7 @@ DOMInterfaces = {
 },
 
 'HTMLScriptElement': {
-    'canGc': ['InnerText', 'SetAsync', 'SetCrossOrigin', 'SetInnerText', 'SetSrc', 'SetText', 'SetTextContent']
+    'canGc': ['SetAsync', 'SetCrossOrigin', 'SetInnerText', 'SetSrc', 'SetText', 'SetTextContent']
 },
 
 'HTMLSelectElement': {
@@ -492,10 +488,6 @@ DOMInterfaces = {
     'canGc': ['Ports'],
 },
 
-'MouseEvent': {
-    'canGc': ['InitMouseEvent', 'OffsetX', 'OffsetY'],
-},
-
 'NavigationPreloadManager': {
     'inRealms': ['Disable', 'Enable', 'GetState', 'SetHeaderValue'],
     'canGc': ['Disable', 'Enable', 'GetState', 'SetHeaderValue'],
@@ -528,11 +520,11 @@ DOMInterfaces = {
 },
 
 'OffscreenCanvasRenderingContext2D': {
-    'canGc': ['CreateImageData', 'CreateImageData_', 'GetImageData', 'GetTransform', 'SetFont', 'FillText', 'MeasureText', 'SetStrokeStyle', 'SetFillStyle', 'SetShadowColor', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
+    'canGc': ['CreateImageData', 'CreateImageData_', 'GetImageData', 'GetTransform', 'MeasureText', 'CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient'],
 },
 
 'PaintRenderingContext2D': {
-    'canGc': ['GetTransform', 'SetStrokeStyle', 'SetFillStyle', 'SetShadowColor'],
+    'canGc': ['GetTransform'],
 },
 
 'Performance': {
@@ -591,7 +583,7 @@ DOMInterfaces = {
 },
 
 'ShadowRoot': {
-    'canGc': ['SetHTMLUnsafe', 'ElementFromPoint', 'ElementsFromPoint', 'SetInnerHTML', 'GetHTML', 'InnerHTML', 'AdoptedStyleSheets'],
+    'canGc': ['SetHTMLUnsafe', 'SetInnerHTML', 'GetHTML', 'InnerHTML', 'AdoptedStyleSheets'],
 },
 
 'StaticRange': {
@@ -654,12 +646,8 @@ DOMInterfaces = {
     'additionalTraits': ['crate::interfaces::WebGL2RenderingContextHelpers'],
 },
 
-'WheelEvent': {
-    'canGc': ['InitWheelEvent'],
-},
-
 'Window': {
-    'canGc': ['Stop', 'Fetch', 'Scroll', 'Scroll_','ScrollBy', 'ScrollBy_', 'Stop', 'Fetch', 'Open', 'CreateImageBitmap', 'CreateImageBitmap_', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException'],
+    'canGc': ['Stop', 'Fetch', 'Stop', 'Fetch', 'Open', 'CreateImageBitmap', 'CreateImageBitmap_', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException'],
     'inRealms': ['Fetch', 'GetOpener', 'WebdriverCallback', 'WebdriverException'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
 },

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -259,6 +259,9 @@ pub trait Layout {
     /// not exist in the tree.
     fn scroll_offset(&self, id: ExternalScrollId) -> Option<LayoutVector2D>;
 
+    /// Returns true if this layout needs to produce a new display list for rendering updates.
+    fn needs_new_display_list(&self) -> bool;
+
     fn query_content_box(&self, node: TrustedNodeAddress) -> Option<Rect<Au>>;
     fn query_content_boxes(&self, node: TrustedNodeAddress) -> Vec<Rect<Au>>;
     fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32>;

--- a/tests/wpt/meta/css/css-cascade/layer-statement-before-import.html.ini
+++ b/tests/wpt/meta/css/css-cascade/layer-statement-before-import.html.ini
@@ -1,3 +1,0 @@
-[layer-statement-before-import.html]
-  [insert other rules before the first layer statement without imports]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12595,7 +12595,7 @@
       ]
      ],
      "basic-transition.html": [
-      "b80e8a666a6e6202b4ecafe628ef00ebcecfe168",
+      "c3461d3a5f9f1259296168742028db3bd4fc3668",
       [
        null,
        {}
@@ -12623,7 +12623,7 @@
       ]
      ],
      "transition-raf.html": [
-      "c38404503408e04b3c75b42df18ec3a7ec0819f5",
+      "aa3ed54e3e08a190f227c87165523306aed5a6bc",
       [
        null,
        {}
@@ -12743,7 +12743,7 @@
      ]
     ],
     "stylesheet_media_queries.html": [
-     "49956367a16c3de98d173d4cf5692c05451340a0",
+     "d04eb4b23f107b1e4d127cf633d4155ab3bdf629",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/css/animations/basic-transition.html
+++ b/tests/wpt/mozilla/tests/css/animations/basic-transition.html
@@ -20,15 +20,26 @@ var div = document.getElementById('check-me');
 var span = div.childNodes[0];
 async_test(function(t) {
   window.addEventListener('load', function() {
-    assert_equals(getComputedStyle(div).getPropertyValue('background-color'), 'rgb(255, 0, 0)');
-    div.id = "check-me-2";
-    requestAnimationFrame(function() {
-      var test = new window.TestBinding();
+    var test = new window.TestBinding();
+
+    div.addEventListener("transitionstart", () => {
+      // The transition should have just started so the current value of the style should
+      // not be the value expected after the transition.
+      assert_not_equals(getComputedStyle(div).getPropertyValue('background-color'), 'rgb(0, 0, 0)');
       test.advanceClock(2000);
-      span.innerHTML = "a";
+    });
+
+    div.addEventListener("transitionend", () => {
+      // The transition should be finished so the value of the style should be the final one.
       assert_equals(getComputedStyle(div).getPropertyValue('background-color'), 'rgb(0, 0, 0)');
       t.done();
     });
+
+    // The starting value should be the one set in the style.
+    assert_equals(getComputedStyle(div).getPropertyValue('background-color'), 'rgb(255, 0, 0)');
+
+    // Start the transition.
+    div.id = "check-me-2";
   })
 })
 </script>

--- a/tests/wpt/mozilla/tests/css/animations/transition-raf.html
+++ b/tests/wpt/mozilla/tests/css/animations/transition-raf.html
@@ -32,9 +32,12 @@ async_test(function(t) {
 
   window.addEventListener('load', function() {
     assert_equals(getComputedStyle(box).getPropertyValue('width'), '100px');
+
+    box.addEventListener("transitionstart", () => {
+      // Let the first restyle run at zero, then advance the clock.
+      test.advanceClock(500);
+    });
     box.className = "expose";
-    // Let the first restyle run at zero, then advance the clock.
-    setTimeout(function() { test.advanceClock(500) }, 0);
   });
 }, "Transitions should work during RAF loop")
 </script>

--- a/tests/wpt/mozilla/tests/css/stylesheet_media_queries.html
+++ b/tests/wpt/mozilla/tests/css/stylesheet_media_queries.html
@@ -14,8 +14,10 @@ window.onload = test.step_func(function() {
   assert_equals(frame.contentWindow.getComputedStyle(element).backgroundColor, "rgb(255, 0, 0)");
   frame.width = "300";
   frameDoc.documentElement.offsetWidth; // Force layout
-  window.requestAnimationFrame(test.step_func_done(function () {
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(test.step_func_done(function () {
       assert_equals(frame.contentWindow.getComputedStyle(element).backgroundColor, "rgb(0, 255, 0)");
-  }));
+    }))
+  });
 });
 </script>


### PR DESCRIPTION
Instead of running "update the rendering" at every IPC message, only run
it when a timeout has occured in script. In addition, avoid updating the
rendering if a rendering update isn't necessary. This should greatly
reduce the amount of processing that has to happen in script.

Because we are running many fewer calls to "update the rendering" it is
reasonable now to ensure that these always work the same way. In
particular, we always run rAF and update the animation timeline when
updating the ernder

In addition, pull the following things out of reflow:

 - Code dealing with informing the Constellation that a Pipeline has
   become Idle when waiting for a screenshot.
 - Detecting when it is time to fulfill the `document.fonts.ready`
   promise.

The latter means that reflow can never cause a garbage collection,
making timing of reflows more consistent and simplifying many callsites
that need to do script queries.

Followup changes will seek to simplify the way that ScriptThread-driven
animation timeouts happen even simpler.

Testing: In general, this should not change testable behavior so much, though it
does seem to fix one test.  The main improvement here should be that
the ScriptThread does less work.
