### PR TITLE
Use GenericChannel for script_chan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,6 +727,7 @@ dependencies = [
  "malloc_size_of_derive",
  "parking_lot",
  "serde",
+ "servo_config",
  "servo_malloc_size_of",
  "time",
  "webrender_api",

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -241,8 +241,7 @@ impl Pipeline {
             },
             None => {
                 let (script_chan, script_port) =
-                    base::generic_channel::channel(opts::get().multiprocess)
-                        .expect("Pipeline script chan");
+                    base::generic_channel::channel().expect("Pipeline script chan");
 
                 // Route messages coming from content to devtools as appropriate.
                 let script_to_devtools_ipc_sender =

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -12,6 +12,7 @@ use background_hang_monitor_api::{
     BackgroundHangMonitorControlMsg, BackgroundHangMonitorRegister, HangMonitorAlert,
 };
 use base::Epoch;
+use base::generic_channel::{GenericReceiver, GenericSender};
 use base::id::{
     BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespace, PipelineNamespaceId,
     PipelineNamespaceRequest, WebViewId,
@@ -239,7 +240,9 @@ impl Pipeline {
                 (script_chan, (None, None, None))
             },
             None => {
-                let (script_chan, script_port) = ipc::channel().expect("Pipeline script chan");
+                let (script_chan, script_port) =
+                    base::generic_channel::channel(opts::get().multiprocess)
+                        .expect("Pipeline script chan");
 
                 // Route messages coming from content to devtools as appropriate.
                 let script_to_devtools_ipc_sender =
@@ -482,9 +485,9 @@ pub struct UnprivilegedPipelineContent {
     mem_profiler_chan: profile_mem::ProfilerChan,
     viewport_details: ViewportDetails,
     theme: Theme,
-    script_chan: IpcSender<ScriptThreadMessage>,
+    script_chan: GenericSender<ScriptThreadMessage>,
     load_data: LoadData,
-    script_port: IpcReceiver<ScriptThreadMessage>,
+    script_port: GenericReceiver<ScriptThreadMessage>,
     opts: Opts,
     prefs: Box<Preferences>,
     pipeline_namespace_id: PipelineNamespaceId,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, LazyLock};
 
 use app_units::Au;
 use base::Epoch;
+use base::generic_channel::GenericSender;
 use base::id::{PipelineId, WebViewId};
 use bitflags::bitflags;
 use compositing_traits::CrossProcessCompositorApi;
@@ -25,7 +26,6 @@ use fnv::FnvHashMap;
 use fonts::{FontContext, FontContextWebFontMethods};
 use fonts_traits::StylesheetWebFontLoadFinishedCallback;
 use fxhash::FxHashMap;
-use ipc_channel::ipc::IpcSender;
 use layout_api::wrapper_traits::LayoutNode;
 use layout_api::{
     IFrameSizes, Layout, LayoutConfig, LayoutDamage, LayoutFactory, OffsetParentResponse,
@@ -135,7 +135,7 @@ pub struct LayoutThread {
     is_iframe: bool,
 
     /// The channel on which messages can be sent to the script thread.
-    script_chan: IpcSender<ScriptThreadMessage>,
+    script_chan: GenericSender<ScriptThreadMessage>,
 
     /// The channel on which messages can be sent to the time profiler.
     time_profiler_chan: profile_time::ProfilerChan,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 use app_units::Au;
 use backtrace::Backtrace;
 use base::cross_process_instant::CrossProcessInstant;
+use base::generic_channel::GenericSender;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use base64::Engine;
 #[cfg(feature = "bluetooth")]
@@ -3043,7 +3044,7 @@ impl Window {
         time_profiler_chan: TimeProfilerChan,
         devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
         constellation_chan: ScriptToConstellationChan,
-        control_chan: IpcSender<ScriptThreadMessage>,
+        control_chan: GenericSender<ScriptThreadMessage>,
         pipeline_id: PipelineId,
         parent_info: Option<PipelineId>,
         viewport_details: ViewportDetails,
@@ -3292,7 +3293,7 @@ impl Window {
 #[derive(MallocSizeOf)]
 pub(crate) struct CSSErrorReporter {
     pub(crate) pipelineid: PipelineId,
-    pub(crate) script_chan: IpcSender<ScriptThreadMessage>,
+    pub(crate) script_chan: GenericSender<ScriptThreadMessage>,
 }
 unsafe_no_jsmanaged_fields!(CSSErrorReporter);
 

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -8,6 +8,7 @@ use std::cell::RefCell;
 use std::option::Option;
 use std::result::Result;
 
+use base::generic_channel::GenericSender;
 use base::id::PipelineId;
 #[cfg(feature = "bluetooth")]
 use bluetooth_traits::BluetoothRequest;
@@ -331,7 +332,7 @@ pub(crate) struct ScriptThreadSenders {
 
     /// A [`Sender`] that sends messages to the `Constellation`.
     #[no_trace]
-    pub(crate) constellation_sender: IpcSender<ScriptThreadMessage>,
+    pub(crate) constellation_sender: GenericSender<ScriptThreadMessage>,
 
     /// A [`Sender`] that sends messages to the `Constellation` associated with
     /// particular pipelines.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -871,9 +871,7 @@ impl ScriptThread {
             JS_AddInterruptCallback(cx, Some(interrupt_callback));
         }
 
-        // Ask the router to proxy IPC messages from the control port to us.
-        let constellation_receiver =
-            ROUTER.route_ipc_receiver_to_new_crossbeam_receiver(state.constellation_receiver);
+        let constellation_receiver = state.constellation_receiver.into_inner();
 
         // Ask the router to proxy IPC messages from the devtools to us.
         let devtools_server_sender = state.devtools_server_sender;

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -20,9 +20,9 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
+servo_config = { path = "../../config" }
 time = { workspace = true }
 webrender_api = { workspace = true }
-servo_config = { path = "../../config" }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 mach2 = { workspace = true }

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -22,6 +22,7 @@ parking_lot = { workspace = true }
 serde = { workspace = true }
 time = { workspace = true }
 webrender_api = { workspace = true }
+servo_config = { path = "../../config" }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 mach2 = { workspace = true }

--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -7,6 +7,7 @@
 use std::fmt;
 
 use ipc_channel::router::ROUTER;
+use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 static GENERIC_CHANNEL_USAGE_ERROR_PANIC_MSG: &str = "May not send a crossbeam channel over an IPC channel. \
@@ -62,6 +63,12 @@ impl<T: Serialize> GenericSender<T> {
             GenericSender::Ipc(ref sender) => sender.send(msg).map_err(|_| SendError),
             GenericSender::Crossbeam(ref sender) => sender.send(msg).map_err(|_| SendError),
         }
+    }
+}
+
+impl<T: Serialize> MallocSizeOf for GenericSender<T> {
+    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
+        0
     }
 }
 

--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -152,11 +152,11 @@ where
 /// Creates a Servo channel that can select different channel implementations based on multiprocess
 /// mode or not. If the scenario doesn't require message to pass process boundary, a simple
 /// crossbeam channel is preferred.
-pub fn channel<T>(multiprocess: bool) -> Option<(GenericSender<T>, GenericReceiver<T>)>
+pub fn channel<T>() -> Option<(GenericSender<T>, GenericReceiver<T>)>
 where
     T: for<'de> Deserialize<'de> + Serialize,
 {
-    if multiprocess {
+    if servo_config::opts::get().multiprocess {
         ipc_channel::ipc::channel()
             .map(|(tx, rx)| (GenericSender::Ipc(tx), GenericReceiver::Ipc(rx)))
             .ok()

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -33,7 +33,7 @@ pub fn webgl_channel<T>() -> Option<(WebGLSender<T>, WebGLReceiver<T>)>
 where
     T: for<'de> Deserialize<'de> + Serialize,
 {
-    base::generic_channel::channel(servo_config::opts::get().multiprocess)
+    base::generic_channel::channel()
 }
 
 /// Entry point channel type used for sending WebGLMsg messages to the WebGL renderer.

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -20,6 +20,7 @@ use std::thread::JoinHandle;
 use app_units::Au;
 use atomic_refcell::AtomicRefCell;
 use base::Epoch;
+use base::generic_channel::GenericSender;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use bitflags::bitflags;
 use compositing_traits::CrossProcessCompositorApi;
@@ -30,7 +31,6 @@ use euclid::default::{Point2D as UntypedPoint2D, Rect};
 use fnv::FnvHashMap;
 use fonts::{FontContext, SystemFontServiceProxy};
 use fxhash::FxHashMap;
-use ipc_channel::ipc::IpcSender;
 pub use layout_damage::LayoutDamage;
 use libc::c_void;
 use malloc_size_of::{MallocSizeOf as MallocSizeOfTrait, MallocSizeOfOps, malloc_size_of_is_0};
@@ -197,7 +197,7 @@ pub struct LayoutConfig {
     pub webview_id: WebViewId,
     pub url: ServoUrl,
     pub is_iframe: bool,
-    pub script_chan: IpcSender<ScriptThreadMessage>,
+    pub script_chan: GenericSender<ScriptThreadMessage>,
     pub image_cache: Arc<dyn ImageCache>,
     pub font_context: Arc<FontContext>,
     pub time_profiler_chan: time::ProfilerChan,

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 
 use background_hang_monitor_api::BackgroundHangMonitorRegister;
 use base::cross_process_instant::CrossProcessInstant;
+use base::generic_channel::{GenericReceiver, GenericSender};
 use base::id::{BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespaceId, WebViewId};
 #[cfg(feature = "bluetooth")]
 use bluetooth_traits::BluetoothRequest;
@@ -307,9 +308,9 @@ pub struct InitialScriptState {
     /// Loading into a Secure Context
     pub inherited_secure_context: Option<bool>,
     /// A channel with which messages can be sent to us (the script thread).
-    pub constellation_sender: IpcSender<ScriptThreadMessage>,
+    pub constellation_sender: GenericSender<ScriptThreadMessage>,
     /// A port on which messages sent by the constellation to script can be received.
-    pub constellation_receiver: IpcReceiver<ScriptThreadMessage>,
+    pub constellation_receiver: GenericReceiver<ScriptThreadMessage>,
     /// A channel on which messages can be sent to the constellation from script.
     pub pipeline_to_constellation_sender: ScriptToConstellationChan,
     /// A handle to register script-(and associated layout-)threads for hang monitoring.


### PR DESCRIPTION
Motivation: 
Using our GenericChannel abstraction allows us to optimize IPC in single-process mode to just use cross-beam channel.
To keep the diff low, and get early feedback, this PR only tackles a single channel, but the intention is to port all ipc channels to the generic channel, which allows us to skip serializing and deserializing messages in single process mode.

Based on: 
- https://github.com/servo/servo/pull/38638
- https://github.com/servo/servo/pull/38636

Testing: Covered by existing tests

