### PR TITLE
script: abort planned form navigations

### DIFF
--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1027,9 +1027,9 @@ impl HTMLFormElement {
         // <https://html.spec.whatwg.org/multipage/#nav-stop>
         //
         // The concept of ongoing navigation must be separated from the form's
-        // planned navigation conceopt, because each planned navigation cancels the previous one
+        // planned navigation concept, because each planned navigation cancels the previous one
         // for a given form,
-        // whereas an ongoing navigation is a per navigable(read: window for now) concept.
+        // whereas an ongoing navigation is a per navigable (read: window for now) concept.
         //
         // Setting the ongoing navigation now
         // means the navigation could be cancelled even if the below task has not run yet.

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1028,8 +1028,8 @@ impl HTMLFormElement {
         //
         // The concept of ongoing navigation must be separated from the form's
         // planned navigation concept, because each planned navigation cancels the previous one
-        // for a given form,
-        // whereas an ongoing navigation is a per navigable (read: window for now) concept.
+        // for a given form, whereas an ongoing navigation is a per navigable (read: window for now)
+        // concept.
         //
         // Setting the ongoing navigation now
         // means the navigation could be cancelled even if the below task has not run yet.

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -1031,12 +1031,11 @@ impl HTMLFormElement {
         // for a given form, whereas an ongoing navigation is a per navigable (read: window for now)
         // concept.
         //
-        // Setting the ongoing navigation now
-        // means the navigation could be cancelled even if the below task has not run yet.
-        // This is not how the spec is written: it seems instead to imply that
-        // a `window.stop` should only cancel the navigation that has already started
-        // (here the task is queued, but the nav starts only in the task).
-        // See https://github.com/whatwg/html/issues/11562
+        // Setting the ongoing navigation now means the navigation could be cancelled
+        // even if the below task has not run yet. This is not how the spec is written: it
+        // seems instead to imply that a `window.stop` should only cancel the navigation 
+        // that has already started (here the task is queued, but the navigation starts only
+        // in the task). See <https://github.com/whatwg/html/issues/11562>.
         let ongoing_navigation = target.set_ongoing_navigation();
 
         let referrer_policy = target.Document().get_referrer_policy();

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -226,7 +226,7 @@ impl LayoutBlocker {
 /// An id used to cancel navigations; for now only used for planned form navigations.
 /// Loosely based on
 /// <https://html.spec.whatwg.org/multipage/#ongoing-navigation>
-#[derive(Clone, Copy, Default, JSTraceable, MallocSizeOf, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) struct OngoingNavigation(u32);
 
 type PendingImageRasterizationKey = (PendingImageId, DeviceIntSize);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -729,12 +729,12 @@ impl Window {
         // we just increment it (it is not a uuid).
         let new_value = self.ongoing_navigation.get().0.wrapping_add(1);
 
-        // If navigable's ongoing navigation is equal to newValue, then return.
+        // 1. If navigable's ongoing navigation is equal to newValue, then return.
         // Note: cannot happen in the way it is currently used.
 
-        // TODO: Inform the navigation API about aborting navigation given navigable.
+        // TODO: 2. Inform the navigation API about aborting navigation given navigable.
 
-        // Set navigable's ongoing navigation to newValue.
+        // 3. Set navigable's ongoing navigation to newValue.
         self.ongoing_navigation.set(OngoingNavigation(new_value));
 
         // Note: Return the ongoing navigation for the caller to use.
@@ -743,21 +743,21 @@ impl Window {
 
     /// <https://html.spec.whatwg.org/multipage/#nav-stop>
     fn stop_loading(&self, can_gc: CanGc) {
-        // Let document be navigable's active document.
+        // 1. Let document be navigable's active document.
         let doc = self.Document();
 
-        // If document's unload counter is 0,
+        // 2. If document's unload counter is 0,
         // and navigable's ongoing navigation is a navigation ID,
         // then set the ongoing navigation for navigable to null.
         //
         // Note: since the concept of `navigable` is nascent in Servo,
         // for now we do two things:
-        // 1. increment the `ongoing_navigation`(preventing planned form navigations).
-        // 2. Send a `AbortLoadUrl` message(in case the navigation
+        // - increment the `ongoing_navigation`(preventing planned form navigations).
+        // - Send a `AbortLoadUrl` message(in case the navigation
         // already started at the constellation).
         self.set_ongoing_navigation();
 
-        // Abort a document and its descendants given document.
+        // 3. Abort a document and its descendants given document.
         doc.abort(can_gc);
     }
 }
@@ -915,10 +915,10 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     // https://html.spec.whatwg.org/multipage/#dom-window-stop
     fn Stop(&self, can_gc: CanGc) {
-        // If this's navigable is null, then return.
+        // 1. If this's navigable is null, then return.
         // Note: Servo doesn't have a concept of navigable yet.
 
-        // Stop loading this's navigable.
+        // 2. Stop loading this's navigable.
         self.stop_loading(can_gc);
     }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -725,7 +725,7 @@ impl Window {
 
     /// <https://html.spec.whatwg.org/multipage/#set-the-ongoing-navigation>
     pub(crate) fn set_ongoing_navigation(&self) -> OngoingNavigation {
-        // Note: since this value, for now, is only used in a single script-thread,
+        // Note: since this value, for now, is only used in a single `ScriptThread`,
         // we just increment it (it is not a uuid).
         let new_value = self.ongoing_navigation.get().0.wrapping_add(1);
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -727,7 +727,7 @@ impl Window {
     /// <https://html.spec.whatwg.org/multipage/#set-the-ongoing-navigation>
     pub(crate) fn set_ongoing_navigation(&self) -> OngoingNavigation {
         // Note: since this value, for now, is only used in a single script-thread,
-        // we just increment it(it is not a uuid).
+        // we just increment it (it is not a uuid).
         let new_value = self.ongoing_navigation.get().0.wrapping_add(1);
 
         // If navigable's ongoing navigation is equal to newValue, then return.
@@ -738,7 +738,7 @@ impl Window {
         // Set navigable's ongoing navigation to newValue.
         self.ongoing_navigation.set(OngoingNavigation(new_value));
 
-        // Return the ongoing navigation for the caller to use.
+        // Note: Return the ongoing navigation for the caller to use.
         OngoingNavigation(new_value)
     }
 
@@ -757,7 +757,6 @@ impl Window {
         // 2. Send a `AbortLoadUrl` message(in case the navigation
         // already started at the constellation).
         self.set_ongoing_navigation();
-        //self.send_to_constellation(ScriptToConstellationMessage::AbortLoadUrl);
 
         // Abort a document and its descendants given document.
         doc.abort(can_gc);

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -224,8 +224,7 @@ impl LayoutBlocker {
 }
 
 /// An id used to cancel navigations; for now only used for planned form navigations.
-/// Loosely based on
-/// <https://html.spec.whatwg.org/multipage/#ongoing-navigation>
+/// Loosely based on <https://html.spec.whatwg.org/multipage/#ongoing-navigation>.
 #[derive(Clone, Copy, Debug, Default, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) struct OngoingNavigation(u32);
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -223,6 +223,12 @@ impl LayoutBlocker {
     }
 }
 
+/// An id used to cancel navigations; for now only used for planned form navigations.
+/// Loosely based on
+/// <https://html.spec.whatwg.org/multipage/#ongoing-navigation>
+#[derive(Clone, Copy, Default, JSTraceable, MallocSizeOf, PartialEq)]
+pub(crate) struct OngoingNavigation(u32);
+
 type PendingImageRasterizationKey = (PendingImageId, DeviceIntSize);
 
 #[dom_struct]
@@ -262,6 +268,10 @@ pub(crate) struct Window {
     local_storage: MutNullableDom<Storage>,
     status: DomRefCell<DOMString>,
     trusted_types: MutNullableDom<TrustedTypePolicyFactory>,
+
+    /// The start of something resembling
+    /// <https://html.spec.whatwg.org/multipage/#ongoing-navigation>
+    ongoing_navigation: Cell<OngoingNavigation>,
 
     /// For sending timeline markers. Will be ignored if
     /// no devtools server
@@ -709,6 +719,49 @@ impl Window {
     pub(crate) fn font_context(&self) -> &Arc<FontContext> {
         &self.font_context
     }
+
+    pub(crate) fn ongoing_navigation(&self) -> OngoingNavigation {
+        self.ongoing_navigation.get()
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#set-the-ongoing-navigation>
+    pub(crate) fn set_ongoing_navigation(&self) -> OngoingNavigation {
+        // Note: since this value, for now, is only used in a single script-thread,
+        // we just increment it(it is not a uuid).
+        let new_value = self.ongoing_navigation.get().0.wrapping_add(1);
+
+        // If navigable's ongoing navigation is equal to newValue, then return.
+        // Note: cannot happen in the way it is currently used.
+
+        // TODO: Inform the navigation API about aborting navigation given navigable.
+
+        // Set navigable's ongoing navigation to newValue.
+        self.ongoing_navigation.set(OngoingNavigation(new_value));
+
+        // Return the ongoing navigation for the caller to use.
+        OngoingNavigation(new_value)
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#nav-stop>
+    fn stop_loading(&self, can_gc: CanGc) {
+        // Let document be navigable's active document.
+        let doc = self.Document();
+
+        // If document's unload counter is 0,
+        // and navigable's ongoing navigation is a navigation ID,
+        // then set the ongoing navigation for navigable to null.
+        //
+        // Note: since the concept of `navigable` is nascent in Servo,
+        // for now we do two things:
+        // 1. increment the `ongoing_navigation`(preventing planned form navigations).
+        // 2. Send a `AbortLoadUrl` message(in case the navigation
+        // already started at the constellation).
+        self.set_ongoing_navigation();
+        //self.send_to_constellation(ScriptToConstellationMessage::AbortLoadUrl);
+
+        // Abort a document and its descendants given document.
+        doc.abort(can_gc);
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/#atob
@@ -864,9 +917,11 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     // https://html.spec.whatwg.org/multipage/#dom-window-stop
     fn Stop(&self, can_gc: CanGc) {
-        // TODO: Cancel ongoing navigation.
-        let doc = self.Document();
-        doc.abort(can_gc);
+        // If this's navigable is null, then return.
+        // Note: Servo doesn't have a concept of navigable yet.
+
+        // Stop loading this's navigable.
+        self.stop_loading(can_gc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-window-focus>
@@ -3076,6 +3131,7 @@ impl Window {
                 inherited_secure_context,
                 unminify_js,
             ),
+            ongoing_navigation: Default::default(),
             script_chan,
             layout: RefCell::new(layout),
             font_context,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -726,7 +726,8 @@ impl Window {
     /// <https://html.spec.whatwg.org/multipage/#set-the-ongoing-navigation>
     pub(crate) fn set_ongoing_navigation(&self) -> OngoingNavigation {
         // Note: since this value, for now, is only used in a single `ScriptThread`,
-        // we just increment it (it is not a uuid).
+        // we just increment it (it is not a uuid), which implies not
+        // using a `newValue` variable.
         let new_value = self.ongoing_navigation.get().0.wrapping_add(1);
 
         // 1. If navigable's ongoing navigation is equal to newValue, then return.

--- a/tests/wpt/tests/html/browsers/browsing-the-web/navigating-across-documents/form-submit-and-window-stop.html
+++ b/tests/wpt/tests/html/browsers/browsing-the-web/navigating-across-documents/form-submit-and-window-stop.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>The planned navigation of a form should be cancelled by a window stop 
+<title>The planned navigation of a form should be cancelled by a window stop
   in the same task as the form submission</title>
 <link rel="help" href="https://github.com/whatwg/html/issues/3730">
 <script src="/resources/testharness.js"></script>

--- a/tests/wpt/tests/html/browsers/browsing-the-web/navigating-across-documents/form-submit-and-window-stop.html
+++ b/tests/wpt/tests/html/browsers/browsing-the-web/navigating-across-documents/form-submit-and-window-stop.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>The planned navigation of a form should be cancelled by a window stop 
+  in the same task as the form submission</title>
+<link rel="help" href="https://github.com/whatwg/html/issues/3730">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+
+<body>
+<script>
+"use strict";
+async_test(t => {
+  let unloaded = false;
+  window.onload = t.step_func(() => {
+    form.submit();
+    window.stop();
+  });
+  window.onunload = () => {
+    unloaded = true;
+  };
+  t.step_timeout(() => {
+    // The document should not have unloaded.
+    assert_equals(unloaded, false);
+    t.done();
+  }, 100);
+});
+</script>
+<form id="form">


### PR DESCRIPTION
Servo shows a behavior unlike FF and Safari(I don't have Chrome), where stopping a window does not cancel planned form navigation, resulting in an infinite navigation loop. The current behavior of Servo does seem to follow the wording of the spec, so I will open a [companion issue at the spec](https://github.com/whatwg/html/issues/11562), and I have also written a WPT tests for the non-standard but widely followed behavior. This PR also adds a beginning of an implementation of the "ongoing navigation" concept, which is used by the spec to cancel navigations, and which is used in this PR only to cancel planned form navigations. The generation id concept, which corresponds to the planned navigation concept in the spec, is turned into a simple struct private cell, and is documented per the spec.

Testing: A new WPT test is added
Fixes: Only one part of https://github.com/servo/servo/issues/36747
