### PR TITLE
script: Throw error when lower is greater than upper in IDBKeyRange

### DIFF
--- a/components/script/dom/idbkeyrange.rs
+++ b/components/script/dom/idbkeyrange.rs
@@ -10,7 +10,7 @@ use script_bindings::codegen::GenericBindings::IDBKeyRangeBinding::IDBKeyRangeMe
 use script_bindings::root::DomRoot;
 use script_bindings::script_runtime::CanGc;
 
-use crate::dom::bindings::error::Fallible;
+use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::import::module::SafeJSContext;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::globalscope::GlobalScope;
@@ -111,6 +111,9 @@ impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
     ) -> Fallible<DomRoot<IDBKeyRange>> {
         let lower_key = convert_value_to_key(cx, lower, None)?;
         let upper_key = convert_value_to_key(cx, upper, None)?;
+        if lower_key > upper_key {
+            return Err(Error::Data);
+        }
         let inner =
             IndexedDBKeyRange::new(Some(lower_key), Some(upper_key), lower_open, upper_open);
         Ok(IDBKeyRange::new(global, inner, CanGc::note()))

--- a/components/script/dom/idbkeyrange.rs
+++ b/components/script/dom/idbkeyrange.rs
@@ -109,11 +109,24 @@ impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
         lower_open: bool,
         upper_open: bool,
     ) -> Fallible<DomRoot<IDBKeyRange>> {
+        // Step 1. Let lowerKey be the result of running the steps to convert a value to a key with
+        // lower. Rethrow any exceptions.
+        // Step 2. If lowerKey is invalid, throw a "DataError" DOMException.
         let lower_key = convert_value_to_key(cx, lower, None)?;
+
+        // Step 3. Let upperKey be the result of running the steps to convert a value to a key with
+        // upper. Rethrow any exceptions.
+        // Step 4. If upperKey is invalid, throw a "DataError" DOMException.
         let upper_key = convert_value_to_key(cx, upper, None)?;
+
+        // Step 5. If lowerKey is greater than upperKey, throw a "DataError" DOMException.
         if lower_key > upper_key {
             return Err(Error::Data);
         }
+
+        // Step 6. Create and return a new key range with lower bound set to lowerKey, lower open
+        // flag set if lowerOpen is true, upper bound set to upperKey and upper open flag set if
+        // upperOpen is true.
         let inner =
             IndexedDBKeyRange::new(Some(lower_key), Some(upper_key), lower_open, upper_open);
         Ok(IDBKeyRange::new(global, inner, CanGc::note()))

--- a/tests/wpt/meta/IndexedDB/idbkeyrange_incorrect.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbkeyrange_incorrect.any.js.ini
@@ -1,15 +1,9 @@
 [idbkeyrange_incorrect.any.html]
-  [IDBKeyRange.bound(lower, upper / lower > upper) - lower' is greater than 'upper'.]
-    expected: FAIL
-
   [IDBKeyRange.bound(DOMString/Date/Array, 1) - A DOMString, Date and Array are greater than a float.]
     expected: FAIL
 
 
 [idbkeyrange_incorrect.any.worker.html]
-  [IDBKeyRange.bound(lower, upper / lower > upper) - lower' is greater than 'upper'.]
-    expected: FAIL
-
   [IDBKeyRange.bound(DOMString/Date/Array, 1) - A DOMString, Date and Array are greater than a float.]
     expected: FAIL
 


### PR DESCRIPTION
IDBKeyRange::Bound doesn't check if the lower bound is greater than the upper bound. When this happens, it should throw DataError.

Reference: Step 5 of <https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-bound>

Testing: Passing WPT tests that were expected to fail before.
