### PR TITLE
bump mozjs to 137.0-1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3988,9 +3988,9 @@ checksum = "820499e77e852162190608b4f444e7b4552619150eafc39a9e39333d9efae9e1"
 
 [[package]]
 name = "icu_capi"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f73a82a8307633c08ca119631cd90b006e448009da2d4466f7d76ca8fedf3b1"
+checksum = "acc33c4f501b515cdb6b583b31ec009479a4c0cb4cf28dcdfcd54b29069d725e"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
@@ -5243,7 +5243,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#75ba574b452573d8d4275331294556180bd6cea9"
+source = "git+https://github.com/servo/mozjs#1410a4bafe4674ea17b1c4f0053a3e589ebce989"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -5254,8 +5254,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.137.0-0"
-source = "git+https://github.com/servo/mozjs#75ba574b452573d8d4275331294556180bd6cea9"
+version = "0.137.0-1"
+source = "git+https://github.com/servo/mozjs#1410a4bafe4674ea17b1c4f0053a3e589ebce989"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/components/script/window_named_properties.rs
+++ b/components/script/window_named_properties.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::ptr;
+use std::ptr::NonNull;
 use std::sync::LazyLock;
 
 use js::conversions::jsstr_to_string;
@@ -115,7 +116,7 @@ unsafe extern "C" fn get_own_property_descriptor(
     }
 
     let s = if id.is_string() {
-        unsafe { jsstr_to_string(*cx, id.to_string()) }
+        unsafe { jsstr_to_string(*cx, NonNull::new(id.to_string()).unwrap()) }
     } else if id.is_int() {
         // If the property key is an integer index, convert it to a String too.
         // For indexed access on the window object, which may shadow this, see

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -133,7 +133,7 @@ impl FromJSValConvertible for DOMString {
 pub unsafe fn jsstring_to_str(cx: *mut JSContext, s: ptr::NonNull<JSString>) -> DOMString {
     let latin1 = JS_DeprecatedStringHasLatin1Chars(s.as_ptr());
     DOMString::from_string(if latin1 {
-        latin1_to_string(cx, s.as_ptr())
+        latin1_to_string(cx, s)
     } else {
         let mut length = 0;
         let chars = JS_GetTwoByteStringCharsAndLength(cx, ptr::null(), s.as_ptr(), &mut length);


### PR DESCRIPTION
This bump downgrades icu_capi to 1.5.0, to match the version vendored in spidermonkey.

Previous mozjs PRs:
- https://github.com/servo/mozjs/pull/606
- https://github.com/servo/mozjs/pull/605


Testing: Covered by existing tests

