### PR TITLE
compositing: Use `webrender_api::ExternalImageSource` instead of `WebRenderImageSource`

### DIFF
--- a/components/media/lib.rs
+++ b/components/media/lib.rs
@@ -10,8 +10,8 @@ mod media_thread;
 use std::sync::{Arc, Mutex};
 
 use compositing_traits::{
-    WebrenderExternalImageApi, WebrenderExternalImageHandlers, WebrenderExternalImageRegistry,
-    WebrenderImageHandlerType, WebrenderImageSource,
+    ExternalImageSource, WebrenderExternalImageApi, WebrenderExternalImageHandlers,
+    WebrenderExternalImageRegistry, WebrenderImageHandlerType,
 };
 use euclid::default::Size2D;
 use ipc_channel::ipc::{IpcReceiver, IpcSender, channel};
@@ -214,7 +214,7 @@ impl GLPlayerExternalImages {
 }
 
 impl WebrenderExternalImageApi for GLPlayerExternalImages {
-    fn lock(&mut self, id: u64) -> (WebrenderImageSource, Size2D<i32>) {
+    fn lock(&mut self, id: u64) -> (ExternalImageSource, Size2D<i32>) {
         // The GLPlayerMsgForward::Lock message inserts a fence in the
         // GLPlayer command queue.
         self.glplayer_channel
@@ -228,7 +228,7 @@ impl WebrenderExternalImageApi for GLPlayerExternalImages {
         // internal OpenGL subsystem.
         //self.webrender_gl
         //    .wait_sync(gl_sync as gl::GLsync, 0, gl::TIMEOUT_IGNORED);
-        (WebrenderImageSource::TextureHandle(image_id), size)
+        (ExternalImageSource::NativeTexture(image_id), size)
     }
 
     fn unlock(&mut self, id: u64) {

--- a/components/webgl/webgl_mode/inprocess.rs
+++ b/components/webgl/webgl_mode/inprocess.rs
@@ -9,8 +9,8 @@ use std::sync::{Arc, Mutex};
 use canvas_traits::webgl::{GlType, WebGLContextId, WebGLMsg, WebGLThreads, webgl_channel};
 use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::{
-    CrossProcessCompositorApi, WebrenderExternalImageApi, WebrenderExternalImageRegistry,
-    WebrenderImageSource,
+    CrossProcessCompositorApi, ExternalImageSource, WebrenderExternalImageApi,
+    WebrenderExternalImageRegistry,
 };
 use euclid::default::Size2D;
 use fnv::FnvHashMap;
@@ -134,10 +134,10 @@ impl WebGLExternalImages {
 }
 
 impl WebrenderExternalImageApi for WebGLExternalImages {
-    fn lock(&mut self, id: u64) -> (WebrenderImageSource, Size2D<i32>) {
+    fn lock(&mut self, id: u64) -> (ExternalImageSource, Size2D<i32>) {
         let id = WebGLContextId(id);
         let (texture_id, size) = self.lock_swap_chain(id).unwrap_or_default();
-        (WebrenderImageSource::TextureHandle(texture_id), size)
+        (ExternalImageSource::NativeTexture(texture_id), size)
     }
 
     fn unlock(&mut self, id: u64) {

--- a/components/webgpu/swapchain.rs
+++ b/components/webgpu/swapchain.rs
@@ -9,8 +9,8 @@ use std::sync::{Arc, Mutex};
 
 use arrayvec::ArrayVec;
 use compositing_traits::{
-    CrossProcessCompositorApi, SerializableImageData, WebrenderExternalImageApi,
-    WebrenderImageSource,
+    CrossProcessCompositorApi, ExternalImageSource, SerializableImageData,
+    WebrenderExternalImageApi,
 };
 use euclid::default::Size2D;
 use ipc_channel::ipc::IpcSender;
@@ -83,7 +83,7 @@ pub struct WGPUExternalImages {
 }
 
 impl WebrenderExternalImageApi for WGPUExternalImages {
-    fn lock(&mut self, id: u64) -> (WebrenderImageSource, Size2D<i32>) {
+    fn lock(&mut self, id: u64) -> (ExternalImageSource, Size2D<i32>) {
         let id = WebGPUContextId(id);
         let webgpu_contexts = self.images.lock().unwrap();
         let context_data = webgpu_contexts.get(&id).unwrap();
@@ -99,7 +99,7 @@ impl WebrenderExternalImageApi for WGPUExternalImages {
         };
         self.locked_ids.insert(id, data);
         (
-            WebrenderImageSource::Raw(self.locked_ids.get(&id).unwrap().as_slice()),
+            ExternalImageSource::RawData(self.locked_ids.get(&id).unwrap().as_slice()),
             size,
         )
     }


### PR DESCRIPTION
There is no reason to roll our own type.

Motivation: I need `ExternalImageSource::Invalid`.

Testing: Covered by existing WPT tests, but it's just refactor