### PR TITLE
content: Make QuotaExceededError serializable

### DIFF
--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -11,7 +11,7 @@ use std::ptr;
 
 use base::id::{
     BlobId, DomExceptionId, DomPointId, ImageBitmapId, Index, MessagePortId, NamespaceIndex,
-    OffscreenCanvasId, PipelineNamespaceId,
+    OffscreenCanvasId, PipelineNamespaceId, QuotaExceededErrorId,
 };
 use constellation_traits::{
     BlobImpl, DomException, DomPoint, MessagePortImpl, Serializable as SerializableInterface,
@@ -576,7 +576,7 @@ pub(crate) struct StructuredDataReader<'a> {
     pub(crate) exceptions: Option<HashMap<DomExceptionId, DomException>>,
     /// A map of serialized quota exceeded errors.
     pub(crate) quota_exceeded_errors:
-        Option<HashMap<DomExceptionId, SerializableQuotaExceededError>>,
+        Option<HashMap<QuotaExceededErrorId, SerializableQuotaExceededError>>,
     // A map of serialized image bitmaps.
     pub(crate) image_bitmaps: Option<HashMap<ImageBitmapId, SerializableImageBitmap>>,
     /// A map of transferred image bitmaps.
@@ -601,7 +601,7 @@ pub(crate) struct StructuredDataWriter {
     pub(crate) exceptions: Option<HashMap<DomExceptionId, DomException>>,
     /// Serialized quota exceeded errors.
     pub(crate) quota_exceeded_errors:
-        Option<HashMap<DomExceptionId, SerializableQuotaExceededError>>,
+        Option<HashMap<QuotaExceededErrorId, SerializableQuotaExceededError>>,
     /// Serialized blobs.
     pub(crate) blobs: Option<HashMap<BlobId, BlobImpl>>,
     /// Serialized image bitmaps.

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -15,8 +15,8 @@ use base::id::{
 };
 use constellation_traits::{
     BlobImpl, DomException, DomPoint, MessagePortImpl, Serializable as SerializableInterface,
-    SerializableImageBitmap, StructuredSerializedData, TransferableOffscreenCanvas,
-    Transferrable as TransferrableInterface, TransformStreamData,
+    SerializableImageBitmap, SerializableQuotaExceededError, StructuredSerializedData,
+    TransferableOffscreenCanvas, Transferrable as TransferrableInterface, TransformStreamData,
 };
 use js::gc::RootedVec;
 use js::glue::{
@@ -574,6 +574,9 @@ pub(crate) struct StructuredDataReader<'a> {
     pub(crate) points: Option<HashMap<DomPointId, DomPoint>>,
     /// A map of serialized exceptions.
     pub(crate) exceptions: Option<HashMap<DomExceptionId, DomException>>,
+    /// A map of serialized quota exceeded errors.
+    pub(crate) quota_exceeded_errors:
+        Option<HashMap<DomExceptionId, SerializableQuotaExceededError>>,
     // A map of serialized image bitmaps.
     pub(crate) image_bitmaps: Option<HashMap<ImageBitmapId, SerializableImageBitmap>>,
     /// A map of transferred image bitmaps.
@@ -596,6 +599,9 @@ pub(crate) struct StructuredDataWriter {
     pub(crate) points: Option<HashMap<DomPointId, DomPoint>>,
     /// Serialized exceptions.
     pub(crate) exceptions: Option<HashMap<DomExceptionId, DomException>>,
+    /// Serialized quota exceeded errors.
+    pub(crate) quota_exceeded_errors:
+        Option<HashMap<DomExceptionId, SerializableQuotaExceededError>>,
     /// Serialized blobs.
     pub(crate) blobs: Option<HashMap<BlobId, BlobImpl>>,
     /// Serialized image bitmaps.
@@ -660,6 +666,7 @@ pub(crate) fn write(
             transform_streams: sc_writer.transform_streams_port.take(),
             points: sc_writer.points.take(),
             exceptions: sc_writer.exceptions.take(),
+            quota_exceeded_errors: sc_writer.quota_exceeded_errors.take(),
             blobs: sc_writer.blobs.take(),
             image_bitmaps: sc_writer.image_bitmaps.take(),
             transferred_image_bitmaps: sc_writer.transferred_image_bitmaps.take(),
@@ -688,6 +695,7 @@ pub(crate) fn read(
         blob_impls: data.blobs.take(),
         points: data.points.take(),
         exceptions: data.exceptions.take(),
+        quota_exceeded_errors: data.quota_exceeded_errors.take(),
         image_bitmaps: data.image_bitmaps.take(),
         transferred_image_bitmaps: data.transferred_image_bitmaps.take(),
         offscreen_canvases: data.offscreen_canvases.take(),

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -49,7 +49,7 @@ use crate::dom::imagebitmap::ImageBitmap;
 use crate::dom::messageport::MessagePort;
 use crate::dom::offscreencanvas::OffscreenCanvas;
 use crate::dom::readablestream::ReadableStream;
-use crate::dom::types::{DOMException, TransformStream};
+use crate::dom::types::{DOMException, QuotaExceededError, TransformStream};
 use crate::dom::writablestream::WritableStream;
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
@@ -73,6 +73,7 @@ pub(super) enum StructuredCloneTags {
     TransformStream = 0xFFFF8009,
     ImageBitmap = 0xFFFF800A,
     OffscreenCanvas = 0xFFFF800B,
+    QuotaExceededError = 0xFFFF800C,
     Max = 0xFFFFFFFF,
 }
 
@@ -84,6 +85,7 @@ impl From<SerializableInterface> for StructuredCloneTags {
             SerializableInterface::DomPoint => StructuredCloneTags::DomPoint,
             SerializableInterface::DomException => StructuredCloneTags::DomException,
             SerializableInterface::ImageBitmap => StructuredCloneTags::ImageBitmap,
+            SerializableInterface::QuotaExceededError => StructuredCloneTags::QuotaExceededError,
         }
     }
 }
@@ -115,6 +117,7 @@ fn reader_for_type(
         SerializableInterface::DomPoint => read_object::<DOMPoint>,
         SerializableInterface::DomException => read_object::<DOMException>,
         SerializableInterface::ImageBitmap => read_object::<ImageBitmap>,
+        SerializableInterface::QuotaExceededError => read_object::<QuotaExceededError>,
     }
 }
 
@@ -259,6 +262,7 @@ fn serialize_for_type(val: SerializableInterface) -> SerializeOperation {
         SerializableInterface::DomPoint => try_serialize::<DOMPoint>,
         SerializableInterface::DomException => try_serialize::<DOMException>,
         SerializableInterface::ImageBitmap => try_serialize::<ImageBitmap>,
+        SerializableInterface::QuotaExceededError => try_serialize::<QuotaExceededError>,
     }
 }
 

--- a/components/script/dom/quotaexceedederror.rs
+++ b/components/script/dom/quotaexceedederror.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::id::DomExceptionIndex;
 use dom_struct::dom_struct;
 use js::gc::HandleObject;
 use script_bindings::codegen::GenericBindings::QuotaExceededErrorBinding::{
@@ -14,6 +15,7 @@ use script_bindings::str::DOMString;
 
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::reflector::{reflect_dom_object, reflect_dom_object_with_proto};
+use crate::dom::bindings::serializable::Serializable;
 use crate::dom::types::{DOMException, GlobalScope};
 
 /// <https://webidl.spec.whatwg.org/#quotaexceedederror>
@@ -114,5 +116,36 @@ impl QuotaExceededErrorMethods<crate::DomTypeHolder> for QuotaExceededError {
     fn GetRequested(&self) -> Option<Finite<f64>> {
         // The requested getter steps are to return this’s requested.
         self.requested
+    }
+}
+
+impl Serializable for QuotaExceededError {
+    // FIXME: see if QuotaExceededError needs its own exception index since it inherits from DOMException
+    type Index = DomExceptionIndex;
+    type Data = QuotaExceededError;
+
+    /// <https://webidl.spec.whatwg.org/#quotaexceedederror>
+    fn serialize(&self) -> Result<(base::id::NamespaceIndex<Self::Index>, Self::Data), ()> {
+        todo!()
+    }
+
+    /// <https://webidl.spec.whatwg.org/#quotaexceedederror>
+    fn deserialize(
+        owner: &GlobalScope,
+        serialized: Self::Data,
+        can_gc: CanGc,
+    ) -> Result<DomRoot<Self>, ()>
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+
+    /// <https://webidl.spec.whatwg.org/#quotaexceedederror>
+    fn serialized_storage<'a>(
+        data: super::bindings::structuredclone::StructuredData<'a, '_>,
+    ) -> &'a mut Option<std::collections::HashMap<base::id::NamespaceIndex<Self::Index>, Self::Data>>
+    {
+        todo!()
     }
 }

--- a/components/script/dom/quotaexceedederror.rs
+++ b/components/script/dom/quotaexceedederror.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use base::id::{DomExceptionId, DomExceptionIndex};
+use base::id::{QuotaExceededErrorId, QuotaExceededErrorIndex};
 use constellation_traits::SerializableQuotaExceededError;
 use dom_struct::dom_struct;
 use js::gc::HandleObject;
@@ -124,19 +124,18 @@ impl QuotaExceededErrorMethods<crate::DomTypeHolder> for QuotaExceededError {
 }
 
 impl Serializable for QuotaExceededError {
-    // FIXME: see if QuotaExceededError needs its own exception index since it inherits from DOMException
-    type Index = DomExceptionIndex;
+    type Index = QuotaExceededErrorIndex;
     type Data = SerializableQuotaExceededError;
 
     /// <https://webidl.spec.whatwg.org/#quotaexceedederror>
-    fn serialize(&self) -> Result<(DomExceptionId, Self::Data), ()> {
-        let (id, dom_exception) = self.dom_exception.serialize()?;
+    fn serialize(&self) -> Result<(QuotaExceededErrorId, Self::Data), ()> {
+        let (_, dom_exception) = self.dom_exception.serialize()?;
         let serialized = SerializableQuotaExceededError {
             dom_exception,
             quota: self.quota.as_deref().copied(),
             requested: self.requested.as_deref().copied(),
         };
-        Ok((id, serialized))
+        Ok((QuotaExceededErrorId::new(), serialized))
     }
 
     /// <https://webidl.spec.whatwg.org/#quotaexceedederror>
@@ -166,7 +165,7 @@ impl Serializable for QuotaExceededError {
     /// <https://webidl.spec.whatwg.org/#quotaexceedederror>
     fn serialized_storage<'a>(
         data: StructuredData<'a, '_>,
-    ) -> &'a mut Option<HashMap<DomExceptionId, Self::Data>> {
+    ) -> &'a mut Option<HashMap<QuotaExceededErrorId, Self::Data>> {
         match data {
             StructuredData::Reader(reader) => &mut reader.quota_exceeded_errors,
             StructuredData::Writer(writer) => &mut writer.quota_exceeded_errors,

--- a/components/script/dom/quotaexceedederror.rs
+++ b/components/script/dom/quotaexceedederror.rs
@@ -167,6 +167,9 @@ impl Serializable for QuotaExceededError {
     fn serialized_storage<'a>(
         data: StructuredData<'a, '_>,
     ) -> &'a mut Option<HashMap<DomExceptionId, Self::Data>> {
-        todo!()
+        match data {
+            StructuredData::Reader(reader) => &mut reader.quota_exceeded_errors,
+            StructuredData::Writer(writer) => &mut writer.quota_exceeded_errors,
+        }
     }
 }

--- a/components/script_bindings/webidls/QuotaExceededError.webidl
+++ b/components/script_bindings/webidls/QuotaExceededError.webidl
@@ -6,7 +6,7 @@
 
 [
   Exposed=(Window,Worker,Worklet,DissimilarOriginWindow),
-  // Serializable
+  Serializable
 ]
 interface QuotaExceededError : DOMException {
   [Throws] constructor(optional DOMString message = "", optional QuotaExceededErrorOptions options = {});

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -368,6 +368,8 @@ namespace_id! {DomPointId, DomPointIndex, "DomPoint"}
 
 namespace_id! {DomExceptionId, DomExceptionIndex, "DomException"}
 
+namespace_id! {QuotaExceededErrorId, QuotaExceededErrorIndex, "QuotaExceededError"}
+
 namespace_id! {HistoryStateId, HistoryStateIndex, "HistoryState"}
 
 namespace_id! {ImageBitmapId, ImageBitmapIndex, "ImageBitmap"}

--- a/components/shared/constellation/structured_data/mod.rs
+++ b/components/shared/constellation/structured_data/mod.rs
@@ -32,6 +32,8 @@ pub struct StructuredSerializedData {
     pub points: Option<HashMap<DomPointId, DomPoint>>,
     /// Serialized exception objects.
     pub exceptions: Option<HashMap<DomExceptionId, DomException>>,
+    /// Serialized quota exceeded errors.
+    pub quota_exceeded_errors: Option<HashMap<DomExceptionId, SerializableQuotaExceededError>>,
     /// Transferred objects.
     pub ports: Option<HashMap<MessagePortId, MessagePortImpl>>,
     /// Transform streams transferred objects.

--- a/components/shared/constellation/structured_data/mod.rs
+++ b/components/shared/constellation/structured_data/mod.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 
 use base::id::{
     BlobId, DomExceptionId, DomPointId, ImageBitmapId, MessagePortId, OffscreenCanvasId,
+    QuotaExceededErrorId,
 };
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
@@ -33,7 +34,8 @@ pub struct StructuredSerializedData {
     /// Serialized exception objects.
     pub exceptions: Option<HashMap<DomExceptionId, DomException>>,
     /// Serialized quota exceeded errors.
-    pub quota_exceeded_errors: Option<HashMap<DomExceptionId, SerializableQuotaExceededError>>,
+    pub quota_exceeded_errors:
+        Option<HashMap<QuotaExceededErrorId, SerializableQuotaExceededError>>,
     /// Transferred objects.
     pub ports: Option<HashMap<MessagePortId, MessagePortImpl>>,
     /// Transform streams transferred objects.

--- a/components/shared/constellation/structured_data/serializable.rs
+++ b/components/shared/constellation/structured_data/serializable.rs
@@ -11,7 +11,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use base::id::{BlobId, DomExceptionId, DomPointId, ImageBitmapId};
+use base::id::{BlobId, DomExceptionId, DomPointId, ImageBitmapId, QuotaExceededErrorId};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::filemanager_thread::RelativePos;
 use pixels::Snapshot;
@@ -333,8 +333,7 @@ pub struct SerializableQuotaExceededError {
 }
 
 impl BroadcastClone for SerializableQuotaExceededError {
-    // FIXME: see if we need a separate id than domexception
-    type Id = DomExceptionId;
+    type Id = QuotaExceededErrorId;
 
     fn source(data: &StructuredSerializedData) -> &Option<HashMap<Self::Id, Self>> {
         &data.quota_exceeded_errors

--- a/components/shared/constellation/structured_data/serializable.rs
+++ b/components/shared/constellation/structured_data/serializable.rs
@@ -38,6 +38,9 @@ where
 }
 
 /// All the DOM interfaces that can be serialized.
+///
+/// NOTE: Variants which are derived from other serializable interfaces must come before their
+/// parents because serialization is attempted in order of the variants.
 #[derive(Clone, Copy, Debug, EnumIter)]
 pub enum Serializable {
     /// The `Blob` interface.
@@ -46,12 +49,12 @@ pub enum Serializable {
     DomPoint,
     /// The `DOMPointReadOnly` interface.
     DomPointReadOnly,
+    /// The `QuotaExceededError` interface.
+    QuotaExceededError,
     /// The `DOMException` interface.
     DomException,
     /// The `ImageBitmap` interface.
     ImageBitmap,
-    /// The `QuotaExceededError` interface.
-    QuotaExceededError,
 }
 
 impl Serializable {

--- a/components/shared/constellation/structured_data/serializable.rs
+++ b/components/shared/constellation/structured_data/serializable.rs
@@ -72,7 +72,7 @@ impl Serializable {
             },
             Serializable::QuotaExceededError => {
                 StructuredSerializedData::clone_all_of_type::<SerializableQuotaExceededError>
-            }
+            },
         }
     }
 }
@@ -324,6 +324,7 @@ impl BroadcastClone for DomException {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 /// A serializable version of the QuotaExceededError interface.
 pub struct SerializableQuotaExceededError {
     pub dom_exception: DomException,
@@ -336,15 +337,15 @@ impl BroadcastClone for SerializableQuotaExceededError {
     type Id = DomExceptionId;
 
     fn source(data: &StructuredSerializedData) -> &Option<HashMap<Self::Id, Self>> {
-        todo!()
+        &data.quota_exceeded_errors
     }
 
     fn destination(data: &mut StructuredSerializedData) -> &mut Option<HashMap<Self::Id, Self>> {
-        todo!()
+        &mut data.quota_exceeded_errors
     }
 
     fn clone_for_broadcast(&self) -> Option<Self> {
-        todo!()
+        Some(self.clone())
     }
 }
 

--- a/components/shared/constellation/structured_data/serializable.rs
+++ b/components/shared/constellation/structured_data/serializable.rs
@@ -50,6 +50,8 @@ pub enum Serializable {
     DomException,
     /// The `ImageBitmap` interface.
     ImageBitmap,
+    /// The `QuotaExceededError` interface.
+    QuotaExceededError,
 }
 
 impl Serializable {
@@ -68,6 +70,9 @@ impl Serializable {
             Serializable::ImageBitmap => {
                 StructuredSerializedData::clone_all_of_type::<SerializableImageBitmap>
             },
+            Serializable::QuotaExceededError => {
+                StructuredSerializedData::clone_all_of_type::<SerializableQuotaExceededError>
+            }
         }
     }
 }
@@ -324,6 +329,23 @@ pub struct SerializableQuotaExceededError {
     pub dom_exception: DomException,
     pub quota: Option<f64>,
     pub requested: Option<f64>,
+}
+
+impl BroadcastClone for SerializableQuotaExceededError {
+    // FIXME: see if we need a separate id than domexception
+    type Id = DomExceptionId;
+
+    fn source(data: &StructuredSerializedData) -> &Option<HashMap<Self::Id, Self>> {
+        todo!()
+    }
+
+    fn destination(data: &mut StructuredSerializedData) -> &mut Option<HashMap<Self::Id, Self>> {
+        todo!()
+    }
+
+    fn clone_for_broadcast(&self) -> Option<Self> {
+        todo!()
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]

--- a/components/shared/constellation/structured_data/serializable.rs
+++ b/components/shared/constellation/structured_data/serializable.rs
@@ -319,6 +319,13 @@ impl BroadcastClone for DomException {
     }
 }
 
+/// A serializable version of the QuotaExceededError interface.
+pub struct SerializableQuotaExceededError {
+    pub dom_exception: DomException,
+    pub quota: Option<f64>,
+    pub requested: Option<f64>,
+}
+
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 /// A serializable version of the ImageBitmap interface.
 pub struct SerializableImageBitmap {

--- a/tests/wpt/tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0.html
+++ b/tests/wpt/tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0.html
@@ -609,19 +609,35 @@
                 var t = async_test("QuotaExceededError objects can be cloned");
                 t.id = 41;
                 worker.onmessage = t.step_func_done(function(e) {
-                    console.log("data:");
-                    console.log(e.data);
-                    console.log(Object.getPrototypeOf(e.data));
-                    // assert_equals(Object.getPrototypeOf(e.data), QuotaExceededError.prototype, "Checking prototype");
-                    // assert_equals(e.data.constructor, QuotaExceededError, "Checking constructor");
-                    // assert_equals(e.data.name, "IndexSizeError", "Checking name");
-                    // assert_equals(e.data.message, "some message", "Checking message");
-                    // assert_equals(e.data.code, DOMException.INDEX_SIZE_ERR, "Checking code");
-                    // assert_equals(e.data.foo, undefined, "Checking custom property");
+                    assert_equals(Object.getPrototypeOf(e.data), QuotaExceededError.prototype, "Checking prototype");
+                    assert_equals(e.data.constructor, QuotaExceededError, "Checking constructor");
+                    assert_equals(e.data.name, "QuotaExceededError", "Checking name");
+                    assert_equals(e.data.message, "some message", "Checking message");
+                    assert_equals(e.data.code, DOMException.QUOTA_EXCEEDED_ERR, "Checking code");
+                    assert_equals(e.data.quota, 0.1, "Checking quota");
+                    assert_equals(e.data.requested, 1.0, "Checking requested");
+                    assert_equals(e.data.foo, undefined, "Checking custom property");
                 });
                 t.step(function() {
-                    const error = new QuotaExceededError(options = {quota: 0.0, requested: 1.0});
-                    console.log(error);
+                    const error = new QuotaExceededError(message = "some message", options = {quota: 0.1, requested: 1.0});
+                    worker.postMessage(error);
+                });
+            },
+            function() {
+                var t = async_test("QuotaExceededError objects with empty quota/requested can be cloned");
+                t.id = 42;
+                worker.onmessage = t.step_func_done(function(e) {
+                    assert_equals(Object.getPrototypeOf(e.data), QuotaExceededError.prototype, "Checking prototype");
+                    assert_equals(e.data.constructor, QuotaExceededError, "Checking constructor");
+                    assert_equals(e.data.name, "QuotaExceededError", "Checking name");
+                    assert_equals(e.data.message, "some message", "Checking message");
+                    assert_equals(e.data.code, DOMException.QUOTA_EXCEEDED_ERR, "Checking code");
+                    assert_equals(e.data.quota, null, "Checking quota");
+                    assert_equals(e.data.requested, null, "Checking requested");
+                    assert_equals(e.data.foo, undefined, "Checking custom property");
+                });
+                t.step(function() {
+                    const error = new QuotaExceededError(message = "some message");
                     worker.postMessage(error);
                 });
             },

--- a/tests/wpt/tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0.html
+++ b/tests/wpt/tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0.html
@@ -605,6 +605,26 @@
                     assert_unreached("Window must not be clonable");
                 });
             },
+            function() {
+                var t = async_test("QuotaExceededError objects can be cloned");
+                t.id = 41;
+                worker.onmessage = t.step_func_done(function(e) {
+                    console.log("data:");
+                    console.log(e.data);
+                    console.log(Object.getPrototypeOf(e.data));
+                    // assert_equals(Object.getPrototypeOf(e.data), QuotaExceededError.prototype, "Checking prototype");
+                    // assert_equals(e.data.constructor, QuotaExceededError, "Checking constructor");
+                    // assert_equals(e.data.name, "IndexSizeError", "Checking name");
+                    // assert_equals(e.data.message, "some message", "Checking message");
+                    // assert_equals(e.data.code, DOMException.INDEX_SIZE_ERR, "Checking code");
+                    // assert_equals(e.data.foo, undefined, "Checking custom property");
+                });
+                t.step(function() {
+                    const error = new QuotaExceededError(options = {quota: 0.0, requested: 1.0});
+                    console.log(error);
+                    worker.postMessage(error);
+                });
+            },
         ];
     }, {explicit_done:true});
 


### PR DESCRIPTION
Implements (de)serialization behavior for QuotaExceededError and enables the annotation on the WebIDL spec.

Testing: Adds its own WPT tests
Fixes: https://github.com/servo/servo/issues/38685
