### PR TITLE
script: Send JS evaluation errors to constellation

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -4024,14 +4024,21 @@ impl ScriptThread {
         let context = window.get_cx();
 
         rooted!(in(*context) let mut return_value = UndefinedValue());
-        _ = global_scope.evaluate_js_on_global_with_result(
+        if let Err(err) = global_scope.evaluate_js_on_global_with_result(
             &script,
             return_value.handle_mut(),
             ScriptFetchOptions::default_classic_script(global_scope),
             global_scope.api_base_url(),
             can_gc,
             None, // No known `introductionType` for JS code from embedder
-        );
+        ) {
+            _ = self.senders.pipeline_to_constellation_sender.send((
+                pipeline_id,
+                ScriptToConstellationMessage::FinishJavaScriptEvaluation(evaluation_id, Err(err)),
+            ));
+            return;
+        };
+
         let result = match jsval_to_webdriver(
             context,
             global_scope,

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -125,6 +125,12 @@ fn test_evaluate_javascript_basic(servo_test: &ServoTest) -> Result<(), anyhow::
     );
     ensure!(matches!(result, Ok(JSValue::Frame(..))));
 
+    let result = evaluate_javascript(servo_test, webview.clone(), "lettt badsyntax = 123");
+    ensure!(result == Err(JavaScriptEvaluationError::CompilationFailure));
+
+    let result = evaluate_javascript(servo_test, webview.clone(), "throw new Error()");
+    ensure!(result == Err(JavaScriptEvaluationError::EvaluationFailure));
+
     Ok(())
 }
 


### PR DESCRIPTION
Send JS evaluation errors to constellation in `script_thread::handle_evaluate_javascript` instead of silently swallowing.

Testing: New test cases in `tests/webview.rs`: one for compilation failure, another for evaluation failure.
Fixes: #37810 