### PR TITLE
webdriver: Search ancestors instead of preceding nodes when computing container for `option`&`optgroup`

### DIFF
--- a/tests/wpt/meta/webdriver/tests/classic/add_cookie/add.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/add_cookie/add.py.ini
@@ -1,6 +1,6 @@
 [add.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_cookie_unsupported_scheme[about\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/delete_cookie/delete.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/delete_cookie/delete.py.ini
@@ -1,3 +1,3 @@
 [delete.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/click.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/click.py.ini
@@ -1,3 +1,3 @@
 [click.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/form_controls.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/form_controls.py.ini
@@ -8,9 +8,6 @@
   [test_input_append]
     expected: FAIL
 
-  [test_textarea_append]
-    expected: FAIL
-
   [test_input_insert_when_focused]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/interactability.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/interactability.py.ini
@@ -16,3 +16,6 @@
 
   [test_transparent_element]
     expected: FAIL
+
+  [test_obscured_element]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/find_element_from_shadow_root/find.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/find_element_from_shadow_root/find.py.ini
@@ -1,3 +1,3 @@
 [find.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/find_elements_from_element/find.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/find_elements_from_element/find.py.ini
@@ -1,6 +1,6 @@
 [find.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_parent_htmldocument]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/forward/forward.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/forward/forward.py.ini
@@ -10,6 +10,3 @@
 
   [test_seen_nodes[https coop\]]
     expected: FAIL
-
-  [test_removed_iframe]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_alert_text/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_alert_text/get.py.ini
@@ -1,3 +1,6 @@
 [get.py]
   [test_get_confirm_text]
     expected: FAIL
+
+  [test_get_prompt_text]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_computed_role/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_computed_role/get.py.ini
@@ -1,6 +1,6 @@
 [get.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_computed_roles[<article>foo</article>-article-article\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_current_url/file.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_current_url/file.py.ini
@@ -1,0 +1,3 @@
+[file.py]
+  [test_get_current_url_file_protocol]
+    expected: ERROR

--- a/tests/wpt/meta/webdriver/tests/classic/get_current_url/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_current_url/get.py.ini
@@ -1,3 +1,0 @@
-[get.py]
-  [test_no_browsing_context]
-    expected: ERROR

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_css_value/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_css_value/get.py.ini
@@ -1,3 +1,3 @@
 [get.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_property/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_property/get.py.ini
@@ -1,6 +1,6 @@
 [get.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_web_reference[shadowRoot-ShadowRoot\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_rect/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_rect/get.py.ini
@@ -1,3 +1,3 @@
 [get.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_shadow_root/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_shadow_root/get.py.ini
@@ -1,3 +1,3 @@
 [get.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_tag_name/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_tag_name/get.py.ini
@@ -1,6 +1,6 @@
 [get.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_get_element_tag_name]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_text/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_text/get.py.ini
@@ -1,6 +1,6 @@
 [get.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_shadow_root_slot[custom outside\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_named_cookie/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_named_cookie/get.py.ini
@@ -1,6 +1,6 @@
 [get.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_get_named_session_cookie]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_page_source/source.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_page_source/source.py.ini
@@ -1,3 +1,3 @@
 [source.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_window_handle/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_window_handle/get.py.ini
@@ -1,3 +1,0 @@
-[get.py]
-  [test_no_browsing_context]
-    expected: ERROR

--- a/tests/wpt/meta/webdriver/tests/classic/get_window_handles/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_window_handles/get.py.ini
@@ -1,3 +1,0 @@
-[get.py]
-  [test_no_browsing_context]
-    expected: ERROR

--- a/tests/wpt/meta/webdriver/tests/classic/get_window_rect/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_window_rect/get.py.ini
@@ -1,3 +1,0 @@
-[get.py]
-  [test_no_browsing_context]
-    expected: ERROR

--- a/tests/wpt/meta/webdriver/tests/classic/is_element_enabled/enabled.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/is_element_enabled/enabled.py.ini
@@ -1,6 +1,6 @@
 [enabled.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_option_with_select[disabled\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/maximize_window/maximize.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/maximize_window/maximize.py.ini
@@ -10,6 +10,3 @@
 
   [test_maximize_twice_is_idempotent]
     expected: FAIL
-
-  [test_no_browsing_context]
-    expected: ERROR

--- a/tests/wpt/meta/webdriver/tests/classic/minimize_window/minimize.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/minimize_window/minimize.py.ini
@@ -3,7 +3,7 @@
     expected: FAIL
 
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_response_payload]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/new_window/new.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/new_window/new.py.ini
@@ -1,3 +1,0 @@
-[new.py]
-  [test_no_browsing_context]
-    expected: ERROR

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/key.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/key.py.ini
@@ -1,6 +1,6 @@
 [key.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_key_down_closes_browsing_context]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_mouse.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_mouse.py.ini
@@ -1,6 +1,6 @@
 [pointer_mouse.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_pointer_down_closes_browsing_context]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_touch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_touch.py.ini
@@ -1,6 +1,6 @@
 [pointer_touch.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_pointer_down_closes_browsing_context]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/print/printcmd.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/print/printcmd.py.ini
@@ -3,7 +3,7 @@
     expected: FAIL
 
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL
 
   [test_html_document]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/release_actions/release.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/release_actions/release.py.ini
@@ -1,3 +1,3 @@
 [release.py]
   [test_no_browsing_context]
-    expected: ERROR
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/switch_to_frame/switch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/switch_to_frame/switch.py.ini
@@ -1,12 +1,9 @@
 [switch.py]
   [test_no_browsing_context[0\]]
-    expected: ERROR
+    expected: FAIL
 
   [test_no_browsing_context[id2\]]
     expected: FAIL
 
   [test_find_element_while_frame_is_still_loading]
     expected: FAIL
-
-  [test_no_browsing_context[None\]]
-    expected: ERROR

--- a/tests/wpt/meta/webdriver/tests/classic/switch_to_window/switch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/switch_to_window/switch.py.ini
@@ -1,3 +1,0 @@
-[switch.py]
-  [test_no_browsing_context]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/screenshot.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/screenshot.py.ini
@@ -1,3 +1,0 @@
-[screenshot.py]
-  [test_no_browsing_context]
-    expected: ERROR

--- a/tests/wpt/meta/webdriver/tests/classic/take_screenshot/screenshot.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/take_screenshot/screenshot.py.ini
@@ -1,3 +1,0 @@
-[screenshot.py]
-  [test_no_browsing_context]
-    expected: ERROR


### PR DESCRIPTION
Fix the bug from 6 years ago https://github.com/servo/servo/pull/24090.

According to [spec](https://w3c.github.io/webdriver/#dfn-container), we should search ancestor instead of preceding nodes (which is reverse order of pre-order DFS and can end up weird places) when computing container for `option`&`optgroup`.


Testing: Update WPT.
Fixes: https://github.com/servo/servo/pull/36467#discussion_r2255834497.