### PR TITLE
indexeddb: Implement autoincremented keys and report autoincrementedness properly through DOM interface

### DIFF
--- a/components/net/indexeddb/engines/sqlite/create.rs
+++ b/components/net/indexeddb/engines/sqlite/create.rs
@@ -22,7 +22,7 @@ create table object_store (
     name           varchar               not null
         unique,
     key_path       varbinary_blob,
-    auto_increment boolean default FALSE not null
+    auto_increment integer default FALSE not null
 );"#;
     conn.execute(OBJECT_STORE, [])?;
 

--- a/components/net/indexeddb/engines/sqlite/object_store_model.rs
+++ b/components/net/indexeddb/engines/sqlite/object_store_model.rs
@@ -20,7 +20,7 @@ pub struct Model {
     pub id: i32,
     pub name: String,
     pub key_path: Option<Vec<u8>>,
-    pub auto_increment: bool,
+    pub auto_increment: i32,
 }
 
 impl TryFrom<&Row<'_>> for Model {

--- a/components/net/tests/sqlite.rs
+++ b/components/net/tests/sqlite.rs
@@ -210,7 +210,7 @@ fn test_async_operations() {
                 store_name: store_name.to_owned(),
                 operation: AsyncOperation::ReadWrite(AsyncReadWriteOperation::PutItem {
                     sender: channel.0,
-                    key: IndexedDBKeyType::Number(1.0),
+                    key: Some(IndexedDBKeyType::Number(1.0)),
                     value: vec![1, 2, 3],
                     should_overwrite: false,
                 }),

--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -277,7 +277,7 @@ pub enum AsyncReadWriteOperation {
     /// Sets the value of the given key in the associated idb data
     PutItem {
         sender: IpcSender<BackendResult<PutItemResult>>,
-        key: IndexedDBKeyType,
+        key: Option<IndexedDBKeyType>,
         value: Vec<u8>,
         should_overwrite: bool,
     },

--- a/tests/wpt/meta/IndexedDB/clone-before-keypath-eval.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/clone-before-keypath-eval.any.js.ini
@@ -1,7 +1,4 @@
 [clone-before-keypath-eval.any.worker.html]
-  [Key generator and key path validity check operates on a clone]
-    expected: FAIL
-
   [Failing key path validity check operates on a clone]
     expected: FAIL
 
@@ -19,9 +16,6 @@
   expected: ERROR
 
 [clone-before-keypath-eval.any.html]
-  [Key generator and key path validity check operates on a clone]
-    expected: FAIL
-
   [Failing key path validity check operates on a clone]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/crashtests/create-index.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/crashtests/create-index.any.js.ini
@@ -1,11 +1,11 @@
 [create-index.any.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Assure no crash when populating index]
     expected: TIMEOUT
 
 
 [create-index.any.worker.html]
-  expected: CRASH
+  expected: TIMEOUT
   [Assure no crash when populating index]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-request-source.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-request-source.any.js.ini
@@ -2,12 +2,6 @@
   expected: ERROR
 
 [idbobjectstore-request-source.any.worker.html]
-  [The source of the request from store => store.put(0) is the object store itself]
-    expected: FAIL
-
-  [The source of the request from store => store.add(0) is the object store itself]
-    expected: FAIL
-
   [The source of the request from store => store.getAll() is the object store itself]
     expected: FAIL
 
@@ -28,12 +22,6 @@
   expected: ERROR
 
 [idbobjectstore-request-source.any.html]
-  [The source of the request from store => store.put(0) is the object store itself]
-    expected: FAIL
-
-  [The source of the request from store => store.add(0) is the object store itself]
-    expected: FAIL
-
   [The source of the request from store => store.getAll() is the object store itself]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getKey.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getKey.any.js.ini
@@ -1,33 +1,34 @@
 [idbobjectstore_getKey.any.worker.html]
+  expected: TIMEOUT
   [IDBObjectStore.getKey() - basic - key]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - basic - range]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - basic - key - no match]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - basic - range - no match]
     expected: FAIL
 
   [IDBObjectStore.getKey() - key path - key]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key path - range]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key path - key - no match]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key path - range - no match]
     expected: FAIL
 
   [IDBObjectStore.getKey() - key generator - key]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key generator - range]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key generator - key - no match]
     expected: FAIL
@@ -36,51 +37,49 @@
     expected: FAIL
 
   [IDBObjectStore.getKey() - key generator and key path - key]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key generator and key path - range]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key generator and key path - key - no match]
     expected: FAIL
 
   [IDBObjectStore.getKey() - key generator and key path - range - no match]
-    expected: FAIL
-
-  [IDBObjectStore.getKey() - invalid parameters]
     expected: FAIL
 
 
 [idbobjectstore_getKey.any.html]
+  expected: TIMEOUT
   [IDBObjectStore.getKey() - basic - key]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - basic - range]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - basic - key - no match]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - basic - range - no match]
     expected: FAIL
 
   [IDBObjectStore.getKey() - key path - key]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key path - range]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key path - key - no match]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key path - range - no match]
     expected: FAIL
 
   [IDBObjectStore.getKey() - key generator - key]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key generator - range]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key generator - key - no match]
     expected: FAIL
@@ -89,16 +88,13 @@
     expected: FAIL
 
   [IDBObjectStore.getKey() - key generator and key path - key]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key generator and key path - range]
-    expected: FAIL
+    expected: TIMEOUT
 
   [IDBObjectStore.getKey() - key generator and key path - key - no match]
     expected: FAIL
 
   [IDBObjectStore.getKey() - key generator and key path - range - no match]
-    expected: FAIL
-
-  [IDBObjectStore.getKey() - invalid parameters]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbtransaction_abort.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbtransaction_abort.any.js.ini
@@ -1,4 +1,5 @@
 [idbtransaction_abort.any.worker.html]
+  expected: TIMEOUT
   [Abort event should fire during transaction]
     expected: FAIL
 
@@ -6,7 +7,7 @@
     expected: FAIL
 
   [Abort on completed transaction should throw InvalidStateError.]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [idbtransaction_abort.any.sharedworker.html]
@@ -16,6 +17,7 @@
   expected: ERROR
 
 [idbtransaction_abort.any.html]
+  expected: TIMEOUT
   [Abort event should fire during transaction]
     expected: FAIL
 
@@ -23,4 +25,4 @@
     expected: FAIL
 
   [Abort on completed transaction should throw InvalidStateError.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/IndexedDB/interleaved-cursors-large.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/interleaved-cursors-large.any.js.ini
@@ -1,6 +1,7 @@
 [interleaved-cursors-large.any.html]
+  expected: TIMEOUT
   [250 cursors]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [interleaved-cursors-large.any.serviceworker.html]
@@ -10,5 +11,6 @@
   expected: ERROR
 
 [interleaved-cursors-large.any.worker.html]
+  expected: TIMEOUT
   [250 cursors]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/IndexedDB/interleaved-cursors-small.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/interleaved-cursors-small.any.js.ini
@@ -2,25 +2,27 @@
   expected: ERROR
 
 [interleaved-cursors-small.any.worker.html]
+  expected: TIMEOUT
   [1 cursors]
-    expected: FAIL
+    expected: TIMEOUT
 
   [10 cursors]
-    expected: FAIL
+    expected: NOTRUN
 
   [100 cursors]
-    expected: FAIL
+    expected: NOTRUN
 
 
 [interleaved-cursors-small.any.sharedworker.html]
   expected: ERROR
 
 [interleaved-cursors-small.any.html]
+  expected: TIMEOUT
   [1 cursors]
-    expected: FAIL
+    expected: TIMEOUT
 
   [10 cursors]
-    expected: FAIL
+    expected: NOTRUN
 
   [100 cursors]
-    expected: FAIL
+    expected: NOTRUN


### PR DESCRIPTION
Autoincrementedness was previously being reported as always false. This PR makes the state become queried from the backend, as the spec specifies. Additionally this PR ensures the backend correctly handles an object store which autoincrements.

Testing: WPT
Fixes: None