### PR TITLE
script: Replace `allow(unused_imports)` with conditional `use` statements

### DIFF
--- a/components/script/dom/webglframebuffer.rs
+++ b/components/script/dom/webglframebuffer.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![allow(unused_imports)]
-
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 use std::cell::Cell;
 
@@ -12,6 +10,7 @@ use canvas_traits::webgl::{
     WebGLRenderbufferId, WebGLResult, WebGLTextureId, WebGLVersion, webgl_channel,
 };
 use dom_struct::dom_struct;
+#[cfg(feature = "webxr")]
 use euclid::Size2D;
 use script_bindings::weakref::WeakRef;
 #[cfg(feature = "webxr")]
@@ -21,7 +20,9 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
-use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+#[cfg(feature = "webxr")]
+use crate::dom::bindings::root::MutNullableDom;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::webglobject::WebGLObject;
 use crate::dom::webglrenderbuffer::WebGLRenderbuffer;
 use crate::dom::webglrenderingcontext::{Operation, WebGLRenderingContext};

--- a/components/script/dom/webgltexture.rs
+++ b/components/script/dom/webgltexture.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#![allow(unused_imports)]
-
 // https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
 
 use std::cell::Cell;
@@ -20,7 +18,9 @@ use crate::dom::bindings::codegen::Bindings::EXTTextureFilterAnisotropicBinding:
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
-use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+#[cfg(feature = "webxr")]
+use crate::dom::bindings::root::Dom;
+use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::webgl_validations::types::TexImageTarget;
 use crate::dom::webglframebuffer::WebGLFramebuffer;
 use crate::dom::webglobject::WebGLObject;


### PR DESCRIPTION
A few places in the code are using a blanket `allow(unused_imports)`
compiler directive to silence errors about unused imports when the
`webxr` feature is disabled. Since this can hide other kinds of unused
imports, replace these directives with conditional `use` statements.

Testing: No behavior change, so existing tests suffice.
