### PR TITLE
webdriver: Reuse `JSValue` as `WebDriverJSValue`

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3979,16 +3979,14 @@ impl ScriptThread {
             return;
         };
 
-        let result = match jsval_to_webdriver(
+        let result = jsval_to_webdriver(
             context,
             global_scope,
             return_value.handle(),
             (&realm).into(),
             can_gc,
-        ) {
-            Ok(ref value) => Ok(value.into()),
-            Err(_) => Err(JavaScriptEvaluationError::SerializationError),
-        };
+        )
+        .map_err(|_| JavaScriptEvaluationError::SerializationError);
 
         let _ = self.senders.pipeline_to_constellation_sender.send((
             pipeline_id,

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -1003,29 +1003,6 @@ pub enum JSValue {
     Object(HashMap<String, JSValue>),
 }
 
-impl From<&WebDriverJSValue> for JSValue {
-    fn from(value: &WebDriverJSValue) -> Self {
-        match value {
-            WebDriverJSValue::Undefined => Self::Undefined,
-            WebDriverJSValue::Null => Self::Null,
-            WebDriverJSValue::Boolean(value) => Self::Boolean(*value),
-            WebDriverJSValue::Number(value) => Self::Number(*value),
-            WebDriverJSValue::String(value) => Self::String(value.clone()),
-            WebDriverJSValue::Element(web_element) => Self::Element(web_element.0.clone()),
-            WebDriverJSValue::Frame(web_frame) => Self::Frame(web_frame.0.clone()),
-            WebDriverJSValue::Window(web_window) => Self::Window(web_window.0.clone()),
-            WebDriverJSValue::ArrayLike(vector) => {
-                Self::Array(vector.iter().map(Into::into).collect())
-            },
-            WebDriverJSValue::Object(map) => Self::Object(
-                map.iter()
-                    .map(|(key, value)| (key.clone(), value.into()))
-                    .collect(),
-            ),
-        }
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum JavaScriptEvaluationError {
     /// The script could not be compiled

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -19,11 +19,10 @@ use serde::{Deserialize, Serialize};
 use servo_geometry::DeviceIndependentIntRect;
 use servo_url::ServoUrl;
 use style_traits::CSSPixel;
-use webdriver::common::{WebElement, WebFrame, WebWindow};
 use webdriver::error::ErrorStatus;
 use webrender_api::units::DevicePixel;
 
-use crate::{FocusId, MouseButton, MouseButtonAction, TraversalId};
+use crate::{FocusId, JSValue, MouseButton, MouseButtonAction, TraversalId};
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct WebDriverMessageId(pub usize);
@@ -226,11 +225,7 @@ pub enum WebDriverScriptCommand {
         String,
         IpcSender<Result<Option<String>, ErrorStatus>>,
     ),
-    GetElementProperty(
-        String,
-        String,
-        IpcSender<Result<WebDriverJSValue, ErrorStatus>>,
-    ),
+    GetElementProperty(String, String, IpcSender<Result<JSValue, ErrorStatus>>),
     GetElementCSS(String, String, IpcSender<Result<String, ErrorStatus>>),
     GetElementRect(String, IpcSender<Result<UntypedRect<f64>, ErrorStatus>>),
     GetElementTagName(String, IpcSender<Result<String, ErrorStatus>>),
@@ -254,33 +249,19 @@ pub enum WebDriverScriptCommand {
     GetWindowHandle(IpcSender<Result<String, ErrorStatus>>),
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum WebDriverJSValue {
-    Undefined,
-    Null,
-    Boolean(bool),
-    Number(f64),
-    String(String),
-    Element(WebElement),
-    Frame(WebFrame),
-    Window(WebWindow),
-    ArrayLike(Vec<WebDriverJSValue>),
-    Object(HashMap<String, WebDriverJSValue>),
-}
-
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebDriverJSError {
     /// Occurs when handler received an event message for a layout channel that is not
     /// associated with the current script thread
     BrowsingContextNotFound,
-    JSException(WebDriverJSValue),
+    JSException(JSValue),
     JSError,
     StaleElementReference,
     Timeout,
     UnknownType,
 }
 
-pub type WebDriverJSResult = Result<WebDriverJSValue, WebDriverJSError>;
+pub type WebDriverJSResult = Result<JSValue, WebDriverJSError>;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebDriverFrameId {

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -20,10 +20,9 @@ use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 use servo::{
     AllowOrDenyRequest, AuthenticationRequest, FilterPattern, FocusId, FormControl,
-    GamepadHapticEffectType, KeyboardEvent, LoadStatus, PermissionRequest, Servo, ServoDelegate,
-    ServoError, SimpleDialog, TraversalId, WebDriverCommandMsg, WebDriverJSResult,
-    WebDriverJSValue, WebDriverLoadStatus, WebDriverUserPrompt, WebView, WebViewBuilder,
-    WebViewDelegate,
+    GamepadHapticEffectType, JSValue, KeyboardEvent, LoadStatus, PermissionRequest, Servo,
+    ServoDelegate, ServoError, SimpleDialog, TraversalId, WebDriverCommandMsg, WebDriverJSResult,
+    WebDriverLoadStatus, WebDriverUserPrompt, WebView, WebViewBuilder, WebViewDelegate,
 };
 use url::Url;
 
@@ -500,8 +499,10 @@ impl RunningAppState {
             .borrow()
             .script_evaluation_interrupt_sender
         {
-            sender.send(Ok(WebDriverJSValue::Null)).unwrap_or_else(|err| {
-                info!("Notify dialog appear failed. Maybe the channel to webdriver is closed: {err}");
+            sender.send(Ok(JSValue::Null)).unwrap_or_else(|err| {
+                info!(
+                    "Notify dialog appear failed. Maybe the channel to webdriver is closed: {err}"
+                );
             });
         }
     }

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/node.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/node.py.ini
@@ -27,7 +27,7 @@
     expected: FAIL
 
   [test_not_supported_nodes[document\]]
-    expected: ERROR
+    expected: FAIL
 
   [test_not_supported_nodes[doctype\]]
-    expected: ERROR
+    expected: FAIL


### PR DESCRIPTION
After #38748, `WebDriverJSValue` is almost same as `JSValue`. Now we turn "potentially merge into one in the future" into reality. The only thing we should be cautious is to properly serialize `WebFrame`, `WebWindow`, `WebElement` for WebDriver.

Testing: No regression. Some error is fixed previously by #38709 which didn't update test :)
Binary size reduced by 134KB.