### PR TITLE
opts: Use OnceLock for Options

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -254,7 +254,7 @@ impl Servo {
     fn new(builder: ServoBuilder) -> Self {
         // Global configuration options, parsed from the command line.
         let opts = builder.opts.map(|opts| *opts);
-        opts::set_options(opts.unwrap_or_default());
+        opts::initialize_options(opts.unwrap_or_default());
         let opts = opts::get();
 
         // Set the preferences globally.
@@ -1244,7 +1244,7 @@ pub fn run_content_process(token: String) {
         .unwrap();
 
     let unprivileged_content = unprivileged_content_receiver.recv().unwrap();
-    opts::set_options(unprivileged_content.opts());
+    opts::initialize_options(unprivileged_content.opts());
     prefs::set(unprivileged_content.prefs().clone());
 
     // Enter the sandbox if necessary.


### PR DESCRIPTION
Currently, the options are only initialized once and then never changed. Making this explicit allows optimizing accesses, e.g. caching opt values.
For some options like `multiprocess` it is obvious that we would never want to support changing the value at runtime, however there are other options where it could be conceivable that we want to change them at runtime. However, imho such options might be better suited to put into a different datastructure, so that it is explicit which options can be changed at runtime, and which are fixed.

Testing: Covered by existing tests (and manually running servo in multiprocess mode).

