### PR TITLE
indexeddb: Initialize DB version to zero.

### DIFF
--- a/components/net/indexeddb/idb_thread.rs
+++ b/components/net/indexeddb/idb_thread.rs
@@ -308,7 +308,6 @@ impl IndexedDBManager {
                             SqliteEngine::new(
                                 idb_base_dir,
                                 &idb_description,
-                                version,
                                 self.thread_pool.clone(),
                             )
                             .expect("Failed to create sqlite engine"),

--- a/tests/wpt/meta/IndexedDB/back-forward-cache-open-transaction.window.js.ini
+++ b/tests/wpt/meta/IndexedDB/back-forward-cache-open-transaction.window.js.ini
@@ -1,4 +1,3 @@
 [back-forward-cache-open-transaction.window.html]
-  expected: TIMEOUT
   [BFCache support test for page with open IndexedDB transaction]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/blob-composite-blob-reads.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/blob-composite-blob-reads.any.js.ini
@@ -1,14 +1,16 @@
 [blob-composite-blob-reads.any.worker.html]
+  expected: TIMEOUT
   [Composite Blob Handling: Many blobs: fetch-blob-url]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Composite Blob Handling: Many blobs: direct]
-    expected: FAIL
+    expected: NOTRUN
 
 
 [blob-composite-blob-reads.any.html]
+  expected: TIMEOUT
   [Composite Blob Handling: Many blobs: fetch-blob-url]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Composite Blob Handling: Many blobs: direct]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/IndexedDB/blob-valid-after-abort.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/blob-valid-after-abort.any.js.ini
@@ -2,13 +2,13 @@
   expected: ERROR
 
 [blob-valid-after-abort.any.worker.html]
-  expected: TIMEOUT
+  expected: CRASH
   [A blob can be read back after the transaction that added it was aborted.]
     expected: TIMEOUT
 
 
 [blob-valid-after-abort.any.html]
-  expected: TIMEOUT
+  expected: CRASH
   [A blob can be read back after the transaction that added it was aborted.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/IndexedDB/blob-valid-after-deletion.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/blob-valid-after-deletion.any.js.ini
@@ -1,10 +1,10 @@
 [blob-valid-after-deletion.any.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Blobs stay alive after their records are deleted.]
     expected: TIMEOUT
 
 
 [blob-valid-after-deletion.any.worker.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Blobs stay alive after their records are deleted.]
     expected: TIMEOUT

--- a/tests/wpt/meta/IndexedDB/blob-valid-before-commit.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/blob-valid-before-commit.any.js.ini
@@ -1,10 +1,10 @@
 [blob-valid-before-commit.any.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Blobs can be read back before their records are committed.]
     expected: TIMEOUT
 
 
 [blob-valid-before-commit.any.worker.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Blobs can be read back before their records are committed.]
     expected: TIMEOUT

--- a/tests/wpt/meta/IndexedDB/clone-before-keypath-eval.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/clone-before-keypath-eval.any.js.ini
@@ -11,6 +11,9 @@
   [Cursor update checks and keypath evaluations operate on a clone]
     expected: FAIL
 
+  [Index key path evaluations operate on a clone]
+    expected: FAIL
+
 
 [clone-before-keypath-eval.any.serviceworker.html]
   expected: ERROR
@@ -26,6 +29,9 @@
     expected: FAIL
 
   [Cursor update checks and keypath evaluations operate on a clone]
+    expected: FAIL
+
+  [Index key path evaluations operate on a clone]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/crashtests/create-index.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/crashtests/create-index.any.js.ini
@@ -5,7 +5,7 @@
 
 
 [create-index.any.worker.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Assure no crash when populating index]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/IndexedDB/database-names-by-origin.html.ini
+++ b/tests/wpt/meta/IndexedDB/database-names-by-origin.html.ini
@@ -1,12 +1,13 @@
 [database-names-by-origin.html]
+  expected: TIMEOUT
   [open database names don't leak to cross-origin iframe]
-    expected: FAIL
+    expected: TIMEOUT
 
   [open database names don't leak to cross-origin window]
-    expected: FAIL
+    expected: NOTRUN
 
   [closed database names don't leak to cross-origin iframe]
-    expected: FAIL
+    expected: NOTRUN
 
   [closed database names don't leak to cross-origin window]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/IndexedDB/delete-request-queue.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/delete-request-queue.any.js.ini
@@ -1,9 +1,15 @@
 [delete-request-queue.any.html]
+  [Deletes are processed as a FIFO queue]
+    expected: FAIL
+
 
 [delete-request-queue.any.serviceworker.html]
   expected: ERROR
 
 [delete-request-queue.any.worker.html]
+  [Deletes are processed as a FIFO queue]
+    expected: FAIL
+
 
 [delete-request-queue.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/event-dispatch-active-flag.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/event-dispatch-active-flag.any.js.ini
@@ -1,18 +1,6 @@
 [event-dispatch-active-flag.any.html]
-  [Active during success handlers]
-    expected: FAIL
-
-  [Active during success listeners]
-    expected: FAIL
-
 
 [event-dispatch-active-flag.any.worker.html]
-  [Active during success handlers]
-    expected: FAIL
-
-  [Active during success listeners]
-    expected: FAIL
-
 
 [event-dispatch-active-flag.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idb-explicit-commit.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idb-explicit-commit.any.js.ini
@@ -2,9 +2,6 @@
   [Explicitly committed data can be read back out.]
     expected: FAIL
 
-  [commit() on a version change transaction does not cause errors.]
-    expected: FAIL
-
   [A committed transaction becomes inactive immediately.]
     expected: FAIL
 
@@ -38,9 +35,6 @@
 
 [idb-explicit-commit.any.html]
   [Explicitly committed data can be read back out.]
-    expected: FAIL
-
-  [commit() on a version change transaction does not cause errors.]
     expected: FAIL
 
   [A committed transaction becomes inactive immediately.]

--- a/tests/wpt/meta/IndexedDB/idb-partitioned-coverage.sub.html.ini
+++ b/tests/wpt/meta/IndexedDB/idb-partitioned-coverage.sub.html.ini
@@ -1,7 +1,4 @@
 [idb-partitioned-coverage.sub.html]
-  [Deletes are processed in order]
-    expected: FAIL
-
   [ - advance]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idb_webworkers.htm.ini
+++ b/tests/wpt/meta/IndexedDB/idb_webworkers.htm.ini
@@ -1,4 +1,0 @@
-[idb_webworkers.htm]
-  expected: TIMEOUT
-  [IndexedDB inside of a WebWorker ]
-    expected: TIMEOUT

--- a/tests/wpt/meta/IndexedDB/idbcursor-advance-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbcursor-advance-exception-order.any.js.ini
@@ -1,10 +1,9 @@
 [idbcursor-advance-exception-order.any.worker.html]
-  expected: TIMEOUT
   [IDBCursor.advance exception order: TypeError vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBCursor.advance exception order: TransactionInactiveError vs. InvalidStateError #1]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBCursor.advance exception order: TransactionInactiveError vs. InvalidStateError #2]
     expected: FAIL
@@ -14,12 +13,11 @@
   expected: ERROR
 
 [idbcursor-advance-exception-order.any.html]
-  expected: TIMEOUT
   [IDBCursor.advance exception order: TypeError vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBCursor.advance exception order: TransactionInactiveError vs. InvalidStateError #1]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBCursor.advance exception order: TransactionInactiveError vs. InvalidStateError #2]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbcursor-continuePrimaryKey-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbcursor-continuePrimaryKey-exception-order.any.js.ini
@@ -2,87 +2,85 @@
   expected: ERROR
 
 [idbcursor-continuePrimaryKey-exception-order.any.html]
-  expected: TIMEOUT
   [TransactionInactiveError v.s. InvalidStateError(deleted index)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidStateError(deleted source) v.s. InvalidAccessError(incorrect source)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidStateError(deleted source) v.s. InvalidAccessError(incorrect direction)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidAccessError(incorrect direction) v.s. InvalidStateError(iteration complete)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidAccessError(incorrect direction) v.s. InvalidStateError(iteration ongoing)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidAccessError(incorrect source) v.s. InvalidStateError(iteration ongoing)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidAccessError(incorrect source) v.s. InvalidStateError(iteration complete)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidStateError(iteration ongoing) v.s. DataError(unset key)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidStateError(iteration complete) v.s. DataError(unset key)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [DataError(unset key)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [DataError(unset primary key)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [DataError(keys are lower then current one) in 'next' direction]
-    expected: TIMEOUT
+    expected: FAIL
 
   [DataError(keys are larger then current one) in 'prev' direction]
-    expected: TIMEOUT
+    expected: FAIL
 
 
 [idbcursor-continuePrimaryKey-exception-order.any.worker.html]
-  expected: TIMEOUT
   [TransactionInactiveError v.s. InvalidStateError(deleted index)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidStateError(deleted source) v.s. InvalidAccessError(incorrect source)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidStateError(deleted source) v.s. InvalidAccessError(incorrect direction)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidAccessError(incorrect direction) v.s. InvalidStateError(iteration complete)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidAccessError(incorrect direction) v.s. InvalidStateError(iteration ongoing)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidAccessError(incorrect source) v.s. InvalidStateError(iteration ongoing)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidAccessError(incorrect source) v.s. InvalidStateError(iteration complete)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidStateError(iteration ongoing) v.s. DataError(unset key)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [InvalidStateError(iteration complete) v.s. DataError(unset key)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [DataError(unset key)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [DataError(unset primary key)]
-    expected: TIMEOUT
+    expected: FAIL
 
   [DataError(keys are lower then current one) in 'next' direction]
-    expected: TIMEOUT
+    expected: FAIL
 
   [DataError(keys are larger then current one) in 'prev' direction]
-    expected: TIMEOUT
+    expected: FAIL
 
 
 [idbcursor-continuePrimaryKey-exception-order.any.sharedworker.html]

--- a/tests/wpt/meta/IndexedDB/idbdatabase-createObjectStore-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbdatabase-createObjectStore-exception-order.any.js.ini
@@ -1,16 +1,9 @@
 [idbdatabase-createObjectStore-exception-order.any.worker.html]
-  expected: TIMEOUT
   [IDBDatabase.createObjectStore exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
-  [IDBDatabase.createObjectStore exception order: TransactionInactiveError vs. SyntaxError]
-    expected: FAIL
-
   [IDBDatabase.createObjectStore exception order: SyntaxError vs. ConstraintError]
-    expected: TIMEOUT
-
-  [IDBDatabase.createObjectStore exception order: ConstraintError vs. InvalidAccessError]
-    expected: TIMEOUT
+    expected: FAIL
 
 
 [idbdatabase-createObjectStore-exception-order.any.sharedworker.html]
@@ -20,15 +13,8 @@
   expected: ERROR
 
 [idbdatabase-createObjectStore-exception-order.any.html]
-  expected: TIMEOUT
   [IDBDatabase.createObjectStore exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
-  [IDBDatabase.createObjectStore exception order: TransactionInactiveError vs. SyntaxError]
-    expected: FAIL
-
   [IDBDatabase.createObjectStore exception order: SyntaxError vs. ConstraintError]
-    expected: TIMEOUT
-
-  [IDBDatabase.createObjectStore exception order: ConstraintError vs. InvalidAccessError]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbdatabase-deleteObjectStore-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbdatabase-deleteObjectStore-exception-order.any.js.ini
@@ -2,18 +2,12 @@
   [IDBDatabase.deleteObjectStore exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
-  [IDBDatabase.deleteObjectStore exception order: TransactionInactiveError vs. NotFoundError]
-    expected: FAIL
-
 
 [idbdatabase-deleteObjectStore-exception-order.any.sharedworker.html]
   expected: ERROR
 
 [idbdatabase-deleteObjectStore-exception-order.any.worker.html]
   [IDBDatabase.deleteObjectStore exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBDatabase.deleteObjectStore exception order: TransactionInactiveError vs. NotFoundError]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
@@ -28,9 +28,6 @@
   [IDBFactory.open() - error in version change transaction aborts open]
     expected: FAIL
 
-  [Calling open() with version argument 1.5 should not throw.]
-    expected: FAIL
-
   [Calling open() with version argument undefined should not throw.]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbindex-query-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbindex-query-exception-order.any.js.ini
@@ -5,78 +5,76 @@
   expected: ERROR
 
 [idbindex-query-exception-order.any.html]
-  expected: TIMEOUT
   [IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBIndex.get exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBIndex.getAll exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.getAllKeys exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBIndex.getAllKeys exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBIndex.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBIndex.openCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBIndex.openKeyCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
 
 [idbindex-query-exception-order.any.worker.html]
-  expected: TIMEOUT
   [IDBIndex.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBIndex.get exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.getAll exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBIndex.getAll exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.getAllKeys exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBIndex.getAllKeys exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBIndex.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBIndex.openCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBIndex.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBIndex.openKeyCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-add-put-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-add-put-exception-order.any.js.ini
@@ -5,30 +5,28 @@
   expected: ERROR
 
 [idbobjectstore-add-put-exception-order.any.html]
-  expected: TIMEOUT
   [IDBObjectStore.put exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.put exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
 
   [IDBObjectStore.add exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.add exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
 
 
 [idbobjectstore-add-put-exception-order.any.worker.html]
-  expected: TIMEOUT
   [IDBObjectStore.put exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.put exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
 
   [IDBObjectStore.add exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.add exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-clear-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-clear-exception-order.any.js.ini
@@ -1,7 +1,6 @@
 [idbobjectstore-clear-exception-order.any.worker.html]
-  expected: TIMEOUT
   [IDBObjectStore.clear exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.clear exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
@@ -11,9 +10,8 @@
   expected: ERROR
 
 [idbobjectstore-clear-exception-order.any.html]
-  expected: TIMEOUT
   [IDBObjectStore.clear exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.clear exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-delete-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-delete-exception-order.any.js.ini
@@ -2,9 +2,8 @@
   expected: ERROR
 
 [idbobjectstore-delete-exception-order.any.html]
-  expected: TIMEOUT
   [IDBObjectStore.delete exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.delete exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL
@@ -14,9 +13,8 @@
   expected: ERROR
 
 [idbobjectstore-delete-exception-order.any.worker.html]
-  expected: TIMEOUT
   [IDBObjectStore.delete exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.delete exception order: TransactionInactiveError vs. ReadOnlyError]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-deleteIndex-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-deleteIndex-exception-order.any.js.ini
@@ -1,25 +1,23 @@
 [idbobjectstore-deleteIndex-exception-order.any.worker.html]
-  expected: TIMEOUT
   [IDBObjectStore.deleteIndex exception order: InvalidStateError #1 vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBObjectStore.deleteIndex exception order: InvalidStateError #2 vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.deleteIndex exception order: TransactionInactiveError vs. NotFoundError]
-    expected: TIMEOUT
+    expected: FAIL
 
 
 [idbobjectstore-deleteIndex-exception-order.any.html]
-  expected: TIMEOUT
   [IDBObjectStore.deleteIndex exception order: InvalidStateError #1 vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBObjectStore.deleteIndex exception order: InvalidStateError #2 vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.deleteIndex exception order: TransactionInactiveError vs. NotFoundError]
-    expected: TIMEOUT
+    expected: FAIL
 
 
 [idbobjectstore-deleteIndex-exception-order.any.serviceworker.html]

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-query-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-query-exception-order.any.js.ini
@@ -1,37 +1,36 @@
 [idbobjectstore-query-exception-order.any.html]
-  expected: TIMEOUT
   [IDBObjectStore.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.get exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.getAll exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.getAll exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.getAllKeys exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.getAllKeys exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.openCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.openKeyCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
@@ -41,39 +40,38 @@
   expected: ERROR
 
 [idbobjectstore-query-exception-order.any.worker.html]
-  expected: TIMEOUT
   [IDBObjectStore.get exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.get exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.getAll exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.getAll exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.getAllKeys exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.getAllKeys exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.count exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.openCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
   [IDBObjectStore.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBObjectStore.openKeyCursor exception order: TransactionInactiveError vs. DataError]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_createIndex.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_createIndex.any.js.ini
@@ -46,13 +46,13 @@
     expected: TIMEOUT
 
   [TransactionInactiveError vs. ConstraintError. Transaction-state check should precede index name check.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [ConstraintError vs. SyntaxError. Index name check should precede syntax check of the key path]
-    expected: TIMEOUT
+    expected: FAIL
 
   [SyntaxError vs. InvalidAccessError. Syntax check should precede multiEntry check of the key path.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Explicit Primary Key]
     expected: FAIL
@@ -118,13 +118,13 @@
     expected: TIMEOUT
 
   [TransactionInactiveError vs. ConstraintError. Transaction-state check should precede index name check.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [ConstraintError vs. SyntaxError. Index name check should precede syntax check of the key path]
-    expected: TIMEOUT
+    expected: FAIL
 
   [SyntaxError vs. InvalidAccessError. Syntax check should precede multiEntry check of the key path.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Explicit Primary Key]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAll-options.tentative.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAll-options.tentative.any.js.ini
@@ -1,4 +1,5 @@
 [idbobjectstore_getAll-options.tentative.any.worker.html]
+  expected: CRASH
   [Single item get]
     expected: FAIL
 
@@ -79,6 +80,7 @@
   expected: ERROR
 
 [idbobjectstore_getAll-options.tentative.any.html]
+  expected: CRASH
   [Single item get]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAll.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAll.any.js.ini
@@ -1,4 +1,5 @@
 [idbobjectstore_getAll.any.html]
+  expected: CRASH
   [Single item get]
     expected: FAIL
 
@@ -58,6 +59,7 @@
   expected: ERROR
 
 [idbobjectstore_getAll.any.worker.html]
+  expected: CRASH
   [Single item get]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys-options.tentative.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys-options.tentative.any.js.ini
@@ -1,4 +1,5 @@
 [idbobjectstore_getAllKeys-options.tentative.any.worker.html]
+  expected: CRASH
   [Single item get]
     expected: FAIL
 
@@ -73,6 +74,7 @@
   expected: ERROR
 
 [idbobjectstore_getAllKeys-options.tentative.any.html]
+  expected: CRASH
   [Single item get]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys.any.js.ini
@@ -5,6 +5,7 @@
   expected: ERROR
 
 [idbobjectstore_getAllKeys.any.worker.html]
+  expected: CRASH
   [Single item get]
     expected: FAIL
 
@@ -55,6 +56,7 @@
 
 
 [idbobjectstore_getAllKeys.any.html]
+  expected: CRASH
   [Single item get]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAllRecords.tentative.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAllRecords.tentative.any.js.ini
@@ -1,4 +1,5 @@
 [idbobjectstore_getAllRecords.tentative.any.worker.html]
+  expected: CRASH
   [Single item]
     expected: FAIL
 
@@ -76,6 +77,7 @@
 
 
 [idbobjectstore_getAllRecords.tentative.any.html]
+  expected: CRASH
   [Single item]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getKey.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getKey.any.js.ini
@@ -47,6 +47,9 @@
   [IDBObjectStore.getKey() - key generator and key path - range - no match]
     expected: FAIL
 
+  [IDBObjectStore.getKey() - invalid parameters]
+    expected: FAIL
+
 
 [idbobjectstore_getKey.any.html]
   [IDBObjectStore.getKey() - basic - key]
@@ -95,4 +98,7 @@
     expected: FAIL
 
   [IDBObjectStore.getKey() - key generator and key path - range - no match]
+    expected: FAIL
+
+  [IDBObjectStore.getKey() - invalid parameters]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbtransaction_objectStoreNames.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbtransaction_objectStoreNames.any.js.ini
@@ -18,6 +18,9 @@
   [IDBTransaction.objectStoreNames - unusual names]
     expected: FAIL
 
+  [IDBTransaction.objectStoreNames - during upgrade transaction]
+    expected: FAIL
+
 
 [idbtransaction_objectStoreNames.any.worker.html]
   expected: TIMEOUT
@@ -37,6 +40,9 @@
     expected: FAIL
 
   [IDBTransaction.objectStoreNames - unusual names]
+    expected: FAIL
+
+  [IDBTransaction.objectStoreNames - during upgrade transaction]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/key-conversion-exceptions.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/key-conversion-exceptions.any.js.ini
@@ -17,6 +17,69 @@
   [IDBKeyRange bound() static with throwing/invalid keys]
     expected: FAIL
 
+  [IDBCursor continue() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IndexedDB: Exceptions thrown during key conversion]
+    expected: FAIL
+
+  [IDBCursor update() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore add() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore put() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore delete() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore get() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore getKey() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore count() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore openCursor() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore openKeyCursor() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex get() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex getKey() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex count() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex openCursor() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex openKeyCursor() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore getAll() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore getAllKeys() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex getAll() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex getAllKeys() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex getAllRecords() method with throwing/invalid keys]
+    expected: FAIL
+
 
 [key-conversion-exceptions.any.html]
   [IDBFactory cmp() static with throwing/invalid keys]
@@ -32,6 +95,69 @@
     expected: FAIL
 
   [IDBKeyRange bound() static with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBCursor continue() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IndexedDB: Exceptions thrown during key conversion]
+    expected: FAIL
+
+  [IDBCursor update() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore add() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore put() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore delete() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore get() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore getKey() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore count() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore openCursor() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore openKeyCursor() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex get() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex getKey() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex count() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex openCursor() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex openKeyCursor() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore getAll() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBObjectStore getAllKeys() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex getAll() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex getAllKeys() method with throwing/invalid keys]
+    expected: FAIL
+
+  [IDBIndex getAllRecords() method with throwing/invalid keys]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/keypath-exceptions.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/keypath-exceptions.any.js.ini
@@ -1,4 +1,5 @@
 [keypath-exceptions.any.html]
+  expected: CRASH
   [Array key conversion should not invoke prototype getters]
     expected: FAIL
 
@@ -10,5 +11,6 @@
   expected: ERROR
 
 [keypath-exceptions.any.worker.html]
+  expected: CRASH
   [Array key conversion should not invoke prototype getters]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/nested-cloning-basic.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/nested-cloning-basic.any.js.ini
@@ -2,6 +2,7 @@
   expected: ERROR
 
 [nested-cloning-basic.any.worker.html]
+  expected: CRASH
   [small typed array]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/nested-cloning-large-multiple.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/nested-cloning-large-multiple.any.js.ini
@@ -5,6 +5,7 @@
   expected: ERROR
 
 [nested-cloning-large-multiple.any.html]
+  expected: CRASH
   [multiple requests of objects with blobs and large typed arrays]
     expected: FAIL
 
@@ -13,6 +14,7 @@
 
 
 [nested-cloning-large-multiple.any.worker.html]
+  expected: CRASH
   [multiple requests of objects with blobs and large typed arrays]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/nested-cloning-large.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/nested-cloning-large.any.js.ini
@@ -1,4 +1,5 @@
 [nested-cloning-large.any.html]
+  expected: CRASH
   [large typed array]
     expected: FAIL
 
@@ -25,6 +26,7 @@
   expected: ERROR
 
 [nested-cloning-large.any.worker.html]
+  expected: CRASH
   [large typed array]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/nested-cloning-small.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/nested-cloning-small.any.js.ini
@@ -1,4 +1,5 @@
 [nested-cloning-small.any.html]
+  expected: CRASH
   [blob with small typed array]
     expected: FAIL
 
@@ -25,6 +26,7 @@
   expected: ERROR
 
 [nested-cloning-small.any.worker.html]
+  expected: CRASH
   [blob with small typed array]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/structured-clone.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/structured-clone.any.js.ini
@@ -267,21 +267,6 @@
   [FileList: [object FileList\]]
     expected: FAIL
 
-  [Not serializable: function: function() {}]
-    expected: FAIL
-
-  [Not serializable: symbol: Symbol(desc)]
-    expected: FAIL
-
-  [Not serializable: Window: [object Window\]]
-    expected: FAIL
-
-  [Not serializable: Event: [object Event\]]
-    expected: FAIL
-
-  [Not serializable: MessageChannel: [object MessageChannel\]]
-    expected: FAIL
-
   [SyntaxError: SyntaxError: ghi]
     expected: FAIL
 
@@ -891,21 +876,6 @@
     expected: FAIL
 
   [File: [object File\]]
-    expected: FAIL
-
-  [Not serializable: function: function() {}]
-    expected: FAIL
-
-  [Not serializable: symbol: Symbol(desc)]
-    expected: FAIL
-
-  [Not serializable: DedicatedWorkerGlobalScope: [object DedicatedWorkerGlobalScope\]]
-    expected: FAIL
-
-  [Not serializable: Event: [object Event\]]
-    expected: FAIL
-
-  [Not serializable: MessageChannel: [object MessageChannel\]]
     expected: FAIL
 
   [SyntaxError: SyntaxError: ghi]

--- a/tests/wpt/meta/IndexedDB/transaction-deactivation-timing.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/transaction-deactivation-timing.any.js.ini
@@ -1,9 +1,11 @@
 [transaction-deactivation-timing.any.worker.html]
-  expected: TIMEOUT
   [Deactivation of new transactions happens at end of invocation]
-    expected: TIMEOUT
+    expected: FAIL
 
   [New transactions are deactivated before next task]
+    expected: FAIL
+
+  [New transactions from microtask are deactivated before next task]
     expected: FAIL
 
 
@@ -11,11 +13,7 @@
   expected: ERROR
 
 [transaction-deactivation-timing.any.html]
-  expected: TIMEOUT
   [Deactivation of new transactions happens at end of invocation]
-    expected: TIMEOUT
-
-  [New transactions are deactivated before next task]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/transaction-lifetime-empty.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/transaction-lifetime-empty.any.js.ini
@@ -5,16 +5,18 @@
   expected: ERROR
 
 [transaction-lifetime-empty.any.worker.html]
+  expected: TIMEOUT
   [Transactions without requests complete in the expected order]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Multiple transactions without requests complete in the expected order]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [transaction-lifetime-empty.any.html]
+  expected: TIMEOUT
   [Transactions without requests complete in the expected order]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Multiple transactions without requests complete in the expected order]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/IndexedDB/transaction-lifetime.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/transaction-lifetime.any.js.ini
@@ -2,19 +2,21 @@
   expected: ERROR
 
 [transaction-lifetime.any.html]
+  expected: TIMEOUT
   [No Blocked event]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Blocked event]
-    expected: FAIL
+    expected: NOTRUN
 
 
 [transaction-lifetime.any.sharedworker.html]
   expected: ERROR
 
 [transaction-lifetime.any.worker.html]
+  expected: TIMEOUT
   [No Blocked event]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Blocked event]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/IndexedDB/transaction-scheduling-within-database.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/transaction-scheduling-within-database.any.js.ini
@@ -1,8 +1,10 @@
 [transaction-scheduling-within-database.any.html]
+  expected: TIMEOUT
   [Check that read-only transactions within a database can run in parallel.]
-    expected: FAIL
+    expected: TIMEOUT
 
 
 [transaction-scheduling-within-database.any.worker.html]
+  expected: TIMEOUT
   [Check that read-only transactions within a database can run in parallel.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/IndexedDB/upgrade-transaction-deactivation-timing.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/upgrade-transaction-deactivation-timing.any.js.ini
@@ -1,6 +1,24 @@
 [upgrade-transaction-deactivation-timing.any.worker.html]
+  [Upgrade transactions are active in upgradeneeded callback]
+    expected: FAIL
+
+  [Upgrade transactions are active in upgradeneeded callback and microtasks]
+    expected: FAIL
+
+  [Upgrade transactions are deactivated before next task]
+    expected: FAIL
+
 
 [upgrade-transaction-deactivation-timing.any.html]
+  [Upgrade transactions are active in upgradeneeded callback]
+    expected: FAIL
+
+  [Upgrade transactions are active in upgradeneeded callback and microtasks]
+    expected: FAIL
+
+  [Upgrade transactions are deactivated before next task]
+    expected: FAIL
+
 
 [upgrade-transaction-deactivation-timing.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/worker-termination-aborts-upgrade.window.js.ini
+++ b/tests/wpt/meta/IndexedDB/worker-termination-aborts-upgrade.window.js.ini
@@ -1,3 +1,0 @@
-[worker-termination-aborts-upgrade.window.html]
-  [Worker Termination Aborts a Pending Upgrade]
-    expected: FAIL


### PR DESCRIPTION
None of our automated tests were executing the initial DB setup code because the requested version always matched. 

Testing: Existing WPT coverage.