### PR TITLE
layout: Introduce `ReflowPhasesRun`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -43,7 +43,8 @@ use ipc_channel::ipc;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use keyboard_types::{Code, Key, KeyState, Modifiers, NamedKey};
 use layout_api::{
-    PendingRestyle, ReflowGoal, RestyleReason, TrustedNodeAddress, node_id_from_scroll_id,
+    PendingRestyle, ReflowGoal, ReflowPhasesRun, RestyleReason, TrustedNodeAddress,
+    node_id_from_scroll_id,
 };
 use metrics::{InteractiveFlag, InteractiveWindow, ProgressiveWebMetrics};
 use net_traits::CookieSource::NonHTTP;
@@ -3694,8 +3695,8 @@ impl Document {
     // > Step 22: For each doc of docs, update the rendering or user interface of
     // > doc and its node navigable to reflect the current state.
     //
-    // Returns true if a reflow occured.
-    pub(crate) fn update_the_rendering(&self) -> bool {
+    // Returns the set of reflow phases run as a [`ReflowPhasesRun`].
+    pub(crate) fn update_the_rendering(&self) -> ReflowPhasesRun {
         self.update_animating_images();
 
         // All dirty canvases are flushed before updating the rendering.
@@ -3730,9 +3731,7 @@ impl Document {
             receiver.recv().unwrap();
         }
 
-        self.window()
-            .reflow(ReflowGoal::UpdateTheRendering)
-            .reflow_issued
+        self.window().reflow(ReflowGoal::UpdateTheRendering)
     }
 
     /// From <https://drafts.csswg.org/css-font-loading/#fontfaceset-pending-on-the-environment>:

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -387,8 +387,8 @@ impl RestyleReason {
 /// Information derived from a layout pass that needs to be returned to the script thread.
 #[derive(Debug, Default)]
 pub struct ReflowResult {
-    /// Whether or not this reflow produced a display list.
-    pub built_display_list: bool,
+    /// The phases that were run during this reflow.
+    pub reflow_phases_run: ReflowPhasesRun,
     /// The list of images that were encountered that are in progress.
     pub pending_images: Vec<PendingImage>,
     /// The list of vector images that were encountered that still need to be rasterized.
@@ -399,23 +399,17 @@ pub struct ReflowResult {
     /// finished before reaching this stage of the layout. I.e., no update
     /// required.
     pub iframe_sizes: Option<IFrameSizes>,
-    /// Whether the reflow is for [ReflowGoal::UpdateScrollNode] and the target is scrolled.
-    /// Specifically, a node is scrolled whenever the scroll position of it changes.
-    pub update_scroll_reflow_target_scrolled: bool,
-    /// Do the reflow results in a new component within layout. Incremental layout could be
-    /// skipped if it is deemed unnecessary or the required component is not ready to be
-    /// processed.
-    pub processed_relayout: bool,
 }
 
-impl ReflowResult {
-    /// In incremental reflow, we could skip the layout calculation completely, if it is deemed
-    /// unecessary. In those cases, many of the [ReflowResult] would be irrelevant.
-    pub fn new_without_relayout(update_scroll_reflow_target_scrolled: bool) -> Self {
-        ReflowResult {
-            update_scroll_reflow_target_scrolled,
-            ..Default::default()
-        }
+bitflags! {
+    /// The phases of reflow that were run when processing a reflow in layout.
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    pub struct ReflowPhasesRun: u8 {
+        const RanLayout = 1 << 0;
+        const CalculatedOverflow = 1 << 1;
+        const BuiltStackingContextTree = 1 << 2;
+        const BuiltDisplayList = 1 << 3;
+        const UpdatedScrollNodeOffset = 1 << 4;
     }
 }
 


### PR DESCRIPTION
There were various booleans on `ReflowResults` that represented various
actions that might have been taken during a reflow request. Replace
those with a bitflags that better represents what reflow phases have
actually been run. Update variable names to reflect what they mean.

In addition, run some post-layout tasks unconditionally. They are
already contingent on the results returned from layout.

This simplifies and clarifies the code a good deal.

Testing: This should not change observable behavior and thus is covered
by existing WPT tests.
