### PR TITLE
script_bindings: Assert that serializable/transferable types have accurate WebIDL annotations

### DIFF
--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -8,6 +8,7 @@
 use std::collections::HashMap;
 
 use base::id::{Index, NamespaceIndex, PipelineNamespaceId};
+use script_bindings::structuredclone::SerializableMarker;
 
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
@@ -45,7 +46,7 @@ impl<T> From<StorageKey> for NamespaceIndex<T> {
 
 /// Interface for serializable platform objects.
 /// <https://html.spec.whatwg.org/multipage/#serializable>
-pub(crate) trait Serializable: DomObject
+pub(crate) trait Serializable: DomObject + SerializableMarker
 where
     Self: Sized,
 {
@@ -69,3 +70,5 @@ where
         data: StructuredData<'a, '_>,
     ) -> &'a mut Option<HashMap<NamespaceIndex<Self::Index>, Self::Data>>;
 }
+
+pub(crate) fn assert_serializable<T: Serializable>() {}

--- a/components/script/dom/bindings/serializable.rs
+++ b/components/script/dom/bindings/serializable.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 
 use base::id::{Index, NamespaceIndex, PipelineNamespaceId};
-use script_bindings::structuredclone::SerializableMarker;
+use script_bindings::structuredclone::MarkedAsSerializableInIdl;
 
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::DomRoot;
@@ -46,7 +46,7 @@ impl<T> From<StorageKey> for NamespaceIndex<T> {
 
 /// Interface for serializable platform objects.
 /// <https://html.spec.whatwg.org/multipage/#serializable>
-pub(crate) trait Serializable: DomObject + SerializableMarker
+pub(crate) trait Serializable: DomObject + MarkedAsSerializableInIdl
 where
     Self: Sized,
 {

--- a/components/script/dom/bindings/transferable.rs
+++ b/components/script/dom/bindings/transferable.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 use base::id::NamespaceIndex;
+use script_bindings::structuredclone::TransferableMarker;
 
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::DomObject;
@@ -16,7 +17,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::structuredclone::StructuredData;
 use crate::dom::globalscope::GlobalScope;
 
-pub(crate) trait Transferable: DomObject
+pub(crate) trait Transferable: DomObject + TransferableMarker
 where
     Self: Sized,
 {
@@ -41,3 +42,5 @@ where
         data: StructuredData<'a, '_>,
     ) -> &'a mut Option<HashMap<NamespaceIndex<Self::Index>, Self::Data>>;
 }
+
+pub(crate) fn assert_transferable<T: Transferable>() {}

--- a/components/script/dom/bindings/transferable.rs
+++ b/components/script/dom/bindings/transferable.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 use base::id::NamespaceIndex;
-use script_bindings::structuredclone::TransferableMarker;
+use script_bindings::structuredclone::MarkedAsTransferableInIdl;
 
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::DomObject;
@@ -17,7 +17,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::structuredclone::StructuredData;
 use crate::dom::globalscope::GlobalScope;
 
-pub(crate) trait Transferable: DomObject + TransferableMarker
+pub(crate) trait Transferable: DomObject + MarkedAsTransferableInIdl
 where
     Self: Sized,
 {

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -2784,7 +2784,7 @@ def DomTypes(descriptors, descriptorProvider, dictionaries, callbacks, typedefs,
 
         for marker in ["Serializable", "Transferable"]:
             if descriptor.interface.getExtendedAttribute(marker):
-                traits += [f"crate::structuredclone::{marker}Marker"]
+                traits += [f"crate::structuredclone::MarkedAs{marker}InIdl"]
 
         iterableDecl = descriptor.interface.maplikeOrSetlikeOrIterable
         if iterableDecl:
@@ -7626,7 +7626,7 @@ class CGStructuredCloneMarker(CGThing):
     def define(self):
         ifaceName = self.descriptor.interface.identifier.name
         return f"""
-impl script_bindings::structuredclone::{self.marker}Marker for {ifaceName} {{
+impl script_bindings::structuredclone::MarkedAs{self.marker}InIdl for {ifaceName} {{
     #[allow(path_statements)]
     fn assert_{self.marker_lower}() {{
         crate::dom::bindings::{self.marker_lower}::assert_{self.marker_lower}::<Self>;

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -41,6 +41,7 @@ pub mod root;
 pub mod script_runtime;
 pub mod settings_stack;
 pub mod str;
+pub mod structuredclone;
 pub mod trace;
 pub mod utils;
 pub mod weakref;

--- a/components/script_bindings/structuredclone.rs
+++ b/components/script_bindings/structuredclone.rs
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/// A marker to ensure that the `[Serializable]` attribute is present on
+/// types that can be serialized.
+pub trait SerializableMarker {
+    /// Used to define compile-time assertions about the type implementing this trait.
+    fn assert_serializable();
+}
+
+/// A marker to ensure that the `[Transferable]` attribute is present on
+/// types that can be transferred.
+pub trait TransferableMarker {
+    /// Used to define compile-time assertions about the type implementing this trait.
+    fn assert_transferable();
+}

--- a/components/script_bindings/structuredclone.rs
+++ b/components/script_bindings/structuredclone.rs
@@ -3,15 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /// A marker to ensure that the `[Serializable]` attribute is present on
-/// types that can be serialized.
-pub trait SerializableMarker {
+/// types that can be serialized. This trait should not be implemented manually.
+pub trait MarkedAsSerializableInIdl {
     /// Used to define compile-time assertions about the type implementing this trait.
     fn assert_serializable();
 }
 
 /// A marker to ensure that the `[Transferable]` attribute is present on
-/// types that can be transferred.
-pub trait TransferableMarker {
+/// types that can be transferred. This trait should not be implemented manually.
+pub trait MarkedAsTransferableInIdl {
     /// Used to define compile-time assertions about the type implementing this trait.
     fn assert_transferable();
 }

--- a/components/script_bindings/webidls/Blob.webidl
+++ b/components/script_bindings/webidls/Blob.webidl
@@ -4,7 +4,7 @@
 
 // https://w3c.github.io/FileAPI/#blob
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), Serializable]
 interface Blob {
   [Throws] constructor(optional sequence<BlobPart> blobParts,
     optional BlobPropertyBag options = {});

--- a/components/script_bindings/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script_bindings/webidls/CanvasRenderingContext2D.webidl
@@ -269,7 +269,7 @@ dictionary ImageDataSettings {
 };
 
 [Exposed=(Window,Worker),
- Serializable]
+ /*Serializable*/]
 interface ImageData {
   [Throws] constructor(unsigned long sw, unsigned long sh, optional ImageDataSettings settings = {});
   [Throws] constructor(ImageDataArray data, unsigned long sw,

--- a/components/script_bindings/webidls/CryptoKey.webidl
+++ b/components/script_bindings/webidls/CryptoKey.webidl
@@ -8,7 +8,7 @@ enum KeyType { "public", "private", "secret" };
 
 enum KeyUsage { "encrypt", "decrypt", "sign", "verify", "deriveKey", "deriveBits", "wrapKey", "unwrapKey" };
 
-[SecureContext, Exposed=(Window,Worker), Serializable, Pref="dom_crypto_subtle_enabled"]
+[SecureContext, Exposed=(Window,Worker), /*Serializable,*/ Pref="dom_crypto_subtle_enabled"]
 interface CryptoKey {
   readonly attribute KeyType type;
   readonly attribute boolean extractable;

--- a/components/script_bindings/webidls/DOMException.webidl
+++ b/components/script_bindings/webidls/DOMException.webidl
@@ -9,7 +9,8 @@
 
 [
   ExceptionClass,
-  Exposed=(Window,Worker,Worklet,DissimilarOriginWindow)
+  Exposed=(Window,Worker,Worklet,DissimilarOriginWindow),
+  Serializable,
 ]
 interface DOMException {
   [Throws] constructor(optional DOMString message="", optional DOMString name="Error");

--- a/components/script_bindings/webidls/DOMPoint.webidl
+++ b/components/script_bindings/webidls/DOMPoint.webidl
@@ -10,7 +10,8 @@
  */
 
 // http://dev.w3.org/fxtf/geometry/Overview.html#dompoint
-[Exposed=(Window,Worker,PaintWorklet)]
+[Exposed=(Window,Worker,PaintWorklet),
+ Serializable]
 interface DOMPoint : DOMPointReadOnly {
     [Throws] constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
                 optional unrestricted double z = 0, optional unrestricted double w = 1);

--- a/components/script_bindings/webidls/DOMPointReadOnly.webidl
+++ b/components/script_bindings/webidls/DOMPointReadOnly.webidl
@@ -10,7 +10,8 @@
  */
 
 // http://dev.w3.org/fxtf/geometry/Overview.html#dompointreadonly
-[Exposed=(Window,Worker,PaintWorklet)]
+[Exposed=(Window,Worker,PaintWorklet),
+ Serializable]
 interface DOMPointReadOnly {
     [Throws] constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
                 optional unrestricted double z = 0, optional unrestricted double w = 1);

--- a/components/script_bindings/webidls/DOMRect.webidl
+++ b/components/script_bindings/webidls/DOMRect.webidl
@@ -5,7 +5,7 @@
 // https://drafts.fxtf.org/geometry/#domrect
 
 [Exposed=(Window,Worker),
- Serializable,
+ /*Serializable,*/
  LegacyWindowAlias=SVGRect]
 interface DOMRect : DOMRectReadOnly {
     [Throws] constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,

--- a/components/script_bindings/webidls/DOMRectReadOnly.webidl
+++ b/components/script_bindings/webidls/DOMRectReadOnly.webidl
@@ -5,7 +5,7 @@
 // https://drafts.fxtf.org/geometry/#domrect
 
 [Exposed=(Window,Worker),
- Serializable]
+ /*Serializable*/]
 interface DOMRectReadOnly {
   [Throws] constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
               optional unrestricted double width = 0, optional unrestricted double height = 0);

--- a/components/script_bindings/webidls/MessagePort.webidl
+++ b/components/script_bindings/webidls/MessagePort.webidl
@@ -6,7 +6,7 @@
  * https://html.spec.whatwg.org/multipage/#messageport
  */
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), Transferable]
 interface MessagePort : EventTarget {
   [Throws] undefined postMessage(any message, sequence<object> transfer);
   [Throws] undefined postMessage(any message, optional StructuredSerializeOptions options = {});

--- a/components/script_bindings/webidls/ReadableStream.webidl
+++ b/components/script_bindings/webidls/ReadableStream.webidl
@@ -4,7 +4,7 @@
 
 // https://streams.spec.whatwg.org/#readablestream
 
-[Exposed=*] // [Transferable] - See Bug 1562065
+[Exposed=*, Transferable]
 interface _ReadableStream {
   [Throws]
   constructor(optional object underlyingSource, optional QueuingStrategy strategy = {});

--- a/components/script_bindings/webidls/TransformStream.webidl
+++ b/components/script_bindings/webidls/TransformStream.webidl
@@ -6,7 +6,7 @@
  * https://streams.spec.whatwg.org/#ts-class-definition
  */
 
-[Exposed=*] // [Transferable] - See Bug 1562065
+[Exposed=*, Transferable]
 interface TransformStream {
   [Throws]
   constructor(optional object transformer,

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -170,7 +170,7 @@ interface GPUDevice: EventTarget {
 };
 GPUDevice includes GPUObjectBase;
 
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPUBuffer {
     readonly attribute GPUSize64Out size;
     readonly attribute GPUFlagsConstant usage;
@@ -222,7 +222,7 @@ namespace GPUMapMode {
     const GPUFlagsConstant WRITE = 0x0002;
 };
 
-[Exposed=(Window, DedicatedWorker), Serializable , Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPUTexture {
     [Throws, NewObject]
     GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {});
@@ -458,7 +458,7 @@ enum GPUCompareFunction {
     "always"
 };
 
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPUBindGroupLayout {
 };
 GPUBindGroupLayout includes GPUObjectBase;
@@ -479,7 +479,7 @@ dictionary GPUBindGroupLayoutEntry {
 };
 
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPUShaderStage {
     const GPUShaderStageFlags VERTEX = 1;
     const GPUShaderStageFlags FRAGMENT = 2;
@@ -560,7 +560,7 @@ dictionary GPUBufferBinding {
     GPUSize64 size;
 };
 
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPUPipelineLayout {
 };
 GPUPipelineLayout includes GPUObjectBase;
@@ -569,7 +569,7 @@ dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
     required sequence<GPUBindGroupLayout> bindGroupLayouts;
 };
 
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPUShaderModule {
     Promise<GPUCompilationInfo> getCompilationInfo();
 };
@@ -638,7 +638,7 @@ dictionary GPUProgrammableStage {
 
 typedef double GPUPipelineConstantValue; // May represent WGSL's bool, f32, i32, u32, and f16 if enabled.
 
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPUComputePipeline {
 };
 GPUComputePipeline includes GPUObjectBase;
@@ -648,7 +648,7 @@ dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUProgrammableStage compute;
 };
 
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPURenderPipeline {
 };
 GPURenderPipeline includes GPUObjectBase;
@@ -873,7 +873,7 @@ dictionary GPUImageCopyExternalImage {
     boolean flipY = false;
 };
 
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPUCommandBuffer {
 };
 GPUCommandBuffer includes GPUObjectBase;
@@ -881,7 +881,7 @@ GPUCommandBuffer includes GPUObjectBase;
 dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
 };
 
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPUCommandEncoder {
     [NewObject]
     GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
@@ -939,7 +939,7 @@ dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
     boolean measureExecutionTime = false;
 };
 
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPUComputePassEncoder {
     undefined setPipeline(GPUComputePipeline pipeline);
     undefined dispatchWorkgroups(GPUSize32 x, optional GPUSize32 y = 1, optional GPUSize32 z = 1);
@@ -1090,7 +1090,7 @@ dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
     boolean stencilReadOnly = false;
 };
 
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPUQueue {
     undefined submit(sequence<GPUCommandBuffer> buffers);
 
@@ -1119,7 +1119,7 @@ interface GPUQueue {
 };
 GPUQueue includes GPUObjectBase;
 
-[Exposed=(Window, DedicatedWorker), Serializable, Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
 interface GPUQuerySet {
     undefined destroy();
 };

--- a/components/script_bindings/webidls/WritableStream.webidl
+++ b/components/script_bindings/webidls/WritableStream.webidl
@@ -4,7 +4,7 @@
 
 // https://streams.spec.whatwg.org/#writablestream
 
-[Exposed=*] // [Transferable] - See Bug 1562065
+[Exposed=*, Transferable]
 interface WritableStream {
   [Throws]
   constructor(optional object underlyingSink, optional QueuingStrategy strategy = {});


### PR DESCRIPTION
These changes add compile-time assertions that:
* any type that implements the Serializable/Transferable trait has a `[Serializable]` or `[Transferable]` annotation in the interface WebIDL
* any WebIDL interface with the `[Serializable]` or `[Transferable]` annotation implements the corresponding trait

This is useful because it means that WebIDL definitions will be less confusing if you're trying to figure out whether Servo supports serializing/transferring a particular interface type. It also makes fixing #21715 in the future a little bit easier, because the annotations will remain up to date.

Testing: compile-time only; no point in writing tests for this since it involves webidl codegen.
