### PR TITLE
Implement HTMLDocument API

### DIFF
--- a/components/script/dom/htmldocument.rs
+++ b/components/script/dom/htmldocument.rs
@@ -30,10 +30,7 @@ impl HTMLDocumentMethods<crate::DomTypeHolder> for HTMLDocument {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#htmldocument>
-    fn NamedGetter(
-        &self,
-        name: DOMString,
-    ) -> Result<Option<NamedPropertyValue>, script_bindings::error::Error> {
-        Ok(self.document.NamedGetter(name, CanGc::note()))
+    fn NamedGetter(&self, name: DOMString) -> Option<NamedPropertyValue> {
+        self.document.NamedGetter(name, CanGc::note())
     }
 }

--- a/components/script/dom/htmldocument.rs
+++ b/components/script/dom/htmldocument.rs
@@ -2,18 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::ptr::NonNull;
-
 use dom_struct::dom_struct;
-use js::jsapi::JSObject;
 use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
 use script_bindings::codegen::GenericBindings::HTMLDocumentBinding::HTMLDocumentMethods;
-use script_bindings::error::Fallible;
 use script_bindings::root::DomRoot;
-use script_bindings::script_runtime::JSContext;
+use script_bindings::script_runtime::CanGc;
 use script_bindings::str::DOMString;
 
 use super::types::{Document, Location};
+use crate::dom::bindings::codegen::Bindings::DocumentBinding::NamedPropertyValue;
 
 /// <https://html.spec.whatwg.org/multipage/#htmldocument>
 #[dom_struct]
@@ -33,7 +30,10 @@ impl HTMLDocumentMethods<crate::DomTypeHolder> for HTMLDocument {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#htmldocument>
-    fn NamedGetter(&self, _cx: JSContext, _name: DOMString) -> Fallible<Option<NonNull<JSObject>>> {
-        Err(script_bindings::error::Error::NotFound)
+    fn NamedGetter(
+        &self,
+        name: DOMString,
+    ) -> Result<Option<NamedPropertyValue>, script_bindings::error::Error> {
+        Ok(self.document.NamedGetter(name, CanGc::note()))
     }
 }

--- a/components/script/dom/htmldocument.rs
+++ b/components/script/dom/htmldocument.rs
@@ -19,17 +19,17 @@ pub(crate) struct HTMLDocument {
 }
 
 impl HTMLDocumentMethods<crate::DomTypeHolder> for HTMLDocument {
-    /// <https://html.spec.whatwg.org/multipage/#htmldocument>
+    /// <https://html.spec.whatwg.org/multipage/#dom-document-location>
     fn GetLocation(&self) -> Option<DomRoot<Location>> {
         self.document.GetLocation()
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#htmldocument>
+    /// <https://html.spec.whatwg.org/multipage/#dom-tree-accessors:supported-property-names>
     fn SupportedPropertyNames(&self) -> Vec<DOMString> {
         self.document.SupportedPropertyNames()
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#htmldocument>
+    /// <https://html.spec.whatwg.org/multipage/#dom-tree-accessors:dom-document-nameditem-filter>
     fn NamedGetter(&self, name: DOMString) -> Option<NamedPropertyValue> {
         self.document.NamedGetter(name, CanGc::note())
     }

--- a/components/script/dom/htmldocument.rs
+++ b/components/script/dom/htmldocument.rs
@@ -1,0 +1,35 @@
+use std::ptr::NonNull;
+
+use dom_struct::dom_struct;
+use js::jsapi::JSObject;
+use script_bindings::codegen::GenericBindings::DocumentBinding::DocumentMethods;
+use script_bindings::codegen::GenericBindings::HTMLDocumentBinding::HTMLDocumentMethods;
+use script_bindings::error::Fallible;
+use script_bindings::root::DomRoot;
+use script_bindings::script_runtime::JSContext;
+use script_bindings::str::DOMString;
+
+use super::types::{Document, Location};
+
+/// <https://html.spec.whatwg.org/multipage/nav-history-apis.html#htmldocument>
+#[dom_struct]
+pub(crate) struct HTMLDocument {
+    document: Document,
+}
+
+impl HTMLDocumentMethods<crate::DomTypeHolder> for HTMLDocument {
+    /// <https://html.spec.whatwg.org/multipage/#htmldocument>
+    fn GetLocation(&self) -> Option<DomRoot<Location>> {
+        self.document.GetLocation()
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#htmldocument>
+    fn SupportedPropertyNames(&self) -> Vec<DOMString> {
+        self.document.SupportedPropertyNames()
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#htmldocument>
+    fn NamedGetter(&self, _cx: JSContext, _name: DOMString) -> Fallible<Option<NonNull<JSObject>>> {
+        Err(script_bindings::error::Error::NotFound)
+    }
+}

--- a/components/script/dom/htmldocument.rs
+++ b/components/script/dom/htmldocument.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use std::ptr::NonNull;
 
 use dom_struct::dom_struct;
@@ -11,7 +15,7 @@ use script_bindings::str::DOMString;
 
 use super::types::{Document, Location};
 
-/// <https://html.spec.whatwg.org/multipage/nav-history-apis.html#htmldocument>
+/// <https://html.spec.whatwg.org/multipage/#htmldocument>
 #[dom_struct]
 pub(crate) struct HTMLDocument {
     document: Document,

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -362,6 +362,7 @@ pub(crate) mod htmldialogelement;
 pub(crate) mod htmldirectoryelement;
 pub(crate) mod htmldivelement;
 pub(crate) mod htmldlistelement;
+pub(crate) mod htmldocument;
 pub(crate) mod htmlelement;
 pub(crate) mod htmlembedelement;
 pub(crate) mod htmlfieldsetelement;

--- a/components/script_bindings/webidls/HTMLDocument.webidl
+++ b/components/script_bindings/webidls/HTMLDocument.webidl
@@ -10,5 +10,5 @@
 interface HTMLDocument : Document {
   // DOM tree accessors
   [Throws]
-  getter object (DOMString name);
+  getter NamedPropertyValue (DOMString name);
 };

--- a/components/script_bindings/webidls/HTMLDocument.webidl
+++ b/components/script_bindings/webidls/HTMLDocument.webidl
@@ -9,6 +9,5 @@
  Exposed=Window]
 interface HTMLDocument : Document {
   // DOM tree accessors
-  [Throws]
   getter NamedPropertyValue (DOMString name);
 };

--- a/components/script_bindings/webidls/HTMLDocument.webidl
+++ b/components/script_bindings/webidls/HTMLDocument.webidl
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+// https://html.spec.whatwg.org/multipage/#htmldocument
+
+[LegacyOverrideBuiltIns,
+ Exposed=Window]
+interface HTMLDocument : Document {
+  // DOM tree accessors
+  [Throws]
+  getter object (DOMString name);
+};

--- a/tests/wpt/meta/html/editing/dnd/historical.html.ini
+++ b/tests/wpt/meta/html/editing/dnd/historical.html.ini
@@ -1,3 +1,0 @@
-[historical.html]
-  [ondragexit must not be present on the GlobalEventHandlers locations]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/contextmenu-historical.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/contextmenu-historical.html.ini
@@ -1,3 +1,0 @@
-[contextmenu-historical.html]
-  [onshow must not be present on the GlobalEventHandlers locations]
-    expected: FAIL

--- a/tests/wpt/meta/webidl/ecmascript-binding/interface-prototype-constructor-set-receiver.html.ini
+++ b/tests/wpt/meta/webidl/ecmascript-binding/interface-prototype-constructor-set-receiver.html.ini
@@ -1,3 +1,0 @@
-[interface-prototype-constructor-set-receiver.html]
-  [Direct [[Set\]\] preserves [[Enumerable\]\]: false property attribute]
-    expected: FAIL

--- a/tests/wpt/meta/webidl/ecmascript-binding/invalid-this-value-cross-realm.html.ini
+++ b/tests/wpt/meta/webidl/ecmascript-binding/invalid-this-value-cross-realm.html.ini
@@ -1,3 +1,0 @@
-[invalid-this-value-cross-realm.html]
-  [Cross-realm operation throws when called on incompatible object]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13725,7 +13725,7 @@
      ]
     ],
     "interfaces.https.html": [
-     "efb780c382456b1fda514b33fe5b317c447fa09e",
+     "05ead2c3e2c362586506be77c8093c8bc4f0fb53",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -164,6 +164,7 @@ test_interfaces([
   "HTMLDirectoryElement",
   "HTMLDivElement",
   "HTMLDListElement",
+  "HTMLDocument",
   "HTMLElement",
   "HTMLEmbedElement",
   "HTMLFieldSetElement",


### PR DESCRIPTION
This updates the pull request from here https://github.com/servo/servo/pull/32553 that looks to be dormant. The main change is that I've switched out `reflector` with `document` based off this suggestion https://github.com/servo/servo/pull/32553#issuecomment-2179568743, and the `GetLocation` and `SupportedPropertyNames` methods pass through the values from `Document`.

The implementation details are otherwise the same as the original PR

Testing: I don't see any WPT tests for this feature, I could make a custom test if desired
Fixes: https://github.com/servo/servo/issues/32536
