### PR TITLE
layout: Use the `PseudoElement` from `ServoThreadSafeLayoutNode` in `NodeAndStyleInfo`

### DIFF
--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -228,7 +228,7 @@ impl<'a, 'dom> ModernContainerBuilder<'a, 'dom> {
 
         let anonymous_info = LazyLock::new(|| {
             self.info
-                .pseudo(self.context, PseudoElement::ServoAnonymousBox)
+                .with_pseudo_element(self.context, PseudoElement::ServoAnonymousBox)
                 .expect("Should always be able to construct info for anonymous boxes.")
         });
 

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -228,7 +228,7 @@ impl<'dom, 'style> BlockContainerBuilder<'dom, 'style> {
         self.inline_formatting_context_builder.take()?.finish(
             self.context,
             !self.have_already_seen_first_line_for_text_indent,
-            self.info.is_single_line_text_input(),
+            self.info.node.is_single_line_text_input(),
             self.info.style.to_bidi_level(),
         )
     }
@@ -414,7 +414,7 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
         // TODO: We do not currently support saving box slots for ::marker pseudo-elements
         // that are part nested in ::before and ::after pseudo elements. For now, just
         // forget about them once they are built.
-        let box_slot = match container_info.pseudo_element_type {
+        let box_slot = match container_info.pseudo_element() {
             Some(_) => BoxSlot::dummy(),
             None => marker_info
                 .node
@@ -441,7 +441,7 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
         // TODO: We do not currently support saving box slots for ::marker pseudo-elements
         // that are part nested in ::before and ::after pseudo elements. For now, just
         // forget about them once they are built.
-        let box_slot = match container_info.pseudo_element_type {
+        let box_slot = match container_info.pseudo_element() {
             Some(_) => BoxSlot::dummy(),
             None => marker_info
                 .node
@@ -686,7 +686,7 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
             .anonymous_box_info
             .get_or_insert_with(|| {
                 self.info
-                    .pseudo(layout_context, PseudoElement::ServoAnonymousBox)
+                    .with_pseudo_element(layout_context, PseudoElement::ServoAnonymousBox)
                     .expect("Should never fail to create anonymous box")
             })
             .clone();

--- a/components/layout/lists.rs
+++ b/components/layout/lists.rs
@@ -15,7 +15,8 @@ pub(crate) fn make_marker<'dom>(
     context: &LayoutContext,
     info: &NodeAndStyleInfo<'dom>,
 ) -> Option<(NodeAndStyleInfo<'dom>, Vec<PseudoElementContentItem>)> {
-    let marker_info = info.pseudo(context, style::selector_parser::PseudoElement::Marker)?;
+    let marker_info =
+        info.with_pseudo_element(context, style::selector_parser::PseudoElement::Marker)?;
     let style = &marker_info.style;
     let list_style = style.get_list();
 

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -91,7 +91,7 @@ impl Table {
         propagated_data: PropagatedBoxTreeData,
     ) -> (NodeAndStyleInfo<'dom>, IndependentFormattingContext) {
         let table_info = parent_info
-            .pseudo(context, PseudoElement::ServoAnonymousTable)
+            .with_pseudo_element(context, PseudoElement::ServoAnonymousTable)
             .expect("Should never fail to create anonymous table info.");
         let table_style = table_info.style.clone();
         let mut table_builder =
@@ -688,7 +688,7 @@ impl<'style, 'dom> TableBuilderTraversal<'style, 'dom> {
         let row_content = std::mem::take(&mut self.current_anonymous_row_content);
         let anonymous_info = self
             .info
-            .pseudo(self.context, PseudoElement::ServoAnonymousTableRow)
+            .with_pseudo_element(self.context, PseudoElement::ServoAnonymousTableRow)
             .expect("Should never fail to create anonymous row info.");
         let mut row_builder =
             TableRowBuilder::new(self, &anonymous_info, self.current_propagated_data);
@@ -957,7 +957,7 @@ impl<'style, 'builder, 'dom, 'a> TableRowBuilder<'style, 'builder, 'dom, 'a> {
         let context = self.table_traversal.context;
         let anonymous_info = self
             .info
-            .pseudo(context, PseudoElement::ServoAnonymousTableCell)
+            .with_pseudo_element(context, PseudoElement::ServoAnonymousTableCell)
             .expect("Should never fail to create anonymous table cell info");
         let propagated_data = self.propagated_data.disallowing_percentage_table_columns();
         let mut builder = BlockContainerBuilder::new(context, &anonymous_info, propagated_data);
@@ -1027,7 +1027,7 @@ impl<'dom> TraversalHandler<'dom> for TableRowBuilder<'_, '_, 'dom, '_> {
                     let cell = old_cell.unwrap_or_else(|| {
                         // This value will already have filtered out rowspan=0
                         // in quirks mode, so we don't have to worry about that.
-                        let (rowspan, colspan) = if info.pseudo_element_type.is_none() {
+                        let (rowspan, colspan) = if info.pseudo_element().is_none() {
                             let rowspan = info.node.get_rowspan().unwrap_or(1) as usize;
                             let colspan = info.node.get_colspan().unwrap_or(1) as usize;
 
@@ -1148,7 +1148,7 @@ fn add_column(
     is_anonymous: bool,
     old_column: Option<ArcRefCell<TableTrack>>,
 ) -> ArcRefCell<TableTrack> {
-    let span = if column_info.pseudo_element_type.is_none() {
+    let span = if column_info.pseudo_element().is_none() {
         column_info.node.get_span().unwrap_or(1)
     } else {
         1

--- a/components/script/layout_dom/node.rs
+++ b/components/script/layout_dom/node.rs
@@ -14,8 +14,8 @@ use layout_api::wrapper_traits::{
     LayoutDataTrait, LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
 };
 use layout_api::{
-    GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutNodeType, SVGElementData, StyleData,
-    TrustedNodeAddress,
+    GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutElementType, LayoutNodeType,
+    SVGElementData, StyleData, TrustedNodeAddress,
 };
 use net_traits::image_cache::Image;
 use pixels::ImageMetadata;
@@ -258,8 +258,16 @@ impl<'dom> ServoThreadSafeLayoutNode<'dom> {
             .map(Self::new)
     }
 
-    pub fn is_text_container_of_single_line_input(&self) -> bool {
-        self.pseudo.is_none() && self.node.node.is_text_container_of_single_line_input()
+    /// Whether this is a container for the text within a single-line text input. This
+    /// is used to solve the special case of line height for a text entry widget.
+    /// <https://html.spec.whatwg.org/multipage/#the-input-element-as-a-text-entry-widget>
+    // TODO(stevennovaryo): Remove the addition of HTMLInputElement here once all of the
+    //                      input element is implemented with UA shadow DOM. This is temporary
+    //                      workaround for past version of input element where we are
+    //                      rendering it as a bare html element.
+    pub fn is_single_line_text_input(&self) -> bool {
+        self.type_id() == Some(LayoutNodeType::Element(LayoutElementType::HTMLInputElement)) ||
+            (self.pseudo.is_none() && self.node.node.is_text_container_of_single_line_input())
     }
 
     pub fn is_text_input(&self) -> bool {


### PR DESCRIPTION
Instead of storing the non-pseudo version of the node in
`NodeAndStyleInfo`, store the pseudo version and use that to query the
`PseudoElement` that a `NodeAndStyleInfo` refers to.

This is a step on the way toward fixing nested pseudo-elements in Servo.

Testing: This should not change behavior and is thus covered by existing WPT tests.
