### PR TITLE
base: Allow sending GenericReceiver

### DIFF
--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -33,7 +33,7 @@ impl<'a, T: Serialize> Deserialize<'a> for GenericSender<T> {
         D: Deserializer<'a>,
     {
         // Only ipc_channel will encounter deserialize scenario.
-        ipc_channel::ipc::IpcSender::<T>::deserialize(d).map(|s| GenericSender::Ipc(s))
+        ipc_channel::ipc::IpcSender::<T>::deserialize(d).map(GenericSender::Ipc)
     }
 }
 
@@ -138,8 +138,7 @@ where
         D: Deserializer<'a>,
     {
         // Only ipc_channel will encounter deserialize scenario.
-        ipc_channel::ipc::IpcReceiver::<T>::deserialize(d)
-            .map(|receiver| GenericReceiver::Ipc(receiver))
+        ipc_channel::ipc::IpcReceiver::<T>::deserialize(d).map(GenericReceiver::Ipc)
     }
 }
 


### PR DESCRIPTION
Implement Serialize and Deserialize for GenericReceiver to also allow the Receiver to be sent across
ipc channels.
This is necessary to allow using the GenericChannel in more places.

Testing: Manually tested on follow-up feature branch. Does not require new tests.

