### PR TITLE
fonts: Use skrifa to get raw font table data on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,6 +2648,7 @@ dependencies = [
  "servo_config",
  "servo_malloc_size_of",
  "servo_url",
+ "skrifa",
  "smallvec",
  "stylo",
  "stylo_atoms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
 servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
+skrifa = "0.31.3"
 smallbitvec = "2.6.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 string_cache = "0.8"

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -45,6 +45,7 @@ serde = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { path = "../config" }
 servo_url = { path = "../url" }
+skrifa = { workspace = true }
 smallvec = { workspace = true }
 stylo = { workspace = true }
 stylo_atoms = { workspace = true }

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -11,16 +11,17 @@ use app_units::Au;
 use euclid::default::{Point2D, Rect, Size2D};
 use freetype_sys::{
     FT_Byte, FT_Done_Face, FT_Error, FT_F26Dot6, FT_FACE_FLAG_COLOR, FT_FACE_FLAG_FIXED_SIZES,
-    FT_FACE_FLAG_SCALABLE, FT_Face, FT_Get_Char_Index, FT_Get_Kerning, FT_GlyphSlot, FT_Int32,
-    FT_KERNING_DEFAULT, FT_LOAD_COLOR, FT_LOAD_DEFAULT, FT_LOAD_NO_HINTING, FT_Load_Glyph, FT_Long,
-    FT_New_Face, FT_New_Memory_Face, FT_Pos, FT_Select_Size, FT_Set_Char_Size, FT_Size_Metrics,
-    FT_SizeRec, FT_UInt, FT_ULong, FT_Vector,
+    FT_FACE_FLAG_SCALABLE, FT_Face, FT_Get_Kerning, FT_GlyphSlot, FT_Int32, FT_KERNING_DEFAULT,
+    FT_LOAD_COLOR, FT_LOAD_DEFAULT, FT_LOAD_NO_HINTING, FT_Load_Glyph, FT_Long, FT_New_Face,
+    FT_New_Memory_Face, FT_Pos, FT_Select_Size, FT_Set_Char_Size, FT_Size_Metrics, FT_SizeRec,
+    FT_UInt, FT_ULong, FT_Vector,
 };
 use log::debug;
 use memmap2::Mmap;
 use parking_lot::ReentrantMutex;
 use read_fonts::tables::os2::SelectionFlags;
 use read_fonts::{FontRef, ReadError, TableProvider};
+use skrifa::MetadataProvider as _;
 use style::Zero;
 use style::computed_values::font_stretch::T as FontStretch;
 use style::computed_values::font_weight::T as FontWeight;
@@ -202,21 +203,15 @@ impl PlatformFontMethods for PlatformFont {
     }
 
     fn glyph_index(&self, codepoint: char) -> Option<GlyphId> {
-        let face = self.face.lock();
-        assert!(!face.is_null());
-
-        unsafe {
-            let idx = FT_Get_Char_Index(*face, codepoint as FT_ULong);
-            if idx != 0 as FT_UInt {
-                Some(idx as GlyphId)
-            } else {
-                debug!(
-                    "Invalid codepoint: U+{:04X} ('{}')",
-                    codepoint as u32, codepoint
-                );
-                None
-            }
+        let font_ref = self.table_provider_data.font_ref().ok()?;
+        let glyph_id = font_ref.charmap().map(codepoint);
+        if glyph_id.is_none() {
+            debug!(
+                "Invalid codepoint: U+{:04X} ('{}')",
+                codepoint as u32, codepoint
+            );
         }
+        glyph_id.map(|id| id.to_u32())
     }
 
     fn glyph_h_kerning(&self, first_glyph: GlyphId, second_glyph: GlyphId) -> FractionalPixel {

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -10,18 +10,18 @@ use std::{mem, ptr};
 use app_units::Au;
 use euclid::default::{Point2D, Rect, Size2D};
 use freetype_sys::{
-    FT_Byte, FT_Done_Face, FT_Error, FT_F26Dot6, FT_FACE_FLAG_COLOR, FT_FACE_FLAG_FIXED_SIZES,
-    FT_FACE_FLAG_SCALABLE, FT_Face, FT_Get_Kerning, FT_GlyphSlot, FT_Int32, FT_KERNING_DEFAULT,
-    FT_LOAD_COLOR, FT_LOAD_DEFAULT, FT_LOAD_NO_HINTING, FT_Load_Glyph, FT_Long, FT_New_Face,
-    FT_New_Memory_Face, FT_Pos, FT_Select_Size, FT_Set_Char_Size, FT_Size_Metrics, FT_SizeRec,
-    FT_UInt, FT_ULong, FT_Vector,
+    FT_Done_Face, FT_F26Dot6, FT_FACE_FLAG_COLOR, FT_FACE_FLAG_FIXED_SIZES, FT_FACE_FLAG_SCALABLE,
+    FT_Face, FT_Get_Kerning, FT_GlyphSlot, FT_Int32, FT_KERNING_DEFAULT, FT_LOAD_COLOR,
+    FT_LOAD_DEFAULT, FT_LOAD_NO_HINTING, FT_Load_Glyph, FT_Long, FT_New_Face, FT_New_Memory_Face,
+    FT_Pos, FT_Select_Size, FT_Set_Char_Size, FT_Size_Metrics, FT_SizeRec, FT_UInt, FT_Vector,
 };
 use log::debug;
 use memmap2::Mmap;
 use parking_lot::ReentrantMutex;
-use read_fonts::font_types::tag::Tag;
 use read_fonts::tables::os2::SelectionFlags;
+use read_fonts::types::Tag;
 use read_fonts::{FontRef, ReadError, TableProvider};
+use servo_arc::Arc;
 use skrifa::MetadataProvider as _;
 use style::Zero;
 use style::computed_values::font_stretch::T as FontStretch;
@@ -51,12 +51,17 @@ fn fixed_26_dot_6_to_float(fixed: FT_F26Dot6) -> f64 {
 
 #[derive(Debug)]
 pub struct FontTable {
-    buffer: Vec<u8>,
+    data: FreeTypeFaceTableProviderData,
+    tag: Tag,
 }
 
 impl FontTableMethods for FontTable {
     fn buffer(&self) -> &[u8] {
-        &self.buffer
+        let font_ref = self.data.font_ref().expect("Font checked before creating");
+        let table_data = font_ref
+            .table_data(self.tag)
+            .expect("Table existence checked before creating");
+        table_data.as_bytes()
     }
 }
 
@@ -166,7 +171,7 @@ impl PlatformFontMethods for PlatformFont {
             requested_face_size,
             actual_face_size,
             table_provider_data: FreeTypeFaceTableProviderData::Local(
-                memory_mapped_font_data,
+                Arc::new(memory_mapped_font_data),
                 font_identifier.index(),
             ),
         })
@@ -391,9 +396,11 @@ impl PlatformFontMethods for PlatformFont {
     fn table_for_tag(&self, tag: FontTableTag) -> Option<FontTable> {
         let tag = Tag::from_u32(tag);
         let font_ref = self.table_provider_data.font_ref().ok()?;
-        let table_data = font_ref.table_data(tag)?;
-        let buffer = table_data.as_bytes().to_vec();
-        Some(FontTable { buffer })
+        let _table_data = font_ref.table_data(tag)?;
+        Some(FontTable {
+            data: self.table_provider_data.clone(),
+            tag,
+        })
     }
 
     fn typographic_bounds(&self, glyph_id: GlyphId) -> Rect<f32> {
@@ -514,19 +521,10 @@ impl FreeTypeFaceHelpers for FT_Face {
     }
 }
 
-unsafe extern "C" {
-    fn FT_Load_Sfnt_Table(
-        face: FT_Face,
-        tag: FT_ULong,
-        offset: FT_Long,
-        buffer: *mut FT_Byte,
-        length: *mut FT_ULong,
-    ) -> FT_Error;
-}
-
+#[derive(Clone)]
 enum FreeTypeFaceTableProviderData {
     Web(FontData),
-    Local(Mmap, u32),
+    Local(Arc<Mmap>, u32),
 }
 
 impl FreeTypeFaceTableProviderData {


### PR DESCRIPTION
Use skrifa instead of freetype for extracting raw table data. Allows us to replace unsafe Freetype code with safe Skrifa code. Also allows us to avoid copying the table data. Instead we return Arc'd data.
