### PR TITLE
indexeddb: Initialize DB connections with existing object store names.

### DIFF
--- a/components/net/indexeddb/engines/mod.rs
+++ b/components/net/indexeddb/engines/mod.rs
@@ -98,4 +98,6 @@ pub trait KvsEngine {
 
     fn version(&self) -> Result<u64, Self::Error>;
     fn set_version(&self, version: u64) -> Result<(), Self::Error>;
+
+    fn object_store_names(&self) -> Result<Vec<String>, Self::Error>;
 }

--- a/components/net/indexeddb/engines/sqlite.rs
+++ b/components/net/indexeddb/engines/sqlite.rs
@@ -538,6 +538,16 @@ impl KvsEngine for SqliteEngine {
         }
         Ok(())
     }
+
+    fn object_store_names(&self) -> Result<Vec<String>, Self::Error> {
+        let mut stmt = self.connection.prepare("SELECT name FROM object_store")?;
+        let object_store_iter = stmt.query_map([], |r| r.get(0))?;
+        let mut object_stores = vec![];
+        for object_store in object_store_iter {
+            object_stores.push(object_store?);
+        }
+        Ok(object_stores)
+    }
 }
 
 #[cfg(test)]

--- a/components/script/dom/idbdatabase.rs
+++ b/components/script/dom/idbdatabase.rs
@@ -51,12 +51,16 @@ pub struct IDBDatabase {
 }
 
 impl IDBDatabase {
-    pub fn new_inherited(name: DOMString, version: u64) -> IDBDatabase {
+    pub fn new_inherited(
+        name: DOMString,
+        version: u64,
+        object_stores: Vec<DOMString>,
+    ) -> IDBDatabase {
         IDBDatabase {
             eventtarget: EventTarget::new_inherited(),
             name,
             version: Cell::new(version),
-            object_store_names: Default::default(),
+            object_store_names: DomRefCell::new(object_stores),
 
             upgrade_transaction: Default::default(),
             closing: Cell::new(false),
@@ -67,10 +71,11 @@ impl IDBDatabase {
         global: &GlobalScope,
         name: DOMString,
         version: u64,
+        object_stores: Vec<DOMString>,
         can_gc: CanGc,
     ) -> DomRoot<IDBDatabase> {
         reflect_dom_object(
-            Box::new(IDBDatabase::new_inherited(name, version)),
+            Box::new(IDBDatabase::new_inherited(name, version, object_stores)),
             global,
             can_gc,
         )

--- a/components/script/dom/idbopendbrequest.rs
+++ b/components/script/dom/idbopendbrequest.rs
@@ -41,6 +41,7 @@ impl OpenRequestListener {
         name: String,
         request_version: Option<u64>,
         db_version: u64,
+        object_stores: Vec<String>,
         can_gc: CanGc,
     ) -> (Fallible<DomRoot<IDBDatabase>>, bool) {
         // Step 5-6
@@ -67,6 +68,7 @@ impl OpenRequestListener {
             &global,
             DOMString::from_string(name.clone()),
             request_version,
+            object_stores.into_iter().map(DOMString::from).collect(),
             can_gc,
         );
 
@@ -255,8 +257,9 @@ impl IDBOpenDBRequest {
 
                 task_source.queue(
                     task!(set_request_result_to_database: move || {
+                        let (db_version, object_stores) = message.unwrap();
                         let (result, did_upgrade) =
-                            response_listener.handle_open_db(name, version, message.unwrap(), CanGc::note());
+                            response_listener.handle_open_db(name, version, db_version, object_stores, CanGc::note());
                         // If an upgrade event was created, it will be responsible for
                         // dispatching the success event
                         if did_upgrade {

--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -383,7 +383,7 @@ pub enum SyncOperation {
     ),
 
     OpenDatabase(
-        IpcSender<u64>, // Returns the version
+        IpcSender<(u64, Vec<String>)>, // Returns the version and object stores
         ImmutableOrigin,
         String,      // Database
         Option<u64>, // Eventual version


### PR DESCRIPTION
Per https://w3c.github.io/IndexedDB/#connection-object-store-set, connections must have their object store sets initialized to any existing set when the connection is opened.

Testing: WPT coverage