### PR TITLE
tidy: Remove dead and redundant code from Servo Rust tidy check

### DIFF
--- a/python/tidy/test.py
+++ b/python/tidy/test.py
@@ -117,13 +117,8 @@ class CheckTidiness(unittest.TestCase):
 
     def test_rust(self):
         errors = tidy.collect_errors_for_files(iterFile("rust_tidy.rs"), [], [tidy.check_rust], print_text=False)
-        self.assertEqual("found an empty line following a {", next(errors)[2])
-        self.assertEqual("use &[T] instead of &Vec<T>", next(errors)[2])
-        self.assertEqual("use &str instead of &String", next(errors)[2])
         self.assertEqual("use &T instead of &Root<T>", next(errors)[2])
         self.assertEqual("use &T instead of &DomRoot<T>", next(errors)[2])
-        self.assertEqual("encountered function signature with -> ()", next(errors)[2])
-        self.assertEqual("operators should go at the end of the first line", next(errors)[2])
         self.assertNoMoreErrors(errors)
 
         feature_errors = tidy.collect_errors_for_files(iterFile("lib.rs"), [], [tidy.check_rust], print_text=False)


### PR DESCRIPTION
- Remove all handling of comments and attributes. This was not affecting
  the checks in any way.
- Remove `is_associated_type()` as it was unused.
- Remove the check for `&String`, `&Vec`, operators at the end of the
  line, and the unit return type as clippy already checks these (and
  handles the mutable variants).

Testing: This is covered by tidy script tests.