### PR TITLE
webdriver: Support "scroll into view" for commands

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2367,8 +2367,8 @@ impl ScriptThread {
             WebDriverScriptCommand::GetElementRect(node_id, reply) => {
                 webdriver_handlers::handle_get_rect(&documents, pipeline_id, node_id, reply, can_gc)
             },
-            WebDriverScriptCommand::GetBoundingClientRect(node_id, reply) => {
-                webdriver_handlers::handle_get_bounding_client_rect(
+            WebDriverScriptCommand::ScrollAndGetBoundingClientRect(node_id, reply) => {
+                webdriver_handlers::handle_scroll_and_get_bounding_client_rect(
                     &documents,
                     pipeline_id,
                     node_id,

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -39,7 +39,7 @@ use crate::dom::bindings::codegen::Bindings::CSSStyleDeclarationBinding::CSSStyl
 use crate::dom::bindings::codegen::Bindings::DOMRectBinding::DOMRectMethods;
 use crate::dom::bindings::codegen::Bindings::DocumentBinding::DocumentMethods;
 use crate::dom::bindings::codegen::Bindings::ElementBinding::{
-    ElementMethods, ScrollLogicalPosition, ScrollIntoViewOptions,
+    ElementMethods, ScrollIntoViewOptions, ScrollLogicalPosition,
 };
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLInputElementBinding::HTMLInputElementMethods;
@@ -2094,7 +2094,12 @@ pub(crate) fn handle_remove_load_status_sender(
 }
 
 /// <https://w3c.github.io/webdriver/#dfn-scrolls-into-view>
-fn scroll_into_view(element: &Element, documents: &DocumentCollection, pipeline: &PipelineId, can_gc: CanGc) {
+fn scroll_into_view(
+    element: &Element,
+    documents: &DocumentCollection,
+    pipeline: &PipelineId,
+    can_gc: CanGc,
+) {
     // Check if element is already in view
     let paint_tree = get_element_pointer_interactable_paint_tree(
         element,
@@ -2110,14 +2115,12 @@ fn scroll_into_view(element: &Element, documents: &DocumentCollection, pipeline:
     // Step 1. Let options be the following ScrollIntoViewOptions:
     // - Logical scroll position "block": end
     // - Logical scroll position "inline": nearest
-    let options = BooleanOrScrollIntoViewOptions::ScrollIntoViewOptions(
-        ScrollIntoViewOptions {
-            parent: Default::default(),
-            block: ScrollLogicalPosition::End,
-            inline: ScrollLogicalPosition::Nearest,
-            container: Default::default(),
-        }
-    );
+    let options = BooleanOrScrollIntoViewOptions::ScrollIntoViewOptions(ScrollIntoViewOptions {
+        parent: Default::default(),
+        block: ScrollLogicalPosition::End,
+        inline: ScrollLogicalPosition::Nearest,
+        container: Default::default(),
+    });
     // Step 2. Run scrollIntoView
     element.ScrollIntoView(options);
 }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1242,7 +1242,7 @@ pub(crate) fn handle_will_send_keys(
                         if !element.is_active_element() {
                             // TODO: "Focusing steps" has a different meaning from the focus() method.
                             // The actual focusing steps should be implemented
-                            html_element.Focus(&FocusOptions::default(), can_gc);
+                            html_element.Focus(&FocusOptions{ preventScroll: true }, can_gc);
                         } else {
                             element_has_focus = element.focus_state();
                         }
@@ -1784,7 +1784,7 @@ fn clear_a_resettable_element(element: &Element, can_gc: CanGc) -> Result<(), Er
     // Step 3. Invoke the focusing steps for the element.
     // TODO: "Focusing steps" has a different meaning from the focus() method.
     // The actual focusing steps should be implemented
-    html_element.Focus(&FocusOptions::default(), can_gc);
+    html_element.Focus(&FocusOptions{ preventScroll: true }, can_gc);
 
     // Step 4. Run clear algorithm for element.
     if let Some(input_element) = element.downcast::<HTMLInputElement>() {
@@ -1937,7 +1937,7 @@ pub(crate) fn handle_element_click(
                             Some(html_element) => {
                                 // TODO: "Focusing steps" has a different meaning from the focus() method.
                                 // The actual focusing steps should be implemented
-                                html_element.Focus(&FocusOptions::default(), can_gc);
+                                html_element.Focus(&FocusOptions{ preventScroll: true }, can_gc);
                             },
                             None => return Err(ErrorStatus::UnknownError),
                         }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1242,7 +1242,12 @@ pub(crate) fn handle_will_send_keys(
                         if !element.is_active_element() {
                             // TODO: "Focusing steps" has a different meaning from the focus() method.
                             // The actual focusing steps should be implemented
-                            html_element.Focus(&FocusOptions{ preventScroll: true }, can_gc);
+                            html_element.Focus(
+                                &FocusOptions {
+                                    preventScroll: true,
+                                },
+                                can_gc,
+                            );
                         } else {
                             element_has_focus = element.focus_state();
                         }
@@ -1784,7 +1789,12 @@ fn clear_a_resettable_element(element: &Element, can_gc: CanGc) -> Result<(), Er
     // Step 3. Invoke the focusing steps for the element.
     // TODO: "Focusing steps" has a different meaning from the focus() method.
     // The actual focusing steps should be implemented
-    html_element.Focus(&FocusOptions{ preventScroll: true }, can_gc);
+    html_element.Focus(
+        &FocusOptions {
+            preventScroll: true,
+        },
+        can_gc,
+    );
 
     // Step 4. Run clear algorithm for element.
     if let Some(input_element) = element.downcast::<HTMLInputElement>() {
@@ -1937,7 +1947,12 @@ pub(crate) fn handle_element_click(
                             Some(html_element) => {
                                 // TODO: "Focusing steps" has a different meaning from the focus() method.
                                 // The actual focusing steps should be implemented
-                                html_element.Focus(&FocusOptions{ preventScroll: true }, can_gc);
+                                html_element.Focus(
+                                    &FocusOptions {
+                                        preventScroll: true,
+                                    },
+                                    can_gc,
+                                );
                             },
                             None => return Err(ErrorStatus::UnknownError),
                         }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1225,7 +1225,7 @@ pub(crate) fn handle_will_send_keys(
                 // Step 7. If file is false or the session's strict file interactability
                 if !is_file_input || strict_file_interactability {
                     // Step 7.1. Scroll into view the element
-                    scroll_into_view(&element, &documents, &pipeline, can_gc);
+                    scroll_into_view(&element, documents, &pipeline, can_gc);
 
                     // TODO: Step 7.2 - 7.5
                     // Wait until element become keyboard-interactable
@@ -1571,7 +1571,7 @@ pub(crate) fn handle_scroll_and_get_bounding_client_rect(
     reply
         .send(
             get_known_element(documents, pipeline, element_id).map(|element| {
-                scroll_into_view(&element, &documents, &pipeline, can_gc);
+                scroll_into_view(&element, documents, &pipeline, can_gc);
 
                 let rect = element.GetBoundingClientRect(can_gc);
                 Rect::new(
@@ -1824,7 +1824,7 @@ pub(crate) fn handle_element_clear(
                 }
 
                 // Step 5. Scroll Into View
-                scroll_into_view(&element, &documents, &pipeline, can_gc);
+                scroll_into_view(&element, documents, &pipeline, can_gc);
 
                 // TODO: Step 6 - 10
                 // Wait until element become interactable and check.
@@ -1894,7 +1894,7 @@ pub(crate) fn handle_element_click(
                 };
 
                 // Step 5
-                scroll_into_view(&container, &documents, &pipeline, can_gc);
+                scroll_into_view(&container, documents, &pipeline, can_gc);
 
                 // Step 6. If element's container is still not in view
                 // return error with error code element not interactable.

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -230,7 +230,7 @@ pub enum WebDriverScriptCommand {
     GetElementTagName(String, IpcSender<Result<String, ErrorStatus>>),
     GetElementText(String, IpcSender<Result<String, ErrorStatus>>),
     GetElementInViewCenterPoint(String, IpcSender<Result<Option<(i64, i64)>, ErrorStatus>>),
-    GetBoundingClientRect(String, IpcSender<Result<UntypedRect<f32>, ErrorStatus>>),
+    ScrollAndGetBoundingClientRect(String, IpcSender<Result<UntypedRect<f32>, ErrorStatus>>),
     GetBrowsingContextId(
         WebDriverFrameId,
         IpcSender<Result<BrowsingContextId, ErrorStatus>>,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2358,7 +2358,8 @@ impl Handler {
         self.handle_any_user_prompts(webview_id)?;
 
         // Step 3 - 4
-        let cmd = WebDriverScriptCommand::ScrollAndGetBoundingClientRect(element.to_string(), sender);
+        let cmd =
+            WebDriverScriptCommand::ScrollAndGetBoundingClientRect(element.to_string(), sender);
         self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
 
         match wait_for_ipc_response(receiver)? {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2358,8 +2358,8 @@ impl Handler {
         self.handle_any_user_prompts(webview_id)?;
 
         // Step 3 - 4
-        let cmd = WebDriverScriptCommand::GetBoundingClientRect(element.to_string(), sender);
-        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+        let cmd = WebDriverScriptCommand::ScrollAndGetBoundingClientRect(element.to_string(), sender);
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
 
         match wait_for_ipc_response(receiver)? {
             Ok(rect) => {

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/interactability.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/interactability.py.ini
@@ -1,0 +1,3 @@
+[interactability.py]
+  [test_element_not_visible_overflow_hidden]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/scroll_into_view.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/scroll_into_view.py.ini
@@ -1,3 +1,0 @@
-[scroll_into_view.py]
-  [test_scroll_into_view]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/scroll_into_view.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/scroll_into_view.py.ini
@@ -1,12 +1,3 @@
 [scroll_into_view.py]
   [test_contenteditable_element_outside_of_scrollable_viewport]
     expected: FAIL
-
-  [test_element_already_in_viewport[{block: 'start'}\]]
-    expected: FAIL
-
-  [test_element_already_in_viewport[{block: 'end'}\]]
-    expected: FAIL
-
-  [test_element_already_in_viewport[{block: 'nearest'}\]]
-    expected: FAIL


### PR DESCRIPTION
Implement scroll into view steps for all WebDriver command that requires it (element click, element send keys, element clear, and take element screenshot).

Testing: `element_send_keys/scroll_into_view.py`, `element_click/scroll_into_view.py`, `element_clear/clear.py`