### PR TITLE
Enable dom_abort_controller_enabled for AbortController test subdirectory

### DIFF
--- a/tests/wpt/meta/dom/abort/__dir__.ini
+++ b/tests/wpt/meta/dom/abort/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "dom_abort_controller_enabled:true",
+]

--- a/tests/wpt/meta/dom/abort/abort-signal-any.any.js.ini
+++ b/tests/wpt/meta/dom/abort/abort-signal-any.any.js.ini
@@ -1,10 +1,86 @@
 [abort-signal-any.any.worker.html]
-  expected: ERROR
   [AbortSignal.any() works with an empty array of signals]
+    expected: FAIL
+
+  [AbortSignal.any() follows a single signal (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() follows multiple signals (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() returns an aborted signal if passed an aborted signal (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() can be passed the same signal more than once (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() uses the first instance of a duplicate signal (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() signals are composable (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() works with signals returned by AbortSignal.timeout() (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() works with intermediate signals (using AbortController)]
+    expected: FAIL
+
+  [Abort events for AbortSignal.any() signals fire in the right order (using AbortController)]
+    expected: FAIL
+
+  [Dependent signals for AbortSignal.any() are marked aborted before abort events fire (using AbortController)]
+    expected: FAIL
+
+  [Dependent signals for AbortSignal.any() are aborted correctly for reentrant aborts (using AbortController)]
+    expected: FAIL
+
+  [Dependent signals for AbortSignal.any() should use the same DOMException instance from the already aborted source signal (using AbortController)]
+    expected: FAIL
+
+  [Dependent signals for AbortSignal.any() should use the same DOMException instance from the source signal being aborted later (using AbortController)]
     expected: FAIL
 
 
 [abort-signal-any.any.html]
-  expected: ERROR
   [AbortSignal.any() works with an empty array of signals]
+    expected: FAIL
+
+  [AbortSignal.any() follows a single signal (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() follows multiple signals (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() returns an aborted signal if passed an aborted signal (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() can be passed the same signal more than once (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() uses the first instance of a duplicate signal (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() signals are composable (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() works with signals returned by AbortSignal.timeout() (using AbortController)]
+    expected: FAIL
+
+  [AbortSignal.any() works with intermediate signals (using AbortController)]
+    expected: FAIL
+
+  [Abort events for AbortSignal.any() signals fire in the right order (using AbortController)]
+    expected: FAIL
+
+  [Dependent signals for AbortSignal.any() are marked aborted before abort events fire (using AbortController)]
+    expected: FAIL
+
+  [Dependent signals for AbortSignal.any() are aborted correctly for reentrant aborts (using AbortController)]
+    expected: FAIL
+
+  [Dependent signals for AbortSignal.any() should use the same DOMException instance from the already aborted source signal (using AbortController)]
+    expected: FAIL
+
+  [Dependent signals for AbortSignal.any() should use the same DOMException instance from the source signal being aborted later (using AbortController)]
     expected: FAIL

--- a/tests/wpt/meta/dom/abort/event.any.js.ini
+++ b/tests/wpt/meta/dom/abort/event.any.js.ini
@@ -1,28 +1,4 @@
 [event.any.html]
-  [AbortController abort() should fire event synchronously]
-    expected: FAIL
-
-  [controller.abort() should do nothing the second time it is called]
-    expected: FAIL
-
-  [event handler should not be called if added after controller.abort()]
-    expected: FAIL
-
-  [the abort event should have the right properties]
-    expected: FAIL
-
-  [AbortController abort(reason) should set signal.reason]
-    expected: FAIL
-
-  [aborting AbortController without reason creates an "AbortError" DOMException]
-    expected: FAIL
-
-  [AbortController abort(undefined) creates an "AbortError" DOMException]
-    expected: FAIL
-
-  [AbortController abort(null) should set signal.reason]
-    expected: FAIL
-
   [static aborting signal should have right properties]
     expected: FAIL
 
@@ -35,44 +11,11 @@
   [throwIfAborted() should throw primitive abort.reason if signal aborted]
     expected: FAIL
 
-  [throwIfAborted() should not throw if signal not aborted]
-    expected: FAIL
-
   [AbortSignal.reason returns the same DOMException]
-    expected: FAIL
-
-  [AbortController.signal.reason returns the same DOMException]
-    expected: FAIL
-
-  [controller.signal should always return the same object]
     expected: FAIL
 
 
 [event.any.worker.html]
-  [AbortController abort() should fire event synchronously]
-    expected: FAIL
-
-  [controller.abort() should do nothing the second time it is called]
-    expected: FAIL
-
-  [event handler should not be called if added after controller.abort()]
-    expected: FAIL
-
-  [the abort event should have the right properties]
-    expected: FAIL
-
-  [AbortController abort(reason) should set signal.reason]
-    expected: FAIL
-
-  [aborting AbortController without reason creates an "AbortError" DOMException]
-    expected: FAIL
-
-  [AbortController abort(undefined) creates an "AbortError" DOMException]
-    expected: FAIL
-
-  [AbortController abort(null) should set signal.reason]
-    expected: FAIL
-
   [static aborting signal should have right properties]
     expected: FAIL
 
@@ -85,16 +28,7 @@
   [throwIfAborted() should throw primitive abort.reason if signal aborted]
     expected: FAIL
 
-  [throwIfAborted() should not throw if signal not aborted]
-    expected: FAIL
-
   [AbortSignal.reason returns the same DOMException]
-    expected: FAIL
-
-  [AbortController.signal.reason returns the same DOMException]
-    expected: FAIL
-
-  [controller.signal should always return the same object]
     expected: FAIL
 
 

--- a/tests/wpt/meta/streams/__dir__.ini
+++ b/tests/wpt/meta/streams/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "dom_abort_controller_enabled:true",
+]


### PR DESCRIPTION
Since we don't enable the preference as part of `--enable-experimental-web-platform-features` yet, we don't run any automated tests for the AbortController feature. This change means that we at least explicitly test the interface.

Testing: Just enabling new tests.
Part of: https://github.com/servo/servo/issues/34866
