### PR TITLE
script: Add new worker globals as debuggees

### DIFF
--- a/components/script/dom/debuggerevent.rs
+++ b/components/script/dom/debuggerevent.rs
@@ -8,13 +8,14 @@ use dom_struct::dom_struct;
 use js::jsapi::{JSObject, Value};
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::reflector::DomObject;
+use script_bindings::str::DOMString;
 
 use crate::dom::bindings::codegen::Bindings::DebuggerEventBinding::DebuggerEventMethods;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::event::Event;
-use crate::dom::types::GlobalScope;
+use crate::dom::types::{GlobalScope, PipelineId};
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -22,17 +23,23 @@ use crate::script_runtime::CanGc;
 pub(crate) struct DebuggerEvent {
     event: Event,
     global: Dom<GlobalScope>,
+    pipeline_id: Dom<PipelineId>,
+    worker_id: Option<DOMString>,
 }
 
 impl DebuggerEvent {
     pub(crate) fn new(
         debugger_global: &GlobalScope,
         global: &GlobalScope,
+        pipeline_id: &PipelineId,
+        worker_id: Option<DOMString>,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
         let result = Box::new(Self {
             event: Event::new_inherited(),
             global: Dom::from_ref(global),
+            pipeline_id: Dom::from_ref(pipeline_id),
+            worker_id,
         });
         let result = reflect_dom_object(result, debugger_global, can_gc);
         result.event.init_event("addDebuggee".into(), false, false);
@@ -51,6 +58,16 @@ impl DebuggerEventMethods<crate::DomTypeHolder> for DebuggerEvent {
             .reflector()
             .safe_to_jsval(cx, result.handle_mut());
         NonNull::new(result.to_object()).unwrap()
+    }
+
+    fn PipelineId(
+        &self,
+    ) -> DomRoot<<crate::DomTypeHolder as script_bindings::DomTypes>::PipelineId> {
+        DomRoot::from_ref(&self.pipeline_id)
+    }
+
+    fn GetWorkerId(&self) -> Option<DOMString> {
+        self.worker_id.clone()
     }
 
     fn IsTrusted(&self) -> bool {

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -500,6 +500,7 @@ pub(crate) mod performancepainttiming;
 pub(crate) mod performanceresourcetiming;
 pub(crate) mod permissions;
 pub(crate) mod permissionstatus;
+pub(crate) mod pipelineid;
 pub(crate) mod plugin;
 pub(crate) mod pluginarray;
 #[allow(dead_code)]

--- a/components/script/dom/pipelineid.rs
+++ b/components/script/dom/pipelineid.rs
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use dom_struct::dom_struct;
+
+use crate::dom::bindings::codegen::Bindings::DebuggerEventBinding::PipelineIdMethods;
+use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+pub(crate) struct PipelineId {
+    reflector_: Reflector,
+    #[no_trace]
+    inner: base::id::PipelineId,
+}
+
+impl PipelineId {
+    pub(crate) fn new(
+        global: &GlobalScope,
+        pipeline_id: base::id::PipelineId,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        reflect_dom_object(
+            Box::new(Self {
+                reflector_: Reflector::new(),
+                inner: pipeline_id,
+            }),
+            global,
+            can_gc,
+        )
+    }
+}
+
+impl PipelineIdMethods<crate::DomTypeHolder> for PipelineId {
+    // check-tidy: no specs after this line
+    fn NamespaceId(&self) -> u32 {
+        self.inner.namespace_id.0
+    }
+
+    fn Index(&self) -> u32 {
+        self.inner.index.0.get()
+    }
+}

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -950,7 +950,7 @@ impl ScriptThread {
         };
         let debugger_global = DebuggerGlobalScope::new(
             &js_runtime.clone(),
-            senders.self_sender.clone(),
+            PipelineId::new(),
             senders.devtools_server_sender.clone(),
             senders.memory_profiler_sender.clone(),
             senders.time_profiler_sender.clone(),
@@ -3446,8 +3446,12 @@ impl ScriptThread {
             incomplete.load_data.inherited_secure_context,
             incomplete.theme,
         );
-        self.debugger_global
-            .fire_add_debuggee(can_gc, window.upcast());
+        self.debugger_global.fire_add_debuggee(
+            can_gc,
+            window.upcast(),
+            incomplete.pipeline_id,
+            None,
+        );
 
         let _realm = enter_realm(&*window);
 

--- a/components/script_bindings/webidls/DebuggerEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerEvent.webidl
@@ -7,4 +7,12 @@
 [Exposed=DebuggerGlobalScope]
 interface DebuggerEvent : Event {
     readonly attribute object global;
+    readonly attribute PipelineId pipelineId;
+    readonly attribute DOMString? workerId;
+};
+
+[Exposed=DebuggerGlobalScope]
+interface PipelineId {
+    readonly attribute unsigned long namespaceId;
+    readonly attribute unsigned long index;
 };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -12,7 +12,9 @@
 
 use core::fmt;
 use std::collections::HashMap;
+use std::fmt::Display;
 use std::net::TcpStream;
+use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base::cross_process_instant::CrossProcessInstant;
@@ -488,6 +490,18 @@ impl StartedTimelineMarker {
 }
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct WorkerId(pub Uuid);
+impl Display for WorkerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+impl FromStr for WorkerId {
+    type Err = uuid::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.parse()?))
+    }
+}
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -1,14 +1,42 @@
-if (!("dbg" in this)) {
-    dbg = new Debugger;
-
-    dbg.onNewGlobalObject = function(global) {
-    };
-
-    dbg.onNewScript = function(script, global) {
-    };
+if ("dbg" in this) {
+    throw new Error("Debugger script must not run more than once!");
 }
 
+const dbg = new Debugger;
+const debuggeesToPipelineIds = new Map;
+const debuggeesToWorkerIds = new Map;
+
+dbg.onNewGlobalObject = function(global) {
+};
+
+dbg.onNewScript = function(script, /* undefined; seems to be `script.global` now */ global) {
+    try {
+        // TODO: notify script system about new source
+        /* notifyNewSource */({
+            pipelineId: debuggeesToPipelineIds.get(script.global),
+            workerId: debuggeesToWorkerIds.get(script.global),
+            spidermonkeyId: script.source.id,
+            url: script.source.url,
+            urlOverride: script.source.displayURL,
+            text: script.source.text,
+            introductionType: script.source.introductionType ?? null,
+        });
+    } catch (error) {
+        logError(error);
+    }
+};
+
 addEventListener("addDebuggee", event => {
-    const {global} = event;
+    const {global, pipelineId: {namespaceId, index}, workerId} = event;
     dbg.addDebuggee(global);
+    const debuggerObject = dbg.addDebuggee(global);
+    debuggeesToPipelineIds.set(debuggerObject, {
+        namespaceId,
+        index,
+    });
+    debuggeesToWorkerIds.set(debuggerObject, workerId);
 });
+
+function logError(error) {
+    console.log(`[debugger] ERROR at ${error.fileName}:${error.lineNumber}:${error.columnNumber}: ${error.name}: ${error.message}`);
+}


### PR DESCRIPTION
to debug workers in a page with the [SpiderMonkey Debugger API](https://firefox-source-docs.mozilla.org/js/Debugger/), we need to pass the worker’s global object to [Debugger.prototype.**addDebuggee()**](https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.html#adddebuggee-global). we could pick up the global via the [onNewGlobalObject() hook](https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.html#onnewglobalobject-global), but if our script system passes the global to the debugger script instead, we can later add details like the PipelineId that will help servo identify debuggees that the API is notifying us about (#38334).

this patch creates a debugger global in worker threads, runs the debugger script in those new globals, and plumbs new worker globals from those threads into addDebuggee() via the debugger script. since worker threads can’t generate PipelineId values, but they only ever run workers on behalf of one pipeline, we use that pipeline’s PipelineId as the PipelineId of the debugger global, rather than generating a unique PipelineId like we do in script threads.

Testing: will undergo many automated tests in #38334
Fixes: part of #36027