### PR TITLE
script: Focus on mousedown instead of mouse click according to spec

### DIFF
--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -222,6 +222,7 @@ impl MouseEvent {
     }
 
     /// Create a [MouseEvent] triggered by the embedder
+    /// <https://w3c.github.io/uievents/#create-a-cancelable-mouseevent-id>
     pub(crate) fn for_platform_mouse_event(
         event: embedder_traits::MouseButtonEvent,
         pressed_mouse_buttons: u16,

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/navigate.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/navigate.py.ini
@@ -1,9 +1,17 @@
 [navigate.py]
-  expected: TIMEOUT
-  [test_link_hash]
+  [test_link_from_toplevel_context_with_target[_blank\]]
     expected: FAIL
 
-  [test_link_from_toplevel_context_with_target[_blank\]]
+  [test_link_from_nested_context_with_target[]]
+    expected: FAIL
+
+  [test_link_from_nested_context_with_target[_parent]]
+    expected: FAIL
+
+  [test_link_from_nested_context_with_target[_self]]
+    expected: FAIL
+
+  [test_link_from_nested_context_with_target[_top]]
     expected: FAIL
 
   [test_link_from_toplevel_context_with_target[_parent\]]

--- a/tests/wpt/meta/webdriver/tests/classic/element_send_keys/user_prompts.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_send_keys/user_prompts.py.ini
@@ -7,3 +7,9 @@
 
   [test_dismiss[prompt-None\]]
     expected: FAIL
+
+  [test_accept[alert-None\]]
+    expected: FAIL
+
+  [test_dismiss[confirm-False\]]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/forward/forward.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/forward/forward.py.ini
@@ -10,3 +10,6 @@
 
   [test_seen_nodes[https coop\]]
     expected: FAIL
+
+  [test_removed_iframe]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/navigation.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/navigation.py.ini
@@ -1,3 +1,4 @@
 [navigation.py]
+  expected: TIMEOUT
   [test_pointer]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_modifier_click.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_modifier_click.py.ini
@@ -1,0 +1,3 @@
+[pointer_modifier_click.py]
+  [test_many_modifiers_click]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/set_window_rect/set.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/set_window_rect/set.py.ini
@@ -4,3 +4,6 @@
 
   [test_set_to_available_size]
     expected: FAIL
+
+  [test_negative_x_y]
+    expected: FAIL


### PR DESCRIPTION
- Focus on mousedown instead of mouse click according to [spec](https://w3c.github.io/uievents/#handle-native-mouse-down)
- Refactor to follow spec closer and make things more clear.
- Add some spec link.
- Remove some dead spec link.

Still some preparation before implementing #38435.
Testing: No regression in WebDriver & WPT. But update some outdated test.
Fixes: #38588 