### PR TITLE
constellation: Use one image cache thread pool in the single-process mode

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1289,6 +1289,7 @@ pub fn run_content_process(token: String) {
                 true,
                 layout_factory,
                 background_hang_monitor_register,
+                None,
             );
 
             // Since wait_for_completion is true,


### PR DESCRIPTION
Previously, each ScriptThread was creating a new image cache with a separate thread pool. These changes add an image cache to the constellation and create new image caches by calling the `create_new_image_cache` method. It reuses the original image cache's thread pool and reduces the number of spawned threads in the single-process mode.

Testing: Tested manually, using `ps -M` to see the number of spawned threads with multiple tabs open in servoshell before and after these changes.
Fixes: #37770 
