### PR TITLE
embedder: Remove `Int` variant from `WebDriverJSValue`

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -367,14 +367,7 @@ unsafe fn jsval_to_webdriver_inner(
         Ok(WebDriverJSValue::Null)
     } else if val.get().is_boolean() {
         Ok(WebDriverJSValue::Boolean(val.get().to_boolean()))
-    } else if val.get().is_int32() {
-        Ok(WebDriverJSValue::Int(
-            match FromJSValConvertible::from_jsval(cx, val, ConversionBehavior::Default).unwrap() {
-                ConversionResult::Success(c) => c,
-                _ => unreachable!(),
-            },
-        ))
-    } else if val.get().is_double() {
+    } else if val.get().is_number() {
         Ok(WebDriverJSValue::Number(
             match FromJSValConvertible::from_jsval(cx, val, ()).unwrap() {
                 ConversionResult::Success(c) => c,

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -1009,7 +1009,6 @@ impl From<&WebDriverJSValue> for JSValue {
             WebDriverJSValue::Undefined => Self::Undefined,
             WebDriverJSValue::Null => Self::Null,
             WebDriverJSValue::Boolean(value) => Self::Boolean(*value),
-            WebDriverJSValue::Int(value) => Self::Number(*value as f64),
             WebDriverJSValue::Number(value) => Self::Number(*value),
             WebDriverJSValue::String(value) => Self::String(value.clone()),
             WebDriverJSValue::Element(web_element) => Self::Element(web_element.0.clone()),

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -259,7 +259,6 @@ pub enum WebDriverJSValue {
     Undefined,
     Null,
     Boolean(bool),
-    Int(i32),
     Number(f64),
     String(String),
     Element(WebElement),

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -305,7 +305,6 @@ impl Serialize for SendableWebDriverJSValue {
             WebDriverJSValue::Undefined => serializer.serialize_unit(),
             WebDriverJSValue::Null => serializer.serialize_unit(),
             WebDriverJSValue::Boolean(x) => serializer.serialize_bool(x),
-            WebDriverJSValue::Int(x) => serializer.serialize_i32(x),
             WebDriverJSValue::Number(x) => serializer.serialize_f64(x),
             WebDriverJSValue::String(ref x) => serializer.serialize_str(x),
             WebDriverJSValue::Element(ref x) => x.serialize(serializer),


### PR DESCRIPTION
According to [spec](https://w3c.github.io/webdriver/#dfn-json-deserialize), we should only care about [Number](https://262.ecma-international.org/5.1/#sec-4.3.19) that is f64.

This change also closes the gap between `JSValue` and `WebDriverJSValue` and potentially merge into one in the future.

Testing: No regression. However, we have lots of TIMEOUT due to https://github.com/servo/servo/pull/38622.