### PR TITLE
layout: Use `ServoThreadSafeLayoutNode` in more places

### DIFF
--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -9,6 +9,7 @@ use euclid::Size2D;
 use fnv::FnvHashMap;
 use fonts::FontContext;
 use fxhash::FxHashMap;
+use layout_api::wrapper_traits::ThreadSafeLayoutNode;
 use layout_api::{
     IFrameSizes, ImageAnimationState, PendingImage, PendingImageState, PendingRasterizationImage,
 };
@@ -18,9 +19,10 @@ use net_traits::image_cache::{
 };
 use parking_lot::{Mutex, RwLock};
 use pixels::RasterImage;
+use script::layout_dom::ServoThreadSafeLayoutNode;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::context::SharedStyleContext;
-use style::dom::{OpaqueNode, TNode};
+use style::dom::OpaqueNode;
 use style::values::computed::image::{Gradient, Image};
 use webrender_api::units::{DeviceIntSize, DeviceSize};
 
@@ -247,7 +249,7 @@ impl ImageResolver {
 
     pub(crate) fn queue_svg_element_for_serialization(
         &self,
-        element: script::layout_dom::ServoLayoutNode<'_>,
+        element: ServoThreadSafeLayoutNode<'_>,
     ) {
         self.pending_svg_elements_for_serialization
             .lock()

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -2,22 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::any::Any;
 use std::marker::PhantomData;
 
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
 use base::id::{BrowsingContextId, PipelineId};
 use html5ever::{local_name, ns};
-use layout_api::wrapper_traits::{
-    LayoutDataTrait, LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
-};
+use layout_api::wrapper_traits::{LayoutDataTrait, ThreadSafeLayoutElement, ThreadSafeLayoutNode};
 use layout_api::{
     GenericLayoutDataTrait, LayoutDamage, LayoutElementType,
     LayoutNodeType as ScriptLayoutNodeType, SVGElementData,
 };
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::image_cache::Image;
-use script::layout_dom::ServoLayoutNode;
+use script::layout_dom::ServoThreadSafeLayoutNode;
 use servo_arc::Arc as ServoArc;
 use smallvec::SmallVec;
 use style::context::SharedStyleContext;
@@ -116,13 +113,13 @@ impl LayoutBox {
     fn repair_style(
         &self,
         context: &SharedStyleContext,
-        node: &ServoLayoutNode,
+        node: &ServoThreadSafeLayoutNode,
         new_style: &ServoArc<ComputedValues>,
     ) {
         match self {
             LayoutBox::DisplayContents(inline_shared_styles) => {
                 *inline_shared_styles.style.borrow_mut() = new_style.clone();
-                *inline_shared_styles.selected.borrow_mut() = node.to_threadsafe().selected_style();
+                *inline_shared_styles.selected.borrow_mut() = node.selected_style();
             },
             LayoutBox::BlockLevel(block_level_box) => {
                 block_level_box
@@ -172,7 +169,7 @@ pub struct DOMLayoutData(AtomicRefCell<InnerDOMLayoutData>);
 // The implementation of this trait allows the data to be stored in the DOM.
 impl LayoutDataTrait for DOMLayoutData {}
 impl GenericLayoutDataTrait for DOMLayoutData {
-    fn as_any(&self) -> &dyn Any {
+    fn as_any(&self) -> &dyn std::any::Any {
         self
     }
 }
@@ -235,7 +232,6 @@ pub(crate) trait NodeExt<'dom> {
     fn as_video(&self) -> Option<(Option<webrender_api::ImageKey>, Option<PhysicalSize<f64>>)>;
     fn as_svg(&self) -> Option<SVGElementData>;
     fn as_typeless_object_with_data_attribute(&self) -> Option<String>;
-    fn style(&self, context: &SharedStyleContext) -> ServoArc<ComputedValues>;
 
     fn layout_data_mut(&self) -> AtomicRefMut<'dom, InnerDOMLayoutData>;
     fn layout_data(&self) -> Option<AtomicRef<'dom, InnerDOMLayoutData>>;
@@ -255,10 +251,9 @@ pub(crate) trait NodeExt<'dom> {
     fn take_restyle_damage(&self) -> LayoutDamage;
 }
 
-impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
+impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
     fn as_image(&self) -> Option<(Option<Image>, PhysicalSize<f64>)> {
-        let node = self.to_threadsafe();
-        let (resource, metadata) = node.image_data()?;
+        let (resource, metadata) = self.image_data()?;
         let (width, height) = resource
             .as_ref()
             .map(|image| {
@@ -268,7 +263,7 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
             .or_else(|| metadata.map(|metadata| (metadata.width, metadata.height)))
             .unwrap_or((0, 0));
         let (mut width, mut height) = (width as f64, height as f64);
-        if let Some(density) = node.image_density().filter(|density| *density != 1.) {
+        if let Some(density) = self.image_density().filter(|density| *density != 1.) {
             width /= density;
             height /= density;
         }
@@ -276,12 +271,11 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
     }
 
     fn as_svg(&self) -> Option<SVGElementData> {
-        self.to_threadsafe().svg_data()
+        self.svg_data()
     }
 
     fn as_video(&self) -> Option<(Option<webrender_api::ImageKey>, Option<PhysicalSize<f64>>)> {
-        let node = self.to_threadsafe();
-        let data = node.media_data()?;
+        let data = self.media_data()?;
         let natural_size = if let Some(frame) = data.current_frame {
             Some(PhysicalSize::new(frame.width.into(), frame.height.into()))
         } else {
@@ -295,8 +289,7 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
     }
 
     fn as_canvas(&self) -> Option<(CanvasInfo, PhysicalSize<f64>)> {
-        let node = self.to_threadsafe();
-        let canvas_data = node.canvas_data()?;
+        let canvas_data = self.canvas_data()?;
         let source = canvas_data.source;
         Some((
             CanvasInfo { source },
@@ -305,8 +298,7 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
     }
 
     fn as_iframe(&self) -> Option<(PipelineId, BrowsingContextId)> {
-        let node = self.to_threadsafe();
-        match (node.iframe_pipeline_id(), node.iframe_browsing_context_id()) {
+        match (self.iframe_pipeline_id(), self.iframe_browsing_context_id()) {
             (Some(pipeline_id), Some(browsing_context_id)) => {
                 Some((pipeline_id, browsing_context_id))
             },
@@ -315,8 +307,10 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
     }
 
     fn as_typeless_object_with_data_attribute(&self) -> Option<String> {
-        if LayoutNode::type_id(self) !=
-            ScriptLayoutNodeType::Element(LayoutElementType::HTMLObjectElement)
+        if self.type_id() !=
+            Some(ScriptLayoutNodeType::Element(
+                LayoutElementType::HTMLObjectElement,
+            ))
         {
             return None;
         }
@@ -324,7 +318,7 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
         // TODO: This is the what the legacy layout system did, but really if Servo
         // supports any `<object>` that's an image, it should support those with URLs
         // and `type` attributes with image mime types.
-        let element = self.to_threadsafe().as_element()?;
+        let element = self.as_element()?;
         if element.get_attr(&ns!(), &local_name!("type")).is_some() {
             return None;
         }
@@ -333,15 +327,11 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
             .map(|string| string.to_owned())
     }
 
-    fn style(&self, context: &SharedStyleContext) -> ServoArc<ComputedValues> {
-        self.to_threadsafe().style(context)
-    }
-
     fn layout_data_mut(&self) -> AtomicRefMut<'dom, InnerDOMLayoutData> {
-        if LayoutNode::layout_data(self).is_none() {
+        if ThreadSafeLayoutNode::layout_data(self).is_none() {
             self.initialize_layout_data::<DOMLayoutData>();
         }
-        LayoutNode::layout_data(self)
+        ThreadSafeLayoutNode::layout_data(self)
             .unwrap()
             .as_any()
             .downcast_ref::<DOMLayoutData>()
@@ -351,7 +341,7 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
     }
 
     fn layout_data(&self) -> Option<AtomicRef<'dom, InnerDOMLayoutData>> {
-        LayoutNode::layout_data(self).map(|data| {
+        ThreadSafeLayoutNode::layout_data(self).map(|data| {
             data.as_any()
                 .downcast_ref::<DOMLayoutData>()
                 .unwrap()
@@ -416,13 +406,13 @@ impl<'dom> NodeExt<'dom> for ServoLayoutNode<'dom> {
     fn repair_style(&self, context: &SharedStyleContext) {
         let data = self.layout_data_mut();
         if let Some(layout_object) = &*data.self_box.borrow() {
-            let style = self.to_threadsafe().style(context);
+            let style = self.style(context);
             layout_object.repair_style(context, self, &style);
         }
 
         for pseudo_layout_data in data.pseudo_boxes.iter() {
             if let Some(layout_box) = pseudo_layout_data.box_slot.borrow().as_ref() {
-                if let Some(node) = self.to_threadsafe().with_pseudo(pseudo_layout_data.pseudo) {
+                if let Some(node) = self.with_pseudo(pseudo_layout_data.pseudo) {
                     layout_box.repair_style(context, self, &node.style(context));
                 }
             }

--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -4,7 +4,7 @@
 
 use geom::{FlexAxis, MainStartCrossStart};
 use malloc_size_of_derive::MallocSizeOf;
-use script::layout_dom::ServoLayoutNode;
+use script::layout_dom::ServoThreadSafeLayoutNode;
 use servo_arc::Arc as ServoArc;
 use style::context::SharedStyleContext;
 use style::logical_geometry::WritingMode;
@@ -161,7 +161,7 @@ impl FlexLevelBox {
     pub(crate) fn repair_style(
         &mut self,
         context: &SharedStyleContext,
-        node: &ServoLayoutNode,
+        node: &ServoThreadSafeLayoutNode,
         new_style: &ServoArc<ComputedValues>,
     ) {
         match self {

--- a/components/layout/flow/inline/inline_box.rs
+++ b/components/layout/flow/inline/inline_box.rs
@@ -6,9 +6,8 @@ use std::vec::IntoIter;
 
 use app_units::Au;
 use fonts::FontMetrics;
-use layout_api::wrapper_traits::{LayoutNode, ThreadSafeLayoutNode};
 use malloc_size_of_derive::MallocSizeOf;
-use script::layout_dom::ServoLayoutNode;
+use script::layout_dom::ServoThreadSafeLayoutNode;
 use servo_arc::Arc as ServoArc;
 use style::properties::ComputedValues;
 
@@ -73,12 +72,12 @@ impl InlineBox {
 
     pub(crate) fn repair_style(
         &mut self,
-        node: &ServoLayoutNode,
+        node: &ServoThreadSafeLayoutNode,
         new_style: &ServoArc<ComputedValues>,
     ) {
         self.base.repair_style(new_style);
         *self.shared_inline_styles.style.borrow_mut() = new_style.clone();
-        *self.shared_inline_styles.selected.borrow_mut() = node.to_threadsafe().selected_style();
+        *self.shared_inline_styles.selected.borrow_mut() = node.selected_style();
     }
 }
 

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -7,9 +7,10 @@
 
 use app_units::{Au, MAX_AU};
 use inline::InlineFormattingContext;
+use layout_api::wrapper_traits::ThreadSafeLayoutNode;
 use malloc_size_of_derive::MallocSizeOf;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
-use script::layout_dom::ServoLayoutNode;
+use script::layout_dom::ServoThreadSafeLayoutNode;
 use servo_arc::Arc;
 use style::Zero;
 use style::computed_values::clear::T as StyleClear;
@@ -23,7 +24,6 @@ use style::values::specified::{Display, TextAlignKeyword};
 
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
-use crate::dom::NodeExt;
 use crate::flow::float::{
     Clear, ContainingBlockPositionInfo, FloatBox, FloatSide, PlacementAmongFloats,
     SequentialLayoutState,
@@ -76,7 +76,11 @@ impl BlockContainer {
         }
     }
 
-    pub(crate) fn repair_style(&mut self, node: &ServoLayoutNode, new_style: &Arc<ComputedValues>) {
+    pub(crate) fn repair_style(
+        &mut self,
+        node: &ServoThreadSafeLayoutNode,
+        new_style: &Arc<ComputedValues>,
+    ) {
         match self {
             BlockContainer::BlockLevelBoxes(..) => {},
             BlockContainer::InlineFormattingContext(inline_formatting_context) => {
@@ -103,7 +107,7 @@ impl BlockLevelBox {
     pub(crate) fn repair_style(
         &mut self,
         context: &SharedStyleContext,
-        node: &ServoLayoutNode,
+        node: &ServoThreadSafeLayoutNode,
         new_style: &Arc<ComputedValues>,
     ) {
         self.with_base_mut(|base| {
@@ -412,7 +416,7 @@ impl OutsideMarker {
     fn repair_style(
         &mut self,
         context: &SharedStyleContext,
-        node: &ServoLayoutNode,
+        node: &ServoThreadSafeLayoutNode,
         new_style: &Arc<ComputedValues>,
     ) {
         self.list_item_style = node.style(context);
@@ -477,7 +481,11 @@ impl BlockFormattingContext {
         LayoutStyle::Default(&base.style)
     }
 
-    pub(crate) fn repair_style(&mut self, node: &ServoLayoutNode, new_style: &Arc<ComputedValues>) {
+    pub(crate) fn repair_style(
+        &mut self,
+        node: &ServoThreadSafeLayoutNode,
+        new_style: &Arc<ComputedValues>,
+    ) {
         self.contents.repair_style(node, new_style);
     }
 }

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -4,7 +4,7 @@
 
 use app_units::Au;
 use malloc_size_of_derive::MallocSizeOf;
-use script::layout_dom::{ServoLayoutElement, ServoLayoutNode};
+use script::layout_dom::{ServoLayoutElement, ServoThreadSafeLayoutNode};
 use servo_arc::Arc;
 use style::context::SharedStyleContext;
 use style::logical_geometry::Direction;
@@ -217,7 +217,7 @@ impl IndependentFormattingContext {
     pub(crate) fn repair_style(
         &mut self,
         context: &SharedStyleContext,
-        node: &ServoLayoutNode,
+        node: &ServoThreadSafeLayoutNode,
         new_style: &Arc<ComputedValues>,
     ) {
         self.base.repair_style(new_style);

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -8,13 +8,13 @@ use data_url::DataUrl;
 use embedder_traits::ViewportDetails;
 use euclid::{Scale, Size2D};
 use layout_api::IFrameSize;
+use layout_api::wrapper_traits::ThreadSafeLayoutNode;
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::image_cache::{Image, ImageOrMetadataAvailable, UsePlaceholder, VectorImage};
-use script::layout_dom::ServoLayoutNode;
+use script::layout_dom::ServoThreadSafeLayoutNode;
 use servo_arc::Arc as ServoArc;
 use style::Zero;
 use style::computed_values::object_fit::T as ObjectFit;
-use style::dom::TNode;
 use style::logical_geometry::{Direction, WritingMode};
 use style::properties::ComputedValues;
 use style::servo::url::ComputedUrl;
@@ -131,7 +131,10 @@ pub(crate) enum ReplacedContentKind {
 }
 
 impl ReplacedContents {
-    pub fn for_element(element: ServoLayoutNode<'_>, context: &LayoutContext) -> Option<Self> {
+    pub fn for_element(
+        element: ServoThreadSafeLayoutNode<'_>,
+        context: &LayoutContext,
+    ) -> Option<Self> {
         if let Some(ref data_attribute_string) = element.as_typeless_object_with_data_attribute() {
             if let Some(url) = try_to_parse_image_data_url(data_attribute_string) {
                 return Self::from_image_url(
@@ -219,7 +222,7 @@ impl ReplacedContents {
     }
 
     pub fn from_image_url(
-        element: ServoLayoutNode<'_>,
+        element: ServoThreadSafeLayoutNode<'_>,
         context: &LayoutContext,
         image_url: &ComputedUrl,
     ) -> Option<Self> {
@@ -255,7 +258,7 @@ impl ReplacedContents {
     }
 
     pub fn from_image(
-        element: ServoLayoutNode<'_>,
+        element: ServoThreadSafeLayoutNode<'_>,
         context: &LayoutContext,
         image: &ComputedImage,
     ) -> Option<Self> {

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -6,7 +6,7 @@ use std::borrow::Cow;
 use std::iter::repeat;
 
 use atomic_refcell::AtomicRef;
-use layout_api::wrapper_traits::{LayoutNode, ThreadSafeLayoutNode};
+use layout_api::wrapper_traits::ThreadSafeLayoutNode;
 use log::warn;
 use servo_arc::Arc;
 use style::properties::ComputedValues;
@@ -1028,9 +1028,8 @@ impl<'dom> TraversalHandler<'dom> for TableRowBuilder<'_, '_, 'dom, '_> {
                         // This value will already have filtered out rowspan=0
                         // in quirks mode, so we don't have to worry about that.
                         let (rowspan, colspan) = if info.pseudo_element_type.is_none() {
-                            let node = info.node.to_threadsafe();
-                            let rowspan = node.get_rowspan().unwrap_or(1) as usize;
-                            let colspan = node.get_colspan().unwrap_or(1) as usize;
+                            let rowspan = info.node.get_rowspan().unwrap_or(1) as usize;
+                            let colspan = info.node.get_colspan().unwrap_or(1) as usize;
 
                             // The HTML specification clamps value of `rowspan` to [0, 65534] and
                             // `colspan` to [1, 1000].
@@ -1150,7 +1149,7 @@ fn add_column(
     old_column: Option<ArcRefCell<TableTrack>>,
 ) -> ArcRefCell<TableTrack> {
     let span = if column_info.pseudo_element_type.is_none() {
-        column_info.node.to_threadsafe().get_span().unwrap_or(1)
+        column_info.node.get_span().unwrap_or(1)
     } else {
         1
     };

--- a/components/layout/table/mod.rs
+++ b/components/layout/table/mod.rs
@@ -76,7 +76,7 @@ pub(crate) use construct::AnonymousTableContent;
 pub use construct::TableBuilder;
 use euclid::{Point2D, Size2D, UnknownUnit, Vector2D};
 use malloc_size_of_derive::MallocSizeOf;
-use script::layout_dom::{ServoLayoutElement, ServoLayoutNode};
+use script::layout_dom::{ServoLayoutElement, ServoThreadSafeLayoutNode};
 use servo_arc::Arc;
 use style::context::SharedStyleContext;
 use style::properties::ComputedValues;
@@ -425,7 +425,7 @@ impl TableLevelBox {
     pub(crate) fn repair_style(
         &self,
         context: &SharedStyleContext<'_>,
-        node: &ServoLayoutNode,
+        node: &ServoThreadSafeLayoutNode,
         new_style: &Arc<ComputedValues>,
     ) {
         match self {

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -7,7 +7,7 @@ use std::fmt;
 
 use app_units::Au;
 use malloc_size_of_derive::MallocSizeOf;
-use script::layout_dom::ServoLayoutNode;
+use script::layout_dom::ServoThreadSafeLayoutNode;
 use servo_arc::Arc;
 use style::context::SharedStyleContext;
 use style::properties::ComputedValues;
@@ -159,7 +159,7 @@ impl TaffyItemBox {
     pub(crate) fn repair_style(
         &mut self,
         context: &SharedStyleContext,
-        node: &ServoLayoutNode,
+        node: &ServoThreadSafeLayoutNode,
         new_style: &Arc<ComputedValues>,
     ) {
         self.style = new_style.clone();

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -974,6 +974,20 @@ pub struct ServoThreadSafeLayoutElement<'dom> {
     pub(super) pseudo: Option<PseudoElement>,
 }
 
+impl<'dom> ServoThreadSafeLayoutElement<'dom> {
+    /// The shadow root this element is a host of.
+    pub fn shadow_root(&self) -> Option<ServoShadowRoot<'dom>> {
+        self.element
+            .element
+            .get_shadow_root_for_layout()
+            .map(ServoShadowRoot::from_layout_js)
+    }
+
+    pub fn slotted_nodes(&self) -> &[ServoLayoutNode<'dom>] {
+        self.element.slotted_nodes()
+    }
+}
+
 impl<'dom> ThreadSafeLayoutElement<'dom> for ServoThreadSafeLayoutElement<'dom> {
     type ConcreteThreadSafeLayoutNode = ServoThreadSafeLayoutNode<'dom>;
     type ConcreteElement = ServoLayoutElement<'dom>;

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -6,11 +6,13 @@
 
 use std::borrow::Cow;
 use std::fmt;
+use std::iter::FusedIterator;
 
 use base::id::{BrowsingContextId, PipelineId};
 use fonts_traits::ByteIndex;
-use html5ever::{local_name, ns};
-use layout_api::wrapper_traits::{LayoutDataTrait, LayoutNode, ThreadSafeLayoutNode};
+use layout_api::wrapper_traits::{
+    LayoutDataTrait, LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
+};
 use layout_api::{
     GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutNodeType, SVGElementData, StyleData,
     TrustedNodeAddress,
@@ -97,22 +99,6 @@ impl<'dom> ServoLayoutNode<'dom> {
             .as_ref()
             .map(LayoutDom::upcast)
             .map(ServoLayoutElement::from_layout_js)
-    }
-
-    pub fn is_text_input(&self) -> bool {
-        self.node.is_text_input()
-    }
-
-    pub fn is_text_container_of_single_line_input(&self) -> bool {
-        self.node.is_text_container_of_single_line_input()
-    }
-
-    pub fn is_in_ua_widget(&self) -> bool {
-        self.node.is_in_ua_widget()
-    }
-
-    pub fn containing_shadow_host(&self) -> Option<ServoLayoutNode> {
-        Some(self.as_element()?.containing_shadow_host()?.as_node())
     }
 }
 
@@ -214,15 +200,6 @@ impl<'dom> LayoutNode<'dom> for ServoLayoutNode<'dom> {
         }
     }
 
-    fn initialize_layout_data<RequestedLayoutDataType: LayoutDataTrait>(&self) {
-        let inner = self.get_jsmanaged();
-        if inner.layout_data().is_none() {
-            unsafe {
-                inner.initialize_layout_data(Box::<RequestedLayoutDataType>::default());
-            }
-        }
-    }
-
     fn is_connected(&self) -> bool {
         unsafe { self.node.get_flag(NodeFlags::IS_CONNECTED) }
     }
@@ -280,6 +257,35 @@ impl<'dom> ServoThreadSafeLayoutNode<'dom> {
             .map(ServoLayoutNode::from_layout_js)
             .map(Self::new)
     }
+
+    pub fn is_text_container_of_single_line_input(&self) -> bool {
+        self.pseudo.is_none() && self.node.node.is_text_container_of_single_line_input()
+    }
+
+    pub fn is_text_input(&self) -> bool {
+        self.node.node.is_text_input()
+    }
+
+    pub fn selected_style(&self) -> Arc<ComputedValues> {
+        let Some(element) = self.as_element() else {
+            // TODO(stshine): What should the selected style be for text?
+            debug_assert!(self.is_text_node());
+            return self.parent_style();
+        };
+
+        let style_data = &element.style_data().styles;
+        let get_selected_style = || {
+            // This is a workaround for handling the `::selection` pseudos where it would not
+            // propagate to the children and Shadow DOM elements. For this case, UA widget
+            // inner elements should follow the originating element in terms of selection.
+            if self.node.node.is_in_ua_widget() {
+                return Some(element.containing_shadow_host()?.as_node().selected_style());
+            }
+            style_data.pseudos.get(&PseudoElement::Selection).cloned()
+        };
+
+        get_selected_style().unwrap_or_else(|| style_data.primary().clone())
+    }
 }
 
 impl style::dom::NodeInfo for ServoThreadSafeLayoutNode<'_> {
@@ -320,16 +326,20 @@ impl<'dom> ThreadSafeLayoutNode<'dom> for ServoThreadSafeLayoutNode<'dom> {
         parent_data.styles.primary().clone()
     }
 
+    fn initialize_layout_data<RequestedLayoutDataType: LayoutDataTrait>(&self) {
+        let inner = self.node.get_jsmanaged();
+        if inner.layout_data().is_none() {
+            unsafe {
+                inner.initialize_layout_data(Box::<RequestedLayoutDataType>::default());
+            }
+        }
+    }
+
     fn debug_id(self) -> usize {
         self.node.debug_id()
     }
 
     fn children(&self) -> style::dom::LayoutIterator<Self::ChildrenIterator> {
-        if let Some(shadow) = self.node.as_element().and_then(|e| e.shadow_root()) {
-            return style::dom::LayoutIterator(ServoThreadSafeLayoutNodeChildrenIterator::new(
-                shadow.as_node().to_threadsafe(),
-            ));
-        }
         style::dom::LayoutIterator(ServoThreadSafeLayoutNodeChildrenIterator::new(*self))
     }
 
@@ -444,98 +454,46 @@ impl<'dom> ThreadSafeLayoutNode<'dom> for ServoThreadSafeLayoutNode<'dom> {
     }
 }
 
-pub struct ServoThreadSafeLayoutNodeChildrenIterator<'dom> {
-    current_node: Option<ServoThreadSafeLayoutNode<'dom>>,
-    parent_node: ServoThreadSafeLayoutNode<'dom>,
+pub enum ServoThreadSafeLayoutNodeChildrenIterator<'dom> {
+    /// Iterating over the children of a node
+    Node(Option<ServoThreadSafeLayoutNode<'dom>>),
+    /// Iterating over the assigned nodes of a `HTMLSlotElement`
+    Slottables(<Vec<ServoLayoutNode<'dom>> as IntoIterator>::IntoIter),
 }
 
 impl<'dom> ServoThreadSafeLayoutNodeChildrenIterator<'dom> {
-    pub fn new(parent: ServoThreadSafeLayoutNode<'dom>) -> Self {
-        let first_child = match parent.pseudo_element() {
-            None => parent
-                .with_pseudo(PseudoElement::Before)
-                .or_else(|| parent.with_pseudo(PseudoElement::DetailsSummary))
-                .or_else(|| unsafe { parent.dangerous_first_child() }),
-            Some(PseudoElement::DetailsContent) | Some(PseudoElement::DetailsSummary) => unsafe {
-                parent.dangerous_first_child()
-            },
-            _ => None,
-        };
-        ServoThreadSafeLayoutNodeChildrenIterator {
-            current_node: first_child,
-            parent_node: parent,
+    #[allow(unsafe_code)]
+    fn new(
+        parent: ServoThreadSafeLayoutNode<'dom>,
+    ) -> ServoThreadSafeLayoutNodeChildrenIterator<'dom> {
+        if let Some(element) = parent.as_element() {
+            if let Some(shadow) = element.shadow_root() {
+                return Self::new(shadow.as_node().to_threadsafe());
+            };
+
+            let slotted_nodes = element.slotted_nodes();
+            if !slotted_nodes.is_empty() {
+                #[allow(clippy::unnecessary_to_owned)] // Clippy is wrong.
+                return Self::Slottables(slotted_nodes.to_owned().into_iter());
+            }
         }
+
+        Self::Node(unsafe { parent.dangerous_first_child() })
     }
 }
 
 impl<'dom> Iterator for ServoThreadSafeLayoutNodeChildrenIterator<'dom> {
     type Item = ServoThreadSafeLayoutNode<'dom>;
-    fn next(&mut self) -> Option<ServoThreadSafeLayoutNode<'dom>> {
-        use selectors::Element;
-        match self.parent_node.pseudo_element() {
-            Some(PseudoElement::Before) | Some(PseudoElement::After) => None,
 
-            Some(PseudoElement::DetailsSummary) => {
-                let mut current_node = self.current_node;
-                loop {
-                    let next_node = if let Some(ref node) = current_node {
-                        if let Some(element) = node.as_element() {
-                            if element.has_local_name(&local_name!("summary")) &&
-                                element.has_namespace(&ns!(html))
-                            {
-                                self.current_node = None;
-                                return Some(*node);
-                            }
-                        }
-                        unsafe { node.dangerous_next_sibling() }
-                    } else {
-                        self.current_node = None;
-                        return None;
-                    };
-                    current_node = next_node;
-                }
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Node(node) => {
+                let next_sibling = unsafe { (*node)?.dangerous_next_sibling() };
+                std::mem::replace(node, next_sibling)
             },
-
-            Some(PseudoElement::DetailsContent) => {
-                let node = self.current_node;
-                let node = node.and_then(|node| {
-                    if node.is_element() &&
-                        node.as_element()
-                            .unwrap()
-                            .has_local_name(&local_name!("summary")) &&
-                        node.as_element().unwrap().has_namespace(&ns!(html))
-                    {
-                        unsafe { node.dangerous_next_sibling() }
-                    } else {
-                        Some(node)
-                    }
-                });
-                self.current_node = node.and_then(|node| unsafe { node.dangerous_next_sibling() });
-                node
-            },
-
-            None | Some(_) => {
-                let node = self.current_node;
-                if let Some(ref node) = node {
-                    self.current_node = match node.pseudo_element() {
-                        Some(PseudoElement::Before) => self
-                            .parent_node
-                            .with_pseudo(PseudoElement::DetailsSummary)
-                            .or_else(|| unsafe { self.parent_node.dangerous_first_child() })
-                            .or_else(|| self.parent_node.with_pseudo(PseudoElement::After)),
-                        Some(PseudoElement::DetailsSummary) => {
-                            self.parent_node.with_pseudo(PseudoElement::DetailsContent)
-                        },
-                        Some(PseudoElement::DetailsContent) => {
-                            self.parent_node.with_pseudo(PseudoElement::After)
-                        },
-                        Some(PseudoElement::After) => None,
-                        None | Some(_) => unsafe { node.dangerous_next_sibling() }
-                            .or_else(|| self.parent_node.with_pseudo(PseudoElement::After)),
-                    };
-                }
-                node
-            },
+            Self::Slottables(slots) => slots.next().map(|node| node.to_threadsafe()),
         }
     }
 }
+
+impl FusedIterator for ServoThreadSafeLayoutNodeChildrenIterator<'_> {}


### PR DESCRIPTION
Use `ServoThreadSafeLayoutNode` in more places in layout rather than
`ServoLayoutNode`. The former is meant to be used during layout, but
layout 2020 was written against the latter. In general, this reduces the
amount of conversion to the thread-safe version in many places in
layout.

In addition, an unused iterator from the `script` crate
`ServoThreadSafeLayoutNodeChildrenIterator` is replaced with the child
iterator from `layout`. The `layout` version must be directly in
`script` now as it uses the dangerous variants of `next_sibling` and
`first_child`, which allow encapsulating the unsafe bits into one
module.

This will ultimately be useful for storing the layout data of
pseudo-element children of pseudo-elements properly.

Testing: This should not change any behavior and thus is covered by existing tests.
