### PR TITLE
script: Change signature of `Event::dispatch` to match the spec and simplify things

### DIFF
--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -24,7 +24,6 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::CustomTraceable;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
-use crate::dom::event::EventStatus;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::{DebuggerEvent, Event};
 #[cfg(feature = "testbinding")]
@@ -126,7 +125,7 @@ impl DebuggerGlobalScope {
         assert_eq!(
             DomRoot::upcast::<Event>(DebuggerEvent::new(self.upcast(), global, can_gc))
                 .fire(self.upcast(), can_gc),
-            EventStatus::NotCanceled,
+            true,
             "Guaranteed by DebuggerEvent::new"
         );
     }

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -122,10 +122,9 @@ impl DebuggerGlobalScope {
     }
 
     pub(crate) fn fire_add_debuggee(&self, can_gc: CanGc, global: &GlobalScope) {
-        assert_eq!(
+        assert!(
             DomRoot::upcast::<Event>(DebuggerEvent::new(self.upcast(), global, can_gc))
                 .fire(self.upcast(), can_gc),
-            true,
             "Guaranteed by DebuggerEvent::new"
         );
     }

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -46,7 +46,7 @@ use crate::dom::bindings::trace::{CustomTraceable, RootedTraceableBox};
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
 use crate::dom::csp::{Violation, parse_csp_list_from_metadata};
 use crate::dom::errorevent::ErrorEvent;
-use crate::dom::event::{Event, EventBubbles, EventCancelable, EventStatus};
+use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::messageevent::MessageEvent;
@@ -731,11 +731,9 @@ impl DedicatedWorkerGlobalScope {
                 HandleValue::null(),
                 CanGc::note(),
             );
-            let event_status =
-                event.upcast::<Event>().fire(worker.upcast::<EventTarget>(), CanGc::note());
 
             // Step 2.
-            if event_status == EventStatus::NotCanceled {
+            if event.upcast::<Event>().fire(worker.upcast::<EventTarget>(), CanGc::note()) {
                 global.report_an_error(error_info, HandleValue::null(), CanGc::note());
             }
         }));

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2393,13 +2393,8 @@ impl Document {
             false,
             can_gc,
         );
-        let event = event.upcast::<Event>();
-        let result = event.fire(&target, can_gc);
 
-        match result {
-            EventStatus::Canceled => TouchEventResult::Processed(false),
-            EventStatus::NotCanceled => TouchEventResult::Processed(true),
-        }
+        TouchEventResult::Processed(event.upcast::<Event>().fire(&target, can_gc))
     }
 
     // If hittest fails, we still need to update the active point information.

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3022,8 +3022,7 @@ impl Document {
             );
             let event = event.upcast::<Event>();
             event.set_trusted(true);
-            let _ = self
-                .window
+            self.window
                 .dispatch_event_with_target_override(event, can_gc);
             // Step 6 Update the visibility state of oldDocument to "hidden".
             self.update_visibility_state(DocumentVisibilityState::Hidden, can_gc);
@@ -3040,8 +3039,7 @@ impl Document {
             event.set_trusted(true);
             let event_target = self.window.upcast::<EventTarget>();
             let has_listeners = event_target.has_listeners_for(&atom!("unload"));
-            let _ = self
-                .window
+            self.window
                 .dispatch_event_with_target_override(&event, can_gc);
             self.fired_unload.set(true);
             // Step 9

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -151,7 +151,7 @@ use crate::dom::element::{
     CustomElementCreationMode, Element, ElementCreator, ElementPerformFullscreenEnter,
     ElementPerformFullscreenExit,
 };
-use crate::dom::event::{Event, EventBubbles, EventCancelable, EventDefault, EventStatus};
+use crate::dom::event::{Event, EventBubbles, EventCancelable, EventDefault};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::focusevent::FocusEvent;
 use crate::dom::fontfaceset::FontFaceSet;
@@ -1678,11 +1678,12 @@ impl Document {
             vec![],                   // predicted_events
             can_gc,
         );
-        let event = menu_event.upcast::<Event>();
-        event.fire(target, can_gc);
 
-        // if the event was not canceled, notify the embedder to show the context menu
-        if event.status() == EventStatus::NotCanceled {
+        // Step 3. Let result = dispatch menuevent at target.
+        let result = menu_event.upcast::<Event>().fire(target, can_gc);
+
+        // Step 4. If result is true, then show the UA context menu
+        if result {
             let (sender, receiver) =
                 ipc::channel::<ContextMenuResult>().expect("Failed to create IPC channel.");
             self.send_to_embedder(EmbedderMsg::ShowContextMenu(

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -629,15 +629,7 @@ impl Event {
         }
 
         // Step 12 Return false if event’s canceled flag is set; otherwise true.
-        self.status() == EventStatus::NotCanceled
-    }
-
-    pub(crate) fn status(&self) -> EventStatus {
-        if self.DefaultPrevented() {
-            EventStatus::Canceled
-        } else {
-            EventStatus::NotCanceled
-        }
+        !self.DefaultPrevented()
     }
 
     #[inline]
@@ -1103,12 +1095,6 @@ pub(crate) enum EventDefault {
     /// The event has been handled somewhere in the DOM, and it should be prevented from being
     /// re-handled elsewhere. This doesn't affect the judgement of `DefaultPrevented`
     Handled,
-}
-
-#[derive(Debug, PartialEq)]
-pub(crate) enum EventStatus {
-    Canceled,
-    NotCanceled,
 }
 
 /// <https://dom.spec.whatwg.org/#concept-event-fire>

--- a/components/script/dom/event.rs
+++ b/components/script/dom/event.rs
@@ -279,7 +279,7 @@ impl Event {
         legacy_target_override: bool,
         can_gc: CanGc,
         // TODO legacy_did_output_listeners_throw_flag for indexeddb
-    ) -> EventStatus {
+    ) -> bool {
         let mut target = DomRoot::from_ref(target);
 
         // Step 1. Set event’s dispatch flag.
@@ -629,7 +629,7 @@ impl Event {
         }
 
         // Step 12 Return false if event’s canceled flag is set; otherwise true.
-        self.status()
+        self.status() == EventStatus::NotCanceled
     }
 
     pub(crate) fn status(&self) -> EventStatus {
@@ -673,8 +673,8 @@ impl Event {
         self.composed.set(composed);
     }
 
-    /// <https://html.spec.whatwg.org/multipage/#fire-a-simple-event>
-    pub(crate) fn fire(&self, target: &EventTarget, can_gc: CanGc) -> EventStatus {
+    /// <https://dom.spec.whatwg.org/#firing-events>
+    pub(crate) fn fire(&self, target: &EventTarget, can_gc: CanGc) -> bool {
         self.set_trusted(true);
         target.dispatch_event(self, can_gc)
     }

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -57,7 +57,7 @@ use crate::dom::csp::{CspReporting, InlineCheckType};
 use crate::dom::document::Document;
 use crate::dom::element::Element;
 use crate::dom::errorevent::ErrorEvent;
-use crate::dom::event::{Event, EventBubbles, EventCancelable, EventComposed, EventStatus};
+use crate::dom::event::{Event, EventBubbles, EventCancelable, EventComposed};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlformelement::FormControlElementHelpers;
 use crate::dom::node::{Node, NodeTraits};
@@ -430,7 +430,7 @@ impl EventTarget {
             .map_or(EventListeners(vec![]), |listeners| listeners.clone())
     }
 
-    pub(crate) fn dispatch_event(&self, event: &Event, can_gc: CanGc) -> EventStatus {
+    pub(crate) fn dispatch_event(&self, event: &Event, can_gc: CanGc) -> bool {
         event.dispatch(self, false, can_gc)
     }
 
@@ -994,10 +994,7 @@ impl EventTargetMethods<crate::DomTypeHolder> for EventTarget {
             return Err(Error::InvalidState);
         }
         event.set_trusted(false);
-        Ok(match self.dispatch_event(event, can_gc) {
-            EventStatus::Canceled => false,
-            EventStatus::NotCanceled => true,
-        })
+        Ok(self.dispatch_event(event, can_gc))
     }
 }
 

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -1381,7 +1381,7 @@ impl HTMLScriptElement {
         bubbles: EventBubbles,
         cancelable: EventCancelable,
         can_gc: CanGc,
-    ) -> EventStatus {
+    ) -> bool {
         let window = self.owner_window();
         let event = Event::new(window.upcast(), type_, bubbles, cancelable, can_gc);
         event.fire(self.upcast(), can_gc)

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -65,7 +65,7 @@ use crate::dom::element::{
     referrer_policy_for_element, reflect_cross_origin_attribute, reflect_referrer_policy_attribute,
     set_cross_origin_attribute,
 };
-use crate::dom::event::{Event, EventBubbles, EventCancelable, EventStatus};
+use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::node::{ChildrenMutation, CloneChildrenFlag, Node, NodeTraits};

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -130,7 +130,7 @@ use crate::dom::cssstyledeclaration::{CSSModificationAccess, CSSStyleDeclaration
 use crate::dom::customelementregistry::CustomElementRegistry;
 use crate::dom::document::{AnimationFrameCallback, Document};
 use crate::dom::element::Element;
-use crate::dom::event::{Event, EventBubbles, EventCancelable, EventStatus};
+use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::gamepad::{Gamepad, contains_user_gesture};
 use crate::dom::gamepadevent::GamepadEventType;
@@ -705,12 +705,8 @@ impl Window {
     }
 
     // see note at https://dom.spec.whatwg.org/#concept-event-dispatch step 2
-    pub(crate) fn dispatch_event_with_target_override(
-        &self,
-        event: &Event,
-        can_gc: CanGc,
-    ) -> EventStatus {
-        event.dispatch(self.upcast(), true, can_gc)
+    pub(crate) fn dispatch_event_with_target_override(&self, event: &Event, can_gc: CanGc) {
+        event.dispatch(self.upcast(), true, can_gc);
     }
 
     pub(crate) fn font_context(&self) -> &Arc<FontContext> {

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -74,7 +74,7 @@ use crate::dom::bindings::root::trace_roots;
 use crate::dom::bindings::utils::DOM_CALLBACKS;
 use crate::dom::bindings::{principals, settings_stack};
 use crate::dom::csp::CspReporting;
-use crate::dom::event::{Event, EventBubbles, EventCancelable, EventStatus};
+use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
@@ -559,10 +559,11 @@ pub(crate) fn notify_about_rejected_promises(global: &GlobalScope) {
                             CanGc::note()
                         );
 
-                        let event_status = event.upcast::<Event>().fire(&target, CanGc::note());
+                        let not_canceled = event.upcast::<Event>().fire(&target, CanGc::note());
 
-                        // Step 4-3.
-                        if event_status == EventStatus::Canceled {
+                        // Step 4-3. If notCanceled is true, then the user agent
+                        // may report p.[[PromiseResult]] to a developer console.
+                        if not_canceled {
                             // TODO: The promise rejection is not handled; we need to add it back to the list.
                         }
 


### PR DESCRIPTION
- [Dispatch Event](https://dom.spec.whatwg.org/#concept-event-dispatch) should return a Boolean. This function is used frequently in spec and the change makes things easier to follow.
- Remove `enum EventStatus` and related functions.
- Update some dead spec link.
- Update some steps.

This is intended as cleanup before working on #38435 and reduces binary size by 488KB in Release profile.

Testing: No behaviour change.