### PR TITLE
Implement Trusted Types for ShadowRoot

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4074,8 +4074,7 @@ impl Document {
             string = TrustedHTML::get_trusted_script_compliant_string(
                 &self.global(),
                 TrustedHTMLOrString::String(string.into()),
-                containing_class,
-                field,
+                &format!("{} {}", containing_class, field),
                 can_gc,
             )?
             .as_ref()

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3787,8 +3787,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let html = TrustedHTML::get_trusted_script_compliant_string(
             &self.owner_global(),
             html,
-            "Element",
-            "setHTMLUnsafe",
+            "Element setHTMLUnsafe",
             can_gc,
         )?;
         // Step 2. Let target be this's template contents if this is a template element; otherwise this.
@@ -3844,8 +3843,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let value = TrustedHTML::get_trusted_script_compliant_string(
             &self.owner_global(),
             value.convert(),
-            "Element",
-            "innerHTML",
+            "Element innerHTML",
             can_gc,
         )?;
         // https://github.com/w3c/DOM-Parsing/issues/1
@@ -3902,8 +3900,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let value = TrustedHTML::get_trusted_script_compliant_string(
             &self.owner_global(),
             value.convert(),
-            "Element",
-            "outerHTML",
+            "Element outerHTML",
             can_gc,
         )?;
         let context_document = self.owner_document();
@@ -4118,8 +4115,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let text = TrustedHTML::get_trusted_script_compliant_string(
             &self.owner_global(),
             text,
-            "Element",
-            "insertAdjacentHTML",
+            "Element insertAdjacentHTML",
             can_gc,
         )?;
         let position = position.parse::<AdjacentPosition>()?;

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -616,17 +616,15 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, the given value, "HTMLIFrameElement srcdoc", and "script".
         let element = self.upcast::<Element>();
-        let local_name = &local_name!("srcdoc");
         let value = TrustedHTML::get_trusted_script_compliant_string(
             &element.owner_global(),
             value,
-            "HTMLIFrameElement",
-            local_name,
+            "HTMLIFrameElement srcdoc",
             can_gc,
         )?;
         // Step 2: Set an attribute value given this, srcdoc's local name, and compliantString.
         element.set_attribute(
-            local_name,
+            &local_name!("srcdoc"),
             AttrValue::String(value.as_ref().to_owned()),
             can_gc,
         );

--- a/components/script/dom/trustedhtml.rs
+++ b/components/script/dom/trustedhtml.rs
@@ -43,18 +43,16 @@ impl TrustedHTML {
     pub(crate) fn get_trusted_script_compliant_string(
         global: &GlobalScope,
         value: TrustedHTMLOrString,
-        containing_class: &str,
-        field: &str,
+        sink: &str,
         can_gc: CanGc,
     ) -> Fallible<DOMString> {
         match value {
             TrustedHTMLOrString::String(value) => {
-                let sink = format!("{} {}", containing_class, field);
                 TrustedTypePolicyFactory::get_trusted_type_compliant_string(
                     TrustedType::TrustedHTML,
                     global,
                     value,
-                    &sink,
+                    sink,
                     "'script'",
                     can_gc,
                 )

--- a/components/script_bindings/webidls/ShadowRoot.webidl
+++ b/components/script_bindings/webidls/ShadowRoot.webidl
@@ -25,9 +25,8 @@ ShadowRoot includes DocumentOrShadowRoot;
 
 // https://html.spec.whatwg.org/multipage/#dom-parsing-and-serialization
 partial interface ShadowRoot {
-  [CEReactions] undefined setHTMLUnsafe(DOMString html);
+  [CEReactions, Throws] undefined setHTMLUnsafe((TrustedHTML or DOMString) html);
   DOMString getHTML(optional GetHTMLOptions options = {});
 
-  // [CEReactions] attribute (TrustedHTML or [LegacyNullToEmptyString] DOMString) innerHTML;
-  [CEReactions, Throws] attribute [LegacyNullToEmptyString] DOMString innerHTML;
+  [CEReactions, Throws] attribute (TrustedHTML or [LegacyNullToEmptyString] DOMString) innerHTML;
 };

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-ShadowRoot-innerHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-ShadowRoot-innerHTML.html.ini
@@ -1,9 +1,0 @@
-[block-string-assignment-to-ShadowRoot-innerHTML.html]
-  [`shadowRoot.innerHTML = string` throws.]
-    expected: FAIL
-
-  [`shadowRoot.innerHTML = null` throws.]
-    expected: FAIL
-
-  [`shadowRoot.innerHTML = string` assigned via default policy (successful HTML transformation).]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/block-string-assignment-to-ShadowRoot-setHTMLUnsafe.html.ini
+++ b/tests/wpt/meta/trusted-types/block-string-assignment-to-ShadowRoot-setHTMLUnsafe.html.ini
@@ -1,9 +1,0 @@
-[block-string-assignment-to-ShadowRoot-setHTMLUnsafe.html]
-  [`shadowRoot.setHTMLUnsafe(string)` assigned via default policy (successful HTML transformation).]
-    expected: FAIL
-
-  [`shadowRoot.setHTMLUnsafe(string)` throws.]
-    expected: FAIL
-
-  [`shadowRoot.setHTMLUnsafe(null)` throws.]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ShadowRoot-innerHTML.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ShadowRoot-innerHTML.html.ini
@@ -1,3 +1,0 @@
-[trusted-types-reporting-for-ShadowRoot-innerHTML.html]
-  [Violation report for plain string.]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ShadowRoot-setHTMLUnsafe.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-reporting-for-ShadowRoot-setHTMLUnsafe.html.ini
@@ -1,3 +1,0 @@
-[trusted-types-reporting-for-ShadowRoot-setHTMLUnsafe.html]
-  [Violation report for plain string.]
-    expected: FAIL


### PR DESCRIPTION
Also make TrustedHTML work the same as TrustedScript by
only taking 1 `&str` to make things easier.

Part of #36258