### PR TITLE
script: Mark the entire shadow tree for restyle when its stylesheet is invalidated

### DIFF
--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -14,6 +14,7 @@ use script_bindings::script_runtime::JSContext;
 use servo_arc::Arc;
 use style::author_styles::AuthorStyles;
 use style::dom::TElement;
+use style::invalidation::element::restyle_hints::RestyleHint;
 use style::shared_lock::SharedRwLockReadGuard;
 use style::stylesheets::Stylesheet;
 use style::stylist::{CascadeData, Stylist};
@@ -270,6 +271,11 @@ impl ShadowRoot {
         // Mark the host element dirty so a reflow will be performed.
         if let Some(host) = self.host.get() {
             host.upcast::<Node>().dirty(NodeDamage::Style);
+
+            // Also mark the host element with `RestyleHint::restyle_subtree` so a reflow
+            // can traverse into the shadow tree.
+            let mut restyle = self.document.ensure_pending_restyle(&host);
+            restyle.hint.insert(RestyleHint::restyle_subtree());
         }
     }
 

--- a/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-baseURL.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-baseURL.html.ini
@@ -1,3 +1,9 @@
 [CSSStyleSheet-constructable-baseURL.html]
+  [Constructing sheet with custom base URL ueses that URL for CSS rules]
+    expected: FAIL
+
+  [Constructing sheet with relative URL adds to the constructor document's base URL]
+    expected: FAIL
+
   [Constructing sheet with invalid base URL throws a NotAllowedError]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-disallow-import.tentative.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-disallow-import.tentative.html.ini
@@ -1,9 +1,3 @@
 [CSSStyleSheet-constructable-disallow-import.tentative.html]
-  [@import rules are not parsed in CSSStyleSheet.replaceSync]
-    expected: FAIL
-
-  [@import rules are not parsed in CSSStyleSheet.replace]
-    expected: FAIL
-
   [@import rules should not trigger any loads.]
     expected: FAIL

--- a/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable.html.ini
@@ -14,9 +14,6 @@
   [Constructed stylesheet can be used and modified in multiple TreeScopes]
     expected: FAIL
 
-  [CSSStyleSheet.replaceSync correctly updates the style of its adopters synchronously]
-    expected: FAIL
-
   [Adopted sheets are ordered after non-adopted sheets in the shadow root]
     expected: FAIL
 


### PR DESCRIPTION
This change fix this bugs: modify stylesheet of shadow tree does not take effect if there is no other Dom change within  the shadow tree happens. 

Fixes: This change fix some bugs reported by this issue #38211. 
Testing: This fixes some subtests in `/css/cssom/CSSStyleSheet-constructable.html` and `/css/cssom/CSSStyleSheet-constructable-disallow-import.tentative.html`, and make some subtest failed in `/css/cssom/CSSStyleSheet-constructable-baseURL.html`, because the `BaseUrl` is not yet supported for `CSSStylesheet`.
