### PR TITLE
opts: Add a --force-ipc option

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -47,6 +47,10 @@ pub struct Opts {
     /// Whether we're running in multiprocess mode.
     pub multiprocess: bool,
 
+    /// Whether to force using ipc_channel instead of crossbeam_channel in singleprocess mode. Does
+    /// nothing in multiprocess mode.
+    pub force_ipc: bool,
+
     /// Whether we want background hang monitor enabled or not
     pub background_hang_monitor: bool,
 
@@ -189,6 +193,7 @@ impl Default for Opts {
             user_stylesheets: Vec::new(),
             hard_fail: true,
             multiprocess: false,
+            force_ipc: false,
             background_hang_monitor: false,
             random_pipeline_closure_probability: None,
             random_pipeline_closure_seed: None,

--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -156,7 +156,7 @@ pub fn channel<T>() -> Option<(GenericSender<T>, GenericReceiver<T>)>
 where
     T: for<'de> Deserialize<'de> + Serialize,
 {
-    if servo_config::opts::get().multiprocess {
+    if servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc {
         ipc_channel::ipc::channel()
             .map(|(tx, rx)| (GenericSender::Ipc(tx), GenericReceiver::Ipc(rx)))
             .ok()

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -284,6 +284,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         "1024x768",
     );
     opts.optflag("M", "multiprocess", "Run in multiprocess mode");
+    opts.optflag("I", "force-ipc", "Use ipc_channel in singleprocess mode");
     opts.optflag("B", "bhm", "Background Hang Monitor enabled");
     opts.optflag("S", "sandbox", "Run in a sandbox if multiprocess");
     opts.optopt(
@@ -695,6 +696,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         user_stylesheets,
         hard_fail: opt_match.opt_present("f") && !opt_match.opt_present("F"),
         multiprocess: opt_match.opt_present("M"),
+        force_ipc: opt_match.opt_present("I"),
         background_hang_monitor: opt_match.opt_present("B"),
         sandbox: opt_match.opt_present("S"),
         random_pipeline_closure_probability,


### PR DESCRIPTION
Testing: servo.org loads properly with `./mach run -- -I`
Fixes: https://github.com/servo/servo/issues/38823
