### PR TITLE
Revert "Include the scrollable overflow of a child box if either its parent or child has `overflow: visible` (#38443)"

### DIFF
--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -24,7 +24,7 @@ use crate::formatting_contexts::Baselines;
 use crate::geom::{
     AuOrAuto, LengthPercentageOrAuto, PhysicalPoint, PhysicalRect, PhysicalSides, ToLogical,
 };
-use crate::style_ext::{AxesOverflow, ComputedValuesExt};
+use crate::style_ext::ComputedValuesExt;
 use crate::table::SpecificTableGridInfo;
 use crate::taffy::SpecificTaffyGridInfo;
 
@@ -271,13 +271,12 @@ impl BoxFragment {
         // overflow together, but from the specification it seems that if the border
         // box of an item is in the "wholly unreachable scrollable overflow region", but
         // its scrollable overflow is not, it should also be excluded.
-        let overflow_style = self.style.effective_overflow(self.base.flags);
         let scrollable_overflow = self
             .children
             .iter()
             .fold(physical_padding_rect, |acc, child| {
                 let scrollable_overflow_from_child = child
-                    .calculate_scrollable_overflow_for_parent(Some(overflow_style))
+                    .calculate_scrollable_overflow_for_parent()
                     .translate(content_origin);
 
                 // Note that this doesn't just exclude scrollable overflow outside the
@@ -360,33 +359,27 @@ impl BoxFragment {
         tree.end_level();
     }
 
-    pub(crate) fn scrollable_overflow_for_parent(
-        &self,
-        parent_overflow_style: Option<AxesOverflow>,
-    ) -> PhysicalRect<Au> {
+    pub(crate) fn scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
         let mut overflow = self.border_rect();
-        let overflow_style = self.style.effective_overflow(self.base.flags);
-        let scrollable_overflow = self.scrollable_overflow();
-        let bottom_right = PhysicalPoint::new(
-            overflow.max_x().max(scrollable_overflow.max_x()),
-            overflow.max_y().max(scrollable_overflow.max_y()),
-        );
+        if !self.style.establishes_scroll_container(self.base.flags) {
+            // https://www.w3.org/TR/css-overflow-3/#scrollable
+            // Only include the scrollable overflow of a child box if it has overflow: visible.
+            let scrollable_overflow = self.scrollable_overflow();
+            let bottom_right = PhysicalPoint::new(
+                overflow.max_x().max(scrollable_overflow.max_x()),
+                overflow.max_y().max(scrollable_overflow.max_y()),
+            );
 
-        // https://www.w3.org/TR/css-overflow-3/#scrollable
-        // For each axis, we only include the scrollable overflow of a child box
-        // if either its parent or child has overflow: visible.
-        if parent_overflow_style.is_some_and(|style| style.y == ComputedOverflow::Visible) ||
-            overflow_style.y == ComputedOverflow::Visible
-        {
-            overflow.origin.y = overflow.origin.y.min(scrollable_overflow.origin.y);
-            overflow.size.height = bottom_right.y - overflow.origin.y;
-        }
+            let overflow_style = self.style.effective_overflow(self.base.flags);
+            if overflow_style.y == ComputedOverflow::Visible {
+                overflow.origin.y = overflow.origin.y.min(scrollable_overflow.origin.y);
+                overflow.size.height = bottom_right.y - overflow.origin.y;
+            }
 
-        if parent_overflow_style.is_some_and(|style| style.x == ComputedOverflow::Visible) ||
-            overflow_style.x == ComputedOverflow::Visible
-        {
-            overflow.origin.x = overflow.origin.x.min(scrollable_overflow.origin.x);
-            overflow.size.width = bottom_right.x - overflow.origin.x;
+            if overflow_style.x == ComputedOverflow::Visible {
+                overflow.origin.x = overflow.origin.x.min(scrollable_overflow.origin.x);
+                overflow.size.width = bottom_right.x - overflow.origin.x;
+            }
         }
 
         if !self

--- a/components/layout/fragment_tree/fragment.rs
+++ b/components/layout/fragment_tree/fragment.rs
@@ -23,7 +23,7 @@ use super::{
 use crate::cell::ArcRefCell;
 use crate::flow::inline::SharedInlineStyles;
 use crate::geom::{LogicalSides, PhysicalPoint, PhysicalRect};
-use crate::style_ext::{AxesOverflow, ComputedValuesExt};
+use crate::style_ext::ComputedValuesExt;
 
 #[derive(Clone, MallocSizeOf)]
 pub(crate) enum Fragment {
@@ -168,19 +168,14 @@ impl Fragment {
                 let fragment = fragment.borrow();
                 fragment.offset_by_containing_block(&fragment.scrollable_overflow())
             },
-            _ => self.scrollable_overflow_for_parent(None),
+            _ => self.scrollable_overflow_for_parent(),
         }
     }
 
-    pub(crate) fn scrollable_overflow_for_parent(
-        &self,
-        parent_overflow_style: Option<AxesOverflow>,
-    ) -> PhysicalRect<Au> {
+    pub(crate) fn scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
         match self {
             Fragment::Box(fragment) | Fragment::Float(fragment) => {
-                return fragment
-                    .borrow()
-                    .scrollable_overflow_for_parent(parent_overflow_style);
+                return fragment.borrow().scrollable_overflow_for_parent();
             },
             Fragment::AbsoluteOrFixedPositioned(_) => PhysicalRect::zero(),
             Fragment::Positioning(fragment) => fragment.borrow().scrollable_overflow_for_parent(),
@@ -190,12 +185,9 @@ impl Fragment {
         }
     }
 
-    pub(crate) fn calculate_scrollable_overflow_for_parent(
-        &self,
-        parent_overflow_style: Option<AxesOverflow>,
-    ) -> PhysicalRect<Au> {
+    pub(crate) fn calculate_scrollable_overflow_for_parent(&self) -> PhysicalRect<Au> {
         self.calculate_scrollable_overflow();
-        self.scrollable_overflow_for_parent(parent_overflow_style)
+        self.scrollable_overflow_for_parent()
     }
 
     pub(crate) fn calculate_scrollable_overflow(&self) {

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -15,7 +15,6 @@ use super::{BoxFragment, ContainingBlockManager, Fragment};
 use crate::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::geom::PhysicalRect;
-use crate::style_ext::ComputedValuesExt;
 
 #[derive(MallocSizeOf)]
 pub struct FragmentTree {
@@ -118,15 +117,8 @@ impl FragmentTree {
             let scrollable_overflow = self.root_fragments.iter().fold(
                 self.initial_containing_block,
                 |overflow, fragment| {
-                    let overflow_style = match fragment {
-                        Fragment::Box(fragment) | Fragment::Float(fragment) => {
-                            let fragment_flags = fragment.borrow().base.flags;
-                            Some(fragment.borrow().style.effective_overflow(fragment_flags))
-                        },
-                        _ => None,
-                    };
                     fragment
-                        .calculate_scrollable_overflow_for_parent(overflow_style)
+                        .calculate_scrollable_overflow_for_parent()
                         .union(&overflow)
                 },
             );

--- a/components/layout/fragment_tree/positioning_fragment.rs
+++ b/components/layout/fragment_tree/positioning_fragment.rs
@@ -79,7 +79,7 @@ impl PositioningFragment {
             |acc, child| {
                 acc.union(
                     &child
-                        .calculate_scrollable_overflow_for_parent(None)
+                        .calculate_scrollable_overflow_for_parent()
                         .translate(self.rect.origin.to_vector()),
                 )
             },

--- a/tests/wpt/meta/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
+++ b/tests/wpt/meta/css/cssom-view/scrolling-quirks-vs-nonquirks.html.ini
@@ -1,0 +1,27 @@
+[scrolling-quirks-vs-nonquirks.html]
+  [scrollWidth/scrollHeight on the root element in non-quirks mode]
+    expected: FAIL
+
+  [scrollWidth/scrollHeight on the root element in quirks mode]
+    expected: FAIL
+
+  [scrollWidth/scrollHeight on the HTML body element in quirks mode]
+    expected: FAIL
+
+  [scroll() on the root element in non-quirks mode]
+    expected: FAIL
+
+  [scrollBy() on the root element in non-quirks mode]
+    expected: FAIL
+
+  [scrollLeft/scrollTop on the root element in non-quirks mode]
+    expected: FAIL
+
+  [scroll() on the HTML body element in quirks mode]
+    expected: FAIL
+
+  [scrollBy() on the HTML body element in quirks mode]
+    expected: FAIL
+
+  [scrollLeft/scrollTop on the HTML body element in quirks mode]
+    expected: FAIL


### PR DESCRIPTION
This reverts commit dcb90bb85eb31c483cd43bfabba235dcea84929d.

This broke scrollable overflow calculation in the following case:

```
<div id="foo" style="width: 200px; height: 200px; outline: solid; overflow: auto;">
    <div style="height: 5000px; background: pink;">hello</div>
</div>
```

In this case the overflow is propagating through the `overflow: auto`
`<div>` and into the parents. When dumping the flow tree I see the root
node being 5000 pixels tall. It's unclear why this change didn't break
any tests, so it's likely that we need to add a test for this case.
