### PR TITLE
mach(test-tidy): Make wpt lint logic `servo-tidy.toml` and optimize checking for changed files 

### DIFF
--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -232,7 +232,7 @@ class FileList(object):
 
 
 def filter_file(file_name: str) -> bool:
-    current_file = f"./{relative_path(file_name)}"
+    current_file = os.path.join(".", relative_path(file_name))
     if any(current_file.startswith(ignored_file) for ignored_file in config["ignore"]["files"]):
         return False
     base_name = os.path.basename(file_name)

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -854,7 +854,8 @@ def lint_wpt_test_files() -> Iterator[tuple[str, int, str]]:
         if lint.lint(suite_directory, tests_changed, output_format="normal"):
             for message in messages:
                 (filename, message) = message.split(":", maxsplit=1)
-                yield (filename, 0, message)
+                current_path = relative_path(os.path.join(suite_directory, filename))
+                yield (current_path, 0, message)
 
 
 def run_wpt_lints(only_changed_files: bool) -> Iterator[tuple[str, int, str]]:

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -855,8 +855,7 @@ def lint_wpt_test_files() -> Iterator[tuple[str, int, str]]:
         if lint.lint(suite_directory, tests_changed, output_format="normal"):
             for message in messages:
                 (filename, message) = message.split(":", maxsplit=1)
-                current_path = relative_path(os.path.join(suite_directory, filename))
-                yield (current_path, 0, message)
+                yield (filename, 0, message)
 
 
 def run_wpt_lints(only_changed_files: bool) -> Iterator[tuple[str, int, str]]:

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -232,7 +232,8 @@ class FileList(object):
 
 
 def filter_file(file_name: str) -> bool:
-    if any(file_name.startswith(ignored_file) for ignored_file in config["ignore"]["files"]):
+    current_file = f"./{relative_path(file_name)}"
+    if any(current_file.startswith(ignored_file) for ignored_file in config["ignore"]["files"]):
         return False
     base_name = os.path.basename(file_name)
     if any(fnmatch.fnmatch(base_name, pattern) for pattern in FILE_PATTERNS_TO_IGNORE):


### PR DESCRIPTION
Fix wpt lint logic to respect servo-tidy.toml ignores and --all flag

Testing: Should be covered on CI
Fixes: #38510  #37991 
