### PR TITLE
webdriver: Simplify deserialize `window_handles: Vec<String>`

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1067,11 +1067,6 @@ impl Handler {
         let mut handles = self.get_window_handles()?;
         handles.sort();
 
-        let handles = handles
-            .into_iter()
-            .map(serde_json::to_value)
-            .collect::<Result<Vec<_>, _>>()?;
-
         Ok(WebDriverResponse::Generic(ValueResponse(
             serde_json::to_value(handles)?,
         )))


### PR DESCRIPTION
We don't need to serialize internal String and then serialize the Result type.

Testing: Tested. No behaviour change.