### PR TITLE
build(deps): bump Stylo to servo/stylo#221

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.31.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#7f8df16fddb15b6ac9097f8ab25caffff1a7095e"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -7617,7 +7617,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#7f8df16fddb15b6ac9097f8ab25caffff1a7095e"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8089,7 +8089,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#7f8df16fddb15b6ac9097f8ab25caffff1a7095e"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8146,7 +8146,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#7f8df16fddb15b6ac9097f8ab25caffff1a7095e"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8155,12 +8155,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#7f8df16fddb15b6ac9097f8ab25caffff1a7095e"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
 
 [[package]]
 name = "stylo_derive"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#7f8df16fddb15b6ac9097f8ab25caffff1a7095e"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8172,7 +8172,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#7f8df16fddb15b6ac9097f8ab25caffff1a7095e"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -8181,7 +8181,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#7f8df16fddb15b6ac9097f8ab25caffff1a7095e"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8198,12 +8198,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#7f8df16fddb15b6ac9097f8ab25caffff1a7095e"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
 
 [[package]]
 name = "stylo_traits"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#7f8df16fddb15b6ac9097f8ab25caffff1a7095e"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -8618,7 +8618,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#7f8df16fddb15b6ac9097f8ab25caffff1a7095e"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8631,7 +8631,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#7f8df16fddb15b6ac9097f8ab25caffff1a7095e"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
Bumps Stylo to "Drop obsolete `layout.css.transition-behavior.enabled` flag".

Testing: Not needed (no behavior change).
