### PR TITLE
script/compositor: Send `mouseleave` events when cursor moves between `<iframe>`s

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2939,34 +2939,8 @@ where
             }
         }
 
-        let pipeline_id = match &hit_test_result {
-            Some(hit_test) => hit_test.pipeline_id,
-            None => {
-                // If there's no hit test, send to the focused browsing context of the given webview.
-                let Some(browsing_context_id) = self
-                    .webviews
-                    .get(webview_id)
-                    .map(|webview| webview.focused_browsing_context_id)
-                else {
-                    warn!("Handling InputEvent for an unknown webview: {webview_id}");
-                    return;
-                };
-
-                let Some(pipeline_id) = self
-                    .browsing_contexts
-                    .get(&browsing_context_id)
-                    .map(|context| context.pipeline_id)
-                else {
-                    warn!("{browsing_context_id}: Got InputEvent for nonexistent browsing context");
-                    return;
-                };
-
-                pipeline_id
-            },
-        };
-
-        let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
-            debug!("Got event for pipeline ({pipeline_id}) after closure");
+        let Some(webview) = self.webviews.get_mut(webview_id) else {
+            warn!("Got input event for unknown WebViewId: {webview_id:?}");
             return;
         };
 
@@ -2976,13 +2950,7 @@ where
             active_keyboard_modifiers,
             event,
         };
-
-        if let Err(error) = pipeline
-            .event_loop
-            .send(ScriptThreadMessage::SendInputEvent(pipeline_id, event))
-        {
-            self.handle_send_error(pipeline_id, error);
-        }
+        webview.forward_input_event(event, &self.pipelines, &self.browsing_contexts);
     }
 
     #[servo_tracing::instrument(skip_all)]

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -2,9 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base::id::BrowsingContextId;
-use embedder_traits::Theme;
+use std::collections::HashMap;
 
+use base::id::{BrowsingContextId, PipelineId};
+use embedder_traits::{InputEvent, MouseLeaveEvent, Theme};
+use euclid::Point2D;
+use log::warn;
+use script_traits::{ConstellationInputEvent, ScriptThreadMessage};
+use style_traits::CSSPixel;
+
+use crate::browsingcontext::BrowsingContext;
+use crate::pipeline::Pipeline;
 use crate::session_history::JointSessionHistory;
 
 /// The `Constellation`'s view of a `WebView` in the embedding layer. This tracks all of the
@@ -14,6 +22,14 @@ pub(crate) struct ConstellationWebView {
     /// The focused pipeline is the current entry of the focused browsing
     /// context.
     pub focused_browsing_context_id: BrowsingContextId,
+
+    /// The [`BrowsingContextId`] of the currently hovered browsing context, to use for
+    /// knowing which frame is currently receiving cursor events.
+    pub hovered_browsing_context_id: Option<BrowsingContextId>,
+
+    /// The last mouse move point in the coordinate space of the Pipeline that it
+    /// happened int.
+    pub last_mouse_move_point: Point2D<f32, CSSPixel>,
 
     /// The joint session history for this webview.
     pub session_history: JointSessionHistory,
@@ -27,6 +43,8 @@ impl ConstellationWebView {
     pub(crate) fn new(focused_browsing_context_id: BrowsingContextId) -> Self {
         Self {
             focused_browsing_context_id,
+            hovered_browsing_context_id: None,
+            last_mouse_move_point: Default::default(),
             session_history: JointSessionHistory::new(),
             theme: Theme::Light,
         }
@@ -41,5 +59,92 @@ impl ConstellationWebView {
     /// Get the [`Theme`] of this [`ConstellationWebView`].
     pub(crate) fn theme(&self) -> Theme {
         self.theme
+    }
+
+    fn target_pipeline_id_for_input_event(
+        &self,
+        event: &ConstellationInputEvent,
+        browsing_contexts: &HashMap<BrowsingContextId, BrowsingContext>,
+    ) -> Option<PipelineId> {
+        if let Some(hit_test_result) = &event.hit_test_result {
+            return Some(hit_test_result.pipeline_id);
+        }
+
+        // If there's no hit test, send the event to either the hovered or focused browsing context,
+        // depending on the event type.
+        let browsing_context_id = if matches!(event.event, InputEvent::MouseLeave(_)) {
+            self.hovered_browsing_context_id
+                .unwrap_or(self.focused_browsing_context_id)
+        } else {
+            self.focused_browsing_context_id
+        };
+
+        Some(browsing_contexts.get(&browsing_context_id)?.pipeline_id)
+    }
+
+    pub(crate) fn forward_input_event(
+        &mut self,
+        event: ConstellationInputEvent,
+        pipelines: &HashMap<PipelineId, Pipeline>,
+        browsing_contexts: &HashMap<BrowsingContextId, BrowsingContext>,
+    ) {
+        let Some(pipeline_id) = self.target_pipeline_id_for_input_event(&event, browsing_contexts)
+        else {
+            warn!("Unknown pipeline for input event. Ignoring.");
+            return;
+        };
+        let Some(pipeline) = pipelines.get(&pipeline_id) else {
+            warn!("Unknown pipeline id {pipeline_id:?} for input event. Ignoring.");
+            return;
+        };
+
+        let mut update_hovered_browsing_context = |newly_hovered_browsing_context_id| {
+            let old_hovered_context_id = std::mem::replace(
+                &mut self.hovered_browsing_context_id,
+                newly_hovered_browsing_context_id,
+            );
+            if old_hovered_context_id == newly_hovered_browsing_context_id {
+                return;
+            }
+            let Some(old_hovered_context_id) = old_hovered_context_id else {
+                return;
+            };
+            let Some(pipeline) = browsing_contexts
+                .get(&old_hovered_context_id)
+                .and_then(|browsing_context| pipelines.get(&browsing_context.pipeline_id))
+            else {
+                return;
+            };
+
+            let mut synthetic_mouse_leave_event = event.clone();
+            synthetic_mouse_leave_event.event = InputEvent::MouseLeave(MouseLeaveEvent {
+                focus_moving_to_another_iframe: true,
+            });
+
+            let _ = pipeline
+                .event_loop
+                .send(ScriptThreadMessage::SendInputEvent(
+                    pipeline.id,
+                    synthetic_mouse_leave_event,
+                ));
+        };
+
+        if let InputEvent::MouseLeave(_) = &event.event {
+            update_hovered_browsing_context(None);
+            return;
+        }
+
+        if let InputEvent::MouseMove(_) = &event.event {
+            update_hovered_browsing_context(Some(pipeline.browsing_context_id));
+            self.last_mouse_move_point = event
+                .hit_test_result
+                .as_ref()
+                .expect("MouseMove events should always have hit tests.")
+                .point_in_viewport;
+        }
+
+        let _ = pipeline
+            .event_loop
+            .send(ScriptThreadMessage::SendInputEvent(pipeline.id, event));
     }
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -30,8 +30,8 @@ use dom_struct::dom_struct;
 use embedder_traits::{
     AllowOrDeny, AnimationState, ContextMenuResult, Cursor, EditingActionEvent, EmbedderMsg,
     FocusSequenceNumber, ImeEvent, InputEvent, LoadStatus, MouseButton, MouseButtonAction,
-    MouseButtonEvent, ScrollEvent, TouchEvent, TouchEventType, TouchId, UntrustedNodeAddress,
-    WheelEvent,
+    MouseButtonEvent, MouseLeaveEvent, ScrollEvent, TouchEvent, TouchEventType, TouchId,
+    UntrustedNodeAddress, WheelEvent,
 };
 use encoding_rs::{Encoding, UTF_8};
 use euclid::Point2D;
@@ -141,6 +141,7 @@ use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::customelementregistry::CustomElementDefinition;
 use crate::dom::customevent::CustomEvent;
 use crate::dom::datatransfer::DataTransfer;
+use crate::dom::document_event_handler::DocumentEventHandler;
 use crate::dom::documentfragment::DocumentFragment;
 use crate::dom::documentorshadowroot::{
     DocumentOrShadowRoot, ServoStylesheetInDocument, StylesheetSource,
@@ -322,6 +323,8 @@ pub(crate) struct Document {
     #[ignore_malloc_size_of = "defined in selectors"]
     #[no_trace]
     quirks_mode: Cell<QuirksMode>,
+    /// A helper used to process and store data related to input event handling.
+    event_handler: DocumentEventHandler,
     /// Caches for the getElement methods
     id_map: DomRefCell<HashMapTracedValues<Atom, Vec<Dom<Element>>>>,
     name_map: DomRefCell<HashMapTracedValues<Atom, Vec<Dom<Element>>>>,
@@ -2001,7 +2004,6 @@ impl Document {
     pub(crate) unsafe fn handle_mouse_move_event(
         &self,
         input_event: &ConstellationInputEvent,
-        prev_mouse_over_target: &MutNullableDom<Element>,
         can_gc: CanGc,
     ) {
         // Ignore all incoming events without a hit test.
@@ -2021,7 +2023,9 @@ impl Document {
             return;
         };
 
-        let target_has_changed = prev_mouse_over_target
+        let target_has_changed = self
+            .event_handler
+            .current_hover_target
             .get()
             .as_ref()
             .is_none_or(|old_target| old_target != &new_target);
@@ -2030,7 +2034,7 @@ impl Document {
         // dispatch mouseout to the previous one, mouseover to the new one.
         if target_has_changed {
             // Dispatch mouseout and mouseleave to previous target.
-            if let Some(old_target) = prev_mouse_over_target.get() {
+            if let Some(old_target) = self.event_handler.current_hover_target.get() {
                 let old_target_is_ancestor_of_new_target = old_target
                     .upcast::<Node>()
                     .is_ancestor_of(new_target.upcast::<Node>());
@@ -2078,9 +2082,6 @@ impl Document {
                 .inclusive_ancestors(ShadowIncluding::No)
                 .filter_map(DomRoot::downcast::<Element>)
             {
-                if element.hover_state() {
-                    break;
-                }
                 element.set_hover_state(true);
             }
 
@@ -2094,7 +2095,9 @@ impl Document {
                 can_gc,
             );
 
-            let moving_from = prev_mouse_over_target
+            let moving_from = self
+                .event_handler
+                .current_hover_target
                 .get()
                 .map(|old_target| DomRoot::from_ref(old_target.upcast::<Node>()));
             let event_target = DomRoot::from_ref(new_target.upcast::<Node>());
@@ -2120,56 +2123,107 @@ impl Document {
             can_gc,
         );
 
-        // If the target has changed then store the current mouse over target for next frame.
-        if target_has_changed {
-            prev_mouse_over_target.set(Some(&new_target));
-        }
+        self.update_current_hover_target_and_status(Some(new_target));
     }
 
-    pub(crate) fn set_cursor(&self, cursor: Cursor) {
-        self.send_to_embedder(EmbedderMsg::SetCursor(self.webview_id(), cursor));
+    fn update_current_hover_target_and_status(&self, new_hover_target: Option<DomRoot<Element>>) {
+        let previous_hover_target = self.event_handler.current_hover_target.get();
+        if previous_hover_target == new_hover_target {
+            return;
+        }
+
+        self.event_handler
+            .current_hover_target
+            .set(new_hover_target.as_deref());
+
+        // If the new hover target is an anchor with a status value, inform the embedder
+        // of the new value.
+        let window = self.window();
+        if let Some(anchor) = new_hover_target.and_then(|new_hover_target| {
+            new_hover_target
+                .upcast::<Node>()
+                .inclusive_ancestors(ShadowIncluding::No)
+                .filter_map(DomRoot::downcast::<HTMLAnchorElement>)
+                .next()
+        }) {
+            let status = anchor
+                .upcast::<Element>()
+                .get_attribute(&ns!(), &local_name!("href"))
+                .and_then(|href| {
+                    let value = href.value();
+                    let url = self.url();
+                    url.join(&value).map(|url| url.to_string()).ok()
+                });
+            window.send_to_embedder(EmbedderMsg::Status(self.webview_id(), status));
+            return;
+        }
+
+        // No state was set above, which means that the new value of the status in the embedder
+        // should be `None`. Set that now. If `previous_hover_target` is `None` that means this
+        // is the first mouse move event we are seeing after getting the cursor. In that case,
+        // we also clear the status.
+        if previous_hover_target.is_none_or(|previous_hover_target| {
+            previous_hover_target
+                .upcast::<Node>()
+                .inclusive_ancestors(ShadowIncluding::No)
+                .filter_map(DomRoot::downcast::<HTMLAnchorElement>)
+                .next()
+                .is_some()
+        }) {
+            window.send_to_embedder(EmbedderMsg::Status(window.webview_id(), None));
+        }
     }
 
     #[allow(unsafe_code)]
     pub(crate) fn handle_mouse_leave_event(
         &self,
         input_event: &ConstellationInputEvent,
+        mouse_leave_event: &MouseLeaveEvent,
         can_gc: CanGc,
     ) {
-        // Ignore all incoming events without a hit test.
-        let Some(hit_test_result) = self.window.hit_test_from_input_event(input_event) else {
-            return;
-        };
+        if let Some(current_hover_target) = self.event_handler.current_hover_target.get() {
+            let current_hover_target = current_hover_target.upcast::<Node>();
+            for element in current_hover_target
+                .inclusive_ancestors(ShadowIncluding::No)
+                .filter_map(DomRoot::downcast::<Element>)
+            {
+                element.set_hover_state(false);
+                element.set_active_state(false);
+            }
 
-        self.window()
-            .send_to_embedder(EmbedderMsg::Status(self.webview_id(), None));
-
-        for element in hit_test_result
-            .node
-            .inclusive_ancestors(ShadowIncluding::No)
-            .filter_map(DomRoot::downcast::<Element>)
-        {
-            element.set_hover_state(false);
-            element.set_active_state(false);
+            if let Some(hit_test_result) = self
+                .window()
+                .hit_test_from_point_in_viewport(self.event_handler.most_recent_mousemove_point)
+            {
+                self.fire_mouse_event(
+                    current_hover_target.upcast(),
+                    FireMouseEventType::Out,
+                    EventBubbles::Bubbles,
+                    EventCancelable::Cancelable,
+                    &hit_test_result,
+                    input_event,
+                    can_gc,
+                );
+                self.handle_mouse_enter_leave_event(
+                    DomRoot::from_ref(current_hover_target),
+                    None,
+                    FireMouseEventType::Leave,
+                    &hit_test_result,
+                    input_event,
+                    can_gc,
+                );
+            }
         }
 
-        self.fire_mouse_event(
-            hit_test_result.node.upcast(),
-            FireMouseEventType::Out,
-            EventBubbles::Bubbles,
-            EventCancelable::Cancelable,
-            &hit_test_result,
-            input_event,
-            can_gc,
-        );
-        self.handle_mouse_enter_leave_event(
-            hit_test_result.node.clone(),
-            None,
-            FireMouseEventType::Leave,
-            &hit_test_result,
-            input_event,
-            can_gc,
-        );
+        self.event_handler.current_cursor.set(None);
+        self.event_handler.current_hover_target.set(None);
+
+        // If focus is moving to another frame, it will decide what the new status text is, but if
+        // this mouse leave event is leaving the WebView entirely, then clear it.
+        if !mouse_leave_event.focus_moving_to_another_iframe {
+            self.window()
+                .send_to_embedder(EmbedderMsg::Status(self.webview_id(), None));
+        }
     }
 
     fn handle_mouse_enter_leave_event(
@@ -4123,6 +4177,14 @@ impl Document {
 
         Ok(())
     }
+
+    pub(crate) fn set_cursor(&self, cursor: Cursor) {
+        if Some(cursor) == self.event_handler.current_cursor.get() {
+            return;
+        }
+        self.event_handler.current_cursor.set(Some(cursor));
+        self.send_to_embedder(EmbedderMsg::SetCursor(self.webview_id(), cursor));
+    }
 }
 
 fn is_character_value_key(key: &Key) -> bool {
@@ -4321,6 +4383,7 @@ impl Document {
             url: DomRefCell::new(url),
             // https://dom.spec.whatwg.org/#concept-document-quirks
             quirks_mode: Cell::new(QuirksMode::NoQuirks),
+            event_handler: DocumentEventHandler::default(),
             id_map: DomRefCell::new(HashMapTracedValues::new()),
             name_map: DomRefCell::new(HashMapTracedValues::new()),
             // https://dom.spec.whatwg.org/#concept-document-encoding
@@ -4821,14 +4884,14 @@ impl Document {
         })
     }
 
-    pub(crate) fn element_state_will_change(&self, el: &Element) {
-        let mut entry = self.ensure_pending_restyle(el);
+    pub(crate) fn element_state_will_change(&self, element: &Element) {
+        let mut entry = self.ensure_pending_restyle(element);
         if entry.snapshot.is_none() {
             entry.snapshot = Some(Snapshot::new());
         }
         let snapshot = entry.snapshot.as_mut().unwrap();
         if snapshot.state.is_none() {
-            snapshot.state = Some(el.state());
+            snapshot.state = Some(element.state());
         }
     }
 

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::Cell;
+
+use embedder_traits::Cursor;
+use euclid::Point2D;
+use style_traits::CSSPixel;
+
+use crate::dom::bindings::root::MutNullableDom;
+use crate::dom::types::Element;
+
+/// The [`DocumentEventHandler`] is a structure responsible for handling events for
+/// the [`crate::Document`] and storing data related to event handling. It exists to
+/// decrease the size of the [`crate::Document`] structure.
+#[derive(Default, JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+pub(crate) struct DocumentEventHandler {
+    /// The element that is currently hovered by the cursor.
+    pub(crate) current_hover_target: MutNullableDom<Element>,
+    /// The most recent mouse movement point, used for processing `mouseleave` events.
+    #[no_trace]
+    pub(crate) most_recent_mousemove_point: Point2D<f32, CSSPixel>,
+    /// The currently set [`Cursor`] or `None` if the `Document` isn't being hovered
+    /// by the cursor.
+    #[no_trace]
+    pub(crate) current_cursor: Cell<Option<Cursor>>,
+}

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -5425,8 +5425,8 @@ impl Element {
     }
 
     pub(crate) fn set_focus_state(&self, value: bool) {
-        self.set_state(ElementState::FOCUS, value);
         self.upcast::<Node>().dirty(NodeDamage::Other);
+        self.set_state(ElementState::FOCUS, value);
     }
 
     pub(crate) fn hover_state(&self) -> bool {

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -298,6 +298,7 @@ pub(crate) mod dissimilaroriginlocation;
 pub(crate) mod dissimilaroriginwindow;
 #[allow(dead_code)]
 pub(crate) mod document;
+pub(crate) mod document_event_handler;
 pub(crate) mod documentfragment;
 pub(crate) mod documentorshadowroot;
 pub(crate) mod documenttype;

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2597,21 +2597,25 @@ impl Window {
         self.layout().query_elements_from_point(point, flags)
     }
 
-    #[allow(unsafe_code)]
     pub(crate) fn hit_test_from_input_event(
         &self,
         input_event: &ConstellationInputEvent,
     ) -> Option<HitTestResult> {
-        let compositor_hit_test_result = input_event.hit_test_result.as_ref()?;
+        self.hit_test_from_point_in_viewport(
+            input_event.hit_test_result.as_ref()?.point_in_viewport,
+        )
+    }
+
+    #[allow(unsafe_code)]
+    pub(crate) fn hit_test_from_point_in_viewport(
+        &self,
+        point_in_frame: Point2D<f32, CSSPixel>,
+    ) -> Option<HitTestResult> {
         let result = self
-            .elements_from_point_query(
-                compositor_hit_test_result.point_in_viewport.cast_unit(),
-                ElementsFromPointFlags::empty(),
-            )
+            .elements_from_point_query(point_in_frame.cast_unit(), ElementsFromPointFlags::empty())
             .into_iter()
             .nth(0)?;
 
-        let point_in_frame = compositor_hit_test_result.point_in_viewport;
         let point_relative_to_initial_containing_block =
             point_in_frame + self.scroll_offset().cast_unit();
 

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -43,7 +43,7 @@ impl InputEvent {
             InputEvent::Keyboard(..) => None,
             InputEvent::MouseButton(event) => Some(event.point),
             InputEvent::MouseMove(event) => Some(event.point),
-            InputEvent::MouseLeave(event) => Some(event.point),
+            InputEvent::MouseLeave(_) => None,
             InputEvent::Touch(event) => Some(event.point),
             InputEvent::Wheel(event) => Some(event.point),
             InputEvent::Scroll(..) => None,
@@ -218,15 +218,9 @@ impl MouseMoveEvent {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
 pub struct MouseLeaveEvent {
-    pub point: DevicePoint,
-}
-
-impl MouseLeaveEvent {
-    pub fn new(point: DevicePoint) -> Self {
-        Self { point }
-    }
+    pub focus_moving_to_another_iframe: bool,
 }
 
 /// The type of input represented by a multi-touch event.

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -613,17 +613,17 @@ impl WindowPortsMethods for Window {
                 if webview.rect().contains(point) {
                     webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point)));
                 } else if webview.rect().contains(previous_point) {
-                    webview.notify_input_event(InputEvent::MouseLeave(MouseLeaveEvent::new(
-                        previous_point,
-                    )));
+                    webview.notify_input_event(InputEvent::MouseLeave(MouseLeaveEvent::default()));
                 }
 
                 self.webview_relative_mouse_point.set(point);
             },
             WindowEvent::CursorLeft { .. } => {
-                let point = self.webview_relative_mouse_point.get();
-                if webview.rect().contains(point) {
-                    webview.notify_input_event(InputEvent::MouseLeave(MouseLeaveEvent::new(point)));
+                if webview
+                    .rect()
+                    .contains(self.webview_relative_mouse_point.get())
+                {
+                    webview.notify_input_event(InputEvent::MouseLeave(MouseLeaveEvent::default()));
                 }
             },
             WindowEvent::MouseWheel { delta, .. } => {


### PR DESCRIPTION
Properly send `mouseleave` events when the cursor moves between
`<iframe>`s. This allows a better handling of cursor changes and status
text updates. Specifically, we do not need to continuously update the
cursor and the value can be cached in the `Document`. In addition,
status updates can now be sent properly when moving focus between
`<iframe>`s.

Note that style updates for `:hover` values are still broken, but less
so than before. Now the hover state on the `Node` is updated, but for some
reason the restyle isn't taking place properly. This maintains the
status quo as far as behavior goes when hover moves between `<iframe>`s.

This change also adds a helper data structure to `Document` which will
eventually be responsible for event handling.

Testing: Cursor and status change are currently very hard to test as
the API test harness makes this difficult at the moment.
