### PR TITLE
layout: Floor content-box size by zero when stretching flex item

### DIFF
--- a/components/layout/flexbox/layout.rs
+++ b/components/layout/flexbox/layout.rs
@@ -1584,7 +1584,7 @@ impl InitialFlexLineLayout<'_> {
                     axis,
                     Size::Stretch,
                     Au::zero,
-                    Some(final_line_cross_size - item.item.pbm_auto_is_zero.cross),
+                    Some(Au::zero().max(final_line_cross_size - item.item.pbm_auto_is_zero.cross)),
                     || content_size.into(),
                     // Tables have a special sizing in the block axis in that handles collapsed rows,
                     // but it would prevent stretching. So we only recognize tables in the inline axis.

--- a/tests/wpt/tests/css/css-sizing/stretch/flexbox-stretch-minimum-001.html
+++ b/tests/wpt/tests/css/css-sizing/stretch/flexbox-stretch-minimum-001.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Non-negative content-box size of stretched flex item with `stretch` min cross size</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#stretched">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11076">
+<link rel="help" href="https://github.com/servo/servo/issues/38517">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta assert="Stretching the cross size of a flex item to the flex line should never result
+              in a negative content-box size.">
+
+<style>
+#red {
+  position: absolute;
+  z-index: -1;
+  width: 200px;
+  height: 200px;
+  background: red;
+}
+#flex-container {
+  display: flex;
+  flex-direction: row;
+  height: 0;
+}
+#flex-item {
+  min-height: stretch;
+  border: 100px solid green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="red"></div>
+<div id="flex-container">
+  <div id="flex-item"></div>
+</div>

--- a/tests/wpt/tests/css/css-sizing/stretch/flexbox-stretch-minimum-002.html
+++ b/tests/wpt/tests/css/css-sizing/stretch/flexbox-stretch-minimum-002.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Non-negative content-box size of stretched flex item with `stretch` min cross size</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#stretch-fit-sizing">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#stretched">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11076">
+<link rel="help" href="https://github.com/servo/servo/issues/38517">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta assert="Stretching the cross size of a flex item to the flex line should never result
+              in a negative content-box size.">
+
+<style>
+#red {
+  position: absolute;
+  z-index: -1;
+  width: 200px;
+  height: 200px;
+  background: red;
+}
+#flex-container {
+  display: flex;
+  flex-direction: column;
+  width: 0;
+}
+#flex-item {
+  min-width: stretch;
+  border: 100px solid green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="red"></div>
+<div id="flex-container">
+  <div id="flex-item"></div>
+</div>


### PR DESCRIPTION
When stretching the cross size of a flex item to its flex line, we were computing the stretch size by subtracting padding, border and margin from the line size. However, this could result in a negative amount for the content-box cross size. Therefore, this floors it by zero.

Testing: Adding new tests
Fixes: #38517
