### PR TITLE
script: Generate only a single frame during "update the rendering"

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -660,6 +660,11 @@ impl IOCompositor {
                 transaction
                     .set_display_list(display_list_info.epoch, (pipeline_id, built_display_list));
                 self.update_transaction_with_all_scroll_offsets(&mut transaction);
+                self.global.borrow_mut().send_transaction(transaction);
+            },
+
+            CompositorMsg::GenerateFrame => {
+                let mut transaction = Transaction::new();
                 self.generate_frame(&mut transaction, RenderReasons::SCENE);
                 self.global.borrow_mut().send_transaction(transaction);
             },

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -42,6 +42,7 @@ mod from_constellation {
                 Self::SendInitialTransaction(..) => target!("SendInitialTransaction"),
                 Self::SendScrollNode(..) => target!("SendScrollNode"),
                 Self::SendDisplayList { .. } => target!("SendDisplayList"),
+                Self::GenerateFrame { .. } => target!("GenerateFrame"),
                 Self::GenerateImageKey(..) => target!("GenerateImageKey"),
                 Self::UpdateImages(..) => target!("UpdateImages"),
                 Self::GenerateFontKeys(..) => target!("GenerateFontKeys"),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2112,6 +2112,9 @@ impl Window {
         // properly process ScrollBehavior here.
         let reflow_phases_run =
             self.reflow(ReflowGoal::UpdateScrollNode(scroll_id, Vector2D::new(x, y)));
+        if reflow_phases_run.needs_frame() {
+            self.compositor_api().generate_frame();
+        }
 
         // > If the scroll position did not change as a result of the user interaction or programmatic
         // > invocation, where no translations were applied as a result, then no scrollend event fires
@@ -2352,7 +2355,9 @@ impl Window {
         // iframe size updates.
         //
         // See <https://github.com/servo/servo/issues/14719>
-        self.Document().update_the_rendering();
+        if self.Document().update_the_rendering().needs_frame() {
+            self.compositor_api().generate_frame();
+        }
     }
 
     pub(crate) fn layout_blocked(&self) -> bool {

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -111,6 +111,9 @@ pub enum CompositorMsg {
         /// An [ipc::IpcBytesReceiver] used to send the raw data of the display list.
         display_list_receiver: ipc::IpcBytesReceiver,
     },
+    /// Ask the renderer to generate a frame for the current set of display lists that
+    /// have been sent to the renderer.
+    GenerateFrame,
     /// Create a new image key. The result will be returned via the
     /// provided channel sender.
     GenerateImageKey(IpcSender<ImageKey>),
@@ -241,6 +244,13 @@ impl CrossProcessCompositorApi {
         }
         if let Err(error) = display_list_sender.send(&display_list_data.spatial_tree) {
             warn!("Error sending display spatial tree: {error}");
+        }
+    }
+
+    /// Ask the Servo renderer to generate a new frame after having new display lists.
+    pub fn generate_frame(&self) {
+        if let Err(error) = self.0.send(CompositorMsg::GenerateFrame) {
+            warn!("Error generating frame: {error}");
         }
     }
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -441,6 +441,15 @@ bitflags! {
         const BuiltStackingContextTree = 1 << 2;
         const BuiltDisplayList = 1 << 3;
         const UpdatedScrollNodeOffset = 1 << 4;
+        const UpdatedCanvasContents = 1 << 5;
+    }
+}
+
+impl ReflowPhasesRun {
+    pub fn needs_frame(&self) -> bool {
+        self.intersects(
+            Self::BuiltDisplayList | Self::UpdatedScrollNodeOffset | Self::UpdatedCanvasContents,
+        )
     }
 }
 


### PR DESCRIPTION
Instead of generating a frame for every display list, which might be one
rendered frame per `<iframe>`, generate only a single frame per call to
"update the rendering." This should make rendering more efficient when
there are `<iframe>`s present and also open up optimizations for
non-display list frames.

Testing: This could potentially reduce flashing of content during rendering
updates, but that is very difficult to test.
