### PR TITLE
layout: Stop making `<video>` fall back to a preferred aspect ratio of 2

### DIFF
--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -475,20 +475,10 @@ impl ReplacedContents {
         style: &ComputedValues,
         padding_border_sums: &LogicalVec2<Au>,
     ) -> Option<AspectRatio> {
-        style
-            .preferred_aspect_ratio(
-                self.inline_size_over_block_size_intrinsic_ratio(style),
-                padding_border_sums,
-            )
-            .or_else(|| {
-                matches!(self.kind, ReplacedContentKind::Video(_)).then(Self::default_aspect_ratio)
-            })
-    }
-
-    /// The aspect ratio of the default object sizes.
-    /// <https://drafts.csswg.org/css-images-3/#default-object-size>
-    pub(crate) fn default_aspect_ratio() -> AspectRatio {
-        AspectRatio::from_content_ratio(2.0)
+        style.preferred_aspect_ratio(
+            self.inline_size_over_block_size_intrinsic_ratio(style),
+            padding_border_sums,
+        )
     }
 
     /// The inline size that would result from combining the natural size

--- a/tests/wpt/meta/css/css-sizing/intrinsic-size-fallback-video.html.ini
+++ b/tests/wpt/meta/css/css-sizing/intrinsic-size-fallback-video.html.ini
@@ -1,9 +1,0 @@
-[intrinsic-size-fallback-video.html]
-  [.wrapper 2]
-    expected: FAIL
-
-  [.wrapper 3]
-    expected: FAIL
-
-  [.wrapper 4]
-    expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-aspect-ratio.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-aspect-ratio.html.ini
@@ -1,3 +1,0 @@
-[video-aspect-ratio.html]
-  [Aspect ratio for regular video with aspect-ratio:auto]
-    expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-intrinsic-width-height.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/video-intrinsic-width-height.html.ini
@@ -1,9 +1,3 @@
 [video-intrinsic-width-height.html]
-  [only width attribute]
-    expected: FAIL
-
-  [only height attribute]
-    expected: FAIL
-
   [both width/height attributes and style keeping aspect-ratio]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-video-element/intrinsic_sizes.htm.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-video-element/intrinsic_sizes.htm.ini
@@ -1,6 +1,0 @@
-[intrinsic_sizes.htm]
-  [default height is still 150]
-    expected: FAIL
-
-  [default width is still 300]
-    expected: FAIL


### PR DESCRIPTION
This is simpler, and has been successfully shipped in Blink.
See https://github.com/w3c/csswg-drafts/issues/12053 for more information.

Testing: Improves WPT tests.
