### PR TITLE
Enable access to transaction from idbobjectstore

### DIFF
--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -449,9 +449,9 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
     // }
 
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-transaction
-    // fn Transaction(&self) -> DomRoot<IDBTransaction> {
-    //     unimplemented!();
-    // }
+    fn GetTransaction(&self) -> Option<DomRoot<IDBTransaction>> {
+        self.transaction()
+    }
 
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-autoincrement
     fn AutoIncrement(&self) -> bool {

--- a/components/script_bindings/webidls/IDBObjectStore.webidl
+++ b/components/script_bindings/webidls/IDBObjectStore.webidl
@@ -13,7 +13,7 @@ interface IDBObjectStore {
   attribute DOMString name;
   // readonly attribute any keyPath;
   // readonly attribute DOMStringList indexNames;
-  // [SameObject] readonly attribute IDBTransaction transaction;
+  [SameObject] readonly attribute IDBTransaction? transaction;
   readonly attribute boolean autoIncrement;
 
   [NewObject, Throws] IDBRequest put(any value, optional any key);

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_get.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_get.any.js.ini
@@ -2,13 +2,8 @@
   expected: ERROR
 
 [idbobjectstore_get.any.html]
-  [When a transaction is aborted, throw TransactionInactiveError]
-    expected: FAIL
-
 
 [idbobjectstore_get.any.serviceworker.html]
   expected: ERROR
 
 [idbobjectstore_get.any.worker.html]
-  [When a transaction is aborted, throw TransactionInactiveError]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
@@ -11,9 +11,6 @@
   [IDBObjectStore interface: attribute indexNames]
     expected: FAIL
 
-  [IDBObjectStore interface: attribute transaction]
-    expected: FAIL
-
   [IDBObjectStore interface: operation getAll(optional any, optional unsigned long)]
     expected: FAIL
 
@@ -176,9 +173,6 @@
     expected: FAIL
 
   [IDBObjectStore interface: attribute indexNames]
-    expected: FAIL
-
-  [IDBObjectStore interface: attribute transaction]
     expected: FAIL
 
   [IDBObjectStore interface: operation getAll(optional any, optional unsigned long)]


### PR DESCRIPTION
Adds the transaction property to IDBObjectStore, as per spec.

Testing: WPT
Fixes: None