### PR TITLE
script: Remove logging in debugger script

### DIFF
--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -2,19 +2,13 @@ if (!("dbg" in this)) {
     dbg = new Debugger;
 
     dbg.onNewGlobalObject = function(global) {
-        console.log("[debugger] onNewGlobalObject");
-        console.log(this, global);
     };
 
     dbg.onNewScript = function(script, global) {
-        console.log("[debugger] onNewScript");
-        console.log(this, script, global);
     };
 }
 
 addEventListener("addDebuggee", event => {
     const {global} = event;
-    console.log("[debugger] Adding debuggee");
     dbg.addDebuggee(global);
-    console.log("[debugger] getDebuggees().length =", dbg.getDebuggees().length);
 });


### PR DESCRIPTION
#38333 adds new code to the debugger script containing some console.log() calls, which unlike native rust log messages can’t be turned off. this patch removes them for now, until we find a better approach.

Testing: no testable changes in this patch
Fixes: noisy logging as of #38333