### PR TITLE
CI: Bump setup-ohos-sdk to 0.2.3

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -67,7 +67,7 @@ jobs:
         run: sudo apt update && ./mach bootstrap --skip-lints
       - name: Setup OpenHarmony SDK
         id: setup_sdk
-        uses: openharmony-rs/setup-ohos-sdk@v0.2.1
+        uses: openharmony-rs/setup-ohos-sdk@v0.2.3
         with:
           version: "5.0.2"
           fixup-path: true


### PR DESCRIPTION
Includes a fix, which deletes the SDK for ohos-native hosts, saving some disk and cache space, since we only need the version for linux hosts.

Testing: [mach try ohos](https://github.com/jschwe/servo/actions/runs/17024914816)