### PR TITLE
mach: remove ubuntu version warning

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -191,7 +191,6 @@ class Linux(Base):
             print("  $ nix-shell")
             return False
 
-        # FIXME: Better version checking for these distributions.
         if self.distro.lower() not in [
             "arch linux",
             "arch",

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -11,7 +11,7 @@ import distro
 import os
 import subprocess
 import shutil
-from typing import Optional, Tuple
+from typing import Optional
 
 from .base import Base
 from .build_target import BuildTarget

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -167,19 +167,7 @@ class Linux(Base):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.is_linux = True
-        self.distro = Linux.get_distro()
-
-    @staticmethod
-    def get_distro() -> str:
-        distrib = distro.name()
-
-        if distrib in ["LinuxMint", "Linux Mint", "KDE neon", "Pop!_OS", "TUXEDO OS"]:
-            distrib = "Ubuntu"
-
-        if distrib.lower() == "elementary":
-            distrib = "Ubuntu"
-
-        return distrib
+        self.distro = distro.name()
 
     def _platform_bootstrap(self, force: bool) -> bool:
         if self.distro.lower() == "nixos":
@@ -204,6 +192,12 @@ class Linux(Base):
             "fedora",
             "nixos",
             "ubuntu",
+            "linuxmint",
+            "linux mint",
+            "kde neon",
+            "pop!_os",
+            "tuxedo os",
+            "elementary",
             "void",
             "fedora linux asahi remix",
         ]:

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -167,39 +167,19 @@ class Linux(Base):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.is_linux = True
-        (self.distro, self.version) = Linux.get_distro_and_version()
+        self.distro = Linux.get_distro()
 
     @staticmethod
-    def get_distro_and_version() -> Tuple[str, str]:
+    def get_distro() -> str:
         distrib = distro.name()
-        version = distro.version()
 
         if distrib in ["LinuxMint", "Linux Mint", "KDE neon", "Pop!_OS", "TUXEDO OS"]:
-            if "." in version:
-                major, _ = version.split(".", 1)
-            else:
-                major = version
-
             distrib = "Ubuntu"
-            if major == "22":
-                version = "22.04"
-            elif major == "21":
-                version = "21.04"
-            elif major == "20":
-                version = "20.04"
-            elif major == "19":
-                version = "18.04"
-            elif major == "18":
-                version = "16.04"
 
         if distrib.lower() == "elementary":
             distrib = "Ubuntu"
-            if version == "5.0":
-                version = "18.04"
-            elif version[0:3] == "0.4":
-                version = "16.04"
 
-        return (distrib, version)
+        return distrib
 
     def _platform_bootstrap(self, force: bool) -> bool:
         if self.distro.lower() == "nixos":

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -211,9 +211,6 @@ class Linux(Base):
             print("  $ nix-shell")
             return False
 
-        if self.distro.lower() == "ubuntu" and self.version > "22.04":
-            print(f"WARNING: unsupported version of {self.distro}: {self.version}")
-
         # FIXME: Better version checking for these distributions.
         if self.distro.lower() not in [
             "arch linux",


### PR DESCRIPTION
Removes the unsupported ubuntu version warning from mach. Also removes the related version values on the Linux object, as they're not used anywhere else nor are they maintained.

Testing: Only removes a warning, no test necessary.
Fixes: #38505.
