### PR TITLE
layout: Improve sizing for inline SVG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7324,7 +7324,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.31.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#d2519c05c9d7db31c91552d3337578270645d797"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -7630,7 +7630,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#d2519c05c9d7db31c91552d3337578270645d797"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8102,7 +8102,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#d2519c05c9d7db31c91552d3337578270645d797"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8159,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#d2519c05c9d7db31c91552d3337578270645d797"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8168,12 +8168,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#d2519c05c9d7db31c91552d3337578270645d797"
 
 [[package]]
 name = "stylo_derive"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#d2519c05c9d7db31c91552d3337578270645d797"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8185,7 +8185,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#d2519c05c9d7db31c91552d3337578270645d797"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -8194,7 +8194,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#d2519c05c9d7db31c91552d3337578270645d797"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8211,12 +8211,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#d2519c05c9d7db31c91552d3337578270645d797"
 
 [[package]]
 name = "stylo_traits"
 version = "0.6.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#d2519c05c9d7db31c91552d3337578270645d797"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -8631,7 +8631,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#d2519c05c9d7db31c91552d3337578270645d797"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8644,7 +8644,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-08-01#092e34b20bd666da62b7dfc1da5c5e0b64d3c960"
+source = "git+https://github.com/servo/stylo?branch=2025-08-01#d2519c05c9d7db31c91552d3337578270645d797"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/components/script/dom/svgsvgelement.rs
+++ b/components/script/dom/svgsvgelement.rs
@@ -83,6 +83,7 @@ impl SVGSVGElement {
 
     fn invalidate_cached_serialized_subtree(&self) {
         *self.cached_serialized_data_url.borrow_mut() = None;
+        self.upcast::<Node>().dirty(NodeDamage::Other);
     }
 }
 
@@ -149,13 +150,6 @@ impl VirtualMethods for SVGSVGElement {
             .attribute_mutated(attr, mutation, can_gc);
 
         self.invalidate_cached_serialized_subtree();
-
-        match attr.local_name() {
-            &local_name!("width") | &local_name!("height") | &local_name!("viewBox") => {
-                self.upcast::<Node>().dirty(NodeDamage::Other);
-            },
-            _ => {},
-        };
     }
 
     fn parse_plain_attribute(&self, name: &LocalName, value: DOMString) -> AttrValue {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -135,6 +135,9 @@ pub struct HTMLCanvasData {
 pub struct SVGElementData {
     /// The SVG's XML source represented as a base64 encoded `data:` url.
     pub source: Option<Result<ServoUrl, ()>>,
+    pub width: Option<i32>,
+    pub height: Option<i32>,
+    pub ratio: Option<f32>,
 }
 
 /// The address of a node known to be valid. These are sent from script to layout.

--- a/tests/wpt/meta/css/CSS2/floats-clear/float-replaced-width-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/floats-clear/float-replaced-width-007.xht.ini
@@ -1,2 +1,0 @@
-[float-replaced-width-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/block-replaced-width-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/block-replaced-width-002.xht.ini
@@ -1,2 +1,0 @@
-[block-replaced-width-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-block-replaced-height-009.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-block-replaced-height-009.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-replaced-height-009.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-block-replaced-width-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-block-replaced-width-002.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-replaced-width-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-block-replaced-width-007.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-block-replaced-width-007.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-replaced-width-007.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-block-replaced-width-008.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-block-replaced-width-008.xht.ini
@@ -1,2 +1,0 @@
-[inline-block-replaced-width-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-height-009.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-height-009.xht.ini
@@ -1,2 +1,0 @@
-[inline-replaced-height-009.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-width-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-width-002.xht.ini
@@ -1,2 +1,0 @@
-[inline-replaced-width-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-width-008.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-width-008.xht.ini
@@ -1,2 +1,0 @@
-[inline-replaced-width-008.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-width-009.xht.ini
+++ b/tests/wpt/meta/css/CSS2/normal-flow/inline-replaced-width-009.xht.ini
@@ -1,2 +1,0 @@
-[inline-replaced-width-009.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-002.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-002.xht.ini
@@ -1,2 +1,0 @@
-[absolute-replaced-width-002.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-003a.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-003a.xht.ini
@@ -1,2 +1,0 @@
-[absolute-replaced-width-003a.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-003b.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-003b.xht.ini
@@ -1,2 +1,0 @@
-[absolute-replaced-width-003b.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-003c.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-003c.xht.ini
@@ -1,2 +1,0 @@
-[absolute-replaced-width-003c.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-009.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-009.xht.ini
@@ -1,2 +1,0 @@
-[absolute-replaced-width-009.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-023.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-023.xht.ini
@@ -1,2 +1,0 @@
-[absolute-replaced-width-023.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-030.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-030.xht.ini
@@ -1,2 +1,0 @@
-[absolute-replaced-width-030.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-037.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-037.xht.ini
@@ -1,2 +1,0 @@
-[absolute-replaced-width-037.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-051.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-051.xht.ini
@@ -1,2 +1,0 @@
-[absolute-replaced-width-051.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-065.xht.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/absolute-replaced-width-065.xht.ini
@@ -1,2 +1,0 @@
-[absolute-replaced-width-065.xht]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-column-018.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-column-018.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-column-018.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-row-015.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flex-aspect-ratio-img-row-015.html.ini
@@ -1,2 +1,0 @@
-[flex-aspect-ratio-img-row-015.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-flexbox/svg-root-as-flex-item-006.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/svg-root-as-flex-item-006.html.ini
@@ -1,6 +1,0 @@
-[svg-root-as-flex-item-006.html]
-  [svg 1]
-    expected: FAIL
-
-  [svg 1: undefined]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-overflow/display-flex-svg-overflow-default.html.ini
+++ b/tests/wpt/meta/css/css-overflow/display-flex-svg-overflow-default.html.ini
@@ -1,0 +1,2 @@
+[display-flex-svg-overflow-default.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/intrinsic-size-fallback-replaced.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-size-fallback-replaced.html.ini
@@ -10,9 +10,3 @@
 
   [.test 8]
     expected: FAIL
-
-  [.test 3]
-    expected: FAIL
-
-  [.test 7]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/replaced-aspect-ratio-stretch-fit-002.html.ini
+++ b/tests/wpt/meta/css/css-sizing/replaced-aspect-ratio-stretch-fit-002.html.ini
@@ -1,0 +1,2 @@
+[replaced-aspect-ratio-stretch-fit-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-001.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-001.html.ini
@@ -1,29 +1,5 @@
 [svg-intrinsic-size-001.html]
-  [svg 1: undefined]
-    expected: FAIL
-
-  [svg 2: undefined]
-    expected: FAIL
-
-  [svg 3: undefined]
-    expected: FAIL
-
-  [svg 4: undefined]
-    expected: FAIL
-
-  [svg 5: undefined]
-    expected: FAIL
-
-  [svg 1]
-    expected: FAIL
-
   [svg 2]
-    expected: FAIL
-
-  [svg 3]
-    expected: FAIL
-
-  [svg 4]
     expected: FAIL
 
   [svg 5]

--- a/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-002.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-002.html.ini
@@ -1,29 +1,5 @@
 [svg-intrinsic-size-002.html]
-  [svg 1: undefined]
-    expected: FAIL
-
-  [svg 2: undefined]
-    expected: FAIL
-
-  [svg 3: undefined]
-    expected: FAIL
-
-  [svg 4: undefined]
-    expected: FAIL
-
-  [svg 5: undefined]
-    expected: FAIL
-
-  [svg 1]
-    expected: FAIL
-
   [svg 2]
-    expected: FAIL
-
-  [svg 3]
-    expected: FAIL
-
-  [svg 4]
     expected: FAIL
 
   [svg 5]

--- a/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-003.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-003.html.ini
@@ -1,29 +1,5 @@
 [svg-intrinsic-size-003.html]
-  [svg 1: undefined]
-    expected: FAIL
-
-  [svg 2: undefined]
-    expected: FAIL
-
-  [svg 3: undefined]
-    expected: FAIL
-
-  [svg 4: undefined]
-    expected: FAIL
-
-  [svg 5: undefined]
-    expected: FAIL
-
-  [svg 1]
-    expected: FAIL
-
   [svg 2]
-    expected: FAIL
-
-  [svg 3]
-    expected: FAIL
-
-  [svg 4]
     expected: FAIL
 
   [svg 5]

--- a/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-004.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-intrinsic-size-004.html.ini
@@ -1,24 +1,6 @@
 [svg-intrinsic-size-004.html]
-  [svg 1: undefined]
-    expected: FAIL
-
-  [svg 2: undefined]
-    expected: FAIL
-
-  [svg 3: undefined]
-    expected: FAIL
-
-  [svg 4: undefined]
-    expected: FAIL
-
-  [svg 1]
-    expected: FAIL
-
   [svg 2]
     expected: FAIL
 
-  [svg 3]
-    expected: FAIL
-
-  [svg 4]
+  [svg 5]
     expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/svg-no-ar-max-height-min-content.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-no-ar-max-height-min-content.html.ini
@@ -1,2 +1,0 @@
-[svg-no-ar-max-height-min-content.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/svg-no-ar-min-height-min-content.html.ini
+++ b/tests/wpt/meta/css/css-sizing/svg-no-ar-min-height-min-content.html.ini
@@ -1,2 +1,0 @@
-[svg-no-ar-min-height-min-content.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/css-skew-001.html.ini
+++ b/tests/wpt/meta/css/css-transforms/css-skew-001.html.ini
@@ -1,2 +1,0 @@
-[css-skew-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/css-skew-002.html.ini
+++ b/tests/wpt/meta/css/css-transforms/css-skew-002.html.ini
@@ -1,2 +1,0 @@
-[css-skew-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/group/svg-transform-group-011.html.ini
+++ b/tests/wpt/meta/css/css-transforms/group/svg-transform-group-011.html.ini
@@ -1,2 +1,0 @@
-[svg-transform-group-011.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/group/svg-transform-nested-021.html.ini
+++ b/tests/wpt/meta/css/css-transforms/group/svg-transform-nested-021.html.ini
@@ -1,2 +1,0 @@
-[svg-transform-nested-021.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/group/svg-transform-nested-029.html.ini
+++ b/tests/wpt/meta/css/css-transforms/group/svg-transform-nested-029.html.ini
@@ -1,2 +1,0 @@
-[svg-transform-nested-029.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-036.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-036.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-036.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-039.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-039.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-039.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-041.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-041.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-041.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-042.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-042.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-042.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-043.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-043.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-043.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-044.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-044.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-044.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-045.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-045.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-045.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-046.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-046.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-046.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-048.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-048.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-048.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-058.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-058.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-058.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-059.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-059.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-059.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-060.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-060.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-060.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-061.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-061.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-061.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-062.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-062.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-062.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-063.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-063.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-063.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-064.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-064.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-064.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-065.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-065.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-065.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-066.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-066.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-066.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-067.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-067.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-067.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-068.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-068.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-068.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-069.html.ini
+++ b/tests/wpt/meta/css/css-transforms/matrix/svg-matrix-069.html.ini
@@ -1,2 +1,0 @@
-[svg-matrix-069.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-001.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-001.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-001.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-002.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-002.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-003.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-003.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-003.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-004.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-004.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-004.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-008.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-008.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-008.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-009.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-009.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-009.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-010.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-010.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-010.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-011.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-011.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-011.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-012.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-012.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-012.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-013.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-013.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-013.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-014.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-014.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-014.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-015.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-015.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-015.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-016.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-016.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-016.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/scale/svg-scale-017.html.ini
+++ b/tests/wpt/meta/css/css-transforms/scale/svg-scale-017.html.ini
@@ -1,0 +1,2 @@
+[svg-scale-017.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/skewX/svg-skewx-with-units.html.ini
+++ b/tests/wpt/meta/css/css-transforms/skewX/svg-skewx-with-units.html.ini
@@ -1,0 +1,2 @@
+[svg-skewx-with-units.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/skewY/svg-skewy-with-units.html.ini
+++ b/tests/wpt/meta/css/css-transforms/skewY/svg-skewy-with-units.html.ini
@@ -1,0 +1,2 @@
+[svg-skewy-with-units.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/translate/svg-translate-with-units.html.ini
+++ b/tests/wpt/meta/css/css-transforms/translate/svg-translate-with-units.html.ini
@@ -1,2 +1,0 @@
-[svg-translate-with-units.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/cssom-view/outer-svg.html.ini
+++ b/tests/wpt/meta/css/cssom-view/outer-svg.html.ini
@@ -1,7 +1,3 @@
 [outer-svg.html]
-  [scrollWidth, scrollHeight, scrollTop and scrollLeft work on outer svg element]
-    expected: FAIL
-
   [clientWidth, clientHeight, clientTop and clientLeft work on outer svg element]
     expected: FAIL
-

--- a/tests/wpt/meta/css/filter-effects/svg-feimage-004.html.ini
+++ b/tests/wpt/meta/css/filter-effects/svg-feimage-004.html.ini
@@ -1,2 +1,0 @@
-[svg-feimage-004.html]
-  expected: FAIL


### PR DESCRIPTION
The metadata provided by usvg has unreliable sizes. Ignore it, and rely on the `width`, `height` and `viewBox` attributes instead.

Note that inline SVG with a natural aspect ratio but no natural sizes should stretch to the containing block. This is left for a follow-up.

Bumps Stylo to https://github.com/servo/stylo/pull/229

Testing: Improves several WPT.
