### PR TITLE
devtools: Warn when sending common protocol errors

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::PipelineId;
-use log::debug;
+use log::{debug, warn};
 use serde_json::{Map, Value, json};
 
 use crate::StreamId;
@@ -223,9 +223,14 @@ impl ActorRegistry {
                     actor.handle_message(req, self, msg_type, msg, stream_id)
                 }) {
                     // <https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#error-packets>
-                    let _ = stream.write_json_packet(&json!({
+                    let error = json!({
                         "from": actor.name(), "error": error.name()
-                    }));
+                    });
+                    warn!(
+                        "Sending devtools protocol error: error={:?} request={:?}",
+                        error, msg
+                    );
+                    let _ = stream.write_json_packet(&error);
                 }
             },
         }

--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -226,10 +226,7 @@ impl ActorRegistry {
                     let error = json!({
                         "from": actor.name(), "error": error.name()
                     });
-                    warn!(
-                        "Sending devtools protocol error: error={:?} request={:?}",
-                        error, msg
-                    );
+                    warn!("Sending devtools protocol error: error={error:?} request={msg:?}");
                     let _ = stream.write_json_packet(&error);
                 }
             },


### PR DESCRIPTION
#37686 fixed an entire class of devtools protocol bugs that led to protocol desyncs with warnings in the Servo log, but it also removed the warnings, making it harder to spot where our devtools impl is incomplete.

this patch reintroduces a warning whenever some Actor::handle_message() returns Err(ActorError).

Testing: debug logging only, so not really worth testing
