### PR TITLE
uv: Fix warning by adding `project` table to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[project]
+# `uv` logs warnings if this file doesn't contain a `project` table.
+name = "servo"
+version = "0.0.1"
+
 [tool.ruff]
 line-length = 120
 extend-exclude = [


### PR DESCRIPTION
`uv` logs a warning if the pyproject.toml does not contain a project table.
There is not really much point in adding the table, but no downsides either,
so lets just add the table to make `uv` happy.

Testing: Manual run of `RUST_LOG=warn ./mach run`
Fixes: #38761
