### PR TITLE
script: make `Node::xml_serialize` fallible.

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3830,7 +3830,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
                 .html_serialize(ChildrenOnly(Some(qname)), false, vec![], can_gc)
         } else {
             self.upcast::<Node>()
-                .xml_serialize(XmlChildrenOnly(Some(qname)))
+                .xml_serialize(XmlChildrenOnly(Some(qname)))?
         };
 
         Ok(TrustedHTMLOrNullIsEmptyString::NullIsEmptyString(result))
@@ -3888,7 +3888,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
             self.upcast::<Node>()
                 .html_serialize(IncludeNode, false, vec![], can_gc)
         } else {
-            self.upcast::<Node>().xml_serialize(XmlIncludeNode)
+            self.upcast::<Node>().xml_serialize(XmlIncludeNode)?
         };
 
         Ok(TrustedHTMLOrNullIsEmptyString::NullIsEmptyString(result))

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -464,6 +464,8 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
         // algorithm steps with this and true.
         self.upcast::<Node>()
             .fragment_serialization_algorithm(true, can_gc)
+            .inspect_err(|error| warn!("fragment serialization failed: {error:?}"))
+            .unwrap_or_default()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-shadowroot-innerhtml>


### PR DESCRIPTION
Testing: [Try run][1] did not reveal any test failures. There doesn't seem to be any straightforward failure scenarios that can be triggered in `xml5ever` that are not IO errors and the xml_serialize method simply serializes to a String buffer.

[1]: https://github.com/servo/servo/actions/runs/16824267959/job/47657275606l