### PR TITLE
Servoshell: Update `Window::inner_size` on `WindowEvent::Resized` (fix resize bug)

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -687,6 +687,7 @@ impl WindowPortsMethods for Window {
             },
             WindowEvent::Resized(new_inner_size) => {
                 if self.inner_size.get() != new_inner_size {
+                    self.inner_size.set(new_inner_size);
                     // This should always be set to inner size
                     // because we are resizing `SurfmanRenderingContext`.
                     // See https://github.com/servo/servo/issues/38369#issuecomment-3138378527


### PR DESCRIPTION
Just adds back a line that was omitted when a different commit was reverted, see the issue for details, I've tested on Gnome Wayland with Fedora 42 and the bug is fixed

Fixes: https://github.com/servo/servo/issues/38441
cc @yezhizhen 
