### PR TITLE
script: Wrap unsafe code in `components/script/bindings` in `unsafe {}`

### DIFF
--- a/components/script/dom/bindings/buffer_source.rs
+++ b/components/script/dom/bindings/buffer_source.rs
@@ -604,7 +604,7 @@ unsafe impl<T> crate::dom::bindings::trace::JSTraceable for HeapBufferSource<T> 
     unsafe fn trace(&self, tracer: *mut js::jsapi::JSTracer) {
         match &self.buffer_source {
             BufferSource::ArrayBufferView(buffer) | BufferSource::ArrayBuffer(buffer) => {
-                buffer.trace(tracer);
+                unsafe { buffer.trace(tracer) };
             },
         }
     }
@@ -879,7 +879,7 @@ impl DataBlock {
             // the exact same line to fix it. Doing the cast is tricky because of the use of
             // a generic type in this parameter.
             #[allow(clippy::from_raw_with_void_ptr)]
-            drop(Arc::from_raw(free_user_data as *const _));
+            drop(unsafe { Arc::from_raw(free_user_data as *const _) });
         }
         let raw: *mut Box<[u8]> = Arc::into_raw(Arc::clone(&self.data)) as _;
         rooted!(in(*cx) let object = unsafe {

--- a/components/script/dom/bindings/cell.rs
+++ b/components/script/dom/bindings/cell.rs
@@ -49,9 +49,11 @@ impl<T> DomRefCell<T> {
     #[allow(unsafe_code)]
     pub(crate) unsafe fn borrow_for_layout(&self) -> &T {
         assert_in_layout();
-        self.value
-            .try_borrow_unguarded()
-            .expect("cell is mutably borrowed")
+        unsafe {
+            self.value
+                .try_borrow_unguarded()
+                .expect("cell is mutably borrowed")
+        }
     }
 
     /// Borrow the contents for the purpose of script deallocation.
@@ -68,7 +70,7 @@ impl<T> DomRefCell<T> {
     #[allow(unsafe_code, clippy::mut_from_ref)]
     pub(crate) unsafe fn borrow_for_script_deallocation(&self) -> &mut T {
         assert_in_script();
-        &mut *self.value.as_ptr()
+        unsafe { &mut *self.value.as_ptr() }
     }
 
     /// Mutably borrow a cell for layout. Ideally this would use
@@ -86,7 +88,7 @@ impl<T> DomRefCell<T> {
     #[allow(unsafe_code, clippy::mut_from_ref)]
     pub(crate) unsafe fn borrow_mut_for_layout(&self) -> &mut T {
         assert_in_layout();
-        &mut *self.value.as_ptr()
+        unsafe { &mut *self.value.as_ptr() }
     }
 }
 

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -179,11 +179,7 @@ impl ErrorInfo {
     }
 
     fn from_dom_exception(object: HandleObject, cx: SafeJSContext) -> Option<ErrorInfo> {
-        let exception = match unsafe { root_from_object::<DOMException>(object.get(), *cx) } {
-            Ok(exception) => exception,
-            Err(_) => return None,
-        };
-
+        let exception = unsafe { root_from_object::<DOMException>(object.get(), *cx).ok()? };
         Some(ErrorInfo {
             filename: "".to_string(),
             message: exception.stringifier().into(),

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -18,13 +18,14 @@ pub(crate) unsafe fn is_platform_object_same_origin(
     cx: SafeJSContext,
     obj: RawHandleObject,
 ) -> bool {
-    let subject_realm = get_context_realm(*cx);
-    let obj_realm = GetObjectRealmOrNull(*obj);
+    let subject_realm = unsafe { get_context_realm(*cx) };
+    let obj_realm = unsafe { GetObjectRealmOrNull(*obj) };
     assert!(!obj_realm.is_null());
 
     let subject_principals =
-        ServoJSPrincipalsRef::from_raw_unchecked(GetRealmPrincipals(subject_realm));
-    let obj_principals = ServoJSPrincipalsRef::from_raw_unchecked(GetRealmPrincipals(obj_realm));
+        unsafe { ServoJSPrincipalsRef::from_raw_unchecked(GetRealmPrincipals(subject_realm)) };
+    let obj_principals =
+        unsafe { ServoJSPrincipalsRef::from_raw_unchecked(GetRealmPrincipals(obj_realm)) };
 
     let subject_origin = subject_principals.origin();
     let obj_origin = obj_principals.origin();

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -71,7 +71,7 @@ impl<T: DomObject> ToLayout<T> for Dom<T> {
     unsafe fn to_layout(&self) -> LayoutDom<T> {
         assert_in_layout();
         LayoutDom {
-            value: self.as_ptr().as_ref().unwrap(),
+            value: unsafe { self.as_ptr().as_ref().unwrap() },
         }
     }
 }
@@ -162,7 +162,7 @@ impl LayoutDom<'_, Node> {
         assert_in_layout();
         let TrustedNodeAddress(addr) = inner;
         LayoutDom {
-            value: &*(addr as *const Node),
+            value: unsafe { &*(addr as *const Node) },
         }
     }
 }
@@ -268,7 +268,7 @@ impl<T: DomObject> MutNullableDom<T> {
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) unsafe fn get_inner_as_layout(&self) -> Option<LayoutDom<T>> {
         assert_in_layout();
-        (*self.ptr.get()).as_ref().map(|js| js.to_layout())
+        unsafe { (*self.ptr.get()).as_ref().map(|js| js.to_layout()) }
     }
 
     /// Get a rooted value out of this object
@@ -385,7 +385,7 @@ impl<T: DomObject> MallocSizeOf for DomOnceCell<T> {
 unsafe impl<T: DomObject> JSTraceable for DomOnceCell<T> {
     unsafe fn trace(&self, trc: *mut JSTracer) {
         if let Some(ptr) = self.ptr.get() {
-            ptr.trace(trc);
+            unsafe { ptr.trace(trc) };
         }
     }
 }
@@ -407,7 +407,7 @@ where
         // This doesn't compile if Dom and LayoutDom don't have the same
         // representation.
         let _ = mem::transmute::<Dom<T>, LayoutDom<T>>;
-        &*(slice as *const [Dom<T>] as *const [LayoutDom<T>])
+        unsafe { &*(slice as *const [Dom<T>] as *const [LayoutDom<T>]) }
     }
 }
 

--- a/components/script/dom/bindings/settings_stack.rs
+++ b/components/script/dom/bindings/settings_stack.rs
@@ -20,7 +20,7 @@ thread_local!(pub(super) static STACK: RefCell<Vec<StackEntry<crate::DomTypeHold
 /// Traces the script settings stack.
 pub(crate) unsafe fn trace(tracer: *mut JSTracer) {
     STACK.with(|stack| {
-        stack.borrow().trace(tracer);
+        unsafe { stack.borrow().trace(tracer) };
     })
 }
 

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -54,7 +54,7 @@ use crate::task::TaskBox;
 
 unsafe impl<T: CustomTraceable> CustomTraceable for DomRefCell<T> {
     unsafe fn trace(&self, trc: *mut JSTracer) {
-        (*self).borrow().trace(trc)
+        unsafe { (*self).borrow().trace(trc) }
     }
 }
 
@@ -193,7 +193,7 @@ unsafe impl<K, V: JSTraceable, S> JSTraceable for HashMapTracedValues<K, V, S> {
     #[inline]
     unsafe fn trace(&self, trc: *mut ::js::jsapi::JSTracer) {
         for v in self.0.values() {
-            v.trace(trc);
+            unsafe { v.trace(trc) };
         }
     }
 }
@@ -247,7 +247,7 @@ pub(crate) fn trace_string(tracer: *mut JSTracer, description: &str, s: &Heap<*m
 
 unsafe impl<T: JSTraceable> JSTraceable for DomRefCell<T> {
     unsafe fn trace(&self, trc: *mut JSTracer) {
-        (*self).borrow().trace(trc)
+        unsafe { (*self).borrow().trace(trc) };
     }
 }
 

--- a/components/script/dom/bindings/weakref.rs
+++ b/components/script/dom/bindings/weakref.rs
@@ -54,12 +54,9 @@ impl<T: WeakReferenceable> MallocSizeOf for MutableWeakRef<T> {
 unsafe impl<T: WeakReferenceable> JSTraceable for MutableWeakRef<T> {
     unsafe fn trace(&self, _: *mut JSTracer) {
         let ptr = self.cell.get();
-        let should_drop = match *ptr {
-            Some(ref value) => !value.is_alive(),
-            None => false,
-        };
-        if should_drop {
-            mem::drop((*ptr).take().unwrap());
+        let value = unsafe { &mut *ptr };
+        if value.as_ref().is_some_and(|value| !value.is_alive()) {
+            mem::drop(value.take().unwrap());
         }
     }
 }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -428,7 +428,8 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         rooted!(in(*cx) let proto_object = prototype.to_object());
         let mut callbacks = {
             let _ac = JSAutoRealm::new(*cx, proto_object.get());
-            match unsafe { self.get_callbacks(proto_object.handle()) } {
+            let callbacks = unsafe { self.get_callbacks(proto_object.handle()) };
+            match callbacks {
                 Ok(callbacks) => callbacks,
                 Err(error) => {
                     self.element_definition_is_running.set(false);


### PR DESCRIPTION
Clippy now checks to see if unsafe code is wrapped in unsafe blocks. We
have this lint disabled for `script` and `script_bindings` because of a
lot of legacy code that doesn't do this. The lint is useful though as it
makes it more obvious what code is unsafe. This is an incremental step
toward being able to turn this lint on for `script`.

This has the benefit of silencing warnings that show up in some IDEs
that use rust-analyzer.

Testing: This should not change behavior at all and is thus covered by
existing tests.
