### PR TITLE
fonts: Measure more FontContext heap usage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7703,6 +7703,7 @@ dependencies = [
  "keyboard-types",
  "markup5ever",
  "mime",
+ "parking_lot",
  "resvg",
  "servo_allocator",
  "servo_arc",

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -4,6 +4,7 @@
 
 use std::borrow::ToOwned;
 use std::collections::HashMap;
+use std::ops::Deref;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
@@ -548,7 +549,15 @@ impl Font {
     }
 }
 
-pub type FontRef = Arc<Font>;
+#[derive(Clone, MallocSizeOf)]
+pub struct FontRef(#[conditional_malloc_size_of] pub(crate) Arc<Font>);
+
+impl Deref for FontRef {
+    type Target = Arc<Font>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// A `FontGroup` is a prioritised list of fonts for a given set of font styles. It is used by
 /// `TextRun` to decide which font to render a character with. If none of the fonts listed in the

--- a/components/fonts/font_store.rs
+++ b/components/fonts/font_store.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::collections::HashMap;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use log::warn;
@@ -21,7 +22,16 @@ pub struct FontStore {
     web_fonts_loading_for_stylesheets: Vec<(DocumentStyleSheet, usize)>,
     web_fonts_loading_for_script: usize,
 }
-pub(crate) type CrossThreadFontStore = Arc<RwLock<FontStore>>;
+
+#[derive(Default, MallocSizeOf)]
+pub(crate) struct CrossThreadFontStore(#[conditional_malloc_size_of] Arc<RwLock<FontStore>>);
+
+impl Deref for CrossThreadFontStore {
+    type Target = Arc<RwLock<FontStore>>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 impl FontStore {
     pub(crate) fn clear(&mut self) {

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -22,6 +22,7 @@ pub use font_store::*;
 pub use font_template::*;
 pub use glyph::*;
 use ipc_channel::ipc::IpcSharedMemory;
+use malloc_size_of_derive::MallocSizeOf;
 pub use platform::LocalFontIdentifier;
 pub use shaper::*;
 pub use system_font_service::*;
@@ -30,8 +31,8 @@ use unicode_properties::{EmojiStatus, UnicodeEmoji, emoji};
 /// A data structure to store data for fonts. Data is stored internally in an
 /// [`IpcSharedMemory`] handle, so that it can be send without serialization
 /// across IPC channels.
-#[derive(Clone)]
-pub struct FontData(pub(crate) Arc<IpcSharedMemory>);
+#[derive(Clone, MallocSizeOf)]
+pub struct FontData(#[conditional_malloc_size_of] pub(crate) Arc<IpcSharedMemory>);
 
 impl FontData {
     pub fn from_bytes(bytes: &[u8]) -> Self {

--- a/components/fonts/system_font_service.rs
+++ b/components/fonts/system_font_service.rs
@@ -363,7 +363,7 @@ struct FontTemplateCacheKey {
 
 /// The public interface to the [`SystemFontService`], used by per-Document
 /// `FontContext` instances.
-#[derive(Debug)]
+#[derive(Debug, MallocSizeOf)]
 pub struct SystemFontServiceProxy {
     sender: Mutex<IpcSender<SystemFontServiceMessage>>,
     templates: RwLock<HashMap<FontTemplateCacheKey, Vec<FontTemplateRef>>>,

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -23,6 +23,7 @@ ipc-channel = { workspace = true }
 keyboard-types = { workspace = true }
 markup5ever = { workspace = true }
 mime = { workspace = true }
+parking_lot = { workspace = true }
 resvg = { workspace = true }
 servo_allocator = { path = "../allocator" }
 servo_arc = { workspace = true }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -613,6 +613,18 @@ impl<T: MallocSizeOf> MallocSizeOf for std::sync::Mutex<T> {
     }
 }
 
+impl<T: MallocSizeOf> MallocSizeOf for parking_lot::Mutex<T> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        (*self.lock()).size_of(ops)
+    }
+}
+
+impl<T: MallocSizeOf> MallocSizeOf for parking_lot::RwLock<T> {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        (*self.read()).size_of(ops)
+    }
+}
+
 impl<T: MallocSizeOf, Unit> MallocSizeOf for euclid::Length<T, Unit> {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.0.size_of(ops)


### PR DESCRIPTION
Replace a hand-written MallocSizeOf implementation with an automatically derived one. This exposes more than 1MB of previously-untracked heap data on servo.org.

Testing: Compared about:memory output for servo.org before and after.
Part of: #11559 
