### PR TITLE
webdriver: Greatly simplify window handles related command

### DIFF
--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -157,8 +157,8 @@ pub enum WebDriverCommandMsg {
     FocusWebView(WebViewId, IpcSender<bool>),
     /// Get focused webview. For now, this is only used when start new session.
     GetFocusedWebView(IpcSender<Option<WebViewId>>),
-    /// Get all webviews
-    GetAllWebViews(IpcSender<Result<Vec<WebViewId>, ErrorStatus>>),
+    /// Get all webviews.
+    GetAllWebViews(IpcSender<Vec<WebViewId>>),
     /// Check whether top-level browsing context is open.
     IsWebViewOpen(WebViewId, IpcSender<bool>),
     /// Check whether browsing context is open.

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -388,7 +388,7 @@ impl App {
                         .map(|(id, _)| *id)
                         .collect::<Vec<_>>();
 
-                    if let Err(error) = response_sender.send(Ok(webviews)) {
+                    if let Err(error) = response_sender.send(webviews) {
                         warn!("Failed to send response of GetAllWebViews: {error}");
                     }
                 },


### PR DESCRIPTION
This is mostly meant as simplification and reducing redundant work. There are many cases where the operation is guaranteed to succeed, and the change should make things much easier to read.

Also refresh the cache of handles when `handle_switch_to_window`, since it's possible we have a new window/lost a window but webdriver server is not aware of.

Testing: No regression.
Fixes: Switching to window that webdriver not aware of yet + One small issue https://github.com/servo/servo/pull/38622#discussion_r2280145921
