### PR TITLE
script: Stop handling native `mousedown` and `mouseup` for disabled elements

### DIFF
--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -530,12 +530,12 @@ impl DocumentEventHandler {
 
         let node = el.upcast::<Node>();
         debug!("{:?} on {:?}", event.action, node.debug_str());
-        // Prevent click event if form control element is disabled.
-        if let MouseButtonAction::Click = event.action {
-            // The click event is filtered by the disabled state.
-            if el.is_actually_disabled() {
-                return;
-            }
+
+        // https://w3c.github.io/uievents/#hit-test
+        // Prevent mouse event if element is disabled.
+        // TODO: also inert.
+        if el.is_actually_disabled() {
+            return;
         }
 
         let dom_event = DomRoot::upcast::<Event>(MouseEvent::for_platform_mouse_event(


### PR DESCRIPTION
According to spec of [hit-test](https://w3c.github.io/uievents/#hit-test) for native mouse event, mousedown/mouseup should also be excluded when interacting with disabled element, even tho it may be the frontmost of [elementFromPoint](https://drafts.csswg.org/cssom-view/#dom-document-elementfrompoint).

Testing: Now it matches the behaviour of other browsers in #38670 for disabled element. Also testdriver test: `tests\wpt\tests\html\semantics\disabled-elements\disabled-event-dispatch.tentative.html` has 4 more passing tests.
Fixes: Part of #38670.
