### PR TITLE
script: Implement `getModifierState` for mouse event

### DIFF
--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -526,4 +526,23 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
     fn IsTrusted(&self) -> bool {
         self.uievent.IsTrusted()
     }
+
+    /// <https://w3c.github.io/uievents/#dom-mouseevent-getmodifierstate>
+    fn GetModifierState(&self, key_arg: DOMString) -> bool {
+        self.modifiers.get().contains(match &*key_arg {
+            "Alt" => Modifiers::ALT,
+            "AltGraph" => Modifiers::ALT_GRAPH,
+            "CapsLock" => Modifiers::CAPS_LOCK,
+            "Control" => Modifiers::CONTROL,
+            "Fn" => Modifiers::FN,
+            "FnLock" => Modifiers::FN_LOCK,
+            "Meta" => Modifiers::META,
+            "NumLock" => Modifiers::NUM_LOCK,
+            "ScrollLock" => Modifiers::SCROLL_LOCK,
+            "Shift" => Modifiers::SHIFT,
+            "Symbol" => Modifiers::SYMBOL,
+            "SymbolLock" => Modifiers::SYMBOL_LOCK,
+            _ => return false,
+        })
+    }
 }

--- a/components/script_bindings/webidls/MouseEvent.webidl
+++ b/components/script_bindings/webidls/MouseEvent.webidl
@@ -24,7 +24,7 @@ interface MouseEvent : UIEvent {
     readonly    attribute EventTarget?   relatedTarget;
     // Introduced in DOM Level 3
     readonly    attribute unsigned short buttons;
-    //boolean getModifierState (DOMString keyArg);
+    boolean getModifierState (DOMString keyArg);
 
     [Pref="dom_mouse_event_which_enabled"]
     readonly    attribute long           which;

--- a/tests/wpt/meta/uievents/idlharness.window.js.ini
+++ b/tests/wpt/meta/uievents/idlharness.window.js.ini
@@ -11,22 +11,7 @@
   [UIEvent interface: new FocusEvent("event") must inherit property "which" with the proper type]
     expected: FAIL
 
-  [MouseEvent interface: operation getModifierState(DOMString)]
-    expected: FAIL
-
   [MouseEvent interface: operation initMouseEvent(DOMString, optional boolean, optional boolean, optional Window?, optional long, optional long, optional long, optional long, optional long, optional boolean, optional boolean, optional boolean, optional boolean, optional short, optional EventTarget?)]
-    expected: FAIL
-
-  [MouseEvent interface: new MouseEvent("event") must inherit property "getModifierState(DOMString)" with the proper type]
-    expected: FAIL
-
-  [MouseEvent interface: calling getModifierState(DOMString) on new MouseEvent("event") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [MouseEvent interface: new WheelEvent("event") must inherit property "getModifierState(DOMString)" with the proper type]
-    expected: FAIL
-
-  [MouseEvent interface: calling getModifierState(DOMString) on new WheelEvent("event") with too few arguments must throw TypeError]
     expected: FAIL
 
   [InputEvent interface: attribute inputType]


### PR DESCRIPTION
Implement missing idl function `getModifierState` for mouse event. The implementation is exactly the same as in keyboard event https://w3c.github.io/uievents/#dom-keyboardevent-getmodifierstate.

https://github.com/servo/servo/blob/6651f37c05138112cecf33d59de2709b715841f1/components/script/dom/keyboardevent.rs#L267-L283

Testing: Fix `./tests/wpt/tests/infrastructure/testdriver/actions/actionsWithKeyPressed.html`
