### PR TITLE
webdriver: Add handle user prompt for some command

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -949,11 +949,19 @@ impl Handler {
     }
 
     fn handle_is_enabled(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
-        let (sender, receiver) = ipc::channel().unwrap();
+        // Step 1. If session's current browsing context is no longer open,
+        // return error with error code no such window.
+        let browsing_context = self.session()?.browsing_context_id;
+        self.verify_browsing_context_is_open(browsing_context)?;
 
+        // Step 2. Try to handle any user prompts with session.
+        let webview_id = self.session()?.webview_id;
+        self.handle_any_user_prompts(webview_id)?;
+
+        let (sender, receiver) = ipc::channel().unwrap();
         self.browsing_context_script_command(
             WebDriverScriptCommand::IsEnabled(element.to_string(), sender),
-            VerifyBrowsingContextIsOpen::Yes,
+            VerifyBrowsingContextIsOpen::No,
         )?;
 
         match wait_for_ipc_response(receiver)? {
@@ -965,11 +973,19 @@ impl Handler {
     }
 
     fn handle_is_selected(&self, element: &WebElement) -> WebDriverResult<WebDriverResponse> {
-        let (sender, receiver) = ipc::channel().unwrap();
+        // Step 1. If session's current browsing context is no longer open,
+        // return error with error code no such window.
+        let browsing_context = self.session()?.browsing_context_id;
+        self.verify_browsing_context_is_open(browsing_context)?;
 
+        // Step 2. Try to handle any user prompts with session.
+        let webview_id = self.session()?.webview_id;
+        self.handle_any_user_prompts(webview_id)?;
+
+        let (sender, receiver) = ipc::channel().unwrap();
         self.browsing_context_script_command(
             WebDriverScriptCommand::IsSelected(element.to_string(), sender),
-            VerifyBrowsingContextIsOpen::Yes,
+            VerifyBrowsingContextIsOpen::No,
         )?;
 
         match wait_for_ipc_response(receiver)? {
@@ -2241,13 +2257,7 @@ impl Handler {
     }
 
     fn take_screenshot(&self, rect: Option<Rect<f32, CSSPixel>>) -> WebDriverResult<String> {
-        // Step 1. If session's current top-level browsing context is no longer open,
-        // return error with error code no such window.
         let webview_id = self.session()?.webview_id;
-        self.verify_top_level_browsing_context_is_open(webview_id)?;
-
-        self.handle_any_user_prompts(webview_id)?;
-
         let mut img = None;
 
         let interval = 1000;
@@ -2300,6 +2310,14 @@ impl Handler {
     }
 
     fn handle_take_screenshot(&self) -> WebDriverResult<WebDriverResponse> {
+        // Step 1. If session's current top-level browsing context is no longer open,
+        // return error with error code no such window.
+        let webview_id = self.session()?.webview_id;
+        self.verify_top_level_browsing_context_is_open(webview_id)?;
+
+        self.handle_any_user_prompts(webview_id)?;
+
+        // Step 2
         let encoded = self.take_screenshot(None)?;
 
         Ok(WebDriverResponse::Generic(ValueResponse(
@@ -2313,13 +2331,24 @@ impl Handler {
     ) -> WebDriverResult<WebDriverResponse> {
         let (sender, receiver) = ipc::channel().unwrap();
 
+        // Step 1. If session's current top-level browsing context is no longer open,
+        // return error with error code no such window.
+        let webview_id = self.session()?.webview_id;
+        self.verify_top_level_browsing_context_is_open(webview_id)?;
+
+        // Step 2. Try to handle any user prompts with session.
+        self.handle_any_user_prompts(webview_id)?;
+
+        // Step 3 - 4
         let cmd = WebDriverScriptCommand::GetBoundingClientRect(element.to_string(), sender);
-        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::Yes)?;
+        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
 
         match wait_for_ipc_response(receiver)? {
             Ok(rect) => {
+                // Step 5
                 let encoded = self.take_screenshot(Some(Rect::from_untyped(&rect)))?;
 
+                // Step 6 return success with data encoded string.
                 Ok(WebDriverResponse::Generic(ValueResponse(
                     serde_json::to_value(encoded)?,
                 )))

--- a/tests/wpt/meta/webdriver/tests/classic/is_element_enabled/user_prompts.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/is_element_enabled/user_prompts.py.ini
@@ -1,2 +1,0 @@
-[user_prompts.py]
-  expected: TIMEOUT

--- a/tests/wpt/meta/webdriver/tests/classic/is_element_selected/user_prompts.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/is_element_selected/user_prompts.py.ini
@@ -1,2 +1,0 @@
-[user_prompts.py]
-  expected: TIMEOUT

--- a/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/user_prompts.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/user_prompts.py.ini
@@ -1,2 +1,0 @@
-[user_prompts.py]
-  expected: TIMEOUT


### PR DESCRIPTION
- When taking element screenshot, we should handle the user prompt before getting the element bounding rectangle
- Handle user prompt for `is element enabled` and `is element selected`

Testing: `./tests/wpt/tests/webdriver/tests/classic/{take_element_screenshot, is_element_enabled, is_element_selected}/user_prompts.py`
