### PR TITLE
script: mark `innerHTML` as fallible in `ShadowRoot`

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -587,7 +587,7 @@ DOMInterfaces = {
 },
 
 'ShadowRoot': {
-    'canGc': ['SetHTMLUnsafe', 'SetInnerHTML', 'GetHTML', 'InnerHTML', 'AdoptedStyleSheets'],
+    'canGc': ['SetHTMLUnsafe', 'SetInnerHTML', 'GetHTML', 'GetInnerHTML', 'AdoptedStyleSheets'],
 },
 
 'StaticRange': {

--- a/components/script_bindings/webidls/ShadowRoot.webidl
+++ b/components/script_bindings/webidls/ShadowRoot.webidl
@@ -29,5 +29,5 @@ partial interface ShadowRoot {
   DOMString getHTML(optional GetHTMLOptions options = {});
 
   // [CEReactions] attribute (TrustedHTML or [LegacyNullToEmptyString] DOMString) innerHTML;
-  [CEReactions] attribute [LegacyNullToEmptyString] DOMString innerHTML;
+  [CEReactions, Throws] attribute [LegacyNullToEmptyString] DOMString innerHTML;
 };


### PR DESCRIPTION
This is a follow-up to #38532 which simply defaulted to an empty string as the spec's WebIDL doesn't mark `innerHTML` as `Throws`. However, since the absence of `Throws` in the spec doesn't imply no-throw, we can mark this as fallible in our WebIDL. This makes the `ShadowRoot`'s implementation match `Element`'s `innerHTML`.

Testing: Same as #38532.