### PR TITLE
ci: bump uv version

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -21,4 +21,4 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@v4
       with:
-        version: "0.5.6"
+        version: "0.8.5"


### PR DESCRIPTION
Bumps uv in CI to 0.8.5

Testing: try run: https://github.com/servo/servo/actions/runs/16782161133

