### PR TITLE
Update expectations for /css/cssom-view/elementsFromPoint.html

### DIFF
--- a/tests/wpt/meta/css/cssom-view/elementsFromPoint.html.ini
+++ b/tests/wpt/meta/css/cssom-view/elementsFromPoint.html.ini
@@ -1,4 +1,7 @@
 [elementsFromPoint.html]
+  [SVG element at x,y]
+    expected: FAIL
+
   [transformed element at x,y]
     expected: FAIL
 


### PR DESCRIPTION
this expectation was removed in #38188, but it seems to be consistently failing locally and blocking the merge queue:

- <https://github.com/servo/servo/actions/runs/16898593081/job/47873622938>
  (#37667)
- <https://github.com/servo/servo/actions/runs/16897775830/job/47871113823>
  (#38601)

(cc @mukilan)