### PR TITLE
script(webdriver): Check if element is disabled based on WebDriver specification

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1991,9 +1991,11 @@ pub(crate) fn handle_is_enabled(
                 // current browsing context's active document's type is not "xml".
                 // Otherwise, let enabled to false and jump to the last step of this algorithm.
                 // Step 5. Set enabled to false if a form control is disabled.
-                document.is_html_document() &&
-                    document.is_xhtml_document() &&
+                if document.is_html_document() || document.is_xhtml_document() {
                     !is_disabled(&element)
+                } else {
+                    false
+                }
             }),
         )
         .unwrap();

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1982,7 +1982,7 @@ pub(crate) fn handle_is_enabled(
     reply
         .send(
             // Step 3. Let element be the result of trying to get a known element
-            get_known_element(documents, pipeline, element_id).and_then(|element| {
+            get_known_element(documents, pipeline, element_id).map(|element| {
                 // In `get_known_element`, we confirmed that document exists
                 let document = documents.find_document(pipeline).unwrap();
 
@@ -1990,12 +1990,10 @@ pub(crate) fn handle_is_enabled(
                 // Let enabled be a boolean initially set to true if session's
                 // current browsing context's active document's type is not "xml".
                 // Otherwise, let enabled to false and jump to the last step of this algorithm.
-                if document.is_html_document() || document.is_xhtml_document() {
-                    // Step 5. Set enabled to false if a form control is disabled.
-                    Ok(!is_disabled(&element))
-                } else {
-                    Ok(false)
-                }
+                // Step 5. Set enabled to false if a form control is disabled.
+                document.is_html_document() &&
+                    document.is_xhtml_document() &&
+                    !is_disabled(&element)
             }),
         )
         .unwrap();

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1844,7 +1844,7 @@ pub(crate) fn handle_element_click(
     reply
         .send(
             // Step 3
-            get_known_element(documents, pipeline, element_id).and_then(|ref element| {
+            get_known_element(documents, pipeline, element_id).and_then(|element| {
                 // Step 4
                 if let Some(input_element) = element.downcast::<HTMLInputElement>() {
                     if input_element.input_type() == InputType::File {
@@ -1852,7 +1852,7 @@ pub(crate) fn handle_element_click(
                     }
                 }
 
-                let Some(container) = get_container(element) else {
+                let Some(container) = get_container(&element) else {
                     return Err(ErrorStatus::UnknownError);
                 };
 
@@ -1892,7 +1892,7 @@ pub(crate) fn handle_element_click(
                         }
 
                         // Step 8.6
-                        if !is_disabled(element) {
+                        if !is_disabled(&element) {
                             // Step 8.6.1
                             event_target.fire_event(atom!("input"), can_gc);
 

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -95,19 +95,15 @@ fn is_stale(element: &Element) -> bool {
 fn is_disabled(element: &Element) -> bool {
     // Step 1. If element is an option element or element is an optgroup element
     if element.is::<HTMLOptionElement>() || element.is::<HTMLOptGroupElement>() {
-        // Step 1.1. For each inclusive ancestor ancestor of element
+        // Step 1.1. For each inclusive ancestor `ancestor` of element
         let disabled = element
             .upcast::<Node>()
             .inclusive_ancestors(ShadowIncluding::No)
             .any(|node| {
                 if node.is::<HTMLOptGroupElement>() || node.is::<HTMLSelectElement>() {
-                    // Step 1.1.1. If ancestor is an optgroup element or ancestor is a select element,
-                    // and ancestor is actually disabled, return true.
-                    if let Some(element) = node.downcast::<Element>() {
-                        element.is_actually_disabled()
-                    } else {
-                        false
-                    }
+                    // Step 1.1.1. If `ancestor` is an optgroup element or `ancestor` is a select element,
+                    // and `ancestor` is actually disabled, return true.
+                    node.downcast::<Element>().unwrap().is_actually_disabled()
                 } else {
                     false
                 }
@@ -1976,6 +1972,7 @@ fn get_element_pointer_interactable_paint_tree(
     }
 }
 
+/// <https://w3c.github.io/webdriver/#is-element-enabled>
 pub(crate) fn handle_is_enabled(
     documents: &DocumentCollection,
     pipeline: PipelineId,
@@ -1984,16 +1981,20 @@ pub(crate) fn handle_is_enabled(
 ) {
     reply
         .send(
-            get_known_element(documents, pipeline, element_id).and_then(|ref element| {
-                if let Some(document) = documents.find_document(pipeline) {
-                    if document.is_html_document() || document.is_xhtml_document() {
-                        Ok(!is_disabled(element))
-                    } else {
-                        Ok(false)
-                    }
+            // Step 3. Let element be the result of trying to get a known element
+            get_known_element(documents, pipeline, element_id).and_then(|element| {
+                // In `get_known_element`, we confirmed that document exists
+                let document = documents.find_document(pipeline).unwrap();
+
+                // Step 4
+                // Let enabled be a boolean initially set to true if session's
+                // current browsing context's active document's type is not "xml".
+                // Otherwise, let enabled to false and jump to the last step of this algorithm.
+                if document.is_html_document() || document.is_xhtml_document() {
+                    // Step 5. Set enabled to false if a form control is disabled.
+                    Ok(!is_disabled(&element))
                 } else {
-                    warn!("Cannot find document");
-                    Err(ErrorStatus::UnknownError)
+                    Ok(false)
                 }
             }),
         )

--- a/tests/wpt/meta/webdriver/tests/classic/is_element_enabled/enabled.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/is_element_enabled/enabled.py.ini
@@ -2,8 +2,5 @@
   [test_no_browsing_context]
     expected: FAIL
 
-  [test_option_with_select[disabled\]]
-    expected: FAIL
-
-  [test_optgroup_with_select[disabled\]]
+  [test_option_with_optgroup[disabled\]]
     expected: FAIL


### PR DESCRIPTION
Checking if an element is disabled based on [spec](https://w3c.github.io/webdriver/#dfn-disabled). Fix the command `Is Element Enabled`.

Testing: Covered in WPT (`./tests/wpt/tests/webdriver/tests/classic/is_element_enabled/enabled.py`)
