### PR TITLE
mach(test-tidy): Remove alphabetical order and line length rule from tidy

### DIFF
--- a/python/tidy/test.py
+++ b/python/tidy/test.py
@@ -73,11 +73,6 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual("file is empty", next(errors)[2])
         self.assertNoMoreErrors(errors)
 
-    def test_long_line(self):
-        errors = tidy.collect_errors_for_files(iterFile("long_line.rs"), [], [tidy.check_by_line], print_text=False)
-        self.assertEqual("Line is longer than 120 characters", next(errors)[2])
-        self.assertNoMoreErrors(errors)
-
     def test_whatwg_link(self):
         errors = tidy.collect_errors_for_files(iterFile("whatwg_link.rs"), [], [tidy.check_by_line], print_text=False)
         self.assertEqual(
@@ -122,9 +117,6 @@ class CheckTidiness(unittest.TestCase):
 
     def test_rust(self):
         errors = tidy.collect_errors_for_files(iterFile("rust_tidy.rs"), [], [tidy.check_rust], print_text=False)
-        self.assertTrue("mod declaration is not in alphabetical order" in next(errors)[2])
-        self.assertEqual("mod declaration spans multiple lines", next(errors)[2])
-        self.assertTrue("derivable traits list is not in alphabetical order" in next(errors)[2])
         self.assertEqual("found an empty line following a {", next(errors)[2])
         self.assertEqual("use &[T] instead of &Vec<T>", next(errors)[2])
         self.assertEqual("use &str instead of &String", next(errors)[2])
@@ -138,10 +130,6 @@ class CheckTidiness(unittest.TestCase):
 
         feature_errors = tidy.collect_errors_for_files(iterFile("lib.rs"), [], [tidy.check_rust], print_text=False)
 
-        self.assertTrue("feature attribute is not in alphabetical order" in next(feature_errors)[2])
-        self.assertTrue("feature attribute is not in alphabetical order" in next(feature_errors)[2])
-        self.assertTrue("feature attribute is not in alphabetical order" in next(feature_errors)[2])
-        self.assertTrue("feature attribute is not in alphabetical order" in next(feature_errors)[2])
         self.assertNoMoreErrors(feature_errors)
 
         ban_errors = tidy.collect_errors_for_files(iterFile("ban.rs"), [], [tidy.check_rust], print_text=False)

--- a/python/tidy/tests/servo-tidy.toml
+++ b/python/tidy/tests/servo-tidy.toml
@@ -1,7 +1,6 @@
 key-outside = ""
 
 [configs]
-skip-check-length = false
 skip-check-licenses = false
 wrong-key = false
 

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -1,7 +1,5 @@
 [configs]
-skip-check-length = false
 skip-check-licenses = false
-check-alphabetical-order = true
 
 [ignore]
 # Files that are ignored for all tidy and lint checks.


### PR DESCRIPTION
As we plan to adopt more rules from Ruff and rustfmt, we would like to retire the following rules:

1. `Line length check`, as this is already handled by Ruff and rustfmt configurations.
2. `Alphabetical order`


Testing: `./mach test-tidy --no-progress --all`
Fixes: #37121