### PR TITLE
script: Do not iterate through all image frames when advancing animated images

### DIFF
--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -311,18 +311,21 @@ impl RasterImage {
         self.frames.len() > 1
     }
 
-    pub fn frames(&self) -> impl Iterator<Item = ImageFrameView<'_>> {
-        self.frames.iter().map(|frame| ImageFrameView {
+    fn frame_view<'image>(&'image self, frame: &ImageFrame) -> ImageFrameView<'image> {
+        ImageFrameView {
             delay: frame.delay,
             bytes: self.bytes.get(frame.byte_range.clone()).unwrap(),
             width: frame.width,
             height: frame.height,
-        })
+        }
+    }
+
+    pub fn frame(&self, index: usize) -> Option<ImageFrameView<'_>> {
+        self.frames.get(index).map(|frame| self.frame_view(frame))
     }
 
     pub fn first_frame(&self) -> ImageFrameView<'_> {
-        self.frames()
-            .next()
+        self.frame(0)
             .expect("All images should have at least one frame")
     }
 }

--- a/components/script/image_animation.rs
+++ b/components/script/image_animation.rs
@@ -72,8 +72,7 @@ impl ImageAnimationManager {
 
                 let image = &state.image;
                 let frame = image
-                    .frames()
-                    .nth(state.active_frame)
+                    .frame(state.active_frame)
                     .expect("active_frame should within range of frames");
 
                 if let Some(node) = rooted_nodes.get(&NoTrace(*node)) {


### PR DESCRIPTION
Instead of iterating through all frames every time we are looking for a
particular frame, just index into the `Vec` of frames directly. This
should do less work on every frame transition.

Testing: This is just a small optimization, so shouldn't change observable
behavior.
