### PR TITLE
Rename `InputEvent::MouseLeave` to `InputEvent::MouseLeftViewport`

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -355,7 +355,7 @@ impl WebViewRenderer {
             InputEvent::MouseMove(_) => {
                 self.global.borrow_mut().last_mouse_move_position = event_point;
             },
-            InputEvent::MouseLeave(_) => {
+            InputEvent::CursorLeft(_) => {
                 self.global.borrow_mut().last_mouse_move_position = None;
             },
             InputEvent::MouseButton(_) | InputEvent::Wheel(_) => {},

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -355,7 +355,7 @@ impl WebViewRenderer {
             InputEvent::MouseMove(_) => {
                 self.global.borrow_mut().last_mouse_move_position = event_point;
             },
-            InputEvent::CursorLeft(_) => {
+            InputEvent::MouseLeftViewport(_) => {
                 self.global.borrow_mut().last_mouse_move_position = None;
             },
             InputEvent::MouseButton(_) | InputEvent::Wheel(_) => {},

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 
 use base::id::{BrowsingContextId, PipelineId};
-use embedder_traits::{InputEvent, MouseLeaveEvent, Theme};
+use embedder_traits::{CursorLeftEvent, InputEvent, Theme};
 use euclid::Point2D;
 use log::warn;
 use script_traits::{ConstellationInputEvent, ScriptThreadMessage};
@@ -72,7 +72,7 @@ impl ConstellationWebView {
 
         // If there's no hit test, send the event to either the hovered or focused browsing context,
         // depending on the event type.
-        let browsing_context_id = if matches!(event.event, InputEvent::MouseLeave(_)) {
+        let browsing_context_id = if matches!(event.event, InputEvent::CursorLeft(_)) {
             self.hovered_browsing_context_id
                 .unwrap_or(self.focused_browsing_context_id)
         } else {
@@ -117,7 +117,7 @@ impl ConstellationWebView {
             };
 
             let mut synthetic_mouse_leave_event = event.clone();
-            synthetic_mouse_leave_event.event = InputEvent::MouseLeave(MouseLeaveEvent {
+            synthetic_mouse_leave_event.event = InputEvent::CursorLeft(CursorLeftEvent {
                 focus_moving_to_another_iframe: true,
             });
 
@@ -129,7 +129,7 @@ impl ConstellationWebView {
                 ));
         };
 
-        if let InputEvent::MouseLeave(_) = &event.event {
+        if let InputEvent::CursorLeft(_) = &event.event {
             update_hovered_browsing_context(None);
             return;
         }

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -72,7 +72,7 @@ impl ConstellationWebView {
 
         // If there's no hit test, send the event to either the hovered or focused browsing context,
         // depending on the event type.
-        let browsing_context_id = if matches!(event.event, InputEvent::CursorLeft(_)) {
+        let browsing_context_id = if matches!(event.event, InputEvent::MouseLeftViewport(_)) {
             self.hovered_browsing_context_id
                 .unwrap_or(self.focused_browsing_context_id)
         } else {
@@ -117,7 +117,7 @@ impl ConstellationWebView {
             };
 
             let mut synthetic_mouse_leave_event = event.clone();
-            synthetic_mouse_leave_event.event = InputEvent::CursorLeft(CursorLeftEvent {
+            synthetic_mouse_leave_event.event = InputEvent::MouseLeftViewport(CursorLeftEvent {
                 focus_moving_to_another_iframe: true,
             });
 
@@ -129,7 +129,7 @@ impl ConstellationWebView {
                 ));
         };
 
-        if let InputEvent::CursorLeft(_) = &event.event {
+        if let InputEvent::MouseLeftViewport(_) = &event.event {
             update_hovered_browsing_context(None);
             return;
         }

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 
 use base::id::{BrowsingContextId, PipelineId};
-use embedder_traits::{CursorLeftEvent, InputEvent, Theme};
+use embedder_traits::{InputEvent, MouseLeftViewportEvent, Theme};
 use euclid::Point2D;
 use log::warn;
 use script_traits::{ConstellationInputEvent, ScriptThreadMessage};
@@ -117,9 +117,10 @@ impl ConstellationWebView {
             };
 
             let mut synthetic_mouse_leave_event = event.clone();
-            synthetic_mouse_leave_event.event = InputEvent::MouseLeftViewport(CursorLeftEvent {
-                focus_moving_to_another_iframe: true,
-            });
+            synthetic_mouse_leave_event.event =
+                InputEvent::MouseLeftViewport(MouseLeftViewportEvent {
+                    focus_moving_to_another_iframe: true,
+                });
 
             let _ = pipeline
                 .event_loop

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -96,7 +96,7 @@ mod from_compositor {
                 InputEvent::Keyboard(..) => target_variant!("Keyboard"),
                 InputEvent::MouseButton(..) => target_variant!("MouseButton"),
                 InputEvent::MouseMove(..) => target_variant!("MouseMove"),
-                InputEvent::CursorLeft(..) => target_variant!("CursorLeft"),
+                InputEvent::MouseLeftViewport(..) => target_variant!("MouseLeftViewport"),
                 InputEvent::Touch(..) => target_variant!("Touch"),
                 InputEvent::Wheel(..) => target_variant!("Wheel"),
                 InputEvent::Scroll(..) => target_variant!("Scroll"),

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -96,7 +96,7 @@ mod from_compositor {
                 InputEvent::Keyboard(..) => target_variant!("Keyboard"),
                 InputEvent::MouseButton(..) => target_variant!("MouseButton"),
                 InputEvent::MouseMove(..) => target_variant!("MouseMove"),
-                InputEvent::CursorLeft(..) => target_variant!("MouseLeave"),
+                InputEvent::CursorLeft(..) => target_variant!("CursorLeft"),
                 InputEvent::Touch(..) => target_variant!("Touch"),
                 InputEvent::Wheel(..) => target_variant!("Wheel"),
                 InputEvent::Scroll(..) => target_variant!("Scroll"),

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -96,7 +96,7 @@ mod from_compositor {
                 InputEvent::Keyboard(..) => target_variant!("Keyboard"),
                 InputEvent::MouseButton(..) => target_variant!("MouseButton"),
                 InputEvent::MouseMove(..) => target_variant!("MouseMove"),
-                InputEvent::MouseLeave(..) => target_variant!("MouseLeave"),
+                InputEvent::CursorLeft(..) => target_variant!("MouseLeave"),
                 InputEvent::Touch(..) => target_variant!("Touch"),
                 InputEvent::Wheel(..) => target_variant!("Wheel"),
                 InputEvent::Scroll(..) => target_variant!("Scroll"),

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -160,10 +160,10 @@ impl DocumentEventHandler {
 
             match event.event.clone() {
                 InputEvent::MouseButton(mouse_button_event) => {
-                    self.handle_mouse_button_event(mouse_button_event, &event, can_gc);
+                    self.handle_native_mouse_button_event(mouse_button_event, &event, can_gc);
                 },
                 InputEvent::MouseMove(_) => {
-                    self.handle_mouse_move_event(&event, can_gc);
+                    self.handle_native_mouse_move_event(&event, can_gc);
                 },
                 InputEvent::MouseLeave(mouse_leave_event) => {
                     self.handle_mouse_leave_event(&event, &mouse_leave_event, can_gc);
@@ -328,7 +328,8 @@ impl DocumentEventHandler {
         }
     }
 
-    fn handle_mouse_move_event(&self, input_event: &ConstellationInputEvent, can_gc: CanGc) {
+    /// <https://w3c.github.io/uievents/#handle-native-mouse-move>
+    fn handle_native_mouse_move_event(&self, input_event: &ConstellationInputEvent, can_gc: CanGc) {
         // Ignore all incoming events without a hit test.
         let Some(hit_test_result) = self.window.hit_test_from_input_event(input_event) else {
             return;
@@ -349,8 +350,7 @@ impl DocumentEventHandler {
         let target_has_changed = self
             .current_hover_target
             .get()
-            .as_ref()
-            .is_none_or(|old_target| old_target != &new_target);
+            .is_none_or(|old_target| old_target != new_target);
 
         // Here we know the target has changed, so we must update the state,
         // dispatch mouseout to the previous one, mouseover to the new one.
@@ -503,7 +503,8 @@ impl DocumentEventHandler {
     }
 
     /// <https://w3c.github.io/uievents/#mouseevent-algorithms>
-    fn handle_mouse_button_event(
+    /// Handles native mouse down, mouse up, mouse click.
+    fn handle_native_mouse_button_event(
         &self,
         event: MouseButtonEvent,
         input_event: &ConstellationInputEvent,

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -166,7 +166,7 @@ impl DocumentEventHandler {
                     self.handle_native_mouse_move_event(&event, can_gc);
                 },
                 InputEvent::MouseLeftViewport(mouse_leave_event) => {
-                    self.handle_cursor_left_event(&event, &mouse_leave_event, can_gc);
+                    self.handle_mouse_left_viewport_event(&event, &mouse_leave_event, can_gc);
                 },
                 InputEvent::Touch(touch_event) => {
                     self.handle_touch_event(touch_event, &event, can_gc);
@@ -221,7 +221,7 @@ impl DocumentEventHandler {
             .send_to_embedder(EmbedderMsg::SetCursor(self.window.webview_id(), cursor));
     }
 
-    fn handle_cursor_left_event(
+    fn handle_mouse_left_viewport_event(
         &self,
         input_event: &ConstellationInputEvent,
         mouse_leave_event: &MouseLeftViewportEvent,

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -11,11 +11,11 @@ use std::time::{Duration, Instant};
 
 use constellation_traits::ScriptToConstellationMessage;
 use embedder_traits::{
-    Cursor, EditingActionEvent, EmbedderMsg, GamepadEvent as EmbedderGamepadEvent,
+    Cursor, CursorLeftEvent, EditingActionEvent, EmbedderMsg, GamepadEvent as EmbedderGamepadEvent,
     GamepadSupportedHapticEffects, GamepadUpdateType, ImeEvent, InputEvent,
     KeyboardEvent as EmbedderKeyboardEvent, MouseButton, MouseButtonAction, MouseButtonEvent,
-    MouseLeaveEvent, ScrollEvent, TouchEvent as EmbedderTouchEvent, TouchEventType, TouchId,
-    UntrustedNodeAddress, WheelEvent as EmbedderWheelEvent,
+    ScrollEvent, TouchEvent as EmbedderTouchEvent, TouchEventType, TouchId, UntrustedNodeAddress,
+    WheelEvent as EmbedderWheelEvent,
 };
 use euclid::Point2D;
 use ipc_channel::ipc;
@@ -165,8 +165,8 @@ impl DocumentEventHandler {
                 InputEvent::MouseMove(_) => {
                     self.handle_native_mouse_move_event(&event, can_gc);
                 },
-                InputEvent::MouseLeave(mouse_leave_event) => {
-                    self.handle_mouse_leave_event(&event, &mouse_leave_event, can_gc);
+                InputEvent::CursorLeft(mouse_leave_event) => {
+                    self.handle_cursor_left_event(&event, &mouse_leave_event, can_gc);
                 },
                 InputEvent::Touch(touch_event) => {
                     self.handle_touch_event(touch_event, &event, can_gc);
@@ -221,10 +221,10 @@ impl DocumentEventHandler {
             .send_to_embedder(EmbedderMsg::SetCursor(self.window.webview_id(), cursor));
     }
 
-    fn handle_mouse_leave_event(
+    fn handle_cursor_left_event(
         &self,
         input_event: &ConstellationInputEvent,
-        mouse_leave_event: &MouseLeaveEvent,
+        mouse_leave_event: &CursorLeftEvent,
         can_gc: CanGc,
     ) {
         if let Some(current_hover_target) = self.current_hover_target.get() {

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -11,11 +11,11 @@ use std::time::{Duration, Instant};
 
 use constellation_traits::ScriptToConstellationMessage;
 use embedder_traits::{
-    Cursor, CursorLeftEvent, EditingActionEvent, EmbedderMsg, GamepadEvent as EmbedderGamepadEvent,
+    Cursor, EditingActionEvent, EmbedderMsg, GamepadEvent as EmbedderGamepadEvent,
     GamepadSupportedHapticEffects, GamepadUpdateType, ImeEvent, InputEvent,
     KeyboardEvent as EmbedderKeyboardEvent, MouseButton, MouseButtonAction, MouseButtonEvent,
-    ScrollEvent, TouchEvent as EmbedderTouchEvent, TouchEventType, TouchId, UntrustedNodeAddress,
-    WheelEvent as EmbedderWheelEvent,
+    MouseLeftViewportEvent, ScrollEvent, TouchEvent as EmbedderTouchEvent, TouchEventType, TouchId,
+    UntrustedNodeAddress, WheelEvent as EmbedderWheelEvent,
 };
 use euclid::Point2D;
 use ipc_channel::ipc;
@@ -224,7 +224,7 @@ impl DocumentEventHandler {
     fn handle_cursor_left_event(
         &self,
         input_event: &ConstellationInputEvent,
-        mouse_leave_event: &CursorLeftEvent,
+        mouse_leave_event: &MouseLeftViewportEvent,
         can_gc: CanGc,
     ) {
         if let Some(current_hover_target) = self.current_hover_target.get() {

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -165,7 +165,7 @@ impl DocumentEventHandler {
                 InputEvent::MouseMove(_) => {
                     self.handle_native_mouse_move_event(&event, can_gc);
                 },
-                InputEvent::CursorLeft(mouse_leave_event) => {
+                InputEvent::MouseLeftViewport(mouse_leave_event) => {
                     self.handle_cursor_left_event(&event, &mouse_leave_event, can_gc);
                 },
                 InputEvent::Touch(touch_event) => {

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -20,7 +20,7 @@ pub enum InputEvent {
     Keyboard(KeyboardEvent),
     MouseButton(MouseButtonEvent),
     MouseMove(MouseMoveEvent),
-    CursorLeft(CursorLeftEvent),
+    MouseLeftViewport(CursorLeftEvent),
     Touch(TouchEvent),
     Wheel(WheelEvent),
     Scroll(ScrollEvent),
@@ -43,7 +43,7 @@ impl InputEvent {
             InputEvent::Keyboard(..) => None,
             InputEvent::MouseButton(event) => Some(event.point),
             InputEvent::MouseMove(event) => Some(event.point),
-            InputEvent::CursorLeft(_) => None,
+            InputEvent::MouseLeftViewport(_) => None,
             InputEvent::Touch(event) => Some(event.point),
             InputEvent::Wheel(event) => Some(event.point),
             InputEvent::Scroll(..) => None,
@@ -58,7 +58,7 @@ impl InputEvent {
             InputEvent::Keyboard(event) => event.webdriver_id,
             InputEvent::MouseButton(event) => event.webdriver_id,
             InputEvent::MouseMove(event) => event.webdriver_id,
-            InputEvent::CursorLeft(..) => None,
+            InputEvent::MouseLeftViewport(..) => None,
             InputEvent::Touch(..) => None,
             InputEvent::Wheel(event) => event.webdriver_id,
             InputEvent::Scroll(..) => None,
@@ -79,7 +79,7 @@ impl InputEvent {
             InputEvent::MouseMove(ref mut event) => {
                 event.webdriver_id = webdriver_id;
             },
-            InputEvent::CursorLeft(..) => {},
+            InputEvent::MouseLeftViewport(..) => {},
             InputEvent::Touch(..) => {},
             InputEvent::Wheel(ref mut event) => {
                 event.webdriver_id = webdriver_id;

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -20,7 +20,7 @@ pub enum InputEvent {
     Keyboard(KeyboardEvent),
     MouseButton(MouseButtonEvent),
     MouseMove(MouseMoveEvent),
-    MouseLeftViewport(CursorLeftEvent),
+    MouseLeftViewport(MouseLeftViewportEvent),
     Touch(TouchEvent),
     Wheel(WheelEvent),
     Scroll(ScrollEvent),
@@ -219,7 +219,7 @@ impl MouseMoveEvent {
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
-pub struct CursorLeftEvent {
+pub struct MouseLeftViewportEvent {
     pub focus_moving_to_another_iframe: bool,
 }
 

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -20,7 +20,7 @@ pub enum InputEvent {
     Keyboard(KeyboardEvent),
     MouseButton(MouseButtonEvent),
     MouseMove(MouseMoveEvent),
-    MouseLeave(MouseLeaveEvent),
+    CursorLeft(CursorLeftEvent),
     Touch(TouchEvent),
     Wheel(WheelEvent),
     Scroll(ScrollEvent),
@@ -43,7 +43,7 @@ impl InputEvent {
             InputEvent::Keyboard(..) => None,
             InputEvent::MouseButton(event) => Some(event.point),
             InputEvent::MouseMove(event) => Some(event.point),
-            InputEvent::MouseLeave(_) => None,
+            InputEvent::CursorLeft(_) => None,
             InputEvent::Touch(event) => Some(event.point),
             InputEvent::Wheel(event) => Some(event.point),
             InputEvent::Scroll(..) => None,
@@ -58,7 +58,7 @@ impl InputEvent {
             InputEvent::Keyboard(event) => event.webdriver_id,
             InputEvent::MouseButton(event) => event.webdriver_id,
             InputEvent::MouseMove(event) => event.webdriver_id,
-            InputEvent::MouseLeave(..) => None,
+            InputEvent::CursorLeft(..) => None,
             InputEvent::Touch(..) => None,
             InputEvent::Wheel(event) => event.webdriver_id,
             InputEvent::Scroll(..) => None,
@@ -79,7 +79,7 @@ impl InputEvent {
             InputEvent::MouseMove(ref mut event) => {
                 event.webdriver_id = webdriver_id;
             },
-            InputEvent::MouseLeave(..) => {},
+            InputEvent::CursorLeft(..) => {},
             InputEvent::Touch(..) => {},
             InputEvent::Wheel(ref mut event) => {
                 event.webdriver_id = webdriver_id;
@@ -219,7 +219,7 @@ impl MouseMoveEvent {
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
-pub struct MouseLeaveEvent {
+pub struct CursorLeftEvent {
     pub focus_moving_to_another_iframe: bool,
 }
 

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -624,7 +624,7 @@ impl WindowPortsMethods for Window {
                 if webview.rect().contains(point) {
                     webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point)));
                 } else if webview.rect().contains(previous_point) {
-                    webview.notify_input_event(InputEvent::CursorLeft(CursorLeftEvent::default()));
+                    webview.notify_input_event(InputEvent::MouseLeftViewport(CursorLeftEvent::default()));
                 }
 
                 self.webview_relative_mouse_point.set(point);
@@ -634,7 +634,7 @@ impl WindowPortsMethods for Window {
                     .rect()
                     .contains(self.webview_relative_mouse_point.get())
                 {
-                    webview.notify_input_event(InputEvent::CursorLeft(CursorLeftEvent::default()));
+                    webview.notify_input_event(InputEvent::MouseLeftViewport(CursorLeftEvent::default()));
                 }
             },
             WindowEvent::MouseWheel { delta, .. } => {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -24,11 +24,11 @@ use servo::servo_geometry::{
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel};
 use servo::{
-    Cursor, CursorLeftEvent, ImeEvent, InputEvent, Key, KeyState, KeyboardEvent, Modifiers,
-    MouseButton as ServoMouseButton, MouseButtonAction, MouseButtonEvent, MouseMoveEvent, NamedKey,
-    OffscreenRenderingContext, RenderingContext, ScreenGeometry, Theme, TouchEvent, TouchEventType,
-    TouchId, WebRenderDebugOption, WebView, WheelDelta, WheelEvent, WheelMode,
-    WindowRenderingContext,
+    Cursor, ImeEvent, InputEvent, Key, KeyState, KeyboardEvent, Modifiers,
+    MouseButton as ServoMouseButton, MouseButtonAction, MouseButtonEvent, MouseLeftViewportEvent,
+    MouseMoveEvent, NamedKey, OffscreenRenderingContext, RenderingContext, ScreenGeometry, Theme,
+    TouchEvent, TouchEventType, TouchId, WebRenderDebugOption, WebView, WheelDelta, WheelEvent,
+    WheelMode, WindowRenderingContext,
 };
 use surfman::{Context, Device};
 use url::Url;
@@ -624,7 +624,9 @@ impl WindowPortsMethods for Window {
                 if webview.rect().contains(point) {
                     webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point)));
                 } else if webview.rect().contains(previous_point) {
-                    webview.notify_input_event(InputEvent::MouseLeftViewport(CursorLeftEvent::default()));
+                    webview.notify_input_event(InputEvent::MouseLeftViewport(
+                        MouseLeftViewportEvent::default(),
+                    ));
                 }
 
                 self.webview_relative_mouse_point.set(point);
@@ -634,7 +636,9 @@ impl WindowPortsMethods for Window {
                     .rect()
                     .contains(self.webview_relative_mouse_point.get())
                 {
-                    webview.notify_input_event(InputEvent::MouseLeftViewport(CursorLeftEvent::default()));
+                    webview.notify_input_event(InputEvent::MouseLeftViewport(
+                        MouseLeftViewportEvent::default(),
+                    ));
                 }
             },
             WindowEvent::MouseWheel { delta, .. } => {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -24,11 +24,11 @@ use servo::servo_geometry::{
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel};
 use servo::{
-    Cursor, ImeEvent, InputEvent, Key, KeyState, KeyboardEvent, Modifiers,
-    MouseButton as ServoMouseButton, MouseButtonAction, MouseButtonEvent, MouseLeaveEvent,
-    MouseMoveEvent, NamedKey, OffscreenRenderingContext, RenderingContext, ScreenGeometry, Theme,
-    TouchEvent, TouchEventType, TouchId, WebRenderDebugOption, WebView, WheelDelta, WheelEvent,
-    WheelMode, WindowRenderingContext,
+    Cursor, CursorLeftEvent, ImeEvent, InputEvent, Key, KeyState, KeyboardEvent, Modifiers,
+    MouseButton as ServoMouseButton, MouseButtonAction, MouseButtonEvent, MouseMoveEvent, NamedKey,
+    OffscreenRenderingContext, RenderingContext, ScreenGeometry, Theme, TouchEvent, TouchEventType,
+    TouchId, WebRenderDebugOption, WebView, WheelDelta, WheelEvent, WheelMode,
+    WindowRenderingContext,
 };
 use surfman::{Context, Device};
 use url::Url;
@@ -624,7 +624,7 @@ impl WindowPortsMethods for Window {
                 if webview.rect().contains(point) {
                     webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point)));
                 } else if webview.rect().contains(previous_point) {
-                    webview.notify_input_event(InputEvent::MouseLeave(MouseLeaveEvent::default()));
+                    webview.notify_input_event(InputEvent::CursorLeft(CursorLeftEvent::default()));
                 }
 
                 self.webview_relative_mouse_point.set(point);
@@ -634,7 +634,7 @@ impl WindowPortsMethods for Window {
                     .rect()
                     .contains(self.webview_relative_mouse_point.get())
                 {
-                    webview.notify_input_event(InputEvent::MouseLeave(MouseLeaveEvent::default()));
+                    webview.notify_input_event(InputEvent::CursorLeft(CursorLeftEvent::default()));
                 }
             },
             WindowEvent::MouseWheel { delta, .. } => {


### PR DESCRIPTION
1. `InputEvent::MouseLeave` indicates that mouse has left the viewport (fired by embedder) or iframe (synthesized in Constellation https://github.com/servo/servo/blob/f24f225db8b234c0545c57e80356af84e42bcb4b/components/constellation/constellation_webview.rs#L119-L122). Its handler in script is named as `handle_mouse_leave_event`, which is very misleading as we have DOM event [mouseleave](https://w3c.github.io/uievents/#event-type-mouseleave). I rename it to `MouseLeftViewport` to be consistent with `WindowEvent::CursorLeft`: https://github.com/servo/servo/blob/f24f225db8b234c0545c57e80356af84e42bcb4b/ports/servoshell/desktop/headed_window.rs#L632-L638
2. Add doc and rename function, such as `handle_mouse_move_event` to `handle_native_mouse_move_event` to be closer to [spec](https://w3c.github.io/uievents/#handle-native-mouse-move).

Testing: Just renaming + skipping unnecessary hit-test in simple case.
Fixes: Nothing but preparing for #38670 and #38435.