### PR TITLE
wpt: Fix linting error multiple indent on `wpt/mozilla` fonts

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -8915,7 +8915,7 @@
      },
      "takao-p-gothic": {
       "COPYING.html": [
-       "5d7045cb7cf14e50ddc98a0ce04a0db07465ab2a",
+       "a7f2373317c52245016f6b9e34296b3e020ab695",
        []
       ],
       "TakaoPGothic.ttf": [

--- a/tests/wpt/mozilla/tests/css/fonts/takao-p-gothic/COPYING.html
+++ b/tests/wpt/mozilla/tests/css/fonts/takao-p-gothic/COPYING.html
@@ -19,147 +19,147 @@
 
 <body id="comment-detail">
 
-			<h4 id="LicenceTOP">IPA Font License Agreement v1.0 <a href="#LicenceJP">日本語/Japanese</a>　<a href="#LicenceEng">English</a></h4>
+    <h4 id="LicenceTOP">IPA Font License Agreement v1.0 <a href="#LicenceJP">日本語/Japanese</a>  <a href="#LicenceEng">English</a></h4>
 
-			<h3 id="LicenceJP">IPAフォントライセンスv1.0 </h3>
-			<p>許諾者は、この使用許諾（以下「本契約」といいます。）に定める条件の下で、許諾プログラム（1条に定義するところによります。）を提供します。受領者（1条に定義するところによります。）が、許諾プログラムを使用し、複製し、または頒布する行為、その他、本契約に定める権利の利用を行った場合、受領者は本契約に同意したものと見なします。</p>
+   <h3 id="LicenceJP">IPAフォントライセンスv1.0 </h3>
+   <p>許諾者は、この使用許諾（以下「本契約」といいます。）に定める条件の下で、許諾プログラム（1条に定義するところによります。）を提供します。受領者（1条に定義するところによります。）が、許諾プログラムを使用し、複製し、または頒布する行為、その他、本契約に定める権利の利用を行った場合、受領者は本契約に同意したものと見なします。</p>
 
-			<h4>第1条　用語の定義</h4>
-			<p>本契約において、次の各号に掲げる用語は、当該各号に定めるところによります。</p>
-			<ol class="mainclass">
-			<li>「デジタル･フォント･プログラム」とは、フォントを含み、レンダリングしまたは表示するために用いられるコンピュータ・プログラムをいいます。</li>
-			<li>「許諾プログラム」とは、許諾者が本契約の下で許諾するデジタル･フォント･プログラムをいいます。</li>
-			<li>「派生プログラム」とは、許諾プログラムの一部または全部を、改変し、加除修正等し、入れ替え、その他翻案したデジタル･フォント･プログラムをいい、許諾プログラムの一部もしくは全部から文字情報を取り出し、またはデジタル･ドキュメント･ファイルからエンベッドされたフォントを取り出し、取り出された文字情報をそのまま、または改変をなして新たなデジタル・フォント・プログラムとして製作されたものを含みます。</li>
-			<li>「デジタル・コンテンツ」とは、デジタル・データ形式によってエンド・ユーザに提供される制作物のことをいい、動画・静止画等の映像コンテンツおよびテレビ番組等の放送コンテンツ、ならびに文字テキスト、画像、図形等を含んで構成された制作物を含みます。</li>
-			<li>「デジタル・ドキュメント・ファイル」とは、PDFファイルその他、各種ソフトウェア･プログラムによって製作されたデジタル・コンテンツであって、その中にフォントを表示するために許諾プログラムの全部または一部が埋め込まれた（エンベッドされた）ものをいいます。フォントが「エンベッドされた」とは、当該フォントが埋め込まれた特定の「デジタル・ドキュメント・ファイル」においてのみ表示されるために使用されている状態を指し、その特定の「デジタル・ドキュメント・ファイル」以外でフォントを表示するために使用できるデジタル・フォント・プログラムに含まれている場合と区別されます。</li>
-			<li>「コンピュータ｣とは、本契約においては、サーバを含みます。</li>
-			<li>「複製その他の利用」とは、複製、譲渡、頒布、貸与、公衆送信、上映、展示、翻案その他の利用をいいます。</li>
-			<li>「受領者」とは、許諾プログラムを本契約の下で受領した人をいい、受領者から許諾プログラムを受領した人を含みます。</li>
-			</ol>
-			<h4>第２条 使用許諾の付与</h4>
-			<p>許諾者は受領者に対し、本契約の条項に従い、すべての国で、許諾プログラムを使用することを許諾します。ただし、許諾プログラムに存在する一切の権利はすべて許諾者が保有しています。本契約は、本契約で明示的に定められている場合を除き、いかなる意味においても、許諾者が保有する許諾プログラムに関する一切の権利および、いかなる商標、商号、もしくはサービス・マークに関する権利をも受領者に移転するものではありません。</p>
-			<ol class="mainclass">
-			<li>受領者は本契約に定める条件に従い、許諾プログラムを任意の数のコンピュータにインストールし、当該コンピュータで使用することができます。</li>
-			<li> 受領者はコンピュータにインストールされた許諾プログラムをそのまま、または改変を行ったうえで、印刷物およびデジタル・コンテンツにおいて、文字テキスト表現等として使用することができます。</li>
-			<li>受領者は前項の定めに従い作成した印刷物およびデジタル・コンテンツにつき、その商用・非商用の別、および放送、通信、各種記録メディアなどの媒体の形式を問わず、複製その他の利用をすることができます。</li>
-			<li>受領者がデジタル・ドキュメント・ファイルからエンベッドされたフォントを取り出して派生プログラムを作成した場合には、かかる派生プログラムは本契約に定める条件に従う必要があります。</li>
-			<li>許諾プログラムのエンベッドされたフォントがデジタル・ドキュメント・ファイル内のデジタル・コンテンツをレンダリングするためにのみ使用される場合において、受領者が当該デジタル・ドキュメント・ファイルを複製その他の利用をする場合には、受領者はかかる行為に関しては本契約の下ではいかなる義務をも負いません。</li>
-			<li>受領者は、3条2項の定めに従い、商用・非商用を問わず、許諾プログラムをそのままの状態で改変することなく複製して第三者への譲渡し、公衆送信し、その他の方法で再配布することができます(以下、「再配布」といいます。)。</li>
-			<li>受領者は、上記の許諾プログラムについて定められた条件と同様の条件に従って、派生プログラムを作成し、使用し、複製し、再配布することができます。ただし、受領者が派生プログラムを再配布する場合には、3条1項の定めに従うものとします。</li>
-			</ol>
+   <h4>第1条　用語の定義</h4>
+   <p>本契約において、次の各号に掲げる用語は、当該各号に定めるところによります。</p>
+   <ol class="mainclass">
+   <li>「デジタル･フォント･プログラム」とは、フォントを含み、レンダリングしまたは表示するために用いられるコンピュータ・プログラムをいいます。</li>
+   <li>「許諾プログラム」とは、許諾者が本契約の下で許諾するデジタル･フォント･プログラムをいいます。</li>
+   <li>「派生プログラム」とは、許諾プログラムの一部または全部を、改変し、加除修正等し、入れ替え、その他翻案したデジタル･フォント･プログラムをいい、許諾プログラムの一部もしくは全部から文字情報を取り出し、またはデジタル･ドキュメント･ファイルからエンベッドされたフォントを取り出し、取り出された文字情報をそのまま、または改変をなして新たなデジタル・フォント・プログラムとして製作されたものを含みます。</li>
+   <li>「デジタル・コンテンツ」とは、デジタル・データ形式によってエンド・ユーザに提供される制作物のことをいい、動画・静止画等の映像コンテンツおよびテレビ番組等の放送コンテンツ、ならびに文字テキスト、画像、図形等を含んで構成された制作物を含みます。</li>
+   <li>「デジタル・ドキュメント・ファイル」とは、PDFファイルその他、各種ソフトウェア･プログラムによって製作されたデジタル・コンテンツであって、その中にフォントを表示するために許諾プログラムの全部または一部が埋め込まれた（エンベッドされた）ものをいいます。フォントが「エンベッドされた」とは、当該フォントが埋め込まれた特定の「デジタル・ドキュメント・ファイル」においてのみ表示されるために使用されている状態を指し、その特定の「デジタル・ドキュメント・ファイル」以外でフォントを表示するために使用できるデジタル・フォント・プログラムに含まれている場合と区別されます。</li>
+   <li>「コンピュータ｣とは、本契約においては、サーバを含みます。</li>
+   <li>「複製その他の利用」とは、複製、譲渡、頒布、貸与、公衆送信、上映、展示、翻案その他の利用をいいます。</li>
+   <li>「受領者」とは、許諾プログラムを本契約の下で受領した人をいい、受領者から許諾プログラムを受領した人を含みます。</li>
+   </ol>
+   <h4>第２条 使用許諾の付与</h4>
+   <p>許諾者は受領者に対し、本契約の条項に従い、すべての国で、許諾プログラムを使用することを許諾します。ただし、許諾プログラムに存在する一切の権利はすべて許諾者が保有しています。本契約は、本契約で明示的に定められている場合を除き、いかなる意味においても、許諾者が保有する許諾プログラムに関する一切の権利および、いかなる商標、商号、もしくはサービス・マークに関する権利をも受領者に移転するものではありません。</p>
+   <ol class="mainclass">
+   <li>受領者は本契約に定める条件に従い、許諾プログラムを任意の数のコンピュータにインストールし、当該コンピュータで使用することができます。</li>
+   <li> 受領者はコンピュータにインストールされた許諾プログラムをそのまま、または改変を行ったうえで、印刷物およびデジタル・コンテンツにおいて、文字テキスト表現等として使用することができます。</li>
+   <li>受領者は前項の定めに従い作成した印刷物およびデジタル・コンテンツにつき、その商用・非商用の別、および放送、通信、各種記録メディアなどの媒体の形式を問わず、複製その他の利用をすることができます。</li>
+   <li>受領者がデジタル・ドキュメント・ファイルからエンベッドされたフォントを取り出して派生プログラムを作成した場合には、かかる派生プログラムは本契約に定める条件に従う必要があります。</li>
+   <li>許諾プログラムのエンベッドされたフォントがデジタル・ドキュメント・ファイル内のデジタル・コンテンツをレンダリングするためにのみ使用される場合において、受領者が当該デジタル・ドキュメント・ファイルを複製その他の利用をする場合には、受領者はかかる行為に関しては本契約の下ではいかなる義務をも負いません。</li>
+   <li>受領者は、3条2項の定めに従い、商用・非商用を問わず、許諾プログラムをそのままの状態で改変することなく複製して第三者への譲渡し、公衆送信し、その他の方法で再配布することができます(以下、「再配布」といいます。)。</li>
+   <li>受領者は、上記の許諾プログラムについて定められた条件と同様の条件に従って、派生プログラムを作成し、使用し、複製し、再配布することができます。ただし、受領者が派生プログラムを再配布する場合には、3条1項の定めに従うものとします。</li>
+   </ol>
 
-			<h4>第３条　制限</h4>
-			<p>前条により付与された使用許諾は、以下の制限に服します。</p>
-			<ol class="mainclass">
-			<li>派生プログラムが前条4項及び7項に基づき再配布される場合には、以下の全ての条件を満たさなければなりません。
-			<ul style="list-style-type:none;">
-			<li>(1)	派生プログラムを再配布する際には、下記もまた、当該派生プログラムと一緒に再配布され、オンラインで提供され、または、郵送費・媒体及び取扱手数料の合計を超えない実費と引き換えに媒体を郵送する方法により提供されなければなりません。
-			<ul style="list-style-type:none;">
-			<li>(a)	派生プログラムの写し; および</li>
-			<li>(b)	派生プログラムを作成する過程でフォント開発プログラムによって作成された追加のファイルであって派生プログラムをさらに加工するにあたって利用できるファイルが存在すれば、当該ファイル</li>
-			</ul >
-			</li>
+   <h4>第３条　制限</h4>
+   <p>前条により付与された使用許諾は、以下の制限に服します。</p>
+   <ol class="mainclass">
+   <li>派生プログラムが前条4項及び7項に基づき再配布される場合には、以下の全ての条件を満たさなければなりません。
+   <ul style="list-style-type:none;">
+   <li>(1) 派生プログラムを再配布する際には、下記もまた、当該派生プログラムと一緒に再配布され、オンラインで提供され、または、郵送費・媒体及び取扱手数料の合計を超えない実費と引き換えに媒体を郵送する方法により提供されなければなりません。
+   <ul style="list-style-type:none;">
+   <li>(a) 派生プログラムの写し; および</li>
+   <li>(b) 派生プログラムを作成する過程でフォント開発プログラムによって作成された追加のファイルであって派生プログラムをさらに加工するにあたって利用できるファイルが存在すれば、当該ファイル</li>
+   </ul >
+   </li>
 
-			<li>(2)	派生プログラムの受領者が、派生プログラムを、このライセンスの下で最初にリリースされた許諾プログラム（以下、「オリジナル・プログラム」といいます。）に置き換えることができる方法を再配布するものとします。かかる方法は、オリジナル・ファイルからの差分ファイルの提供、または、派生プログラムをオリジナル・プログラムに置き換える方法を示す指示の提供などが考えられます。</li>
-			<li>(3)	派生プログラムを、本契約書に定められた条件の下でライセンスしなければなりません。</li>
-			<li>(4)	派生プログラムのプログラム名、フォント名またはファイル名として、許諾プログラムが用いているのと同一の名称、またはこれを含む名称を使用してはなりません。</li>
-			<li>(5)	本項の要件を満たすためにオンラインで提供し、または媒体を郵送する方法で提供されるものは、その提供を希望するいかなる者によっても提供が可能です。</li>
-			</ul >
-			</li>
-			<li>受領者が前条6項に基づき許諾プログラムを再配布する場合には、以下の全ての条件を満たさなければなりません。
-			<ul style="list-style-type:none;">
-			<li>(1)	許諾プログラムの名称を変更してはなりません。</li>
-			<li>(2)	許諾プログラムに加工その他の改変を加えてはなりません。</li>
-			<li>(3)	本契約の写しを許諾プログラムに添付しなければなりません。</li>
-			</ul >
-			</li>
-			<li>許諾プログラムは、現状有姿で提供されており、許諾プログラムまたは派生プログラムについて、許諾者は一切の明示または黙示の保証（権利の所在、非侵害、商品性、特定目的への適合性を含むがこれに限られません）を行いません。いかなる場合にも、その原因を問わず、契約上の責任か厳格責任か過失その他の不法行為責任かにかかわらず、また事前に通知されたか否かにかかわらず、許諾者は、許諾プログラムまたは派生プログラムのインストール、使用、複製その他の利用または本契約上の権利の行使によって生じた一切の損害（直接・間接・付随的・特別・拡大・懲罰的または結果的損害）（商品またはサービスの代替品の調達、システム障害から生じた損害、現存するデータまたはプログラムの紛失または破損、逸失利益を含むがこれに限られません）について責任を負いません。</li>
-			<li>許諾プログラムまたは派生プログラムのインストール、使用、複製その他の利用に関して、許諾者は技術的な質問や問い合わせ等に対する対応その他、いかなるユーザ・サポートをも行う義務を負いません。</li>
-			</ol>
+   <li>(2) 派生プログラムの受領者が、派生プログラムを、このライセンスの下で最初にリリースされた許諾プログラム（以下、「オリジナル・プログラム」といいます。）に置き換えることができる方法を再配布するものとします。かかる方法は、オリジナル・ファイルからの差分ファイルの提供、または、派生プログラムをオリジナル・プログラムに置き換える方法を示す指示の提供などが考えられます。</li>
+   <li>(3) 派生プログラムを、本契約書に定められた条件の下でライセンスしなければなりません。</li>
+   <li>(4) 派生プログラムのプログラム名、フォント名またはファイル名として、許諾プログラムが用いているのと同一の名称、またはこれを含む名称を使用してはなりません。</li>
+   <li>(5) 本項の要件を満たすためにオンラインで提供し、または媒体を郵送する方法で提供されるものは、その提供を希望するいかなる者によっても提供が可能です。</li>
+   </ul >
+   </li>
+   <li>受領者が前条6項に基づき許諾プログラムを再配布する場合には、以下の全ての条件を満たさなければなりません。
+   <ul style="list-style-type:none;">
+   <li>(1) 許諾プログラムの名称を変更してはなりません。</li>
+   <li>(2) 許諾プログラムに加工その他の改変を加えてはなりません。</li>
+   <li>(3) 本契約の写しを許諾プログラムに添付しなければなりません。</li>
+   </ul >
+   </li>
+   <li>許諾プログラムは、現状有姿で提供されており、許諾プログラムまたは派生プログラムについて、許諾者は一切の明示または黙示の保証（権利の所在、非侵害、商品性、特定目的への適合性を含むがこれに限られません）を行いません。いかなる場合にも、その原因を問わず、契約上の責任か厳格責任か過失その他の不法行為責任かにかかわらず、また事前に通知されたか否かにかかわらず、許諾者は、許諾プログラムまたは派生プログラムのインストール、使用、複製その他の利用または本契約上の権利の行使によって生じた一切の損害（直接・間接・付随的・特別・拡大・懲罰的または結果的損害）（商品またはサービスの代替品の調達、システム障害から生じた損害、現存するデータまたはプログラムの紛失または破損、逸失利益を含むがこれに限られません）について責任を負いません。</li>
+   <li>許諾プログラムまたは派生プログラムのインストール、使用、複製その他の利用に関して、許諾者は技術的な質問や問い合わせ等に対する対応その他、いかなるユーザ・サポートをも行う義務を負いません。</li>
+   </ol>
 
-			<h4>第４条　契約の終了</h4>
-			<ol class="mainclass">
-			<li>本契約の有効期間は、受領者が許諾プログラムを受領した時に開始し、受領者が許諾プログラムを何らかの方法で保持する限り続くものとします。</li>
-			<li>前項の定めにかかわらず、受領者が本契約に定める各条項に違反したときは、本契約は、何らの催告を要することなく、自動的に終了し、当該受領者はそれ以後、許諾プログラムおよび派生プログラムを一切使用しまたは複製その他の利用をすることができないものとします。ただし、かかる契約の終了は、当該違反した受領者から許諾プログラムまたは派生プログラムの配布を受けた受領者の権利に影響を及ぼすものではありません。</li>
-			</ol>
+   <h4>第４条　契約の終了</h4>
+   <ol class="mainclass">
+   <li>本契約の有効期間は、受領者が許諾プログラムを受領した時に開始し、受領者が許諾プログラムを何らかの方法で保持する限り続くものとします。</li>
+   <li>前項の定めにかかわらず、受領者が本契約に定める各条項に違反したときは、本契約は、何らの催告を要することなく、自動的に終了し、当該受領者はそれ以後、許諾プログラムおよび派生プログラムを一切使用しまたは複製その他の利用をすることができないものとします。ただし、かかる契約の終了は、当該違反した受領者から許諾プログラムまたは派生プログラムの配布を受けた受領者の権利に影響を及ぼすものではありません。</li>
+   </ol>
 
-			<h4>第５条　準拠法</h4>
-			<ol class="mainclass">
-			<li>IPAは、本契約の変更バージョンまたは新しいバージョンを公表することができます。その場合には、受領者は、許諾プログラムまたは派生プログラムの使用、複製その他の利用または再配布にあたり、本契約または変更後の契約のいずれかを選択することができます。その他、上記に記載されていない条項に関しては日本の著作権法および関連法規に従うものとします。</li>
-			<li>本契約は、日本法に基づき解釈されます。</li>
-			</ol>
-			<p><a href="#LicenceTOP">TOP</a></p>
+   <h4>第５条　準拠法</h4>
+   <ol class="mainclass">
+   <li>IPAは、本契約の変更バージョンまたは新しいバージョンを公表することができます。その場合には、受領者は、許諾プログラムまたは派生プログラムの使用、複製その他の利用または再配布にあたり、本契約または変更後の契約のいずれかを選択することができます。その他、上記に記載されていない条項に関しては日本の著作権法および関連法規に従うものとします。</li>
+   <li>本契約は、日本法に基づき解釈されます。</li>
+   </ol>
+   <p><a href="#LicenceTOP">TOP</a></p>
 
-			<hr/>
-			<h3 id="LicenceEng">IPA Font License Agreement v1.0 </h3>
-			<p>The Licensor provides the Licensed Program (as defined in Article 1 below) under the terms of this license agreement (“Agreement”).&nbsp; Any use, reproduction or distribution of the Licensed Program, or any exercise of rights under this Agreement by a Recipient (as defined in Article 1 below) constitutes the Recipient’s acceptance of this Agreement.</p>
+   <hr/>
+   <h3 id="LicenceEng">IPA Font License Agreement v1.0 </h3>
+   <p>The Licensor provides the Licensed Program (as defined in Article 1 below) under the terms of this license agreement (“Agreement”).&nbsp; Any use, reproduction or distribution of the Licensed Program, or any exercise of rights under this Agreement by a Recipient (as defined in Article 1 below) constitutes the Recipient’s acceptance of this Agreement.</p>
 
-			<h4>Article 1 (Definitions)</h4>
-			<ol class="mainclass">
-			<li>“Digital Font Program” shall mean
-			a computer program containing, or used to render or display fonts.</li>
-			<li>“Licensed Program” shall mean a
-			Digital Font Program licensed by the Licensor under this Agreement.</li>
-			<li>“Derived Program” shall mean a Digital Font Program created as a result of a modification, addition, deletion, replacement or any other adaptation to or of a part or all of the Licensed Program, and includes a case where a Digital Font Program newly created by retrieving font information from a part or all of the Licensed Program or Embedded Fonts from a Digital Document File with or without modification of the retrieved font information. </li>
-			<li>“Digital Content” shall mean products provided to end users in the form of digital data, including video content, motion and/or still pictures, TV programs or other broadcasting content and products consisting of character text, pictures, photographic images, graphic symbols and/or the like.</li>
-			<li>“Digital Document File” shall mean a PDF file or other Digital Content created by various software programs in which a part or all of the Licensed Program becomes embedded or contained in the file for the display of the font (“Embedded Fonts”).  Embedded Fonts are used only in the display of characters in the particular Digital Document File within which they are embedded, and shall be distinguished from those in any Digital Font Program, which may be used for display of characters outside that particular Digital Document File.</li>
-			<li>“Computer” shall include a server in this Agreement.</li>
-			<li>“Reproduction and Other Exploitation” shall mean reproduction, transfer, distribution, lease, public transmission, presentation, exhibition, adaptation and any other exploitation.</li>
-			<li>“Recipient” shall mean anyone who receives the Licensed Program under this Agreement, including one that receives the Licensed Program from a Recipient.</li>
-			</ol>
+   <h4>Article 1 (Definitions)</h4>
+   <ol class="mainclass">
+   <li>“Digital Font Program” shall mean
+   a computer program containing, or used to render or display fonts.</li>
+   <li>“Licensed Program” shall mean a
+   Digital Font Program licensed by the Licensor under this Agreement.</li>
+   <li>“Derived Program” shall mean a Digital Font Program created as a result of a modification, addition, deletion, replacement or any other adaptation to or of a part or all of the Licensed Program, and includes a case where a Digital Font Program newly created by retrieving font information from a part or all of the Licensed Program or Embedded Fonts from a Digital Document File with or without modification of the retrieved font information. </li>
+   <li>“Digital Content” shall mean products provided to end users in the form of digital data, including video content, motion and/or still pictures, TV programs or other broadcasting content and products consisting of character text, pictures, photographic images, graphic symbols and/or the like.</li>
+   <li>“Digital Document File” shall mean a PDF file or other Digital Content created by various software programs in which a part or all of the Licensed Program becomes embedded or contained in the file for the display of the font (“Embedded Fonts”).  Embedded Fonts are used only in the display of characters in the particular Digital Document File within which they are embedded, and shall be distinguished from those in any Digital Font Program, which may be used for display of characters outside that particular Digital Document File.</li>
+   <li>“Computer” shall include a server in this Agreement.</li>
+   <li>“Reproduction and Other Exploitation” shall mean reproduction, transfer, distribution, lease, public transmission, presentation, exhibition, adaptation and any other exploitation.</li>
+   <li>“Recipient” shall mean anyone who receives the Licensed Program under this Agreement, including one that receives the Licensed Program from a Recipient.</li>
+   </ol>
 
-			<h4>Article 2 (Grant of License)</h4>
-			<p>The Licensor grants to the Recipient a license to use the Licensed Program in any and all countries in accordance with each of the provisions set forth in this Agreement. However, any and all rights underlying in the Licensed Program shall be held by the Licensor. In no sense is this Agreement intended to transfer any right relating to the Licensed Program held by the Licensor except as specifically set forth herein or any right relating to any trademark, trade name, or service mark to the Recipient.</p>
-			<ol class="mainclass">
-			<li>The Recipient may install the Licensed Program on any number of Computers and use the same in accordance with the provisions set forth in this Agreement.</li>
-			<li>The Recipient may use the Licensed Program, with or without modification in printed materials or in Digital Content as an expression of character texts or the like.</li>
-			<li>The Recipient may conduct Reproduction and Other Exploitation of the printed materials and Digital Content created in accordance with the preceding Paragraph, for commercial or non-commercial purposes and in any form of media including but not limited to broadcasting, communication and various recording media.</li>
-			<li>If any Recipient extracts Embedded Fonts from a Digital Document File to create a Derived Program, such Derived Program shall be subject to the terms of this agreement.</li>
-			<li>If any Recipient performs Reproduction or Other Exploitation of a Digital Document File in which Embedded Fonts of the Licensed Program are used only for rendering the Digital Content within such Digital Document File then such Recipient shall have no further obligations under this Agreement in relation to such actions.</li>
-			<li>The Recipient may reproduce the Licensed Program as is without modification and transfer such copies, publicly transmit or otherwise redistribute the Licensed Program to a third party for commercial or non-commercial purposes (“Redistribute”), in accordance with the provisions set forth in Article 3 Paragraph 2.</li>
-			<li>The Recipient may create, use, reproduce and/or Redistribute a Derived Program under the terms stated above for the Licensed Program: provided, that the Recipient shall follow the provisions set forth in Article 3 Paragraph 1 when Redistributing the Derived Program. </li>
-			</ol>
+   <h4>Article 2 (Grant of License)</h4>
+   <p>The Licensor grants to the Recipient a license to use the Licensed Program in any and all countries in accordance with each of the provisions set forth in this Agreement. However, any and all rights underlying in the Licensed Program shall be held by the Licensor. In no sense is this Agreement intended to transfer any right relating to the Licensed Program held by the Licensor except as specifically set forth herein or any right relating to any trademark, trade name, or service mark to the Recipient.</p>
+   <ol class="mainclass">
+   <li>The Recipient may install the Licensed Program on any number of Computers and use the same in accordance with the provisions set forth in this Agreement.</li>
+   <li>The Recipient may use the Licensed Program, with or without modification in printed materials or in Digital Content as an expression of character texts or the like.</li>
+   <li>The Recipient may conduct Reproduction and Other Exploitation of the printed materials and Digital Content created in accordance with the preceding Paragraph, for commercial or non-commercial purposes and in any form of media including but not limited to broadcasting, communication and various recording media.</li>
+   <li>If any Recipient extracts Embedded Fonts from a Digital Document File to create a Derived Program, such Derived Program shall be subject to the terms of this agreement.</li>
+   <li>If any Recipient performs Reproduction or Other Exploitation of a Digital Document File in which Embedded Fonts of the Licensed Program are used only for rendering the Digital Content within such Digital Document File then such Recipient shall have no further obligations under this Agreement in relation to such actions.</li>
+   <li>The Recipient may reproduce the Licensed Program as is without modification and transfer such copies, publicly transmit or otherwise redistribute the Licensed Program to a third party for commercial or non-commercial purposes (“Redistribute”), in accordance with the provisions set forth in Article 3 Paragraph 2.</li>
+   <li>The Recipient may create, use, reproduce and/or Redistribute a Derived Program under the terms stated above for the Licensed Program: provided, that the Recipient shall follow the provisions set forth in Article 3 Paragraph 1 when Redistributing the Derived Program. </li>
+   </ol>
 
-			<h4>Article 3 (Restriction)</h4>
-			<p>The license granted in the preceding Article shall be subject to the following restrictions:</p>
-			<ol class="mainclass">
-			<li>If a Derived Program is Redistributed pursuant to Paragraph 4 and 7 of the preceding Article, the following conditions must be met :
-			<ul style="list-style-type:none;">
-			<li>(1)The following must be also Redistributed together with the Derived Program, or be made available online or by means of mailing mechanisms in exchange for a cost which does not exceed the total costs of postage, storage medium and handling fees:
-			<ul style="list-style-type:none;">
-			<li>(a)a copy of the Derived Program; and</li>
-			<li>(b)any additional file created by the font developing program in the course of creating the Derived Program that can be used for further modification of the Derived Program, if any.</li>
-			</ul >
-			</li>
-			<li>(2)It is required to also Redistribute means to enable recipients of the Derived Program to replace the Derived Program with the Licensed Program first released under this License (the “Original Program”).  Such means may be to provide a difference file from the Original Program, or instructions setting out a method to replace the Derived Program with the Original Program.</li>
-			<li>(3)The Recipient must license the Derived Program under the terms and conditions of this Agreement.</li>
-			<li>(4)No one may use or include the name of the Licensed Program as a program name, font name or file name of the Derived Program.</li>
-			<li>(5) Any material to be made available online or by means of mailing a medium to satisfy the requirements of this paragraph may be provided, verbatim, by any party wishing to do so.</li>
-			</ul >
-			</li>
-			<li>If the Recipient Redistributes the Licensed Program pursuant to Paragraph 6 of the preceding Article, the Recipient shall meet all of the following conditions:
-			<ul style="list-style-type:none;">
-			<li>(1)The Recipient may not change the name of the Licensed Program.</li>
-			<li>(2)The Recipient may not alter or otherwise modify the Licensed Program.</li>
-			<li>(3)The Recipient must attach a copy of this Agreement to the Licensed Program.</li>
-			</ul >
-			</li>
-			<li>THIS LICENSED PROGRAM IS PROVIDED BY THE LICENSOR “AS IS” AND ANY EXPRESSED OR IMPLIED WARRANTY AS TO THE LICENSED PROGRAM OR ANY DERIVED PROGRAM, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE, ARE DISCLAIMED.  IN NO EVENT SHALL THE LICENSOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXTENDED, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO; PROCUREMENT OF SUBSTITUTED GOODS OR SERVICE; DAMAGES ARISING FROM SYSTEM FAILURE; LOSS OR CORRUPTION OF EXISTING DATA OR PROGRAM; LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE INSTALLATION, USE, THE REPRODUCTION OR OTHER EXPLOITATION OF THE LICENSED PROGRAM OR ANY DERIVED PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</li>
-			<li>The Licensor is under no obligation to respond to any technical questions or inquiries, or provide any other user support in connection with the installation, use or the Reproduction and Other Exploitation of the Licensed Program or Derived Programs thereof.</li>
-			</ol>
+   <h4>Article 3 (Restriction)</h4>
+   <p>The license granted in the preceding Article shall be subject to the following restrictions:</p>
+   <ol class="mainclass">
+   <li>If a Derived Program is Redistributed pursuant to Paragraph 4 and 7 of the preceding Article, the following conditions must be met :
+   <ul style="list-style-type:none;">
+   <li>(1)The following must be also Redistributed together with the Derived Program, or be made available online or by means of mailing mechanisms in exchange for a cost which does not exceed the total costs of postage, storage medium and handling fees:
+   <ul style="list-style-type:none;">
+   <li>(a)a copy of the Derived Program; and</li>
+   <li>(b)any additional file created by the font developing program in the course of creating the Derived Program that can be used for further modification of the Derived Program, if any.</li>
+   </ul >
+   </li>
+   <li>(2)It is required to also Redistribute means to enable recipients of the Derived Program to replace the Derived Program with the Licensed Program first released under this License (the “Original Program”).  Such means may be to provide a difference file from the Original Program, or instructions setting out a method to replace the Derived Program with the Original Program.</li>
+   <li>(3)The Recipient must license the Derived Program under the terms and conditions of this Agreement.</li>
+   <li>(4)No one may use or include the name of the Licensed Program as a program name, font name or file name of the Derived Program.</li>
+   <li>(5) Any material to be made available online or by means of mailing a medium to satisfy the requirements of this paragraph may be provided, verbatim, by any party wishing to do so.</li>
+   </ul >
+   </li>
+   <li>If the Recipient Redistributes the Licensed Program pursuant to Paragraph 6 of the preceding Article, the Recipient shall meet all of the following conditions:
+   <ul style="list-style-type:none;">
+   <li>(1)The Recipient may not change the name of the Licensed Program.</li>
+   <li>(2)The Recipient may not alter or otherwise modify the Licensed Program.</li>
+   <li>(3)The Recipient must attach a copy of this Agreement to the Licensed Program.</li>
+   </ul >
+   </li>
+   <li>THIS LICENSED PROGRAM IS PROVIDED BY THE LICENSOR “AS IS” AND ANY EXPRESSED OR IMPLIED WARRANTY AS TO THE LICENSED PROGRAM OR ANY DERIVED PROGRAM, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE, ARE DISCLAIMED.  IN NO EVENT SHALL THE LICENSOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXTENDED, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO; PROCUREMENT OF SUBSTITUTED GOODS OR SERVICE; DAMAGES ARISING FROM SYSTEM FAILURE; LOSS OR CORRUPTION OF EXISTING DATA OR PROGRAM; LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE INSTALLATION, USE, THE REPRODUCTION OR OTHER EXPLOITATION OF THE LICENSED PROGRAM OR ANY DERIVED PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</li>
+   <li>The Licensor is under no obligation to respond to any technical questions or inquiries, or provide any other user support in connection with the installation, use or the Reproduction and Other Exploitation of the Licensed Program or Derived Programs thereof.</li>
+   </ol>
 
-			<h4>Article 4 (Termination of Agreement)</h4>
-			<ol class="mainclass">
-			<li>The term of this Agreement shall begin from the time of receipt of the Licensed Program by the Recipient and shall continue as long as the Recipient retains any such Licensed Program in any way.</li>
-			<li>Notwithstanding the provision set forth in the preceding Paragraph, in the event of the breach of any of the provisions set forth in this Agreement by the Recipient, this Agreement shall automatically terminate without any notice. In the case of such termination, the Recipient may not use or conduct Reproduction and Other Exploitation of the Licensed Program or a Derived Program: provided that such termination shall not affect any rights of any other Recipient receiving the Licensed Program or the Derived Program from such Recipient who breached this Agreement.</li>
-			</ol>
+   <h4>Article 4 (Termination of Agreement)</h4>
+   <ol class="mainclass">
+   <li>The term of this Agreement shall begin from the time of receipt of the Licensed Program by the Recipient and shall continue as long as the Recipient retains any such Licensed Program in any way.</li>
+   <li>Notwithstanding the provision set forth in the preceding Paragraph, in the event of the breach of any of the provisions set forth in this Agreement by the Recipient, this Agreement shall automatically terminate without any notice. In the case of such termination, the Recipient may not use or conduct Reproduction and Other Exploitation of the Licensed Program or a Derived Program: provided that such termination shall not affect any rights of any other Recipient receiving the Licensed Program or the Derived Program from such Recipient who breached this Agreement.</li>
+   </ol>
 
-			<h4>Article 5 (Governing Law)</h4>
-			<ol class="mainclass">
-			<li>IPA may publish revised and/or new versions of this License.  In such an event, the Recipient may select either this Agreement or any subsequent version of the Agreement in using, conducting the Reproduction and Other Exploitation of, or Redistributing the Licensed Program or a Derived Program. Other matters not specified above shall be subject to the Copyright Law of Japan and other related laws and regulations of Japan.</li>
-			<li>This Agreement shall be construed under the laws of Japan.</li>
-			</ol>
-			<p><a href="#LicenceTOP">TOP</a></p>
+   <h4>Article 5 (Governing Law)</h4>
+   <ol class="mainclass">
+   <li>IPA may publish revised and/or new versions of this License.  In such an event, the Recipient may select either this Agreement or any subsequent version of the Agreement in using, conducting the Reproduction and Other Exploitation of, or Redistributing the Licensed Program or a Derived Program. Other matters not specified above shall be subject to the Copyright Law of Japan and other related laws and regulations of Japan.</li>
+   <li>This Agreement shall be construed under the laws of Japan.</li>
+   </ol>
+   <p><a href="#LicenceTOP">TOP</a></p>
 
-	</body>
+ </body>
 </html>


### PR DESCRIPTION
Fix linting error multiple indent on tests/wpt/mozilla/tests/css/fonts/takao-p-gothic/COPYING.html

I think this related to old [issues here](https://github.com/servo/servo/pull/12576)

Testing: `./mach test-tidy --no-progress --all`
Fixes: #12421