### PR TITLE
servoshell: Do not send mouse button events to Servo that happen outside the `WebView`

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -287,6 +287,10 @@ impl Window {
         };
 
         let point = self.webview_relative_mouse_point.get();
+        // `point` can be outside viewport, such as at toolbar with negative y-coordinate.
+        if !webview.rect().contains(point) {
+            return;
+        }
         let action = match action {
             ElementState::Pressed => MouseButtonAction::Down,
             ElementState::Released => MouseButtonAction::Up,


### PR DESCRIPTION
`webview_relative_mouse_point` can have negative y-coordinate when at toolbar, but we still would notify compositor the native mousebutton event to do hit-test.

Testing: This fixes the way that mouse events are passed from servoshell to Servo,
but there is currently no way to test those kind of interactions.
