### PR TITLE
Upgrade vello, vello_cpu, skrifa, and read-fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6874,9 +6874,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.29.3"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ca636dac446b5664bd16c069c00a9621806895b8bb02c2dc68542b23b8f25d"
+checksum = "50ea612a55c08586a1d15134be8a776186c440c312ebda3b9e8efbfe4255b7f4"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -8024,9 +8024,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skrifa"
-version = "0.31.3"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbeb4ca4399663735553a09dd17ce7e49a0a0203f03b706b39628c4d913a8607"
+checksum = "576e60c7de4bb6a803a0312f9bef17e78cf1e8d25a80e1ade76770d7a0237955"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -9306,7 +9306,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 [[package]]
 name = "vello"
 version = "0.5.0"
-source = "git+https://github.com/linebender/vello?rev=b0e2e598ac62c7b3d04d8660e7b1b7659b596970#b0e2e598ac62c7b3d04d8660e7b1b7659b596970"
+source = "git+https://github.com/linebender/vello?rev=472c43ccc80c731d32d167c9e9748c78df1977f4#472c43ccc80c731d32d167c9e9748c78df1977f4"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
@@ -9324,7 +9324,7 @@ dependencies = [
 [[package]]
 name = "vello_common"
 version = "0.0.1"
-source = "git+https://github.com/linebender/vello?rev=b0e2e598ac62c7b3d04d8660e7b1b7659b596970#b0e2e598ac62c7b3d04d8660e7b1b7659b596970"
+source = "git+https://github.com/linebender/vello?rev=472c43ccc80c731d32d167c9e9748c78df1977f4#472c43ccc80c731d32d167c9e9748c78df1977f4"
 dependencies = [
  "bytemuck",
  "fearless_simd",
@@ -9338,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "vello_cpu"
 version = "0.0.1"
-source = "git+https://github.com/linebender/vello?rev=b0e2e598ac62c7b3d04d8660e7b1b7659b596970#b0e2e598ac62c7b3d04d8660e7b1b7659b596970"
+source = "git+https://github.com/linebender/vello?rev=472c43ccc80c731d32d167c9e9748c78df1977f4#472c43ccc80c731d32d167c9e9748c78df1977f4"
 dependencies = [
  "bytemuck",
  "vello_common",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "vello_encoding"
 version = "0.5.0"
-source = "git+https://github.com/linebender/vello?rev=b0e2e598ac62c7b3d04d8660e7b1b7659b596970#b0e2e598ac62c7b3d04d8660e7b1b7659b596970"
+source = "git+https://github.com/linebender/vello?rev=472c43ccc80c731d32d167c9e9748c78df1977f4#472c43ccc80c731d32d167c9e9748c78df1977f4"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -9359,7 +9359,7 @@ dependencies = [
 [[package]]
 name = "vello_shaders"
 version = "0.5.0"
-source = "git+https://github.com/linebender/vello?rev=b0e2e598ac62c7b3d04d8660e7b1b7659b596970#b0e2e598ac62c7b3d04d8660e7b1b7659b596970"
+source = "git+https://github.com/linebender/vello?rev=472c43ccc80c731d32d167c9e9748c78df1977f4#472c43ccc80c731d32d167c9e9748c78df1977f4"
 dependencies = [
  "bytemuck",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ rand_core = "0.6"
 rand_isaac = "0.3"
 raw-window-handle = "0.6"
 rayon = "1"
-read-fonts = "0.29.2"
+read-fonts = "0.33.1"
 regex = "1.11"
 resvg = "0.45.0"
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
@@ -138,7 +138,7 @@ servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
 servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
-skrifa = "0.31.3"
+skrifa = "0.35.0"
 smallbitvec = "2.6.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 string_cache = "0.8"
@@ -173,8 +173,8 @@ unicode-segmentation = "1.12.0"
 url = "2.5"
 urlpattern = "0.3"
 uuid = { version = "1.18.0", features = ["v4"] }
-vello = { git = "https://github.com/linebender/vello", rev = "b0e2e598ac62c7b3d04d8660e7b1b7659b596970" }
-vello_cpu = { git = "https://github.com/linebender/vello", rev = "b0e2e598ac62c7b3d04d8660e7b1b7659b596970" }
+vello = { git = "https://github.com/linebender/vello", rev = "472c43ccc80c731d32d167c9e9748c78df1977f4" }
+vello_cpu = { git = "https://github.com/linebender/vello", rev = "472c43ccc80c731d32d167c9e9748c78df1977f4" }
 webdriver = "0.53.0"
 webgpu_traits = { path = "components/shared/webgpu" }
 webpki-roots = "1.0"

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -111,9 +111,7 @@ impl VelloCPUDrawTarget {
         if self.state == State::Drawing {
             self.ignore_clips(|self_| {
                 self_.ctx.flush();
-                self_
-                    .ctx
-                    .render_to_pixmap(&mut self_.pixmap, vello_cpu::RenderMode::OptimizeSpeed);
+                self_.ctx.render_to_pixmap(&mut self_.pixmap);
                 self_.ctx.reset();
                 self_.state = State::Rendered;
             });


### PR DESCRIPTION
Bumps `vello`, `vello_cpu`,`skrifa`, and `read-fonts` dependencies.

Notes:
- The primary motivation for this is so that our version of `read-fonts` matches the version used by current releases of `harfrust`
- `vello_cpu` now defaults to `RenderMode::OptimizeSpeed` so we don't need to pass this explicitly.
