### PR TITLE
Make transaction field non-null in IDBObjectStore

### DIFF
--- a/components/script/dom/idbdatabase.rs
+++ b/components/script/dom/idbdatabase.rs
@@ -244,8 +244,8 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
             name.clone(),
             Some(options),
             CanGc::note(),
+            &upgrade_transaction,
         );
-        object_store.set_transaction(&upgrade_transaction);
 
         let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
 

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -19,7 +19,7 @@ use crate::dom::bindings::codegen::Bindings::IDBTransactionBinding::IDBTransacti
 use crate::dom::bindings::codegen::UnionTypes::StringOrStringSequence as StrOrStringSequence;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
-use crate::dom::bindings::root::{DomRoot, MutDom};
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::domstringlist::DOMStringList;
@@ -42,7 +42,7 @@ pub struct IDBObjectStore {
     name: DomRefCell<DOMString>,
     key_path: Option<KeyPath>,
     index_names: DomRoot<DOMStringList>,
-    transaction: MutDom<IDBTransaction>,
+    transaction: Dom<IDBTransaction>,
     auto_increment: bool,
 
     // We store the db name in the object store to be able to find the correct
@@ -75,7 +75,7 @@ impl IDBObjectStore {
             key_path,
 
             index_names: DOMStringList::new(global, Vec::new(), can_gc),
-            transaction: MutDom::new(transaction),
+            transaction: Dom::from_ref(transaction),
             // FIXME:(arihant2math)
             auto_increment: false,
 
@@ -110,7 +110,7 @@ impl IDBObjectStore {
     }
 
     pub fn transaction(&self) -> DomRoot<IDBTransaction> {
-        self.transaction.get()
+        self.transaction.as_rooted()
     }
 
     fn has_key_generator(&self) -> bool {
@@ -174,7 +174,7 @@ impl IDBObjectStore {
     /// Checks if the transation is active, throwing a "TransactionInactiveError" DOMException if not.
     fn check_transaction_active(&self) -> Fallible<()> {
         // Let transaction be this object store handle's transaction.
-        let transaction = self.transaction.get();
+        let transaction = &self.transaction;
 
         // If transaction is not active, throw a "TransactionInactiveError" DOMException.
         if !transaction.is_active() {
@@ -188,7 +188,7 @@ impl IDBObjectStore {
     /// it then checks if the transaction is a read-only transaction, throwing a "ReadOnlyError" DOMException if so.
     fn check_readwrite_transaction_active(&self) -> Fallible<()> {
         // Let transaction be this object store handle's transaction.
-        let transaction = self.transaction.get();
+        let transaction = &self.transaction;
 
         // If transaction is not active, throw a "TransactionInactiveError" DOMException.
         if !transaction.is_active() {

--- a/components/script/dom/idbrequest.rs
+++ b/components/script/dom/idbrequest.rs
@@ -254,7 +254,7 @@ impl IDBRequest {
         T: Into<IdbResult> + for<'a> Deserialize<'a> + Serialize + Send + Sync + 'static,
     {
         // Step 1: Let transaction be the transaction associated with source.
-        let transaction = source.transaction().expect("Store has no transaction");
+        let transaction = source.transaction();
         let global = transaction.global();
 
         // Step 2: Assert: transaction is active.

--- a/components/script/dom/idbtransaction.rs
+++ b/components/script/dom/idbtransaction.rs
@@ -236,8 +236,8 @@ impl IDBTransactionMethods<crate::DomTypeHolder> for IDBTransaction {
                 name,
                 None,
                 CanGc::note(),
+                self,
             );
-            store.set_transaction(self);
             Dom::from_ref(&*store)
         });
 

--- a/components/script_bindings/webidls/IDBObjectStore.webidl
+++ b/components/script_bindings/webidls/IDBObjectStore.webidl
@@ -13,7 +13,7 @@ interface IDBObjectStore {
   attribute DOMString name;
   // readonly attribute any keyPath;
   // readonly attribute DOMStringList indexNames;
-  [SameObject] readonly attribute IDBTransaction? transaction;
+  [SameObject] readonly attribute IDBTransaction transaction;
   readonly attribute boolean autoIncrement;
 
   [NewObject, Throws] IDBRequest put(any value, optional any key);


### PR DESCRIPTION
In the `IDBObjectStore::new` constructor, the `transaction` field is initialized to null, but when using this constructor, we always execute `set_transaction` immediately afterward. Therefore, we refactored to require the `transaction` field to be specified during construction and thereby also removed some no longer necessary assertions.

We also updated the `transaction` field in WebIDL to remove the nullable capability.

Testing: WPT
Fixes: #38814 