### PR TITLE
test config: Add escape character

### DIFF
--- a/tests/wpt/meta/webdriver/tests/classic/element_click/navigate.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/navigate.py.ini
@@ -2,16 +2,16 @@
   [test_link_from_toplevel_context_with_target[_blank\]]
     expected: FAIL
 
-  [test_link_from_nested_context_with_target[]]
+  [test_link_from_nested_context_with_target[\]]
     expected: FAIL
 
-  [test_link_from_nested_context_with_target[_parent]]
+  [test_link_from_nested_context_with_target[_parent\]]
     expected: FAIL
 
-  [test_link_from_nested_context_with_target[_self]]
+  [test_link_from_nested_context_with_target[_self\]]
     expected: FAIL
 
-  [test_link_from_nested_context_with_target[_top]]
+  [test_link_from_nested_context_with_target[_top\]]
     expected: FAIL
 
   [test_link_from_toplevel_context_with_target[_parent\]]


### PR DESCRIPTION
Add escape character for config. Otherwise cannot run webdriver test.

Fixes: `wptrunner.wptmanifest.parser.ParseError: Junk before EOL ]`
