### PR TITLE
script_bindings: Remove `jsstring_to_str`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5256,6 +5256,10 @@ dependencies = [
 name = "mozjs_sys"
 version = "0.137.0-1"
 source = "git+https://github.com/servo/mozjs#1410a4bafe4674ea17b1c4f0053a3e589ebce989"
+dependencies = [
+ "bindgen 0.71.1",
+ "cc",
+ "encoding_c",
  "encoding_c_mem",
  "flate2",
  "icu_capi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5256,10 +5256,6 @@ dependencies = [
 name = "mozjs_sys"
 version = "0.137.0-1"
 source = "git+https://github.com/servo/mozjs#1410a4bafe4674ea17b1c4f0053a3e589ebce989"
-dependencies = [
- "bindgen 0.71.1",
- "cc",
- "encoding_c",
  "encoding_c_mem",
  "flate2",
  "icu_capi",

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -83,14 +83,15 @@ pub(crate) fn handle_evaluate_js(
                 },
             )
         } else if rval.is_string() {
-            EvaluateJSReply::StringValue(jsstr_to_string(*cx, rval.to_string()))
+            let jsstr = std::ptr::NonNull::new(ToString(*cx, rval.handle())).unwrap();
+            EvaluateJSReply::StringValue(jsstr_to_string(*cx, jsstr))
         } else if rval.is_null() {
             EvaluateJSReply::NullValue
         } else {
             assert!(rval.is_object());
 
             let jsstr = std::ptr::NonNull::new(ToString(*cx, rval.handle())).unwrap();
-            let class_name = jsstr_to_string(*cx, jsstr.as_ptr());
+            let class_name = jsstr_to_string(*cx, jsstr);
 
             EvaluateJSReply::ActorValue {
                 class: class_name,

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -83,7 +83,7 @@ pub(crate) fn handle_evaluate_js(
                 },
             )
         } else if rval.is_string() {
-            let jsstr = std::ptr::NonNull::new(ToString(*cx, rval.handle())).unwrap();
+            let jsstr = std::ptr::NonNull::new(rval.to_string()).unwrap();
             EvaluateJSReply::StringValue(jsstr_to_string(*cx, jsstr))
         } else if rval.is_null() {
             EvaluateJSReply::NullValue

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -12,6 +12,7 @@ use devtools_traits::{
     NodeInfo, NodeStyle, RuleModification, TimelineMarker, TimelineMarkerType,
 };
 use ipc_channel::ipc::IpcSender;
+use js::conversions::jsstr_to_string;
 use js::jsval::UndefinedValue;
 use js::rust::ToString;
 use servo_config::pref;
@@ -28,7 +29,7 @@ use crate::dom::bindings::codegen::Bindings::ElementBinding::ElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeConstants;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
-use crate::dom::bindings::conversions::{ConversionResult, FromJSValConvertible, jsstring_to_str};
+use crate::dom::bindings::conversions::{ConversionResult, FromJSValConvertible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -82,18 +83,17 @@ pub(crate) fn handle_evaluate_js(
                 },
             )
         } else if rval.is_string() {
-            let jsstr = std::ptr::NonNull::new(rval.to_string()).unwrap();
-            EvaluateJSReply::StringValue(String::from(jsstring_to_str(*cx, jsstr)))
+            EvaluateJSReply::StringValue(jsstr_to_string(*cx, rval.to_string()))
         } else if rval.is_null() {
             EvaluateJSReply::NullValue
         } else {
             assert!(rval.is_object());
 
             let jsstr = std::ptr::NonNull::new(ToString(*cx, rval.handle())).unwrap();
-            let class_name = jsstring_to_str(*cx, jsstr);
+            let class_name = jsstr_to_string(*cx, jsstr.as_ptr());
 
             EvaluateJSReply::ActorValue {
-                class: class_name.to_string(),
+                class: class_name,
                 uuid: Uuid::new_v4().to_string(),
             }
         }

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -835,8 +835,8 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
 
             unsafe {
                 rooted!(in(*cx) let mut rooted_value = value);
-                let serialization =
-                    std::ptr::NonNull::new(ToString(*cx, rooted_value.handle())).unwrap();
+                let serialization = std::ptr::NonNull::new(ToString(*cx, rooted_value.handle()))
+                    .expect("Pointer cannot be null");
                 jsstr_to_string(*cx, serialization)
             }
         };

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -835,7 +835,8 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
 
             unsafe {
                 rooted!(in(*cx) let mut rooted_value = value);
-                let serialization = ToString(*cx, rooted_value.handle());
+                let serialization =
+                    std::ptr::NonNull::new(ToString(*cx, rooted_value.handle())).unwrap();
                 jsstr_to_string(*cx, serialization)
             }
         };

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -9,6 +9,7 @@ use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
 use euclid::Angle;
 use euclid::default::{Transform2D, Transform3D};
+use js::conversions::jsstr_to_string;
 use js::jsapi::JSObject;
 use js::jsval;
 use js::rust::{CustomAutoRooterGuard, HandleObject, ToString};
@@ -24,7 +25,6 @@ use crate::dom::bindings::codegen::Bindings::DOMMatrixBinding::{
 use crate::dom::bindings::codegen::Bindings::DOMMatrixReadOnlyBinding::DOMMatrixReadOnlyMethods;
 use crate::dom::bindings::codegen::Bindings::DOMPointBinding::DOMPointInit;
 use crate::dom::bindings::codegen::UnionTypes::StringOrUnrestrictedDoubleSequence;
-use crate::dom::bindings::conversions::jsstring_to_str;
 use crate::dom::bindings::error;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::inheritance::Castable;
@@ -836,10 +836,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
             unsafe {
                 rooted!(in(*cx) let mut rooted_value = value);
                 let serialization = ToString(*cx, rooted_value.handle());
-                jsstring_to_str(
-                    *cx,
-                    ptr::NonNull::new(serialization).expect("Pointer cannot be null"),
-                )
+                jsstr_to_string(*cx, serialization)
             }
         };
 

--- a/components/script/indexed_db.rs
+++ b/components/script/indexed_db.rs
@@ -104,7 +104,7 @@ pub fn convert_value_to_key(
 
     if input.is_string() {
         let string_ptr = std::ptr::NonNull::new(input.to_string()).unwrap();
-        let key = unsafe { jsstr_to_string(*cx, string_ptr.as_ptr()) };
+        let key = unsafe { jsstr_to_string(*cx, string_ptr) };
         return Ok(IndexedDBKeyType::String(key));
     }
 

--- a/components/script/indexed_db.rs
+++ b/components/script/indexed_db.rs
@@ -5,6 +5,7 @@
 use std::iter::repeat;
 use std::ptr;
 
+use js::conversions::jsstr_to_string;
 use js::gc::MutableHandle;
 use js::jsapi::{
     ESClass, GetBuiltinClass, IsArrayBufferObject, JS_DeleteUCProperty,
@@ -18,7 +19,6 @@ use script_bindings::conversions::{SafeToJSValConvertible, root_from_object};
 use script_bindings::str::DOMString;
 
 use crate::dom::bindings::codegen::UnionTypes::StringOrStringSequence as StrOrStringSequence;
-use crate::dom::bindings::conversions::jsstring_to_str;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::import::module::SafeJSContext;
 use crate::dom::bindings::structuredclone;
@@ -104,7 +104,7 @@ pub fn convert_value_to_key(
 
     if input.is_string() {
         let string_ptr = std::ptr::NonNull::new(input.to_string()).unwrap();
-        let key = unsafe { jsstring_to_str(*cx, string_ptr).str().to_string() };
+        let key = unsafe { jsstr_to_string(*cx, string_ptr.as_ptr()) };
         return Ok(IndexedDBKeyType::String(key));
     }
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -630,9 +630,10 @@ impl ModuleTree {
             let length = GetRequestedModulesCount(*cx, module_object);
 
             for index in 0..length {
-                let specifier = DOMString::from_string(
-                    jsstr_to_string(*cx, GetRequestedModuleSpecifier(*cx, module_object, index)), // TODO check null?
-                );
+                let jsstr =
+                    std::ptr::NonNull::new(GetRequestedModuleSpecifier(*cx, module_object, index))
+                        .unwrap();
+                let specifier = DOMString::from_string(jsstr_to_string(*cx, jsstr));
 
                 rooted!(in(*cx) let mut private = UndefinedValue());
                 JS_GetModulePrivate(module_object.get(), private.handle_mut());
@@ -1517,10 +1518,8 @@ fn fetch_an_import_module_script_graph(
     // Step 1.
     let cx = GlobalScope::get_cx();
     let specifier = unsafe {
-        DOMString::from_string(jsstr_to_string(
-            *cx,
-            GetModuleRequestSpecifier(*cx, module_request),
-        ))
+        let jsstr = std::ptr::NonNull::new(GetModuleRequestSpecifier(*cx, module_request)).unwrap();
+        DOMString::from_string(jsstr_to_string(*cx, jsstr))
     };
     let mut options = ScriptFetchOptions::default_classic_script(global);
     let module_data = unsafe { module_script_from_reference_private(&reference_private) };
@@ -1592,10 +1591,8 @@ unsafe extern "C" fn HostResolveImportedModule(
 
     // Step 5.
     let module_data = module_script_from_reference_private(&reference_private);
-    let specifier = DOMString::from_string(jsstr_to_string(
-        cx,
-        GetModuleRequestSpecifier(cx, specifier),
-    ));
+    let jsstr = std::ptr::NonNull::new(GetModuleRequestSpecifier(cx, specifier)).unwrap();
+    let specifier = DOMString::from_string(jsstr_to_string(cx, jsstr));
     let url =
         ModuleTree::resolve_module_specifier(&global_scope, module_data, specifier, CanGc::note());
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -17,6 +17,7 @@ use headers::{HeaderMapExt, ReferrerPolicy as ReferrerPolicyHeader};
 use html5ever::local_name;
 use hyper_serde::Serde;
 use indexmap::{IndexMap, IndexSet};
+use js::conversions::jsstr_to_string;
 use js::jsapi::{
     CompileModule1, ExceptionStackBehavior, FinishDynamicModuleImport, GetModuleRequestSpecifier,
     GetModuleResolveHook, GetRequestedModuleSpecifier, GetRequestedModulesCount,
@@ -50,7 +51,6 @@ use uuid::Uuid;
 use crate::document_loader::LoadType;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
-use crate::dom::bindings::conversions::jsstring_to_str;
 use crate::dom::bindings::error::{
     Error, ErrorToJsval, report_pending_exception, throw_dom_exception,
 };
@@ -630,10 +630,8 @@ impl ModuleTree {
             let length = GetRequestedModulesCount(*cx, module_object);
 
             for index in 0..length {
-                let specifier = jsstring_to_str(
-                    *cx,
-                    ptr::NonNull::new(GetRequestedModuleSpecifier(*cx, module_object, index))
-                        .unwrap(),
+                let specifier = DOMString::from_string(
+                    jsstr_to_string(*cx, GetRequestedModuleSpecifier(*cx, module_object, index)), // TODO check null?
                 );
 
                 rooted!(in(*cx) let mut private = UndefinedValue());
@@ -1519,10 +1517,10 @@ fn fetch_an_import_module_script_graph(
     // Step 1.
     let cx = GlobalScope::get_cx();
     let specifier = unsafe {
-        jsstring_to_str(
+        DOMString::from_string(jsstr_to_string(
             *cx,
-            ptr::NonNull::new(GetModuleRequestSpecifier(*cx, module_request)).unwrap(),
-        )
+            GetModuleRequestSpecifier(*cx, module_request),
+        ))
     };
     let mut options = ScriptFetchOptions::default_classic_script(global);
     let module_data = unsafe { module_script_from_reference_private(&reference_private) };
@@ -1594,10 +1592,10 @@ unsafe extern "C" fn HostResolveImportedModule(
 
     // Step 5.
     let module_data = module_script_from_reference_private(&reference_private);
-    let specifier = jsstring_to_str(
+    let specifier = DOMString::from_string(jsstr_to_string(
         cx,
-        ptr::NonNull::new(GetModuleRequestSpecifier(cx, specifier)).unwrap(),
-    );
+        GetModuleRequestSpecifier(cx, specifier),
+    ));
     let url =
         ModuleTree::resolve_module_specifier(&global_scope, module_data, specifier, CanGc::note());
 

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -490,9 +490,8 @@ unsafe extern "C" fn content_security_policy_allows(
 
         allowed = match runtime_code {
             RuntimeCode::JS => {
-                let source = NonNull::new(*sample)
-                    .map(|sample| jsstr_to_string(*cx, sample))
-                    .unwrap_or("".to_string());
+                let source = std::ptr::NonNull::new(*sample)
+                    .map_or_else(String::new, |jsstr| jsstr_to_string(*cx, jsstr));
                 global
                     .get_csp_list()
                     .is_js_evaluation_allowed(global, &source)

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -13,7 +13,6 @@ use std::ffi::{CStr, CString};
 use std::io::{Write, stdout};
 use std::ops::Deref;
 use std::os::raw::c_void;
-use std::ptr::NonNull;
 use std::rc::Rc;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -270,7 +270,7 @@ unsafe fn is_arguments_object(cx: *mut JSContext, value: HandleValue) -> bool {
     let Some(class_name) = NonNull::new(class_name.get()) else {
         return false;
     };
-    jsstr_to_string(cx, class_name.as_ptr()) == "[object Arguments]"
+    jsstr_to_string(cx, class_name) == "[object Arguments]"
 }
 
 #[derive(Clone, Eq, Hash, PartialEq)]

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -14,6 +14,7 @@ use embedder_traits::{
 use euclid::default::{Point2D, Rect, Size2D};
 use hyper_serde::Serde;
 use ipc_channel::ipc::{self, IpcSender};
+use js::conversions::jsstr_to_string;
 use js::jsapi::{
     self, GetPropertyKeys, HandleValueArray, JS_GetOwnPropertyDescriptorById, JS_GetPropertyById,
     JS_IsExceptionPending, JSAutoRealm, JSContext, JSType, PropertyDescriptor,
@@ -52,7 +53,7 @@ use crate::dom::bindings::codegen::Bindings::XPathResultBinding::{
 };
 use crate::dom::bindings::conversions::{
     ConversionBehavior, ConversionResult, FromJSValConvertible, StringificationBehavior,
-    get_property, get_property_jsval, jsid_to_string, jsstring_to_str, root_from_object,
+    get_property, get_property_jsval, jsid_to_string, root_from_object,
 };
 use crate::dom::bindings::error::{Error, report_pending_exception, throw_dom_exception};
 use crate::dom::bindings::inheritance::Castable;
@@ -269,7 +270,7 @@ unsafe fn is_arguments_object(cx: *mut JSContext, value: HandleValue) -> bool {
     let Some(class_name) = NonNull::new(class_name.get()) else {
         return false;
     };
-    jsstring_to_str(cx, class_name) == "[object Arguments]"
+    jsstr_to_string(cx, class_name.as_ptr()) == "[object Arguments]"
 }
 
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -327,7 +328,7 @@ unsafe fn jsval_to_webdriver_inner(
             },
         ))
     } else if val.get().is_string() {
-        //FIXME: use jsstring_to_str when jsval grows to_jsstring
+        //FIXME: use jsstr_to_string when jsval grows to_jsstring
         let string: DOMString =
             match FromJSValConvertible::from_jsval(cx, val, StringificationBehavior::Default)
                 .unwrap()

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -5,7 +5,7 @@
 use std::{ptr, slice};
 
 use js::conversions::{
-    ConversionResult, FromJSValConvertible, ToJSValConvertible, latin1_to_string,
+    ConversionResult, FromJSValConvertible, ToJSValConvertible, jsstr_to_string,
 };
 use js::error::throw_type_error;
 use js::glue::{
@@ -14,7 +14,7 @@ use js::glue::{
 };
 use js::jsapi::{
     Heap, IsWindowProxy, JS_DeprecatedStringHasLatin1Chars, JS_GetLatin1StringCharsAndLength,
-    JS_GetTwoByteStringCharsAndLength, JS_NewStringCopyN, JSContext, JSObject, JSString,
+    JS_GetTwoByteStringCharsAndLength, JS_NewStringCopyN, JSContext, JSObject,
 };
 use js::jsval::{ObjectValue, StringValue, UndefinedValue};
 use js::rust::wrappers::IsArrayObject;
@@ -115,7 +115,9 @@ impl FromJSValConvertible for DOMString {
             Ok(ConversionResult::Success(DOMString::new()))
         } else {
             match ptr::NonNull::new(ToString(cx, value)) {
-                Some(jsstr) => Ok(ConversionResult::Success(jsstring_to_str(cx, jsstr))),
+                Some(jsstr) => Ok(ConversionResult::Success(DOMString::from_string(
+                    jsstr_to_string(cx, jsstr.as_ptr()),
+                ))),
                 None => {
                     debug!("ToString failed");
                     Err(())
@@ -123,34 +125,6 @@ impl FromJSValConvertible for DOMString {
             }
         }
     }
-}
-
-/// Convert the given `JSString` to a `DOMString`. Fails if the string does not
-/// contain valid UTF-16.
-///
-/// # Safety
-/// cx and s must point to valid values.
-pub unsafe fn jsstring_to_str(cx: *mut JSContext, s: ptr::NonNull<JSString>) -> DOMString {
-    let latin1 = JS_DeprecatedStringHasLatin1Chars(s.as_ptr());
-    DOMString::from_string(if latin1 {
-        latin1_to_string(cx, s)
-    } else {
-        let mut length = 0;
-        let chars = JS_GetTwoByteStringCharsAndLength(cx, ptr::null(), s.as_ptr(), &mut length);
-        assert!(!chars.is_null());
-        let potentially_ill_formed_utf16 = slice::from_raw_parts(chars, length);
-        let mut s = String::with_capacity(length);
-        for item in char::decode_utf16(potentially_ill_formed_utf16.iter().cloned()) {
-            match item {
-                Ok(c) => s.push(c),
-                Err(_) => {
-                    error!("Found an unpaired surrogate in a DOM string.");
-                    s.push('\u{FFFD}');
-                },
-            }
-        }
-        s
-    })
 }
 
 // http://heycam.github.io/webidl/#es-USVString
@@ -168,8 +142,9 @@ impl FromJSValConvertible for USVString {
         let latin1 = JS_DeprecatedStringHasLatin1Chars(jsstr.as_ptr());
         if latin1 {
             // FIXME(ajeffrey): Convert directly from DOMString to USVString
-            return Ok(ConversionResult::Success(USVString(String::from(
-                jsstring_to_str(cx, jsstr),
+            return Ok(ConversionResult::Success(USVString(jsstr_to_string(
+                cx,
+                jsstr.as_ptr(),
             ))));
         }
         let mut length = 0;
@@ -445,7 +420,7 @@ pub unsafe fn jsid_to_string(cx: *mut JSContext, id: HandleId) -> Option<DOMStri
     let id_raw = *id;
     if id_raw.is_string() {
         let jsstr = std::ptr::NonNull::new(id_raw.to_string()).unwrap();
-        return Some(jsstring_to_str(cx, jsstr));
+        return Some(DOMString::from_string(jsstr_to_string(cx, jsstr.as_ptr())));
     }
 
     if id_raw.is_int() {

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -116,7 +116,7 @@ impl FromJSValConvertible for DOMString {
         } else {
             match ptr::NonNull::new(ToString(cx, value)) {
                 Some(jsstr) => Ok(ConversionResult::Success(DOMString::from_string(
-                    jsstr_to_string(cx, jsstr.as_ptr()),
+                    jsstr_to_string(cx, jsstr),
                 ))),
                 None => {
                     debug!("ToString failed");
@@ -143,8 +143,7 @@ impl FromJSValConvertible for USVString {
         if latin1 {
             // FIXME(ajeffrey): Convert directly from DOMString to USVString
             return Ok(ConversionResult::Success(USVString(jsstr_to_string(
-                cx,
-                jsstr.as_ptr(),
+                cx, jsstr,
             ))));
         }
         let mut length = 0;
@@ -420,7 +419,7 @@ pub unsafe fn jsid_to_string(cx: *mut JSContext, id: HandleId) -> Option<DOMStri
     let id_raw = *id;
     if id_raw.is_string() {
         let jsstr = std::ptr::NonNull::new(id_raw.to_string()).unwrap();
-        return Some(DOMString::from_string(jsstr_to_string(cx, jsstr.as_ptr())));
+        return Some(DOMString::from_string(jsstr_to_string(cx, jsstr)));
     }
 
     if id_raw.is_int() {

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -232,7 +232,7 @@ pub(crate) fn id_to_source(cx: SafeJSContext, id: RawHandleId) -> Option<DOMStri
                 jsstr.get()
             })
             .and_then(ptr::NonNull::new)
-            .map(|jsstr| DOMString::from_string(jsstr_to_string(*cx, jsstr.as_ptr())))
+            .map(|jsstr| DOMString::from_string(jsstr_to_string(*cx, jsstr)))
     }
 }
 

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -8,7 +8,7 @@ use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::ptr;
 
-use js::conversions::ToJSValConvertible;
+use js::conversions::{ToJSValConvertible, jsstr_to_string};
 use js::glue::{
     GetProxyHandler, GetProxyHandlerFamily, GetProxyPrivate, InvokeGetOwnPropertyDescriptor,
     SetProxyPrivate,
@@ -33,7 +33,7 @@ use js::rust::{Handle, HandleObject, HandleValue, MutableHandle, MutableHandleOb
 use js::{jsapi, rooted};
 
 use crate::DomTypes;
-use crate::conversions::{is_dom_proxy, jsid_to_string, jsstring_to_str};
+use crate::conversions::{is_dom_proxy, jsid_to_string};
 use crate::error::Error;
 use crate::interfaces::{DomHelpers, GlobalScopeHelpers};
 use crate::realms::{AlreadyInRealm, InRealm};
@@ -232,7 +232,7 @@ pub(crate) fn id_to_source(cx: SafeJSContext, id: RawHandleId) -> Option<DOMStri
                 jsstr.get()
             })
             .and_then(ptr::NonNull::new)
-            .map(|jsstr| jsstring_to_str(*cx, jsstr))
+            .map(|jsstr| DOMString::from_string(jsstr_to_string(*cx, jsstr.as_ptr())))
     }
 }
 

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -7,7 +7,7 @@ use std::os::raw::{c_char, c_void};
 use std::ptr::{self, NonNull};
 use std::slice;
 
-use js::conversions::ToJSValConvertible;
+use js::conversions::{ToJSValConvertible, jsstr_to_string};
 use js::gc::Handle;
 use js::glue::{
     AppendToIdVector, CallJitGetterOp, CallJitMethodOp, CallJitSetterOp, JS_GetReservedSlot,
@@ -40,7 +40,7 @@ use crate::DomTypes;
 use crate::codegen::Globals::Globals;
 use crate::codegen::InheritTypes::TopTypeId;
 use crate::codegen::PrototypeList::{self, MAX_PROTO_CHAIN_LENGTH, PROTO_OR_IFACE_LENGTH};
-use crate::conversions::{PrototypeCheck, jsstring_to_str, private_from_proto_check};
+use crate::conversions::{PrototypeCheck, private_from_proto_check};
 use crate::error::throw_invalid_this;
 use crate::interfaces::DomHelpers;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
@@ -222,7 +222,7 @@ pub(crate) unsafe fn find_enum_value<'a, T>(
 ) -> Result<(Option<&'a T>, DOMString), ()> {
     match ptr::NonNull::new(ToString(cx, v)) {
         Some(jsstr) => {
-            let search = jsstring_to_str(cx, jsstr);
+            let search = DOMString::from_string(jsstr_to_string(cx, jsstr.as_ptr()));
             Ok((
                 pairs
                     .iter()

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -222,7 +222,7 @@ pub(crate) unsafe fn find_enum_value<'a, T>(
 ) -> Result<(Option<&'a T>, DOMString), ()> {
     match ptr::NonNull::new(ToString(cx, v)) {
         Some(jsstr) => {
-            let search = DOMString::from_string(jsstr_to_string(cx, jsstr.as_ptr()));
+            let search = DOMString::from_string(jsstr_to_string(cx, jsstr));
             Ok((
                 pairs
                     .iter()


### PR DESCRIPTION
This PR removes `jsstring_to_str`, which is replaced with `jsstr_to_string`, and updates `mozjs` to https://github.com/servo/mozjs/commit/6f3dcb99a71e41ad0c50f2a99a2f6568d3f71c11.

Given that servo now always replaces unpaired surrogate since https://github.com/servo/servo/pull/35381, the internal conversion function `jsstring_to_str` is functionally the same as `jsstr_to_string` from `mozjs`. This PR removes `jsstring_to_str` and replaces with `jsstr_to_string` with conversions to `DOMString` where necessary.

Testing: Passes all unit test. No regression was found in WPT test (see try run: https://github.com/minghuaw/servo/actions/runs/16821156583)
