### PR TITLE
script_bindings(python): Add type to a function for `codegen.py`

### DIFF
--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -649,7 +649,6 @@ def typeIsSequenceOrHasSequenceMember(type: IDLType) -> bool:
     if type.isSequence():
         return True
     if type.isDictionary():
-        assert isinstance(type, IDLDictionary)
         # pyrefly: ignore  # missing-attribute
         return dictionaryHasSequenceMember(type.inner)
     if type.isUnion():

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -433,7 +433,7 @@ class CGMethodCall(CGThing):
                 requiredArgs -= 1
             return requiredArgs
 
-        signatures: list[tuple[IDLType, list[IDLArgument]]] = method.signatures()
+        signatures = method.signatures()
 
         def getPerSignatureCall(signature: tuple[IDLType, list[IDLArgument]], argConversionStartsAt: int = 0) -> CGThing:
             signatureIndex = signatures.index(signature)

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -12,7 +12,7 @@ from WebIDL import IDLUnionType
 from WebIDL import IDLSequenceType
 from collections import defaultdict
 from itertools import groupby
-from typing import Optional, Any, Generic, TypeVar, cast
+from typing import cast, Optional, Any, Generic, TypeVar
 from collections.abc import Generator, Callable, Iterator
 from abc import abstractmethod
 
@@ -1759,13 +1759,13 @@ pub(crate) fn init_{name}_prefs<D: DomTypes>() {{
 
     def generateUnguardedArray(
             self,
-            array: list[dict[str, Any]],
+            array: list[PropertyDefinerElementType],
             name: str,
-            specTemplate: Callable[[dict[str, Any]], str] | str,
+            specTemplate: Callable[[PropertyDefinerElementType], str] | str,
             specTerminator: str,
             specType: str,
-            getCondition: Callable[[dict[str, Any], Descriptor], list[str]],
-            getDataTuple: Callable[[dict[str, Any]], tuple[str, ...]]
+            getCondition: Callable[[PropertyDefinerElementType, Descriptor], list[str]],
+            getDataTuple: Callable[[PropertyDefinerElementType], tuple[str, ...]]
     ) -> str:
         """
         Takes the same set of parameters as generateGuardedArray but instead
@@ -2189,7 +2189,8 @@ class ConstDefiner(PropertyDefiner[IDLConst]):
                     convertConstIDLValueToJSVal(const.value))
 
         return self.generateGuardedArray(
-            array, name,
+            array,
+            name,
             '    ConstantSpec { name: %s, value: %s }',
             None,
             'ConstantSpec',

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -6810,7 +6810,7 @@ class CGInterfaceTrait(CGThing):
                         arguments = method_arguments(descriptor, rettype, arguments,
                                                      inRealm=name in descriptor.inRealmMethods,
                                                      canGc=name in descriptor.canGcMethods)
-                        rettype = return_type(descriptor, cast(IDLType, rettype), infallible)
+                        rettype = return_type(descriptor, rettype, infallible)
                         yield f"{name}{'_' * idx}", arguments, rettype, m.isStatic()
                 elif m.isAttr():
                     name = CGSpecializedGetter.makeNativeName(descriptor, m)


### PR DESCRIPTION
This PR focuses on adding type annotations to utility functions, PropertyDefiner, and its child classes.