### PR TITLE
tidy: Replace custom `panic`/`unwrap` lint with clippy lint

### DIFF
--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -16,6 +16,10 @@ default = []
 tracing = ["dep:tracing"]
 webxr = ["dep:webxr"]
 
+[lints.clippy]
+unwrap_used = "deny"
+panic = "deny"
+
 [dependencies]
 base = { workspace = true }
 bincode = { workspace = true }

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -20,6 +20,10 @@ vello = ["canvas/vello"]
 vello_cpu = ["canvas/vello_cpu"]
 raqote = ["canvas/raqote"]
 
+[lints.clippy]
+unwrap_used = "deny"
+panic = "deny"
+
 [dependencies]
 background_hang_monitor = { path = "../background_hang_monitor" }
 background_hang_monitor_api = { workspace = true }

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -4,6 +4,9 @@
 
 //! A winit window implementation.
 
+#![deny(clippy::panic)]
+#![deny(clippy::unwrap_used)]
+
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::env;
@@ -118,7 +121,10 @@ impl Window {
             winit_window.set_window_icon(Some(load_icon(icon_bytes)));
         }
 
-        Window::force_srgb_color_space(winit_window.window_handle().unwrap().as_raw());
+        let window_handle = winit_window
+            .window_handle()
+            .expect("winit window did not have a window handle");
+        Window::force_srgb_color_space(window_handle.as_raw());
 
         let monitor = winit_window
             .current_monitor()
@@ -153,7 +159,9 @@ impl Window {
         }
 
         // Make sure the gl context is made current.
-        window_rendering_context.make_current().unwrap();
+        window_rendering_context
+            .make_current()
+            .expect("Could not make window RenderingContext current");
 
         let rendering_context = Rc::new(window_rendering_context.offscreen_context(inner_size));
 
@@ -405,7 +413,10 @@ impl Window {
                 }
             })
             .shortcut(CMD_OR_CONTROL, 'T', || {
-                state.create_and_focus_toplevel_webview(Url::parse("servo:newtab").unwrap());
+                state.create_and_focus_toplevel_webview(
+                    Url::parse("servo:newtab")
+                        .expect("Should be able to unconditionally parse 'servo:newtab' as URL"),
+                );
             })
             .shortcut(CMD_OR_CONTROL, 'Q', || state.servo().start_shutting_down())
             .otherwise(|| handled = false);
@@ -425,7 +436,7 @@ impl Window {
                 unsafe {
                     let view = handle.ns_view.cast::<NSView>().as_ref();
                     view.window()
-                        .unwrap()
+                        .expect("Should have a window")
                         .setColorSpace(Some(&NSColorSpace::sRGBColorSpace()));
                 }
             }
@@ -888,7 +899,9 @@ impl servo::webxr::glwindow::GlWindow for XRWindow {
     }
 
     fn display_handle(&self) -> raw_window_handle::DisplayHandle {
-        self.winit_window.display_handle().unwrap()
+        self.winit_window
+            .display_handle()
+            .expect("Every window should have a display handle")
     }
 }
 

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -4,6 +4,9 @@
 
 //! A headless window implementation.
 
+#![deny(clippy::panic)]
+#![deny(clippy::unwrap_used)]
+
 use std::cell::Cell;
 use std::rc::Rc;
 

--- a/python/tidy/test.py
+++ b/python/tidy/test.py
@@ -124,8 +124,6 @@ class CheckTidiness(unittest.TestCase):
         self.assertEqual("use &T instead of &DomRoot<T>", next(errors)[2])
         self.assertEqual("encountered function signature with -> ()", next(errors)[2])
         self.assertEqual("operators should go at the end of the first line", next(errors)[2])
-        self.assertEqual("unwrap() or panic!() found in code which should not panic.", next(errors)[2])
-        self.assertEqual("unwrap() or panic!() found in code which should not panic.", next(errors)[2])
         self.assertNoMoreErrors(errors)
 
         feature_errors = tidy.collect_errors_for_files(iterFile("lib.rs"), [], [tidy.check_rust], print_text=False)

--- a/python/tidy/tests/rust_tidy.rs
+++ b/python/tidy/tests/rust_tidy.rs
@@ -78,8 +78,4 @@ impl test {
     } else {
         let xif = 42 in {  xif  } // Should not trigger
     }
-
-    let option = Some(3);
-    println!("{}", option.unwrap());
-    panic!("What a way to end.");
 }

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -557,20 +557,8 @@ def check_rust(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:
     import_block = False
     whitespace = False
 
-    PANIC_NOT_ALLOWED_PATHS = [
-        os.path.join("*", "components", "compositing", "compositor.rs"),
-        os.path.join("*", "components", "constellation", "*"),
-        os.path.join("*", "ports", "servoshell", "headed_window.rs"),
-        os.path.join("*", "ports", "servoshell", "headless_window.rs"),
-        os.path.join("*", "ports", "servoshell", "embedder.rs"),
-        os.path.join("*", "rust_tidy.rs"),  # This is for the tests.
-    ]
-    is_panic_not_allowed_rs_file = any([fnmatch.fnmatch(file_name, path) for path in PANIC_NOT_ALLOWED_PATHS])
-
     prev_open_brace = False
     multi_line_string = False
-
-    panic_message = "unwrap() or panic!() found in code which should not panic."
 
     for idx, original_line in enumerate(map(lambda line: line.decode("utf-8"), lines)):
         # simplify the analysis
@@ -659,11 +647,6 @@ def check_rust(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:
         if prev_open_brace and not line:
             yield (idx + 1, "found an empty line following a {")
         prev_open_brace = line.endswith("{")
-
-        if is_panic_not_allowed_rs_file:
-            match = re.search(r"unwrap\(|panic!\(", line)
-            if match:
-                yield (idx + 1, panic_message)
 
 
 # Avoid flagging <Item=Foo> constructs


### PR DESCRIPTION
This change replaces our custom `panic` / `unwrap` lint with the one
from clippy. This rule as not properly applied in servoshell, so this
change fixes some clippy errors raised by the new configuration.

Testing: This change removes the tidy tests for the custom lints, but
otherwise the behavior is tested as part of clippy itself.
