### PR TITLE
tidy: Add a rule ensuring that `//` comments are followed by a space in Rust

### DIFF
--- a/components/background_hang_monitor/sampler_linux.rs
+++ b/components/background_hang_monitor/sampler_linux.rs
@@ -173,7 +173,7 @@ impl Sampler for LinuxSampler {
                     let ip = frame.ip();
                     let sp = frame.sp();
 
-                    //This return value here determines whether we proceed to the next stack frame or not.
+                    // This return value here determines whether we proceed to the next stack frame or not.
                     native_stack.process_register(ip, sp).is_ok()
                 })
             };

--- a/components/canvas/vello_backend.rs
+++ b/components/canvas/vello_backend.rs
@@ -358,7 +358,7 @@ impl GenericDrawTarget for VelloDrawTarget {
         In vello we do not need new draw target (we will use layers) and we need to pass whole rect.
         offsets will be applied to rect directly. shadow blur will be passed directly to let backend do transforms.
         */
-        //self_.scene.draw_blurred_rounded_rect(self_.transform, rect, color, 0.0, sigma);
+        // self_.scene.draw_blurred_rounded_rect(self_.transform, rect, color, 0.0, sigma);
     }
 
     fn fill(

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -192,7 +192,7 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
         self.ignore_clips(|self_| {
             // Clipped blending does not work correctly:
             // https://github.com/linebender/vello/issues/1119
-            //self_.push_layer(Some(rect.to_path(0.1)), Some(peniko::Compose::Copy.into()), None, None);
+            // self_.push_layer(Some(rect.to_path(0.1)), Some(peniko::Compose::Copy.into()), None, None);
 
             self_.ctx.set_paint(vello_cpu::Image {
                 source: vello_cpu::ImageSource::Pixmap(surface),
@@ -202,7 +202,7 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
             });
             self_.ctx.fill_rect(&rect);
 
-            //self_.ctx.pop_layer();
+            // self_.ctx.pop_layer();
         });
     }
 
@@ -263,7 +263,7 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
         In vello we do not need new draw target (we will use layers) and we need to pass whole rect.
         offsets will be applied to rect directly. shadow blur will be passed directly to let backend do transforms.
         */
-        //self_.scene.draw_blurred_rounded_rect(self_.transform, rect, color, 0.0, sigma);
+        // self_.scene.draw_blurred_rounded_rect(self_.transform, rect, color, 0.0, sigma);
     }
 
     fn fill(

--- a/components/devtools/actors/console.rs
+++ b/components/devtools/actors/console.rs
@@ -373,7 +373,7 @@ impl Actor for ConsoleActor {
             },
 
             "startListeners" => {
-                //TODO: actually implement listener filters that support starting/stopping
+                // TODO: actually implement listener filters that support starting/stopping
                 let listeners = msg.get("listeners").unwrap().as_array().unwrap().to_owned();
                 let msg = StartedListenersReply {
                     from: self.name(),
@@ -388,7 +388,7 @@ impl Actor for ConsoleActor {
             },
 
             "stopListeners" => {
-                //TODO: actually implement listener filters that support starting/stopping
+                // TODO: actually implement listener filters that support starting/stopping
                 let msg = StopListenersReply {
                     from: self.name(),
                     stopped_listeners: msg
@@ -403,7 +403,7 @@ impl Actor for ConsoleActor {
                 request.reply_final(&msg)?
             },
 
-            //TODO: implement autocompletion like onAutocomplete in
+            // TODO: implement autocompletion like onAutocomplete in
             //      http://mxr.mozilla.org/mozilla-central/source/toolkit/devtools/server/actors/webconsole.js
             "autocomplete" => {
                 let msg = AutocompleteReply {

--- a/components/devtools/actors/timeline.rs
+++ b/components/devtools/actors/timeline.rs
@@ -126,7 +126,7 @@ impl Serialize for HighResolutionStamp {
     }
 }
 
-static DEFAULT_TIMELINE_DATA_PULL_TIMEOUT: u64 = 200; //ms
+static DEFAULT_TIMELINE_DATA_PULL_TIMEOUT: u64 = 200; // ms
 
 impl TimelineActor {
     pub fn new(
@@ -209,7 +209,7 @@ impl Actor for TimelineActor {
                     ))
                     .unwrap();
 
-                //TODO: support multiple connections by using root actor's streams instead.
+                // TODO: support multiple connections by using root actor's streams instead.
                 *self.stream.borrow_mut() = request.try_clone_stream().ok();
 
                 // init memory actor
@@ -268,7 +268,7 @@ impl Actor for TimelineActor {
                     ))
                     .unwrap();
 
-                //TODO: move this to the cleanup method.
+                // TODO: move this to the cleanup method.
                 if let Some(ref actor_name) = *self.framerate_actor.borrow() {
                     registry.drop_actor_later(actor_name.clone());
                 }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -527,7 +527,7 @@ impl DevtoolsInstance {
         let mut actors = self.actors.lock().unwrap();
         match self.actor_requests.entry(request_id) {
             Occupied(name) => {
-                //TODO: Delete from map like Firefox does?
+                // TODO: Delete from map like Firefox does?
                 name.into_mut().clone()
             },
             Vacant(entry) => {

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -71,7 +71,7 @@ pub(crate) struct InlineFormattingContextBuilder {
     /// The traversal is at all times as deep in the tree as this stack is,
     /// which is why the code doesn't need to keep track of the actual
     /// container root (see `handle_inline_level_element`).
-    //_
+    // _
     /// When an inline box ends, it's removed from this stack.
     inline_box_stack: Vec<InlineBoxIdentifier>,
 

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -512,8 +512,8 @@ impl<T: MallocSizeOf> MallocSizeOf for OnceCell<T> {
 // We don't want MallocSizeOf to be defined for Rc and Arc. If negative trait bounds are
 // ever allowed, this code should be uncommented.  Instead, there is a compile-fail test for
 // this.
-//impl<T> !MallocSizeOf for Arc<T> { }
-//impl<T> !MallocShallowSizeOf for Arc<T> { }
+// impl<T> !MallocSizeOf for Arc<T> { }
+// impl<T> !MallocShallowSizeOf for Arc<T> { }
 
 impl<T> MallocUnconditionalShallowSizeOf for servo_arc::Arc<T> {
     fn unconditional_shallow_size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
@@ -876,7 +876,7 @@ impl<T> MallocSizeOf for style::shared_lock::Locked<T> {
     fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
         // TODO: fix this implementation when Locked derives MallocSizeOf.
         0
-        //<style::shared_lock::Locked<T> as stylo_malloc_size_of::MallocSizeOf>::size_of(self, ops)
+        // <style::shared_lock::Locked<T> as stylo_malloc_size_of::MallocSizeOf>::size_of(self, ops)
     }
 }
 

--- a/components/media/lib.rs
+++ b/components/media/lib.rs
@@ -194,7 +194,7 @@ impl PlayerGLContext for WindowGLContext {
 struct GLPlayerExternalImages {
     // @FIXME(victor): this should be added when GstGLSyncMeta is
     // added
-    //webrender_gl: Rc<dyn gl::Gl>,
+    // webrender_gl: Rc<dyn gl::Gl>,
     glplayer_channel: IpcSender<GLPlayerMsg>,
     // Used to avoid creating a new channel on each received WebRender
     // request.
@@ -226,7 +226,7 @@ impl WebrenderExternalImageApi for GLPlayerExternalImages {
         // order to avoid WR using a semi-ready GLPlayer texture.
         // glWaitSync doesn't block WR thread, it affects only
         // internal OpenGL subsystem.
-        //self.webrender_gl
+        // self.webrender_gl
         //    .wait_sync(gl_sync as gl::GLsync, 0, gl::TIMEOUT_IGNORED);
         (ExternalImageSource::NativeTexture(image_id), size)
     }

--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -303,7 +303,7 @@ fn test_set_dcl() {
     let dcl = metrics.dom_content_loaded();
     assert!(dcl.is_some());
 
-    //try to overwrite
+    // try to overwrite
     metrics.maybe_set_tti(InteractiveFlag::DOMContentLoaded);
     assert_eq!(metrics.dom_content_loaded(), dcl);
     assert_eq!(metrics.get_tti(), None);
@@ -318,7 +318,7 @@ fn test_set_mta() {
     assert!(main_thread_available_time.is_some());
     assert_eq!(main_thread_available_time, Some(now));
 
-    //try to overwrite
+    // try to overwrite
     metrics.maybe_set_tti(InteractiveFlag::TimeToInteractive(
         CrossProcessInstant::now(),
     ));

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -34,7 +34,7 @@ use crate::fetch::methods::{CancellationListener, Data, RangeRequestBounds};
 use crate::protocols::get_range_request_bounds;
 use crate::resource_thread::CoreResourceThreadPool;
 
-pub const FILE_CHUNK_SIZE: usize = 32768; //32 KB
+pub const FILE_CHUNK_SIZE: usize = 32768; // 32 KB
 
 /// FileManagerStore's entry
 struct FileStoreEntry {

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -1018,7 +1018,7 @@ impl ImageCache for ImageCacheImpl {
                 let pending_load = store.pending_loads.get_by_key_mut(&id).unwrap();
                 pending_load.bytes.extend_from_slice(&data);
 
-                //jmr0 TODO: possibly move to another task?
+                // jmr0 TODO: possibly move to another task?
                 if pending_load.metadata.is_none() {
                     let mut reader = std::io::Cursor::new(pending_load.bytes.as_slice());
                     if let Ok(info) = imsz_from_reader(&mut reader) {

--- a/components/net/subresource_integrity.rs
+++ b/components/net/subresource_integrity.rs
@@ -123,7 +123,7 @@ fn apply_algorithm_to_response<S: ArrayLength<u8>, D: Digest<OutputSize = S>>(
 ) -> String {
     if let ResponseBody::Done(ref vec) = *body {
         hasher.update(vec);
-        let response_digest = hasher.finalize(); //Now hash
+        let response_digest = hasher.finalize(); // Now hash
         base64::engine::general_purpose::STANDARD.encode(&response_digest)
     } else {
         unreachable!("Tried to calculate digest of incomplete response body")

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -1299,7 +1299,7 @@ fn test_fetch_with_devtools() {
     let devhttprequests = expect_devtools_http_request(&devtools_port);
     let mut devhttpresponse = devtools_response_with_body(&devtools_port);
 
-    //Creating default headers for request
+    // Creating default headers for request
     let mut headers = HeaderMap::new();
 
     headers.insert(header::ACCEPT, HeaderValue::from_static("*/*"));

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -352,7 +352,7 @@ fn test_request_and_response_data_with_network_messages() {
     let devhttprequests = expect_devtools_http_request(&devtools_port);
     let devhttpresponse = devtools_response_with_body(&devtools_port);
 
-    //Creating default headers for request
+    // Creating default headers for request
     let mut headers = HeaderMap::new();
 
     headers.insert(

--- a/components/pixels/snapshot.rs
+++ b/components/pixels/snapshot.rs
@@ -84,7 +84,7 @@ impl SnapshotAlphaMode {
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub enum SnapshotData {
     // TODO: https://github.com/servo/servo/issues/36594
-    //IPC(IpcSharedMemory),
+    // IPC(IpcSharedMemory),
     Owned(Vec<u8>),
 }
 
@@ -93,7 +93,7 @@ impl Deref for SnapshotData {
 
     fn deref(&self) -> &Self::Target {
         match &self {
-            //Data::IPC(ipc_shared_memory) => ipc_shared_memory,
+            // Data::IPC(ipc_shared_memory) => ipc_shared_memory,
             SnapshotData::Owned(items) => items,
         }
     }
@@ -102,7 +102,7 @@ impl Deref for SnapshotData {
 impl DerefMut for SnapshotData {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
-            //Data::IPC(ipc_shared_memory) => unsafe { ipc_shared_memory.deref_mut() },
+            // Data::IPC(ipc_shared_memory) => unsafe { ipc_shared_memory.deref_mut() },
             SnapshotData::Owned(items) => items,
         }
     }
@@ -288,7 +288,7 @@ impl Snapshot<SnapshotData> {
             alpha_mode,
         } = self;
         let data = match data {
-            //Data::IPC(ipc_shared_memory) => ipc_shared_memory,
+            // Data::IPC(ipc_shared_memory) => ipc_shared_memory,
             SnapshotData::Owned(items) => IpcSharedMemory::from_bytes(&items),
         };
         Snapshot {

--- a/components/script/canvas_context.rs
+++ b/components/script/canvas_context.rs
@@ -265,10 +265,10 @@ impl CanvasContext for RenderingContext {
 pub(crate) enum OffscreenRenderingContext {
     Context2d(Dom<OffscreenCanvasRenderingContext2D>),
     BitmapRenderer(Dom<ImageBitmapRenderingContext>),
-    //WebGL(Dom<WebGLRenderingContext>),
-    //WebGL2(Dom<WebGL2RenderingContext>),
-    //#[cfg(feature = "webgpu")]
-    //WebGPU(Dom<GPUCanvasContext>),
+    // WebGL(Dom<WebGLRenderingContext>),
+    // WebGL2(Dom<WebGL2RenderingContext>),
+    // #[cfg(feature = "webgpu")]
+    // WebGPU(Dom<GPUCanvasContext>),
     Detached,
 }
 

--- a/components/script/dom/bindings/principals.rs
+++ b/components/script/dom/bindings/principals.rs
@@ -95,7 +95,7 @@ unsafe extern "C" fn principals_is_system_or_addon_principal(_: *mut JSPrincipal
     false
 }
 
-//TODO is same_origin_domain equivalent to subsumes for our purposes
+// TODO is same_origin_domain equivalent to subsumes for our purposes
 pub(crate) unsafe extern "C" fn subsumes(obj: *mut JSPrincipals, other: *mut JSPrincipals) -> bool {
     match (NonNull::new(obj), NonNull::new(other)) {
         (Some(obj), Some(other)) => {

--- a/components/script/dom/bindings/settings_stack.rs
+++ b/components/script/dom/bindings/settings_stack.rs
@@ -8,7 +8,7 @@ use js::jsapi::{GetScriptedCallerGlobal, JSTracer};
 use js::rust::Runtime;
 use script_bindings::settings_stack::*;
 
-//use script_bindings::interfaces::{DomHelpers, GlobalScopeHelpers};
+// use script_bindings::interfaces::{DomHelpers, GlobalScopeHelpers};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::globalscope::GlobalScope;

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -564,7 +564,7 @@ impl BluetoothMethods<crate::DomTypeHolder> for Bluetooth {
             sender,
             can_gc,
         );
-        //Note: Step 3 - 4. in response function, Step 5. in handle_response function.
+        // Note: Step 3 - 4. in response function, Step 5. in handle_response function.
         p
     }
 

--- a/components/script/dom/bluetooth/bluetoothuuid.rs
+++ b/components/script/dom/bluetooth/bluetoothuuid.rs
@@ -25,7 +25,7 @@ pub(crate) struct BluetoothUUID {
     reflector_: Reflector,
 }
 
-//https://developer.bluetooth.org/gatt/services/Pages/ServicesHome.aspx
+// https://developer.bluetooth.org/gatt/services/Pages/ServicesHome.aspx
 const BLUETOOTH_ASSIGNED_SERVICES: &[(&str, u32)] = &[
     ("org.bluetooth.service.alert_notification", 0x1811_u32),
     ("org.bluetooth.service.automation_io", 0x1815_u32),
@@ -76,7 +76,7 @@ const BLUETOOTH_ASSIGNED_SERVICES: &[(&str, u32)] = &[
     ("org.bluetooth.service.weight_scale", 0x181d_u32),
 ];
 
-//https://developer.bluetooth.org/gatt/services/Pages/ServicesHome.aspx
+// https://developer.bluetooth.org/gatt/services/Pages/ServicesHome.aspx
 const BLUETOOTH_ASSIGNED_CHARCTERISTICS: &[(&str, u32)] = &[
     (
         "org.bluetooth.characteristic.aerobic_heart_rate_lower_limit",
@@ -524,7 +524,7 @@ const BLUETOOTH_ASSIGNED_CHARCTERISTICS: &[(&str, u32)] = &[
     ("org.bluetooth.characteristic.wind_chill", 0x2a79_u32),
 ];
 
-//https://developer.bluetooth.org/gatt/services/Pages/ServicesHome.aspx
+// https://developer.bluetooth.org/gatt/services/Pages/ServicesHome.aspx
 const BLUETOOTH_ASSIGNED_DESCRIPTORS: &[(&str, u32)] = &[
     (
         "org.bluetooth.descriptor.gatt.characteristic_extended_properties",

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -169,7 +169,7 @@ fn create_html_element(
                 // steps while catching any exceptions:
                 CustomElementCreationMode::Synchronous => {
                     let local_name = name.local.clone();
-                    //TODO(jdm) Pass proto to create_element?
+                    // TODO(jdm) Pass proto to create_element?
                     // Steps 4.1.1-4.1.11
                     return match definition.create_element(document, prefix.clone(), can_gc) {
                         Ok(element) => {

--- a/components/script/dom/datatransfer.rs
+++ b/components/script/dom/datatransfer.rs
@@ -205,7 +205,7 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
             // Step 9 If convert-to-URL is true, then parse result as appropriate for text/uri-list data,
             // and then set result to the first URL from the list, if any, or the empty string otherwise.
             if convert_to_url {
-                //TODO parse uri-list as [RFC2483]
+                // TODO parse uri-list as [RFC2483]
             }
 
             // Step 10 Return result.

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1868,7 +1868,7 @@ impl Document {
         // TODO: Step 1, increase the event loop's termination nesting level by 1.
         // Step 2
         self.incr_ignore_opens_during_unload_counter();
-        //Step 3-5.
+        // Step 3-5.
         let beforeunload_event = BeforeUnloadEvent::new(
             &self.window,
             atom!("beforeunload"),
@@ -3267,7 +3267,7 @@ impl Document {
                     LazyLock::new(StyleSharedRwLock::new);
 
                 PER_PROCESS_AUTHOR_SHARED_LOCK.clone()
-                //StyleSharedRwLock::new()
+                // StyleSharedRwLock::new()
             },
             stylesheets: DomRefCell::new(DocumentStylesheetSet::new()),
             stylesheet_list: MutNullableDom::new(None),

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -1275,7 +1275,7 @@ impl DocumentEventHandler {
                 _ => (),
             }
         }
-        //Step 5
+        // Step 5
         true
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2940,8 +2940,8 @@ impl Element {
                 HTMLElementTypeId::HTMLAnchorElement,
             )) => element.has_attribute(&local_name!("href")),
 
-            //TODO focusable if editing host
-            //TODO focusable if "sorting interface th elements"
+            // TODO focusable if editing host
+            // TODO focusable if "sorting interface th elements"
             _ => {
                 // Draggable elements are focusable.
                 element.get_string_attribute(&local_name!("draggable")) == "true"

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -718,7 +718,7 @@ impl EventSourceTimeoutCallback {
         let mut request = event_source.request();
         // Step 5.3
         if !event_source.last_event_id.borrow().is_empty() {
-            //TODO(eijebong): Change this once typed header support custom values
+            // TODO(eijebong): Change this once typed header support custom values
             request.headers.insert(
                 HeaderName::from_static("last-event-id"),
                 HeaderValue::from_str(&String::from(event_source.last_event_id.borrow().clone()))

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -377,7 +377,7 @@ impl CompiledEventListener {
                         ) {
                             let value = rooted_return_value.handle();
 
-                            //Step 5
+                            // Step 5
                             let should_cancel = value.is_boolean() && !value.to_boolean();
 
                             if should_cancel {

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -139,7 +139,7 @@ impl FileReaderSharedFunctionality {
         blob_type: &str,
         blob_label: &Option<String>,
     ) -> DOMString {
-        //https://w3c.github.io/FileAPI/#encoding-determination
+        // https://w3c.github.io/FileAPI/#encoding-determination
         // Steps 1 & 2 & 3
         let mut encoding = blob_label
             .as_ref()
@@ -194,7 +194,7 @@ impl FileReader {
         reflect_dom_object_with_proto(Box::new(FileReader::new_inherited()), global, proto, can_gc)
     }
 
-    //https://w3c.github.io/FileAPI/#dfn-error-steps
+    // https://w3c.github.io/FileAPI/#dfn-error-steps
     pub(crate) fn process_read_error(
         filereader: TrustedFileReader,
         gen_id: GenerationId,
@@ -244,7 +244,7 @@ impl FileReader {
             );
         );
         return_on_abort!();
-        //FIXME Step 7 send current progress
+        // FIXME Step 7 send current progress
         fr.dispatch_progress_event(atom!("progress"), 0, None, can_gc);
     }
 
@@ -328,7 +328,7 @@ impl FileReader {
         *result.borrow_mut() = Some(FileReaderResult::String(output));
     }
 
-    //https://w3c.github.io/FileAPI/#dfn-readAsDataURL
+    // https://w3c.github.io/FileAPI/#dfn-readAsDataURL
     fn perform_readasdataurl(
         result: &DomRefCell<Option<FileReaderResult>>,
         data: ReadMetaData,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2691,7 +2691,7 @@ impl GlobalScope {
                             type_: "PageError".to_string(),
                             error_message: error_info.message.clone(),
                             source_name: error_info.filename.clone(),
-                            line_text: "".to_string(), //TODO
+                            line_text: "".to_string(), // TODO
                             line_number: error_info.lineno,
                             column_number: error_info.column,
                             category: "script".to_string(),

--- a/components/script/dom/headers.rs
+++ b/components/script/dom/headers.rs
@@ -527,7 +527,7 @@ fn is_legal_header_value(value: &[u8]) -> bool {
     // If accepting non-UTF8 header values causes breakage,
     // removing the above "true" and uncommenting the below code
     // would ameliorate it while still accepting most reasonable headers:
-    //match str::from_utf8(value) {
+    // match str::from_utf8(value) {
     //    Ok(_) => true,
     //    Err(_) => {
     //        warn!(

--- a/components/script/dom/htmlanchorelement.rs
+++ b/components/script/dom/htmlanchorelement.rs
@@ -318,7 +318,7 @@ impl Activatable for HTMLAnchorElement {
         self.as_element().has_attribute(&local_name!("href"))
     }
 
-    //https://html.spec.whatwg.org/multipage/#the-a-element:activation-behaviour
+    // https://html.spec.whatwg.org/multipage/#the-a-element:activation-behaviour
     fn activation_behavior(&self, event: &Event, target: &EventTarget, _: CanGc) {
         let element = self.as_element();
         let mouse_event = event.downcast::<MouseEvent>().unwrap();
@@ -339,7 +339,7 @@ impl Activatable for HTMLAnchorElement {
         }
 
         // Step 2.
-        //TODO: Download the link is `download` attribute is set.
+        // TODO: Download the link is `download` attribute is set.
         follow_hyperlink(element, self.relations.get(), ismap_suffix);
     }
 }

--- a/components/script/dom/htmlbodyelement.rs
+++ b/components/script/dom/htmlbodyelement.rs
@@ -197,7 +197,7 @@ impl VirtualMethods for HTMLBodyElement {
                     &local_name!("onunload") => {
                         let source = &**attr.value();
                         let evtarget = window.upcast::<EventTarget>(); // forwarded event
-                        let source_line = 1; //TODO(#9604) obtain current JS execution line
+                        let source_line = 1; // TODO(#9604) obtain current JS execution line
                         evtarget.set_event_handler_uncompiled(
                             window.get_url(),
                             source_line,

--- a/components/script/dom/htmlbuttonelement.rs
+++ b/components/script/dom/htmlbuttonelement.rs
@@ -354,7 +354,7 @@ impl Activatable for HTMLButtonElement {
     }
 
     fn is_instance_activatable(&self) -> bool {
-        //https://html.spec.whatwg.org/multipage/#the-button-element
+        // https://html.spec.whatwg.org/multipage/#the-button-element
         !self.upcast::<Element>().disabled_state()
     }
 
@@ -362,7 +362,7 @@ impl Activatable for HTMLButtonElement {
     fn activation_behavior(&self, _event: &Event, _target: &EventTarget, can_gc: CanGc) {
         let ty = self.button_type.get();
         match ty {
-            //https://html.spec.whatwg.org/multipage/#attr-button-type-submit-state
+            // https://html.spec.whatwg.org/multipage/#attr-button-type-submit-state
             ButtonType::Submit => {
                 // TODO: is document owner fully active?
                 if let Some(owner) = self.form_owner() {

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -717,7 +717,7 @@ fn to_camel_case(name: &str) -> Option<DOMString> {
     let mut result = String::with_capacity(name.len().saturating_sub(DATA_PREFIX.len()));
     let mut name_chars = name.chars();
     while let Some(curr_char) = name_chars.next() {
-        //check for hyphen followed by character
+        // check for hyphen followed by character
         if curr_char == DATA_HYPHEN_SEPARATOR {
             if let Some(next_char) = name_chars.next() {
                 if next_char.is_ascii_lowercase() {
@@ -1105,7 +1105,7 @@ impl VirtualMethods for HTMLElement {
             (name, AttributeMutation::Set(_)) if name.starts_with("on") => {
                 let source = &**attr.value();
                 let evtarget = self.upcast::<EventTarget>();
-                let source_line = 1; //TODO(#9604) get current JS execution line
+                let source_line = 1; // TODO(#9604) get current JS execution line
                 evtarget.set_event_handler_uncompiled(
                     self.owner_window().get_url(),
                     source_line,

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -789,7 +789,7 @@ impl HTMLImageElement {
                 let wid = imgsource.descriptor.width.unwrap();
                 imgsource.descriptor.density = Some(wid as f64 / source_size_length.to_f64_px());
             } else {
-                //Step 2.3
+                // Step 2.3
                 imgsource.descriptor.density = Some(1_f64);
             }
         }
@@ -1547,7 +1547,7 @@ impl LayoutHTMLImageElementHelpers for LayoutDom<'_, HTMLImageElement> {
     }
 }
 
-//https://html.spec.whatwg.org/multipage/#parse-a-sizes-attribute
+// https://html.spec.whatwg.org/multipage/#parse-a-sizes-attribute
 pub(crate) fn parse_a_sizes_attribute(value: DOMString) -> SourceSizeList {
     let mut input = ParserInput::new(&value);
     let mut parser = Parser::new(&mut input);

--- a/components/script/dom/htmlinputelement.rs
+++ b/components/script/dom/htmlinputelement.rs
@@ -810,7 +810,7 @@ impl HTMLInputElement {
         if (value - step_base) % allowed_value_step != 0.0 {
             value = match dir {
                 StepDirection::Down =>
-                //step down a fractional step to be on a step multiple
+                // step down a fractional step to be on a step multiple
                 {
                     let intervals_from_base = ((value - step_base) / allowed_value_step).floor();
                     intervals_from_base * allowed_value_step + step_base
@@ -3065,7 +3065,7 @@ impl VirtualMethods for HTMLInputElement {
             // WHATWG-specified activation behaviors are handled elsewhere;
             // this is for all the other things a UI click might do
 
-            //TODO(#10083): set the editing position for text inputs
+            // TODO(#10083): set the editing position for text inputs
 
             if self.input_type().is_textual_or_password() &&
                 // Check if we display a placeholder. Layout doesn't know about this.

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -424,7 +424,7 @@ impl FetchResponseListener for ClassicContext {
 
         let elem = self.elem.root();
         let global = elem.global();
-        //let cx = GlobalScope::get_cx();
+        // let cx = GlobalScope::get_cx();
         let _ar = enter_realm(&*global);
 
         /*
@@ -471,7 +471,7 @@ impl FetchResponseListener for ClassicContext {
             Ok(load),
             CanGc::note(),
         );
-        //}
+        // }
     }
 
     fn resource_timing_mut(&mut self) -> &mut ResourceFetchTiming {

--- a/components/script/dom/htmltextareaelement.rs
+++ b/components/script/dom/htmltextareaelement.rs
@@ -641,7 +641,7 @@ impl VirtualMethods for HTMLTextAreaElement {
         }
 
         if event.type_() == atom!("click") && !event.DefaultPrevented() {
-            //TODO: set the editing position for text inputs
+            // TODO: set the editing position for text inputs
         } else if event.type_() == atom!("keydown") && !event.DefaultPrevented() {
             if let Some(kevent) = event.downcast::<KeyboardEvent>() {
                 // This can't be inlined, as holding on to textinput.borrow_mut()

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -306,7 +306,7 @@ impl Performance {
         }
 
         // Step 4.
-        //add the new entry to the buffer.
+        // add the new entry to the buffer.
         self.buffer
             .borrow_mut()
             .entries

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -27,7 +27,7 @@ use crate::script_runtime::{CanGc, JSContext};
 
 /// List of allowed performance entry types, in alphabetical order.
 pub(crate) const VALID_ENTRY_TYPES: &[&str] = &[
-    // "frame", //TODO Frame Timing API
+    // "frame", // TODO Frame Timing API
     "mark",       // User Timing API
     "measure",    // User Timing API
     "navigation", // Navigation Timing API

--- a/components/script/dom/performanceresourcetiming.rs
+++ b/components/script/dom/performanceresourcetiming.rs
@@ -63,9 +63,9 @@ pub(crate) struct PerformanceResourceTiming {
     response_start: Option<CrossProcessInstant>,
     #[no_trace]
     response_end: Option<CrossProcessInstant>,
-    transfer_size: u64,     //size in octets
-    encoded_body_size: u64, //size in octets
-    decoded_body_size: u64, //size in octets
+    transfer_size: u64,     // size in octets
+    encoded_body_size: u64, // size in octets
+    decoded_body_size: u64, // size in octets
 }
 
 // TODO(#21269): next_hop
@@ -114,7 +114,7 @@ impl PerformanceResourceTiming {
         }
     }
 
-    //TODO fetch start should be in RFT
+    // TODO fetch start should be in RFT
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     fn from_resource_timing(
         url: ServoUrl,
@@ -140,7 +140,7 @@ impl PerformanceResourceTiming {
             redirect_end: resource_timing.redirect_end,
             fetch_start: resource_timing.fetch_start,
             domain_lookup_start: resource_timing.domain_lookup_start,
-            //TODO (#21260)
+            // TODO (#21260)
             domain_lookup_end: None,
             connect_start: resource_timing.connect_start,
             connect_end: resource_timing.connect_end,

--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -23,7 +23,7 @@ use crate::dom::range::WeakRangeVec;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::window::LayoutValue;
 
-//XXX(ferjm) Ideally merge NodeRareData and ElementRareData so they share
+// XXX(ferjm) Ideally merge NodeRareData and ElementRareData so they share
 //           storage.
 
 #[derive(Default, JSTraceable, MallocSizeOf)]

--- a/components/script/dom/readablebytestreamcontroller.rs
+++ b/components/script/dom/readablebytestreamcontroller.rs
@@ -1180,7 +1180,7 @@ impl ReadableByteStreamController {
         // Assert: bytesFilled ≤ pullIntoDescriptor’s byte length.
         assert!(bytes_filled <= pull_into_descriptor.byte_length);
 
-        //Assert: the remainder after dividing bytesFilled by elementSize is 0.
+        // Assert: the remainder after dividing bytesFilled by elementSize is 0.
         assert!(bytes_filled % element_size == 0);
 
         // Let buffer be ! TransferArrayBuffer(pullIntoDescriptor’s buffer).

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -252,7 +252,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
 
     /// <https://fetch.spec.whatwg.org/#dom-response-type>
     fn Type(&self) -> DOMResponseType {
-        *self.response_type.borrow() //into()
+        *self.response_type.borrow() // into()
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-url>

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -186,7 +186,7 @@ impl ShadowRoot {
     }
 
     pub(crate) fn get_focused_element(&self) -> Option<DomRoot<Element>> {
-        //XXX get retargeted focused element
+        // XXX get retargeted focused element
         None
     }
 

--- a/components/script/dom/trustedscript.rs
+++ b/components/script/dom/trustedscript.rs
@@ -72,9 +72,9 @@ impl TrustedScript {
         global: &GlobalScope,
         code_string: DOMString,
         compilation_type: CompilationType,
-        _parameter_strings: u8, //FIXME in bindings generation
+        _parameter_strings: u8, // FIXME in bindings generation
         body_string: DOMString,
-        _parameter_args: u8, //FIXME in bindings generation
+        _parameter_args: u8, // FIXME in bindings generation
         body_arg: HandleValue,
         can_gc: CanGc,
     ) -> bool {

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -178,7 +178,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapter-isfallbackadapter>
     fn IsFallbackAdapter(&self) -> bool {
-        //TODO
+        // TODO
         false
     }
 

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -102,12 +102,12 @@ pub(crate) struct WebSocket {
     url: ServoUrl,
     ready_state: Cell<WebSocketRequestState>,
     buffered_amount: Cell<u64>,
-    clearing_buffer: Cell<bool>, //Flag to tell if there is a running thread to clear buffered_amount
+    clearing_buffer: Cell<bool>, // Flag to tell if there is a running thread to clear buffered_amount
     #[ignore_malloc_size_of = "Defined in std"]
     #[no_trace]
     sender: IpcSender<WebSocketDomAction>,
     binary_type: Cell<BinaryType>,
-    protocol: DomRefCell<String>, //Subprotocol selected by server
+    protocol: DomRefCell<String>, // Subprotocol selected by server
 }
 
 impl WebSocket {
@@ -421,22 +421,22 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
     // https://html.spec.whatwg.org/multipage/#dom-websocket-close
     fn Close(&self, code: Option<u16>, reason: Option<USVString>) -> ErrorResult {
         if let Some(code) = code {
-            //Fail if the supplied code isn't normal and isn't reserved for libraries, frameworks, and applications
+            // Fail if the supplied code isn't normal and isn't reserved for libraries, frameworks, and applications
             if code != close_code::NORMAL && !(3000..=4999).contains(&code) {
                 return Err(Error::InvalidAccess);
             }
         }
         if let Some(ref reason) = reason {
             if reason.0.len() > 123 {
-                //reason cannot be larger than 123 bytes
+                // reason cannot be larger than 123 bytes
                 return Err(Error::Syntax);
             }
         }
 
         match self.ready_state.get() {
-            WebSocketRequestState::Closing | WebSocketRequestState::Closed => {}, //Do nothing
+            WebSocketRequestState::Closing | WebSocketRequestState::Closed => {}, // Do nothing
             WebSocketRequestState::Connecting => {
-                //Connection is not yet established
+                // Connection is not yet established
                 /*By setting the state to closing, the open function
                 will abort connecting the websocket*/
                 self.ready_state.set(WebSocketRequestState::Closing);
@@ -459,7 +459,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
                 let _ = self.sender.send(WebSocketDomAction::Close(code, reason));
             },
         }
-        Ok(()) //Return Ok
+        Ok(()) // Return Ok
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1502,7 +1502,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-window-innerheight
-    //TODO Include Scrollbar
+    // TODO Include Scrollbar
     fn InnerHeight(&self) -> i32 {
         self.viewport_details
             .get()
@@ -1513,7 +1513,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     }
 
     // https://drafts.csswg.org/cssom-view/#dom-window-innerwidth
-    //TODO Include Scrollbar
+    // TODO Include Scrollbar
     fn InnerWidth(&self) -> i32 {
         self.viewport_details.get().size.width.to_i32().unwrap_or(0)
     }
@@ -1611,7 +1611,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     // https://drafts.csswg.org/cssom-view/#dom-window-moveto
     fn MoveTo(&self, x: i32, y: i32) {
         // Step 1
-        //TODO determine if this operation is allowed
+        // TODO determine if this operation is allowed
         let dpr = self.device_pixel_ratio();
         let point = Point2D::new(x, y).to_f32() * dpr;
         let msg = EmbedderMsg::MoveTo(self.webview_id(), point.to_i32());
@@ -2019,13 +2019,13 @@ impl Window {
             .max(0.0f64);
 
         // Step 10
-        //TODO handling ongoing smooth scrolling
+        // TODO handling ongoing smooth scrolling
         let scroll_offset = self.scroll_offset();
         if x == scroll_offset.x as f64 && y == scroll_offset.y as f64 {
             return;
         }
 
-        //TODO Step 11
+        // TODO Step 11
 
         // Step 12: Perform a scroll of the viewport to position, document’s root element
         // as the associated element, if there is one, or null otherwise, and the scroll
@@ -3313,7 +3313,7 @@ impl ParseErrorReporter for CSSErrorReporter {
             )
         }
 
-        //TODO: report a real filename
+        // TODO: report a real filename
         let _ = self.script_chan.send(ScriptThreadMessage::ReportCSSError(
             self.pipelineid,
             url.0.to_string(),

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -344,7 +344,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         }
 
         // Step 5
-        //FIXME(seanmonstar): use a Trie instead?
+        // FIXME(seanmonstar): use a Trie instead?
         let maybe_method = method.as_str().and_then(|s| {
             // Note: hyper tests against the uppercase versions
             // Since we want to pass methods not belonging to the short list above
@@ -662,7 +662,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         }
 
         // Step 6
-        //TODO - set referrer_policy/referrer_url in request
+        // TODO - set referrer_policy/referrer_url in request
         let credentials_mode = if self.with_credentials.get() {
             CredentialsMode::Include
         } else {

--- a/components/script/resources/media-controls.js
+++ b/components/script/resources/media-controls.js
@@ -265,7 +265,7 @@
 
       // Error
       if (this.state == ERRORED) {
-        //XXX render errored state
+        // XXX render errored state
         return;
       }
 

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1440,7 +1440,7 @@ pub(crate) unsafe extern "C" fn host_import_module_dynamically(
     let global_scope = GlobalScope::from_context(*cx, InRealm::Already(&in_realm_proof));
     let promise = Promise::new_with_js_promise(Handle::from_raw(promise), cx);
 
-    //Step 5 & 6.
+    // Step 5 & 6.
     if let Err(e) = fetch_an_import_module_script_graph(
         &global_scope,
         specifier,

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -504,9 +504,9 @@ unsafe extern "C" fn content_security_policy_allows(
     runtime_code: RuntimeCode,
     code_string: HandleString,
     compilation_type: CompilationType,
-    parameter_strings: u8, //FIXME in bindings generation
+    parameter_strings: u8, // FIXME in bindings generation
     body_string: HandleString,
-    parameter_args: u8, //FIXME in bindings generation
+    parameter_args: u8, // FIXME in bindings generation
     body_arg: RawHandleValue,
     can_compile_strings: *mut bool,
 ) -> bool {
@@ -1177,14 +1177,14 @@ unsafe extern "C" fn consume_stream(
     let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);
     let global = GlobalScope::from_context(*cx, InRealm::Already(&in_realm_proof));
 
-    //Step 2.1 Upon fulfillment of source, store the Response with value unwrappedSource.
+    // Step 2.1 Upon fulfillment of source, store the Response with value unwrappedSource.
     if let Ok(unwrapped_source) =
         root_from_handleobject::<Response>(RustHandleObject::from_raw(obj), *cx)
     {
-        //Step 2.2 Let mimeType be the result of extracting a MIME type from response’s header list.
+        // Step 2.2 Let mimeType be the result of extracting a MIME type from response’s header list.
         let mimetype = unwrapped_source.Headers(CanGc::note()).extract_mime_type();
 
-        //Step 2.3 If mimeType is not `application/wasm`, return with a TypeError and abort these substeps.
+        // Step 2.3 If mimeType is not `application/wasm`, return with a TypeError and abort these substeps.
         if !&mimetype[..].eq_ignore_ascii_case(b"application/wasm") {
             throw_dom_exception(
                 cx,
@@ -1195,7 +1195,7 @@ unsafe extern "C" fn consume_stream(
             return false;
         }
 
-        //Step 2.4 If response is not CORS-same-origin, return with a TypeError and abort these substeps.
+        // Step 2.4 If response is not CORS-same-origin, return with a TypeError and abort these substeps.
         match unwrapped_source.Type() {
             DOMResponseType::Basic | DOMResponseType::Cors | DOMResponseType::Default => {},
             _ => {
@@ -1209,7 +1209,7 @@ unsafe extern "C" fn consume_stream(
             },
         }
 
-        //Step 2.5 If response’s status is not an ok status, return with a TypeError and abort these substeps.
+        // Step 2.5 If response’s status is not an ok status, return with a TypeError and abort these substeps.
         if !unwrapped_source.Ok() {
             throw_dom_exception(
                 cx,
@@ -1243,7 +1243,7 @@ unsafe extern "C" fn consume_stream(
         }
         unwrapped_source.set_stream_consumer(Some(StreamConsumer(_consumer)));
     } else {
-        //Step 3 Upon rejection of source, return with reason.
+        // Step 3 Upon rejection of source, return with reason.
         throw_dom_exception(
             cx,
             &global,

--- a/components/script/test.rs
+++ b/components/script/test.rs
@@ -3,11 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // For compile-fail tests only.
-//pub use crate::dom::bindings::cell::DomRefCell;
+// pub use crate::dom::bindings::cell::DomRefCell;
 pub use crate::dom::bindings::refcounted::TrustedPromise;
-//pub use crate::dom::bindings::root::Dom;
+// pub use crate::dom::bindings::root::Dom;
 pub use crate::dom::bindings::str::{ByteString, DOMString};
-//pub use crate::dom::node::Node;
+// pub use crate::dom::node::Node;
 
 pub mod area {
     pub use crate::dom::htmlareaelement::{Area, Shape};

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -377,7 +377,7 @@ unsafe fn jsval_to_webdriver_inner(
             },
         ))
     } else if val.get().is_string() {
-        //FIXME: use jsstr_to_string when jsval grows to_jsstring
+        // FIXME: use jsstr_to_string when jsval grows to_jsstring
         let string: DOMString =
             match FromJSValConvertible::from_jsval(cx, val, StringificationBehavior::Default)
                 .unwrap()
@@ -394,7 +394,7 @@ unsafe fn jsval_to_webdriver_inner(
         if seen.contains(&hashable) {
             return Err(WebDriverJSError::JSError);
         }
-        //Step 2. Append value to `seen`.
+        // Step 2. Append value to `seen`.
         seen.insert(hashable.clone());
 
         rooted!(in(cx) let object = match FromJSValConvertible::from_jsval(cx, val, ()).unwrap() {

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -503,7 +503,7 @@ pub(crate) unsafe extern "C" fn generic_static_promise_method(
     let info = RUST_FUNCTION_VALUE_TO_JITINFO(JS_CALLEE(cx, vp));
     assert!(!info.is_null());
     // TODO: we need safe wrappers for this in mozjs!
-    //assert_eq!((*info)._bitfield_1, JSJitInfo_OpType::StaticMethod as u8)
+    // assert_eq!((*info)._bitfield_1, JSJitInfo_OpType::StaticMethod as u8)
     let static_fn = (*info).__bindgen_anon_1.staticMethod.unwrap();
     if static_fn(cx, argc, vp) {
         return true;

--- a/components/shared/net/mime_classifier.rs
+++ b/components/shared/net/mime_classifier.rs
@@ -70,7 +70,7 @@ impl Default for MimeClassifier {
 }
 
 impl MimeClassifier {
-    //Performs MIME Type Sniffing Algorithm (sections 7 and 8)
+    // Performs MIME Type Sniffing Algorithm (sections 7 and 8)
     pub fn classify<'a>(
         &'a self,
         context: LoadContext,
@@ -200,7 +200,7 @@ impl MimeClassifier {
         Ok(())
     }
 
-    //some sort of iterator over the classifiers might be better?
+    // some sort of iterator over the classifiers might be better?
     fn sniff_unknown_type(&self, no_sniff_flag: NoSniffFlag, data: &[u8]) -> Mime {
         let should_sniff_scriptable = no_sniff_flag == NoSniffFlag::Off;
         let sniffed = if should_sniff_scriptable {
@@ -327,7 +327,7 @@ impl MimeClassifier {
     }
 }
 
-//Interface used for composite types
+// Interface used for composite types
 trait MIMEChecker {
     fn classify(&self, data: &[u8]) -> Option<Mime>;
     /// Validate the MIME checker configuration
@@ -743,10 +743,10 @@ impl MIMEChecker for FeedsClassifier {
     }
 }
 
-//Contains hard coded byte matchers
-//TODO: These should be configured and not hard coded
+// Contains hard coded byte matchers
+// TODO: These should be configured and not hard coded
 impl ByteMatcher {
-    //A Windows Icon signature
+    // A Windows Icon signature
     fn image_x_icon() -> ByteMatcher {
         ByteMatcher {
             pattern: b"\x00\x00\x01\x00",
@@ -755,7 +755,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //A Windows Cursor signature.
+    // A Windows Cursor signature.
     fn image_x_icon_cursor() -> ByteMatcher {
         ByteMatcher {
             pattern: b"\x00\x00\x02\x00",
@@ -764,7 +764,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string "BM", a BMP signature.
+    // The string "BM", a BMP signature.
     fn image_bmp() -> ByteMatcher {
         ByteMatcher {
             pattern: b"BM",
@@ -773,7 +773,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string "GIF89a", a GIF signature.
+    // The string "GIF89a", a GIF signature.
     fn image_gif89a() -> ByteMatcher {
         ByteMatcher {
             pattern: b"GIF89a",
@@ -782,7 +782,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string "GIF87a", a GIF signature.
+    // The string "GIF87a", a GIF signature.
     fn image_gif87a() -> ByteMatcher {
         ByteMatcher {
             pattern: b"GIF87a",
@@ -791,7 +791,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string "RIFF" followed by four bytes followed by the string "WEBPVP".
+    // The string "RIFF" followed by four bytes followed by the string "WEBPVP".
     fn image_webp() -> ByteMatcher {
         ByteMatcher {
             pattern: b"RIFF\x00\x00\x00\x00WEBPVP",
@@ -800,8 +800,8 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //An error-checking byte followed by the string "PNG" followed by CR LF SUB LF, the PNG
-    //signature.
+    // An error-checking byte followed by the string "PNG" followed by CR LF SUB LF, the PNG
+    // signature.
     fn image_png() -> ByteMatcher {
         ByteMatcher {
             pattern: b"\x89PNG\r\n\x1A\n",
@@ -819,7 +819,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The WebM signature. [TODO: Use more bytes?]
+    // The WebM signature. [TODO: Use more bytes?]
     fn video_webm() -> ByteMatcher {
         ByteMatcher {
             pattern: b"\x1A\x45\xDF\xA3",
@@ -828,7 +828,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string ".snd", the basic audio signature.
+    // The string ".snd", the basic audio signature.
     fn audio_basic() -> ByteMatcher {
         ByteMatcher {
             pattern: b".snd",
@@ -837,7 +837,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string "FORM" followed by four bytes followed by the string "AIFF", the AIFF signature.
+    // The string "FORM" followed by four bytes followed by the string "AIFF", the AIFF signature.
     fn audio_aiff() -> ByteMatcher {
         ByteMatcher {
             pattern: b"FORM\x00\x00\x00\x00AIFF",
@@ -846,7 +846,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string "ID3", the ID3v2-tagged MP3 signature.
+    // The string "ID3", the ID3v2-tagged MP3 signature.
     fn audio_mpeg() -> ByteMatcher {
         ByteMatcher {
             pattern: b"ID3",
@@ -855,7 +855,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string "OggS" followed by NUL, the Ogg container signature.
+    // The string "OggS" followed by NUL, the Ogg container signature.
     fn application_ogg() -> ByteMatcher {
         ByteMatcher {
             pattern: b"OggS\x00",
@@ -864,8 +864,8 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string "MThd" followed by four bytes representing the number 6 in 32 bits (big-endian),
-    //the MIDI signature.
+    // The string "MThd" followed by four bytes representing the number 6 in 32 bits (big-endian),
+    // the MIDI signature.
     fn audio_midi() -> ByteMatcher {
         ByteMatcher {
             pattern: b"MThd\x00\x00\x00\x06",
@@ -874,7 +874,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string "RIFF" followed by four bytes followed by the string "AVI ", the AVI signature.
+    // The string "RIFF" followed by four bytes followed by the string "AVI ", the AVI signature.
     fn video_avi() -> ByteMatcher {
         ByteMatcher {
             pattern: b"RIFF\x00\x00\x00\x00AVI ",
@@ -1096,7 +1096,7 @@ impl ByteMatcher {
         }
     }
 
-    //The string "<?xml".
+    // The string "<?xml".
     fn text_xml() -> ByteMatcher {
         ByteMatcher {
             pattern: b"<?xml",
@@ -1105,7 +1105,7 @@ impl ByteMatcher {
             leading_ignore: b"\t\n\x0C\r ",
         }
     }
-    //The string "%PDF-", the PDF signature.
+    // The string "%PDF-", the PDF signature.
     fn application_pdf() -> ByteMatcher {
         ByteMatcher {
             pattern: b"%PDF-",
@@ -1114,7 +1114,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //34 bytes followed by the string "LP", the Embedded OpenType signature.
+    // 34 bytes followed by the string "LP", the Embedded OpenType signature.
     fn application_vnd_ms_font_object() -> ByteMatcher {
         ByteMatcher {
             pattern: b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
@@ -1127,7 +1127,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //4 bytes representing the version number 1.0, a TrueType signature.
+    // 4 bytes representing the version number 1.0, a TrueType signature.
     fn true_type() -> ByteMatcher {
         ByteMatcher {
             pattern: b"\x00\x01\x00\x00",
@@ -1136,7 +1136,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string "OTTO", the OpenType signature.
+    // The string "OTTO", the OpenType signature.
     fn open_type() -> ByteMatcher {
         ByteMatcher {
             pattern: b"OTTO",
@@ -1163,7 +1163,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The GZIP archive signature.
+    // The GZIP archive signature.
     fn application_x_gzip() -> ByteMatcher {
         ByteMatcher {
             pattern: b"\x1F\x8B\x08",
@@ -1172,7 +1172,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string "PK" followed by ETX EOT, the ZIP archive signature.
+    // The string "PK" followed by ETX EOT, the ZIP archive signature.
     fn application_zip() -> ByteMatcher {
         ByteMatcher {
             pattern: b"PK\x03\x04",
@@ -1181,7 +1181,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //The string "Rar " followed by SUB BEL NUL, the RAR archive signature.
+    // The string "Rar " followed by SUB BEL NUL, the RAR archive signature.
     fn application_x_rar_compressed() -> ByteMatcher {
         ByteMatcher {
             pattern: b"Rar \x1A\x07\x00",
@@ -1208,7 +1208,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //UTF-16LE BOM
+    // UTF-16LE BOM
     fn text_plain_utf_16le_bom() -> ByteMatcher {
         ByteMatcher {
             pattern: b"\xFF\xFE\x00\x00",
@@ -1217,7 +1217,7 @@ impl ByteMatcher {
             leading_ignore: &[],
         }
     }
-    //UTF-8 BOM
+    // UTF-8 BOM
     fn text_plain_utf_8_bom() -> ByteMatcher {
         ByteMatcher {
             pattern: b"\xEF\xBB\xBF\x00",

--- a/components/shared/net/quality.rs
+++ b/components/shared/net/quality.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//TODO(eijebong): Remove this once typed headers figure out quality
+// TODO(eijebong): Remove this once typed headers figure out quality
 // This is copy pasted from the old hyper headers to avoid hardcoding everything
 // (I would probably also make some silly mistakes while migrating...)
 

--- a/components/webgpu/poll_thread.rs
+++ b/components/webgpu/poll_thread.rs
@@ -86,7 +86,7 @@ impl Poller {
                             while more_work || work.load(Ordering::Acquire) != 0 {
                                 poll_all_devices(&global, &mut more_work, true, &lock);
                             }
-                            std::thread::park(); //TODO: should we use timeout here
+                            std::thread::park(); // TODO: should we use timeout here
                         }
                     })
                     .expect("Spawning thread should not fail"),

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -1026,7 +1026,7 @@ impl WGPU {
                     } => {
                         let global = &self.global;
                         let _guard = self.poller.lock();
-                        //TODO: Report result to content process
+                        // TODO: Report result to content process
                         let result = global.queue_write_texture(
                             queue_id,
                             &texture_cv,

--- a/components/webxr/openxr/graphics_d3d11.rs
+++ b/components/webxr/openxr/graphics_d3d11.rs
@@ -40,7 +40,7 @@ impl GraphicsProviderMethods<D3D11> for GraphicsProvider {
             match *format {
                 dxgiformat::DXGI_FORMAT_B8G8R8A8_UNORM_SRGB => return *format,
                 dxgiformat::DXGI_FORMAT_B8G8R8A8_UNORM => return *format,
-                //dxgiformat::DXGI_FORMAT_R8G8B8A8_UNORM => return *format,
+                // dxgiformat::DXGI_FORMAT_R8G8B8A8_UNORM => return *format,
                 f => {
                     warn!("Backend requested unsupported format {:?}", f);
                 },

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -540,7 +540,7 @@ impl Dialog {
                     })
                     .backdrop_response;
 
-                //FIXME: Doesn't update until you move your mouse or press a key - why?
+                // FIXME: Doesn't update until you move your mouse or press a key - why?
                 if backdrop_response.clicked() {
                     is_open = false;
                 }
@@ -599,7 +599,7 @@ impl Dialog {
                     })
                     .backdrop_response;
 
-                //FIXME: Doesn't update until you move your mouse or press a key - why?
+                // FIXME: Doesn't update until you move your mouse or press a key - why?
                 if backdrop_response.clicked() {
                     is_open = false;
                 }

--- a/python/tidy/test.py
+++ b/python/tidy/test.py
@@ -117,8 +117,11 @@ class CheckTidiness(unittest.TestCase):
 
     def test_rust(self):
         errors = tidy.collect_errors_for_files(iterFile("rust_tidy.rs"), [], [tidy.check_rust], print_text=False)
+        self.assertEqual("Comments starting with `//` should also include a space", next(errors)[2])
         self.assertEqual("use &T instead of &Root<T>", next(errors)[2])
         self.assertEqual("use &T instead of &DomRoot<T>", next(errors)[2])
+        self.assertEqual("Comments starting with `//` should also include a space", next(errors)[2])
+        self.assertEqual("Comments starting with `//` should also include a space", next(errors)[2])
         self.assertNoMoreErrors(errors)
 
         feature_errors = tidy.collect_errors_for_files(iterFile("lib.rs"), [], [tidy.check_rust], print_text=False)

--- a/python/tidy/tests/rust_tidy.rs
+++ b/python/tidy/tests/rust_tidy.rs
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+//! This is a module, but this comment shouldn't trigger an error.
+//* This is also a module doc comment *//
+//This comment should trigger an error, because of missing space.
+
 use    app_units::Au;
 use raqote::{GradientStop, Source, SolidSource};
 use raqote::{Source, SolidSource},
@@ -78,4 +82,11 @@ impl test {
     } else {
         let xif = 42 in {  xif  } // Should not trigger
     }
+
+    //Comment with no space following it, should trigger an error.
+    let a = 3;//This should cause a problem.
+    //~^ This is a compile-test comment and shouldn't cause a problem.
+    // This comment has a URL, but it shouldn't trigger an error http://servo.org.
+    // This comment has a URL, but it shouldn't trigger an error http://servo.org.
+    /* This is another style of comment, but shouldn't trigger an error. */
 }

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -555,6 +555,9 @@ def check_rust(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:
         return
 
     for idx, line in enumerate(map(lambda line: line.decode("utf-8"), lines)):
+        for match in re.finditer(r"(;|\s|^)//\w", line):
+            yield (idx + 1, "Comments starting with `//` should also include a space")
+
         line = re.sub(r"//.*?$|/\*.*?$|^\*.*?$", "//", line)
         rules = [
             # There should be any use of banned types:

--- a/support/crown/tests/compile_test.rs
+++ b/support/crown/tests/compile_test.rs
@@ -33,7 +33,7 @@ fn run_mode(mode: &'static str, bless: bool) {
         PROFILE_PATH.join("deps").display()
     ));
     // Does not work reliably: https://github.com/servo/servo/pull/30508#issuecomment-1834542203
-    //config.link_deps();
+    // config.link_deps();
     config.strict_headers = true;
     // See https://github.com/Manishearth/compiletest-rs/issues/295
     config.compile_test_exit_code = Some(101);

--- a/tests/unit/script/htmlimageelement.rs
+++ b/tests/unit/script/htmlimageelement.rs
@@ -114,7 +114,7 @@ fn without_descriptor() {
     assert_eq!(parse_a_srcset_attribute("small-image.jpg"), sources);
 }
 
-//Does not parse an ImageSource when both width and density descriptor present
+// Does not parse an ImageSource when both width and density descriptor present
 #[test]
 fn two_descriptor() {
     let empty_vec = Vec::new();


### PR DESCRIPTION
This shows up sometimes in code reviews, so it makes sense that tidy
enforces it. `rustfmt` supports this via comment normalization, but it
does many other things and is still an unstable feature (with bugs).

Testing: There are new tidy tests for this change.
