### PR TITLE
script: Greatly simplify exiting fullscreen API

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1477,9 +1477,6 @@ where
                     }
                 }
             },
-            EmbedderToConstellationMessage::ExitFullScreen(webview_id) => {
-                self.handle_exit_fullscreen_msg(webview_id);
-            },
             EmbedderToConstellationMessage::MediaSessionAction(action) => {
                 self.handle_media_session_action_msg(action);
             },
@@ -5005,13 +5002,6 @@ where
         self.resize_browsing_context(new_viewport_details, size_type, browsing_context_id);
     }
 
-    /// Called when the window exits from fullscreen mode
-    #[servo_tracing::instrument(skip_all)]
-    fn handle_exit_fullscreen_msg(&mut self, webview_id: WebViewId) {
-        let browsing_context_id = BrowsingContextId::from(webview_id);
-        self.switch_fullscreen_mode(browsing_context_id);
-    }
-
     /// Checks the state of all script and layout pipelines to see if they are idle
     /// and compares the current layout state to what the compositor has. This is used
     /// to check if the output image is "stable" and can be written as a screenshot
@@ -5230,26 +5220,6 @@ where
                     pipeline.id,
                 );
             }
-        }
-    }
-
-    // Handle switching from fullscreen mode
-    #[servo_tracing::instrument(skip_all)]
-    fn switch_fullscreen_mode(&mut self, browsing_context_id: BrowsingContextId) {
-        if let Some(browsing_context) = self.browsing_contexts.get(&browsing_context_id) {
-            let pipeline_id = browsing_context.pipeline_id;
-            let pipeline = match self.pipelines.get(&pipeline_id) {
-                None => {
-                    return warn!(
-                        "{}: Switched from fullscreen mode after closing",
-                        pipeline_id
-                    );
-                },
-                Some(pipeline) => pipeline,
-            };
-            let _ = pipeline
-                .event_loop
-                .send(ScriptThreadMessage::ExitFullScreen(pipeline.id));
         }
     }
 

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -69,7 +69,6 @@ mod from_compositor {
                 Self::ForwardInputEvent(_webview_id, event, ..) => event.log_target(),
                 Self::RefreshCursor(..) => target!("RefreshCursor"),
                 Self::ToggleProfiler(..) => target!("EnableProfiler"),
-                Self::ExitFullScreen(_) => target!("ExitFullScreen"),
                 Self::MediaSessionAction(_) => target!("MediaSessionAction"),
                 Self::SetWebViewThrottled(_, _) => target!("SetWebViewThrottled"),
                 Self::SetScrollStates(..) => target!("SetScrollStates"),

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -90,7 +90,6 @@ impl MixedMessage {
                 ScriptThreadMessage::ReportCSSError(id, ..) => Some(*id),
                 ScriptThreadMessage::Reload(id, ..) => Some(*id),
                 ScriptThreadMessage::PaintMetric(id, ..) => Some(*id),
-                ScriptThreadMessage::ExitFullScreen(id, ..) => Some(*id),
                 ScriptThreadMessage::MediaSessionAction(..) => None,
                 #[cfg(feature = "webgpu")]
                 ScriptThreadMessage::SetWebGPUPort(..) => None,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1413,10 +1413,6 @@ impl ScriptThread {
                     // An event came-in from a document that is not fully-active, it has been stored by the task-queue.
                     // Continue without adding it to "sequential".
                 },
-                MixedMessage::FromConstellation(ScriptThreadMessage::ExitFullScreen(id)) => self
-                    .profile_event(ScriptThreadEventCategory::ExitFullscreen, Some(id), || {
-                        self.handle_exit_fullscreen(id, can_gc);
-                    }),
                 _ => {
                     sequential.push(event);
                 },
@@ -1860,7 +1856,6 @@ impl ScriptThread {
             msg @ ScriptThreadMessage::AttachLayout(..) |
             msg @ ScriptThreadMessage::Viewport(..) |
             msg @ ScriptThreadMessage::Resize(..) |
-            msg @ ScriptThreadMessage::ExitFullScreen(..) |
             msg @ ScriptThreadMessage::SendInputEvent(..) |
             msg @ ScriptThreadMessage::TickAllAnimations(..) |
             msg @ ScriptThreadMessage::ExitScriptThread => {
@@ -2468,15 +2463,6 @@ impl ScriptThread {
     fn handle_theme_change_msg(&self, theme: Theme) {
         for (_, document) in self.documents.borrow().iter() {
             document.window().handle_theme_change(theme);
-        }
-    }
-
-    // exit_fullscreen creates a new JS promise object, so we need to have entered a realm
-    fn handle_exit_fullscreen(&self, id: PipelineId, can_gc: CanGc) {
-        let document = self.documents.borrow().find_document(id);
-        if let Some(document) = document {
-            let _ac = enter_realm(&*document);
-            document.exit_fullscreen(can_gc);
         }
     }
 

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -516,9 +516,7 @@ impl WebView {
     }
 
     pub fn exit_fullscreen(&self) {
-        self.inner()
-            .constellation_proxy
-            .send(EmbedderToConstellationMessage::ExitFullScreen(self.id()));
+        self.evaluate_javascript("document.exitFullscreen()", |_| {});
     }
 
     pub fn set_throttled(&self, throttled: bool) {

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -83,8 +83,6 @@ pub enum EmbedderToConstellationMessage {
     RefreshCursor(PipelineId, Point2D<f32, CSSPixel>),
     /// Enable the sampling profiler, with a given sampling rate and max total sampling duration.
     ToggleProfiler(Duration, Duration),
-    /// Request to exit from fullscreen mode
-    ExitFullScreen(WebViewId),
     /// Media session action.
     MediaSessionAction(MediaSessionActionType),
     /// Set whether to use less resources, by stopping animations and running timers at a heavily limited rate.

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -137,8 +137,6 @@ pub enum ScriptThreadMessage {
     ThemeChange(PipelineId, Theme),
     /// Notifies script that window has been resized but to not take immediate action.
     ResizeInactive(PipelineId, ViewportDetails),
-    /// Window switched from fullscreen mode.
-    ExitFullScreen(PipelineId),
     /// Notifies the script that the document associated with this pipeline should 'unload'.
     UnloadDocument(PipelineId),
     /// Notifies the script that a pipeline should be closed.


### PR DESCRIPTION
With the introduction of JS evaluation via embedder in #35720, we can greatly simply how we exit fullscreen API.

This reduces binary size **by 543KB** in release profile.

Testing: Use example in #38543. Enter fullscreen API. Press "Esc" to exit fullscreen API. Fullscreen status of the element is changed accordingly when pressing "check fullscreenElement".

Fixes: Part of https://github.com/servo/servo/issues/38543. This would make fixing #38543 + implement webdriver fullscreen much simpler later (as it would be easy to distinguish native OS fullscreen vs fullscreen API).