### PR TITLE
layout: Paint flex and grid items like inline blocks

### DIFF
--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -930,7 +930,8 @@ struct OverflowFrameData {
 
 impl BoxFragment {
     fn get_stacking_context_type(&self) -> Option<StackingContextType> {
-        if self.style.establishes_stacking_context(self.base.flags) {
+        let flags = self.base.flags;
+        if self.style.establishes_stacking_context(flags) {
             return Some(StackingContextType::RealStackingContext);
         }
 
@@ -943,7 +944,10 @@ impl BoxFragment {
             return Some(StackingContextType::FloatStackingContainer);
         }
 
-        if self.is_atomic_inline_level() {
+        // Flex and grid items are painted like inline blocks.
+        // <https://drafts.csswg.org/css-flexbox-1/#painting>
+        // <https://drafts.csswg.org/css-grid/#z-order>
+        if self.is_atomic_inline_level() || flags.contains(FragmentFlags::IS_FLEX_OR_GRID_ITEM) {
             return Some(StackingContextType::AtomicInlineStackingContainer);
         }
 

--- a/tests/wpt/meta/css/css-flexbox/flexbox-items-as-stacking-contexts-002.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-items-as-stacking-contexts-002.html.ini
@@ -1,2 +1,0 @@
-[flexbox-items-as-stacking-contexts-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-mbp-horiz-003-reverse.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-mbp-horiz-003-reverse.xhtml.ini
@@ -1,3 +1,0 @@
-[flexbox-mbp-horiz-003-reverse.xhtml]
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-mbp-horiz-003.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-mbp-horiz-003.xhtml.ini
@@ -1,3 +1,0 @@
-[flexbox-mbp-horiz-003.xhtml]
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/meta/css/css-flexbox/flexbox-mbp-horiz-003v.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-mbp-horiz-003v.xhtml.ini
@@ -1,3 +1,0 @@
-[flexbox-mbp-horiz-003v.xhtml]
-  expected:
-    if os == "linux": FAIL

--- a/tests/wpt/meta/css/css-flexbox/hittest-overlapping-margin.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/hittest-overlapping-margin.html.ini
@@ -1,4 +1,0 @@
-[hittest-overlapping-margin.html]
-  [Flexboxes should perform hit testing in reverse paint order for overlapping elements: negative margin case (crbug.com/844505)]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/css-flexbox/hittest-overlapping-order.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/hittest-overlapping-order.html.ini
@@ -1,4 +1,0 @@
-[hittest-overlapping-order.html]
-  [Flexboxes should perform hit testing in reverse paint order for overlapping elements: flex order case (crbug.com/844505)]
-    expected: FAIL
-

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-inline-items-inline-blocks-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-inline-items-inline-blocks-001.html.ini
@@ -1,2 +1,0 @@
-[grid-inline-items-inline-blocks-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-items/grid-items-inline-blocks-001.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-items/grid-items-inline-blocks-001.html.ini
@@ -1,2 +1,0 @@
-[grid-items-inline-blocks-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/grid-model/grid-item-hit-test.html.ini
+++ b/tests/wpt/meta/css/css-grid/grid-model/grid-item-hit-test.html.ini
@@ -1,3 +1,0 @@
-[grid-item-hit-test.html]
-  [grid-item-hit-test]
-    expected: FAIL


### PR DESCRIPTION
As specified in https://drafts.csswg.org/css-flexbox-1/#painting and https://drafts.csswg.org/css-grid/#z-order

Testing: Makes some WPT pass.
Fixes: #38573