### PR TITLE
Use `Tag` type from font-types crate to represent opentype tags

### DIFF
--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -24,9 +24,7 @@ use webrender_api::{FontInstanceFlags, FontVariation};
 use super::LocalFontIdentifier;
 use super::library_handle::FreeTypeLibraryHandle;
 use crate::FontData;
-use crate::font::{
-    FontMetrics, FontTableMethods, FontTableTag, FractionalPixel, PlatformFontMethods,
-};
+use crate::font::{FontMetrics, FontTableMethods, FractionalPixel, PlatformFontMethods};
 use crate::font_template::FontTemplateDescriptor;
 use crate::glyph::GlyphId;
 use crate::platform::freetype::freetype_face::FreeTypeFace;
@@ -324,8 +322,7 @@ impl PlatformFontMethods for PlatformFont {
         }
     }
 
-    fn table_for_tag(&self, tag: FontTableTag) -> Option<FontTable> {
-        let tag = Tag::from_u32(tag);
+    fn table_for_tag(&self, tag: Tag) -> Option<FontTable> {
         let font_ref = self.table_provider_data.font_ref().ok()?;
         let _table_data = font_ref.table_data(tag)?;
         Some(FontTable {

--- a/components/fonts/platform/macos/font.rs
+++ b/components/fonts/platform/macos/font.rs
@@ -18,15 +18,15 @@ use core_text::font_descriptor::{
 };
 use euclid::default::{Point2D, Rect, Size2D};
 use log::debug;
+use skrifa::Tag;
 use style::values::computed::font::{FontStretch, FontStyle, FontWeight};
 use webrender_api::{FontInstanceFlags, FontVariation};
 
 use super::core_text_font_cache::CoreTextFontCache;
 use super::font_list::LocalFontIdentifier;
 use crate::{
-    CBDT, COLR, FontData, FontIdentifier, FontMetrics, FontTableMethods, FontTableTag,
-    FontTemplateDescriptor, FractionalPixel, GlyphId, KERN, PlatformFontMethods, SBIX,
-    map_platform_values_to_style_values,
+    CBDT, COLR, FontData, FontIdentifier, FontMetrics, FontTableMethods, FontTemplateDescriptor,
+    FractionalPixel, GlyphId, KERN, PlatformFontMethods, SBIX, map_platform_values_to_style_values,
 };
 
 const KERN_PAIR_LEN: usize = 6;
@@ -346,8 +346,9 @@ impl PlatformFontMethods for PlatformFont {
         metrics
     }
 
-    fn table_for_tag(&self, tag: FontTableTag) -> Option<FontTable> {
-        let result: Option<CFData> = self.ctfont.get_font_table(tag);
+    fn table_for_tag(&self, tag: Tag) -> Option<FontTable> {
+        let tag_u32 = u32::from_be_bytes(tag.into_bytes());
+        let result: Option<CFData> = self.ctfont.get_font_table(tag_u32);
         result.map(FontTable::wrap)
     }
 

--- a/components/fonts/platform/macos/font.rs
+++ b/components/fonts/platform/macos/font.rs
@@ -347,7 +347,7 @@ impl PlatformFontMethods for PlatformFont {
     }
 
     fn table_for_tag(&self, tag: Tag) -> Option<FontTable> {
-        let tag_u32 = u32::from_be_bytes(tag.into_bytes());
+        let tag_u32 = u32::from_be_bytes(tag.to_be_bytes());
         let result: Option<CFData> = self.ctfont.get_font_table(tag_u32);
         result.map(FontTable::wrap)
     }

--- a/components/fonts/platform/windows/font.rs
+++ b/components/fonts/platform/windows/font.rs
@@ -26,7 +26,7 @@ use winapi::shared::minwindef::{BOOL, FALSE};
 
 use super::font_list::LocalFontIdentifier;
 use crate::{
-    FontData, FontIdentifier, FontMetrics, FontTableMethods, FontTableTag, FontTemplateDescriptor,
+    FontData, FontIdentifier, FontMetrics, FontTableMethods, FontTemplateDescriptor,
     FractionalPixel, GlyphId, PlatformFontMethods,
 };
 
@@ -282,12 +282,12 @@ impl PlatformFontMethods for PlatformFont {
         metrics
     }
 
-    fn table_for_tag(&self, tag: FontTableTag) -> Option<FontTable> {
+    fn table_for_tag(&self, tag: Tag) -> Option<FontTable> {
         // dwrote (and presumably the Windows APIs) accept a reversed version of the table
         // tag bytes, which means that `u32::swap_bytes` must be called here in order to
         // use a byte order compatible with the rest of Servo.
         self.face
-            .font_table(u32::swap_bytes(tag))
+            .font_table(u32::from_be_bytes(tag.to_be_bytes()).swap_bytes())
             .ok()
             .flatten()
             .map(|bytes| FontTable { data: bytes })


### PR DESCRIPTION
The `font-types` crate is the tiny type-only base crate of `fontations`. This uses a strongly typed representation of open type tags, and allows us to remove our custom macro for creating them.