### PR TITLE
python: Update pyOpenSSL to 24

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -19,7 +19,7 @@ colorama == 0.3.7
 
 # For package uploading
 boto3 == 1.34.95
-pyOpenSSL == 23.0.0
+pyOpenSSL == 24.0.0
 PyGithub == 1.58.1
 
 # For Python3 compatibility


### PR DESCRIPTION
WPT updated something and we need to update pyOpenSSL to 24 to make deps resolvable.
This fixes WPT Imports: https://github.com/servo/servo/actions/runs/16855379913/job/47753105229

Testing: WPT import run: https://github.com/servo/servo/actions/runs/16859665646
