### PR TITLE
script(webdriver): Fix element clear for file

### DIFF
--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -2233,7 +2233,11 @@ impl HTMLInputElement {
         self.update_checked_state(self.DefaultChecked(), false);
         self.value_changed(can_gc);
         // Step 4. Empty selected files
-        self.filelist.set(None);
+        if self.filelist.get().is_some() {
+            let window = self.owner_window();
+            let filelist = FileList::new(&window, vec![], can_gc);
+            self.filelist.set(Some(&filelist));
+        }
         // Step 5. invoke the value sanitization algorithm iff
         // the type attribute's current state defines one.
         // This is covered in `fn sanitize_value` called below.

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/file_upload.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/file_upload.py.ini
@@ -2,9 +2,6 @@
   [test_multiple_files_send_twice]
     expected: FAIL
 
-  [test_multiple_files_reset_with_element_clear]
-    expected: FAIL
-
   [test_single_file_appends_with_multiple_attribute]
     expected: FAIL
 


### PR DESCRIPTION
When clearing input file with WebDriver, we should set input's filelist with empty list instead of setting it with None.

Testing: `./tests/wpt/tests/webdriver/tests/classic/element_send_keys/file_upload.py`