### PR TITLE
servo: Bidirectional MessagePort communication with webview content

### DIFF
--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -74,10 +74,12 @@ mod from_compositor {
                 Self::SetWebViewThrottled(_, _) => target!("SetWebViewThrottled"),
                 Self::SetScrollStates(..) => target!("SetScrollStates"),
                 Self::PaintMetric(..) => target!("PaintMetric"),
-                Self::EvaluateJavaScript(..) => target!("EvaluateJavaScript"),
+                Self::EvaluateJavaScript { .. } => target!("EvaluateJavaScript"),
                 Self::CreateMemoryReport(..) => target!("CreateMemoryReport"),
                 Self::SendImageKeysForPipeline(..) => target!("SendImageKeysForPipeline"),
                 Self::SetWebDriverResponseSender(..) => target!("SetWebDriverResponseSender"),
+                Self::CreateEntangledMessagePorts(..) => target!("CreateEntangledMessagePorts"),
+                Self::PostMessage(..) => target!("PostMessage"),
             }
         }
     }
@@ -249,6 +251,7 @@ mod from_script {
                 Self::FinishJavaScriptEvaluation(..) => {
                     target_variant!("FinishJavaScriptEvaluation")
                 },
+                Self::PostMessage(..) => target_variant!("PostMessage"),
             }
         }
     }

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -8,7 +8,7 @@ use std::ptr;
 use std::rc::Rc;
 
 use base::id::{MessagePortId, MessagePortIndex};
-use constellation_traits::{MessagePortImpl, PortMessageTask};
+use constellation_traits::{MessagePortImpl, PortMessageTask, PostMessageData};
 use dom_struct::dom_struct;
 use js::jsapi::{Heap, JS_NewObject, JSObject};
 use js::jsval::UndefinedValue;
@@ -30,7 +30,9 @@ use crate::dom::bindings::utils::set_dictionary_property;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::js::conversions::ToJSValConvertible;
+use crate::realms::{InRealm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::webdriver_handlers::jsval_to_webdriver;
 
 #[dom_struct]
 /// The MessagePort used in the DOM.
@@ -41,6 +43,7 @@ pub(crate) struct MessagePort {
     #[no_trace]
     entangled_port: RefCell<Option<MessagePortId>>,
     detached: Cell<bool>,
+    forbid_structured_clone: bool,
 }
 
 impl MessagePort {
@@ -50,6 +53,7 @@ impl MessagePort {
             entangled_port: RefCell::new(None),
             detached: Cell::new(false),
             message_port_id,
+            forbid_structured_clone: false,
         }
     }
 
@@ -60,10 +64,11 @@ impl MessagePort {
     }
 
     /// Create a new port for an incoming transfer-received one.
-    pub(crate) fn new_transferred(
+    fn new_transferred(
         owner: &GlobalScope,
         transferred_port: MessagePortId,
         entangled_port: Option<MessagePortId>,
+        forbid_structured_clone: bool,
         can_gc: CanGc,
     ) -> DomRoot<MessagePort> {
         reflect_dom_object(
@@ -72,6 +77,7 @@ impl MessagePort {
                 eventtarget: EventTarget::new_inherited(),
                 detached: Cell::new(false),
                 entangled_port: RefCell::new(entangled_port),
+                forbid_structured_clone,
             }),
             owner,
             can_gc,
@@ -148,7 +154,22 @@ impl MessagePort {
         }
 
         // Step 5
-        let data = structuredclone::write(cx, message, Some(transfer))?;
+        let data = if self.forbid_structured_clone {
+            let realm = enter_realm(self);
+            PostMessageData::Serialized(
+                (&jsval_to_webdriver(
+                    cx,
+                    &self.global(),
+                    message,
+                    InRealm::entered(&realm),
+                    CanGc::note(),
+                )
+                .map_err(|_| Error::InvalidState)?)
+                    .into(),
+            )
+        } else {
+            PostMessageData::StructuredClone(structuredclone::write(cx, message, Some(transfer))?)
+        };
 
         if doomed {
             // TODO: The spec says to optionally report such a case to a dev console.
@@ -280,8 +301,13 @@ impl Transferable for MessagePort {
         id: MessagePortId,
         port_impl: MessagePortImpl,
     ) -> Result<DomRoot<Self>, ()> {
-        let transferred_port =
-            MessagePort::new_transferred(owner, id, port_impl.entangled_port_id(), CanGc::note());
+        let transferred_port = MessagePort::new_transferred(
+            owner,
+            id,
+            port_impl.entangled_port_id(),
+            port_impl.forbid_structured_clone(),
+            CanGc::note(),
+        );
         owner.track_message_port(&transferred_port, Some(port_impl));
         Ok(transferred_port)
     }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1994,6 +1994,8 @@ impl Window {
         const ARG_NAMES: &[*const c_char] = &[c"port".as_ptr()];
         let options = unsafe { CompileOptionsWrapper::new(*cx, self.get_url().as_str(), 0) };
         let scopechain = RootedObjectVectorWrapper::new(*cx);
+        //let body = format!("return (function(port) {{ return {body} }})()");
+        //let body = format!("return {body}");
         rooted!(in(*cx) let mut compiled = unsafe {
             CompileFunction1(
                 *cx,
@@ -2005,8 +2007,10 @@ impl Window {
                 &mut transform_str_to_source_text(&body),
             )
         });
+        assert!(!compiled.get().is_null());
 
         rooted!(in(*cx) let mut function = unsafe { JS_GetFunctionObject(compiled.get())});
+        assert!(!function.get().is_null());
         let callback = unsafe { EmbedderEvaluateJSCallback::new(cx, function.get()) };
 
         callback.Call_(self, port, rval, ExceptionHandling::Report, can_gc)

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -91,7 +91,7 @@ impl MixedMessage {
                 #[cfg(feature = "webgpu")]
                 ScriptThreadMessage::SetWebGPUPort(..) => None,
                 ScriptThreadMessage::SetScrollStates(id, ..) => Some(*id),
-                ScriptThreadMessage::EvaluateJavaScript(id, _, _) => Some(*id),
+                ScriptThreadMessage::EvaluateJavaScript { pipeline_id, .. } => Some(*pipeline_id),
                 ScriptThreadMessage::SendImageKeysBatch(..) => None,
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {

--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -168,6 +168,8 @@ interface mixin WindowLocalStorage {
 };
 Window includes WindowLocalStorage;
 
+callback EmbedderEvaluateJSCallback = any (MessagePort? port);
+
 // http://w3c.github.io/animation-timing/#framerequestcallback
 callback FrameRequestCallback = undefined (DOMHighResTimeStamp time);
 

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -15,6 +15,8 @@ use servo::{Servo, ServoBuilder};
 
 macro_rules! run_api_tests {
     ($($test_function:ident), +) => {
+        env_logger::init();
+
         let mut failed = false;
 
         // Be sure that `servo_test` is dropped before exiting early.
@@ -39,6 +41,7 @@ pub(crate) fn run_test(
     servo_test: &ServoTest,
     failed: &mut bool,
 ) {
+    println!("Starting {test_name}");
     match test_function(servo_test) {
         Ok(_) => println!("    ✅ {test_name}"),
         Err(error) => {

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -3,14 +3,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::path::PathBuf;
+use std::rc::Rc;
 
 use base::id::PipelineId;
 use constellation_traits::EmbedderToConstellationMessage;
 use embedder_traits::{
     AllowOrDeny, AuthenticationResponse, ContextMenuResult, Cursor, FilterPattern,
-    GamepadHapticEffectType, InputMethodType, KeyboardEvent, LoadStatus, MediaSessionEvent,
-    Notification, PermissionFeature, RgbColor, ScreenGeometry, SelectElementOptionOrOptgroup,
-    SimpleDialog, TraversalId, WebResourceRequest, WebResourceResponse, WebResourceResponseMsg,
+    GamepadHapticEffectType, InputMethodType, JSValue, KeyboardEvent, LoadStatus,
+    MediaSessionEvent, Notification, PermissionFeature, RgbColor, ScreenGeometry,
+    SelectElementOptionOrOptgroup, SimpleDialog, TraversalId, WebResourceRequest,
+    WebResourceResponse, WebResourceResponseMsg,
 };
 use ipc_channel::ipc::IpcSender;
 use serde::Serialize;
@@ -18,7 +20,7 @@ use url::Url;
 use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 
 use crate::responders::ServoErrorSender;
-use crate::{ConstellationProxy, WebView};
+use crate::{ConstellationProxy, MessagePort, WebView};
 
 /// A request to navigate a [`WebView`] or one of its inner frames. This can be handled
 /// asynchronously. If not handled, the request will automatically be allowed.
@@ -586,6 +588,15 @@ pub trait WebViewDelegate {
 
     /// Request to display a notification.
     fn show_notification(&self, _webview: WebView, _notification: Notification) {}
+
+    ///
+    fn message_port_onmessage(
+        &self,
+        _webview: WebView,
+        _message_port: Rc<MessagePort>,
+        _data: JSValue,
+    ) {
+    }
 }
 
 pub(crate) struct DefaultWebViewDelegate;

--- a/components/shared/constellation/structured_data/transferable.rs
+++ b/components/shared/constellation/structured_data/transferable.rs
@@ -66,17 +66,26 @@ pub struct MessagePortImpl {
 
     /// The UUID of this port.
     message_port_id: MessagePortId,
+
+    ///
+    forbid_structured_clone: bool,
 }
 
 impl MessagePortImpl {
     /// Create a new messageport impl.
-    pub fn new(port_id: MessagePortId) -> MessagePortImpl {
+    pub fn new(port_id: MessagePortId, forbid_structured_clone: bool) -> MessagePortImpl {
         MessagePortImpl {
             state: MessagePortState::Disabled(false),
             entangled_port: None,
             message_buffer: None,
             message_port_id: port_id,
+            forbid_structured_clone,
         }
+    }
+
+    ///
+    pub fn forbid_structured_clone(&self) -> bool {
+        self.forbid_structured_clone
     }
 
     /// Get the Id.

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -20,7 +20,7 @@ use std::hash::Hash;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use base::id::{PipelineId, ScrollTreeNodeId, WebViewId};
+use base::id::{MessagePortId, PipelineId, ScrollTreeNodeId, WebViewId};
 use crossbeam_channel::Sender;
 use euclid::{Point2D, Scale, Size2D};
 use http::{HeaderMap, Method, StatusCode};
@@ -452,6 +452,8 @@ pub enum EmbedderMsg {
         JavaScriptEvaluationId,
         Result<JSValue, JavaScriptEvaluationError>,
     ),
+    ///
+    PostMessage(MessagePortId, JSValue),
 }
 
 impl Debug for EmbedderMsg {
@@ -972,7 +974,7 @@ impl Display for FocusSequenceNumber {
 #[derive(Clone, Copy, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct JavaScriptEvaluationId(pub usize);
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum JSValue {
     Undefined,
     Null,

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -21,8 +21,8 @@ use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
 use compositing_traits::CrossProcessCompositorApi;
 use constellation_traits::{
-    LoadData, NavigationHistoryBehavior, ScriptToConstellationChan, StructuredSerializedData,
-    WindowSizeType,
+    LoadData, MessagePortImpl, NavigationHistoryBehavior, ScriptToConstellationChan,
+    StructuredSerializedData, WindowSizeType,
 };
 use crossbeam_channel::{RecvTimeoutError, Sender};
 use devtools_traits::ScriptToDevtoolsControlMsg;
@@ -250,7 +250,16 @@ pub enum ScriptThreadMessage {
     SetScrollStates(PipelineId, HashMap<ExternalScrollId, LayoutVector2D>),
     /// Evaluate the given JavaScript and return a result via a corresponding message
     /// to the Constellation.
-    EvaluateJavaScript(PipelineId, JavaScriptEvaluationId, String),
+    EvaluateJavaScript {
+        /// The pipeline in which to evaluate this JS.
+        pipeline_id: PipelineId,
+        /// A unique identifier for this evaluation operation.
+        evaluation_id: JavaScriptEvaluationId,
+        /// The JS source to evaluate.
+        script: String,
+        /// A transferred message port to provide as an argument when evaluating the JS.
+        message_port: Option<MessagePortImpl>,
+    },
     /// A new batch of keys for the image cache for the specific pipeline.
     SendImageKeysBatch(PipelineId, Vec<ImageKey>),
 }

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -851,9 +851,11 @@ class CommandBase(object):
             # See https://github.com/servo/servo/issues/35072#issuecomment-2600749483
             features += ["crown"]
 
-        if "-p" not in cargo_args:  # We're building specific package, that may not have features
+        print(cargo_args)
+        if True or "-p" not in cargo_args:  # We're building specific package, that may not have features
+            print("features: " + str(list(self.features)))
             features += list(self.features)
-            if self.enable_media:
+            if False and self.enable_media:
                 features.append("media-gstreamer")
             if self.config["build"]["debug-mozjs"] or debug_mozjs:
                 features.append("debugmozjs")
@@ -874,6 +876,9 @@ class CommandBase(object):
         # but uv venv on Windows only provides a `python`, not `python3`.
         env["PYTHON3"] = "python"
 
+        print("!!!!!")
+        print(args)
+        print("!!!!!")
         if capture_output:
             return subprocess.run(["cargo", command] + args + cargo_args, env=env, capture_output=capture_output)
 


### PR DESCRIPTION
These changes expose a new embedding API for evaluating JS that makes an entangled MessagePort object available inside the JS scope. The corresponding entangled MessagePort is made available to the embedder, providing an asynchronous, bidrectional communication channel between the embedder and whatever content is loaded in a webview.

This PR is a draft because this is the first successful attempt at addressing this use case, but I want feedback on whether it's too restrictive.

Testing: New unit tests added.
Fixes: #35665
