### PR TITLE
layout: Fix mix-ups between physical and logical aspect ratios

### DIFF
--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -267,19 +267,6 @@ impl ReplacedContents {
         }
     }
 
-    fn inline_size_over_block_size_intrinsic_ratio(
-        &self,
-        style: &ComputedValues,
-    ) -> Option<CSSFloat> {
-        self.natural_size.ratio.map(|width_over_height| {
-            if style.writing_mode.is_vertical() {
-                1. / width_over_height
-            } else {
-                width_over_height
-            }
-        })
-    }
-
     #[inline]
     fn content_size(
         &self,
@@ -474,10 +461,7 @@ impl ReplacedContents {
         style: &ComputedValues,
         padding_border_sums: &LogicalVec2<Au>,
     ) -> Option<AspectRatio> {
-        style.preferred_aspect_ratio(
-            self.inline_size_over_block_size_intrinsic_ratio(style),
-            padding_border_sums,
-        )
+        style.preferred_aspect_ratio(self.natural_size.ratio, padding_border_sums)
     }
 
     /// The inline size that would result from combining the natural size


### PR DESCRIPTION
`ComputedValuesExt::preferred_aspect_ratio()` was getting the natural aspect ratio expressed logically as inline over block, but then it was mixing it with the value of the `aspect-ratio` CSS property, which is expressed physically as width over height.

Therefore, this changes `ComputedValuesExt::preferred_aspect_ratio()` to expect the physical natural ratio, and then it takes care to convert the resulting ratio logically.

Testing: Unneeded. This has no effect in practice because we don't support `writing-mode` yet.
