### PR TITLE
script: correctly handle indexeddb backend errors

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -94,7 +94,7 @@ pub(crate) fn throw_dom_exception(
 /// If possible, create a new DOMException representing the provided error.
 /// If no such DOMException exists, return a subset of the original error values
 /// that may need additional handling.
-fn create_dom_exception(
+pub(crate) fn create_dom_exception(
     global: &GlobalScope,
     result: Error,
     can_gc: CanGc,

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -41,7 +41,7 @@ thread_local! {
 }
 
 /// Error values that have no equivalent DOMException representation.
-enum JsEngineError {
+pub(crate) enum JsEngineError {
     /// An EMCAScript TypeError.
     Type(String),
     /// An ECMAScript RangeError.

--- a/components/script/dom/idbopendbrequest.rs
+++ b/components/script/dom/idbopendbrequest.rs
@@ -15,7 +15,6 @@ use stylo_atoms::Atom;
 use crate::dom::bindings::codegen::Bindings::IDBOpenDBRequestBinding::IDBOpenDBRequestMethods;
 use crate::dom::bindings::codegen::Bindings::IDBTransactionBinding::IDBTransactionMode;
 use crate::dom::bindings::error::{Error, Fallible};
-use crate::dom::bindings::import::base::SafeJSContext;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
@@ -221,8 +220,8 @@ impl IDBOpenDBRequest {
         self.idbrequest.set_result(result);
     }
 
-    pub fn set_error(&self, cx: SafeJSContext, error: Option<Error>, can_gc: CanGc) {
-        self.idbrequest.set_error(cx, error, can_gc);
+    pub fn set_error(&self, error: Option<Error>, can_gc: CanGc) {
+        self.idbrequest.set_error(error, can_gc);
     }
 
     pub fn open_database(&self, name: DOMString, version: Option<u64>) {
@@ -256,7 +255,6 @@ impl IDBOpenDBRequest {
 
                 task_source.queue(
                     task!(set_request_result_to_database: move || {
-                        let cx = GlobalScope::get_cx();
                         let (result, did_upgrade) =
                             response_listener.handle_open_db(name, version, message.unwrap(), CanGc::note());
                         // If an upgrade event was created, it will be responsible for
@@ -272,7 +270,7 @@ impl IDBOpenDBRequest {
                             },
                             Err(dom_exception) => {
                                 request.set_result(HandleValue::undefined());
-                                request.set_error(cx, Some(dom_exception), CanGc::note());
+                                request.set_error(Some(dom_exception), CanGc::note());
                                 let event = Event::new(
                                     &global,
                                     Atom::from("error"),

--- a/components/script/dom/idbopendbrequest.rs
+++ b/components/script/dom/idbopendbrequest.rs
@@ -15,6 +15,7 @@ use stylo_atoms::Atom;
 use crate::dom::bindings::codegen::Bindings::IDBOpenDBRequestBinding::IDBOpenDBRequestMethods;
 use crate::dom::bindings::codegen::Bindings::IDBTransactionBinding::IDBTransactionMode;
 use crate::dom::bindings::error::{Error, Fallible};
+use crate::dom::bindings::import::base::SafeJSContext;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
@@ -220,8 +221,8 @@ impl IDBOpenDBRequest {
         self.idbrequest.set_result(result);
     }
 
-    pub fn set_error(&self, error: Error, can_gc: CanGc) {
-        self.idbrequest.set_error(error, can_gc);
+    pub fn set_error(&self, cx: SafeJSContext, error: Option<Error>, can_gc: CanGc) {
+        self.idbrequest.set_error(cx, error, can_gc);
     }
 
     pub fn open_database(&self, name: DOMString, version: Option<u64>) {
@@ -255,6 +256,7 @@ impl IDBOpenDBRequest {
 
                 task_source.queue(
                     task!(set_request_result_to_database: move || {
+                        let cx = GlobalScope::get_cx();
                         let (result, did_upgrade) =
                             response_listener.handle_open_db(name, version, message.unwrap(), CanGc::note());
                         // If an upgrade event was created, it will be responsible for
@@ -270,7 +272,7 @@ impl IDBOpenDBRequest {
                             },
                             Err(dom_exception) => {
                                 request.set_result(HandleValue::undefined());
-                                request.set_error(dom_exception, CanGc::note());
+                                request.set_error(cx, Some(dom_exception), CanGc::note());
                                 let event = Event::new(
                                     &global,
                                     Atom::from("error"),

--- a/components/script/dom/idbrequest.rs
+++ b/components/script/dom/idbrequest.rs
@@ -253,8 +253,7 @@ impl IDBRequest {
 
     pub fn set_error(&self, error: Option<Error>, can_gc: CanGc) {
         if let Some(error) = error {
-            if let Ok(exception) = create_dom_exception(&self.global(), error, can_gc)
-            {
+            if let Ok(exception) = create_dom_exception(&self.global(), error, can_gc) {
                 self.error.set(Some(&exception));
             }
         } else {

--- a/components/script/dom/idbrequest.rs
+++ b/components/script/dom/idbrequest.rs
@@ -253,7 +253,7 @@ impl IDBRequest {
 
     pub fn set_error(&self, error: Option<Error>, can_gc: CanGc) {
         if let Some(error) = error {
-            if let Some(exception) = create_dom_exception(&self.global(), error, can_gc)
+            if let Ok(exception) = create_dom_exception(&self.global(), error, can_gc)
             {
                 self.error.set(Some(&exception));
             }

--- a/components/script/dom/idbrequest.rs
+++ b/components/script/dom/idbrequest.rs
@@ -143,7 +143,7 @@ impl RequestListener {
             request.set_result(answer.handle());
 
             // Substep 3.2: Set the error of request to undefined
-            request.set_error(cx, None, CanGc::note());
+            request.set_error(None, CanGc::note());
 
             // Substep 3.3: Fire a success event at request.
             // TODO: follow spec here
@@ -185,7 +185,7 @@ impl RequestListener {
         request.set_result(undefined.handle());
 
         // Substep 2: Set the error of request to result.
-        request.set_error(cx, Some(error), CanGc::note());
+        request.set_error(Some(error), CanGc::note());
 
         // Substep 3: Fire an error event at request.
         // TODO: follow the spec here
@@ -251,7 +251,7 @@ impl IDBRequest {
         self.result.set(result.get());
     }
 
-    pub fn set_error(&self, cx: SafeJSContext, error: Option<Error>, can_gc: CanGc) {
+    pub fn set_error(&self, error: Option<Error>, can_gc: CanGc) {
         if let Some(error) = error {
             if let Some(exception) = create_dom_exception_from_error(&self.global(), error, can_gc)
             {

--- a/components/script/dom/idbrequest.rs
+++ b/components/script/dom/idbrequest.rs
@@ -23,7 +23,7 @@ use crate::dom::bindings::codegen::Bindings::IDBRequestBinding::{
     IDBRequestMethods, IDBRequestReadyState,
 };
 use crate::dom::bindings::codegen::Bindings::IDBTransactionBinding::IDBTransactionMode;
-use crate::dom::bindings::error::{Error, Fallible, create_dom_exception_from_error};
+use crate::dom::bindings::error::{Error, Fallible, create_dom_exception};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
@@ -253,7 +253,7 @@ impl IDBRequest {
 
     pub fn set_error(&self, error: Option<Error>, can_gc: CanGc) {
         if let Some(error) = error {
-            if let Some(exception) = create_dom_exception_from_error(&self.global(), error, can_gc)
+            if let Some(exception) = create_dom_exception(&self.global(), error, can_gc)
             {
                 self.error.set(Some(&exception));
             }

--- a/components/script/dom/idbrequest.rs
+++ b/components/script/dom/idbrequest.rs
@@ -23,7 +23,7 @@ use crate::dom::bindings::codegen::Bindings::IDBRequestBinding::{
     IDBRequestMethods, IDBRequestReadyState,
 };
 use crate::dom::bindings::codegen::Bindings::IDBTransactionBinding::IDBTransactionMode;
-use crate::dom::bindings::error::{Error, Fallible, error_to_dom_error_name};
+use crate::dom::bindings::error::{Error, Fallible, create_dom_exception_from_error};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
@@ -253,9 +253,10 @@ impl IDBRequest {
 
     pub fn set_error(&self, cx: SafeJSContext, error: Option<Error>, can_gc: CanGc) {
         if let Some(error) = error {
-            if let Some(error_name) = error_to_dom_error_name(cx, &self.global(), error, can_gc) {
-                self.error
-                    .set(Some(&DOMException::new(&self.global(), error_name, can_gc)));
+            if let Some(exception) =
+                create_dom_exception_from_error(cx, &self.global(), error, can_gc)
+            {
+                self.error.set(Some(&exception));
             }
         } else {
             self.error.set(None);

--- a/components/script/dom/idbrequest.rs
+++ b/components/script/dom/idbrequest.rs
@@ -253,8 +253,7 @@ impl IDBRequest {
 
     pub fn set_error(&self, cx: SafeJSContext, error: Option<Error>, can_gc: CanGc) {
         if let Some(error) = error {
-            if let Some(exception) =
-                create_dom_exception_from_error(cx, &self.global(), error, can_gc)
+            if let Some(exception) = create_dom_exception_from_error(&self.global(), error, can_gc)
             {
                 self.error.set(Some(&exception));
             }

--- a/tests/wpt/meta/IndexedDB/error-attributes.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/error-attributes.any.js.ini
@@ -1,11 +1,13 @@
 [error-attributes.any.worker.html]
+  expected: TIMEOUT
   [IDBRequest and IDBTransaction error properties should be DOMExceptions]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [error-attributes.any.html]
+  expected: TIMEOUT
   [IDBRequest and IDBTransaction error properties should be DOMExceptions]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [error-attributes.any.sharedworker.html]


### PR DESCRIPTION
Sets the indexeddb request error when the backend errors out. This also matches statements to the spec.

Testing: Covered by WPT
Fixes: General indexeddb