### PR TITLE
webdriver: Consider shadow including descendant when computing "obscured" step of “element click”

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1904,7 +1904,7 @@ pub(crate) fn handle_element_click(
                 // `paint_tree` is guaranteed not empty as element is "in view".
                 if !container
                     .upcast::<Node>()
-                    .Contains(Some(paint_tree[0].upcast::<Node>()))
+                    .is_shadow_including_inclusive_ancestor_of(paint_tree[0].upcast::<Node>())
                 {
                     return Err(ErrorStatus::ElementClickIntercepted);
                 }

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/navigate.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/navigate.py.ini
@@ -10,3 +10,12 @@
 
   [test_link_closes_window]
     expected: FAIL
+
+  [test_link_from_nested_context_with_target[\]]
+    expected: FAIL
+
+  [test_link_from_nested_context_with_target[_blank\]]
+    expected: FAIL
+
+  [test_link_from_nested_context_with_target[_self\]]
+    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/select.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/select.py.ini
@@ -13,21 +13,3 @@
 
   [test_out_of_view_dropdown]
     expected: FAIL
-
-  [test_click_multiple_option]
-    expected: FAIL
-
-  [test_click_preselected_multiple_option]
-    expected: FAIL
-
-  [test_click_multiple_does_not_deselect_others]
-    expected: FAIL
-
-  [test_click_selected_multiple_option]
-    expected: FAIL
-
-  [test_out_of_view_multiple]
-    expected: FAIL
-
-  [test_option_disabled]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/element_click/shadow_dom.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/element_click/shadow_dom.py.ini
@@ -1,9 +1,0 @@
-[shadow_dom.py]
-  [test_shadow_element_click[host_element\]]
-    expected: FAIL
-
-  [test_nested_shadow_element_click[outer_element\]]
-    expected: FAIL
-
-  [test_nested_shadow_element_click[inner_element\]]
-    expected: FAIL


### PR DESCRIPTION
Testing: WebDriver Conformance test. In addition to fixing all "Element Intercepted" errors in https://github.com/yezhizhen/servo/actions/runs/17142506541, we are able to fix many other tests.
Fixes: #38837