### PR TITLE
script: Properly implement IndexedDB object store checks

### DIFF
--- a/components/script/dom/domstringlist.rs
+++ b/components/script/dom/domstringlist.rs
@@ -36,6 +36,11 @@ impl DOMStringList {
             can_gc,
         )
     }
+
+    #[inline(always)]
+    pub fn contains(&self, string: &DOMString) -> bool {
+        self.strings.contains(string)
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/#domstringlist
@@ -52,7 +57,7 @@ impl DOMStringListMethods<crate::DomTypeHolder> for DOMStringList {
 
     // https://html.spec.whatwg.org/multipage/#dom-domstringlist-contains
     fn Contains(&self, string: DOMString) -> bool {
-        self.strings.contains(&string)
+        self.contains(&string)
     }
 
     // check-tidy: no specs after this line

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -169,7 +169,7 @@ impl IDBObjectStore {
     }
 
     pub(crate) fn is_deleted(&self, transaction: &IDBTransaction) -> bool {
-        transaction.object_store_names().contains(&self.db_name)
+        !transaction.object_store_names().contains(&self.db_name)
     }
 
     /// Checks if the transation is active, throwing a "TransactionInactiveError" DOMException if not.

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -168,7 +168,7 @@ impl IDBObjectStore {
         self.key_path.is_some()
     }
 
-    fn is_deleted(&self, transaction: &IDBTransaction) -> bool {
+    pub(crate) fn is_deleted(&self, transaction: &IDBTransaction) -> bool {
         transaction.object_store_names().contains(&self.db_name)
     }
 

--- a/components/script/dom/idbtransaction.rs
+++ b/components/script/dom/idbtransaction.rs
@@ -13,7 +13,6 @@ use profile_traits::ipc;
 use stylo_atoms::Atom;
 
 use crate::dom::bindings::cell::DomRefCell;
-use crate::dom::bindings::codegen::Bindings::DOMStringListBinding::DOMStringListMethods;
 use crate::dom::bindings::codegen::Bindings::IDBTransactionBinding::{
     IDBTransactionMethods, IDBTransactionMode,
 };
@@ -204,6 +203,10 @@ impl IDBTransaction {
     fn get_idb_thread(&self) -> IpcSender<IndexedDBThreadMsg> {
         self.global().resource_threads().sender()
     }
+
+    pub(crate) fn object_store_names(&self) -> &Dom<DOMStringList> {
+        &self.object_store_names
+    }
 }
 
 impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
@@ -220,7 +223,7 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
         }
 
         // Step 2: Check that the object store exists
-        if !self.object_store_names.Contains(name.clone()) {
+        if !self.object_store_names.contains(&name) {
             return Err(Error::NotFound);
         }
 

--- a/components/script/dom/idbtransaction.rs
+++ b/components/script/dom/idbtransaction.rs
@@ -204,8 +204,8 @@ impl IDBTransaction {
         self.global().resource_threads().sender()
     }
 
-    pub(crate) fn object_store_names(&self) -> &Dom<DOMStringList> {
-        &self.object_store_names
+    pub(crate) fn object_store_names(&self) -> &DOMStringList {
+        &*self.object_store_names
     }
 }
 


### PR DESCRIPTION
I decided the most ergonomic way to handle this is passing references to the transaction to both checks, since they both need the transaction. This PR adds the check that ensures the object store exists.

Testing: Mostly a refactor, Covered by WPT
