### PR TITLE
devtools: Expose `introductionType` to devtools clients

### DIFF
--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -27,6 +27,8 @@ pub(crate) struct SourceForm {
     /// URL of the script, or URL of the page for inline scripts.
     pub url: String,
     pub is_black_boxed: bool,
+    /// `introductionType` in SpiderMonkey `CompileOptionsWrapper`.
+    pub introduction_type: String,
 }
 
 #[derive(Serialize)]
@@ -53,6 +55,9 @@ pub struct SourceActor {
 
     pub content: Option<String>,
     pub content_type: Option<String>,
+
+    /// `introductionType` in SpiderMonkey `CompileOptionsWrapper`.
+    pub introduction_type: String,
 }
 
 #[derive(Serialize)]
@@ -91,6 +96,7 @@ impl SourceActor {
         url: ServoUrl,
         content: Option<String>,
         content_type: Option<String>,
+        introduction_type: String,
     ) -> SourceActor {
         SourceActor {
             name,
@@ -98,6 +104,7 @@ impl SourceActor {
             content,
             content_type,
             is_black_boxed: false,
+            introduction_type,
         }
     }
 
@@ -107,10 +114,17 @@ impl SourceActor {
         url: ServoUrl,
         content: Option<String>,
         content_type: Option<String>,
+        introduction_type: String,
     ) -> &SourceActor {
         let source_actor_name = actors.new_name("source");
 
-        let source_actor = SourceActor::new(source_actor_name.clone(), url, content, content_type);
+        let source_actor = SourceActor::new(
+            source_actor_name.clone(),
+            url,
+            content,
+            content_type,
+            introduction_type,
+        );
         actors.register(Box::new(source_actor));
         actors.register_source_actor(pipeline_id, &source_actor_name);
 
@@ -122,6 +136,7 @@ impl SourceActor {
             actor: self.name.clone(),
             url: self.url.to_string(),
             is_black_boxed: self.is_black_boxed,
+            introduction_type: self.introduction_type.clone(),
         }
     }
 }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -552,6 +552,7 @@ impl DevtoolsInstance {
             source_info.url,
             source_content,
             source_info.content_type,
+            source_info.introduction_type,
         );
         let source_actor_name = source_actor.name.clone();
         let source_form = source_actor.source_form();

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -59,7 +59,9 @@ use crate::fetch::{CspViolationsProcessor, load_whole_resource};
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
 use crate::script_runtime::ScriptThreadEventCategory::WorkerEvent;
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext, Runtime, ThreadSafeJSContext};
+use crate::script_runtime::{
+    CanGc, IntroductionType, JSContext as SafeJSContext, Runtime, ThreadSafeJSContext,
+};
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
 use crate::task_source::{SendableTaskSource, TaskSourceName};
 
@@ -517,6 +519,10 @@ impl DedicatedWorkerGlobalScope {
                     let pipeline_id = global_scope.pipeline_id();
                     let source_info = SourceInfo {
                         url: metadata.final_url,
+                        introduction_type: IntroductionType::WORKER
+                            .to_str()
+                            .expect("Guaranteed by definition")
+                            .to_owned(),
                         external: true, // Worker scripts are always external.
                         worker_id: Some(global.upcast::<WorkerGlobalScope>().get_worker_id()),
                         content: Some(source.to_string()),

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -72,7 +72,7 @@ use crate::dom::workernavigator::WorkerNavigator;
 use crate::fetch::{CspViolationsProcessor, Fetch, load_whole_resource};
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::realms::{InRealm, enter_realm};
-use crate::script_runtime::{CanGc, JSContext, JSContextHelper, Runtime};
+use crate::script_runtime::{CanGc, IntroductionType, JSContext, JSContextHelper, Runtime};
 use crate::task::TaskCanceller;
 use crate::timers::{IsInterval, TimerCallback};
 
@@ -644,12 +644,13 @@ impl WorkerGlobalScope {
         let _aes = AutoEntryScript::new(self.upcast());
         let cx = self.runtime.borrow().as_ref().unwrap().cx();
         rooted!(in(cx) let mut rval = UndefinedValue());
-        let options = self
+        let mut options = self
             .runtime
             .borrow()
             .as_ref()
             .unwrap()
             .new_compile_options(self.worker_url.borrow().as_str(), 1);
+        options.set_introduction_type(IntroductionType::WORKER);
         match self.runtime.borrow().as_ref().unwrap().evaluate_script(
             self.reflector().get_jsobject(),
             &source,

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -1249,7 +1249,21 @@ impl Runnable {
 pub(crate) use script_bindings::script_runtime::CanGc;
 
 /// `introductionType` values in SpiderMonkey TransitiveCompileOptions.
+///
+/// Value definitions are based on the SpiderMonkey Debugger API docs:
+/// <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Source.html#introductiontype>
+// TODO: squish `scriptElement` <https://searchfox.org/mozilla-central/rev/202069c4c5113a1a9052d84fa4679d4c1b22113e/devtools/server/actors/source.js#199-201>
 pub(crate) struct IntroductionType;
 impl IntroductionType {
-    pub const INLINE_SCRIPT: &'static CStr = c"inlineScript";
+    /// `introductionType` for code belonging to `<script src="file.js">` elements.
+    /// This includes `<script type="module" src="...">`.
+    pub const SRC_SCRIPT: &CStr = c"srcScript";
+
+    /// `introductionType` for code belonging to `<script>code;</script>` elements.
+    /// This includes `<script type="module" src="...">`.
+    pub const INLINE_SCRIPT: &CStr = c"inlineScript";
+
+    /// `introductionType` for web workers.
+    /// <https://searchfox.org/mozilla-central/rev/202069c4c5113a1a9052d84fa4679d4c1b22113e/devtools/docs/user/debugger-api/debugger.source/index.rst#96>
+    pub const WORKER: &CStr = c"Worker";
 }

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -583,6 +583,7 @@ impl fmt::Display for ShadowRootMode {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SourceInfo {
     pub url: ServoUrl,
+    pub introduction_type: String,
     pub external: bool,
     pub worker_id: Option<WorkerId>,
     pub content: Option<String>,

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -33,8 +33,8 @@ LOG_REQUESTS = False
 
 @dataclass(frozen=True)
 class Source:
-    url: str
     introduction_type: str
+    url: str
 
 
 class DevtoolsTests(unittest.IsolatedAsyncioTestCase):

--- a/python/servo/devtools_tests/sources/classic_worker.js
+++ b/python/servo/devtools_tests/sources/classic_worker.js
@@ -1,0 +1,4 @@
+console.log("external classic worker");
+
+// Prevent worker exiting before devtools client can query sources
+setInterval(() => {}, 0);

--- a/python/servo/devtools_tests/sources/module_worker.js
+++ b/python/servo/devtools_tests/sources/module_worker.js
@@ -1,0 +1,4 @@
+console.log("external module worker");
+
+// Prevent worker exiting before devtools client can query sources
+setInterval(() => {}, 0);

--- a/python/servo/devtools_tests/sources/test.html
+++ b/python/servo/devtools_tests/sources/test.html
@@ -2,7 +2,7 @@
 <script src="classic.js"></script>
 <script>
     console.log("inline classic");
-    new Worker("worker.js");
+    new Worker("classic_worker.js");
 </script>
 <script type="module">
     import module from "./module.js";

--- a/python/servo/devtools_tests/sources/test_sources_list_with_classic_worker.html
+++ b/python/servo/devtools_tests/sources/test_sources_list_with_classic_worker.html
@@ -1,0 +1,5 @@
+<!doctype html><meta charset=utf-8>
+<script>
+    console.log("inline classic");
+    new Worker("classic_worker.js");
+</script>

--- a/python/servo/devtools_tests/sources/test_sources_list_with_data_external_module_script.html
+++ b/python/servo/devtools_tests/sources/test_sources_list_with_data_external_module_script.html
@@ -1,0 +1,2 @@
+<!doctype html><meta charset=utf-8>
+<script type="module" src="module.js"></script>

--- a/python/servo/devtools_tests/sources/test_sources_list_with_dynamic_import_module.html
+++ b/python/servo/devtools_tests/sources/test_sources_list_with_dynamic_import_module.html
@@ -1,0 +1,5 @@
+<!doctype html><meta charset=utf-8>
+<script type="module">
+    console.log("inline module");
+    import("./module.js");
+</script>

--- a/python/servo/devtools_tests/sources/test_sources_list_with_module_worker.html
+++ b/python/servo/devtools_tests/sources/test_sources_list_with_module_worker.html
@@ -1,0 +1,5 @@
+<!doctype html><meta charset=utf-8>
+<script>
+    console.log("inline classic");
+    new Worker("module_worker.js");
+</script>

--- a/python/servo/devtools_tests/sources/test_sources_list_with_static_import_module.html
+++ b/python/servo/devtools_tests/sources/test_sources_list_with_static_import_module.html
@@ -1,0 +1,5 @@
+<!doctype html><meta charset=utf-8>
+<script type="module">
+    import module from "./module.js";
+    console.log("inline module");
+</script>

--- a/python/servo/devtools_tests/sources/worker.js
+++ b/python/servo/devtools_tests/sources/worker.js
@@ -1,1 +1,0 @@
-console.log("external classic worker");


### PR DESCRIPTION
in the devtools protocol, [source forms](https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#loading-script-sources) announced in `resources-available-array` messages can include the `introductionType`, which more or less mirrors the field of the same name in SpiderMonkey’s CompileOptions.

this patch exposes `introductionType` accordingly, allowing us to check for the correct values in automated tests.

Testing: new coverage in devtools tests
Fixes: part of #36027