### PR TITLE
ci: Don't give lint job secrets

### DIFF
--- a/.github/workflows/dispatch-workflow.yml
+++ b/.github/workflows/dispatch-workflow.yml
@@ -75,8 +75,8 @@ jobs:
   lint:
     if: ${{ inputs.workflow == 'lint' }}
     name: Lint
+    # Note: The lint workflow does not need access to any secrets.
     uses: ./.github/workflows/lint.yml
-    secrets: inherit
 
   android:
     if: ${{ inputs.workflow == 'android' }}


### PR DESCRIPTION
The lint workflow doesn't seem to use any secrets, so we shouldn't pass them.

Testing: [mach try](https://github.com/servo/servo/actions/runs/16784528217/job/47531648483)

