### PR TITLE
compositor: Remove `IOCompositor::pipeline_to_webview_map`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -85,11 +85,6 @@ pub struct ServoRenderer {
     /// The [`RefreshDriver`] which manages the rythym of painting.
     refresh_driver: RefreshDriver,
 
-    /// This is a temporary map between [`PipelineId`]s and their associated [`WebViewId`]. Once
-    /// all renderer operations become per-`WebView` this map can be removed, but we still sometimes
-    /// need to work backwards to figure out what `WebView` is associated with a `Pipeline`.
-    pub(crate) pipeline_to_webview_map: HashMap<PipelineId, WebViewId>,
-
     /// Tracks whether we are in the process of shutting down, or have shut down and should close
     /// the compositor. This is shared with the `Servo` instance.
     shutdown_state: Rc<Cell<ShutdownState>>,
@@ -313,7 +308,6 @@ impl IOCompositor {
                     state.event_loop_waker,
                 ),
                 shutdown_state: state.shutdown_state,
-                pipeline_to_webview_map: Default::default(),
                 compositor_receiver: state.receiver,
                 constellation_sender: state.constellation_chan,
                 time_profiler_chan: state.time_profiler_chan,

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -101,15 +101,6 @@ pub(crate) struct WebViewRenderer {
     viewport_description: Option<ViewportDescription>,
 }
 
-impl Drop for WebViewRenderer {
-    fn drop(&mut self) {
-        self.global
-            .borrow_mut()
-            .pipeline_to_webview_map
-            .retain(|_, webview_id| self.id != *webview_id);
-    }
-}
-
 impl WebViewRenderer {
     pub(crate) fn new(
         global: Rc<RefCell<ServoRenderer>>,
@@ -154,13 +145,9 @@ impl WebViewRenderer {
         &mut self,
         pipeline_id: PipelineId,
     ) -> &mut PipelineDetails {
-        self.pipelines.entry(pipeline_id).or_insert_with(|| {
-            self.global
-                .borrow_mut()
-                .pipeline_to_webview_map
-                .insert(pipeline_id, self.id);
-            PipelineDetails::new()
-        })
+        self.pipelines
+            .entry(pipeline_id)
+            .or_insert_with(PipelineDetails::new)
     }
 
     pub(crate) fn pipeline_exited(&mut self, pipeline_id: PipelineId, source: PipelineExitSource) {
@@ -179,10 +166,6 @@ impl WebViewRenderer {
         }
 
         pipeline.remove_entry();
-        self.global
-            .borrow_mut()
-            .pipeline_to_webview_map
-            .remove(&pipeline_id);
     }
 
     pub(crate) fn set_frame_tree(&mut self, frame_tree: &SendableFrameTree) {


### PR DESCRIPTION
This data structure is now unused after changes to the way that hit
testing works.

Testing: This is just removing dead code so no tests are necessary.
