### PR TITLE
net: Fix initial indexeddb version storage

### DIFF
--- a/components/net/indexeddb/engines/sqlite.rs
+++ b/components/net/indexeddb/engines/sqlite.rs
@@ -125,10 +125,11 @@ impl SqliteEngine {
         // From https://w3c.github.io/IndexedDB/#database-version:
         // "When a database is first created, its version is 0 (zero)."
         connection.execute(
-            "INSERT INTO database (name, origin, version) VALUES (?, ?, 0)",
+            "INSERT INTO database (name, origin, version) VALUES (?, ?, ?)",
             params![
                 db_info.name.to_owned(),
                 db_info.origin.to_owned().ascii_serialization(),
+                i64::from_ne_bytes(0_u64.to_ne_bytes())
             ],
         )?;
         Ok(connection)


### PR DESCRIPTION
#38819 made a step in the right direction. Unfortunately sqlite doesn't support unsigned integers, so I've been storing them as i64s internally, but deserializing the bytes to u64s. This allows for an extra bit of information, but by inserting 0 into the table, it was interpreted `u64::from_ne_bytes([1,0,0,0....,0])` (or whatever the internal bit representation of `0_i64` is on the platform), which is not intended.