### PR TITLE
fonts: Use `fontations` to read the OS/2 table of DirectWrite fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,11 +2708,11 @@ dependencies = [
  "stylo",
  "stylo_atoms",
  "tracing",
- "truetype",
  "unicode-properties",
  "unicode-script",
  "url",
  "webrender_api",
+ "winapi",
  "xml-rs",
  "yeslogic-fontconfig-sys",
 ]
@@ -8989,15 +8989,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce607aae8ab0ab3abf3a2723a9ab6f09bb8639ed83fdd888d857b8e556c868d8"
 
 [[package]]
-name = "truetype"
-version = "0.47.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ce9543b570c6e8a392274b67e1001816bce953aa89724e52a4639db02a10e0"
-dependencies = [
- "typeface",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9036,12 +9027,6 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
-
-[[package]]
-name = "typeface"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191ea6762cbcd705fbed8f58573fd6c654453ff3da60adb293d9f255bc92af8e"
 
 [[package]]
 name = "typeid"

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -74,7 +74,7 @@ xml-rs = "0.8"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 dwrote = "0.11.4"
-truetype = { version = "0.47.3", features = ["ignore-invalid-language-ids"] }
+winapi = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ohos_mock)'] }


### PR DESCRIPTION
Instead of copying the font table data in memory and parsing it with the
`truetype` crate, use a non-copying API from DirectWrite to implement a
`fontations` `TableProvider`. This has two benefits:

- We remove the dependency on the `truetype` crate finally.
- We do not have to make an in-memory copy of the table data when
  parsing the table.

The hope is that the `TableProvider` will be more generally useful in
the future.

Testing: There are no automated tests for Windows, but I manually verified
that the data retrived via `fontations` matched that retrived by `truetype`.