### PR TITLE
chore: Pin cargo-deny to 0.18.3

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-deny
-          version: 0.18
+          version: 0.18.3
           locked: true
       - name: Bootstrap dependencies
         run: |

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -98,7 +98,7 @@ class Base:
             return False
 
         print(" * Installing cargo-deny...")
-        if subprocess.call(["cargo", "install", "cargo-deny", "--locked"]) != 0:
+        if subprocess.call(["cargo", "install", "cargo-deny@0.18.3", "--locked"]) != 0:
             raise EnvironmentError("Installation of cargo-deny failed.")
         return True
 


### PR DESCRIPTION
cargo-deny@0.18.4 requires Rust 1.88

Testing: Fixes CI.
