### PR TITLE
generic_channel: Preserve IPC errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9710,6 +9710,7 @@ dependencies = [
 name = "webgl"
 version = "0.0.1"
 dependencies = [
+ "base",
  "bitflags 2.9.3",
  "byteorder",
  "canvas_traits",

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -870,7 +870,7 @@ impl ScriptThread {
             JS_AddInterruptCallback(cx, Some(interrupt_callback));
         }
 
-        let constellation_receiver = state.constellation_receiver.into_inner();
+        let constellation_receiver = state.constellation_receiver.route_preserving_errors();
 
         // Ask the router to proxy IPC messages from the devtools to us.
         let devtools_server_sender = state.devtools_server_sender;

--- a/components/webgl/Cargo.toml
+++ b/components/webgl/Cargo.toml
@@ -16,6 +16,7 @@ webgl_backtrace = ["canvas_traits/webgl_backtrace"]
 webxr = ["dep:webxr", "dep:webxr-api"]
 
 [dependencies]
+base = { path = "../shared/base" }
 bitflags = { workspace = true }
 byteorder = { workspace = true }
 canvas_traits = { workspace = true }


### PR DESCRIPTION
We should not be using `route_ipc_receiver_to_new_crossbeam_receiver` or similar methods, that `unwrap()` on the ROUTER thread if they encounter IPC errors. Instead, we now propagate the error to the crossbeam receiver.
In the GenericChannel::Crossbeam case this means, that we need to use a `Result<T>` as the data type, even though the Result variant is always okay, so that the receiver type is the same regardless of `IPC` or not. This is required, so we have the same channel type, and can pass the inner crossbeam channel into e.g. `select!`, without having to wrap or re-implement select.

This also means, that as we switch towards GenericChannel, we will gradually improve our error handling and eventually remove the existing panics on IPC errors.

These changes were extracted out of https://github.com/servo/servo/pull/38782

Testing: Covered by existing tests. No new panics were introduced.

