### PR TITLE
CI: use `--profile` instead of profile shorthands

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -105,7 +105,7 @@ jobs:
           APK_SIGNING_KEY_ALIAS: ${{ secrets.APK_SIGNING_KEY_ALIAS }}
           APK_SIGNING_KEY_PASS: ${{ secrets.APK_SIGNING_KEY_PASS }}
         run: |
-          ./mach build --use-crown --locked --target ${{ matrix.target }} --${{ inputs.profile }}
+          ./mach build --use-crown --locked --target ${{ matrix.target }} --profile ${{ inputs.profile }}
           cp -r target/cargo-timings target/cargo-timings-android-${{ matrix.target }}
       # TODO: This is disabled since APK crashes during startup.
       # See https://github.com/servo/servo/issues/31134

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -81,7 +81,7 @@ jobs:
           mkdir -p wpt-full-logs/linux
           ./mach test-wpt \
             $WPT_ALWAYS_SUCCEED_ARG \
-            --${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
+            --profile ${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ inputs.number-of-wpt-chunks }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/linux/raw/${{ matrix.chunk_id }}.log \
             --log-wptreport wpt-full-logs/linux/wptreport/${{ matrix.chunk_id }}.json \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -181,20 +181,20 @@ jobs:
 
       - name: Build (${{ inputs.profile }})
         run: |
-          ./mach build --use-crown --locked --${{ inputs.profile }} ${{ inputs.build-args }}
+          ./mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }}
           cp -r target/cargo-timings target/cargo-timings-linux
       - name: Smoketest
-        run: xvfb-run ./mach smoketest --${{ inputs.profile  }}
+        run: xvfb-run ./mach smoketest --profile ${{ inputs.profile  }}
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
         env:
           NEXTEST_RETRIES: 2 # https://github.com/servo/servo/issues/30683
-        run: ./mach test-unit --${{ inputs.profile }}
+        run: ./mach test-unit --profile ${{ inputs.profile }}
       - name: Devtools tests
         if: ${{ false && inputs.unit-tests }}  # FIXME #39273
-        run: ./mach test-devtools --${{ inputs.profile }}
+        run: ./mach test-devtools --profile ${{ inputs.profile }}
       - name: Archive build timing
         uses: actions/upload-artifact@v4
         with:
@@ -202,7 +202,7 @@ jobs:
           # Using a wildcard here ensures that the archive includes the path.
           path: target/cargo-timings-*
       - name: Build mach package
-        run: ./mach package --${{ inputs.profile }}
+        run: ./mach package --profile ${{ inputs.profile }}
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -134,26 +134,26 @@ jobs:
           brew install gnu-tar
       - name: Build (${{ inputs.profile }})
         run: |
-          ./mach build --use-crown --locked --${{ inputs.profile }}  ${{ inputs.build-args }}
+          ./mach build --use-crown --locked --profile ${{ inputs.profile }}  ${{ inputs.build-args }}
           cp -r target/cargo-timings target/cargo-timings-macos-arm64
       - name: Smoketest
         uses: nick-fields/retry@v3
         with: # See https://github.com/servo/servo/issues/30757
           timeout_minutes: 5
           max_attempts: 2
-          command: ./mach smoketest --${{ inputs.profile }}
+          command: ./mach smoketest --profile ${{ inputs.profile }}
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
         env:
           NEXTEST_RETRIES: 3 # https://github.com/servo/servo/issues/30683
-        run: ./mach test-unit --${{ inputs.profile }}
+        run: ./mach test-unit --profile ${{ inputs.profile }}
       - name: Devtools tests
         if: ${{ false && inputs.unit-tests }} # FIXME #39273
-        run: ./mach test-devtools --${{ inputs.profile }}
+        run: ./mach test-devtools --profile ${{ inputs.profile }}
       - name: Build mach package
-        run: ./mach package --${{ inputs.profile }}
+        run: ./mach package --profile ${{ inputs.profile }}
       - name: Run DMG smoketest
         uses: nick-fields/retry@v3
         with: # See https://github.com/servo/servo/issues/30757

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -49,13 +49,13 @@ jobs:
           gtar -xzf target.tar.gz
           ./mach bootstrap --skip-lints --skip-nextest
       - name: Smoketest
-        run: ./mach smoketest --${{ inputs.profile }}
+        run: ./mach smoketest --profile ${{ inputs.profile }}
       - name: Run tests
         run: |
           mkdir -p wpt-filtered-logs/${{ env.NAME }}
           mkdir -p wpt-full-logs/${{ env.NAME }}
           ./mach test-wpt \
-            --${{ inputs.profile }} --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
+            --profile ${{ inputs.profile }} --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/${{ env.NAME }}/${{ matrix.chunk_id }}.log \
             --log-raw-stable-unexpected wpt-filtered-logs/${{ env.NAME }}/${{ matrix.chunk_id }}.log \

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -153,26 +153,26 @@ jobs:
           brew install gnu-tar
       - name: Build (${{ inputs.profile }})
         run: |
-          ./mach build --use-crown --locked --${{ inputs.profile }}  ${{ inputs.build-args }}
+          ./mach build --use-crown --locked --profile ${{ inputs.profile }}  ${{ inputs.build-args }}
           cp -r target/cargo-timings target/cargo-timings-macos
       - name: Smoketest
         uses: nick-fields/retry@v3
         with: # See https://github.com/servo/servo/issues/30757
           timeout_minutes: 5
           max_attempts: 2
-          command: ./mach smoketest --${{ inputs.profile }}
+          command: ./mach smoketest --profile ${{ inputs.profile }}
       - name: Script tests
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
         env:
           NEXTEST_RETRIES: 3 # https://github.com/servo/servo/issues/30683
-        run: ./mach test-unit --${{ inputs.profile }}
+        run: ./mach test-unit --profile ${{ inputs.profile }}
       - name: Devtools tests
         if: ${{ false && inputs.unit-tests }}  # FIXME #39273
-        run: ./mach test-devtools --${{ inputs.profile }}
+        run: ./mach test-devtools --profile ${{ inputs.profile }}
       - name: Build mach package
-        run: ./mach package --${{ inputs.profile }}
+        run: ./mach package --profile ${{ inputs.profile }}
       - name: Run DMG smoketest
         uses: nick-fields/retry@v3
         with: # See https://github.com/servo/servo/issues/30757

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -98,7 +98,7 @@ jobs:
           OHOS_SDK_NATIVE: ${{ steps.setup_sdk.outputs.ohos_sdk_native }}
           OHOS_BASE_SDK_HOME: ${{ steps.setup_sdk.outputs.ohos-base-sdk-home }}
         run: |
-          ./mach build --locked --target ${{ matrix.target }} --${{ inputs.profile }}
+          ./mach build --locked --target ${{ matrix.target }} --profile ${{ inputs.profile }}
           cp -r target/cargo-timings target/cargo-timings-ohos-${{ matrix.target }}
       - name: Archive build timing
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -159,14 +159,14 @@ jobs:
 
       - name: Build (${{ inputs.profile }})
         run: |
-          .\mach build --use-crown --locked --${{ inputs.profile }} ${{ inputs.build-args }}
+          .\mach build --use-crown --locked --profile ${{ inputs.profile }} ${{ inputs.build-args }}
           cp C:\a\servo\servo\target\cargo-timings C:\a\servo\servo\target\cargo-timings-windows -Recurse
       - name: Copy resources
         # GitHub-hosted runners sometimes check out the repo on D: drive.
         if: ${{ runner.environment != 'self-hosted' && startsWith(github.workspace, 'D:\') }}
         run: cp D:\a\servo\servo\resources C:\a\servo\servo -Recurse
       - name: Smoketest
-        run: .\mach smoketest --${{ inputs.profile }}
+        run: .\mach smoketest --profile ${{ inputs.profile }}
       - name: Install cargo nextest
         if: ${{ runner.environment != 'self-hosted' }}
         uses: taiki-e/install-action@v2
@@ -180,10 +180,10 @@ jobs:
         if: ${{ inputs.unit-tests }}
         env:
           NEXTEST_RETRIES: 3 # https://github.com/servo/servo/issues/30683
-        run: ./mach test-unit --${{ inputs.profile }}
+        run: ./mach test-unit --profile ${{ inputs.profile }}
       - name: Devtools tests
         if: ${{ false && inputs.unit-tests }}  # FIXME #39273
-        run: .\mach test-devtools --${{ inputs.profile }}
+        run: .\mach test-devtools --profile ${{ inputs.profile }}
       - name: Archive build timing
         uses: actions/upload-artifact@v4
         with:
@@ -191,7 +191,7 @@ jobs:
           # Using a wildcard here ensures that the archive includes the path.
           path: C:\\a\\servo\\servo\\target\\cargo-timings-*
       - name: Build mach package
-        run: .\mach package --${{ inputs.profile }}
+        run: .\mach package --profile ${{ inputs.profile }}
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Before, we used shorthands for profiles selection (`--release`, `--production`), but it would be more correct to just use actual `--profile` so we do not need shorthands for all of them.

Motivation: I want to create "profiling" builds in CI.

Testing: CI change is covered by CI.
