### PR TITLE
layout: Support storing layout data for two-level nested pseudo-elements

### DIFF
--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -190,7 +190,7 @@ fn construct_for_root_element(
 
     let root_box = ArcRefCell::new(root_box);
     root_element
-        .element_box_slot()
+        .box_slot()
         .set(LayoutBox::BlockLevel(root_box.clone()));
     vec![root_box]
 }
@@ -301,7 +301,7 @@ impl<'dom> IncrementalBoxTreeUpdate<'dom> {
             return None;
         }
 
-        let layout_data = NodeExt::layout_data(&potential_thread_safe_dirty_root_node)?;
+        let layout_data = NodeExt::inner_layout_data(&potential_thread_safe_dirty_root_node)?;
         if !layout_data.pseudo_boxes.is_empty() {
             return None;
         }

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -4,10 +4,10 @@
 
 use bitflags::bitflags;
 use layout_api::combine_id_with_fragment_type;
+use layout_api::wrapper_traits::PseudoElementChain;
 use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
 use style::dom::OpaqueNode;
-use style::selector_parser::PseudoElement;
 
 /// This data structure stores fields that are common to all non-base
 /// Fragment types and should generally be the first member of all
@@ -114,23 +114,29 @@ malloc_size_of_is_0!(FragmentFlags);
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq)]
 pub(crate) struct Tag {
     pub(crate) node: OpaqueNode,
-    pub(crate) pseudo: Option<PseudoElement>,
+    pub(crate) pseudo_element_chain: PseudoElementChain,
 }
 
 impl Tag {
     /// Create a new Tag for a non-pseudo element. This is mainly used for
     /// matching existing tags, since it does not accept an `info` argument.
     pub(crate) fn new(node: OpaqueNode) -> Self {
-        Tag { node, pseudo: None }
+        Tag {
+            node,
+            pseudo_element_chain: Default::default(),
+        }
     }
 
     /// Create a new Tag for a pseudo element. This is mainly used for
     /// matching existing tags, since it does not accept an `info` argument.
-    pub(crate) fn new_pseudo(node: OpaqueNode, pseudo: Option<PseudoElement>) -> Self {
-        Tag { node, pseudo }
+    pub(crate) fn new_pseudo(node: OpaqueNode, pseudo_element_chain: PseudoElementChain) -> Self {
+        Tag {
+            node,
+            pseudo_element_chain,
+        }
     }
 
     pub(crate) fn to_display_list_fragment_id(self) -> u64 {
-        combine_id_with_fragment_type(self.node.id(), self.pseudo.into())
+        combine_id_with_fragment_type(self.node.id(), self.pseudo_element_chain.primary.into())
     }
 }

--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -71,8 +71,15 @@ impl FragmentTree {
 
         fragment_tree.find(|fragment, _level, containing_block| {
             if let Some(tag) = fragment.tag() {
-                invalid_animating_nodes.remove(&AnimationSetKey::new(tag.node, tag.pseudo));
-                invalid_image_animating_nodes.remove(&AnimationSetKey::new(tag.node, tag.pseudo));
+                // TODO: Support animations on nested pseudo-elements.
+                invalid_animating_nodes.remove(&AnimationSetKey::new(
+                    tag.node,
+                    tag.pseudo_element_chain.primary,
+                ));
+                invalid_image_animating_nodes.remove(&AnimationSetKey::new(
+                    tag.node,
+                    tag.pseudo_element_chain.primary,
+                ));
             }
 
             fragment.set_containing_block(containing_block);

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -720,9 +720,9 @@ impl<'style, 'dom> TableBuilderTraversal<'style, 'dom> {
         });
         self.push_table_row(table_row.clone());
 
-        self.info
+        anonymous_info
             .node
-            .pseudo_element_box_slot(PseudoElement::ServoAnonymousTableRow)
+            .box_slot()
             .set(LayoutBox::TableLevelBox(TableLevelBox::Track(table_row)))
     }
 
@@ -989,9 +989,9 @@ impl<'style, 'builder, 'dom, 'a> TableRowBuilder<'style, 'builder, 'dom, 'a> {
             .builder
             .add_cell(new_table_cell.clone());
 
-        self.info
+        anonymous_info
             .node
-            .pseudo_element_box_slot(PseudoElement::ServoAnonymousTableCell)
+            .box_slot()
             .set(LayoutBox::TableLevelBox(TableLevelBox::Cell(
                 new_table_cell,
             )));
@@ -1027,7 +1027,7 @@ impl<'dom> TraversalHandler<'dom> for TableRowBuilder<'_, '_, 'dom, '_> {
                     let cell = old_cell.unwrap_or_else(|| {
                         // This value will already have filtered out rowspan=0
                         // in quirks mode, so we don't have to worry about that.
-                        let (rowspan, colspan) = if info.pseudo_element().is_none() {
+                        let (rowspan, colspan) = if info.pseudo_element_chain().is_empty() {
                             let rowspan = info.node.get_rowspan().unwrap_or(1) as usize;
                             let colspan = info.node.get_colspan().unwrap_or(1) as usize;
 
@@ -1148,7 +1148,7 @@ fn add_column(
     is_anonymous: bool,
     old_column: Option<ArcRefCell<TableTrack>>,
 ) -> ArcRefCell<TableTrack> {
-    let span = if column_info.pseudo_element().is_none() {
+    let span = if column_info.pseudo_element_chain().is_empty() {
         column_info.node.get_span().unwrap_or(1)
     } else {
         1


### PR DESCRIPTION
Add basic support for storing layout data for pseudo-elements nested to
up to two levels. This removes the last unstored layout result and fixes
a double-borrow issue. This change does not add properly parsing nor
styling of these element types, but does prepare for those changes which
must come from stylo.

Testing: This fixes a intermittent panic in
`tests/wpt/tests/css/css-lists/nested-marker-styling.html`
Fixes: #38177. 
Closes: #38183.
