### PR TITLE
devtools: Handle `removeBreakpoint` on breakpoint-list actor

### DIFF
--- a/components/devtools/actors/breakpoint.rs
+++ b/components/devtools/actors/breakpoint.rs
@@ -42,6 +42,10 @@ impl Actor for BreakpointListActor {
                 let msg = EmptyReplyMsg { from: self.name() };
                 request.reply_final(&msg)?
             },
+            "removeBreakpoint" => {
+                let msg = EmptyReplyMsg { from: self.name() };
+                request.reply_final(&msg)?
+            },
             _ => return Err(ActorError::UnrecognizedPacketType),
         };
         Ok(())


### PR DESCRIPTION
The breakpoint-list actor did not implement a handler for the `removeBreakpoint` request, causing the client to receive `unrecognizedPacketType` error. This patch adds `removeBreakpoint` handler


Fixes: Part of #36027 