### PR TITLE
Suppress debug representations of network response bodies

### DIFF
--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -474,7 +474,7 @@ impl NetworkEventActor {
         self.request_started = request.started_date_time;
         self.request_time_stamp = request.time_stamp;
         self.request_destination = request.destination;
-        self.request_body = request.body.clone();
+        self.request_body = request.body.as_ref().map(|b| b.0.clone());
         self.request_headers_raw = Some(request.headers.clone());
     }
 
@@ -544,7 +544,7 @@ impl NetworkEventActor {
         response: &DevtoolsHttpResponse,
     ) -> Option<ResponseContentMsg> {
         let body = response.body.as_ref()?;
-        self.response_body = Some(body.clone());
+        self.response_body = Some(body.0.clone());
 
         let mime_type = response
             .headers

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -944,7 +944,7 @@ impl RemoteWebFontDownloader {
                     self.web_font_family_name, new_bytes
                 );
                 if self.response_valid {
-                    self.response_data.extend(new_bytes)
+                    self.response_data.extend(new_bytes.0)
                 }
                 DownloaderResponseResult::InProcess
             },

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -55,8 +55,9 @@ use net_traits::request::{
 };
 use net_traits::response::{CacheState, HttpsState, Response, ResponseBody, ResponseType};
 use net_traits::{
-    CookieSource, DebugVec, DOCUMENT_ACCEPT_HEADER_VALUE, FetchMetadata, NetworkError, RedirectEndValue,
-    RedirectStartValue, ReferrerPolicy, ResourceAttribute, ResourceFetchTiming, ResourceTimeValue,
+    CookieSource, DOCUMENT_ACCEPT_HEADER_VALUE, DebugVec, FetchMetadata, NetworkError,
+    RedirectEndValue, RedirectStartValue, ReferrerPolicy, ResourceAttribute, ResourceFetchTiming,
+    ResourceTimeValue,
 };
 use profile_traits::mem::{Report, ReportKind};
 use profile_traits::path;

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -55,7 +55,7 @@ use net_traits::request::{
 };
 use net_traits::response::{CacheState, HttpsState, Response, ResponseBody, ResponseType};
 use net_traits::{
-    CookieSource, DOCUMENT_ACCEPT_HEADER_VALUE, FetchMetadata, NetworkError, RedirectEndValue,
+    CookieSource, DebugVec, DOCUMENT_ACCEPT_HEADER_VALUE, FetchMetadata, NetworkError, RedirectEndValue,
     RedirectStartValue, ReferrerPolicy, ResourceAttribute, ResourceFetchTiming, ResourceTimeValue,
 };
 use profile_traits::mem::{Report, ReportKind};
@@ -416,7 +416,7 @@ fn prepare_devtools_request(
         url,
         method,
         headers,
-        body: body.map(devtools_traits::DebugVec::from),
+        body: body.map(DebugVec::from),
         pipeline_id,
         started_date_time,
         time_stamp: started_date_time
@@ -491,7 +491,7 @@ pub fn send_response_values_to_devtools(
         let devtoolsresponse = DevtoolsHttpResponse {
             headers,
             status,
-            body: body.map(devtools_traits::DebugVec::from),
+            body: body.map(DebugVec::from),
             from_cache,
             pipeline_id,
             browsing_context_id,

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -416,7 +416,7 @@ fn prepare_devtools_request(
         url,
         method,
         headers,
-        body,
+        body: body.map(devtools_traits::DebugVec::from),
         pipeline_id,
         started_date_time,
         time_stamp: started_date_time
@@ -491,7 +491,7 @@ pub fn send_response_values_to_devtools(
         let devtoolsresponse = DevtoolsHttpResponse {
             headers,
             status,
-            body,
+            body: body.map(devtools_traits::DebugVec::from),
             from_cache,
             pipeline_id,
             browsing_context_id,

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -1463,7 +1463,7 @@ fn test_fetch_with_devtools() {
         url: url,
         method: Method::GET,
         headers: headers,
-        body: Some(vec![]),
+        body: Some(vec![].into()),
         pipeline_id: TEST_PIPELINE_ID,
         started_date_time: devhttprequests.1.started_date_time,
         time_stamp: devhttprequests.1.time_stamp,
@@ -1486,7 +1486,7 @@ fn test_fetch_with_devtools() {
     let httpresponse = DevtoolsHttpResponse {
         headers: Some(response_headers),
         status: HttpStatus::default(),
-        body: Some(content.as_bytes().to_vec()),
+        body: Some(content.as_bytes().to_vec().into()),
         from_cache: false,
         pipeline_id: TEST_PIPELINE_ID,
         browsing_context_id: TEST_WEBVIEW_ID.into(),

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -394,7 +394,7 @@ fn test_request_and_response_data_with_network_messages() {
         url: url,
         method: Method::GET,
         headers: headers,
-        body: Some(vec![]),
+        body: Some(vec![].into()),
         pipeline_id: TEST_PIPELINE_ID,
         started_date_time: devhttprequests.1.started_date_time,
         time_stamp: devhttprequests.1.time_stamp,
@@ -422,7 +422,7 @@ fn test_request_and_response_data_with_network_messages() {
     let httpresponse = DevtoolsHttpResponse {
         headers: Some(response_headers),
         status: HttpStatus::default(),
-        body: Some(content.as_bytes().to_vec()),
+        body: Some(content.as_bytes().to_vec().into()),
         from_cache: false,
         pipeline_id: TEST_PIPELINE_ID,
         browsing_context_id: TEST_WEBVIEW_ID.into(),

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -298,7 +298,7 @@ impl FetchResponseListener for ImageContext {
         if self.status.is_ok() {
             self.image_cache.notify_pending_response(
                 self.id,
-                FetchResponseMsg::ProcessResponseChunk(request_id, payload),
+                FetchResponseMsg::ProcessResponseChunk(request_id, payload.into()),
             );
         }
     }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -1022,7 +1022,7 @@ impl FetchResponseListener for FaviconFetchContext {
     fn process_response_chunk(&mut self, request_id: RequestId, chunk: Vec<u8>) {
         self.image_cache.notify_pending_response(
             self.id,
-            FetchResponseMsg::ProcessResponseChunk(request_id, chunk),
+            FetchResponseMsg::ProcessResponseChunk(request_id, chunk.into()),
         );
     }
 

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -463,7 +463,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
 
         self.image_cache.notify_pending_response(
             self.id,
-            FetchResponseMsg::ProcessResponseChunk(request_id, payload),
+            FetchResponseMsg::ProcessResponseChunk(request_id, payload.into()),
         );
     }
 

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -773,7 +773,7 @@ impl FetchResponseListener for ResourceFetchListener {
         if self.status.is_ok() {
             self.image_cache.notify_pending_response(
                 self.pending_image_id,
-                FetchResponseMsg::ProcessResponseChunk(request_id, payload),
+                FetchResponseMsg::ProcessResponseChunk(request_id, payload.into()),
             );
         }
     }

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -51,7 +51,7 @@ impl FetchResponseListener for LayoutImageContext {
     fn process_response_chunk(&mut self, request_id: RequestId, payload: Vec<u8>) {
         self.cache.notify_pending_response(
             self.id,
-            FetchResponseMsg::ProcessResponseChunk(request_id, payload),
+            FetchResponseMsg::ProcessResponseChunk(request_id, payload.into()),
         );
     }
 

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -124,7 +124,7 @@ impl<Listener: FetchResponseListener> NetworkListener<Listener> {
                     fetch_listener.process_response(request_id, meta)
                 },
                 FetchResponseMsg::ProcessResponseChunk(request_id, data) => {
-                    fetch_listener.process_response_chunk(request_id, data)
+                    fetch_listener.process_response_chunk(request_id, data.0)
                 },
                 FetchResponseMsg::ProcessResponseEOF(request_id, data) => {
                     match data {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3567,7 +3567,7 @@ impl ScriptThread {
                 self.handle_fetch_metadata(pipeline_id, request_id, metadata)
             },
             FetchResponseMsg::ProcessResponseChunk(request_id, chunk) => {
-                self.handle_fetch_chunk(pipeline_id, request_id, chunk)
+                self.handle_fetch_chunk(pipeline_id, request_id, chunk.0)
             },
             FetchResponseMsg::ProcessResponseEOF(request_id, eof) => {
                 self.handle_fetch_eof(pipeline_id, request_id, eof)

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -24,6 +24,7 @@ use embedder_traits::Theme;
 use http::{HeaderMap, Method};
 use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
+use net_traits::DebugVec;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::Destination;
 use serde::{Deserialize, Serialize};
@@ -441,28 +442,6 @@ impl From<ConsoleMessage> for ConsoleLog {
 pub enum CachedConsoleMessage {
     PageError(PageError),
     ConsoleLog(ConsoleLog),
-}
-
-#[derive(Clone, PartialEq)]
-pub struct DebugVec(pub Vec<u8>);
-
-impl std::ops::Deref for DebugVec {
-    type Target = Vec<u8>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl From<Vec<u8>> for DebugVec {
-    fn from(v: Vec<u8>) -> Self {
-        Self(v)
-    }
-}
-
-impl std::fmt::Debug for DebugVec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("[{}; ...]", self.0.len()))
-    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -443,12 +443,34 @@ pub enum CachedConsoleMessage {
     ConsoleLog(ConsoleLog),
 }
 
+#[derive(Clone, PartialEq)]
+pub struct DebugVec(pub Vec<u8>);
+
+impl std::ops::Deref for DebugVec {
+    type Target = Vec<u8>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Vec<u8>> for DebugVec {
+    fn from(v: Vec<u8>) -> Self {
+        Self(v)
+    }
+}
+
+impl std::fmt::Debug for DebugVec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("[{}; ...]", self.0.len()))
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub struct HttpRequest {
     pub url: ServoUrl,
     pub method: Method,
     pub headers: HeaderMap,
-    pub body: Option<Vec<u8>>,
+    pub body: Option<DebugVec>,
     pub pipeline_id: PipelineId,
     pub started_date_time: SystemTime,
     pub time_stamp: i64,
@@ -463,7 +485,7 @@ pub struct HttpRequest {
 pub struct HttpResponse {
     pub headers: Option<HeaderMap>,
     pub status: HttpStatus,
-    pub body: Option<Vec<u8>>,
+    pub body: Option<DebugVec>,
     pub from_cache: bool,
     pub pipeline_id: PipelineId,
     pub browsing_context_id: BrowsingContextId,

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -354,7 +354,10 @@ impl FetchTaskTarget for IpcSender<FetchResponseMsg> {
     }
 
     fn process_response_chunk(&mut self, request: &Request, chunk: Vec<u8>) {
-        let _ = self.send(FetchResponseMsg::ProcessResponseChunk(request.id, chunk.into()));
+        let _ = self.send(FetchResponseMsg::ProcessResponseChunk(
+            request.id,
+            chunk.into(),
+        ));
     }
 
     fn process_response_eof(&mut self, request: &Request, response: &Response) {

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -265,7 +265,7 @@ impl std::ops::Deref for DebugVec {
 
 impl std::fmt::Debug for DebugVec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!("[{}; ...]", self.0.len()))
+        f.write_fmt(format_args!("[...; {}]", self.0.len()))
     }
 }
 

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -242,9 +242,31 @@ pub enum FetchResponseMsg {
     ProcessRequestEOF(RequestId),
     // todo: send more info about the response (or perhaps the entire Response)
     ProcessResponse(RequestId, Result<FetchMetadata, NetworkError>),
-    ProcessResponseChunk(RequestId, Vec<u8>),
+    ProcessResponseChunk(RequestId, DebugVec),
     ProcessResponseEOF(RequestId, Result<ResourceFetchTiming, NetworkError>),
     ProcessCspViolations(RequestId, Vec<csp::Violation>),
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+pub struct DebugVec(pub Vec<u8>);
+
+impl From<Vec<u8>> for DebugVec {
+    fn from(v: Vec<u8>) -> Self {
+        Self(v)
+    }
+}
+
+impl std::ops::Deref for DebugVec {
+    type Target = Vec<u8>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for DebugVec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("[{}; ...]", self.0.len()))
+    }
 }
 
 impl FetchResponseMsg {
@@ -332,7 +354,7 @@ impl FetchTaskTarget for IpcSender<FetchResponseMsg> {
     }
 
     fn process_response_chunk(&mut self, request: &Request, chunk: Vec<u8>) {
-        let _ = self.send(FetchResponseMsg::ProcessResponseChunk(request.id, chunk));
+        let _ = self.send(FetchResponseMsg::ProcessResponseChunk(request.id, chunk.into()));
     }
 
     fn process_response_eof(&mut self, request: &Request, response: &Response) {


### PR DESCRIPTION
Adds a wrapper type for vectors that can contain large response bodies to prevent flooding debug logs with the contents of those bodies.

Testing: Can't test debug log output.
Fixes: #37769
