### PR TITLE
Stylo: detect any style change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7314,7 +7314,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.31.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?rev=4d1bb6085492c15194c4283a5af066c2d939d89b#4d1bb6085492c15194c4283a5af066c2d939d89b"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -7620,7 +7620,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?rev=4d1bb6085492c15194c4283a5af066c2d939d89b#4d1bb6085492c15194c4283a5af066c2d939d89b"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8092,7 +8092,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?rev=4d1bb6085492c15194c4283a5af066c2d939d89b#4d1bb6085492c15194c4283a5af066c2d939d89b"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8149,7 +8149,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?rev=4d1bb6085492c15194c4283a5af066c2d939d89b#4d1bb6085492c15194c4283a5af066c2d939d89b"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8158,12 +8158,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?rev=4d1bb6085492c15194c4283a5af066c2d939d89b#4d1bb6085492c15194c4283a5af066c2d939d89b"
 
 [[package]]
 name = "stylo_derive"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?rev=4d1bb6085492c15194c4283a5af066c2d939d89b#4d1bb6085492c15194c4283a5af066c2d939d89b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8175,7 +8175,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?rev=4d1bb6085492c15194c4283a5af066c2d939d89b#4d1bb6085492c15194c4283a5af066c2d939d89b"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -8184,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?rev=4d1bb6085492c15194c4283a5af066c2d939d89b#4d1bb6085492c15194c4283a5af066c2d939d89b"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8201,12 +8201,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?rev=4d1bb6085492c15194c4283a5af066c2d939d89b#4d1bb6085492c15194c4283a5af066c2d939d89b"
 
 [[package]]
 name = "stylo_traits"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?rev=4d1bb6085492c15194c4283a5af066c2d939d89b#4d1bb6085492c15194c4283a5af066c2d939d89b"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -8621,7 +8621,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?rev=4d1bb6085492c15194c4283a5af066c2d939d89b#4d1bb6085492c15194c4283a5af066c2d939d89b"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8634,7 +8634,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?rev=4d1bb6085492c15194c4283a5af066c2d939d89b#4d1bb6085492c15194c4283a5af066c2d939d89b"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ rustls = { version = "0.23", default-features = false, features = ["logging", "s
 rustls-pemfile = "2.0"
 rustls-pki-types = "1.12"
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
+selectors = { git = "https://github.com/servo/stylo", rev = "4d1bb6085492c15194c4283a5af066c2d939d89b" }
 serde = "1.0.219"
 serde_bytes = "0.11"
 serde_json = "1.0"
@@ -132,7 +132,7 @@ servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "4d1bb6085492c15194c4283a5af066c2d939d89b" }
 smallbitvec = "2.6.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 static_assertions = "1.1"
@@ -140,12 +140,12 @@ string_cache = "0.8"
 string_cache_codegen = "0.5"
 strum = "0.26"
 strum_macros = "0.26"
-stylo = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
-stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
-stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
-stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
-stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
+stylo = { git = "https://github.com/servo/stylo", rev = "4d1bb6085492c15194c4283a5af066c2d939d89b" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "4d1bb6085492c15194c4283a5af066c2d939d89b" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "4d1bb6085492c15194c4283a5af066c2d939d89b" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "4d1bb6085492c15194c4283a5af066c2d939d89b" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "4d1bb6085492c15194c4283a5af066c2d939d89b" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "4d1bb6085492c15194c4283a5af066c2d939d89b" }
 surfman = { git = "https://github.com/servo/surfman", rev = "f7688b4585f9e0b5d4bf8ee8e4a91e82349610b1", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"


### PR DESCRIPTION
Gecko's implementation of restyle damage returns `StyleChange::Changed` to Stylo if *any* style property has changed. Servo's currently only returns `StyleChange::Changed` if a style property that *causes damage* changes. This is an experiment to see if making Servo act like Gecko affects any WPT test results.

Testing: WPT tests
