### PR TITLE
base: Remove last usage of static_assertions crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,7 +728,6 @@ dependencies = [
  "parking_lot",
  "serde",
  "servo_malloc_size_of",
- "static_assertions",
  "time",
  "webrender_api",
  "windows-sys 0.59.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,6 @@ servo-tracing = { path = "components/servo_tracing" }
 servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
 smallbitvec = "2.6.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
-static_assertions = "1.1"
 string_cache = "0.8"
 string_cache_codegen = "0.5"
 strum = "0.26"

--- a/components/shared/base/Cargo.toml
+++ b/components/shared/base/Cargo.toml
@@ -20,7 +20,6 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
-static_assertions = { workspace = true }
 time = { workspace = true }
 webrender_api = { workspace = true }
 

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -22,7 +22,6 @@ use webrender_api::{ExternalScrollId, PipelineId as WebRenderPipelineId};
 /// Asserts the size of a type at compile time.
 macro_rules! size_of_test {
     ($t: ty, $expected_size: expr) => {
-        #[cfg(target_pointer_width = "64")]
         ::static_assertions::const_assert_eq!(std::mem::size_of::<$t>(), $expected_size);
     };
 }

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -22,7 +22,7 @@ use webrender_api::{ExternalScrollId, PipelineId as WebRenderPipelineId};
 /// Asserts the size of a type at compile time.
 macro_rules! size_of_test {
     ($t: ty, $expected_size: expr) => {
-        ::static_assertions::const_assert_eq!(std::mem::size_of::<$t>(), $expected_size);
+        const _: () = assert!(std::mem::size_of::<$t>() == $expected_size);
     };
 }
 


### PR DESCRIPTION
Replace static_assertions in the `size_of_test` macro with `const assert`s. The error message is still informative.
Additionally also remove the `cfg` guard, which caused the assertion to only be enabled on 64 bit platforms, which is something one would not expect given the name `size_of_test` of the macro.
`cargo tree -i static_assertions` now points to only `stylo` using `static_assertions`, so we should be able to remove this dependency fairly easy, since the macro doesn't seem to be used there either at first glance.

Testing: Covered by existing tests.

