### PR TITLE
webdriver: Improve "element click" by using container + Upgrade outdated test

### DIFF
--- a/tests/wpt/meta/webdriver/tests/classic/element_click/interactability.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/interactability.py.ini
@@ -1,6 +1,3 @@
 [interactability.py]
   [test_element_intercepted]
     expected: FAIL
-
-  [test_element_intercepted_no_pointer_events]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/select.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/select.py.ini
@@ -13,21 +13,3 @@
 
   [test_out_of_view_dropdown]
     expected: FAIL
-
-  [test_click_multiple_option]
-    expected: FAIL
-
-  [test_click_preselected_multiple_option]
-    expected: FAIL
-
-  [test_click_multiple_does_not_deselect_others]
-    expected: FAIL
-
-  [test_click_selected_multiple_option]
-    expected: FAIL
-
-  [test_out_of_view_multiple]
-    expected: FAIL
-
-  [test_option_disabled]
-    expected: FAIL

--- a/tests/wpt/tests/webdriver/tests/classic/element_click/interactability.py
+++ b/tests/wpt/tests/webdriver/tests/classic/element_click/interactability.py
@@ -115,11 +115,11 @@ def test_element_intercepted(session, inline):
     assert_error(response, "element click intercepted")
 
 
-def test_element_intercepted_no_pointer_events(session, inline):
+def test_element_not_interactable_no_pointer_events(session, inline):
     session.url = inline("""<input type=button value=Roger style="pointer-events: none">""")
     element = session.find.css("input", all=False)
     response = element_click(session, element)
-    assert_error(response, "element click intercepted")
+    assert_error(response, "element not interactable")
 
 
 def test_element_not_visible_overflow_hidden(session, inline):

--- a/tests/wpt/tests/webdriver/tests/classic/element_click/interactability.py
+++ b/tests/wpt/tests/webdriver/tests/classic/element_click/interactability.py
@@ -115,7 +115,7 @@ def test_element_intercepted(session, inline):
     assert_error(response, "element click intercepted")
 
 
-def test_element_not_interactable_no_pointer_events(session, inline):
+def test_element_not_interactable_pointer_events_none(session, inline):
     session.url = inline("""<input type=button value=Roger style="pointer-events: none">""")
     element = session.find.css("input", all=False)
     response = element_click(session, element)


### PR DESCRIPTION
- According to [spec](https://w3c.github.io/webdriver/#ref-for-dfn-in-view-3), we should use container instead of element itself to determine "in-view".
- Updated `test_element_intercepted_no_pointer_events` in `element_click/interactability.py` to expect "element not interactable". This was outdated with spec as original test was written 7 years ago https://github.com/web-platform-tests/wpt/pull/11453.


Testing: new passing cases for `<option>`, `<select>`.
