### PR TITLE
Fix loading raw data from `.ttc` files on macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,6 +2660,7 @@ dependencies = [
 name = "fonts_traits"
 version = "0.0.1"
 dependencies = [
+ "ipc-channel",
  "malloc_size_of_derive",
  "range",
  "serde",

--- a/components/canvas/peniko_conversions.rs
+++ b/components/canvas/peniko_conversions.rs
@@ -9,6 +9,13 @@ use style::color::AbsoluteColor;
 use crate::backend::Convert;
 use crate::canvas_data::Filter;
 
+impl Convert<peniko::Font> for fonts::RawFont {
+    fn convert(self) -> peniko::Font {
+        use std::sync::Arc;
+        peniko::Font::new(peniko::Blob::new(Arc::new(self.data)), self.index)
+    }
+}
+
 impl Convert<kurbo::Join> for LineJoinStyle {
     fn convert(self) -> kurbo::Join {
         match self {

--- a/components/canvas/peniko_conversions.rs
+++ b/components/canvas/peniko_conversions.rs
@@ -9,7 +9,7 @@ use style::color::AbsoluteColor;
 use crate::backend::Convert;
 use crate::canvas_data::Filter;
 
-impl Convert<peniko::Font> for fonts::RawFont {
+impl Convert<peniko::Font> for fonts::FontDataAndIndex {
     fn convert(self) -> peniko::Font {
         use std::sync::Arc;
         peniko::Font::new(peniko::Blob::new(Arc::new(self.data)), self.index)

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -333,9 +333,11 @@ impl GenericDrawTarget for raqote::DrawTarget {
             SHARED_FONT_CACHE.with(|font_cache| {
                 let identifier = template.identifier();
                 if !font_cache.borrow().contains_key(&identifier) {
-                    let raw_font = run.font.raw_font();
-                    let data = std::sync::Arc::new(raw_font.data.as_ref().to_vec());
-                    let Ok(font) = Font::from_bytes(data, raw_font.index) else {
+                    let Ok(font_data_and_index) = run.font.font_data_and_index() else {
+                        return;
+                    };
+                    let data = std::sync::Arc::new(font_data_and_index.data.as_ref().to_vec());
+                    let Ok(font) = Font::from_bytes(data, font_data_and_index.index) else {
                         return;
                     };
                     font_cache.borrow_mut().insert(identifier.clone(), font);

--- a/components/canvas/raqote_backend.rs
+++ b/components/canvas/raqote_backend.rs
@@ -333,8 +333,9 @@ impl GenericDrawTarget for raqote::DrawTarget {
             SHARED_FONT_CACHE.with(|font_cache| {
                 let identifier = template.identifier();
                 if !font_cache.borrow().contains_key(&identifier) {
-                    let data = std::sync::Arc::new(run.font.data().as_ref().to_vec());
-                    let Ok(font) = Font::from_bytes(data, identifier.index()) else {
+                    let raw_font = run.font.raw_font();
+                    let data = std::sync::Arc::new(raw_font.data.as_ref().to_vec());
+                    let Ok(font) = Font::from_bytes(data, raw_font.index) else {
                         return;
                     };
                     font_cache.borrow_mut().insert(identifier.clone(), font);

--- a/components/canvas/vello_backend.rs
+++ b/components/canvas/vello_backend.rs
@@ -402,13 +402,8 @@ impl GenericDrawTarget for VelloDrawTarget {
                 SHARED_FONT_CACHE.with(|font_cache| {
                     let identifier = template.identifier();
                     if !font_cache.borrow().contains_key(&identifier) {
-                        font_cache.borrow_mut().insert(
-                            identifier.clone(),
-                            peniko::Font::new(
-                                peniko::Blob::from(run.font.data().as_ref().to_vec()),
-                                identifier.index(),
-                            ),
-                        );
+                        let font = run.font.raw_font().clone().convert();
+                        font_cache.borrow_mut().insert(identifier.clone(), font);
                     }
 
                     let font_cache = font_cache.borrow();

--- a/components/canvas/vello_backend.rs
+++ b/components/canvas/vello_backend.rs
@@ -402,7 +402,10 @@ impl GenericDrawTarget for VelloDrawTarget {
                 SHARED_FONT_CACHE.with(|font_cache| {
                     let identifier = template.identifier();
                     if !font_cache.borrow().contains_key(&identifier) {
-                        let font = run.font.raw_font().clone().convert();
+                        let Ok(font) = run.font.font_data_and_index() else {
+                            return;
+                        };
+                        let font = font.clone().convert();
                         font_cache.borrow_mut().insert(identifier.clone(), font);
                     }
 

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -305,13 +305,8 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
                 SHARED_FONT_CACHE.with(|font_cache| {
                     let identifier = template.identifier();
                     if !font_cache.borrow().contains_key(&identifier) {
-                        font_cache.borrow_mut().insert(
-                            identifier.clone(),
-                            peniko::Font::new(
-                                peniko::Blob::from(run.font.data().as_ref().to_vec()),
-                                identifier.index(),
-                            ),
-                        );
+                        let font = run.font.raw_font().clone().convert();
+                        font_cache.borrow_mut().insert(identifier.clone(), font);
                     }
 
                     let font_cache = font_cache.borrow();

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -305,7 +305,10 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
                 SHARED_FONT_CACHE.with(|font_cache| {
                     let identifier = template.identifier();
                     if !font_cache.borrow().contains_key(&identifier) {
-                        let font = run.font.raw_font().clone().convert();
+                        let Ok(font) = run.font.font_data_and_index() else {
+                            return;
+                        };
+                        let font = font.clone().convert();
                         font_cache.borrow_mut().insert(identifier.clone(), font);
                     }
 

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -14,41 +14,16 @@ pub mod platform;
 mod shaper;
 mod system_font_service;
 
-use std::sync::Arc;
-
 pub use font::*;
 pub use font_context::*;
 pub use font_store::*;
 pub use font_template::*;
+pub use fonts_traits::*;
 pub use glyph::*;
-use ipc_channel::ipc::IpcSharedMemory;
-use malloc_size_of_derive::MallocSizeOf;
 pub use platform::LocalFontIdentifier;
 pub use shaper::*;
 pub use system_font_service::*;
 use unicode_properties::{EmojiStatus, UnicodeEmoji, emoji};
-
-/// A data structure to store data for fonts. Data is stored internally in an
-/// [`IpcSharedMemory`] handle, so that it can be send without serialization
-/// across IPC channels.
-#[derive(Clone, MallocSizeOf)]
-pub struct FontData(#[conditional_malloc_size_of] pub(crate) Arc<IpcSharedMemory>);
-
-impl FontData {
-    pub fn from_bytes(bytes: &[u8]) -> Self {
-        Self(Arc::new(IpcSharedMemory::from_bytes(bytes)))
-    }
-
-    pub(crate) fn as_ipc_shared_memory(&self) -> Arc<IpcSharedMemory> {
-        self.0.clone()
-    }
-}
-
-impl AsRef<[u8]> for FontData {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
 
 /// Whether or not font fallback selection prefers the emoji or text representation
 /// of a character. If `None` then either presentation is acceptable.

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -410,7 +410,7 @@ enum FreeTypeFaceTableProviderData {
 impl FreeTypeFaceTableProviderData {
     fn font_ref(&self) -> Result<FontRef<'_>, ReadError> {
         match self {
-            Self::Web(ipc_shared_memory) => FontRef::new(&ipc_shared_memory.0),
+            Self::Web(ipc_shared_memory) => FontRef::new(ipc_shared_memory.as_ref()),
             Self::Local(mmap, index) => FontRef::from_index(mmap, *index),
         }
     }

--- a/components/fonts/platform/freetype/mod.rs
+++ b/components/fonts/platform/freetype/mod.rs
@@ -57,9 +57,9 @@ impl LocalFontIdentifier {
         }
     }
 
-    pub(crate) fn read_data_from_file(&self) -> Option<Vec<u8>> {
+    pub(crate) fn read_data_from_file(&self) -> Option<(Vec<u8>, u32)> {
         let file = File::open(Path::new(&*self.path)).ok()?;
         let mmap = unsafe { Mmap::map(&file).ok()? };
-        Some(mmap[..].to_vec())
+        Some((mmap[..].to_vec(), self.variation_index as u32))
     }
 }

--- a/components/fonts/platform/freetype/mod.rs
+++ b/components/fonts/platform/freetype/mod.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 use style::Atom;
 use webrender_api::NativeFontHandle;
 
+use crate::{FontData, FontDataAndIndex};
+
 pub mod font;
 mod freetype_face;
 
@@ -57,9 +59,14 @@ impl LocalFontIdentifier {
         }
     }
 
-    pub(crate) fn read_data_from_file(&self) -> Option<(Vec<u8>, u32)> {
+    pub(crate) fn font_data_and_index(&self) -> Option<FontDataAndIndex> {
         let file = File::open(Path::new(&*self.path)).ok()?;
         let mmap = unsafe { Mmap::map(&file).ok()? };
-        Some((mmap[..].to_vec(), self.variation_index as u32))
+        let data = FontData::from_bytes(&mmap);
+
+        Some(FontDataAndIndex {
+            data,
+            index: self.variation_index as u32,
+        })
     }
 }

--- a/components/fonts/platform/windows/font_list.rs
+++ b/components/fonts/platform/windows/font_list.rs
@@ -67,14 +67,15 @@ impl LocalFontIdentifier {
         }
     }
 
-    pub(crate) fn read_data_from_file(&self) -> Option<Vec<u8>> {
+    pub(crate) fn read_data_from_file(&self) -> Option<(Vec<u8>, u32)> {
         let font = FontCollection::system()
             .font_from_descriptor(&self.font_descriptor)
             .ok()??;
         let face = font.create_font_face();
+        let index = face.get_index();
         let files = face.get_files();
         assert!(!files.is_empty());
-        Some(files[0].get_font_file_bytes())
+        Some((files[0].get_font_file_bytes(), index))
     }
 }
 

--- a/components/fonts/platform/windows/font_list.rs
+++ b/components/fonts/platform/windows/font_list.rs
@@ -15,8 +15,8 @@ use style::values::specified::font::FontStretchKeyword;
 use webrender_api::NativeFontHandle;
 
 use crate::{
-    EmojiPresentationPreference, FallbackFontSelectionOptions, FontIdentifier, FontTemplate,
-    FontTemplateDescriptor, LowercaseFontFamilyName,
+    EmojiPresentationPreference, FallbackFontSelectionOptions, FontData, FontDataAndIndex,
+    FontIdentifier, FontTemplate, FontTemplateDescriptor, LowercaseFontFamilyName,
 };
 
 pub fn for_each_available_family<F>(mut callback: F)
@@ -67,7 +67,7 @@ impl LocalFontIdentifier {
         }
     }
 
-    pub(crate) fn read_data_from_file(&self) -> Option<(Vec<u8>, u32)> {
+    pub(crate) fn font_data_and_index(&self) -> Option<FontDataAndIndex> {
         let font = FontCollection::system()
             .font_from_descriptor(&self.font_descriptor)
             .ok()??;
@@ -75,7 +75,11 @@ impl LocalFontIdentifier {
         let index = face.get_index();
         let files = face.get_files();
         assert!(!files.is_empty());
-        Some((files[0].get_font_file_bytes(), index))
+
+        let data = files[0].get_font_file_bytes();
+        let data = FontData::from_bytes(&data);
+
+        Some(FontDataAndIndex { data, index })
     }
 }
 

--- a/components/shared/fonts/Cargo.toml
+++ b/components/shared/fonts/Cargo.toml
@@ -12,6 +12,7 @@ name = "fonts_traits"
 path = "lib.rs"
 
 [dependencies]
+ipc-channel = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 range = { path = "../../range" }

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use ipc_channel::ipc::IpcSharedMemory;
 use malloc_size_of_derive::MallocSizeOf;
 use range::{RangeIndex, int_range_index};
 use serde::{Deserialize, Serialize};
@@ -18,3 +19,42 @@ int_range_index! {
 }
 
 pub type StylesheetWebFontLoadFinishedCallback = Arc<dyn Fn(bool) + Send + Sync + 'static>;
+
+/// A data structure to store data for fonts. Data is stored internally in an
+/// [`IpcSharedMemory`] handle, so that it can be sent without serialization
+/// across IPC channels.
+#[derive(Clone, MallocSizeOf)]
+pub struct FontData(#[conditional_malloc_size_of] pub(crate) Arc<IpcSharedMemory>);
+
+impl FontData {
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        Self(Arc::new(IpcSharedMemory::from_bytes(bytes)))
+    }
+
+    pub fn as_ipc_shared_memory(&self) -> Arc<IpcSharedMemory> {
+        self.0.clone()
+    }
+}
+
+impl AsRef<[u8]> for FontData {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// Raw font data and an index
+///
+/// If the font data is of a TTC (TrueType collection) file, then the index of a specific font within
+/// the collection. If the font data is for is single font then the index will always be 0.
+#[derive(Clone)]
+pub struct FontDataAndIndex {
+    /// The raw font file data (.ttf, .otf, .ttc, etc)
+    pub data: FontData,
+    /// The index of the font within the file (0 if the file is not a ttc)
+    pub index: u32,
+}
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum FontDataError {
+    FailedToLoad,
+}


### PR DESCRIPTION
# Objective

Ensure that functionality which uses the raw font data (such as rendering text to canvas) works correctly on macOS when the specified font is a system font that lives in an OpenType Collection (`.ttc`) file.

## Changes made

- The `read_data_from_file` in each backend now returns a `index: u32` in addition to `data: Vec<u8>`
- The `data` field on the `Font` type has been renamed to `raw` and the `data` method on the `Font` type has been renamed to `raw_font`. This allows the index to be cached as computing is moderately expensive on macOS (on the order of 100 microseconds).
- Both of the above now store/return a `struct RawFont` instead of a `FontData` where `RawFont` is defined as `struct RawFont { data: FontData, index: u32 }`.
- The users of the `data` method have been updated to use the cached index from `data` rather than calling `.index()` each time.
