### PR TITLE
script: Rename DebuggerEvent to DebuggerAddDebuggeeEvent

### DIFF
--- a/components/script/dom/debuggeradddebuggeeevent.rs
+++ b/components/script/dom/debuggeradddebuggeeevent.rs
@@ -10,7 +10,7 @@ use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::reflector::DomObject;
 use script_bindings::str::DOMString;
 
-use crate::dom::bindings::codegen::Bindings::DebuggerEventBinding::DebuggerEventMethods;
+use crate::dom::bindings::codegen::Bindings::DebuggerAddDebuggeeEventBinding::DebuggerAddDebuggeeEventMethods;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -20,14 +20,14 @@ use crate::script_runtime::CanGc;
 
 #[dom_struct]
 /// Event for Rust → JS calls in [`crate::dom::DebuggerGlobalScope`].
-pub(crate) struct DebuggerEvent {
+pub(crate) struct DebuggerAddDebuggeeEvent {
     event: Event,
     global: Dom<GlobalScope>,
     pipeline_id: Dom<PipelineId>,
     worker_id: Option<DOMString>,
 }
 
-impl DebuggerEvent {
+impl DebuggerAddDebuggeeEvent {
     pub(crate) fn new(
         debugger_global: &GlobalScope,
         global: &GlobalScope,
@@ -48,7 +48,7 @@ impl DebuggerEvent {
     }
 }
 
-impl DebuggerEventMethods<crate::DomTypeHolder> for DebuggerEvent {
+impl DebuggerAddDebuggeeEventMethods<crate::DomTypeHolder> for DebuggerAddDebuggeeEvent {
     // check-tidy: no specs after this line
     fn Global(&self, cx: script_bindings::script_runtime::JSContext) -> NonNull<JSObject> {
         // Convert the debuggee global’s reflector to a Value, wrapping it from its originating realm (debuggee realm)

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -23,7 +23,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::types::{DebuggerEvent, Event};
+use crate::dom::types::{DebuggerAddDebuggeeEvent, Event};
 #[cfg(feature = "testbinding")]
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
@@ -132,7 +132,7 @@ impl DebuggerGlobalScope {
     ) {
         let debuggee_pipeline_id =
             crate::dom::pipelineid::PipelineId::new(self.upcast(), debuggee_pipeline_id, can_gc);
-        let event = DomRoot::upcast::<Event>(DebuggerEvent::new(
+        let event = DomRoot::upcast::<Event>(DebuggerAddDebuggeeEvent::new(
             self.upcast(),
             debuggee_global,
             &debuggee_pipeline_id,
@@ -141,7 +141,7 @@ impl DebuggerGlobalScope {
         ));
         assert!(
             DomRoot::upcast::<Event>(event).fire(self.upcast(), can_gc),
-            "Guaranteed by DebuggerEvent::new"
+            "Guaranteed by DebuggerAddDebuggeeEvent::new"
         );
     }
 }

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -289,7 +289,7 @@ pub(crate) mod customevent;
 pub(crate) mod datatransfer;
 pub(crate) mod datatransferitem;
 pub(crate) mod datatransferitemlist;
-pub(crate) mod debuggerevent;
+pub(crate) mod debuggeradddebuggeeevent;
 pub(crate) mod debuggerglobalscope;
 pub(crate) mod dedicatedworkerglobalscope;
 pub(crate) mod defaultteereadrequest;

--- a/components/script/dom/pipelineid.rs
+++ b/components/script/dom/pipelineid.rs
@@ -4,7 +4,7 @@
 
 use dom_struct::dom_struct;
 
-use crate::dom::bindings::codegen::Bindings::DebuggerEventBinding::PipelineIdMethods;
+use crate::dom::bindings::codegen::Bindings::DebuggerAddDebuggeeEventBinding::PipelineIdMethods;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;

--- a/components/script_bindings/webidls/DebuggerAddDebuggeeEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerAddDebuggeeEvent.webidl
@@ -5,7 +5,7 @@
 // This interface is entirely internal to Servo, and should not be accessible to
 // web pages.
 [Exposed=DebuggerGlobalScope]
-interface DebuggerEvent : Event {
+interface DebuggerAddDebuggeeEvent : Event {
     readonly attribute object global;
     readonly attribute PipelineId pipelineId;
     readonly attribute DOMString? workerId;


### PR DESCRIPTION
the next debugger script event, `getPossibleBreakpoints` (#37667), will contain a single attribute `unsigned long spidermonkeyId`, so it will have nothing in common with `addDebuggee`. this patch renames the latter accordingly.

Testing: no behaviour changes other than the rename, so no tests needed
Fixes: part of #36027