### PR TITLE
script: Move `point_in_initial_containing_block` calculation to script

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -337,11 +337,10 @@ impl WebViewRenderer {
         };
 
         // If we can't find a pipeline to send this event to, we cannot continue.
-        let get_pipeline_details = |pipeline_id| self.pipelines.get(&pipeline_id);
         let Some(result) = self
             .global
             .borrow()
-            .hit_test_at_point(point, get_pipeline_details)
+            .hit_test_at_point(point)
             .into_iter()
             .nth(0)
         else {
@@ -852,12 +851,10 @@ impl WebViewRenderer {
             ScrollLocation::Start | ScrollLocation::End => scroll_location,
         };
 
-        let get_pipeline_details = |pipeline_id| self.pipelines.get(&pipeline_id);
-        let hit_test_results = self.global.borrow().hit_test_at_point_with_flags(
-            cursor,
-            HitTestFlags::FIND_ALL,
-            get_pipeline_details,
-        );
+        let hit_test_results = self
+            .global
+            .borrow()
+            .hit_test_at_point_with_flags(cursor, HitTestFlags::FIND_ALL);
 
         // Iterate through all hit test results, processing only the first node of each pipeline.
         // This is needed to propagate the scroll events from a pipeline representing an iframe to

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2615,6 +2615,10 @@ impl Window {
             .into_iter()
             .nth(0)?;
 
+        let point_in_frame = compositor_hit_test_result.point_in_viewport;
+        let point_relative_to_initial_containing_block =
+            point_in_frame + self.scroll_offset().cast_unit();
+
         // SAFETY: This is safe because `Window::query_elements_from_point` has ensured that
         // layout has run and any OpaqueNodes that no longer refer to real nodes are gone.
         let address = UntrustedNodeAddress(result.node.0 as *const c_void);
@@ -2622,9 +2626,8 @@ impl Window {
             node: unsafe { from_untrusted_node_address(address) },
             cursor: result.cursor,
             point_in_node: result.point_in_target,
-            point_in_frame: compositor_hit_test_result.point_in_viewport,
-            point_relative_to_initial_containing_block: compositor_hit_test_result
-                .point_relative_to_initial_containing_block,
+            point_in_frame,
+            point_relative_to_initial_containing_block,
         })
     }
 

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -884,10 +884,6 @@ pub struct CompositorHitTestResult {
     /// The hit test point in the item's viewport.
     pub point_in_viewport: Point2D<f32, CSSPixel>,
 
-    /// The hit test point relative to the root scroll node content origin / initial
-    /// containing block.
-    pub point_relative_to_initial_containing_block: Point2D<f32, CSSPixel>,
-
     /// The [`ExternalScrollId`] of the scroll tree node associated with this hit test item.
     pub external_scroll_id: ExternalScrollId,
 }


### PR DESCRIPTION
Instead of calculating this value in the compositor, calculate it in
`ScriptThread` now that it is straightforward to get this value from the
layout spatial tree. This allows removing some tricky callback code in
the Compositor.

Testing: This shouldn't change any observable behavior so is covered by
existing tests.
