### PR TITLE
compositor/layout: Rely on layout for fine-grained input event hit testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,6 +1390,7 @@ dependencies = [
  "ipc-channel",
  "libc",
  "log",
+ "num-traits",
  "pixels",
  "profile_traits",
  "servo-tracing",
@@ -4789,6 +4790,7 @@ dependencies = [
  "servo_malloc_size_of",
  "servo_url",
  "stylo",
+ "stylo_traits",
  "webrender_api",
 ]
 

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -31,6 +31,7 @@ gleam = { workspace = true }
 ipc-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
+num-traits = { workspace = true }
 pixels = { path = "../pixels" }
 profile_traits = { workspace = true }
 servo_allocator = { path = "../allocator" }

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -42,7 +42,6 @@ mod from_constellation {
                 Self::SendInitialTransaction(..) => target!("SendInitialTransaction"),
                 Self::SendScrollNode(..) => target!("SendScrollNode"),
                 Self::SendDisplayList { .. } => target!("SendDisplayList"),
-                Self::HitTest(..) => target!("HitTest"),
                 Self::GenerateImageKey(..) => target!("GenerateImageKey"),
                 Self::UpdateImages(..) => target!("UpdateImages"),
                 Self::GenerateFontKeys(..) => target!("GenerateFontKeys"),

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::collections::hash_map::{Entry, Keys};
-use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
 
 use base::id::{PipelineId, WebViewId};
@@ -27,7 +27,7 @@ use style_traits::{CSSPixel, PinchZoomFactor};
 use webrender_api::units::{DeviceIntPoint, DevicePixel, DevicePoint, DeviceRect, LayoutVector2D};
 use webrender_api::{ExternalScrollId, HitTestFlags, ScrollLocation};
 
-use crate::compositor::{HitTestError, PipelineDetails, ServoRenderer};
+use crate::compositor::{PipelineDetails, ServoRenderer};
 use crate::touch::{TouchHandler, TouchMoveAction, TouchMoveAllowed, TouchSequenceState};
 
 #[derive(Clone, Copy)]
@@ -96,10 +96,6 @@ pub(crate) struct WebViewRenderer {
     /// Whether or not this [`WebViewRenderer`] isn't throttled and has a pipeline with
     /// active animations or animation frame callbacks.
     animating: bool,
-    /// Pending input events queue. Priavte and only this thread pushes events to it.
-    pending_point_input_events: RefCell<VecDeque<InputEvent>>,
-    /// WebRender is not ready between `SendDisplayList` and `WebRenderFrameReady` messages.
-    pub webrender_frame_ready: Cell<bool>,
     /// A [`ViewportDescription`] for this [`WebViewRenderer`], which contains the limitations
     /// and initial values for zoom derived from the `viewport` meta tag in web content.
     viewport_description: Option<ViewportDescription>,
@@ -135,8 +131,6 @@ impl WebViewRenderer {
             pinch_zoom: PinchZoomFactor::new(1.0),
             hidpi_scale_factor: Scale::new(hidpi_scale_factor.0),
             animating: false,
-            pending_point_input_events: Default::default(),
-            webrender_frame_ready: Cell::default(),
             viewport_description: None,
         }
     }
@@ -335,55 +329,24 @@ impl WebViewRenderer {
         }
     }
 
-    pub(crate) fn dispatch_point_input_event(&self, event: InputEvent) -> bool {
-        self.dispatch_point_input_event_internal(event, true)
-    }
-
-    pub(crate) fn dispatch_pending_point_input_events(&self) {
-        while let Some(event) = self.pending_point_input_events.borrow_mut().pop_front() {
-            // TODO: Add multiple retry later if needed.
-            self.dispatch_point_input_event_internal(event, false);
-        }
-    }
-
-    pub(crate) fn dispatch_point_input_event_internal(
-        &self,
-        mut event: InputEvent,
-        retry_on_error: bool,
-    ) -> bool {
+    pub(crate) fn dispatch_point_input_event(&self, mut event: InputEvent) -> bool {
         // Events that do not need to do hit testing are sent directly to the
         // constellation to filter down.
         let Some(point) = event.point() else {
             return false;
         };
 
-        // Delay the event if the epoch is not synchronized yet (new frame is not ready),
-        // or hit test result would fail and the event is rejected anyway.
-        if retry_on_error &&
-            (!self.webrender_frame_ready.get() ||
-                !self.pending_point_input_events.borrow().is_empty())
-        {
-            self.pending_point_input_events
-                .borrow_mut()
-                .push_back(event);
-            return false;
-        }
-
         // If we can't find a pipeline to send this event to, we cannot continue.
         let get_pipeline_details = |pipeline_id| self.pipelines.get(&pipeline_id);
-        let result = match self
+        let Some(result) = self
             .global
             .borrow()
             .hit_test_at_point(point, get_pipeline_details)
-        {
-            Ok(hit_test_results) => Some(hit_test_results),
-            Err(HitTestError::EpochMismatch) if retry_on_error => {
-                self.pending_point_input_events
-                    .borrow_mut()
-                    .push_back(event.clone());
-                return false;
-            },
-            _ => None,
+            .into_iter()
+            .nth(0)
+        else {
+            warn!("Empty hit test result for input event, ignoring.");
+            return false;
         };
 
         match event {
@@ -394,19 +357,15 @@ impl WebViewRenderer {
             InputEvent::MouseLeave(_) |
             InputEvent::MouseMove(_) |
             InputEvent::Wheel(_) => {
-                if let Some(ref result) = result {
-                    self.global
-                        .borrow_mut()
-                        .update_cursor_from_hittest(point, result);
-                } else {
-                    warn!("Not hit test result.");
-                }
+                self.global
+                    .borrow_mut()
+                    .update_cursor_from_hittest(point, &result);
             },
             _ => unreachable!("Unexpected input event type: {event:?}"),
         }
 
         if let Err(error) = self.global.borrow().constellation_sender.send(
-            EmbedderToConstellationMessage::ForwardInputEvent(self.id, event, result),
+            EmbedderToConstellationMessage::ForwardInputEvent(self.id, event, Some(result)),
         ) {
             warn!("Sending event to constellation failed ({error:?}).");
             false
@@ -895,16 +854,11 @@ impl WebViewRenderer {
         };
 
         let get_pipeline_details = |pipeline_id| self.pipelines.get(&pipeline_id);
-        let hit_test_results = self
-            .global
-            .borrow()
-            .hit_test_at_point_with_flags_and_pipeline(
-                cursor,
-                HitTestFlags::FIND_ALL,
-                None,
-                get_pipeline_details,
-            )
-            .unwrap_or_default();
+        let hit_test_results = self.global.borrow().hit_test_at_point_with_flags(
+            cursor,
+            HitTestFlags::FIND_ALL,
+            get_pipeline_details,
+        );
 
         // Iterate through all hit test results, processing only the first node of each pipeline.
         // This is needed to propagate the scroll events from a pipeline representing an iframe to
@@ -916,7 +870,7 @@ impl WebViewRenderer {
                 Some(&hit_test_result.pipeline_id)
             {
                 let scroll_result = pipeline_details.scroll_tree.scroll_node_or_ancestor(
-                    &hit_test_result.scroll_tree_node,
+                    &hit_test_result.external_scroll_id,
                     scroll_location,
                     ScrollType::InputEvents,
                 );

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -28,10 +28,10 @@ use data_url::mime::Mime;
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
 use embedder_traits::{
-    AllowOrDeny, AnimationState, CompositorHitTestResult, ContextMenuResult, EditingActionEvent,
-    EmbedderMsg, FocusSequenceNumber, ImeEvent, InputEvent, LoadStatus, MouseButton,
-    MouseButtonAction, MouseButtonEvent, ScrollEvent, TouchEvent, TouchEventType, TouchId,
-    UntrustedNodeAddress, WheelEvent,
+    AllowOrDeny, AnimationState, ContextMenuResult, EditingActionEvent, EmbedderMsg,
+    FocusSequenceNumber, ImeEvent, InputEvent, LoadStatus, MouseButton, MouseButtonAction,
+    MouseButtonEvent, ScrollEvent, TouchEvent, TouchEventType, TouchId, UntrustedNodeAddress,
+    WheelEvent,
 };
 use encoding_rs::{Encoding, UTF_8};
 use euclid::Point2D;
@@ -167,6 +167,7 @@ use crate::dom::htmlinputelement::HTMLInputElement;
 use crate::dom::htmlscriptelement::{HTMLScriptElement, ScriptResult};
 use crate::dom::htmltextareaelement::HTMLTextAreaElement;
 use crate::dom::htmltitleelement::HTMLTitleElement;
+use crate::dom::inputevent::HitTestResult;
 use crate::dom::intersectionobserver::IntersectionObserver;
 use crate::dom::keyboardevent::KeyboardEvent;
 use crate::dom::location::{Location, NavigationType};
@@ -1525,7 +1526,6 @@ impl Document {
         }
     }
 
-    #[allow(unsafe_code)]
     pub(crate) fn handle_mouse_button_event(
         &self,
         event: MouseButtonEvent,
@@ -1533,17 +1533,17 @@ impl Document {
         can_gc: CanGc,
     ) {
         // Ignore all incoming events without a hit test.
-        let Some(hit_test_result) = &input_event.hit_test_result else {
+        let Some(hit_test_result) = self.window.hit_test_from_input_event(input_event) else {
             return;
         };
 
         debug!(
             "{:?}: at {:?}",
-            event.action, hit_test_result.point_in_viewport
+            event.action, hit_test_result.point_in_frame
         );
 
-        let node = unsafe { node::from_untrusted_node_address(hit_test_result.node) };
-        let Some(el) = node
+        let Some(el) = hit_test_result
+            .node
             .inclusive_ancestors(ShadowIncluding::Yes)
             .filter_map(DomRoot::downcast::<Element>)
             .next()
@@ -1574,7 +1574,7 @@ impl Document {
             event,
             input_event.pressed_mouse_buttons,
             &self.window,
-            hit_test_result,
+            &hit_test_result,
             input_event.active_keyboard_modifiers,
             can_gc,
         ));
@@ -1609,13 +1609,13 @@ impl Document {
             if self.focus_transaction.borrow().is_some() {
                 self.commit_focus_transaction(FocusInitiator::Local, can_gc);
             }
-            self.maybe_fire_dblclick(node, hit_test_result, input_event, can_gc);
+            self.maybe_fire_dblclick(node, &hit_test_result, input_event, can_gc);
         }
 
         // When the contextmenu event is triggered by right mouse button
         // the contextmenu event MUST be dispatched after the mousedown event.
         if let (MouseButtonAction::Down, MouseButton::Right) = (event.action, event.button) {
-            self.maybe_show_context_menu(node.upcast(), hit_test_result, input_event, can_gc);
+            self.maybe_show_context_menu(node.upcast(), &hit_test_result, input_event, can_gc);
         }
     }
 
@@ -1623,7 +1623,7 @@ impl Document {
     fn maybe_show_context_menu(
         &self,
         target: &EventTarget,
-        hit_test_result: &CompositorHitTestResult,
+        hit_test_result: &HitTestResult,
         input_event: &ConstellationInputEvent,
         can_gc: CanGc,
     ) {
@@ -1635,8 +1635,8 @@ impl Document {
             EventCancelable::Cancelable,    // cancelable
             Some(&self.window),             // view
             0,                              // detail
-            hit_test_result.point_in_viewport.to_i32(),
-            hit_test_result.point_in_viewport.to_i32(),
+            hit_test_result.point_in_frame.to_i32(),
+            hit_test_result.point_in_frame.to_i32(),
             hit_test_result
                 .point_relative_to_initial_containing_block
                 .to_i32(),
@@ -1681,13 +1681,13 @@ impl Document {
     fn maybe_fire_dblclick(
         &self,
         target: &Node,
-        hit_test_result: &CompositorHitTestResult,
+        hit_test_result: &HitTestResult,
         input_event: &ConstellationInputEvent,
         can_gc: CanGc,
     ) {
         // https://w3c.github.io/uievents/#event-type-dblclick
         let now = Instant::now();
-        let point_in_viewport = hit_test_result.point_in_viewport;
+        let point_in_frame = hit_test_result.point_in_frame;
         let opt = self.last_click_info.borrow_mut().take();
 
         if let Some((last_time, last_pos)) = opt {
@@ -1696,7 +1696,7 @@ impl Document {
             let DBL_CLICK_DIST_THRESHOLD = pref!(dom_document_dblclick_dist) as u64;
 
             // Calculate distance between this click and the previous click.
-            let line = point_in_viewport - last_pos;
+            let line = point_in_frame - last_pos;
             let dist = (line.dot(line) as f64).sqrt();
 
             if now.duration_since(last_time) < DBL_CLICK_TIMEOUT &&
@@ -1712,8 +1712,8 @@ impl Document {
                     EventCancelable::Cancelable,
                     Some(&self.window),
                     click_count,
-                    point_in_viewport.to_i32(),
-                    point_in_viewport.to_i32(),
+                    point_in_frame.to_i32(),
+                    point_in_frame.to_i32(),
                     hit_test_result
                         .point_relative_to_initial_containing_block
                         .to_i32(),
@@ -1733,7 +1733,7 @@ impl Document {
         }
 
         // Update last_click_info with the time and position of the click.
-        *self.last_click_info.borrow_mut() = Some((now, point_in_viewport));
+        *self.last_click_info.borrow_mut() = Some((now, point_in_frame));
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1743,7 +1743,7 @@ impl Document {
         event_name: FireMouseEventType,
         can_bubble: EventBubbles,
         cancelable: EventCancelable,
-        hit_test_result: &CompositorHitTestResult,
+        hit_test_result: &HitTestResult,
         input_event: &ConstellationInputEvent,
         can_gc: CanGc,
     ) {
@@ -1754,8 +1754,8 @@ impl Document {
             cancelable,
             Some(&self.window),
             0i32,
-            hit_test_result.point_in_viewport.to_i32(),
-            hit_test_result.point_in_viewport.to_i32(),
+            hit_test_result.point_in_frame.to_i32(),
+            hit_test_result.point_in_frame.to_i32(),
             hit_test_result
                 .point_relative_to_initial_containing_block
                 .to_i32(),
@@ -1987,12 +1987,12 @@ impl Document {
         can_gc: CanGc,
     ) {
         // Ignore all incoming events without a hit test.
-        let Some(hit_test_result) = &input_event.hit_test_result else {
+        let Some(hit_test_result) = self.window.hit_test_from_input_event(input_event) else {
             return;
         };
 
-        let node = unsafe { node::from_untrusted_node_address(hit_test_result.node) };
-        let Some(new_target) = node
+        let Some(new_target) = hit_test_result
+            .node
             .inclusive_ancestors(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<Element>)
             .next()
@@ -2032,7 +2032,7 @@ impl Document {
                     FireMouseEventType::Out,
                     EventBubbles::Bubbles,
                     EventCancelable::Cancelable,
-                    hit_test_result,
+                    &hit_test_result,
                     input_event,
                     can_gc,
                 );
@@ -2044,7 +2044,7 @@ impl Document {
                         event_target,
                         moving_into,
                         FireMouseEventType::Leave,
-                        hit_test_result,
+                        &hit_test_result,
                         input_event,
                         can_gc,
                     );
@@ -2068,7 +2068,7 @@ impl Document {
                 FireMouseEventType::Over,
                 EventBubbles::Bubbles,
                 EventCancelable::Cancelable,
-                hit_test_result,
+                &hit_test_result,
                 input_event,
                 can_gc,
             );
@@ -2081,7 +2081,7 @@ impl Document {
                 event_target,
                 moving_from,
                 FireMouseEventType::Enter,
-                hit_test_result,
+                &hit_test_result,
                 input_event,
                 can_gc,
             );
@@ -2094,7 +2094,7 @@ impl Document {
             FireMouseEventType::Move,
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
-            hit_test_result,
+            &hit_test_result,
             input_event,
             can_gc,
         );
@@ -2112,15 +2112,15 @@ impl Document {
         can_gc: CanGc,
     ) {
         // Ignore all incoming events without a hit test.
-        let Some(hit_test_result) = &input_event.hit_test_result else {
+        let Some(hit_test_result) = self.window.hit_test_from_input_event(input_event) else {
             return;
         };
 
         self.window()
             .send_to_embedder(EmbedderMsg::Status(self.webview_id(), None));
 
-        let node = unsafe { node::from_untrusted_node_address(hit_test_result.node) };
-        for element in node
+        for element in hit_test_result
+            .node
             .inclusive_ancestors(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<Element>)
         {
@@ -2129,19 +2129,19 @@ impl Document {
         }
 
         self.fire_mouse_event(
-            node.upcast(),
+            hit_test_result.node.upcast(),
             FireMouseEventType::Out,
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
-            hit_test_result,
+            &hit_test_result,
             input_event,
             can_gc,
         );
         self.handle_mouse_enter_leave_event(
-            node,
+            hit_test_result.node.clone(),
             None,
             FireMouseEventType::Leave,
-            hit_test_result,
+            &hit_test_result,
             input_event,
             can_gc,
         );
@@ -2152,7 +2152,7 @@ impl Document {
         event_target: DomRoot<Node>,
         related_target: Option<DomRoot<Node>>,
         event_type: FireMouseEventType,
-        hit_test_result: &CompositorHitTestResult,
+        hit_test_result: &HitTestResult,
         input_event: &ConstellationInputEvent,
         can_gc: CanGc,
     ) {
@@ -2207,12 +2207,12 @@ impl Document {
         can_gc: CanGc,
     ) {
         // Ignore all incoming events without a hit test.
-        let Some(hit_test_result) = &input_event.hit_test_result else {
+        let Some(hit_test_result) = self.window.hit_test_from_input_event(input_event) else {
             return;
         };
 
-        let node = unsafe { node::from_untrusted_node_address(hit_test_result.node) };
-        let Some(el) = node
+        let Some(el) = hit_test_result
+            .node
             .inclusive_ancestors(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<Element>)
             .next()
@@ -2226,7 +2226,7 @@ impl Document {
             "{}: on {:?} at {:?}",
             wheel_event_type_string,
             node.debug_str(),
-            hit_test_result.point_in_viewport
+            hit_test_result.point_in_frame
         );
 
         // https://w3c.github.io/uievents/#event-wheelevents
@@ -2237,8 +2237,8 @@ impl Document {
             EventCancelable::Cancelable,
             Some(&self.window),
             0i32,
-            hit_test_result.point_in_viewport.to_i32(),
-            hit_test_result.point_in_viewport.to_i32(),
+            hit_test_result.point_in_frame.to_i32(),
+            hit_test_result.point_in_frame.to_i32(),
             hit_test_result
                 .point_relative_to_initial_containing_block
                 .to_i32(),
@@ -2269,11 +2269,11 @@ impl Document {
     pub(crate) fn handle_touch_event(
         &self,
         event: TouchEvent,
-        hit_test_result: Option<CompositorHitTestResult>,
+        input_event: &ConstellationInputEvent,
         can_gc: CanGc,
     ) -> TouchEventResult {
         // Ignore all incoming events without a hit test.
-        let Some(hit_test_result) = hit_test_result else {
+        let Some(hit_test_result) = self.window.hit_test_from_input_event(input_event) else {
             self.update_active_touch_points_when_early_return(event);
             return TouchEventResult::Forwarded;
         };
@@ -2286,8 +2286,8 @@ impl Document {
             TouchEventType::Cancel => "touchcancel",
         };
 
-        let node = unsafe { node::from_untrusted_node_address(hit_test_result.node) };
-        let Some(el) = node
+        let Some(el) = hit_test_result
+            .node
             .inclusive_ancestors(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<Element>)
             .next()
@@ -2299,12 +2299,12 @@ impl Document {
         let target = DomRoot::upcast::<EventTarget>(el);
         let window = &*self.window;
 
-        let client_x = Finite::wrap(hit_test_result.point_in_viewport.x as f64);
-        let client_y = Finite::wrap(hit_test_result.point_in_viewport.y as f64);
+        let client_x = Finite::wrap(hit_test_result.point_in_frame.x as f64);
+        let client_y = Finite::wrap(hit_test_result.point_in_frame.y as f64);
         let page_x =
-            Finite::wrap(hit_test_result.point_in_viewport.x as f64 + window.PageXOffset() as f64);
+            Finite::wrap(hit_test_result.point_in_frame.x as f64 + window.PageXOffset() as f64);
         let page_y =
-            Finite::wrap(hit_test_result.point_in_viewport.y as f64 + window.PageYOffset() as f64);
+            Finite::wrap(hit_test_result.point_in_frame.y as f64 + window.PageYOffset() as f64);
 
         let touch = Touch::new(
             window, identifier, &target, client_x,

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -3,7 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
+use euclid::Point2D;
 use js::rust::HandleObject;
+use style_traits::CSSPixel;
 
 use crate::dom::bindings::codegen::Bindings::InputEventBinding::{self, InputEventMethods};
 use crate::dom::bindings::codegen::Bindings::UIEventBinding::UIEvent_Binding::UIEventMethods;
@@ -11,6 +13,7 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::node::Node;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
@@ -90,4 +93,13 @@ impl InputEventMethods<crate::DomTypeHolder> for InputEvent {
     fn IsTrusted(&self) -> bool {
         self.uievent.IsTrusted()
     }
+}
+
+/// A [`HitTestResult`] that is the result of doing a hit test based on a less-fine-grained
+/// `CompositorHitTestResult` against our current layout.
+pub(crate) struct HitTestResult {
+    pub node: DomRoot<Node>,
+    pub point_in_node: Point2D<f32, CSSPixel>,
+    pub point_in_frame: Point2D<f32, CSSPixel>,
+    pub point_relative_to_initial_containing_block: Point2D<f32, CSSPixel>,
 }

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -6,7 +6,6 @@ use std::cell::Cell;
 use std::default::Default;
 
 use dom_struct::dom_struct;
-use embedder_traits::CompositorHitTestResult;
 use euclid::Point2D;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
@@ -25,6 +24,7 @@ use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
+use crate::dom::inputevent::HitTestResult;
 use crate::dom::node::Node;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
@@ -226,7 +226,7 @@ impl MouseEvent {
         event: embedder_traits::MouseButtonEvent,
         pressed_mouse_buttons: u16,
         window: &Window,
-        hit_test_result: &CompositorHitTestResult,
+        hit_test_result: &HitTestResult,
         modifiers: Modifiers,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
@@ -236,7 +236,7 @@ impl MouseEvent {
             embedder_traits::MouseButtonAction::Down => "mousedown",
         };
 
-        let client_point = hit_test_result.point_in_viewport.to_i32();
+        let client_point = hit_test_result.point_in_frame.to_i32();
         let page_point = hit_test_result
             .point_relative_to_initial_containing_block
             .to_i32();
@@ -256,7 +256,7 @@ impl MouseEvent {
             event.button.into(),
             pressed_mouse_buttons,
             None,
-            Some(hit_test_result.point_relative_to_item),
+            Some(hit_test_result.point_in_node),
             can_gc,
         );
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1137,8 +1137,7 @@ impl ScriptThread {
                     document.handle_mouse_leave_event(&event, can_gc);
                 },
                 InputEvent::Touch(touch_event) => {
-                    let touch_result =
-                        document.handle_touch_event(touch_event, event.hit_test_result, can_gc);
+                    let touch_result = document.handle_touch_event(touch_event, &event, can_gc);
                     if let (TouchEventResult::Processed(handled), true) =
                         (touch_result, touch_event.is_cancelable())
                     {

--- a/components/shared/compositing/tests/compositor.rs
+++ b/components/shared/compositing/tests/compositor.rs
@@ -7,13 +7,12 @@ use std::cell::Cell;
 use base::id::ScrollTreeNodeId;
 use compositing_traits::display_list::{
     AxesScrollSensitivity, ScrollTree, ScrollType, ScrollableNodeInfo, SpatialTreeNodeInfo,
-    StickyNodeInfo,
 };
-use euclid::{SideOffsets2D, Size2D};
+use euclid::Size2D;
 use webrender_api::units::LayoutVector2D;
-use webrender_api::{ExternalScrollId, PipelineId, ScrollLocation, StickyOffsetBounds};
+use webrender_api::{ExternalScrollId, PipelineId, ScrollLocation};
 
-fn add_mock_scroll_node(tree: &mut ScrollTree) -> ScrollTreeNodeId {
+fn add_mock_scroll_node(tree: &mut ScrollTree) -> (ScrollTreeNodeId, ExternalScrollId) {
     let pipeline_id = PipelineId(0, 0);
     let num_nodes = tree.nodes.len();
     let parent = if num_nodes > 0 {
@@ -24,10 +23,11 @@ fn add_mock_scroll_node(tree: &mut ScrollTree) -> ScrollTreeNodeId {
         None
     };
 
-    tree.add_scroll_tree_node(
+    let external_id = ExternalScrollId(num_nodes as u64, pipeline_id);
+    let scroll_node_id = tree.add_scroll_tree_node(
         parent.as_ref(),
         SpatialTreeNodeInfo::Scroll(ScrollableNodeInfo {
-            external_id: ExternalScrollId(num_nodes as u64, pipeline_id),
+            external_id,
             content_rect: Size2D::new(200.0, 200.0).into(),
             clip_rect: Size2D::new(100.0, 100.0).into(),
             scroll_sensitivity: AxesScrollSensitivity {
@@ -37,42 +37,42 @@ fn add_mock_scroll_node(tree: &mut ScrollTree) -> ScrollTreeNodeId {
             offset: LayoutVector2D::zero(),
             offset_changed: Cell::new(false),
         }),
-    )
+    );
+    (scroll_node_id, external_id)
 }
 
 #[test]
 fn test_scroll_tree_simple_scroll() {
     let mut scroll_tree = ScrollTree::default();
-    let pipeline_id = PipelineId(0, 0);
-    let id = add_mock_scroll_node(&mut scroll_tree);
+    let (id, external_id) = add_mock_scroll_node(&mut scroll_tree);
 
     let (scrolled_id, offset) = scroll_tree
         .scroll_node_or_ancestor(
-            &id,
+            &external_id,
             ScrollLocation::Delta(LayoutVector2D::new(20.0, 40.0)),
             ScrollType::Script,
         )
         .unwrap();
     let expected_offset = LayoutVector2D::new(20.0, 40.0);
-    assert_eq!(scrolled_id, ExternalScrollId(0, pipeline_id));
+    assert_eq!(scrolled_id, external_id);
     assert_eq!(offset, expected_offset);
     assert_eq!(scroll_tree.get_node(&id).offset(), Some(expected_offset));
 
     let (scrolled_id, offset) = scroll_tree
         .scroll_node_or_ancestor(
-            &id,
+            &external_id,
             ScrollLocation::Delta(LayoutVector2D::new(-20.0, -40.0)),
             ScrollType::Script,
         )
         .unwrap();
     let expected_offset = LayoutVector2D::new(0.0, 0.0);
-    assert_eq!(scrolled_id, ExternalScrollId(0, pipeline_id));
+    assert_eq!(scrolled_id, external_id);
     assert_eq!(offset, expected_offset);
     assert_eq!(scroll_tree.get_node(&id).offset(), Some(expected_offset));
 
     // Scroll offsets must be positive.
     let result = scroll_tree.scroll_node_or_ancestor(
-        &id,
+        &external_id,
         ScrollLocation::Delta(LayoutVector2D::new(-20.0, -40.0)),
         ScrollType::Script,
     );
@@ -88,26 +88,33 @@ fn test_scroll_tree_simple_scroll_chaining() {
     let mut scroll_tree = ScrollTree::default();
 
     let pipeline_id = PipelineId(0, 0);
-    let parent_id = add_mock_scroll_node(&mut scroll_tree);
+    let (parent_id, parent_external_id) = add_mock_scroll_node(&mut scroll_tree);
+
+    let unscrollable_external_id = ExternalScrollId(100 as u64, pipeline_id);
     let unscrollable_child_id = scroll_tree.add_scroll_tree_node(
         Some(&parent_id),
-        SpatialTreeNodeInfo::Sticky(StickyNodeInfo {
-            frame_rect: Size2D::new(100.0, 100.0).into(),
-            margins: SideOffsets2D::default(),
-            vertical_offset_bounds: StickyOffsetBounds::new(0.0, 0.0),
-            horizontal_offset_bounds: StickyOffsetBounds::new(0.0, 0.0),
+        SpatialTreeNodeInfo::Scroll(ScrollableNodeInfo {
+            external_id: unscrollable_external_id,
+            content_rect: Size2D::new(100.0, 100.0).into(),
+            clip_rect: Size2D::new(100.0, 100.0).into(),
+            scroll_sensitivity: AxesScrollSensitivity {
+                x: ScrollType::Script | ScrollType::InputEvents,
+                y: ScrollType::Script | ScrollType::InputEvents,
+            },
+            offset: LayoutVector2D::zero(),
+            offset_changed: Cell::new(false),
         }),
     );
 
     let (scrolled_id, offset) = scroll_tree
         .scroll_node_or_ancestor(
-            &unscrollable_child_id,
+            &unscrollable_external_id,
             ScrollLocation::Delta(LayoutVector2D::new(20.0, 40.0)),
             ScrollType::Script,
         )
         .unwrap();
     let expected_offset = LayoutVector2D::new(20.0, 40.0);
-    assert_eq!(scrolled_id, ExternalScrollId(0, pipeline_id));
+    assert_eq!(scrolled_id, parent_external_id);
     assert_eq!(offset, expected_offset);
     assert_eq!(
         scroll_tree.get_node(&parent_id).offset(),
@@ -116,35 +123,37 @@ fn test_scroll_tree_simple_scroll_chaining() {
 
     let (scrolled_id, offset) = scroll_tree
         .scroll_node_or_ancestor(
-            &unscrollable_child_id,
+            &unscrollable_external_id,
             ScrollLocation::Delta(LayoutVector2D::new(10.0, 15.0)),
             ScrollType::Script,
         )
         .unwrap();
     let expected_offset = LayoutVector2D::new(30.0, 55.0);
-    assert_eq!(scrolled_id, ExternalScrollId(0, pipeline_id));
+    assert_eq!(scrolled_id, parent_external_id);
     assert_eq!(offset, expected_offset);
     assert_eq!(
         scroll_tree.get_node(&parent_id).offset(),
         Some(expected_offset)
     );
-    assert_eq!(scroll_tree.get_node(&unscrollable_child_id).offset(), None);
+    assert_eq!(
+        scroll_tree.get_node(&unscrollable_child_id).offset(),
+        Some(LayoutVector2D::zero())
+    );
 }
 
 #[test]
 fn test_scroll_tree_chain_when_at_extent() {
     let mut scroll_tree = ScrollTree::default();
 
-    let pipeline_id = PipelineId(0, 0);
-    let parent_id = add_mock_scroll_node(&mut scroll_tree);
-    let child_id = add_mock_scroll_node(&mut scroll_tree);
+    let (parent_id, parent_external_id) = add_mock_scroll_node(&mut scroll_tree);
+    let (child_id, child_external_id) = add_mock_scroll_node(&mut scroll_tree);
 
     let (scrolled_id, offset) = scroll_tree
-        .scroll_node_or_ancestor(&child_id, ScrollLocation::End, ScrollType::Script)
+        .scroll_node_or_ancestor(&child_external_id, ScrollLocation::End, ScrollType::Script)
         .unwrap();
 
     let expected_offset = LayoutVector2D::new(0.0, 100.0);
-    assert_eq!(scrolled_id, ExternalScrollId(1, pipeline_id));
+    assert_eq!(scrolled_id, child_external_id);
     assert_eq!(offset, expected_offset);
     assert_eq!(
         scroll_tree.get_node(&child_id).offset(),
@@ -155,13 +164,13 @@ fn test_scroll_tree_chain_when_at_extent() {
     // of its scroll area in the y axis.
     let (scrolled_id, offset) = scroll_tree
         .scroll_node_or_ancestor(
-            &child_id,
+            &child_external_id,
             ScrollLocation::Delta(LayoutVector2D::new(0.0, 10.0)),
             ScrollType::Script,
         )
         .unwrap();
     let expected_offset = LayoutVector2D::new(0.0, 10.0);
-    assert_eq!(scrolled_id, ExternalScrollId(0, pipeline_id));
+    assert_eq!(scrolled_id, parent_external_id);
     assert_eq!(offset, expected_offset);
     assert_eq!(
         scroll_tree.get_node(&parent_id).offset(),
@@ -175,9 +184,8 @@ fn test_scroll_tree_chain_through_overflow_hidden() {
 
     // Create a tree with a scrollable leaf, but make its `scroll_sensitivity`
     // reflect `overflow: hidden` ie not responsive to non-script scroll events.
-    let pipeline_id = PipelineId(0, 0);
-    let parent_id = add_mock_scroll_node(&mut scroll_tree);
-    let overflow_hidden_id = add_mock_scroll_node(&mut scroll_tree);
+    let (parent_id, parent_external_id) = add_mock_scroll_node(&mut scroll_tree);
+    let (overflow_hidden_id, overflow_hidden_external_id) = add_mock_scroll_node(&mut scroll_tree);
     let node = scroll_tree.get_node_mut(&overflow_hidden_id);
 
     if let SpatialTreeNodeInfo::Scroll(ref mut scroll_node_info) = node.info {
@@ -189,13 +197,13 @@ fn test_scroll_tree_chain_through_overflow_hidden() {
 
     let (scrolled_id, offset) = scroll_tree
         .scroll_node_or_ancestor(
-            &overflow_hidden_id,
+            &overflow_hidden_external_id,
             ScrollLocation::Delta(LayoutVector2D::new(20.0, 40.0)),
             ScrollType::InputEvents,
         )
         .unwrap();
     let expected_offset = LayoutVector2D::new(20.0, 40.0);
-    assert_eq!(scrolled_id, ExternalScrollId(0, pipeline_id));
+    assert_eq!(scrolled_id, parent_external_id);
     assert_eq!(offset, expected_offset);
     assert_eq!(
         scroll_tree.get_node(&parent_id).offset(),

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -20,7 +20,7 @@ use std::hash::Hash;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use base::id::{PipelineId, ScrollTreeNodeId, WebViewId};
+use base::id::{PipelineId, WebViewId};
 use crossbeam_channel::Sender;
 use euclid::{Point2D, Scale, Size2D};
 use http::{HeaderMap, Method, StatusCode};
@@ -38,6 +38,7 @@ use style::queries::values::PrefersColorScheme;
 use style_traits::CSSPixel;
 use url::Url;
 use uuid::Uuid;
+use webrender_api::ExternalScrollId;
 use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, LayoutSize};
 
 pub use crate::input_events::*;
@@ -888,17 +889,11 @@ pub struct CompositorHitTestResult {
     /// containing block.
     pub point_relative_to_initial_containing_block: Point2D<f32, CSSPixel>,
 
-    /// The hit test point relative to the item itself.
-    pub point_relative_to_item: Point2D<f32, CSSPixel>,
-
-    /// The node address of the hit test result.
-    pub node: UntrustedNodeAddress,
-
     /// The cursor that should be used when hovering the item hit by the hit test.
     pub cursor: Option<Cursor>,
 
-    /// The scroll tree node associated with this hit test item.
-    pub scroll_tree_node: ScrollTreeNodeId,
+    /// The [`ExternalScrollId`] of the scroll tree node associated with this hit test item.
+    pub external_scroll_id: ExternalScrollId,
 }
 
 /// Whether the default action for a touch event was prevented by web content

--- a/components/shared/layout/Cargo.toml
+++ b/components/shared/layout/Cargo.toml
@@ -39,5 +39,6 @@ selectors = { workspace = true }
 serde = { workspace = true }
 servo_arc = { workspace = true }
 servo_url = { path = "../../url" }
+stylo_traits = { workspace = true }
 stylo = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -24,7 +24,8 @@ use bitflags::bitflags;
 use compositing_traits::CrossProcessCompositorApi;
 use constellation_traits::LoadData;
 use embedder_traits::{Theme, UntrustedNodeAddress, ViewportDetails};
-use euclid::default::{Point2D, Rect};
+use euclid::Point2D;
+use euclid::default::{Point2D as UntypedPoint2D, Rect};
 use fnv::FnvHashMap;
 use fonts::{FontContext, SystemFontServiceProxy};
 use fxhash::FxHashMap;
@@ -53,6 +54,7 @@ use style::properties::PropertyId;
 use style::properties::style_structs::Font;
 use style::selector_parser::{PseudoElement, RestyleDamage, Snapshot};
 use style::stylesheets::Stylesheet;
+use style_traits::CSSPixel;
 use webrender_api::units::{DeviceIntSize, LayoutPoint, LayoutVector2D};
 use webrender_api::{ExternalScrollId, ImageKey};
 
@@ -283,7 +285,7 @@ pub trait Layout {
         animation_timeline_value: f64,
     ) -> Option<ServoArc<Font>>;
     fn query_scrolling_area(&self, node: Option<TrustedNodeAddress>) -> Rect<i32>;
-    fn query_text_indext(&self, node: OpaqueNode, point: Point2D<f32>) -> Option<usize>;
+    fn query_text_indext(&self, node: OpaqueNode, point: UntypedPoint2D<f32>) -> Option<usize>;
     fn query_elements_from_point(
         &self,
         point: LayoutPoint,
@@ -603,9 +605,9 @@ pub struct ElementsFromPointResult {
     /// An [`OpaqueNode`] that contains a pointer to the node hit by
     /// this hit test result.
     pub node: OpaqueNode,
-    /// The [`LayoutPoint`] of the original query point relative to the
+    /// The [`Point2D`] of the original query point relative to the
     /// node fragment rectangle.
-    pub point_in_target: LayoutPoint,
+    pub point_in_target: Point2D<f32, CSSPixel>,
 }
 
 bitflags! {


### PR DESCRIPTION
Before, the compositor was responsible for doing the hit testing during
input events within a page. This change moves that hit testing to
layout.  With this change, epoch mismatches are no longer a bit deal and
we can simply ignore them, as the Constellation and Script will take
care of ignoring hit tests against scroll nodes and browsing contexts
that no longer exist. This means that hit testing retry support can be
removed.

Add the concept of a Script `HitTest` that transforms the coarse-grained
renderer hit test into one that hit tests against the actual layout
items.

Testing: Currently we do not have good tests for verifying the behavior of
input events, but WebDriver tests should cover this.
Fixes: This is part of #37932.
Fixes: #26608.
Fixes: #25282.
Fixes: #38090.
