### PR TITLE
Update Nom to 8.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,7 +1150,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -5427,7 +5427,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "net_traits",
- "nom",
+ "nom 8.0.0",
  "pixels",
  "profile_traits",
  "rayon",
@@ -5534,6 +5534,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -7167,7 +7176,7 @@ dependencies = [
  "mozangle",
  "mozjs",
  "net_traits",
- "nom",
+ "nom 8.0.0",
  "num-traits",
  "num_cpus",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ mime_guess = "2.0.5"
 mozangle = "0.5.3"
 net_traits = { path = "components/shared/net" }
 nix = "0.29"
-nom = "7.1.3"
+nom = "8.0.0"
 num-traits = "0.2"
 num_cpus = "1.17.0"
 openxr = "0.19"

--- a/deny.toml
+++ b/deny.toml
@@ -189,6 +189,11 @@ skip = [
 
     # duplicated by zbus-xml
     "quick-xml",
+
+    # duplicated by bindgen as build dependency
+    # Remove when cexpr updates its nom version
+    # and bindgen updates the cexpr version
+    "nom",
 ]
 
 # github.com organizations to allow git sources for


### PR DESCRIPTION
There are two relevant breaking changes:
* instead of `)(input)`, we now need to call `).parse(input)`
* tuples are no longer a call, but a `()` call.

There is one other usage of nom 7, however that's in the build dependencies list of mozangle via bindgen. Therefore, we won't have duplicate nom versions in Servo binary.