### PR TITLE
webxr: Fix compile warning for Windows after upgrade to rustc 1.89

### DIFF
--- a/components/webxr/openxr/input.rs
+++ b/components/webxr/openxr/input.rs
@@ -368,7 +368,7 @@ impl OpenXRInput {
         select_name: &str,
         squeeze_name: Option<&str>,
         interaction_profile: &InteractionProfile,
-    ) -> Vec<Binding> {
+    ) -> Vec<Binding<'_>> {
         let hand = hand_str(self.handedness);
         let path_aim_pose = instance
             .string_to_path(&format!("/user/hand/{}/input/aim/pose", hand))


### PR DESCRIPTION
This is a follow up to https://github.com/servo/servo/pull/36818#issuecomment-3135078567. Since openxr is a feature only available on Windows, it was omitted.

Testing: Fixes
```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> components\webxr\openxr\input.rs:366:9
    |
366 |         &self,
    |         ^^^^^ the lifetime is elided here
...
371 |     ) -> Vec<Binding> {
    |              ------- the same lifetime is hidden here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
371 |     ) -> Vec<Binding<'_>> {
```