### PR TITLE
script: Ensure `notify_invalidations()` is always called when modifying stylesheets

### DIFF
--- a/components/script/dom/csskeyframesrule.rs
+++ b/components/script/dom/csskeyframesrule.rs
@@ -114,6 +114,7 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
                 .keyframes
                 .push(rule);
             self.rulelist(can_gc).append_lazy_dom_rule();
+            self.cssrule.parent_stylesheet().notify_invalidations();
         }
     }
 
@@ -145,6 +146,7 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
         let name = KeyframesName::from_ident(&value);
         let mut guard = self.cssrule.shared_lock().write();
         self.keyframesrule.write_with(&mut guard).name = name;
+        self.cssrule.parent_stylesheet().notify_invalidations();
         Ok(())
     }
 }

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -148,6 +148,7 @@ impl CSSRuleList {
         self.dom_rules
             .borrow_mut()
             .insert(index, MutNullableDom::new(Some(&*dom_rule)));
+        parent_stylesheet.notify_invalidations();
         Ok(idx)
     }
 
@@ -167,6 +168,7 @@ impl CSSRuleList {
                     r.detach()
                 }
                 dom_rules.remove(index);
+                self.parent_stylesheet.notify_invalidations();
                 Ok(())
             },
             RulesSource::Keyframes(ref kf) => {
@@ -177,6 +179,7 @@ impl CSSRuleList {
                 }
                 dom_rules.remove(index);
                 kf.write_with(&mut guard).keyframes.remove(index);
+                self.parent_stylesheet.notify_invalidations();
                 Ok(())
             },
         }

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -125,8 +125,6 @@ impl CSSStyleOwner {
                     f(&mut *pdb.write_with(&mut guard), &mut changed)
                 };
                 if changed {
-                    // If this is changed, see also
-                    // CSSStyleRule::SetSelectorText, which does the same thing.
                     rule.parent_stylesheet().notify_invalidations();
                 }
                 result

--- a/components/script/dom/medialist.rs
+++ b/components/script/dom/medialist.rs
@@ -126,6 +126,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
         let mut guard = self.shared_lock().write();
         let media_queries = self.media_queries.write_with(&mut guard);
         *media_queries = Self::parse_media_list(&value, global.as_window());
+        self.parent_stylesheet.notify_invalidations();
     }
 
     // https://drafts.csswg.org/cssom/#dom-medialist-length
@@ -171,6 +172,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
         }
         // Step 4
         mq.media_queries.push(m.unwrap());
+        self.parent_stylesheet.notify_invalidations();
     }
 
     /// <https://drafts.csswg.org/cssom/#dom-medialist-deletemedium>
@@ -192,5 +194,6 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
             .filter(|q| m_serialized != q.to_css_string())
             .collect();
         media_list.media_queries = new_vec;
+        self.parent_stylesheet.notify_invalidations();
     }
 }

--- a/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable.html.ini
@@ -11,16 +11,7 @@
   [Re-attaching shadow host with adopted stylesheets work]
     expected: FAIL
 
-  [Changes to constructed stylesheets through CSSOM is reflected]
-    expected: FAIL
-
   [Constructed stylesheet can be used and modified in multiple TreeScopes]
-    expected: FAIL
-
-  [Stylesheets constructed on the main Document cannot be used in iframes]
-    expected: FAIL
-
-  [Stylesheet constructed on iframe cannot be used in the main Document]
     expected: FAIL
 
   [CSSStyleSheet.replaceSync correctly updates the style of its adopters synchronously]


### PR DESCRIPTION
This change supplements the missing stylesheet invalidation notifications to fix some bugs that the modification of stylesheet does not take effect. Additionally, this PR add a RAII  thing to mark the modification scope of stylesheet rules, which will facilitate to add extra logic before the modification happens.

Fixes: there is relevant issue #38211 , but it can't be fixed by this PR.
Testing: This fixes some subtests in `/css/cssom/CSSStyleSheet-constructable.html`.