### PR TITLE
Implement trusted types processing for JavaScript URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,7 +1631,7 @@ dependencies = [
 [[package]]
 name = "content-security-policy"
 version = "0.5.4"
-source = "git+https://github.com/servo/rust-content-security-policy?branch=servo-csp#e8d4883f9a9349e602465f31a780bc6d70b98528"
+source = "git+https://github.com/servo/rust-content-security-policy?branch=servo-csp#cf67beb96db9244ab6956a4da61dbe83384d5cd7"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.3",

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -630,15 +630,9 @@ impl ScriptThread {
                     .clone();
                 let task = task!(navigate_javascript: move || {
                     // Important re security. See https://github.com/servo/servo/issues/23373
-                    if let Some(window) = trusted_global.root().downcast::<Window>() {
+                    if trusted_global.root().is::<Window>() {
                         let global = &trusted_global.root();
-                        // Step 5: If the result of should navigation request of type be blocked by
-                        // Content Security Policy? given request and cspNavigationType is "Blocked", then return. [CSP]
-                        if global.get_csp_list().should_navigation_request_be_blocked(global, &load_data, None) {
-                            return;
-                        }
-                        if ScriptThread::check_load_origin(&load_data.load_origin, &window.get_url().origin()) {
-                            ScriptThread::eval_js_url(&trusted_global.root(), &mut load_data, CanGc::note());
+                        if Self::navigate_to_javascript_url(global, global, &mut load_data, None, CanGc::note()) {
                             sender
                                 .send((pipeline_id, ScriptToConstellationMessage::LoadUrl(load_data, history_handling)))
                                 .unwrap();
@@ -661,6 +655,36 @@ impl ScriptThread {
                     .expect("Sending a LoadUrl message to the constellation failed");
             }
         });
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#navigate-to-a-javascript:-url>
+    pub(crate) fn navigate_to_javascript_url(
+        global: &GlobalScope,
+        containing_global: &GlobalScope,
+        load_data: &mut LoadData,
+        container: Option<&Element>,
+        can_gc: CanGc,
+    ) -> bool {
+        // Step 3. If initiatorOrigin is not same origin-domain with targetNavigable's active document's origin, then return.
+        //
+        // Important re security. See https://github.com/servo/servo/issues/23373
+        if !Self::check_load_origin(&load_data.load_origin, &global.get_url().origin()) {
+            return false;
+        }
+
+        // Step 5: If the result of should navigation request of type be blocked by
+        // Content Security Policy? given request and cspNavigationType is "Blocked", then return. [CSP]
+        if global
+            .get_csp_list()
+            .should_navigation_request_be_blocked(global, load_data, container)
+        {
+            return false;
+        }
+
+        // Step 6. Let newDocument be the result of evaluating a javascript: URL given targetNavigable,
+        // url, initiatorOrigin, and userInvolvement.
+        Self::eval_js_url(containing_global, load_data, can_gc);
+        true
     }
 
     pub(crate) fn process_attach_layout(new_layout_info: NewLayoutInfo, origin: MutableOrigin) {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -676,7 +676,7 @@ impl ScriptThread {
         // Content Security Policy? given request and cspNavigationType is "Blocked", then return. [CSP]
         if global
             .get_csp_list()
-            .should_navigation_request_be_blocked(global, load_data, container)
+            .should_navigation_request_be_blocked(global, load_data, container, can_gc)
         {
             return false;
         }

--- a/tests/wpt/meta/trusted-types/navigate-to-javascript-url-002.html.ini
+++ b/tests/wpt/meta/trusted-types/navigate-to-javascript-url-002.html.ini
@@ -1,3 +1,0 @@
-[navigate-to-javascript-url-002.html]
-  [Setting window.location to a javascript: URL with a default policy should execute the JavaScript code modified by that policy.]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/navigate-to-javascript-url-003.html.ini
+++ b/tests/wpt/meta/trusted-types/navigate-to-javascript-url-003.html.ini
@@ -1,3 +1,4 @@
 [navigate-to-javascript-url-003.html]
+  expected: ERROR
   [Setting window.location to a javascript: URL with a default policy that throws should report a CSP violation without rethrowing the exception.]
     expected: FAIL

--- a/tests/wpt/meta/trusted-types/navigate-to-javascript-url-005.html.ini
+++ b/tests/wpt/meta/trusted-types/navigate-to-javascript-url-005.html.ini
@@ -1,3 +1,0 @@
-[navigate-to-javascript-url-005.html]
-  [A subframe navigating to a javascript: URL should use the CSP policy associated to its document for pre-navigation check and report a violation when it does not defined a default policy.]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/navigate-to-javascript-url-006.sub.html.ini
+++ b/tests/wpt/meta/trusted-types/navigate-to-javascript-url-006.sub.html.ini
@@ -1,3 +1,0 @@
-[navigate-to-javascript-url-006.sub.html]
-  [A cross-origin subframe navigating to a javascript: URL should use the CSP policy associated to its document for pre-navigation check and execute the JavaScript code modified by its default policy.]
-    expected: FAIL

--- a/tests/wpt/meta/trusted-types/navigate-to-javascript-url-csp-headers.html.ini
+++ b/tests/wpt/meta/trusted-types/navigate-to-javascript-url-csp-headers.html.ini
@@ -1,11 +1,5 @@
 [navigate-to-javascript-url-csp-headers.html]
   expected: TIMEOUT
-  [One enforce require-trusted-types-for 'script' directive: navigation is blocked, violation is reported.]
-    expected: FAIL
-
-  [One report-only require-trusted-types-for 'script' directive: navigation continues, violation is reported.]
-    expected: FAIL
-
   [Multiple enforce require-trusted-types-for directives: one violation reported for each require-trusted-types-for 'script', invalid sink groups ignored.]
     expected: FAIL
 

--- a/tests/wpt/meta/trusted-types/trusted-types-navigation.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-navigation.html.ini
@@ -164,13 +164,7 @@
   [Navigate a window via anchor with javascript:-urls in enforcing mode.]
     expected: FAIL
 
-  [Navigate a window via anchor with javascript:-urls w/ default policy in enforcing mode.]
-    expected: FAIL
-
   [Navigate a window via anchor with javascript:-urls in report-only mode.]
-    expected: FAIL
-
-  [Navigate a window via anchor with javascript:-urls w/ default policy in report-only mode.]
     expected: FAIL
 
   [Navigate a frame via anchor with javascript:-urls in enforcing mode.]


### PR DESCRIPTION
We pass in the new trait implementation to process the value,
which the CSP crate calls in its implementation. Additionally,
since the request url can change, we need to propagate that
to load_data as well.

This also avoids a crash when a discarded browsing context is
accessed while navigating the iframes in the WPT tests. This
is a known issue, but hampers investigation into actual
Trusted Types support.

All tests using iframes don't work, as they don't have the
correct browsing context. The other tests do work, but some
fail on header ascii parsing (#36801) or error while handling
errors. That last one I don't understand based on the current
code and I would need to do a deep-dive in the existing code
to understand better what's going on.

Part of #36258
Part of #37920