### PR TITLE
Remove accesskit_winit from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,13 +16,12 @@ updates:
       patterns:
         - "ecolor"
         - "egui"
+        - "egui-file-dialog"
         - "egui-winit"
         - "egui_glow"
         - "emath"
         - "epaint"
         - "epaint_default_fonts"
-        - "accesskit_winit"
-        - "egui-file-dialog"
     gstreamer-related:
       patterns:
         - "gio*"


### PR DESCRIPTION
See: https://github.com/servo/servo/pull/38792#issuecomment-3207312249

Testing: No tests for dependabot.yml edit.