### PR TITLE
webdriver: Change `TickActions` to vector rather than hashmap

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -42,7 +42,6 @@ pub(crate) enum ActionItem {
 }
 
 // A set of actions with multiple sources executed within a single tick.
-// The order in which they are performed is not guaranteed.
 // The `id` is used to identify the source of the actions.
 pub(crate) type TickActions = Vec<(String, ActionItem)>;
 

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -44,7 +44,7 @@ pub(crate) enum ActionItem {
 // A set of actions with multiple sources executed within a single tick.
 // The order in which they are performed is not guaranteed.
 // The `id` is used to identify the source of the actions.
-pub(crate) type TickActions = HashMap<String, ActionItem>;
+pub(crate) type TickActions = Vec<(String, ActionItem)>;
 
 // Consumed by the `dispatch_actions` method.
 pub(crate) type ActionsByTick = Vec<TickActions>;
@@ -859,12 +859,12 @@ impl Handler {
 
             // Step 4.2.2. Ensure we have enough ticks to hold all actions
             while actions_by_tick.len() < source_actions.len() {
-                actions_by_tick.push(HashMap::new());
+                actions_by_tick.push(Vec::new());
             }
 
             // Step 4.2.3.
             for (tick_index, action_item) in source_actions.into_iter().enumerate() {
-                actions_by_tick[tick_index].insert(id.clone(), action_item);
+                actions_by_tick[tick_index].push((id.clone(), action_item));
             }
         }
 

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2004,7 +2004,7 @@ impl Handler {
             .borrow_mut()
             .drain(..)
             .rev()
-            .map(|(id, action_item)| HashMap::from([(id, action_item)]))
+            .map(|(id, action_item)| Vec::from([(id, action_item)]))
             .collect();
         // Step 7. Dispatch undo actions with current browsing context.
         if let Err(err) = self.dispatch_actions(undo_actions, session.browsing_context_id) {

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_contextmenu.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_contextmenu.py.ini
@@ -1,6 +1,0 @@
-[pointer_contextmenu.py]
-  [test_control_click[\\ue009-ctrlKey\]]
-    expected: FAIL
-
-  [test_control_click[\\ue051-ctrlKey\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_modifier_click.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_modifier_click.py.ini
@@ -1,3 +1,0 @@
-[pointer_modifier_click.py]
-  [test_many_modifiers_click]
-    expected: FAIL


### PR DESCRIPTION
Based on [spec](https://w3c.github.io/webdriver/#dfn-extract-an-action-sequence), `TickActions` should be a list. Previously we used Hashmap, which when iterated has arbitrary order. This causes some tests to be unstable previously (see the linked issue).

Testing: `./webdriver/tests/classic/perform_actions/{pointer_contextmenu, pointer_modifier_click}.py` consistently pass now.
Fixes: https://github.com/servo/servo/issues/38387
