### PR TITLE
embedder+constellation: Remove `SetWebDriverResponseSender` and directly initialize

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -523,6 +523,9 @@ pub struct InitialConstellationState {
 
     /// The async runtime.
     pub async_runtime: Box<dyn AsyncRuntime>,
+
+    /// An [`IpcSender`] to forward responses from the `ScriptThread` to the WebDriver server.
+    pub webdriver_input_command_reponse_sender: Option<IpcSender<WebDriverCommandResponse>>,
 }
 
 /// When we are running reftests, we save an image to compare against a reference.
@@ -693,7 +696,8 @@ where
                     mem_profiler_chan: state.mem_profiler_chan.clone(),
                     phantom: PhantomData,
                     webdriver_load_status_sender: None,
-                    webdriver_input_command_reponse_sender: None,
+                    webdriver_input_command_reponse_sender: state
+                        .webdriver_input_command_reponse_sender,
                     document_states: HashMap::new(),
                     #[cfg(feature = "webgpu")]
                     webrender_wgpu,
@@ -1502,9 +1506,6 @@ where
                         pipeline_id
                     )
                 }
-            },
-            EmbedderToConstellationMessage::SetWebDriverResponseSender(sender) => {
-                self.webdriver_input_command_reponse_sender = Some(sender);
             },
         }
     }

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -77,7 +77,6 @@ mod from_compositor {
                 Self::EvaluateJavaScript(..) => target!("EvaluateJavaScript"),
                 Self::CreateMemoryReport(..) => target!("CreateMemoryReport"),
                 Self::SendImageKeysForPipeline(..) => target!("SendImageKeysForPipeline"),
-                Self::SetWebDriverResponseSender(..) => target!("SetWebDriverResponseSender"),
             }
         }
     }

--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -97,7 +97,7 @@ impl ApplicationHandler<WakerEvent> for App {
 
             let servo = ServoBuilder::new(rendering_context.clone())
                 .event_loop_waker(Box::new(waker.clone()))
-                .build();
+                .build(None);
             servo.setup_logging();
 
             let app_state = Rc::new(AppState {

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -89,7 +89,7 @@ impl ServoTest {
         let user_event_triggered = Arc::new(AtomicBool::new(false));
         let servo = ServoBuilder::new(rendering_context.clone())
             .event_loop_waker(Box::new(EventLoopWakerImpl(user_event_triggered)))
-            .build();
+            .build(None);
         Self { servo }
     }
 

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -20,7 +20,7 @@ use base::cross_process_instant::CrossProcessInstant;
 use base::id::{MessagePortId, PipelineId, WebViewId};
 use embedder_traits::{
     CompositorHitTestResult, FocusId, InputEvent, JavaScriptEvaluationId, MediaSessionActionType,
-    Theme, TraversalId, ViewportDetails, WebDriverCommandMsg, WebDriverCommandResponse,
+    Theme, TraversalId, ViewportDetails, WebDriverCommandMsg,
 };
 use euclid::Point2D;
 pub use from_script_message::*;
@@ -100,8 +100,6 @@ pub enum EmbedderToConstellationMessage {
     CreateMemoryReport(IpcSender<MemoryReportResult>),
     /// Sends the generated image key to the image cache associated with this pipeline.
     SendImageKeysForPipeline(PipelineId, Vec<ImageKey>),
-    /// Set WebDriver input event handled sender.
-    SetWebDriverResponseSender(IpcSender<WebDriverCommandResponse>),
 }
 
 /// A description of a paint metric that is sent from the Servo renderer to the

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -75,9 +75,6 @@ impl WebDriverUserPromptAction {
 /// Messages to the constellation originating from the WebDriver server.
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebDriverCommandMsg {
-    /// Used in the initialization of the WebDriver server to set the sender for sending responses
-    /// back to the WebDriver client. It is set to constellation for now
-    SetWebDriverResponseSender(IpcSender<WebDriverCommandResponse>),
     /// Get the window rectangle.
     GetWindowRect(WebViewId, IpcSender<DeviceIndependentIntRect>),
     /// Get the viewport size.

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -339,9 +339,6 @@ impl App {
 
         while let Ok(msg) = webdriver_receiver.try_recv() {
             match msg {
-                WebDriverCommandMsg::SetWebDriverResponseSender(..) => {
-                    running_state.servo().execute_webdriver_command(msg);
-                },
                 WebDriverCommandMsg::IsWebViewOpen(webview_id, sender) => {
                     let context = running_state.webview_by_id(webview_id);
 


### PR DESCRIPTION
We have `SetWebDriverResponseSender` in `EmbedderToConstellationMessage` and `WebDriverCommandMsg`. But the first is only used to initialize, the second one is never used. 

This PR directly initialize instead of delaying it and relying on IPC.

This removes several import and reduces binary size by 93KB.

Testing: No behaviour change. No regression.
