### PR TITLE
Merge `layout_api::LayoutDamage` and `stylo::RestyleDamage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7312,7 +7312,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.31.0"
-source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
+source = "git+https://github.com/servo/stylo?rev=4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b#4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -7618,7 +7618,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
+source = "git+https://github.com/servo/stylo?rev=4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b#4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8090,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
+source = "git+https://github.com/servo/stylo?rev=4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b#4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8147,7 +8147,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
+source = "git+https://github.com/servo/stylo?rev=4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b#4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8156,12 +8156,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
+source = "git+https://github.com/servo/stylo?rev=4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b#4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b"
 
 [[package]]
 name = "stylo_derive"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
+source = "git+https://github.com/servo/stylo?rev=4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b#4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8173,7 +8173,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
+source = "git+https://github.com/servo/stylo?rev=4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b#4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
+source = "git+https://github.com/servo/stylo?rev=4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b#4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8199,12 +8199,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
+source = "git+https://github.com/servo/stylo?rev=4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b#4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b"
 
 [[package]]
 name = "stylo_traits"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
+source = "git+https://github.com/servo/stylo?rev=4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b#4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -8619,7 +8619,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
+source = "git+https://github.com/servo/stylo?rev=4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b#4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8632,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
+source = "git+https://github.com/servo/stylo?rev=4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b#4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7312,7 +7312,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.31.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
+source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -7618,7 +7618,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
+source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8090,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
+source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8147,7 +8147,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
+source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8156,12 +8156,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
+source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
 
 [[package]]
 name = "stylo_derive"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
+source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8173,7 +8173,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
+source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -8182,7 +8182,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
+source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8199,12 +8199,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
+source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
 
 [[package]]
 name = "stylo_traits"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
+source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -8619,7 +8619,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
+source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8632,7 +8632,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#0d8dd5455daf3bc445312032a0a430e11a817390"
+source = "git+https://github.com/servo/stylo?rev=a58aed7e4011243b9a2b4bce5b7cce474d4e4cae#a58aed7e4011243b9a2b4bce5b7cce474d4e4cae"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ rustls = { version = "0.23", default-features = false, features = ["logging", "s
 rustls-pemfile = "2.0"
 rustls-pki-types = "1.12"
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
+selectors = { git = "https://github.com/servo/stylo", rev = "4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b" }
 serde = "1.0.219"
 serde_bytes = "0.11"
 serde_json = "1.0"
@@ -132,7 +132,7 @@ servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b" }
 smallbitvec = "2.6.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 static_assertions = "1.1"
@@ -140,12 +140,12 @@ string_cache = "0.8"
 string_cache_codegen = "0.5"
 strum = "0.26"
 strum_macros = "0.26"
-stylo = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
-stylo_atoms = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
-stylo_config = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
-stylo_dom = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
-stylo_traits = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
+stylo = { git = "https://github.com/servo/stylo", rev = "4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "4fe9a9a269f2b231ce667f14d39c6a4aa1c9bb9b" }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ rustls = { version = "0.23", default-features = false, features = ["logging", "s
 rustls-pemfile = "2.0"
 rustls-pki-types = "1.12"
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
+selectors = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
 serde = "1.0.219"
 serde_bytes = "0.11"
 serde_json = "1.0"
@@ -132,7 +132,7 @@ servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
 smallbitvec = "2.6.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 static_assertions = "1.1"
@@ -140,12 +140,12 @@ string_cache = "0.8"
 string_cache_codegen = "0.5"
 strum = "0.26"
 strum_macros = "0.26"
-stylo = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
-stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
-stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
-stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
-stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
+stylo = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "a58aed7e4011243b9a2b4bce5b7cce474d4e4cae" }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -8,7 +8,7 @@ use std::iter::FusedIterator;
 use fonts::ByteIndex;
 use html5ever::{LocalName, local_name};
 use layout_api::wrapper_traits::{LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode};
-use layout_api::{LayoutDamage, LayoutElementType, LayoutNodeType};
+use layout_api::{LayoutElementType, LayoutNodeType, ServoRestyleDamage};
 use range::Range;
 use script::layout_dom::ServoLayoutNode;
 use selectors::Element as SelectorsElement;
@@ -34,14 +34,14 @@ pub(crate) struct NodeAndStyleInfo<'dom> {
     pub node: ServoLayoutNode<'dom>,
     pub pseudo_element_type: Option<PseudoElement>,
     pub style: ServoArc<ComputedValues>,
-    pub damage: LayoutDamage,
+    pub damage: ServoRestyleDamage,
 }
 
 impl<'dom> NodeAndStyleInfo<'dom> {
     pub(crate) fn new(
         node: ServoLayoutNode<'dom>,
         style: ServoArc<ComputedValues>,
-        damage: LayoutDamage,
+        damage: ServoRestyleDamage,
     ) -> Self {
         Self {
             node,

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -759,7 +759,6 @@ malloc_size_of_is_0!(std::time::Duration);
 malloc_size_of_is_0!(std::time::Instant);
 malloc_size_of_is_0!(std::time::SystemTime);
 malloc_size_of_is_0!(resvg::usvg::Tree);
-malloc_size_of_is_0!(style::data::ElementData);
 malloc_size_of_is_0!(style::font_face::SourceList);
 malloc_size_of_is_0!(style::properties::ComputedValues);
 malloc_size_of_is_0!(style::properties::declaration_block::PropertyDeclarationBlock);
@@ -770,6 +769,13 @@ malloc_size_of_is_0!(taffy::Layout);
 malloc_size_of_is_0!(unicode_bidi::Level);
 malloc_size_of_is_0!(unicode_script::Script);
 malloc_size_of_is_0!(urlpattern::UrlPattern);
+
+// We can be sure the TElement::RestyleDamage value has a malloc size of 0 because it impls Copy
+impl<T: style::dom::TRestyleDamage> MallocSizeOf for style::data::ElementData<T> {
+    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+        0
+    }
+}
 
 macro_rules! malloc_size_of_is_webrender_malloc_size_of(
     ($($ty:ty),+) => (
@@ -866,7 +872,6 @@ malloc_size_of_is_stylo_malloc_size_of!(
 malloc_size_of_is_stylo_malloc_size_of!(style::properties::longhands::flex_wrap::computed_value::T);
 malloc_size_of_is_stylo_malloc_size_of!(style::properties::style_structs::Font);
 malloc_size_of_is_stylo_malloc_size_of!(style::selector_parser::PseudoElement);
-malloc_size_of_is_stylo_malloc_size_of!(style::selector_parser::RestyleDamage);
 malloc_size_of_is_stylo_malloc_size_of!(style::selector_parser::Snapshot);
 malloc_size_of_is_stylo_malloc_size_of!(style::shared_lock::SharedRwLock);
 malloc_size_of_is_stylo_malloc_size_of!(style::stylesheets::DocumentStyleSheet);

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -23,7 +23,7 @@ use html5ever::{LocalName, Namespace, Prefix, QualName, local_name, namespace_pr
 use js::jsapi::Heap;
 use js::jsval::JSVal;
 use js::rust::HandleObject;
-use layout_api::LayoutDamage;
+use layout_api::ServoRestyleDamage;
 use net_traits::ReferrerPolicy;
 use net_traits::request::CorsSettings;
 use selectors::Element as SelectorsElement;
@@ -47,8 +47,7 @@ use style::properties::{
 };
 use style::rule_tree::CascadeLevel;
 use style::selector_parser::{
-    NonTSPseudoClass, PseudoElement, RestyleDamage, SelectorImpl, SelectorParser,
-    extended_filtering,
+    NonTSPseudoClass, PseudoElement, SelectorImpl, SelectorParser, extended_filtering,
 };
 use style::shared_lock::{Locked, SharedRwLock};
 use style::stylesheets::layer_rule::LayerOrder;
@@ -366,11 +365,11 @@ impl Element {
                 doc.note_node_with_dirty_descendants(self.upcast());
                 restyle
                     .damage
-                    .insert(LayoutDamage::recollect_box_tree_children());
+                    .insert(ServoRestyleDamage::RECOLLECT_BOX_TREE_CHILDREN);
             },
             NodeDamage::Other => {
                 doc.note_node_with_dirty_descendants(self.upcast());
-                restyle.damage.insert(RestyleDamage::reconstruct());
+                restyle.damage.insert(ServoRestyleDamage::all());
             },
         }
     }

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -11,7 +11,7 @@ use embedder_traits::UntrustedNodeAddress;
 use html5ever::{LocalName, Namespace, local_name, ns};
 use js::jsapi::JSObject;
 use layout_api::wrapper_traits::{LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode};
-use layout_api::{LayoutDamage, LayoutNodeType, StyleData};
+use layout_api::{LayoutNodeType, ServoRestyleDamage, StyleData};
 use selectors::Element as _;
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
 use selectors::bloom::{BLOOM_HASH_MASK, BloomFilter};
@@ -28,14 +28,12 @@ use style::data::ElementData;
 use style::dom::{DomChildren, LayoutIterator, TDocument, TElement, TNode, TShadowRoot};
 use style::properties::{ComputedValues, PropertyDeclarationBlock};
 use style::selector_parser::{
-    AttrValue as SelectorAttrValue, Lang, NonTSPseudoClass, PseudoElement, RestyleDamage,
-    SelectorImpl, extended_filtering,
+    AttrValue as SelectorAttrValue, Lang, NonTSPseudoClass, PseudoElement, SelectorImpl,
+    extended_filtering,
 };
 use style::shared_lock::Locked as StyleLocked;
 use style::stylesheets::scope_rule::ImplicitScopeRoot;
-use style::values::computed::{Display, Image};
-use style::values::specified::align::AlignFlags;
-use style::values::specified::box_::{DisplayInside, DisplayOutside};
+use style::values::computed::Display;
 use style::values::{AtomIdent, AtomString};
 use stylo_atoms::Atom;
 use stylo_dom::ElementState;
@@ -179,6 +177,7 @@ where
 
 impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
     type ConcreteNode = ServoLayoutNode<'dom>;
+    type RestyleDamage = ServoRestyleDamage;
     type TraversalChildrenIterator = DOMDescendantIterator<Self>;
 
     fn as_node(&self) -> ServoLayoutNode<'dom> {
@@ -419,7 +418,7 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
         unsafe { self.as_node().get_jsmanaged().clear_style_and_layout_data() }
     }
 
-    unsafe fn ensure_data(&self) -> AtomicRefMut<ElementData> {
+    unsafe fn ensure_data(&self) -> AtomicRefMut<ElementData<ServoRestyleDamage>> {
         unsafe {
             self.as_node().get_jsmanaged().initialize_style_data();
         };
@@ -432,12 +431,12 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
     }
 
     /// Immutably borrows the ElementData.
-    fn borrow_data(&self) -> Option<AtomicRef<ElementData>> {
+    fn borrow_data(&self) -> Option<AtomicRef<ElementData<ServoRestyleDamage>>> {
         self.get_style_data().map(|data| data.element_data.borrow())
     }
 
     /// Mutably borrows the ElementData.
-    fn mutate_data(&self) -> Option<AtomicRefMut<ElementData>> {
+    fn mutate_data(&self) -> Option<AtomicRefMut<ElementData<ServoRestyleDamage>>> {
         self.get_style_data()
             .map(|data| data.element_data.borrow_mut())
     }
@@ -600,97 +599,14 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
         }
     }
 
-    fn compute_layout_damage(old: &ComputedValues, new: &ComputedValues) -> RestyleDamage {
-        let box_tree_needs_rebuild = || {
-            let old_box = old.get_box();
-            let new_box = new.get_box();
-
-            if old_box.display != new_box.display ||
-                old_box.float != new_box.float ||
-                old_box.position != new_box.position
-            {
-                return true;
-            }
-
-            if old.get_font() != new.get_font() {
-                return true;
-            }
-
-            // NOTE: This should be kept in sync with the checks in `impl
-            // StyleExt::establishes_block_formatting_context` for `ComputedValues` in
-            // `components/layout/style_ext.rs`.
-            if new_box.display.outside() == DisplayOutside::Block &&
-                new_box.display.inside() == DisplayInside::Flow
-            {
-                let alignment_establishes_new_block_formatting_context =
-                    |style: &ComputedValues| {
-                        style.get_position().align_content.0.primary() != AlignFlags::NORMAL
-                    };
-
-                let old_column = old.get_column();
-                let new_column = new.get_column();
-                if old_box.overflow_x.is_scrollable() != new_box.overflow_x.is_scrollable() ||
-                    old_column.is_multicol() != new_column.is_multicol() ||
-                    old_column.column_span != new_column.column_span ||
-                    alignment_establishes_new_block_formatting_context(old) !=
-                        alignment_establishes_new_block_formatting_context(new)
-                {
-                    return true;
-                }
-            }
-
-            if old_box.display.is_list_item() {
-                let old_list = old.get_list();
-                let new_list = new.get_list();
-                if old_list.list_style_position != new_list.list_style_position ||
-                    old_list.list_style_image != new_list.list_style_image ||
-                    (new_list.list_style_image == Image::None &&
-                        old_list.list_style_type != new_list.list_style_type)
-                {
-                    return true;
-                }
-            }
-
-            if new.is_pseudo_style() && old.get_counters().content != new.get_counters().content {
-                return true;
-            }
-
-            false
-        };
-
-        let text_shaping_needs_recollect = || {
-            if old.clone_direction() != new.clone_direction() ||
-                old.clone_unicode_bidi() != new.clone_unicode_bidi()
-            {
-                return true;
-            }
-
-            let old_text = old.get_inherited_text().clone();
-            let new_text = new.get_inherited_text().clone();
-            if old_text.white_space_collapse != new_text.white_space_collapse ||
-                old_text.text_transform != new_text.text_transform ||
-                old_text.word_break != new_text.word_break ||
-                old_text.overflow_wrap != new_text.overflow_wrap ||
-                old_text.letter_spacing != new_text.letter_spacing ||
-                old_text.word_spacing != new_text.word_spacing ||
-                old_text.text_rendering != new_text.text_rendering
-            {
-                return true;
-            }
-
-            false
-        };
-
-        if box_tree_needs_rebuild() {
-            RestyleDamage::from_bits_retain(LayoutDamage::REBUILD_BOX.bits())
-        } else if text_shaping_needs_recollect() {
-            RestyleDamage::from_bits_retain(LayoutDamage::RECOLLECT_BOX_TREE_CHILDREN.bits())
-        } else {
-            // This element needs to be laid out again, but does not have any damage to
-            // its box. In the future, we will distinguish between types of damage to the
-            // fragment as well.
-            RestyleDamage::RELAYOUT
-        }
+    fn compute_style_difference(
+        &self,
+        old: &ComputedValues,
+        new: &ComputedValues,
+        pseudo: Option<&PseudoElement>,
+    ) -> style::dom::StyleDifference<Self::RestyleDamage> {
+        debug_assert!(pseudo.is_none_or(|p| p.is_eager()));
+        ServoRestyleDamage::compute_style_difference(old, new)
     }
 }
 
@@ -1040,7 +956,7 @@ impl<'dom> ThreadSafeLayoutElement<'dom> for ServoThreadSafeLayoutElement<'dom> 
         self.element.get_attr(namespace, name)
     }
 
-    fn style_data(&self) -> AtomicRef<ElementData> {
+    fn style_data(&self) -> AtomicRef<ElementData<ServoRestyleDamage>> {
         self.element.borrow_data().expect("Unstyled layout node?")
     }
 

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -2,51 +2,288 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use bitflags::bitflags;
-use style::selector_parser::RestyleDamage;
+//! The restyle damage is a hint that tells layout which kind of operations may
+//! be needed in presence of incremental style changes.
+
+use std::fmt;
+
+use bitflags::{Flags, bitflags};
+use malloc_size_of::malloc_size_of_is_0;
+use style::dom::{StyleChange, StyleDifference, TRestyleDamage};
+use style::properties::{
+    ComputedValues, restyle_damage_rebuild_box, restyle_damage_rebuild_stacking_context,
+    restyle_damage_recalculate_overflow, restyle_damage_repaint,
+};
+use style::values::computed::Image;
+use style::values::specified::align::AlignFlags;
+use style::values::specified::box_::{DisplayInside, DisplayOutside};
 
 bitflags! {
-    /// Individual layout actions that may be necessary after restyling. This is an extension
-    /// of `RestyleDamage` from stylo, which only uses the 4 lower bits.
-    #[derive(Clone, Copy, Default, Eq, PartialEq)]
-    pub struct LayoutDamage: u16 {
+    /// Major phases of layout that need to be run due to the damage to a node during restyling. In
+    /// addition to the 4 bytes used for that, the rest of the `u16` is exposed as an extension point
+    /// for users of the crate to add their own custom types of damage that correspond to the
+    /// layout system they are implementing.
+    #[derive(Clone, Copy, Eq, PartialEq)]
+    pub struct ServoRestyleDamage: u16 {
+        /// Repaint the node itself.
+        ///
+        /// Propagates both up and down the flow tree.
+        const REPAINT = 0b0001;
+
+        /// Rebuilds the stacking contexts.
+        ///
+        /// Propagates both up and down the flow tree.
+        const REBUILD_STACKING_CONTEXT = 0b0011;
+
+        /// Recalculates the scrollable overflow.
+        ///
+        /// Propagates both up and down the flow tree.
+        const RECALCULATE_OVERFLOW = 0b0111;
+
+        /// Any other type of damage, which requires running layout again.
+        ///
+        /// Propagates both up and down the flow tree.
+        const RELAYOUT = 0b1111;
+
         /// Recollect the box children for this element, because some of the them will be
         /// rebuilt.
-        const RECOLLECT_BOX_TREE_CHILDREN = 0b0111_1111_1111 << 4;
+        const RECOLLECT_BOX_TREE_CHILDREN = 0b0001_1111;
+
         /// Rebuild the entire box for this element, which means that every part of layout
-        /// needs to happena again.
-        const REBUILD_BOX = 0b1111_1111_1111 << 4;
+        /// needs to happen again.
+        const REBUILD_BOX = 0b0011_1111;
     }
 }
 
-impl LayoutDamage {
-    pub fn recollect_box_tree_children() -> RestyleDamage {
-        RestyleDamage::from_bits_retain(LayoutDamage::RECOLLECT_BOX_TREE_CHILDREN.bits())
-    }
+malloc_size_of_is_0!(ServoRestyleDamage);
 
-    pub fn rebuild_box_tree() -> RestyleDamage {
-        RestyleDamage::from_bits_retain(LayoutDamage::REBUILD_BOX.bits())
-    }
-
-    pub fn has_box_damage(&self) -> bool {
-        self.intersects(Self::REBUILD_BOX)
+impl Default for ServoRestyleDamage {
+    fn default() -> Self {
+        Self::empty()
     }
 }
 
-impl From<RestyleDamage> for LayoutDamage {
-    fn from(restyle_damage: RestyleDamage) -> Self {
-        LayoutDamage::from_bits_retain(restyle_damage.bits())
-    }
-}
-
-impl std::fmt::Debug for LayoutDamage {
+impl std::fmt::Debug for ServoRestyleDamage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.contains(Self::REBUILD_BOX) {
             f.write_str("REBUILD_BOX")
         } else if self.contains(Self::RECOLLECT_BOX_TREE_CHILDREN) {
             f.write_str("RECOLLECT_BOX_TREE_CHILDREN")
+        } else if self.contains(Self::RELAYOUT) {
+            f.write_str("RELAYOUT")
+        } else if self.contains(Self::RECALCULATE_OVERFLOW) {
+            f.write_str("RECALCULATE_OVERFLOW")
+        } else if self.contains(Self::REBUILD_STACKING_CONTEXT) {
+            f.write_str("REBUILD_STACKING_CONTEXT")
+        } else if self.contains(Self::REPAINT) {
+            f.write_str("REPAINT")
         } else {
             f.write_str("EMPTY")
         }
+    }
+}
+
+impl fmt::Display for ServoRestyleDamage {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let mut first_elem = true;
+
+        let to_iter = [
+            (ServoRestyleDamage::REPAINT, "Repaint"),
+            (
+                ServoRestyleDamage::REBUILD_STACKING_CONTEXT,
+                "Rebuild stacking context",
+            ),
+            (
+                ServoRestyleDamage::RECALCULATE_OVERFLOW,
+                "Recalculate overflow",
+            ),
+            (ServoRestyleDamage::RELAYOUT, "Relayout"),
+        ];
+
+        for &(damage, damage_str) in &to_iter {
+            if self.contains(damage) {
+                if !first_elem {
+                    write!(f, " | ")?;
+                }
+                write!(f, "{}", damage_str)?;
+                first_elem = false;
+            }
+        }
+
+        if first_elem {
+            write!(f, "NoDamage")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl TRestyleDamage for ServoRestyleDamage {
+    /// Clear/reset all damage flags
+    fn clear(&mut self) {
+        Flags::clear(self)
+    }
+    /// Whether the damage is empty ("no styles changed")
+    fn is_empty(&self) -> bool {
+        Flags::is_empty(self)
+    }
+    /// Mark the element as needing it's (eager) pseudo-elements rebuilt
+    fn set_rebuild_pseudos(&mut self) {
+        self.insert(Self::REBUILD_BOX);
+    }
+}
+
+pub fn augmented_restyle_damage_rebuild_box(old: &ComputedValues, new: &ComputedValues) -> bool {
+    let old_box = old.get_box();
+    let new_box = new.get_box();
+    restyle_damage_rebuild_box(old, new) ||
+        old_box.original_display != new_box.original_display ||
+        old_box.has_transform_or_perspective() != new_box.has_transform_or_perspective() ||
+        old.get_effects().filter.0.is_empty() != new.get_effects().filter.0.is_empty()
+}
+
+pub fn augmented_restyle_damage_rebuild_stacking_context(
+    old: &ComputedValues,
+    new: &ComputedValues,
+) -> bool {
+    restyle_damage_rebuild_stacking_context(old, new) ||
+        old.guarantees_stacking_context() != new.guarantees_stacking_context()
+}
+
+impl ServoRestyleDamage {
+    /// Compute the `StyleDifference` (including the appropriate restyle damage)
+    /// for a given style change between `old` and `new`.
+    pub fn compute_style_difference(
+        old: &ComputedValues,
+        new: &ComputedValues,
+    ) -> StyleDifference<Self> {
+        let damage = Self::compute_damage(old, new);
+        StyleDifference {
+            damage,
+            change: if damage.is_empty() {
+                StyleChange::Unchanged
+            } else {
+                // FIXME(emilio): Differentiate between reset and inherited
+                // properties here, and set `reset_only` appropriately so the
+                // optimization to skip the cascade in those cases applies.
+                StyleChange::Changed { reset_only: false }
+            },
+        }
+    }
+
+    fn compute_damage(old: &ComputedValues, new: &ComputedValues) -> Self {
+        let mut damage = ServoRestyleDamage::empty();
+
+        // Damage flags higher up the if-else chain imply damage flags lower down the if-else chain,
+        // so we can skip the diffing process for later flags if an earlier flag is true
+        if augmented_restyle_damage_rebuild_box(old, new) {
+            damage.insert(Self::compute_layout_damage(old, new));
+        } else if restyle_damage_recalculate_overflow(old, new) {
+            damage.insert(ServoRestyleDamage::RECALCULATE_OVERFLOW)
+        } else if augmented_restyle_damage_rebuild_stacking_context(old, new) {
+            damage.insert(ServoRestyleDamage::REBUILD_STACKING_CONTEXT);
+        } else if restyle_damage_repaint(old, new) || !old.custom_properties_equal(new) {
+            // Paint worklets may depend on custom properties, so if they have changed we should repaint.
+            damage.insert(ServoRestyleDamage::REPAINT);
+        }
+
+        damage
+    }
+
+    fn compute_layout_damage(old: &ComputedValues, new: &ComputedValues) -> ServoRestyleDamage {
+        let box_tree_needs_rebuild = || {
+            let old_box = old.get_box();
+            let new_box = new.get_box();
+
+            if old_box.display != new_box.display ||
+                old_box.float != new_box.float ||
+                old_box.position != new_box.position
+            {
+                return true;
+            }
+
+            if old.get_font() != new.get_font() {
+                return true;
+            }
+
+            // NOTE: This should be kept in sync with the checks in `impl
+            // StyleExt::establishes_block_formatting_context` for `ComputedValues` in
+            // `components/layout/style_ext.rs`.
+            if new_box.display.outside() == DisplayOutside::Block &&
+                new_box.display.inside() == DisplayInside::Flow
+            {
+                let alignment_establishes_new_block_formatting_context =
+                    |style: &ComputedValues| {
+                        style.get_position().align_content.0.primary() != AlignFlags::NORMAL
+                    };
+
+                let old_column = old.get_column();
+                let new_column = new.get_column();
+                if old_box.overflow_x.is_scrollable() != new_box.overflow_x.is_scrollable() ||
+                    old_column.is_multicol() != new_column.is_multicol() ||
+                    old_column.column_span != new_column.column_span ||
+                    alignment_establishes_new_block_formatting_context(old) !=
+                        alignment_establishes_new_block_formatting_context(new)
+                {
+                    return true;
+                }
+            }
+
+            if old_box.display.is_list_item() {
+                let old_list = old.get_list();
+                let new_list = new.get_list();
+                if old_list.list_style_position != new_list.list_style_position ||
+                    old_list.list_style_image != new_list.list_style_image ||
+                    (new_list.list_style_image == Image::None &&
+                        old_list.list_style_type != new_list.list_style_type)
+                {
+                    return true;
+                }
+            }
+
+            if new.is_pseudo_style() && old.get_counters().content != new.get_counters().content {
+                return true;
+            }
+
+            false
+        };
+
+        let text_shaping_needs_recollect = || {
+            if old.clone_direction() != new.clone_direction() ||
+                old.clone_unicode_bidi() != new.clone_unicode_bidi()
+            {
+                return true;
+            }
+
+            let old_text = old.get_inherited_text().clone();
+            let new_text = new.get_inherited_text().clone();
+            if old_text.white_space_collapse != new_text.white_space_collapse ||
+                old_text.text_transform != new_text.text_transform ||
+                old_text.word_break != new_text.word_break ||
+                old_text.overflow_wrap != new_text.overflow_wrap ||
+                old_text.letter_spacing != new_text.letter_spacing ||
+                old_text.word_spacing != new_text.word_spacing ||
+                old_text.text_rendering != new_text.text_rendering
+            {
+                return true;
+            }
+
+            false
+        };
+
+        if box_tree_needs_rebuild() {
+            ServoRestyleDamage::REBUILD_BOX
+        } else if text_shaping_needs_recollect() {
+            ServoRestyleDamage::RECOLLECT_BOX_TREE_CHILDREN
+        } else {
+            // This element needs to be laid out again, but does not have any damage to
+            // its box. In the future, we will distinguish between types of damage to the
+            // fragment as well.
+            ServoRestyleDamage::RELAYOUT
+        }
+    }
+
+    pub fn has_box_damage(&self) -> bool {
+        self.intersects(Self::REBUILD_BOX)
     }
 }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -29,7 +29,7 @@ use fnv::FnvHashMap;
 use fonts::{FontContext, SystemFontServiceProxy};
 use fxhash::FxHashMap;
 use ipc_channel::ipc::IpcSender;
-pub use layout_damage::LayoutDamage;
+pub use layout_damage::ServoRestyleDamage;
 use libc::c_void;
 use malloc_size_of::{MallocSizeOf as MallocSizeOfTrait, MallocSizeOfOps, malloc_size_of_is_0};
 use malloc_size_of_derive::MallocSizeOf;
@@ -51,7 +51,7 @@ use style::invalidation::element::restyle_hints::RestyleHint;
 use style::media_queries::Device;
 use style::properties::PropertyId;
 use style::properties::style_structs::Font;
-use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
+use style::selector_parser::{PseudoElement, Snapshot};
 use style::stylesheets::Stylesheet;
 use webrender_api::units::{DeviceIntSize, LayoutPoint, LayoutVector2D};
 use webrender_api::{ExternalScrollId, ImageKey};
@@ -68,7 +68,7 @@ pub struct StyleData {
     /// style system is being used standalone, this is all that hangs
     /// off the node. This must be first to permit the various
     /// transmutations between ElementData and PersistentLayoutData.
-    pub element_data: AtomicRefCell<ElementData>,
+    pub element_data: AtomicRefCell<ElementData<ServoRestyleDamage>>,
 
     /// Information needed during parallel traversals.
     pub parallel: DomParallelInfo,
@@ -468,7 +468,7 @@ pub struct PendingRestyle {
     pub hint: RestyleHint,
 
     /// Any explicit restyles damage that have been accumulated for this element.
-    pub damage: RestyleDamage,
+    pub damage: ServoRestyleDamage,
 }
 
 /// The type of fragment that a scroll root is created for.

--- a/components/shared/layout/wrapper_traits.rs
+++ b/components/shared/layout/wrapper_traits.rs
@@ -26,7 +26,7 @@ use style::stylist::RuleInclusion;
 
 use crate::{
     FragmentType, GenericLayoutData, GenericLayoutDataTrait, HTMLCanvasData, HTMLMediaData,
-    LayoutNodeType, SVGSVGData, StyleData,
+    LayoutNodeType, SVGSVGData, ServoRestyleDamage, StyleData,
 };
 
 pub trait LayoutDataTrait: GenericLayoutDataTrait + Default + Send + Sync + 'static {}
@@ -302,7 +302,7 @@ pub trait ThreadSafeLayoutElement<'dom>:
 
     fn get_attr_enum(&self, namespace: &Namespace, name: &LocalName) -> Option<&AttrValue>;
 
-    fn style_data(&self) -> AtomicRef<ElementData>;
+    fn style_data(&self) -> AtomicRef<ElementData<ServoRestyleDamage>>;
 
     fn pseudo_element(&self) -> Option<PseudoElement>;
 


### PR DESCRIPTION
Inverts the control flow of the restyle damage computation so that Servo implements the top-level function, and Stylo merely provides helpers. Makes `RestyleDamage` an associated type on the Stylo `TElement` trait to (allowing `layout_api::LayoutDamage` and `stylo::RestyleDamage` to be merged into one Servo-owned type) enable this.