### PR TITLE
script: fix set muted on html video element creation

### DIFF
--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1445,7 +1445,15 @@ impl HTMLMediaElement {
             audio_renderer,
             Box::new(window.get_player_context()),
         );
-        let player_id = player.lock().unwrap().get_id();
+        let player_id = {
+            let player_mut = player.lock().unwrap();
+
+            if let Err(e) = player_mut.set_mute(self.muted.get()) {
+                log::warn!("Could not set mute state: {:?}", e);
+            }
+
+            player_mut.get_id()
+        };
 
         *self.player.borrow_mut() = Some(player);
 

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -1446,13 +1446,13 @@ impl HTMLMediaElement {
             Box::new(window.get_player_context()),
         );
         let player_id = {
-            let player_mut = player.lock().unwrap();
+            let player_guard = player.lock().unwrap();
 
-            if let Err(e) = player_mut.set_mute(self.muted.get()) {
+            if let Err(e) = player_guard.set_mute(self.muted.get()) {
                 log::warn!("Could not set mute state: {:?}", e);
             }
 
-            player_mut.get_id()
+            player_guard.get_id()
         };
 
         *self.player.borrow_mut() = Some(player);


### PR DESCRIPTION
Set muted on html video element creation. On `video` element creation, the `set_mute` function will be called before the media player is created, hence the player will still act as not being muted. This PR fix this behaviour by passing `muted` info after player is created as part of `setup_media_player`  process.

Testing: Locally test on Windows11
Fixes: https://github.com/servo/servo/issues/38448
