### PR TITLE
script: Strip `javascript` URL scheme using `Position::AfterScheme` rather than `Position::BeforePath`

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3730,7 +3730,7 @@ impl ScriptThread {
         // Start with the scheme data of the parsed URL;
         // append question mark and query component, if any;
         // append number sign and fragment component if any.
-        let encoded = &load_data.url.clone()[Position::AfterScheme..][1..];
+        let encoded = &load_data.url[Position::AfterScheme..][1..];
 
         // Percent-decode (8.) and UTF-8 decode (9.)
         let script_source = percent_decode(encoded.as_bytes()).decode_utf8_lossy();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3730,7 +3730,7 @@ impl ScriptThread {
         // Start with the scheme data of the parsed URL;
         // append question mark and query component, if any;
         // append number sign and fragment component if any.
-        let encoded = &load_data.url.clone()[Position::BeforePath..];
+        let encoded = &load_data.url.clone()[Position::AfterScheme..][1..];
 
         // Percent-decode (8.) and UTF-8 decode (9.)
         let script_source = percent_decode(encoded.as_bytes()).decode_utf8_lossy();

--- a/tests/wpt/meta/url/javascript-urls.window.js.ini
+++ b/tests/wpt/meta/url/javascript-urls.window.js.ini
@@ -1,4 +1,0 @@
-[javascript-urls.window.html]
-  expected: ERROR
-  [javascript: URL without an opaque path]
-    expected: FAIL

--- a/tests/wpt/tests/url/javascript-urls.window.js
+++ b/tests/wpt/tests/url/javascript-urls.window.js
@@ -20,6 +20,12 @@
     "expected": undefined
   },
   {
+    "description": "javascript: URL with extra slashes at the start",
+    "input": "javascript:///globalThis.shouldNotExistC=1",
+    "property": "shouldNotExistC",
+    "expected": undefined
+  },
+  {
     "description": "javascript: URL without an opaque path",
     "input": "javascript://host/1%0a//../0/;globalThis.shouldBeOne=1;/%0aglobalThis.shouldBeOne=2;/..///",
     "property": "shouldBeOne",


### PR DESCRIPTION
This makes the initial split match step 2 of https://html.spec.whatwg.org/multipage/browsing-the-web.html#evaluate-a-javascript%3A-url.

Testing: Covered by WPT tests.
Fixes: #38547
