### PR TITLE
Add `matrixTransform` for `DOMPointReadOnly`

### DIFF
--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -23,7 +23,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::DOMPoint;
 use crate::script_runtime::CanGc;
 
-/// http://dev.w3.org/fxtf/geometry/Overview.html#dompointreadonly
+/// <http://dev.w3.org/fxtf/geometry/Overview.html#dompointreadonly>
 #[dom_struct]
 pub(crate) struct DOMPointReadOnly {
     reflector_: Reflector,
@@ -76,7 +76,7 @@ impl DOMPointReadOnly {
 
 #[allow(non_snake_case)]
 impl DOMPointReadOnlyMethods<crate::DomTypeHolder> for DOMPointReadOnly {
-    /// https://drafts.fxtf.org/geometry/#dom-dompoint-dompoint
+    /// <https://drafts.fxtf.org/geometry/#dom-dompoint-dompoint>
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
@@ -91,33 +91,33 @@ impl DOMPointReadOnlyMethods<crate::DomTypeHolder> for DOMPointReadOnly {
         ))
     }
 
-    /// https://drafts.fxtf.org/geometry/#dom-dompointreadonly-frompoint
+    /// <https://drafts.fxtf.org/geometry/#dom-dompointreadonly-frompoint>
     fn FromPoint(global: &GlobalScope, init: &DOMPointInit, can_gc: CanGc) -> DomRoot<Self> {
         Self::new(global, init.x, init.y, init.z, init.w, can_gc)
     }
 
-    /// https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-x
+    /// <https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-x>
     fn X(&self) -> f64 {
         self.x.get()
     }
 
-    /// https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-y
+    /// <https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-y>
     fn Y(&self) -> f64 {
         self.y.get()
     }
 
-    /// https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-z
+    /// <https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-z>
     fn Z(&self) -> f64 {
         self.z.get()
     }
 
-    /// https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-w
+    /// <https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-w>
     fn W(&self) -> f64 {
         self.w.get()
     }
 
-    /// https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-matrixtransform
-    /// https://drafts.fxtf.org/geometry/Overview.html#transform-a-point-with-a-matrix
+    /// <https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-matrixtransform>
+    /// <https://drafts.fxtf.org/geometry/Overview.html#transform-a-point-with-a-matrix>
     fn MatrixTransform(
         &self,
         matrix: &DOMMatrixInit,

--- a/components/script/dom/dompointreadonly.rs
+++ b/components/script/dom/dompointreadonly.rs
@@ -23,7 +23,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::DOMPoint;
 use crate::script_runtime::CanGc;
 
-// http://dev.w3.org/fxtf/geometry/Overview.html#dompointreadonly
+/// http://dev.w3.org/fxtf/geometry/Overview.html#dompointreadonly
 #[dom_struct]
 pub(crate) struct DOMPointReadOnly {
     reflector_: Reflector,
@@ -76,7 +76,7 @@ impl DOMPointReadOnly {
 
 #[allow(non_snake_case)]
 impl DOMPointReadOnlyMethods<crate::DomTypeHolder> for DOMPointReadOnly {
-    // https://drafts.fxtf.org/geometry/#dom-dompoint-dompoint
+    /// https://drafts.fxtf.org/geometry/#dom-dompoint-dompoint
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,
@@ -91,48 +91,51 @@ impl DOMPointReadOnlyMethods<crate::DomTypeHolder> for DOMPointReadOnly {
         ))
     }
 
-    // https://drafts.fxtf.org/geometry/#dom-dompointreadonly-frompoint
+    /// https://drafts.fxtf.org/geometry/#dom-dompointreadonly-frompoint
     fn FromPoint(global: &GlobalScope, init: &DOMPointInit, can_gc: CanGc) -> DomRoot<Self> {
         Self::new(global, init.x, init.y, init.z, init.w, can_gc)
     }
 
-    // https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-x
+    /// https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-x
     fn X(&self) -> f64 {
         self.x.get()
     }
 
-    // https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-y
+    /// https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-y
     fn Y(&self) -> f64 {
         self.y.get()
     }
 
-    // https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-z
+    /// https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-z
     fn Z(&self) -> f64 {
         self.z.get()
     }
 
-    // https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-w
+    /// https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-w
     fn W(&self) -> f64 {
         self.w.get()
     }
 
-    // https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-matrixtransform
-    // https://drafts.fxtf.org/geometry/Overview.html#transform-a-point-with-a-matrix
+    /// https://dev.w3.org/fxtf/geometry/Overview.html#dom-dompointreadonly-matrixtransform
+    /// https://drafts.fxtf.org/geometry/Overview.html#transform-a-point-with-a-matrix
     fn MatrixTransform(
         &self,
         matrix: &DOMMatrixInit,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<DOMPoint>> {
+        // Let matrixObject be the result of invoking create a DOMMatrix from the dictionary matrix.
         let matrix_object = match dommatrixinit_to_matrix(matrix) {
             Ok(converted) => converted,
             Err(exception) => {
                 return Err(exception);
             },
         };
+        // Steps 1-4 of transforming a point with a matrix
         let x = self.X();
         let y = self.Y();
         let z = self.Z();
         let w = self.W();
+        // Steps 5-12 of transforming a point with a matrix
         let m = &matrix_object.1;
         let transformed_point = DOMPointInit {
             x: m.m11 * x + m.m21 * y + m.m31 * z + m.m41 * w,
@@ -140,6 +143,8 @@ impl DOMPointReadOnlyMethods<crate::DomTypeHolder> for DOMPointReadOnly {
             z: m.m13 * x + m.m23 * y + m.m33 * z + m.m43 * w,
             w: m.m14 * x + m.m24 * y + m.m34 * z + m.m44 * w,
         };
+        // Return the result of invoking transform a point with a matrix, given the current point
+        // and matrixObject. The current point does not get modified.
         Ok(DOMPoint::new_from_init(
             &self.global(),
             &transformed_point,

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -208,7 +208,7 @@ DOMInterfaces = {
 },
 
 'DOMPointReadOnly': {
-    'canGc': ['FromPoint'],
+    'canGc': ['FromPoint', 'MatrixTransform'],
 },
 
 'DOMQuad': {

--- a/components/script_bindings/webidls/DOMPointReadOnly.webidl
+++ b/components/script_bindings/webidls/DOMPointReadOnly.webidl
@@ -22,5 +22,7 @@ interface DOMPointReadOnly {
     readonly attribute unrestricted double z;
     readonly attribute unrestricted double w;
 
+    [Throws, NewObject] DOMPoint matrixTransform(optional DOMMatrixInit matrix = {});
+
     [Default] object toJSON();
 };

--- a/tests/wpt/meta/css/geometry/DOMPoint-002.html.ini
+++ b/tests/wpt/meta/css/geometry/DOMPoint-002.html.ini
@@ -1,6 +1,0 @@
-[DOMPoint-002.html]
-  [test DOMPoint matrixTransform]
-    expected: FAIL
-
-  [test DOMPointReadOnly matrixTransform]
-    expected: FAIL

--- a/tests/wpt/meta/css/geometry/historical.html.ini
+++ b/tests/wpt/meta/css/geometry/historical.html.ini
@@ -1,3 +1,0 @@
-[historical.html]
-  [DOMPointReadOnly matrixTransform number of required arguments]
-    expected: FAIL

--- a/tests/wpt/meta/css/geometry/idlharness.any.js.ini
+++ b/tests/wpt/meta/css/geometry/idlharness.any.js.ini
@@ -1,34 +1,10 @@
 [idlharness.any.worker.html]
-  [DOMPointReadOnly interface: calling matrixTransform(optional DOMMatrixInit) on new DOMPoint() with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [DOMPointReadOnly interface: operation matrixTransform(optional DOMMatrixInit)]
-    expected: FAIL
-
-  [DOMPointReadOnly interface: new DOMPoint() must inherit property "matrixTransform(optional DOMMatrixInit)" with the proper type]
-    expected: FAIL
-
-  [DOMPointReadOnly interface: new DOMPointReadOnly() must inherit property "matrixTransform(optional DOMMatrixInit)" with the proper type]
-    expected: FAIL
-
-  [DOMPointReadOnly interface: calling matrixTransform(optional DOMMatrixInit) on new DOMPointReadOnly() with too few arguments must throw TypeError]
-    expected: FAIL
-
 
 [idlharness.any.html]
-  [DOMPointReadOnly interface: calling matrixTransform(optional DOMMatrixInit) on new DOMPoint() with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [DOMPointReadOnly interface: operation matrixTransform(optional DOMMatrixInit)]
-    expected: FAIL
-
   [DOMRectList interface: [object DOMRect\] must inherit property "length" with the proper type]
     expected: FAIL
 
   [DOMRectList interface: [object DOMRect\] must inherit property "item(unsigned long)" with the proper type]
-    expected: FAIL
-
-  [DOMPointReadOnly interface: new DOMPoint() must inherit property "matrixTransform(optional DOMMatrixInit)" with the proper type]
     expected: FAIL
 
   [DOMMatrix interface: operation setMatrixValue(DOMString)]
@@ -40,9 +16,6 @@
   [DOMMatrix interface: calling setMatrixValue(DOMString) on new DOMMatrix() with too few arguments must throw TypeError]
     expected: FAIL
 
-  [DOMPointReadOnly interface: new DOMPointReadOnly() must inherit property "matrixTransform(optional DOMMatrixInit)" with the proper type]
-    expected: FAIL
-
   [DOMRectList interface: calling item(unsigned long) on [object DOMRect\] with too few arguments must throw TypeError]
     expected: FAIL
 
@@ -50,9 +23,6 @@
     expected: FAIL
 
   [DOMRectList must be primary interface of [object DOMRect\]]
-    expected: FAIL
-
-  [DOMPointReadOnly interface: calling matrixTransform(optional DOMMatrixInit) on new DOMPointReadOnly() with too few arguments must throw TypeError]
     expected: FAIL
 
   [DOMMatrix interface: legacy window alias]

--- a/tests/wpt/meta/css/geometry/spec-examples.html.ini
+++ b/tests/wpt/meta/css/geometry/spec-examples.html.ini
@@ -1,3 +1,0 @@
-[spec-examples.html]
-  [matrixTransform]
-    expected: FAIL


### PR DESCRIPTION
Adds the `matrixTransform` function for `DOMPointReadOnly`.

Testing: Covered by WPT tests (`css/geometry`)
