### PR TITLE
Reuse `StylesheetContent` for inline style sheets with identical content

### DIFF
--- a/components/script/dom/cssgroupingrule.rs
+++ b/components/script/dom/cssgroupingrule.rs
@@ -3,8 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use style::shared_lock::SharedRwLock;
-use style::stylesheets::{CssRuleType, CssRuleTypes};
+use servo_arc::Arc;
+use style::shared_lock::{Locked, SharedRwLock, SharedRwLockReadGuard};
+use style::stylesheets::{CssRuleType, CssRuleTypes, CssRules};
 
 use crate::dom::bindings::codegen::Bindings::CSSGroupingRuleBinding::CSSGroupingRuleMethods;
 use crate::dom::bindings::error::{ErrorResult, Fallible};
@@ -61,6 +62,16 @@ impl CSSGroupingRule {
 
     pub(crate) fn shared_lock(&self) -> &SharedRwLock {
         self.cssrule.shared_lock()
+    }
+
+    pub(crate) fn update_rules(
+        &self,
+        rules: &Arc<Locked<CssRules>>,
+        guard: &SharedRwLockReadGuard,
+    ) {
+        if let Some(rulelist) = self.rulelist.get() {
+            rulelist.update_rules(RulesSource::Rules(rules.clone()), guard);
+        }
     }
 }
 

--- a/components/script/dom/cssrule.rs
+++ b/components/script/dom/cssrule.rs
@@ -5,7 +5,7 @@
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
-use style::shared_lock::SharedRwLock;
+use style::shared_lock::{SharedRwLock, SharedRwLockReadGuard};
 use style::stylesheets::{CssRule as StyleCssRule, CssRuleType};
 
 use crate::dom::bindings::codegen::Bindings::CSSRuleBinding::CSSRuleMethods;
@@ -157,7 +157,73 @@ impl CSSRule {
     }
 
     pub(crate) fn shared_lock(&self) -> &SharedRwLock {
-        &self.parent_stylesheet.style_stylesheet().shared_lock
+        self.parent_stylesheet.shared_lock()
+    }
+
+    pub(crate) fn update_rule(&self, style_rule: &StyleCssRule, guard: &SharedRwLockReadGuard) {
+        match style_rule {
+            StyleCssRule::Import(s) => {
+                if let Some(rule) = self.downcast::<CSSImportRule>() {
+                    rule.update_rule(s.clone());
+                }
+            },
+            StyleCssRule::Style(s) => {
+                if let Some(rule) = self.downcast::<CSSStyleRule>() {
+                    rule.update_rule(s.clone(), guard);
+                }
+            },
+            StyleCssRule::FontFace(s) => {
+                if let Some(rule) = self.downcast::<CSSFontFaceRule>() {
+                    rule.update_rule(s.clone());
+                }
+            },
+            StyleCssRule::FontFeatureValues(_) => unimplemented!(),
+            StyleCssRule::CounterStyle(_) => unimplemented!(),
+            StyleCssRule::Keyframes(s) => {
+                if let Some(rule) = self.downcast::<CSSKeyframesRule>() {
+                    rule.update_rule(s.clone(), guard);
+                }
+            },
+            StyleCssRule::Media(s) => {
+                if let Some(rule) = self.downcast::<CSSMediaRule>() {
+                    rule.update_rule(s.clone(), guard);
+                }
+            },
+            StyleCssRule::Namespace(s) => {
+                if let Some(rule) = self.downcast::<CSSNamespaceRule>() {
+                    rule.update_rule(s.clone());
+                }
+            },
+            StyleCssRule::Supports(s) => {
+                if let Some(rule) = self.downcast::<CSSSupportsRule>() {
+                    rule.update_rule(s.clone(), guard);
+                }
+            },
+            StyleCssRule::Page(_) => unreachable!(),
+            StyleCssRule::Container(_) => unimplemented!(), // TODO
+            StyleCssRule::Document(_) => unimplemented!(),  // TODO
+            StyleCssRule::LayerBlock(s) => {
+                if let Some(rule) = self.downcast::<CSSLayerBlockRule>() {
+                    rule.update_rule(s.clone(), guard);
+                }
+            },
+            StyleCssRule::LayerStatement(s) => {
+                if let Some(rule) = self.downcast::<CSSLayerStatementRule>() {
+                    rule.update_rule(s.clone());
+                }
+            },
+            StyleCssRule::FontPaletteValues(_) => unimplemented!(), // TODO
+            StyleCssRule::Property(_) => unimplemented!(),          // TODO
+            StyleCssRule::Margin(_) => unimplemented!(),            // TODO
+            StyleCssRule::Scope(_) => unimplemented!(),             // TODO
+            StyleCssRule::StartingStyle(_) => unimplemented!(),     // TODO
+            StyleCssRule::PositionTry(_) => unimplemented!(),       // TODO
+            StyleCssRule::NestedDeclarations(s) => {
+                if let Some(rule) = self.downcast::<CSSNestedDeclarations>() {
+                    rule.update_rule(s.clone(), guard);
+                }
+            },
+        }
     }
 }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4021,7 +4021,7 @@ impl Document {
         debug_assert!(cssom_stylesheet.is_constructed());
 
         let stylesheets = &mut *self.stylesheets.borrow_mut();
-        let sheet = cssom_stylesheet.style_stylesheet_arc().clone();
+        let sheet = cssom_stylesheet.style_stylesheet().clone();
 
         let insertion_point = stylesheets
             .iter()

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -397,7 +397,7 @@ impl DocumentOrShadowRoot {
             if stylesheet_remove_set.insert(sheet_to_remove) {
                 owner.remove_stylesheet(
                     StylesheetSource::Constructed(sheet_to_remove.clone()),
-                    sheet_to_remove.style_stylesheet_arc(),
+                    &sheet_to_remove.style_stylesheet(),
                 );
                 sheet_to_remove.remove_adopter(owner);
             }
@@ -416,7 +416,7 @@ impl DocumentOrShadowRoot {
                 // around.
                 owner.remove_stylesheet(
                     StylesheetSource::Constructed(sheet.clone()),
-                    sheet.style_stylesheet_arc(),
+                    &sheet.style_stylesheet(),
                 );
             } else {
                 sheet.add_adopter(owner.clone());

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -562,6 +562,7 @@ pub(crate) mod storage;
 pub(crate) mod storageevent;
 pub(crate) mod stylepropertymapreadonly;
 pub(crate) mod stylesheet;
+pub(crate) mod stylesheetcontentscache;
 pub(crate) mod stylesheetlist;
 pub(crate) mod submitevent;
 pub(crate) mod subtlecrypto;

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -242,7 +242,7 @@ impl ShadowRoot {
         debug_assert!(cssom_stylesheet.is_constructed());
 
         let stylesheets = &mut self.author_styles.borrow_mut().stylesheets;
-        let sheet = cssom_stylesheet.style_stylesheet_arc().clone();
+        let sheet = cssom_stylesheet.style_stylesheet().clone();
 
         let insertion_point = stylesheets.iter().last().cloned();
 

--- a/components/script/dom/stylesheetcontentscache.rs
+++ b/components/script/dom/stylesheetcontentscache.rs
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::rc::Rc;
+
+use servo_arc::Arc as ServoArc;
+use style::context::QuirksMode;
+use style::shared_lock::SharedRwLock;
+use style::stylesheets::{CssRule, StylesheetContents, UrlExtraData};
+use stylo_atoms::Atom;
+
+const MAX_LENGTH_OF_TEXT_INSERTED_INTO_TABLE: usize = 1024;
+const UNIQUE_OWNED: usize = 2;
+
+/// Using [`Atom`] as a cache key to avoid inefficient string content comparison. Although
+/// the [`Atom`] is already based on reference counting, an extra [`Rc`] is introduced
+/// to trace how many [`style::stylesheets::Stylesheet`]s of style elements are sharing
+/// same [`StylesheetContents`], based on the following considerations:
+/// * The reference count within [`Atom`] is dedicated to lifecycle management and is not
+///   suitable for tracking the number of [`StylesheetContents`]s owners.
+/// * The reference count within [`Atom`] is not publicly acessible.
+#[derive(Clone, Eq, Hash, MallocSizeOf, PartialEq)]
+pub(crate) struct StylesheetContentsCacheKey {
+    #[conditional_malloc_size_of]
+    stylesheet_text: Rc<Atom>,
+    base_url: Atom,
+    #[ignore_malloc_size_of = "defined in style crate"]
+    quirks_mode: QuirksMode,
+}
+
+impl StylesheetContentsCacheKey {
+    fn new(stylesheet_text: &str, base_url: &str, quirks_mode: QuirksMode) -> Self {
+        // The stylesheet text may be quite lengthy, exceeding hundreds of kilobytes.
+        // Instead of directly inserting such a huge string into AtomicString table,
+        // take its hash value and use that. (This is not a cryptographic hash, so a
+        // page could cause collisions if it wanted to.)
+        let contents_atom = if stylesheet_text.len() > MAX_LENGTH_OF_TEXT_INSERTED_INTO_TABLE {
+            let mut hasher = DefaultHasher::new();
+            stylesheet_text.hash(&mut hasher);
+            Atom::from(hasher.finish().to_string().as_str())
+        } else {
+            Atom::from(stylesheet_text)
+        };
+
+        Self {
+            stylesheet_text: Rc::new(contents_atom),
+            base_url: Atom::from(base_url),
+            quirks_mode,
+        }
+    }
+
+    pub(crate) fn is_uniquely_owned(&self) -> bool {
+        // The cache itself already holds one reference.
+        Rc::strong_count(&self.stylesheet_text) <= UNIQUE_OWNED
+    }
+}
+
+thread_local! {
+    static STYLESHEETCONTENTS_CACHE: RefCell<HashMap<StylesheetContentsCacheKey, ServoArc<StylesheetContents>>> =
+       RefCell::default();
+}
+
+pub(crate) struct StylesheetContentsCache;
+
+impl StylesheetContentsCache {
+    fn contents_can_be_cached(contents: &StylesheetContents, shared_lock: &SharedRwLock) -> bool {
+        let guard = shared_lock.read();
+        let rules = contents.rules(&guard);
+        // The copy-on-write can not be performed when the modification happens on the
+        // imported stylesheet, because it containing cssom has no owner dom node.
+        !(rules.is_empty() || rules.iter().any(|rule| matches!(rule, CssRule::Import(_))))
+    }
+
+    pub(crate) fn get_or_insert_with(
+        stylesheet_text: &str,
+        shared_lock: &SharedRwLock,
+        url_data: UrlExtraData,
+        quirks_mode: QuirksMode,
+        stylesheetcontents_create_callback: impl FnOnce() -> ServoArc<StylesheetContents>,
+    ) -> (
+        Option<StylesheetContentsCacheKey>,
+        ServoArc<StylesheetContents>,
+    ) {
+        let cache_key =
+            StylesheetContentsCacheKey::new(stylesheet_text, url_data.as_str(), quirks_mode);
+        STYLESHEETCONTENTS_CACHE.with_borrow_mut(|stylesheetcontents_cache| {
+            let entry = stylesheetcontents_cache.entry(cache_key);
+            match entry {
+                Entry::Occupied(occupied_entry) => {
+                    // Use a copy of the cache key from `Entry` instead of the newly created one above
+                    // to correctly update and track to owner count of `StylesheetContents`.
+                    (
+                        Some(occupied_entry.key().clone()),
+                        occupied_entry.get().clone(),
+                    )
+                },
+                Entry::Vacant(vacant_entry) => {
+                    let contents = stylesheetcontents_create_callback();
+                    if Self::contents_can_be_cached(&contents, shared_lock) {
+                        let occupied_entry = vacant_entry.insert_entry(contents.clone());
+                        // Use a copy of the cache key from `Entry` instead of the newly created one above
+                        // to correctly update and track to owner count of `StylesheetContents`.
+                        (Some(occupied_entry.key().clone()), contents)
+                    } else {
+                        (None, contents)
+                    }
+                },
+            }
+        })
+    }
+
+    pub(crate) fn remove(cache_key: StylesheetContentsCacheKey) {
+        STYLESHEETCONTENTS_CACHE.with_borrow_mut(|stylesheetcontents_cache| {
+            stylesheetcontents_cache.remove(&cache_key)
+        });
+    }
+}

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -214,6 +214,9 @@ impl FetchResponseListener for StylesheetContext {
                         .is_none_or(|generation| generation == link.get_request_generation_id());
                     if is_stylesheet_load_applicable {
                         let shared_lock = document.style_shared_lock().clone();
+                        #[cfg(feature = "tracing")]
+                        let _span = tracing::trace_span!("ParseStylesheet", servo_profiling = true)
+                            .entered();
                         let sheet = Arc::new(Stylesheet::from_bytes(
                             &data,
                             UrlExtraData(final_url.get_arc()),
@@ -235,6 +238,9 @@ impl FetchResponseListener for StylesheetContext {
                     }
                 },
                 StylesheetContextSource::Import(ref stylesheet) => {
+                    #[cfg(feature = "tracing")]
+                    let _span =
+                        tracing::trace_span!("ParseStylesheet", servo_profiling = true).entered();
                     Stylesheet::update_from_bytes(
                         stylesheet,
                         &data,


### PR DESCRIPTION
For duplicate style sheets with identical content, `StylesheetContents` can be reused to avoid redundant parsing of the inline style sheets.  Since duplicate stylesheets is a common case with web components, this change will significantly improve performance. Additionally, the cache hit rate of stylo's `CascadeDataCache` can now be significantly improved. 

When shared `StylesheetContents` is modified, copy-on-write will occur to avoid affecting other sharers. And then updates the references to `CssRule` or `PropertyDeclarationBlock` stored in the CSSOMs to ensure that modifications are made only on the new copy.
