### PR TITLE
Request for Comments: Multiple Rendering Contexts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,10 +244,10 @@ codegen-units = 1
 #
 # Or for WebRender:
 #
-# [patch."https://github.com/servo/webrender"]
-# webrender = { path = "../webrender/webrender" }
-# webrender_api = { path = "../webrender/webrender_api" }
-# wr_malloc_size_of = { path = "../webrender/wr_malloc_size_of" }
+#[patch."https://github.com/servo/webrender"]
+#webrender = { path = "../webrender/webrender" }
+#webrender_api = { path = "../webrender/webrender_api" }
+#wr_malloc_size_of = { path = "../webrender/wr_malloc_size_of" }
 #
 # Or for another Git dependency:
 #

--- a/components/compositing/webview_manager.rs
+++ b/components/compositing/webview_manager.rs
@@ -2,87 +2,454 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use core::panic;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use std::collections::hash_map::{Entry, Values, ValuesMut};
+use std::collections::hash_map::{Values, ValuesMut};
+use std::rc::Rc;
 
-use base::id::WebViewId;
+use base::id::{RenderingGroupId, WebViewId};
+use compositing_traits::rendering_context::RenderingContext;
+use compositing_traits::{CompositorMsg, CompositorProxy};
+use euclid::Size2D;
+use gleam::gl::Gl;
+use log::{error, info};
+use servo_config::pref;
+use webrender::{
+    RenderApi, RenderApiSender, ShaderPrecacheFlags, Transaction, UploadMethod, VertexUsageHint,
+    WebRenderOptions,
+};
+use webrender_api::units::DevicePixel;
+use webrender_api::{
+    ColorF, DocumentId, FramePublishId, FrameReadyParams, IdNamespace, RenderNotifier,
+};
 
+use crate::compositor::RepaintReason;
 use crate::webview_renderer::UnknownWebView;
 
-#[derive(Debug)]
-pub struct WebViewManager<WebView> {
-    /// Our top-level browsing contexts. In the WebRender scene, their pipelines are the children of
-    /// a single root pipeline that also applies any pinch zoom transformation.
-    webviews: HashMap<WebViewId, WebView>,
-
-    /// The order to paint them in, topmost last.
-    pub(crate) painting_order: Vec<WebViewId>,
+pub(crate) struct WebRenderInstance {
+    pub(crate) rendering_context: Rc<dyn RenderingContext>,
+    pub(crate) webrender: webrender::Renderer,
+    pub(crate) webrender_gl: Rc<dyn Gl>,
+    pub(crate) webrender_document: DocumentId,
+    pub(crate) webrender_api: RenderApi,
+    pub(crate) needs_repaint: Cell<RepaintReason>,
+    sender: RenderApiSender,
+    notifier: MyRenderNotifier,
 }
 
-impl<WebView> Default for WebViewManager<WebView> {
-    fn default() -> Self {
-        Self {
-            webviews: Default::default(),
-            painting_order: Default::default(),
+struct MyRenderNotifier {
+    frame_ready_msg: RefCell<Vec<(DocumentId, bool)>>,
+    sender: CompositorProxy,
+    group_id: RenderingGroupId,
+}
+
+impl MyRenderNotifier {
+    pub fn new(sender: CompositorProxy, group_id: RenderingGroupId) -> MyRenderNotifier {
+        MyRenderNotifier {
+            frame_ready_msg: RefCell::new(vec![]),
+            sender,
+            group_id,
         }
     }
 }
 
+impl webrender_api::RenderNotifier for MyRenderNotifier {
+    fn clone(&self) -> Box<dyn webrender_api::RenderNotifier> {
+        Box::new(MyRenderNotifier {
+            frame_ready_msg: self.frame_ready_msg.clone(),
+            sender: self.sender.clone(),
+            group_id: self.group_id.clone(),
+        })
+    }
+
+    fn wake_up(&self, _composite_needed: bool) {}
+
+    fn new_frame_ready(
+        &self,
+        document_id: DocumentId,
+        _: FramePublishId,
+        frame_ready_params: &FrameReadyParams,
+    ) {
+        self.sender.send(CompositorMsg::NewWebRenderFrameReady(
+            document_id,
+            self.group_id.clone(),
+            frame_ready_params.render,
+        ));
+        log::info!("RenderNotifier push from {document_id:?}");
+    }
+}
+
+pub(crate) struct WebViewManager<WebView> {
+    /// Our top-level browsing contexts. In the WebRender scene, their pipelines are the children of
+    /// a single root pipeline that also applies any pinch zoom transformation.
+    webviews: HashMap<WebViewId, WebView>,
+
+    rendering_contexts: HashMap<RenderingGroupId, WebRenderInstance>,
+
+    webview_groups: HashMap<WebViewId, RenderingGroupId>,
+
+    /// The order to paint them in, topmost last.
+    painting_order: HashMap<RenderingGroupId, Vec<WebViewId>>,
+
+    last_used_id: Option<RenderingGroupId>,
+
+    sender: CompositorProxy,
+}
+
 impl<WebView> WebViewManager<WebView> {
-    pub fn remove(&mut self, webview_id: WebViewId) -> Result<WebView, UnknownWebView> {
-        self.painting_order.retain(|b| *b != webview_id);
+    pub(crate) fn new(sender: CompositorProxy) -> Self {
+        Self {
+            webviews: Default::default(),
+            painting_order: Default::default(),
+            webview_groups: Default::default(),
+            rendering_contexts: Default::default(),
+            last_used_id: None,
+            sender,
+        }
+    }
+}
+
+fn gl_error_panic(_gl: &dyn Gl, s: &str, e: gleam::gl::GLenum) {
+    panic!("FOUND GL ERROR s: {:?}, e: {:?}", s, e);
+}
+
+impl<WebView> WebViewManager<WebView> {
+    pub(crate) fn rendering_contexts(&self) -> impl Iterator<Item = &WebRenderInstance> {
+        self.rendering_contexts.iter().map(|(_, v)| v)
+    }
+
+    pub(crate) fn clear_background(&self, webview_group_id: RenderingGroupId) {
+        let rtc = self.rendering_contexts.get(&webview_group_id).unwrap();
+        rtc.rendering_context.make_current().expect("Make current");
+        let gl = &rtc.webrender_gl;
+
+        {
+            debug_assert_eq!(
+                (
+                    gl.get_error(),
+                    gl.check_frame_buffer_status(gleam::gl::FRAMEBUFFER)
+                ),
+                (gleam::gl::NO_ERROR, gleam::gl::FRAMEBUFFER_COMPLETE)
+            );
+        }
+
+        // Always clear the entire RenderingContext, regardless of how many WebViews there are
+        // or where they are positioned. This is so WebView actually clears even before the
+        // first WebView is ready.
+        let color = servo_config::pref!(shell_background_color_rgba);
+
+        gl.clear_color(
+            color[0] as f32,
+            color[1] as f32,
+            color[2] as f32,
+            color[3] as f32,
+        );
+        gl.clear(gleam::gl::COLOR_BUFFER_BIT);
+    }
+
+    pub(crate) fn needs_repaint(&self) -> RepaintReason {
+        let mut repaint_reason = RepaintReason::default();
+        for i in self.rendering_contexts.values() {
+            repaint_reason = i.needs_repaint.get().union(repaint_reason);
+        }
+        repaint_reason
+    }
+
+    pub(crate) fn send_transaction(&mut self, webview_id: WebViewId, transaction: Transaction) {
+        let gid = self.group_id(webview_id).unwrap();
+        self.send_transaction_to_group(gid, transaction);
+    }
+
+    pub(crate) fn assert_no_gl_error(&self, group_id: RenderingGroupId) {
+        let rtc = self
+            .rendering_contexts
+            .get(&group_id)
+            .expect(&format!("No group {:?}", group_id));
+        debug_assert_eq!(rtc.webrender_gl.get_error(), gleam::gl::NO_ERROR);
+    }
+
+    pub(crate) fn send_transaction_to_group(
+        &mut self,
+        gid: RenderingGroupId,
+        transaction: Transaction,
+    ) {
+        self.assert_no_gl_error(gid.clone());
+        let rect = self.rendering_contexts.get_mut(&gid).unwrap();
+        rect.webrender_api
+            .send_transaction(rect.webrender_document, transaction);
+    }
+
+    // This sends the transaction to the namespace id. It requires that the namespace id is unique
+    // and no multiple webrender instances are using it. Panics if the given id has multiple groups with
+    // the same id.
+    pub(crate) fn send_transaction_to_namespace_id(
+        &mut self,
+        transaction: Transaction,
+        id: IdNamespace,
+    ) {
+        let mut namespace_ids = self
+            .rendering_contexts
+            .iter()
+            .filter(|(_group, instance)| instance.webrender_api.get_namespace_id() == id);
+        assert_eq!(namespace_ids.clone().count(), 1);
+
+        if let Some((group, _instance)) = namespace_ids.next() {
+            self.send_transaction_to_group(group.clone(), transaction);
+        } else {
+            error!("Could not find namespace, something is wrong");
+        }
+    }
+
+    // Flush scene builder for all rendering groups
+    pub(crate) fn flush_scene_builder(&self) {
+        for (key, i) in self.rendering_contexts.iter() {
+            self.assert_no_gl_error(key.clone());
+            i.webrender_api.flush_scene_builder();
+        }
+    }
+
+    // Deinit all groups
+    pub(crate) fn deinit(&mut self) {
+        for (_group_id, webrender_instance) in self.rendering_contexts.drain() {
+            webrender_instance
+                .rendering_context
+                .make_current()
+                .expect("Foo");
+            webrender_instance.webrender.deinit();
+        }
+        self.last_used_id = None;
+        self.painting_order.clear();
+        self.webviews.clear();
+        self.webview_groups.clear();
+    }
+
+    fn group_painting_order_mut(&mut self, webview_id: WebViewId) -> &mut Vec<WebViewId> {
+        let group_id = self.webview_groups.get(&webview_id).unwrap();
+        self.painting_order.get_mut(group_id).unwrap()
+    }
+
+    pub(crate) fn webrender_instance(&self, group_id: RenderingGroupId) -> &WebRenderInstance {
+        self.assert_no_gl_error(group_id.clone());
+        self.rendering_contexts.get(&group_id).unwrap()
+    }
+
+    // Gets the `DocumentId` for a `WebViewId`
+    #[allow(unused)]
+    pub(crate) fn document_id(&self, webview_id: &WebViewId) -> DocumentId {
+        self.webview_groups
+            .get(webview_id)
+            .and_then(|rgid| {
+                self.assert_no_gl_error(rgid.clone());
+                self.rendering_contexts.get(rgid)
+            })
+            .map(|rg| rg.webrender_document)
+            .expect("Could not find")
+    }
+
+    pub(crate) fn render_instance(&self, group_id: RenderingGroupId) -> &WebRenderInstance {
+        if let Some(wr) = self.rendering_contexts.get(&group_id) {
+            wr
+        } else {
+            panic!("Could not find WebrenderInstance with group id {group_id:?}");
+        }
+    }
+
+    pub(crate) fn render_instance_mut(
+        &mut self,
+        group_id: RenderingGroupId,
+    ) -> &mut WebRenderInstance {
+        self.assert_no_gl_error(group_id.clone());
+        if let Some(wr) = self.rendering_contexts.get_mut(&group_id) {
+            wr
+        } else {
+            panic!("Could not find WebRenderInstance with group id {group_id:?}");
+        }
+    }
+
+    fn webrender_options(&self, id: RenderingGroupId) -> WebRenderOptions {
+        let clear_color = ColorF::new(1.0, 1.0, 1.0, 1.0);
+        webrender::WebRenderOptions {
+            // We force the use of optimized shaders here because rendering is broken
+            // on Android emulators with unoptimized shaders. This is due to a known
+            // issue in the emulator's OpenGL emulation layer.
+            // See: https://github.com/servo/servo/issues/31726
+            use_optimized_shaders: false,
+            //resource_override_path: opts.shaders_dir.clone(),
+            precache_flags: if pref!(gfx_precache_shaders) {
+                ShaderPrecacheFlags::FULL_COMPILE
+            } else {
+                ShaderPrecacheFlags::empty()
+            },
+            enable_aa: pref!(gfx_text_antialiasing_enabled),
+            enable_subpixel_aa: pref!(gfx_subpixel_text_antialiasing_enabled),
+            allow_texture_swizzling: pref!(gfx_texture_swizzling_enabled),
+            clear_color,
+            upload_method: UploadMethod::PixelBuffer(VertexUsageHint::Stream),
+            panic_on_gl_error: true,
+            size_of_op: Some(servo_allocator::usable_size),
+            renderer_id: id.render_id(),
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn add_webview_group(
+        &mut self,
+        new_group_id: Option<RenderingGroupId>,
+        rendering_context: Rc<dyn RenderingContext>,
+    ) -> RenderingGroupId {
+        let new_group_id = new_group_id.unwrap_or_default();
+
+        //let gl = gleam::gl::ErrorReactingGl::wrap(rendering_context.gleam_gl_api(), gl_error_panic);
+        let gl = rendering_context.gleam_gl_api();
+
+        debug_assert_eq!(
+            (
+                gl.get_error(),
+                gl.check_frame_buffer_status(gleam::gl::FRAMEBUFFER)
+            ),
+            (gleam::gl::NO_ERROR, gleam::gl::FRAMEBUFFER_COMPLETE)
+        );
+        let notifier = MyRenderNotifier::new(self.sender.clone(), new_group_id.clone());
+
+        let (webrender, sender) = webrender::create_webrender_instance(
+            gl.clone(),
+            notifier.clone(),
+            self.webrender_options(new_group_id.clone()),
+            None,
+        )
+        .expect("Could not");
+
+        let api = sender.create_api();
+        let webrender_document = api.add_document(rendering_context.size2d().to_i32());
+
+        let s = WebRenderInstance {
+            sender,
+            webrender_api: api,
+            webrender_document,
+            rendering_context,
+            webrender,
+            webrender_gl: gl,
+            notifier,
+            needs_repaint: Cell::default(),
+        };
+
+        // This would otherwise drop the previous webrender instance which will error
+        // in mysterious ways
+        assert!(!self.rendering_contexts.contains_key(&new_group_id));
+
+        self.rendering_contexts.insert(new_group_id.clone(), s);
+        self.painting_order.insert(new_group_id.clone(), vec![]);
+        self.assert_no_gl_error(new_group_id.clone());
+        new_group_id
+    }
+
+    pub(crate) fn set_webrender_debug_flags(&mut self, flags: webrender_api::DebugFlags) {
+        for webrender in self
+            .rendering_contexts
+            .values_mut()
+            .map(|rc| &mut rc.webrender)
+        {
+            webrender.set_debug_flags(flags);
+        }
+    }
+
+    pub(crate) fn groups(&self) -> Vec<RenderingGroupId> {
+        self.painting_order.keys().cloned().collect()
+    }
+
+    pub(crate) fn rendering_context_size(&self) -> Size2D<u32, DevicePixel> {
+        self.rendering_contexts
+            .values()
+            .next()
+            .expect("No Context")
+            .rendering_context
+            .size2d()
+    }
+
+    pub(crate) fn present_all(&self) {
+        for webrender in self.rendering_contexts() {
+            webrender.rendering_context.present();
+        }
+    }
+
+    pub(crate) fn group_id(&self, webview_id: WebViewId) -> Option<RenderingGroupId> {
+        self.webview_groups.get(&webview_id).cloned()
+    }
+
+    pub(crate) fn remove(&mut self, webview_id: WebViewId) -> Result<WebView, UnknownWebView> {
+        let painting_order = self.group_painting_order_mut(webview_id);
+        painting_order.retain(|b| *b != webview_id);
         self.webviews
             .remove(&webview_id)
             .ok_or(UnknownWebView(webview_id))
     }
 
-    pub fn get(&self, webview_id: WebViewId) -> Option<&WebView> {
+    pub(crate) fn get_webview(&self, webview_id: WebViewId) -> Option<&WebView> {
         self.webviews.get(&webview_id)
     }
 
-    pub fn get_mut(&mut self, webview_id: WebViewId) -> Option<&mut WebView> {
+    pub(crate) fn get_webview_webrender_mut(
+        &mut self,
+        webview_id: WebViewId,
+    ) -> Option<(&mut WebView, &mut WebRenderInstance)> {
+        let group_id = self
+            .group_id(webview_id)
+            .expect("Could not find webrender instance")
+            .clone();
+        //let wri = self.render_instance(group_id);
+        let wri = self.rendering_contexts.get_mut(&group_id).unwrap();
+        self.webviews.get_mut(&webview_id).map(|wv| (wv, wri))
+    }
+
+    pub(crate) fn get_webview_mut(&mut self, webview_id: WebViewId) -> Option<&mut WebView> {
         self.webviews.get_mut(&webview_id)
     }
 
     /// Returns true iff the painting order actually changed.
-    pub fn show(&mut self, webview_id: WebViewId) -> Result<bool, UnknownWebView> {
+    pub(crate) fn show(&mut self, webview_id: WebViewId) -> Result<bool, UnknownWebView> {
         if !self.webviews.contains_key(&webview_id) {
             return Err(UnknownWebView(webview_id));
         }
-        if !self.painting_order.contains(&webview_id) {
-            self.painting_order.push(webview_id);
+        let painting_order = self.group_painting_order_mut(webview_id);
+        if !painting_order.contains(&webview_id) {
+            painting_order.push(webview_id);
             return Ok(true);
         }
         Ok(false)
     }
 
     /// Returns true iff the painting order actually changed.
-    pub fn hide(&mut self, webview_id: WebViewId) -> Result<bool, UnknownWebView> {
+    pub(crate) fn hide(&mut self, webview_id: WebViewId) -> Result<bool, UnknownWebView> {
         if !self.webviews.contains_key(&webview_id) {
             return Err(UnknownWebView(webview_id));
         }
-        if self.painting_order.contains(&webview_id) {
-            self.painting_order.retain(|b| *b != webview_id);
+        let painting_order = self.group_painting_order_mut(webview_id);
+        if painting_order.contains(&webview_id) {
+            painting_order.retain(|b| *b != webview_id);
             return Ok(true);
         }
         Ok(false)
     }
 
     /// Returns true iff the painting order actually changed.
-    pub fn hide_all(&mut self) -> bool {
-        if !self.painting_order.is_empty() {
-            self.painting_order.clear();
+    pub(crate) fn hide_all(&mut self, group_id: RenderingGroupId) -> bool {
+        let v = self.painting_order.get_mut(&group_id);
+        let painting_order = v.unwrap();
+        if !painting_order.is_empty() {
+            painting_order.clear();
             return true;
         }
         false
     }
 
     /// Returns true iff the painting order actually changed.
-    pub fn raise_to_top(&mut self, webview_id: WebViewId) -> Result<bool, UnknownWebView> {
+    pub(crate) fn raise_to_top(&mut self, webview_id: WebViewId) -> Result<bool, UnknownWebView> {
         if !self.webviews.contains_key(&webview_id) {
             return Err(UnknownWebView(webview_id));
         }
-        if self.painting_order.last() != Some(&webview_id) {
+        let painting_order = self.group_painting_order_mut(webview_id);
+        if painting_order.last() != Some(&webview_id) {
             self.hide(webview_id)?;
             self.show(webview_id)?;
             return Ok(true);
@@ -90,21 +457,54 @@ impl<WebView> WebViewManager<WebView> {
         Ok(false)
     }
 
-    pub fn painting_order(&self) -> impl Iterator<Item = (&WebViewId, &WebView)> {
+    pub(crate) fn painting_order(
+        &self,
+        group_id: RenderingGroupId,
+    ) -> impl Iterator<Item = (&WebViewId, &WebView)> {
+        info!(
+            "groups: {:?} || wvs: {:?} || groupid {:?} || painting {:?}",
+            self.webview_groups,
+            self.webviews.keys(),
+            group_id,
+            self.painting_order
+        );
         self.painting_order
+            .get(&group_id)
+            .expect("Could not find group")
             .iter()
-            .flat_map(move |webview_id| self.get(*webview_id).map(|b| (webview_id, b)))
+            .flat_map(move |webview_id| self.get_webview(*webview_id).map(|b| (webview_id, b)))
     }
 
-    pub fn entry(&mut self, webview_id: WebViewId) -> Entry<'_, WebViewId, WebView> {
-        self.webviews.entry(webview_id)
+    pub(crate) fn add_webview(
+        &mut self,
+        group_id: RenderingGroupId,
+        webview_id: WebViewId,
+        webview: WebView,
+    ) {
+        self.webviews.entry(webview_id).or_insert(webview);
+        self.webview_groups.entry(webview_id).or_insert(group_id);
     }
 
-    pub fn iter(&self) -> Values<'_, WebViewId, WebView> {
+    pub(crate) fn iter(&self) -> Values<'_, WebViewId, WebView> {
         self.webviews.values()
     }
 
-    pub fn iter_mut(&mut self) -> ValuesMut<'_, WebViewId, WebView> {
+    /// Mutable iterator for `WebView` and `WebRenderInstance`
+    pub(crate) fn webrender_instance_mut(
+        &mut self,
+    ) -> impl Iterator<Item = (&mut WebView, &WebRenderInstance)> {
+        self.webviews.iter_mut().map(|(id, wv)| {
+            (
+                wv,
+                self.webview_groups
+                    .get(id)
+                    .and_then(|gid| self.rendering_contexts.get(gid))
+                    .expect("Could not get gid"),
+            )
+        })
+    }
+
+    pub(crate) fn iter_mut(&mut self) -> ValuesMut<'_, WebViewId, WebView> {
         self.webviews.values_mut()
     }
 }
@@ -157,15 +557,15 @@ mod test {
 
         // add() returns WebViewAlreadyExists if the webview id already exists.
         webviews.entry(top_level_id(0, 3)).or_insert('d');
-        assert!(webviews.get(top_level_id(0, 3)).is_some());
+        assert!(webviews.get_webview(top_level_id(0, 3)).is_some());
 
         // Other methods return UnknownWebView or None if the webview id doesn’t exist.
         assert_eq!(
             webviews.remove(top_level_id(1, 1)),
             Err(UnknownWebView(top_level_id(1, 1)))
         );
-        assert_eq!(webviews.get(top_level_id(1, 1)), None);
-        assert_eq!(webviews.get_mut(top_level_id(1, 1)), None);
+        assert_eq!(webviews.get_webview(top_level_id(1, 1)), None);
+        assert_eq!(webviews.get_webview_mut(top_level_id(1, 1)), None);
         assert_eq!(
             webviews.show(top_level_id(1, 1)),
             Err(UnknownWebView(top_level_id(1, 1)))

--- a/components/constellation/webview_manager.rs
+++ b/components/constellation/webview_manager.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 
 use base::id::WebViewId;
+use log::error;
 
 #[derive(Debug)]
 pub struct WebViewManager<WebView> {
@@ -68,6 +69,8 @@ impl<WebView> WebViewManager<WebView> {
     }
 
     pub fn focus(&mut self, webview_id: WebViewId) -> Result<(), ()> {
+        error!("FOCUS IN WEBVIWE MANAGER");
+
         if !self.webviews.contains_key(&webview_id) {
             return Err(());
         }

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -12,6 +12,7 @@ use std::time::Instant;
 use std::{iter, str};
 
 use app_units::Au;
+use base::id::WebViewId;
 use bitflags::bitflags;
 use euclid::default::{Point2D, Rect, Size2D};
 use euclid::num::Zero;
@@ -223,7 +224,7 @@ pub struct Font {
 
     shaper: OnceLock<Shaper>,
     cached_shape_data: RwLock<CachedShapeData>,
-    pub font_instance_key: OnceLock<FontInstanceKey>,
+    font_instance_key: RwLock<HashMap<WebViewId, FontInstanceKey>>,
 
     /// If this is a synthesized small caps font, then this font reference is for
     /// the version of the font used to replace lowercase ASCII letters. It's up
@@ -248,12 +249,16 @@ impl malloc_size_of::MallocSizeOf for Font {
     fn size_of(&self, ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
         // TODO: Collect memory usage for platform fonts and for shapers.
         // This skips the template, because they are already stored in the template cache.
-        self.metrics.size_of(ops) +
-            self.descriptor.size_of(ops) +
-            self.cached_shape_data.read().size_of(ops) +
-            self.font_instance_key
+        0
+        /*
+        self.metrics.size_of(ops)
+            + self.descriptor.size_of(ops)
+            + self.cached_shape_data.read().size_of(ops)
+            + self
+                .font_instance_key
                 .get()
                 .map_or(0, |key| key.size_of(ops))
+                 */
     }
 }
 
@@ -306,10 +311,17 @@ impl Font {
         })
     }
 
-    pub fn key(&self, font_context: &FontContext) -> FontInstanceKey {
+    pub fn key(&self, webview_id: WebViewId, font_context: &FontContext) -> FontInstanceKey {
         *self
             .font_instance_key
-            .get_or_init(|| font_context.create_font_instance_key(self))
+            .write()
+            .entry(webview_id)
+            .or_insert_with(|| font_context.create_font_instance_key(self, webview_id))
+        /*
+        *self
+        .font_instance_key
+        .get_or_init(|| font_context.create_font_instance_key(self))
+        */
     }
 
     /// Return the data for this `Font`. Note that this is currently highly inefficient for system

--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -63,6 +63,7 @@ impl<'dom> ModernContainerJob<'dom> {
                     true,  /* has_first_formatted_line */
                     false, /* is_single_line_text_box */
                     builder.info.style.to_bidi_level(),
+                    builder.context.webview_id,
                 )?;
 
                 let block_formatting_context = BlockFormattingContext::from_block_container(

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -4,6 +4,7 @@
 
 use std::sync::Arc;
 
+use base::id::WebViewId;
 use embedder_traits::UntrustedNodeAddress;
 use euclid::Size2D;
 use fnv::FnvHashMap;
@@ -43,6 +44,8 @@ pub(crate) struct LayoutContext<'a> {
     /// An [`ImageResolver`] used for resolving images during box and fragment
     /// tree construction. Later passed to display list construction.
     pub image_resolver: Arc<ImageResolver>,
+
+    pub webview_id: WebViewId,
 }
 
 pub enum ResolvedImage<'a> {

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -229,6 +229,7 @@ impl<'dom, 'style> BlockContainerBuilder<'dom, 'style> {
             !self.have_already_seen_first_line_for_text_indent,
             self.info.node.is_single_line_text_input(),
             self.info.style.to_bidi_level(),
+            self.context.webview_id,
         )
     }
 

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -495,6 +495,7 @@ impl InlineFormattingContextBuilder {
             has_first_formatted_line,
             /* is_single_line_text_input = */ false,
             default_bidi_level,
+            layout_context.webview_id,
         )
     }
 
@@ -505,6 +506,7 @@ impl InlineFormattingContextBuilder {
         has_first_formatted_line: bool,
         is_single_line_text_input: bool,
         default_bidi_level: Level,
+        webview_id: base::id::WebViewId,
     ) -> Option<InlineFormattingContext> {
         if self.is_empty() {
             return None;
@@ -518,6 +520,7 @@ impl InlineFormattingContextBuilder {
             has_first_formatted_line,
             is_single_line_text_input,
             default_bidi_level,
+            webview_id,
         ))
     }
 }

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -79,6 +79,7 @@ use std::mem;
 use std::rc::Rc;
 
 use app_units::{Au, MAX_AU};
+use base::id::WebViewId;
 use bitflags::bitflags;
 use construct::InlineFormattingContextBuilder;
 use fonts::{ByteIndex, FontMetrics, GlyphStore};
@@ -1655,6 +1656,7 @@ impl InlineFormattingContext {
         has_first_formatted_line: bool,
         is_single_line_text_input: bool,
         starting_bidi_level: Level,
+        webview_id: WebViewId,
     ) -> Self {
         // This is to prevent a double borrow.
         let text_content: String = builder.text_segments.into_iter().collect();
@@ -1673,6 +1675,7 @@ impl InlineFormattingContext {
                         &mut new_linebreaker,
                         &mut font_metrics,
                         &bidi_info,
+                        webview_id,
                     );
                 },
                 InlineItem::StartInlineBox(inline_box) => {
@@ -1685,6 +1688,7 @@ impl InlineFormattingContext {
                             &font,
                             &mut font_metrics,
                             &layout_context.font_context,
+                            webview_id,
                         ));
                     }
                 },

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -968,6 +968,7 @@ impl LayoutThread {
             iframe_sizes: Mutex::default(),
             use_rayon: rayon_pool.is_some(),
             image_resolver: image_resolver.clone(),
+            webview_id: self.webview_id,
         };
 
         let restyle = reflow_request

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -35,7 +35,7 @@ use std::thread;
 
 use base::generic_channel;
 pub use base::id::WebViewId;
-use base::id::{PipelineNamespace, PipelineNamespaceId};
+use base::id::{PipelineNamespace, PipelineNamespaceId, RenderingGroupId};
 #[cfg(feature = "bluetooth")]
 use bluetooth::BluetoothThreadFactory;
 #[cfg(feature = "bluetooth")]
@@ -244,6 +244,7 @@ impl webrender_api::RenderNotifier for RenderNotifier {
         self.compositor_proxy
             .send(CompositorMsg::NewWebRenderFrameReady(
                 document_id,
+                RenderingGroupId::dummy(),
                 frame_ready_params.render,
             ));
     }
@@ -368,6 +369,7 @@ impl Servo {
                     clear_color,
                     upload_method,
                     workers,
+                    panic_on_gl_error: true,
                     size_of_op: Some(servo_allocator::usable_size),
                     ..Default::default()
                 },

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -10,7 +10,7 @@ use std::cell::Cell;
 use std::fmt;
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
-use std::sync::{Arc, LazyLock};
+use std::sync::{Arc, LazyLock, RwLock};
 
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use malloc_size_of::MallocSizeOfOps;
@@ -410,4 +410,47 @@ pub const TEST_WEBVIEW_ID: WebViewId = WebViewId(TEST_BROWSING_CONTEXT_ID);
 pub struct ScrollTreeNodeId {
     /// The index of this scroll tree node in the tree's array of nodes.
     pub index: usize,
+}
+
+#[derive(
+    Clone, Debug, PartialEq, PartialOrd, Ord, Hash, Eq, Serialize, Deserialize, MallocSizeOf,
+)]
+pub struct RenderingGroupId(u64);
+
+static RENDER_GROUP_COUNTER: RwLock<RenderingGroupId> = RwLock::new(RenderingGroupId(0));
+
+impl Default for RenderingGroupId {
+    fn default() -> Self {
+        Self(RENDER_GROUP_COUNTER.read().unwrap().clone().0)
+    }
+}
+
+impl RenderingGroupId {
+    pub fn dummy() -> RenderingGroupId {
+        RenderingGroupId(0)
+    }
+
+    /// the new rendering group id. The first returned id will be 1.
+    pub fn new_rendergroup_id() -> RenderingGroupId {
+        let mut cur = RENDER_GROUP_COUNTER.write().unwrap();
+        let n = RenderingGroupId(cur.0 + 1);
+        *cur = n.clone();
+        n
+    }
+
+    pub fn current() -> RenderingGroupId {
+        RenderingGroupId(RENDER_GROUP_COUNTER.read().unwrap().0.saturating_sub(1))
+    }
+
+    pub fn webrender_pipeline_id(&self) -> WebRenderPipelineId {
+        WebRenderPipelineId(0, self.0 as u32)
+    }
+
+    pub fn first(&self) -> bool {
+        self.0 == 0
+    }
+
+    pub fn render_id(&self) -> Option<u64> {
+        Some(self.0)
+    }
 }

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -411,10 +411,7 @@ impl Window {
                 }
             })
             .shortcut(CMD_OR_CONTROL, 'T', || {
-                state.create_and_focus_toplevel_webview(
-                    Url::parse("servo:newtab")
-                        .expect("Should be able to unconditionally parse 'servo:newtab' as URL"),
-                );
+                //state.create_and_focus_toplevel_webview(Url::parse("servo:newtab").unwrap());
             })
             .shortcut(CMD_OR_CONTROL, 'Q', || state.servo().start_shutting_down())
             .otherwise(|| handled = false);
@@ -614,7 +611,9 @@ impl WindowPortsMethods for Window {
             WindowEvent::MouseInput { state, button, .. } => {
                 self.handle_mouse(&webview, button, state);
             },
-            WindowEvent::CursorMoved { position, .. } => {
+            WindowEvent::CursorMoved { .. } => {
+                //WindowEvent::CursorMoved { position, .. } => {
+                /*
                 let mut point = winit_position_to_euclid_point(position).to_f32();
                 point.y -= (self.toolbar_height() * self.hidpi_scale_factor()).0;
 
@@ -628,16 +627,15 @@ impl WindowPortsMethods for Window {
                 }
 
                 self.webview_relative_mouse_point.set(point);
+                */
             },
             WindowEvent::CursorLeft { .. } => {
-                if webview
-                    .rect()
-                    .contains(self.webview_relative_mouse_point.get())
-                {
-                    webview.notify_input_event(InputEvent::MouseLeftViewport(
-                        MouseLeftViewportEvent::default(),
-                    ));
+                /*
+                let point = self.webview_relative_mouse_point.get();
+                if webview.rect().contains(point) {
+                    webview.notify_input_event(InputEvent::MouseLeave(MouseLeaveEvent::new(point)));
                 }
+                */
             },
             WindowEvent::MouseWheel { delta, .. } => {
                 let (mut dx, mut dy, mode) = match delta {
@@ -658,13 +656,13 @@ impl WindowPortsMethods for Window {
                 };
 
                 // Create wheel event before snapping to the major axis of movement
-                let delta = WheelDelta {
+                let _delta = WheelDelta {
                     x: dx,
                     y: dy,
                     z: 0.0,
                     mode,
                 };
-                let point = self.webview_relative_mouse_point.get();
+                let _point = self.webview_relative_mouse_point.get();
 
                 // Scroll events snap to the major axis of movement, with vertical
                 // preferred over horizontal.
@@ -675,28 +673,32 @@ impl WindowPortsMethods for Window {
                 }
 
                 // Send events
-                webview.notify_input_event(InputEvent::Wheel(WheelEvent::new(delta, point)));
-                let scroll_location = ScrollLocation::Delta(-Vector2D::new(dx as f32, dy as f32));
-                webview.notify_scroll_event(scroll_location, point.to_i32());
+                //webview.notify_input_event(InputEvent::Wheel(WheelEvent::new(delta, point)));
+                let _scroll_location = ScrollLocation::Delta(-Vector2D::new(dx as f32, dy as f32));
+                //webview.notify_scroll_event(scroll_location, point.to_i32());
             },
-            WindowEvent::Touch(touch) => {
+            WindowEvent::Touch(_touch) => {
+                /*
                 webview.notify_input_event(InputEvent::Touch(TouchEvent::new(
                     winit_phase_to_touch_event_type(touch.phase),
                     TouchId(touch.id as i32),
                     Point2D::new(touch.location.x as f32, touch.location.y as f32),
                 )));
+                */
             },
             WindowEvent::PinchGesture { delta, .. } => {
-                webview.set_pinch_zoom(delta as f32 + 1.0);
+                //webview.set_pinch_zoom(delta as f32 + 1.0);
             },
             WindowEvent::CloseRequested => {
-                state.servo().start_shutting_down();
+                //state.servo().start_shutting_down();
             },
             WindowEvent::ThemeChanged(theme) => {
+                /*
                 webview.notify_theme_change(match theme {
                     winit::window::Theme::Light => Theme::Light,
                     winit::window::Theme::Dark => Theme::Dark,
                 });
+                */
             },
             WindowEvent::Resized(new_inner_size) => {
                 if self.inner_size.get() != new_inner_size {
@@ -709,31 +711,37 @@ impl WindowPortsMethods for Window {
             },
             WindowEvent::Ime(ime) => match ime {
                 Ime::Enabled => {
+                    /*
                     webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
                         servo::CompositionEvent {
                             state: servo::CompositionState::Start,
                             data: String::new(),
                         },
                     )));
+                    */
                 },
                 Ime::Preedit(text, _) => {
+                    /*
                     webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
                         servo::CompositionEvent {
                             state: servo::CompositionState::Update,
                             data: text,
                         },
                     )));
+                    */
                 },
                 Ime::Commit(text) => {
+                    /*
                     webview.notify_input_event(InputEvent::Ime(ImeEvent::Composition(
                         servo::CompositionEvent {
                             state: servo::CompositionState::End,
                             data: text,
                         },
                     )));
+                    */
                 },
                 Ime::Disabled => {
-                    webview.notify_input_event(InputEvent::Ime(ImeEvent::Dismissed));
+                    //webview.notify_input_event(InputEvent::Ime(ImeEvent::Dismissed));
                 },
             },
             _ => {},

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -18,6 +18,7 @@ use servo::servo_geometry::{
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel};
 use servo::{RenderingContext, ScreenGeometry, SoftwareRenderingContext, WebView};
 use winit::dpi::PhysicalSize;
+use winit::event_loop::ActiveEventLoop;
 
 use super::app_state::RunningAppState;
 use crate::desktop::window_trait::{MIN_INNER_HEIGHT, MIN_INNER_WIDTH, WindowPortsMethods};


### PR DESCRIPTION
This branch has the current code for my proposed multiple webview with different rendering contexts.
This branch also has: The hookup to desktop servoshell on how to use it. This would not be included in the final PR. This includes code in ports/servoshell/deskop/app,app_state,headed_window,minibrowser. It is only included if people want to test this PR.
Other comments to note: The current initialization of webrender before IOCompositor in `servo/lib.rs` is currently essentially thrown away which in the final PR we obviously want to fix.

Overview:
- We introduce a new RenderingGroupId which will correspond to one per RenderingContext.
- `compositing/webview_manager` has now one `WebRenderInstance` per `RenderingGroupId` which holds `webrender::Renderer`, `DocumentId`, `RenderApi` and `needs_repaint`.
- IOCompmositor essentially forwards all messages to the corresponding `WebRenderInstance`. Some of these assume that the `DocumentId` is different but mostly we can make do with `WebViewId` and `PipelineId`.
- `WebViewBuilder` has a new method which adds a separate `RenderingContext` which then increments the `RenderingGroupId` and sets everything up.
- Some methods for fonts needed the `PipelineId` added to route to the correct `WebRenderInstance`.


Notes:
- Currently webgl does not work but can probably made to work for the first RenderingContext given.
- I did not test wgpu or webxr.
- Any comments on how to improve this are very welcome. I think even a partial include in the future will be very welcome, even if it is behind a feature flag or otherwise gated.
