### PR TITLE
script: Ensure autoincrement and keypath are passed in correctly from IDBTransaction

### DIFF
--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use dom_struct::dom_struct;
 use js::gc::MutableHandleValue;
-use js::jsval::{NullValue, UndefinedValue};
+use js::jsval::NullValue;
 use js::rust::HandleValue;
 use net_traits::IpcSend;
 use net_traits::indexeddb_thread::{
@@ -517,17 +517,13 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
 
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-keypath
     fn KeyPath(&self, cx: SafeJSContext, mut ret_val: MutableHandleValue) {
-        if let Some(key_path) = self.key_path.clone() {
+        if let Some(key_path) = &self.key_path {
             match key_path {
                 KeyPath::String(path) => {
-                    rooted!(in(*cx) let mut rooted_path = UndefinedValue());
-                    path.safe_to_jsval(cx, rooted_path.handle_mut());
-                    ret_val.set(*rooted_path)
+                    path.safe_to_jsval(cx, ret_val);
                 },
                 KeyPath::StringSequence(paths) => {
-                    rooted!(in(*cx) let mut rooted_sequence = UndefinedValue());
-                    paths.safe_to_jsval(cx, rooted_sequence.handle_mut());
-                    ret_val.set(*rooted_sequence);
+                    paths.safe_to_jsval(cx, ret_val);
                 },
             }
         } else {

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use dom_struct::dom_struct;
 use js::gc::MutableHandleValue;
 use js::jsval::NullValue;
@@ -517,17 +518,10 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
 
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-keypath
     fn KeyPath(&self, cx: SafeJSContext, mut ret_val: MutableHandleValue) {
-        if let Some(key_path) = &self.key_path {
-            match key_path {
-                KeyPath::String(path) => {
-                    path.safe_to_jsval(cx, ret_val);
-                },
-                KeyPath::StringSequence(paths) => {
-                    paths.safe_to_jsval(cx, ret_val);
-                },
-            }
-        } else {
-            ret_val.set(NullValue());
+        match &self.key_path {
+            Some(KeyPath::String(path)) =>  path.safe_to_jsval(cx, ret_val),
+            Some(KeyPath::StringSequence(paths)) => paths.safe_to_jsval(cx, ret_val),
+            None => ret_val.set(NullValue()),
         }
     }
 

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -519,7 +519,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-keypath
     fn KeyPath(&self, cx: SafeJSContext, mut ret_val: MutableHandleValue) {
         match &self.key_path {
-            Some(KeyPath::String(path)) =>  path.safe_to_jsval(cx, ret_val),
+            Some(KeyPath::String(path)) => path.safe_to_jsval(cx, ret_val),
             Some(KeyPath::StringSequence(paths)) => paths.safe_to_jsval(cx, ret_val),
             None => ret_val.set(NullValue()),
         }

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -133,38 +133,6 @@ impl IDBObjectStore {
         receiver.recv().unwrap().unwrap()
     }
 
-    // fn get_stored_key_path(&mut self) -> Option<KeyPath> {
-    //     let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
-    //
-    //     let operation = SyncOperation::KeyPath(
-    //         sender,
-    //         self.global().origin().immutable().clone(),
-    //         self.db_name.to_string(),
-    //         self.name.borrow().to_string(),
-    //     );
-    //
-    //     self.global()
-    //         .resource_threads()
-    //         .sender()
-    //         .send(IndexedDBThreadMsg::Sync(operation))
-    //         .unwrap();
-    //
-    //     // First unwrap for ipc
-    //     // Second unwrap will never happen unless this db gets manually deleted somehow
-    //     let key_path = receiver.recv().unwrap().unwrap();
-    //     key_path.map(|p| {
-    //         // TODO: have separate storage for string sequence of len 1 and signle string
-    //         if p.len() == 1 {
-    //             KeyPath::String(DOMString::from_string(p[0].clone()))
-    //         } else {
-    //             let strings: Vec<_> = p.into_iter().map(|s| {
-    //                 DOMString::from_string(s)
-    //             }).collect();
-    //             KeyPath::StringSequence(strings)
-    //         }
-    //     })
-    // }
-
     // https://www.w3.org/TR/IndexedDB-2/#object-store-in-line-keys
     fn uses_inline_keys(&self) -> bool {
         self.key_path.is_some()

--- a/components/script/dom/idbtransaction.rs
+++ b/components/script/dom/idbtransaction.rs
@@ -206,7 +206,7 @@ impl IDBTransaction {
         self.global().resource_threads().sender()
     }
 
-    fn get_object_store_parameters(
+    fn object_store_parameters(
         &self,
         object_store_name: &DOMString,
     ) -> Option<IDBObjectStoreParameters> {
@@ -279,7 +279,7 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
         // returns the same IDBObjectStore instance.
         let mut store_handles = self.store_handles.borrow_mut();
         let store = store_handles.entry(name.to_string()).or_insert_with(|| {
-            let parameters = self.get_object_store_parameters(&name);
+            let parameters = self.object_store_parameters(&name);
             let store = IDBObjectStore::new(
                 &self.global(),
                 self.db.get_name(),

--- a/components/script_bindings/webidls/IDBObjectStore.webidl
+++ b/components/script_bindings/webidls/IDBObjectStore.webidl
@@ -13,7 +13,7 @@ interface IDBObjectStore {
   [SetterThrows] attribute DOMString name;
   readonly attribute any keyPath;
   readonly attribute DOMStringList indexNames;
-  [SameObject] readonly attribute IDBTransaction? transaction;
+  [SameObject] readonly attribute IDBTransaction transaction;
   readonly attribute boolean autoIncrement;
 
   [NewObject, Throws] IDBRequest put(any value, optional any key);

--- a/components/script_bindings/webidls/IDBObjectStore.webidl
+++ b/components/script_bindings/webidls/IDBObjectStore.webidl
@@ -13,7 +13,7 @@ interface IDBObjectStore {
   [SetterThrows] attribute DOMString name;
   readonly attribute any keyPath;
   readonly attribute DOMStringList indexNames;
-  [SameObject] readonly attribute IDBTransaction transaction;
+  [SameObject] readonly attribute IDBTransaction? transaction;
   readonly attribute boolean autoIncrement;
 
   [NewObject, Throws] IDBRequest put(any value, optional any key);

--- a/components/script_bindings/webidls/IDBObjectStore.webidl
+++ b/components/script_bindings/webidls/IDBObjectStore.webidl
@@ -11,8 +11,8 @@
 [Pref="dom_indexeddb_enabled", Exposed=(Window,Worker)]
 interface IDBObjectStore {
   [SetterThrows] attribute DOMString name;
-  // readonly attribute any keyPath;
-  // readonly attribute DOMStringList indexNames;
+  readonly attribute any keyPath;
+  readonly attribute DOMStringList indexNames;
   [SameObject] readonly attribute IDBTransaction transaction;
   readonly attribute boolean autoIncrement;
 

--- a/tests/wpt/meta/IndexedDB/clone-before-keypath-eval.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/clone-before-keypath-eval.any.js.ini
@@ -11,6 +11,9 @@
   [Index key path evaluations operate on a clone]
     expected: FAIL
 
+  [Key generator and key path validity check operates on a clone]
+    expected: FAIL
+
 
 [clone-before-keypath-eval.any.serviceworker.html]
   expected: ERROR
@@ -26,6 +29,9 @@
     expected: FAIL
 
   [Index key path evaluations operate on a clone]
+    expected: FAIL
+
+  [Key generator and key path validity check operates on a clone]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbdatabase_createObjectStore.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbdatabase_createObjectStore.any.js.ini
@@ -5,9 +5,6 @@
   [Both with empty name]
     expected: FAIL
 
-  [Object store 'name' and 'keyPath' properties are correctly set ]
-    expected: FAIL
-
   [Attempt to create an object store outside of a version change transaction ]
     expected: FAIL
 
@@ -20,9 +17,6 @@
 
 [idbdatabase_createObjectStore.any.worker.html]
   [Both with empty name]
-    expected: FAIL
-
-  [Object store 'name' and 'keyPath' properties are correctly set ]
     expected: FAIL
 
   [Attempt to create an object store outside of a version change transaction ]

--- a/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
@@ -14,9 +14,6 @@
   [Calling open() with version argument 9007199254740991 should not throw.]
     expected: FAIL
 
-  [Calling open() with version argument 1.5 should not throw.]
-    expected: FAIL
-
 
 [idbfactory_open.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
@@ -14,6 +14,9 @@
   [Calling open() with version argument 9007199254740991 should not throw.]
     expected: FAIL
 
+  [Calling open() with version argument 1.5 should not throw.]
+    expected: FAIL
+
 
 [idbfactory_open.any.sharedworker.html]
   expected: ERROR
@@ -35,7 +38,4 @@
     expected: FAIL
 
   [Calling open() with version argument 9007199254740991 should not throw.]
-    expected: FAIL
-
-  [Calling open() with version argument 1.5 should not throw.]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_get.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_get.any.js.ini
@@ -2,9 +2,6 @@
   expected: ERROR
 
 [idbobjectstore_get.any.html]
-  [Attempts to retrieve a record that doesn't exist]
-    expected: FAIL
-
 
 [idbobjectstore_get.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_get.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_get.any.js.ini
@@ -2,6 +2,9 @@
   expected: ERROR
 
 [idbobjectstore_get.any.html]
+  [Attempts to retrieve a record that doesn't exist]
+    expected: FAIL
+
 
 [idbobjectstore_get.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAll-options.tentative.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAll-options.tentative.any.js.ini
@@ -68,9 +68,6 @@
   [Get all values with both options and count]
     expected: FAIL
 
-  [Get all values with invalid query keys]
-    expected: FAIL
-
 
 [idbobjectstore_getAll-options.tentative.any.serviceworker.html]
   expected: ERROR
@@ -146,7 +143,4 @@
     expected: FAIL
 
   [Get all values with both options and count]
-    expected: FAIL
-
-  [Get all values with invalid query keys]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAll.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAll.any.js.ini
@@ -1,7 +1,4 @@
 [idbobjectstore_getAll.any.html]
-  [Single item get]
-    expected: FAIL
-
   [Single item get (generated key)]
     expected: FAIL
 
@@ -17,12 +14,6 @@
   [Test maxCount]
     expected: FAIL
 
-  [Get bound range]
-    expected: FAIL
-
-  [Get bound range with maxCount]
-    expected: FAIL
-
   [Get upper excluded]
     expected: FAIL
 
@@ -32,19 +23,10 @@
   [Get bound range (generated) with maxCount]
     expected: FAIL
 
-  [Non existent key]
-    expected: FAIL
-
   [zero maxCount]
     expected: FAIL
 
   [Max value count]
-    expected: FAIL
-
-  [Query with empty range where  first key < upperBound]
-    expected: FAIL
-
-  [Query with empty range where lowerBound < last key]
     expected: FAIL
 
   [Get all values with transaction.commit()]
@@ -58,9 +40,6 @@
   expected: ERROR
 
 [idbobjectstore_getAll.any.worker.html]
-  [Single item get]
-    expected: FAIL
-
   [Single item get (generated key)]
     expected: FAIL
 
@@ -76,12 +55,6 @@
   [Test maxCount]
     expected: FAIL
 
-  [Get bound range]
-    expected: FAIL
-
-  [Get bound range with maxCount]
-    expected: FAIL
-
   [Get upper excluded]
     expected: FAIL
 
@@ -91,19 +64,10 @@
   [Get bound range (generated) with maxCount]
     expected: FAIL
 
-  [Non existent key]
-    expected: FAIL
-
   [zero maxCount]
     expected: FAIL
 
   [Max value count]
-    expected: FAIL
-
-  [Query with empty range where  first key < upperBound]
-    expected: FAIL
-
-  [Query with empty range where lowerBound < last key]
     expected: FAIL
 
   [Get all values with transaction.commit()]

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys-options.tentative.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys-options.tentative.any.js.ini
@@ -65,9 +65,6 @@
   [Get all keys with both options and count]
     expected: FAIL
 
-  [Get all keys with invalid query keys]
-    expected: FAIL
-
 
 [idbobjectstore_getAllKeys-options.tentative.any.serviceworker.html]
   expected: ERROR
@@ -137,9 +134,6 @@
     expected: FAIL
 
   [Get all keys with both options and count]
-    expected: FAIL
-
-  [Get all keys with invalid query keys]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys.any.js.ini
@@ -5,12 +5,6 @@
   expected: ERROR
 
 [idbobjectstore_getAllKeys.any.worker.html]
-  [Single item get]
-    expected: FAIL
-
-  [Single item get (generated key)]
-    expected: FAIL
-
   [getAllKeys on empty object store]
     expected: FAIL
 
@@ -20,34 +14,16 @@
   [Test maxCount]
     expected: FAIL
 
-  [Get bound range]
-    expected: FAIL
-
-  [Get bound range with maxCount]
-    expected: FAIL
-
   [Get upper excluded]
     expected: FAIL
 
   [Get lower excluded]
     expected: FAIL
 
-  [Get bound range (generated) with maxCount]
-    expected: FAIL
-
-  [Non existent key]
-    expected: FAIL
-
   [zero maxCount]
     expected: FAIL
 
   [Max value count]
-    expected: FAIL
-
-  [Query with empty range where  first key < upperBound]
-    expected: FAIL
-
-  [Query with empty range where lowerBound < last key]
     expected: FAIL
 
   [Get all keys with invalid query keys]
@@ -55,12 +31,6 @@
 
 
 [idbobjectstore_getAllKeys.any.html]
-  [Single item get]
-    expected: FAIL
-
-  [Single item get (generated key)]
-    expected: FAIL
-
   [getAllKeys on empty object store]
     expected: FAIL
 
@@ -70,34 +40,16 @@
   [Test maxCount]
     expected: FAIL
 
-  [Get bound range]
-    expected: FAIL
-
-  [Get bound range with maxCount]
-    expected: FAIL
-
   [Get upper excluded]
     expected: FAIL
 
   [Get lower excluded]
     expected: FAIL
 
-  [Get bound range (generated) with maxCount]
-    expected: FAIL
-
-  [Non existent key]
-    expected: FAIL
-
   [zero maxCount]
     expected: FAIL
 
   [Max value count]
-    expected: FAIL
-
-  [Query with empty range where  first key < upperBound]
-    expected: FAIL
-
-  [Query with empty range where lowerBound < last key]
     expected: FAIL
 
   [Get all keys with invalid query keys]

--- a/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
@@ -5,12 +5,6 @@
   [IDBFactory interface: operation databases()]
     expected: FAIL
 
-  [IDBObjectStore interface: attribute keyPath]
-    expected: FAIL
-
-  [IDBObjectStore interface: attribute indexNames]
-    expected: FAIL
-
   [IDBObjectStore interface: operation openCursor(optional any, optional IDBCursorDirection)]
     expected: FAIL
 
@@ -113,12 +107,6 @@
 
 [idlharness.any.worker.html]
   [IDBFactory interface: operation databases()]
-    expected: FAIL
-
-  [IDBObjectStore interface: attribute keyPath]
-    expected: FAIL
-
-  [IDBObjectStore interface: attribute indexNames]
     expected: FAIL
 
   [IDBObjectStore interface: operation openCursor(optional any, optional IDBCursorDirection)]

--- a/tests/wpt/meta/IndexedDB/keypath-special-identifiers.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/keypath-special-identifiers.any.js.ini
@@ -1,15 +1,16 @@
 [keypath-special-identifiers.any.html]
+  expected: TIMEOUT
   [Type: String, identifier: length]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Type: Array, identifier: length]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Type: Blob, identifier: size]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Type: Blob, identifier: type]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Type: File, identifier: name]
     expected: FAIL
@@ -25,17 +26,18 @@
   expected: ERROR
 
 [keypath-special-identifiers.any.worker.html]
+  expected: TIMEOUT
   [Type: String, identifier: length]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Type: Array, identifier: length]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Type: Blob, identifier: size]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Type: Blob, identifier: type]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Type: File, identifier: name]
     expected: FAIL


### PR DESCRIPTION
Previously, the correct autoincremented and keypath parameters were only being passed if the object store is being created. This PR queries this info from the backend and passes it onto the constructor in IDBTransaction. Furthermore it exposes keypath and index_names from IDBObjectStore, mainly for WPT.

Testing: WPT
Fixes: None