### PR TITLE
Add legacy window aliases `SVGMatrix`/`SVGPoint` for `DOMMatrix`/`DOMPoint`

### DIFF
--- a/components/script_bindings/webidls/DOMMatrix.webidl
+++ b/components/script_bindings/webidls/DOMMatrix.webidl
@@ -5,7 +5,7 @@
 // https://drafts.fxtf.org/geometry/#dommatrix
 
 [Exposed=(Window,Worker,PaintWorklet),
- LegacyWindowAlias=WebKitCSSMatrix]
+ LegacyWindowAlias=(SVGMatrix,WebKitCSSMatrix)]
 interface DOMMatrix : DOMMatrixReadOnly {
     [Throws] constructor(optional (DOMString or sequence<unrestricted double>) init);
 

--- a/components/script_bindings/webidls/DOMPoint.webidl
+++ b/components/script_bindings/webidls/DOMPoint.webidl
@@ -11,7 +11,8 @@
 
 // http://dev.w3.org/fxtf/geometry/Overview.html#dompoint
 [Exposed=(Window,Worker,PaintWorklet),
- Serializable]
+ Serializable,
+ LegacyWindowAlias=SVGPoint]
 interface DOMPoint : DOMPointReadOnly {
     [Throws] constructor(optional unrestricted double x = 0, optional unrestricted double y = 0,
                 optional unrestricted double z = 0, optional unrestricted double w = 1);

--- a/tests/wpt/meta/css/geometry/idlharness.any.js.ini
+++ b/tests/wpt/meta/css/geometry/idlharness.any.js.ini
@@ -10,9 +10,6 @@
   [DOMMatrix interface: operation setMatrixValue(DOMString)]
     expected: FAIL
 
-  [DOMPoint interface: legacy window alias]
-    expected: FAIL
-
   [DOMMatrix interface: calling setMatrixValue(DOMString) on new DOMMatrix() with too few arguments must throw TypeError]
     expected: FAIL
 
@@ -23,9 +20,6 @@
     expected: FAIL
 
   [DOMRectList must be primary interface of [object DOMRect\]]
-    expected: FAIL
-
-  [DOMMatrix interface: legacy window alias]
     expected: FAIL
 
   [Stringification of [object DOMRect\]]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13725,7 +13725,7 @@
      ]
     ],
     "interfaces.https.html": [
-     "40567f81c201fe775ad4735c231349fac8c33381",
+     "a9447edae08028bd992e3aa7c9e7a2a483baa446",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -320,6 +320,8 @@ test_interfaces([
   "SVGElement",
   "SVGGraphicsElement",
   "SVGImageElement",
+  "SVGMatrix",
+  "SVGPoint",
   "SVGRect",
   "SVGSVGElement",
   "Text",


### PR DESCRIPTION
Adds the legacy window aliases `SVGMatrix`/`SVGPoint` for `DOMMatrix`/`DOMPoint`.

Testing: Covered by WPT (`css/geometry`).
