### PR TITLE
script: Ensure that leaving the `WebView` sets the cursor back to the default cursor

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1601,7 +1601,6 @@ impl IOCompositor {
                 .constellation_sender
                 .send(EmbedderToConstellationMessage::RefreshCursor(
                     hit_test_result.pipeline_id,
-                    hit_test_result.point_in_viewport,
                 ))
         {
             warn!("Sending event to constellation failed ({:?}).", error);

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -136,8 +136,8 @@ use embedder_traits::{
     MouseButton, MouseButtonAction, MouseButtonEvent, Theme, ViewportDetails, WebDriverCommandMsg,
     WebDriverCommandResponse, WebDriverLoadStatus, WebDriverScriptCommand,
 };
+use euclid::Size2D;
 use euclid::default::Size2D as UntypedSize2D;
-use euclid::{Point2D, Size2D};
 use fonts::SystemFontServiceProxy;
 use ipc_channel::Error as IpcError;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
@@ -164,7 +164,6 @@ use servo_config::prefs::{self, PrefValue};
 use servo_config::{opts, pref};
 use servo_rand::{Rng, ServoRng, SliceRandom, random};
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
-use style_traits::CSSPixel;
 #[cfg(feature = "webgpu")]
 use webgpu::swapchain::WGPUImageMap;
 #[cfg(feature = "webgpu")]
@@ -1465,8 +1464,8 @@ where
             EmbedderToConstellationMessage::ForwardInputEvent(webview_id, event, hit_test) => {
                 self.forward_input_event(webview_id, event, hit_test);
             },
-            EmbedderToConstellationMessage::RefreshCursor(pipeline_id, point) => {
-                self.handle_refresh_cursor(pipeline_id, point)
+            EmbedderToConstellationMessage::RefreshCursor(pipeline_id) => {
+                self.handle_refresh_cursor(pipeline_id)
             },
             EmbedderToConstellationMessage::ToggleProfiler(rate, max_duration) => {
                 for background_monitor_control_sender in &self.background_monitor_control_senders {
@@ -3440,14 +3439,14 @@ where
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn handle_refresh_cursor(&self, pipeline_id: PipelineId, point: Point2D<f32, CSSPixel>) {
+    fn handle_refresh_cursor(&self, pipeline_id: PipelineId) {
         let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
             return;
         };
 
         if let Err(error) = pipeline
             .event_loop
-            .send(ScriptThreadMessage::RefreshCursor(pipeline_id, point))
+            .send(ScriptThreadMessage::RefreshCursor(pipeline_id))
         {
             warn!("Could not send RefreshCursor message to pipeline: {error:?}");
         }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3067,22 +3067,6 @@ impl Window {
             node.dirty(NodeDamage::Other);
         }
     }
-
-    pub fn handle_refresh_cursor(&self, cursor_position: Point2D<f32, CSSPixel>) {
-        let layout = self.layout.borrow();
-        layout.ensure_stacking_context_tree(self.viewport_details.get());
-        let Some(hit_test_result) = layout
-            .query_elements_from_point(cursor_position.cast_unit(), ElementsFromPointFlags::empty())
-            .into_iter()
-            .nth(0)
-        else {
-            return;
-        };
-
-        self.Document()
-            .event_handler()
-            .set_cursor(hit_test_result.cursor);
-    }
 }
 
 impl Window {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -91,7 +91,6 @@ use script_traits::{
 use servo_config::{opts, prefs};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use style::thread_state::{self, ThreadState};
-use style_traits::CSSPixel;
 use stylo_atoms::Atom;
 use timers::{TimerEventRequest, TimerId, TimerScheduler};
 use url::Position;
@@ -1884,8 +1883,8 @@ impl ScriptThread {
                     );
                 }
             },
-            ScriptThreadMessage::RefreshCursor(pipeline_id, cursor_position) => {
-                self.handle_refresh_cursor(pipeline_id, cursor_position);
+            ScriptThreadMessage::RefreshCursor(pipeline_id) => {
+                self.handle_refresh_cursor(pipeline_id);
             },
             ScriptThreadMessage::PreferencesUpdated(updates) => {
                 let mut current_preferences = prefs::get().clone();
@@ -3996,15 +3995,11 @@ impl ScriptThread {
         ));
     }
 
-    fn handle_refresh_cursor(
-        &self,
-        pipeline_id: PipelineId,
-        cursor_position: Point2D<f32, CSSPixel>,
-    ) {
-        let Some(window) = self.documents.borrow().find_window(pipeline_id) else {
+    fn handle_refresh_cursor(&self, pipeline_id: PipelineId) {
+        let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
             return;
         };
-        window.handle_refresh_cursor(cursor_position);
+        document.event_handler().handle_refresh_cursor();
     }
 }
 

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -22,7 +22,6 @@ use embedder_traits::{
     CompositorHitTestResult, FocusId, InputEvent, JavaScriptEvaluationId, MediaSessionActionType,
     Theme, TraversalId, ViewportDetails, WebDriverCommandMsg, WebDriverCommandResponse,
 };
-use euclid::Point2D;
 pub use from_script_message::*;
 use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
@@ -32,7 +31,6 @@ use servo_config::prefs::PrefValue;
 use servo_url::{ImmutableOrigin, ServoUrl};
 pub use structured_data::*;
 use strum_macros::IntoStaticStr;
-use style_traits::CSSPixel;
 use webrender_api::units::LayoutVector2D;
 use webrender_api::{ExternalScrollId, ImageKey};
 
@@ -78,9 +76,10 @@ pub enum EmbedderToConstellationMessage {
     BlurWebView,
     /// Forward an input event to an appropriate ScriptTask.
     ForwardInputEvent(WebViewId, InputEvent, Option<CompositorHitTestResult>),
-    /// Request that the given pipeline do a hit test at the location and reset the
-    /// cursor accordingly. This happens after a display list update is rendered.
-    RefreshCursor(PipelineId, Point2D<f32, CSSPixel>),
+    /// Request that the given pipeline refresh the cursor by doing a hit test at the most
+    /// recently hovered cursor position and resetting the cursor. This happens after a
+    /// display list update is rendered.
+    RefreshCursor(PipelineId),
     /// Enable the sampling profiler, with a given sampling rate and max total sampling duration.
     ToggleProfiler(Duration, Duration),
     /// Request to exit from fullscreen mode

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -55,9 +55,10 @@ pub enum ShutdownState {
 /// A cursor for the window. This is different from a CSS cursor (see
 /// `CursorKind`) in that it has no `Auto` value.
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
 pub enum Cursor {
     None,
+    #[default]
     Default,
     Pointer,
     ContextMenu,

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -32,7 +32,7 @@ use embedder_traits::{
     CompositorHitTestResult, FocusSequenceNumber, InputEvent, JavaScriptEvaluationId,
     MediaSessionActionType, Theme, ViewportDetails, WebDriverScriptCommand,
 };
-use euclid::{Point2D, Rect, Scale, Size2D, UnknownUnit};
+use euclid::{Rect, Scale, Size2D, UnknownUnit};
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use keyboard_types::Modifiers;
 use malloc_size_of_derive::MallocSizeOf;
@@ -147,9 +147,10 @@ pub enum ScriptThreadMessage {
     ExitScriptThread,
     /// Sends a DOM event.
     SendInputEvent(PipelineId, ConstellationInputEvent),
-    /// Ask that the given pipeline refreshes the cursor (after a display list render) based
-    /// on the hit test at the given point.
-    RefreshCursor(PipelineId, Point2D<f32, CSSPixel>),
+    /// Request that the given pipeline refresh the cursor by doing a hit test at the most
+    /// recently hovered cursor position and resetting the cursor. This happens after a
+    /// display list update is rendered.
+    RefreshCursor(PipelineId),
     /// Notifies script of the viewport.
     Viewport(PipelineId, Rect<f32, UnknownUnit>),
     /// Requests that the script thread immediately send the constellation the title of a pipeline.


### PR DESCRIPTION
This changes makes a variety of changes to ensure that the cursor is set
back to the default cursor when it leaves the `WebView`:

1. Display list updates can come after a mouse leaves the `WebView`, so
   when refreshing the cursor after the update, base the updated cursor
   on the last hovered location in the `DocumentEventHandler`, rather
   than the compositor. This allows us to catch when the last hovered
   position is `None` (ie the cursor has left the `WebView`).
2. When handling `MouseLeftViewport` events for the cursor leaving the
   entire WebView, properly set the
   MouseLeftViewport::focus_moving_to_another_iframe` on the input event
   passed to the script thread.
3. When moving out of the `WebView` entirely, explicitly ask the
   embedder to set the cursor back to the default.

Testing: This change adds a unit test verifying this behavior.
Fixes: #38710.
