### PR TITLE
tests: Reintroduce CookieStore WPT test expectations

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -13,7 +13,7 @@ skip: true
   skip: false
   [embedded-enforcement]
     skip: true
-[cookie-store]
+[cookiestore]
   skip: false
 [cookies]
   skip: false

--- a/tests/wpt/meta/cookiestore/__dir__.ini
+++ b/tests/wpt/meta/cookiestore/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [dom_cookiestore_enabled: true]

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_already_expired.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_already_expired.https.window.js.ini
@@ -1,0 +1,6 @@
+[change_eventhandler_for_already_expired.https.window.html]
+  [CookieStore setting already-expired cookie should not be observed]
+    expected: FAIL
+
+  [CookieStore setting already-expired partitioned cookie should not be observed]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_document_cookie.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_document_cookie.https.window.js.ini
@@ -1,0 +1,18 @@
+[change_eventhandler_for_document_cookie.https.window.html]
+  [document.cookie set/overwrite/delete observed by CookieStore]
+    expected: FAIL
+
+  [document.cookie set already-expired cookie should not be observed by CookieStore]
+    expected: FAIL
+
+  [document.cookie duplicate cookie should not be observed by CookieStore]
+    expected: FAIL
+
+  [CookieStore set/overwrite/delete observed by document.cookie]
+    expected: FAIL
+
+  [CookieStore agrees with document.cookie on encoding non-ASCII cookies]
+    expected: FAIL
+
+  [document.cookie agrees with CookieStore on encoding non-ASCII cookies]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.js.ini
@@ -1,0 +1,21 @@
+[change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.html]
+  [HTTP set/overwrite/delete observed in CookieStore]
+    expected: FAIL
+
+  [HTTP set already-expired cookie should not be observed by CookieStore]
+    expected: FAIL
+
+  [HTTP duplicate cookie should not be observed by CookieStore]
+    expected: FAIL
+
+  [CookieStore agreed with HTTP headers agree on encoding non-ASCII cookies]
+    expected: FAIL
+
+  [CookieStore set/overwrite/delete observed in HTTP headers]
+    expected: FAIL
+
+  [HTTP headers agreed with CookieStore on encoding non-ASCII cookies]
+    expected: FAIL
+
+  [Binary HTTP set/overwrite/delete observed in CookieStore]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_no_change.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_no_change.https.window.js.ini
@@ -1,0 +1,6 @@
+[change_eventhandler_for_no_change.https.window.html]
+  [CookieStore duplicate cookie should not be observed]
+    expected: FAIL
+
+  [CookieStore duplicate partitioned cookie should not be observed]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_no_name_and_no_value.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_no_name_and_no_value.https.window.js.ini
@@ -1,0 +1,3 @@
+[change_eventhandler_for_no_name_and_no_value.https.window.html]
+  [Verify behavior of no-name and no-value cookies.]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_no_name_equals_in_value.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_no_name_equals_in_value.https.window.js.ini
@@ -1,0 +1,3 @@
+[change_eventhandler_for_no_name_equals_in_value.https.window.html]
+  [Verify that attempting to set a cookie with no name and with '=' in the value does not work.]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_no_name_multiple_values.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_no_name_multiple_values.https.window.js.ini
@@ -1,0 +1,3 @@
+[change_eventhandler_for_no_name_multiple_values.https.window.html]
+  [Verify behavior of multiple no-name cookies]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieListItem_attributes.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieListItem_attributes.https.any.js.ini
@@ -1,0 +1,2 @@
+[cookieListItem_attributes.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/cookieListItem_attributes.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieListItem_attributes.https.window.js.ini
@@ -1,0 +1,33 @@
+[cookieListItem_attributes.https.window.html]
+  [CookieListItem - cookieStore.set defaults with positional name and value]
+    expected: FAIL
+
+  [CookieListItem - cookieStore.set defaults with name and value in options]
+    expected: FAIL
+
+  [CookieListItem - cookieStore.set with expires set to a timestamp 10 years in the future]
+    expected: FAIL
+
+  [CookieListItem - cookieStore.set with expires set to a Date 10 years in the future]
+    expected: FAIL
+
+  [CookieListItem - cookieStore.set with domain set to the current hostname]
+    expected: FAIL
+
+  [CookieListItem - cookieStore.set with path set to the current directory]
+    expected: FAIL
+
+  [CookieListItem - cookieStore.set does not add / to path if it does not end with /]
+    expected: FAIL
+
+  [CookieListItem - cookieStore.set with sameSite set to strict]
+    expected: FAIL
+
+  [CookieListItem - cookieStore.set with sameSite set to lax]
+    expected: FAIL
+
+  [CookieListItem - cookieStore.set with sameSite set to none]
+    expected: FAIL
+
+  [Test max-age attribute over the 400 days]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStoreManager_getSubscriptions_empty.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStoreManager_getSubscriptions_empty.https.any.js.ini
@@ -1,0 +1,7 @@
+[cookieStoreManager_getSubscriptions_empty.https.any.html]
+  [getSubscriptions returns an empty array when there are no subscriptions]
+    expected: FAIL
+
+
+[cookieStoreManager_getSubscriptions_empty.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/cookieStoreManager_getSubscriptions_multiple.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStoreManager_getSubscriptions_multiple.https.any.js.ini
@@ -1,0 +1,6 @@
+[cookieStoreManager_getSubscriptions_multiple.https.any.serviceworker.html]
+  expected: ERROR
+
+[cookieStoreManager_getSubscriptions_multiple.https.any.html]
+  [getSubscriptions returns a subscription passed to subscribe]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStoreManager_getSubscriptions_single.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStoreManager_getSubscriptions_single.https.any.js.ini
@@ -1,0 +1,6 @@
+[cookieStoreManager_getSubscriptions_single.https.any.serviceworker.html]
+  expected: ERROR
+
+[cookieStoreManager_getSubscriptions_single.https.any.html]
+  [getSubscriptions returns a subscription passed to subscribe]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_delete.sub.https.html.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_delete.sub.https.html.ini
@@ -1,0 +1,4 @@
+[cookieStore_delete.sub.https.html]
+  expected: TIMEOUT
+  [Async Cookies: cookieStore basic API across origins]
+    expected: TIMEOUT

--- a/tests/wpt/meta/cookiestore/cookieStore_delete_arguments.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_delete_arguments.https.any.js.ini
@@ -1,0 +1,58 @@
+[cookieStore_delete_arguments.https.any.html]
+  [cookieStore.delete with positional name]
+    expected: FAIL
+
+  [cookieStore.delete with name in options]
+    expected: FAIL
+
+  [cookieStore.delete domain starts with "."]
+    expected: FAIL
+
+  [cookieStore.delete with domain that is not equal current host]
+    expected: FAIL
+
+  [cookieStore.delete with domain set to the current hostname]
+    expected: FAIL
+
+  [cookieStore.delete with domain set to a subdomain of the current hostname]
+    expected: FAIL
+
+  [cookieStore.delete with domain set to a non-domain-matching suffix of the current hostname]
+    expected: FAIL
+
+  [cookieStore.delete with path set to the current directory]
+    expected: FAIL
+
+  [cookieStore.delete with path set to subdirectory of the current directory]
+    expected: FAIL
+
+  [cookieStore.delete does not append / at the end of path]
+    expected: FAIL
+
+  [cookieStore.delete can delete a cookie set by document.cookie if document is defined]
+    expected: FAIL
+
+  [cookieStore.delete with path that does not start with /]
+    expected: FAIL
+
+  [cookieStore.delete with get result]
+    expected: FAIL
+
+  [cookieStore.delete with positional empty name]
+    expected: FAIL
+
+  [cookieStore.delete with empty name in options]
+    expected: FAIL
+
+  [cookieStore.delete with maximum cookie name size]
+    expected: FAIL
+
+  [cookieStore.delete with a __Host- prefix should not have a domain]
+    expected: FAIL
+
+  [cookieStore.delete with whitespace]
+    expected: FAIL
+
+
+[cookieStore_delete_arguments.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/cookieStore_delete_basic.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_delete_basic.https.any.js.ini
@@ -1,0 +1,6 @@
+[cookieStore_delete_basic.https.any.serviceworker.html]
+  expected: ERROR
+
+[cookieStore_delete_basic.https.any.html]
+  [cookieStore.delete return type is Promise<void>]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_event_arguments.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_event_arguments.https.window.js.ini
@@ -1,0 +1,12 @@
+[cookieStore_event_arguments.https.window.html]
+  [CookieChangeEvent construction with default arguments]
+    expected: FAIL
+
+  [CookieChangeEvent construction with changed cookie list]
+    expected: FAIL
+
+  [CookieChangeEvent construction with deleted cookie list]
+    expected: FAIL
+
+  [CookieChangeEvent construction with changed and deleted cookie lists]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_event_basic.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_event_basic.https.window.js.ini
@@ -1,0 +1,4 @@
+[cookieStore_event_basic.https.window.html]
+  expected: ERROR
+  [cookieStore fires change event for cookie set by cookieStore.set()]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_event_delete.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_event_delete.https.window.js.ini
@@ -1,0 +1,7 @@
+[cookieStore_event_delete.https.window.html]
+  expected: ERROR
+  [cookieStore fires change event for cookie deleted by cookieStore.delete()]
+    expected: FAIL
+
+  [cookieStore does not fire change events for non-existing expired cookies]
+    expected: NOTRUN

--- a/tests/wpt/meta/cookiestore/cookieStore_event_overwrite.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_event_overwrite.https.window.js.ini
@@ -1,0 +1,4 @@
+[cookieStore_event_overwrite.https.window.html]
+  expected: ERROR
+  [cookieStore fires change event for cookie overwritten by cookieStore.set()]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_getAll_arguments.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_getAll_arguments.https.any.js.ini
@@ -1,0 +1,39 @@
+[cookieStore_getAll_arguments.https.any.serviceworker.html]
+  expected: ERROR
+
+[cookieStore_getAll_arguments.https.any.html]
+  [cookieStore.getAll with no arguments]
+    expected: FAIL
+
+  [cookieStore.getAll with empty options]
+    expected: FAIL
+
+  [cookieStore.getAll with positional name]
+    expected: FAIL
+
+  [cookieStore.getAll with name in options]
+    expected: FAIL
+
+  [cookieStore.getAll with name in both positional arguments and options]
+    expected: FAIL
+
+  [cookieStore.getAll with absolute url in options]
+    expected: FAIL
+
+  [cookieStore.getAll with relative url in options]
+    expected: FAIL
+
+  [cookieStore.getAll with invalid url path in options]
+    expected: FAIL
+
+  [cookieStore.getAll with invalid url host in options]
+    expected: FAIL
+
+  [cookieStore.getAll with absolute url with fragment in options]
+    expected: FAIL
+
+  [cookieStore.getAll with absolute different url in options]
+    expected: FAIL
+
+  [cookieStore.getAll with whitespace]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_getAll_multiple.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_getAll_multiple.https.any.js.ini
@@ -1,0 +1,7 @@
+[cookieStore_getAll_multiple.https.any.html]
+  [cookieStore.getAll returns multiple cookies written by cookieStore.set]
+    expected: FAIL
+
+
+[cookieStore_getAll_multiple.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/cookieStore_getAll_set_basic.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_getAll_set_basic.https.any.js.ini
@@ -1,0 +1,7 @@
+[cookieStore_getAll_set_basic.https.any.html]
+  [cookieStore.getAll returns the cookie written by cookieStore.set]
+    expected: FAIL
+
+
+[cookieStore_getAll_set_basic.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/cookieStore_getAll_set_creation_url.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_getAll_set_creation_url.https.any.js.ini
@@ -1,0 +1,3 @@
+[cookieStore_getAll_set_creation_url.https.any.html]
+  [cookieStore.set and cookieStore.getAll use the creation url]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_get_arguments.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_get_arguments.https.any.js.ini
@@ -1,0 +1,39 @@
+[cookieStore_get_arguments.https.any.serviceworker.html]
+  expected: ERROR
+
+[cookieStore_get_arguments.https.any.html]
+  [cookieStore.get with no arguments returns TypeError]
+    expected: FAIL
+
+  [cookieStore.get with empty options returns TypeError]
+    expected: FAIL
+
+  [cookieStore.get with positional name]
+    expected: FAIL
+
+  [cookieStore.get with name in options]
+    expected: FAIL
+
+  [cookieStore.get with name in both positional arguments and options]
+    expected: FAIL
+
+  [cookieStore.get with absolute url in options]
+    expected: FAIL
+
+  [cookieStore.get with relative url in options]
+    expected: FAIL
+
+  [cookieStore.get with invalid url path in options]
+    expected: FAIL
+
+  [cookieStore.get with invalid url host in options]
+    expected: FAIL
+
+  [cookieStore.get with absolute url with fragment in options]
+    expected: FAIL
+
+  [cookieStore.get with absolute different url in options]
+    expected: FAIL
+
+  [cookieStore.get with whitespace]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_get_delete_basic.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_get_delete_basic.https.any.js.ini
@@ -1,0 +1,7 @@
+[cookieStore_get_delete_basic.https.any.html]
+  [cookieStore.get returns null for a cookie deleted by cookieStore.delete]
+    expected: FAIL
+
+
+[cookieStore_get_delete_basic.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/cookieStore_get_set_across_frames.https.html.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_get_set_across_frames.https.html.ini
@@ -1,0 +1,6 @@
+[cookieStore_get_set_across_frames.https.html]
+  [cookieStore.get() sees cookieStore.set() in frame]
+    expected: FAIL
+
+  [cookieStore.get() in frame sees cookieStore.set()]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_get_set_across_origins.sub.https.html.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_get_set_across_origins.sub.https.html.ini
@@ -1,0 +1,13 @@
+[cookieStore_get_set_across_origins.sub.https.html]
+  expected: TIMEOUT
+  [cookieStore.get() sees cookieStore.set() in cross-origin frame]
+    expected: TIMEOUT
+
+  [cookieStore.get() in cross-origin frame sees cookieStore.set()]
+    expected: NOTRUN
+
+  [cookieStore.set() in cross-origin does not overwrite the __Host- cookie]
+    expected: NOTRUN
+
+  [__Host- cookies set via cookieStore.set() in same-site domains don't overwrite each other]
+    expected: NOTRUN

--- a/tests/wpt/meta/cookiestore/cookieStore_get_set_basic.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_get_set_basic.https.any.js.ini
@@ -1,0 +1,7 @@
+[cookieStore_get_set_basic.https.any.html]
+  [cookieStore.get returns the cookie written by cookieStore.set]
+    expected: FAIL
+
+
+[cookieStore_get_set_basic.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/cookieStore_get_set_creation_url.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_get_set_creation_url.https.any.js.ini
@@ -1,0 +1,3 @@
+[cookieStore_get_set_creation_url.https.any.html]
+  [cookieStore.set and cookieStore.get use the creation url]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_get_set_creation_url.sub.https.html.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_get_set_creation_url.sub.https.html.ini
@@ -1,0 +1,7 @@
+[cookieStore_get_set_creation_url.sub.https.html]
+  expected: TIMEOUT
+  [cookieStore.get() option url ignores fragments]
+    expected: TIMEOUT
+
+  [cookieStore.get() option url + pushState()]
+    expected: NOTRUN

--- a/tests/wpt/meta/cookiestore/cookieStore_get_set_ordering.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_get_set_ordering.https.any.js.ini
@@ -1,0 +1,11 @@
+[cookieStore_get_set_ordering.https.any.html]
+  expected: ERROR
+  [Set three simple origin session cookies sequentially and ensure they all end up in the cookie jar in order.]
+    expected: FAIL
+
+  [Set three simple origin session cookies in undefined order using Promise.all and ensure they all end up in the cookie jar in any order. ]
+    expected: NOTRUN
+
+
+[cookieStore_get_set_ordering.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/cookieStore_in_detached_frame.https.html.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_in_detached_frame.https.html.ini
@@ -1,0 +1,3 @@
+[cookieStore_in_detached_frame.https.html]
+  [cookieStore on DOMWindow of detached iframe]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_opaque_origin.https.html.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_opaque_origin.https.html.ini
@@ -1,0 +1,7 @@
+[cookieStore_opaque_origin.https.html]
+  expected: TIMEOUT
+  [cookieStore in non-sandboxed iframe should not throw]
+    expected: FAIL
+
+  [cookieStore in sandboxed iframe should throw SecurityError]
+    expected: TIMEOUT

--- a/tests/wpt/meta/cookiestore/cookieStore_set_arguments.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_set_arguments.https.any.js.ini
@@ -1,0 +1,165 @@
+[cookieStore_set_arguments.https.any.serviceworker.html]
+  expected: ERROR
+
+[cookieStore_set_arguments.https.any.html]
+  [cookieStore.set with positional name and value]
+    expected: FAIL
+
+  [cookieStore.set with name and value in options]
+    expected: FAIL
+
+  [cookieStore.set fails with empty name and empty value]
+    expected: FAIL
+
+  [cookieStore.set with empty name and an '=' in value]
+    expected: FAIL
+
+  [cookieStore.set with normal name and an '=' in value]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0000]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0001]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0002]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0003]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0004]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0005]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0006]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0007]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0008]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0010]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0011]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0012]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0013]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0014]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0015]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0016]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0017]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0018]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+0019]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+001A]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+001B]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+001C]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+001D]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+001E]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+001F]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+003B]
+    expected: FAIL
+
+  [cookieStore.set checks if name or value contain invalid character U+007F]
+    expected: FAIL
+
+  [cookieStore.set with expires set to a future Date]
+    expected: FAIL
+
+  [cookieStore.set with expires set to a past Date]
+    expected: FAIL
+
+  [cookieStore.set with expires set to a future timestamp]
+    expected: FAIL
+
+  [cookieStore.set with expires set to a past timestamp]
+    expected: FAIL
+
+  [cookieStore.set domain starts with "."]
+    expected: FAIL
+
+  [cookieStore.set with domain that is not equal current host]
+    expected: FAIL
+
+  [cookieStore.set with domain set to the current hostname]
+    expected: FAIL
+
+  [cookieStore.set with domain set to a subdomain of the current hostname]
+    expected: FAIL
+
+  [cookieStore.set with domain set to a non-domain-matching suffix of the current hostname]
+    expected: FAIL
+
+  [cookieStore.set default domain is null and differs from current hostname]
+    expected: FAIL
+
+  [cookieStore.set with path set to the current directory]
+    expected: FAIL
+
+  [cookieStore.set with path set to a subdirectory of the current directory]
+    expected: FAIL
+
+  [cookieStore.set default path is /]
+    expected: FAIL
+
+  [cookieStore.set does not add / to path that does not end with /]
+    expected: FAIL
+
+  [cookieStore.set can modify a cookie set by document.cookie if document is defined]
+    expected: FAIL
+
+  [cookieStore.set with path that does not start with /]
+    expected: FAIL
+
+  [cookieStore.set with get result]
+    expected: FAIL
+
+  [cookieStore.set checks if the path is too long]
+    expected: FAIL
+
+  [cookieStore.set checks if the domain is too long]
+    expected: FAIL
+
+  [cookieStore.set with a __Host- prefix should not have a domain]
+    expected: FAIL
+
+  [cookieStore.set with whitespace only name and value]
+    expected: FAIL
+
+  [cookieStore.set with whitespace at begining or end]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_set_domain_parsing.sub.https.html.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_set_domain_parsing.sub.https.html.ini
@@ -1,0 +1,6 @@
+[cookieStore_set_domain_parsing.sub.https.html]
+  [cookieStore.set with domain on a IDNA host]
+    expected: FAIL
+
+  [cookieStore.set with domain set to the current hostname but differently cased]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_set_domain_parsing.tentative.sub.https.html.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_set_domain_parsing.tentative.sub.https.html.ini
@@ -1,0 +1,3 @@
+[cookieStore_set_domain_parsing.tentative.sub.https.html]
+  [cookieStore.set with domain on an IP address host]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_set_limit.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_set_limit.https.any.js.ini
@@ -1,0 +1,15 @@
+[cookieStore_set_limit.https.any.serviceworker.html]
+  expected: ERROR
+
+[cookieStore_set_limit.https.any.html]
+  [Set max-size cookie with largest possible name and value (4096 bytes)]
+    expected: FAIL
+
+  [Set max-size value-less cookie]
+    expected: FAIL
+
+  [Set max-size cookie with largest possible value (4095 bytes)]
+    expected: FAIL
+
+  [Set max-size name-less cookie]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_special_names.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_special_names.https.any.js.ini
@@ -1,0 +1,115 @@
+[cookieStore_special_names.https.any.html]
+  [cookieStore.set with __Secure- name on secure origin]
+    expected: FAIL
+
+  [cookieStore.set of expired __Secure- cookie name on secure origin]
+    expected: FAIL
+
+  [cookieStore.delete with __Secure- name on secure origin]
+    expected: FAIL
+
+  [cookieStore.set with __secure- name on secure origin]
+    expected: FAIL
+
+  [cookieStore.set of expired __secure- cookie name on secure origin]
+    expected: FAIL
+
+  [cookieStore.delete with __secure- name on secure origin]
+    expected: FAIL
+
+  [cookieStore.set with __Host- name on secure origin]
+    expected: FAIL
+
+  [cookieStore.set of expired __Host- cookie name on secure origin]
+    expected: FAIL
+
+  [cookieStore.delete with __Host- name on secure origin]
+    expected: FAIL
+
+  [cookieStore.set with __host- name on secure origin]
+    expected: FAIL
+
+  [cookieStore.set of expired __host- cookie name on secure origin]
+    expected: FAIL
+
+  [cookieStore.delete with __host- name on secure origin]
+    expected: FAIL
+
+  [cookieStore.set with __Host- prefix and a domain option]
+    expected: FAIL
+
+  [cookieStore.set with __Host- prefix a path option]
+    expected: FAIL
+
+  [cookieStore.set with __host- prefix and a domain option]
+    expected: FAIL
+
+  [cookieStore.set with __host- prefix a path option]
+    expected: FAIL
+
+  [cookieStore.set with __HostHttp- prefix rejects]
+    expected: FAIL
+
+  [cookieStore.set with __hosthttp- prefix rejects]
+    expected: FAIL
+
+  [cookieStore.set with __Http- prefix rejects]
+    expected: FAIL
+
+  [cookieStore.set with __http- prefix rejects]
+    expected: FAIL
+
+  [cookieStore.set with   __Http- prefix rejects]
+    expected: FAIL
+
+  [cookieStore.set with \t__Http- prefix rejects]
+    expected: FAIL
+
+  [cookieStore.set with   __HostHttp- prefix rejects]
+    expected: FAIL
+
+  [cookieStore.set with \t__HostHttp- prefix rejects]
+    expected: FAIL
+
+  [cookieStore.set with malformed name.]
+    expected: FAIL
+
+  [cookieStore.set a nameless cookie cannot have __Host- prefix]
+    expected: FAIL
+
+  [cookieStore.set a nameless cookie cannot have __Secure- prefix]
+    expected: FAIL
+
+  [cookieStore.set a nameless cookie cannot have __Http- prefix]
+    expected: FAIL
+
+  [cookieStore.set a nameless cookie cannot have __HostHttp- prefix]
+    expected: FAIL
+
+  [cookieStore.set a nameless cookie cannot have  __Host- prefix]
+    expected: FAIL
+
+  [cookieStore.set a nameless cookie cannot have \t__Host- prefix]
+    expected: FAIL
+
+  [cookieStore.set a nameless cookie cannot have  __Secure- prefix]
+    expected: FAIL
+
+  [cookieStore.set a nameless cookie cannot have \t__Secure- prefix]
+    expected: FAIL
+
+  [cookieStore.set a nameless cookie cannot have  __Http- prefix]
+    expected: FAIL
+
+  [cookieStore.set a nameless cookie cannot have \t__Http- prefix]
+    expected: FAIL
+
+  [cookieStore.set a nameless cookie cannot have  __HostHttp- prefix]
+    expected: FAIL
+
+  [cookieStore.set a nameless cookie cannot have \t__HostHttp- prefix]
+    expected: FAIL
+
+
+[cookieStore_special_names.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/cookieStore_subscribe_arguments.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_subscribe_arguments.https.any.js.ini
@@ -1,0 +1,16 @@
+[cookieStore_subscribe_arguments.https.any.html]
+  [cookieStore.subscribe without url in option]
+    expected: FAIL
+
+  [cookieStore.subscribe with invalid url path in option]
+    expected: FAIL
+
+  [cookieStore.subscribe is idempotent]
+    expected: FAIL
+
+  [CookieStore.unsubscribe is idempotent]
+    expected: FAIL
+
+
+[cookieStore_subscribe_arguments.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/cookieStore_subscriptions_empty.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_subscriptions_empty.https.window.js.ini
@@ -1,0 +1,3 @@
+[cookieStore_subscriptions_empty.https.window.html]
+  [Newly registered and activated service worker has no subscriptions]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/encoding.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/encoding.https.any.js.ini
@@ -1,0 +1,10 @@
+[encoding.https.any.html]
+  [BOM not stripped from name]
+    expected: FAIL
+
+  [BOM not stripped from value]
+    expected: FAIL
+
+
+[encoding.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/httponly_cookies.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/httponly_cookies.https.window.js.ini
@@ -1,0 +1,13 @@
+[httponly_cookies.https.window.html]
+  expected: ERROR
+  [HttpOnly cookies are not observed]
+    expected: FAIL
+
+  [HttpOnly cookies can not be set by document.cookie]
+    expected: FAIL
+
+  [HttpOnly cookies can not be set by CookieStore]
+    expected: FAIL
+
+  [HttpOnly cookies are not deleted/overwritten]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/idlharness.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/idlharness.https.any.js.ini
@@ -1,0 +1,114 @@
+[idlharness.https.any.sharedworker.html]
+  expected: ERROR
+
+[idlharness.https.any.html]
+  [idl_test setup]
+    expected: FAIL
+
+  [CookieStore interface: existence and properties of interface object]
+    expected: FAIL
+
+  [CookieStore interface object length]
+    expected: FAIL
+
+  [CookieStore interface object name]
+    expected: FAIL
+
+  [CookieStore interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [CookieStore interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [CookieStore interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [CookieStore interface: operation get(USVString)]
+    expected: FAIL
+
+  [CookieStore interface: operation get(optional CookieStoreGetOptions)]
+    expected: FAIL
+
+  [CookieStore interface: operation getAll(USVString)]
+    expected: FAIL
+
+  [CookieStore interface: operation getAll(optional CookieStoreGetOptions)]
+    expected: FAIL
+
+  [CookieStore interface: operation set(USVString, USVString)]
+    expected: FAIL
+
+  [CookieStore interface: operation set(CookieInit)]
+    expected: FAIL
+
+  [CookieStore interface: operation delete(USVString)]
+    expected: FAIL
+
+  [CookieStore interface: operation delete(CookieStoreDeleteOptions)]
+    expected: FAIL
+
+  [CookieStore interface: attribute onchange]
+    expected: FAIL
+
+  [CookieStoreManager interface: existence and properties of interface object]
+    expected: FAIL
+
+  [CookieStoreManager interface object length]
+    expected: FAIL
+
+  [CookieStoreManager interface object name]
+    expected: FAIL
+
+  [CookieStoreManager interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [CookieStoreManager interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [CookieStoreManager interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [CookieStoreManager interface: operation subscribe(sequence<CookieStoreGetOptions>)]
+    expected: FAIL
+
+  [CookieStoreManager interface: operation getSubscriptions()]
+    expected: FAIL
+
+  [CookieStoreManager interface: operation unsubscribe(sequence<CookieStoreGetOptions>)]
+    expected: FAIL
+
+  [CookieChangeEvent interface: existence and properties of interface object]
+    expected: FAIL
+
+  [CookieChangeEvent interface object length]
+    expected: FAIL
+
+  [CookieChangeEvent interface object name]
+    expected: FAIL
+
+  [CookieChangeEvent interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [CookieChangeEvent interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [CookieChangeEvent interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [CookieChangeEvent interface: attribute changed]
+    expected: FAIL
+
+  [CookieChangeEvent interface: attribute deleted]
+    expected: FAIL
+
+  [ServiceWorkerRegistration interface: attribute cookies]
+    expected: FAIL
+
+  [Window interface: attribute cookieStore]
+    expected: FAIL
+
+
+[idlharness.https.any.serviceworker.html]
+  expected: ERROR
+
+[idlharness.https.any.worker.html]

--- a/tests/wpt/meta/cookiestore/serviceworker_cookieStore_cross_origin.https.sub.html.ini
+++ b/tests/wpt/meta/cookiestore/serviceworker_cookieStore_cross_origin.https.sub.html.ini
@@ -1,0 +1,3 @@
+[serviceworker_cookieStore_cross_origin.https.sub.html]
+  [cookieStore.get() in ServiceWorker reads cookie set in cross-origin frame]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/serviceworker_cookieStore_subscriptions_reset.https.html.ini
+++ b/tests/wpt/meta/cookiestore/serviceworker_cookieStore_subscriptions_reset.https.html.ini
@@ -1,0 +1,6 @@
+[serviceworker_cookieStore_subscriptions_reset.https.html]
+  [cookiechange subscriptions reset across service worker unregistrations]
+    expected: FAIL
+
+  [cookiechange subscriptions persist across service worker updates]
+    expected: FAIL

--- a/tests/wpt/meta/cookiestore/serviceworker_cookiechange_eventhandler_already_expired.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/serviceworker_cookiechange_eventhandler_already_expired.https.any.js.ini
@@ -1,0 +1,2 @@
+[serviceworker_cookiechange_eventhandler_already_expired.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/serviceworker_cookiechange_eventhandler_mismatched_subscription.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/serviceworker_cookiechange_eventhandler_mismatched_subscription.https.any.js.ini
@@ -1,0 +1,2 @@
+[serviceworker_cookiechange_eventhandler_mismatched_subscription.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/serviceworker_cookiechange_eventhandler_multiple_subscriptions.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/serviceworker_cookiechange_eventhandler_multiple_subscriptions.https.any.js.ini
@@ -1,0 +1,2 @@
+[serviceworker_cookiechange_eventhandler_multiple_subscriptions.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/serviceworker_cookiechange_eventhandler_no_change.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/serviceworker_cookiechange_eventhandler_no_change.https.any.js.ini
@@ -1,0 +1,2 @@
+[serviceworker_cookiechange_eventhandler_no_change.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/serviceworker_cookiechange_eventhandler_overlapping_subscriptions.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/serviceworker_cookiechange_eventhandler_overlapping_subscriptions.https.any.js.ini
@@ -1,0 +1,2 @@
+[serviceworker_cookiechange_eventhandler_overlapping_subscriptions.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/serviceworker_cookiechange_eventhandler_single_subscription.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/serviceworker_cookiechange_eventhandler_single_subscription.https.any.js.ini
@@ -1,0 +1,2 @@
+[serviceworker_cookiechange_eventhandler_single_subscription.https.any.serviceworker.html]
+  expected: ERROR

--- a/tests/wpt/meta/cookiestore/serviceworker_oncookiechange_eventhandler_single_subscription.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/serviceworker_oncookiechange_eventhandler_single_subscription.https.any.js.ini
@@ -1,0 +1,2 @@
+[serviceworker_oncookiechange_eventhandler_single_subscription.https.any.serviceworker.html]
+  expected: ERROR


### PR DESCRIPTION
CookieStore spec graduated from WICG and the test suite in WPT got renamed to `cookiestore` from `cookie-store`. This readds the baseline CookieStore expectations in preparation for landing an implementation.

Testing: Reenables tests and readds expectations that were removed.

