### PR TITLE
dependabot: Exclude two testing directories to depndabot scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 updates:
 - package-ecosystem: cargo
   directory: "/"
+  exclude-paths:
+    - "tests/blink_perf/**"
+    - "tests/wpt/**"
   schedule:
     interval: daily
   open-pull-requests-limit: 10


### PR DESCRIPTION
According to dependabot/dependabot-core#4364, dependabot now supports
excluding certain directories from upgrade scanning. This change adds
two problematic directories to the exclusion list.
