### PR TITLE
script: servoparser line number pass to CSP (#38167)

### DIFF
--- a/components/script/dom/csp.rs
+++ b/components/script/dom/csp.rs
@@ -43,6 +43,7 @@ pub(crate) trait CspReporting {
         el: &Element,
         type_: InlineCheckType,
         source: &str,
+        current_line: u32,
     ) -> bool;
     fn is_trusted_type_policy_creation_allowed(
         &self,
@@ -132,6 +133,7 @@ impl CspReporting for Option<CspList> {
         el: &Element,
         type_: InlineCheckType,
         source: &str,
+        current_line: u32,
     ) -> bool {
         let Some(csp_list) = self else {
             return false;
@@ -142,7 +144,9 @@ impl CspReporting for Option<CspList> {
         let (result, violations) =
             csp_list.should_elements_inline_type_behavior_be_blocked(&element, type_, source);
 
-        global.report_csp_violations(violations, Some(el), None);
+        let source_position = el.compute_source_position(current_line.saturating_sub(2).max(1));
+
+        global.report_csp_violations(violations, Some(el), Some(source_position));
 
         result == CheckResult::Blocked
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2383,6 +2383,12 @@ impl Document {
         self.current_parser.get()
     }
 
+    pub(crate) fn get_current_parser_line(&self) -> u32 {
+        self.get_current_parser()
+            .map(|parser| parser.get_current_line())
+            .unwrap_or(0)
+    }
+
     /// A reference to the [`IFrameCollection`] of this [`Document`], holding information about
     /// `<iframe>`s found within it.
     pub(crate) fn iframes(&self) -> Ref<IFrameCollection> {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2731,6 +2731,7 @@ impl Element {
                             self,
                             InlineCheckType::StyleAttribute,
                             source,
+                            doc.get_current_parser_line(),
                         )
                     {
                         return;

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -562,6 +562,7 @@ impl EventTarget {
                     element.upcast(),
                     InlineCheckType::ScriptAttribute,
                     source,
+                    line as u32,
                 )
             {
                 return;

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -708,6 +708,7 @@ impl HTMLScriptElement {
                     element,
                     InlineCheckType::Script,
                     &text,
+                    self.line_number as u32,
                 )
         {
             warn!("Blocking inline script due to CSP");

--- a/components/script/dom/htmlstyleelement.rs
+++ b/components/script/dom/htmlstyleelement.rs
@@ -113,6 +113,7 @@ impl HTMLStyleElement {
                 self.upcast(),
                 InlineCheckType::Style,
                 &node.child_text_content(),
+                doc.get_current_parser_line(),
             )
         {
             return;

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -116,6 +116,10 @@ impl Tokenizer {
     pub(crate) fn set_plaintext_state(&self) {
         self.inner.set_plaintext_state();
     }
+
+    pub(crate) fn get_current_line(&self) -> u32 {
+        self.inner.sink.sink.current_line.get() as u32
+    }
 }
 
 /// <https://html.spec.whatwg.org/multipage/#html-fragment-serialisation-algorithm>

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -467,6 +467,10 @@ impl ServoParser {
         self.script_nesting_level() > 0 && !self.aborted.get()
     }
 
+    pub(crate) fn get_current_line(&self) -> u32 {
+        self.tokenizer.get_current_line()
+    }
+
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     fn new_inherited(document: &Document, tokenizer: Tokenizer, kind: ParserKind) -> Self {
         // Store the whole input for the devtools Sources panel, if the devtools server is running
@@ -822,6 +826,14 @@ impl Tokenizer {
         match *self {
             Tokenizer::Html(ref tokenizer) => tokenizer.set_plaintext_state(),
             Tokenizer::AsyncHtml(ref tokenizer) => tokenizer.set_plaintext_state(),
+            Tokenizer::Xml(_) => unimplemented!(),
+        }
+    }
+
+    fn get_current_line(&self) -> u32 {
+        match *self {
+            Tokenizer::Html(ref tokenizer) => tokenizer.get_current_line(),
+            Tokenizer::AsyncHtml(_) => unimplemented!(),
             Tokenizer::Xml(_) => unimplemented!(),
         }
     }


### PR DESCRIPTION
Based on the issue #38167 and PR #38304 description has following changes :

1. Update the `servoparser html.rs`  `get_current_line()` function to obtain current_line from sink
2. Update mod.rs `get_parser_current_line()` to pass the parser line number to document
3. Add the line_number argument to `should_elements_inline_type_behavior_be_blocked` 
4. In components/script/dom, update element.rs and htmlstyleelement.rs with doc.get_current_parser_line and two other files with line_number attached using existing local values. 

Testing:
`./mach test-wpt content-security-policy/securitypolicyviolation/blockeduri-inline.html`
The line number correctly pass the value, the column number part is not implemented.
