### PR TITLE
net: Send ResponseContentObj to Devtools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,6 +1910,7 @@ name = "devtools"
 version = "0.0.1"
 dependencies = [
  "base",
+ "base64 0.22.1",
  "chrono",
  "crossbeam-channel",
  "devtools_traits",

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -13,6 +13,7 @@ path = "lib.rs"
 
 [dependencies]
 base = { workspace = true }
+base64 = { workspace = true }
 chrono = { workspace = true }
 crossbeam-channel = { workspace = true }
 devtools_traits = { workspace = true }
@@ -21,15 +22,15 @@ headers = { workspace = true }
 http = { workspace = true }
 ipc-channel = { workspace = true }
 log = { workspace = true }
+net = { path = "../net" }
 net_traits = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 servo_config = { path = "../config" }
 servo_rand = { path = "../rand" }
 servo_url = { path = "../url" }
-net = { path = "../net" }
 uuid = { workspace = true }
-base64 = "0.22.1"
+
 
 [build-dependencies]
 chrono = { workspace = true }

--- a/components/devtools/Cargo.toml
+++ b/components/devtools/Cargo.toml
@@ -29,6 +29,7 @@ servo_rand = { path = "../rand" }
 servo_url = { path = "../url" }
 net = { path = "../net" }
 uuid = { workspace = true }
+base64 = "0.22.1"
 
 [build-dependencies]
 chrono = { workspace = true }

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -1,0 +1,56 @@
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::StreamId;
+use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::protocol::ClientRequest;
+
+pub struct LongStringActor {
+    pub name: String,
+    pub full_string: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SubstringReply {
+    from: String,
+    substring: String,
+}
+
+impl Actor for LongStringActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &self,
+        request: ClientRequest,
+        _registry: &ActorRegistry,
+        msg_type: &str,
+        msg: &Map<String, Value>,
+        _id: StreamId,
+    ) -> Result<(), ActorError> {
+        match msg_type {
+            "substring" => {
+                let start = msg.get("start").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+                let end = msg
+                    .get("end")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(self.full_string.len() as u64) as usize;
+                let substring: String = self
+                    .full_string
+                    .chars()
+                    .skip(start)
+                    .take(end - start)
+                    .collect();
+                let reply = SubstringReply {
+                    from: self.name(),
+                    substring,
+                };
+                request.reply_final(&reply)?
+            },
+            _ => return Err(ActorError::UnrecognizedPacketType),
+        }
+        Ok(())
+    }
+}

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -8,10 +8,11 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 
-#[derive(Clone)]
+const INITIAL_LENGTH: usize = 500;
+
 pub struct LongStringActor {
-    pub name: String,
-    pub full_string: String,
+    name: String,
+    full_string: String,
 }
 
 #[derive(Clone, Serialize)]
@@ -70,17 +71,17 @@ impl Actor for LongStringActor {
 }
 
 impl LongStringActor {
-    pub fn new(registry: &crate::actor::ActorRegistry, full_string: String) -> Self {
+    pub fn new(registry: &ActorRegistry, full_string: String) -> Self {
         let name = registry.new_name("longStringActor");
         LongStringActor { name, full_string }
     }
 
-    pub fn long_string_obj(actor: String, length: usize, initial: String) -> LongStringObj {
+    pub fn long_string_obj(&self) -> LongStringObj {
         LongStringObj {
             type_: "longString".to_string(),
-            actor,
-            length,
-            initial,
+            actor: self.name.clone(),
+            length: self.full_string.len(),
+            initial: self.full_string.chars().take(INITIAL_LENGTH).collect(),
         }
     }
 }

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -4,9 +4,9 @@
 use serde::Serialize;
 use serde_json::{Map, Value};
 
+use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
-use crate::StreamId;
 
 #[derive(Clone)]
 pub struct LongStringActor {

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -4,9 +4,9 @@
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
+use crate::StreamId;
 
 #[derive(Clone)]
 pub struct LongStringActor {

--- a/components/devtools/actors/long_string.rs
+++ b/components/devtools/actors/long_string.rs
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use serde::Serialize;
 use serde_json::{Map, Value};
 
@@ -5,9 +8,20 @@ use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
 
+#[derive(Clone)]
 pub struct LongStringActor {
     pub name: String,
     pub full_string: String,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LongStringObj {
+    #[serde(rename = "type")]
+    type_: String,
+    actor: String,
+    length: usize,
+    initial: String,
 }
 
 #[derive(Serialize)]
@@ -52,5 +66,21 @@ impl Actor for LongStringActor {
             _ => return Err(ActorError::UnrecognizedPacketType),
         }
         Ok(())
+    }
+}
+
+impl LongStringActor {
+    pub fn new(registry: &crate::actor::ActorRegistry, full_string: String) -> Self {
+        let name = registry.new_name("longStringActor");
+        LongStringActor { name, full_string }
+    }
+
+    pub fn long_string_obj(actor: String, length: usize, initial: String) -> LongStringObj {
+        LongStringObj {
+            type_: "longString".to_string(),
+            actor,
+            length,
+            initial,
+        }
     }
 }

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -407,7 +407,9 @@ impl NetworkEventActor {
             .as_ref()
             .and_then(|url| Self::response_cookies(&response, url));
         self.response_start = Some(Self::response_start(&response));
-        self.response_content = Self::response_content(&response);
+        if let Some(response_content) = Self::response_content(self, &response) {
+            self.response_content = Some(response_content);
+        }
         self.response_body = response.body.clone();
         self.response_headers_raw = response.headers.clone();
     }
@@ -459,8 +461,12 @@ impl NetworkEventActor {
         }
     }
 
-    pub fn response_content(response: &DevtoolsHttpResponse) -> Option<ResponseContentMsg> {
-        let _body = response.body.as_ref()?;
+    pub fn response_content(
+        &mut self,
+        response: &DevtoolsHttpResponse,
+    ) -> Option<ResponseContentMsg> {
+        let body = response.body.as_ref()?;
+        self.response_body = Some(body.clone());
 
         let mime_type = response
             .headers

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -367,7 +367,7 @@ impl Actor for NetworkEventActor {
 
                     if Self::is_text_mime(&mime_type) {
                         let full_str = String::from_utf8_lossy(body).to_string();
-                        let initial: String = full_str.chars().take(1000).collect();
+                        let initial: String = full_str.chars().collect();
                         // Queue a LongStringActor for this body
                         let long_string_actor_name = format!("longStringActor{}", self.resource_id);
                         let long_string_actor = LongStringActor {

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -357,17 +357,12 @@ impl Actor for NetworkEventActor {
 
                     if Self::is_text_mime(&mime_type) {
                         let full_str = String::from_utf8_lossy(body).to_string();
-                        let initial: String = full_str.chars().take(500).collect();
 
                         // Queue a LongStringActor for this body
-                        let long_string_actor = LongStringActor::new(registry, full_str.clone());
-                        registry.register_later(Box::new(long_string_actor.clone()));
+                        let long_string_actor = LongStringActor::new(registry, full_str);
+                        let long_string_obj = long_string_actor.long_string_obj();
+                        registry.register_later(Box::new(long_string_actor));
 
-                        let long_string_obj = LongStringActor::long_string_obj(
-                            long_string_actor.name(),
-                            full_str.chars().count(),
-                            initial,
-                        );
                         ResponseContentObj {
                             mime_type,
                             text: serde_json::to_value(long_string_obj).unwrap(),

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -357,7 +357,7 @@ impl Actor for NetworkEventActor {
 
                     if Self::is_text_mime(&mime_type) {
                         let full_str = String::from_utf8_lossy(body).to_string();
-                        let initial: String = full_str.chars().take(1000).collect();
+                        let initial: String = full_str.chars().take(500).collect();
 
                         // Queue a LongStringActor for this body
                         let long_string_actor = LongStringActor::new(registry, full_str.clone());

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -60,9 +60,9 @@ mod actors {
     pub mod device;
     pub mod framerate;
     pub mod inspector;
+    pub mod long_string;
     pub mod memory;
     pub mod network_event;
-    pub mod long_string;
     pub mod object;
     pub mod performance;
     pub mod preference;

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -62,6 +62,7 @@ mod actors {
     pub mod inspector;
     pub mod memory;
     pub mod network_event;
+    pub mod long_string;
     pub mod object;
     pub mod performance;
     pub mod preference;


### PR DESCRIPTION
Currently, the response tab for a request's detail in devtools does not show the available data, this was due to how the content is being structured (not the way firefox's devtools client expects it) and also the body being discarded and not stored in the actor.
This PR stores the body  in the actor , which is then retrieved in `getResponseContent`  and then use it to instantiate the new struct `ResponseContentObj` which matches the format firefox's expects

Fixes: https://github.com/servo/servo/issues/38128
