### PR TITLE
layout: Use FastTransform for hit testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6221,7 +6221,7 @@ dependencies = [
 [[package]]
 name = "peek-poke"
 version = "0.3.0"
-source = "git+https://github.com/servo/webrender?branch=0.67#ae2477d9a6da403e5b5dce8a17415a2cd1563074"
+source = "git+https://github.com/servo/webrender?branch=0.67#15318d6627e91ec19fc0a44a7434b08673413140"
 dependencies = [
  "euclid",
  "peek-poke-derive",
@@ -6230,7 +6230,7 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/webrender?branch=0.67#ae2477d9a6da403e5b5dce8a17415a2cd1563074"
+source = "git+https://github.com/servo/webrender?branch=0.67#15318d6627e91ec19fc0a44a7434b08673413140"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7665,6 +7665,7 @@ dependencies = [
  "euclid",
  "malloc_size_of_derive",
  "servo_malloc_size_of",
+ "webrender",
  "webrender_api",
 ]
 
@@ -9655,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "webrender"
 version = "0.66.0"
-source = "git+https://github.com/servo/webrender?branch=0.67#ae2477d9a6da403e5b5dce8a17415a2cd1563074"
+source = "git+https://github.com/servo/webrender?branch=0.67#15318d6627e91ec19fc0a44a7434b08673413140"
 dependencies = [
  "allocator-api2",
  "bincode",
@@ -9690,7 +9691,7 @@ dependencies = [
 [[package]]
 name = "webrender_api"
 version = "0.66.0"
-source = "git+https://github.com/servo/webrender?branch=0.67#ae2477d9a6da403e5b5dce8a17415a2cd1563074"
+source = "git+https://github.com/servo/webrender?branch=0.67#15318d6627e91ec19fc0a44a7434b08673413140"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -9711,7 +9712,7 @@ dependencies = [
 [[package]]
 name = "webrender_build"
 version = "0.0.2"
-source = "git+https://github.com/servo/webrender?branch=0.67#ae2477d9a6da403e5b5dce8a17415a2cd1563074"
+source = "git+https://github.com/servo/webrender?branch=0.67#15318d6627e91ec19fc0a44a7434b08673413140"
 dependencies = [
  "bitflags 2.9.1",
  "lazy_static",
@@ -10423,7 +10424,7 @@ dependencies = [
 [[package]]
 name = "wr_glyph_rasterizer"
 version = "0.1.0"
-source = "git+https://github.com/servo/webrender?branch=0.67#ae2477d9a6da403e5b5dce8a17415a2cd1563074"
+source = "git+https://github.com/servo/webrender?branch=0.67#15318d6627e91ec19fc0a44a7434b08673413140"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics",
@@ -10448,7 +10449,7 @@ dependencies = [
 [[package]]
 name = "wr_malloc_size_of"
 version = "0.2.0"
-source = "git+https://github.com/servo/webrender?branch=0.67#ae2477d9a6da403e5b5dce8a17415a2cd1563074"
+source = "git+https://github.com/servo/webrender?branch=0.67#15318d6627e91ec19fc0a44a7434b08673413140"
 dependencies = [
  "app_units",
  "euclid",

--- a/components/geometry/Cargo.toml
+++ b/components/geometry/Cargo.toml
@@ -16,4 +16,5 @@ app_units = { workspace = true }
 euclid = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
+webrender = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/geometry/lib.rs
+++ b/components/geometry/lib.rs
@@ -8,9 +8,10 @@ use app_units::{Au, MAX_AU, MIN_AU};
 use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect, Size2D as UntypedSize2D};
 use euclid::{Box2D, Length, Point2D, Scale, SideOffsets2D, Size2D, Vector2D};
 use malloc_size_of_derive::MallocSizeOf;
+use webrender::FastTransform;
 use webrender_api::units::{
-    DeviceIntRect, DeviceIntSize, DevicePixel, FramebufferPixel, LayoutPoint, LayoutRect,
-    LayoutSize,
+    DeviceIntRect, DeviceIntSize, DevicePixel, FramebufferPixel, LayoutPixel, LayoutPoint,
+    LayoutRect, LayoutSize,
 };
 
 // Units for use with euclid::length and euclid::scale_factor.
@@ -45,6 +46,8 @@ pub type DeviceIndependentBox2D = Box2D<f32, DeviceIndependentPixel>;
 pub type DeviceIndependentPoint = Point2D<f32, DeviceIndependentPixel>;
 pub type DeviceIndependentVector2D = Vector2D<f32, DeviceIndependentPixel>;
 pub type DeviceIndependentSize = Size2D<f32, DeviceIndependentPixel>;
+
+pub type FastLayoutTransform = FastTransform<LayoutPixel, LayoutPixel>;
 
 // An Au is an "App Unit" and represents 1/60th of a CSS pixel.  It was
 // originally proposed in 2002 as a standard unit of measure in Gecko.

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -272,7 +272,7 @@ impl DisplayListBuilder<'_> {
                         info.origin,
                         *parent_spatial_node_id,
                         info.transform_style,
-                        PropertyBinding::Value(info.transform),
+                        PropertyBinding::Value(*info.transform.to_transform()),
                         info.kind,
                         spatial_tree_item_key,
                     );

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -234,7 +234,7 @@ impl StackingContextTree {
                 origin,
                 frame_origin_for_query,
                 transform_style,
-                transform,
+                transform: transform.into(),
                 kind,
             }),
         )


### PR DESCRIPTION
`FastTransform` provides faster matrix operations when the involved transforms are just translations.

Testing: Not needed (no change in behavior)
