### PR TITLE
layout: Remove workaround for `body` while building overflow frame for `StackingContextTree` construction.

### DIFF
--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -1443,25 +1443,6 @@ impl BoxFragment {
             });
         }
 
-        // scrollable overflow path
-        // From https://drafts.csswg.org/css-overflow/#propdef-overflow:
-        // > UAs must apply the overflow-* values set on the root element to the viewport when the
-        // > root element’s display value is not none. However, when the root element is an [HTML]
-        // > html element (including XML syntax for HTML) whose overflow value is visible (in both
-        // > axes), and that element has as a child a body element whose display value is also not
-        // > none, user agents must instead apply the overflow-* values of the first such child
-        // > element to the viewport. The element from which the value is propagated must then have a
-        // > used overflow value of visible.
-        //
-        // TODO: This should only happen when the `display` value is actually propagated.
-        if self
-            .base
-            .flags
-            .contains(FragmentFlags::IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT)
-        {
-            return None;
-        }
-
         let scroll_frame_rect = self
             .padding_rect()
             .translate(containing_block_rect.origin.to_vector())

--- a/tests/wpt/tests/css/css-overflow/overflow-body-propagation-012-ref.html
+++ b/tests/wpt/tests/css/css-overflow/overflow-body-propagation-012-ref.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>CSS Reference: BODY with overflow:hidden</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<style>
+  div {
+    width: 400px;
+    height: 400px;
+    background: green;
+  }
+</style></head>
+<body><div></div></body>
+</html>

--- a/tests/wpt/tests/css/css-overflow/overflow-body-propagation-012.html
+++ b/tests/wpt/tests/css/css-overflow/overflow-body-propagation-012.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>CSS Test: BODY with overflow:hidden</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/38799">
+<meta name="assert" content="The overflow value that gets propagated to
+  the viewport is the one of the <html>, not the <body>.
+  Therefore, the <body> is able to hide its overflowing contents.">
+<link rel="match" href="overflow-body-propagation-012-ref.html">
+<style>
+  html {
+    overflow: hidden;
+    height: 500px;
+  }
+  body {
+    overflow: hidden;
+    width: 0px;
+    height: 0px;
+    border: solid 200px green;
+  }
+
+  div {
+    background: red;
+    height: 200px;
+    width: 200px;
+  }
+</style></head>
+<body><div></div></body>
+</html>


### PR DESCRIPTION
While building the stacking context tree we were assuming that `<body>` would have propagated its `overflow` value to the viewport, and thus its used `overflow` would be `visible`.

However, the element that propagates `overflow` can be the root element instead. Since #38598 we are correctly taking this into account in `effective_overflow()`, so we no longer need to do anything special in the stacking context logic.

Testing: `css/css-overflow/overflow-body-propagation-012.html`

Fixes: #38799

