### PR TITLE
webdriver: Check if container is obscured for "Element Click"

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1846,8 +1846,18 @@ pub(crate) fn handle_element_click(
                     return Err(ErrorStatus::ElementNotInteractable);
                 }
 
-                // Step 7
-                // TODO: return error if obscured
+                // Step 7. If element's container is obscured by another element,
+                // return error with error code element click intercepted.
+                // https://w3c.github.io/webdriver/#dfn-obscuring
+                // An element is obscured if the pointer-interactable paint tree is empty,
+                // or the first element in this tree is not an inclusive descendant of itself.
+                // `paint_tree` is guaranteed not empty as element is "in view".
+                if !container
+                    .upcast::<Node>()
+                    .Contains(Some(paint_tree[0].upcast::<Node>()))
+                {
+                    return Err(ErrorStatus::ElementClickIntercepted);
+                }
 
                 // Step 8 for <option> element.
                 match element.downcast::<HTMLOptionElement>() {

--- a/tests/wpt/meta/webdriver/tests/classic/element_clear/clear.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_clear/clear.py.ini
@@ -10,6 +10,3 @@
 
   [test_designmode]
     expected: FAIL
-
-  [test_scroll_into_view]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/interactability.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/interactability.py.ini
@@ -1,3 +1,0 @@
-[interactability.py]
-  [test_element_intercepted]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/select.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/select.py.ini
@@ -13,3 +13,21 @@
 
   [test_out_of_view_dropdown]
     expected: FAIL
+
+  [test_click_multiple_option]
+    expected: FAIL
+
+  [test_click_preselected_multiple_option]
+    expected: FAIL
+
+  [test_click_multiple_does_not_deselect_others]
+    expected: FAIL
+
+  [test_click_selected_multiple_option]
+    expected: FAIL
+
+  [test_out_of_view_multiple]
+    expected: FAIL
+
+  [test_option_disabled]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/shadow_dom.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/shadow_dom.py.ini
@@ -1,0 +1,9 @@
+[shadow_dom.py]
+  [test_shadow_element_click[host_element\]]
+    expected: FAIL
+
+  [test_nested_shadow_element_click[outer_element\]]
+    expected: FAIL
+
+  [test_nested_shadow_element_click[inner_element\]]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/form_controls.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/form_controls.py.ini
@@ -16,3 +16,6 @@
 
   [test_date]
     expected: FAIL
+
+  [test_textarea_append]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/scroll_into_view.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/scroll_into_view.py.ini
@@ -1,24 +1,12 @@
 [scroll_into_view.py]
-  [test_element_outside_of_scrollable_viewport]
-    expected: FAIL
-
   [test_contenteditable_element_outside_of_scrollable_viewport]
     expected: FAIL
 
   [test_element_already_in_viewport[{block: 'start'}\]]
     expected: FAIL
 
-  [test_element_already_in_viewport[{block: 'center'}\]]
-    expected: FAIL
-
   [test_element_already_in_viewport[{block: 'end'}\]]
     expected: FAIL
 
   [test_element_already_in_viewport[{block: 'nearest'}\]]
-    expected: FAIL
-
-  [test_element_just_outside_viewport[Just above viewport\]]
-    expected: FAIL
-
-  [test_element_just_outside_viewport[Just below viewport\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/get_current_url/file.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_current_url/file.py.ini
@@ -1,3 +1,0 @@
-[file.py]
-  [test_get_current_url_file_protocol]
-    expected: ERROR


### PR DESCRIPTION
Implement step 7 of [Element Click](https://w3c.github.io/webdriver/#element-click): check whether container is obscured.

Testing: `/webdriver/tests/classic/element_click/interactability.py` can now fully pass. Other changes are combined effect with 17a269a8ade22ec768a566224b29cb4795e94fca due to script execution, and exposes new problem: https://github.com/servo/servo/pull/38497#discussion_r2257866612

