### PR TITLE
script: Tell devtools whether a node is displayed or not

### DIFF
--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -92,13 +92,8 @@ impl Actor for InspectorActor {
                     .clone()
                     .unwrap_or_else(|| registry.new_name("walker"));
 
-                let root = root_info.encode(
-                    registry,
-                    false,
-                    self.script_chan.clone(),
-                    pipeline,
-                    name.clone(),
-                );
+                let root =
+                    root_info.encode(registry, self.script_chan.clone(), pipeline, name.clone());
 
                 if self.walker.borrow().is_none() {
                     let walker = WalkerActor {

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -156,7 +156,6 @@ impl Actor for WalkerActor {
                         .map(|child| {
                             child.encode(
                                 registry,
-                                true,
                                 self.script_chan.clone(),
                                 self.pipeline,
                                 self.name(),
@@ -182,7 +181,6 @@ impl Actor for WalkerActor {
                     .ok_or(ActorError::Internal)?;
                 let node = doc_elem_info.encode(
                     registry,
-                    true,
                     self.script_chan.clone(),
                     self.pipeline,
                     self.name(),
@@ -319,7 +317,7 @@ pub fn find_child(
     let children = rx.recv().unwrap().ok_or(vec![])?;
 
     for child in children {
-        let msg = child.encode(registry, true, script_chan.clone(), pipeline, name.into());
+        let msg = child.encode(registry, script_chan.clone(), pipeline, name.into());
         if compare_fn(&msg) {
             hierarchy.push(msg);
             return Ok(hierarchy);

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1320,6 +1320,10 @@ impl Node {
             is_shadow_host,
             shadow_root_mode,
             display,
+            // It is not entirely clear when this should be set to false.
+            // Firefox considers nodes with "display: contents" to be displayed.
+            // The doctype node is displayed despite being `display: none`.
+            is_displayed: !self.is_display_none() || self.is::<DocumentType>(),
             doctype_name: self
                 .downcast::<DocumentType>()
                 .map(DocumentType::name)

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -149,6 +149,10 @@ pub struct NodeInfo {
     pub shadow_root_mode: Option<ShadowRootMode>,
     pub is_shadow_host: bool,
     pub display: Option<String>,
+    /// Whether this node is currently displayed.
+    ///
+    /// For example, the node might have `display: none`.
+    pub is_displayed: bool,
 
     /// The `DOCTYPE` name if this is a `DocumentType` node, `None` otherwise
     pub doctype_name: Option<String>,


### PR DESCRIPTION
Doing so makes the devtools inspector display the nodes in gray, as it is the case in firefox.
The relevant node parameter already exists but is hardcoded.

Before:
<img width="1108" height="408" alt="image" src="https://github.com/user-attachments/assets/4a442fc9-92db-4a97-9e70-3b02f994a9d1" />


After:
<img width="1169" height="404" alt="image" src="https://github.com/user-attachments/assets/ec1674a4-c025-4ceb-93c8-0cc3f695ddc7" />


Testing: We don't have tests for the devtools inspector.

