### PR TITLE
script: Set correct `introductionType` values in more places

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -57,6 +57,8 @@ pub(crate) fn handle_evaluate_js(
         let _ac = enter_realm(global);
         rooted!(in(*cx) let mut rval = UndefinedValue());
         let source_code = SourceCode::Text(Rc::new(DOMString::from_string(eval)));
+        // TODO: run code with SpiderMonkey Debugger API, like Firefox does
+        // <https://searchfox.org/mozilla-central/rev/f6a806c38c459e0e0d797d264ca0e8ad46005105/devtools/server/actors/webconsole/eval-with-debugger.js#270>
         global.evaluate_script_on_global_with_result(
             &source_code,
             "<eval>",
@@ -65,7 +67,7 @@ pub(crate) fn handle_evaluate_js(
             ScriptFetchOptions::default_classic_script(global),
             global.api_base_url(),
             can_gc,
-            None,
+            Some(c"debugger eval"),
         );
 
         if rval.is_undefined() {

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -42,7 +42,7 @@ use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
 use crate::dom::types::HTMLElement;
 use crate::realms::enter_realm;
 use crate::script_module::ScriptFetchOptions;
-use crate::script_runtime::CanGc;
+use crate::script_runtime::{CanGc, IntroductionType};
 
 #[allow(unsafe_code)]
 pub(crate) fn handle_evaluate_js(
@@ -67,7 +67,7 @@ pub(crate) fn handle_evaluate_js(
             ScriptFetchOptions::default_classic_script(global),
             global.api_base_url(),
             can_gc,
-            Some(c"debugger eval"),
+            Some(IntroductionType::DEBUGGER_EVAL),
         );
 
         if rval.is_undefined() {

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -112,6 +112,7 @@ impl DebuggerGlobalScope {
             ScriptFetchOptions::default_classic_script(&self.global_scope),
             self.global_scope.api_base_url(),
             can_gc,
+            None,
         )
     }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2759,6 +2759,7 @@ impl GlobalScope {
         fetch_options: ScriptFetchOptions,
         script_base_url: ServoUrl,
         can_gc: CanGc,
+        introduction_type: Option<&'static CStr>,
     ) -> bool {
         let source_code = SourceCode::Text(Rc::new(DOMString::from_string((*code).to_string())));
         self.evaluate_script_on_global_with_result(
@@ -2769,7 +2770,7 @@ impl GlobalScope {
             fetch_options,
             script_base_url,
             can_gc,
-            None,
+            introduction_type,
         )
     }
 

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -76,7 +76,7 @@ use crate::dom::text::Text;
 use crate::dom::virtualmethods::vtable_for;
 use crate::network_listener::PreInvoke;
 use crate::realms::enter_realm;
-use crate::script_runtime::CanGc;
+use crate::script_runtime::{CanGc, IntroductionType};
 use crate::script_thread::ScriptThread;
 
 mod async_html;
@@ -682,7 +682,9 @@ impl ServoParser {
 
             self.script_nesting_level.set(script_nesting_level + 1);
             script.set_initial_script_text();
-            script.prepare(can_gc);
+            let introduction_type_override =
+                (script_nesting_level > 0).then_some(IntroductionType::INJECTED_SCRIPT);
+            script.prepare(introduction_type_override, can_gc);
             self.script_nesting_level.set(script_nesting_level);
 
             if self.document.has_pending_parsing_blocking_script() {

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -34,7 +34,7 @@ use crate::dom::worklet::WorkletExecutor;
 use crate::messaging::MainThreadScriptMsg;
 use crate::realms::enter_realm;
 use crate::script_module::ScriptFetchOptions;
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::{CanGc, IntroductionType, JSContext};
 
 #[dom_struct]
 /// <https://drafts.css-houdini.org/worklets/#workletglobalscope>
@@ -133,6 +133,7 @@ impl WorkletGlobalScope {
             ScriptFetchOptions::default_classic_script(&self.globalscope),
             self.globalscope.api_base_url(),
             can_gc,
+            Some(IntroductionType::WORKLET),
         )
     }
 

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -1255,6 +1255,9 @@ pub(crate) use script_bindings::script_runtime::CanGc;
 // TODO: squish `scriptElement` <https://searchfox.org/mozilla-central/rev/202069c4c5113a1a9052d84fa4679d4c1b22113e/devtools/server/actors/source.js#199-201>
 pub(crate) struct IntroductionType;
 impl IntroductionType {
+    /// `introductionType` for code loaded by worklet.
+    pub const WORKLET: &CStr = c"Worklet";
+
     /// `introductionType` for code belonging to `<script src="file.js">` elements.
     /// This includes `<script type="module" src="...">`.
     pub const SRC_SCRIPT: &CStr = c"srcScript";
@@ -1262,6 +1265,23 @@ impl IntroductionType {
     /// `introductionType` for code belonging to `<script>code;</script>` elements.
     /// This includes `<script type="module" src="...">`.
     pub const INLINE_SCRIPT: &CStr = c"inlineScript";
+
+    /// `introductionType` for code belonging to scripts that *would* be `"inlineScript"` except that they were not
+    /// part of the initial file itself.
+    /// For example, scripts created via:
+    /// - `document.write("<script>code;</script>")`
+    /// - `var s = document.createElement("script"); s.text = "code";`
+    pub const INJECTED_SCRIPT: &CStr = c"injectedScript";
+
+    /// `introductionType` for code that was loaded indirectly by being imported by another script
+    /// using ESM static or dynamic imports.
+    pub const IMPORTED_MODULE: &CStr = c"importedModule";
+
+    /// `introductionType` for code presented in `javascript:` URLs.
+    pub const JAVASCRIPT_URL: &CStr = c"javascriptURL";
+
+    /// `introductionType` for code passed to `setTimeout`/`setInterval` as a string.
+    pub const DOM_TIMER: &CStr = c"domTimer";
 
     /// `introductionType` for web workers.
     /// <https://searchfox.org/mozilla-central/rev/202069c4c5113a1a9052d84fa4679d4c1b22113e/devtools/docs/user/debugger-api/debugger.source/index.rst#96>

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -1255,6 +1255,10 @@ pub(crate) use script_bindings::script_runtime::CanGc;
 // TODO: squish `scriptElement` <https://searchfox.org/mozilla-central/rev/202069c4c5113a1a9052d84fa4679d4c1b22113e/devtools/server/actors/source.js#199-201>
 pub(crate) struct IntroductionType;
 impl IntroductionType {
+    /// `introductionType` for code evaluated by debugger.
+    /// This includes code run via the devtools repl, even if the thread is not paused.
+    pub const DEBUGGER_EVAL: &CStr = c"debugger eval";
+
     /// `introductionType` for code loaded by worklet.
     pub const WORKLET: &CStr = c"Worklet";
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -154,7 +154,8 @@ use crate::navigation::{InProgressLoad, NavigationListener};
 use crate::realms::enter_realm;
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{
-    CanGc, JSContext, JSContextHelper, Runtime, ScriptThreadEventCategory, ThreadSafeJSContext,
+    CanGc, IntroductionType, JSContext, JSContextHelper, Runtime, ScriptThreadEventCategory,
+    ThreadSafeJSContext,
 };
 use crate::task_queue::TaskQueue;
 use crate::task_source::{SendableTaskSource, TaskSourceName};
@@ -3739,6 +3740,7 @@ impl ScriptThread {
             ScriptFetchOptions::default_classic_script(global_scope),
             global_scope.api_base_url(),
             can_gc,
+            Some(IntroductionType::JAVASCRIPT_URL),
         );
 
         load_data.js_eval_result = if jsval.get().is_string() {
@@ -4093,6 +4095,7 @@ impl ScriptThread {
             ScriptFetchOptions::default_classic_script(global_scope),
             global_scope.api_base_url(),
             can_gc,
+            None, // No known `introductionType` for JS code from embedder
         );
         let result = match jsval_to_webdriver(
             context,

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -35,7 +35,7 @@ use crate::dom::testbinding::TestBindingCallback;
 use crate::dom::types::{Window, WorkerGlobalScope};
 use crate::dom::xmlhttprequest::XHRTimeoutCallback;
 use crate::script_module::ScriptFetchOptions;
-use crate::script_runtime::CanGc;
+use crate::script_runtime::{CanGc, IntroductionType};
 use crate::script_thread::ScriptThread;
 use crate::task_source::SendableTaskSource;
 
@@ -562,6 +562,7 @@ impl JsTimerTask {
                     ScriptFetchOptions::default_classic_script(&global),
                     global.api_base_url(),
                     can_gc,
+                    Some(IntroductionType::DOM_TIMER),
                 );
             },
             InternalTimerCallback::FunctionTimerCallback(ref function, ref arguments) => {

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -529,6 +529,7 @@ pub(crate) fn handle_execute_script(
                 ScriptFetchOptions::default_classic_script(global),
                 global.api_base_url(),
                 can_gc,
+                None, // No known `introductionType` for JS code from WebDriver
             ) {
                 jsval_to_webdriver(cx, global, rval.handle(), realm, can_gc)
             } else {
@@ -570,6 +571,7 @@ pub(crate) fn handle_execute_async_script(
                 ScriptFetchOptions::default_classic_script(global_scope),
                 global_scope.api_base_url(),
                 can_gc,
+                None, // No known `introductionType` for JS code from WebDriver
             ) {
                 reply_sender.send(Err(WebDriverJSError::JSError)).unwrap();
             }


### PR DESCRIPTION
to use the [SpiderMonkey Debugger API](https://firefox-source-docs.mozilla.org/js/Debugger/) as the single source of truth about scripts and their sources for devtools purposes (servo/servo#38334), we need to keep track of whether scripts come from an actual file or from things like setTimeout(), because for some [introductionType](https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Source.html#introductiontype) [values](https://firefox-source-docs.mozilla.org/devtools-user/debugger-api/debugger.source/#accessor-properties-of-the-debugger-source-prototype-object), we want to disregard the script unless it has a [`//# sourceURL=` override](https://tc39.es/ecma426/#sec-linking-eval) ([displayURL](https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Source.html#displayurl)).

this patch builds on #38363, setting the correct introductionType value in several more cases.

Testing: will undergo many automated tests in #38334
Fixes: part of #36027