### PR TITLE
script: Reduce ScriptThread TLS usage

### DIFF
--- a/components/script/dom/abstractworkerglobalscope.rs
+++ b/components/script/dom/abstractworkerglobalscope.rs
@@ -55,7 +55,7 @@ pub(crate) fn run_worker_event_loop<T, WorkerMsg, Event>(
     let event = select! {
         recv(worker_scope.control_receiver()) -> msg => T::from_control_msg(msg.unwrap()),
         recv(task_queue.select()) -> msg => {
-            task_queue.take_tasks(msg.unwrap(), HashSet::new());
+            task_queue.take_tasks(msg.unwrap(), &HashSet::new());
             T::from_worker_msg(task_queue.recv().unwrap())
         },
         recv(devtools_receiver) -> msg => T::from_devtools_msg(msg.unwrap()),
@@ -74,7 +74,7 @@ pub(crate) fn run_worker_event_loop<T, WorkerMsg, Event>(
     while !scope.is_closing() {
         // Batch all events that are ready.
         // The task queue will throttle non-priority tasks if necessary.
-        match task_queue.take_tasks_and_recv(HashSet::new()) {
+        match task_queue.take_tasks_and_recv(&HashSet::new()) {
             Err(_) => match devtools_receiver.try_recv() {
                 Ok(message) => sequential.push(T::from_devtools_msg(message)),
                 Err(_) => break,

--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -52,7 +52,6 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::htmlelement::HTMLElement;
 use crate::dom::window::Window;
 use crate::script_runtime::{CanGc, JSContext, JSContext as SafeJSContext};
-use crate::script_thread::ScriptThread;
 
 /// <https://html.spec.whatwg.org/multipage/#htmlconstructor>
 fn html_constructor(
@@ -389,14 +388,6 @@ fn get_constructor_object_from_local_name(
     };
     constructor_fn(cx, global, rval);
     true
-}
-
-pub(crate) fn pop_current_element_queue(can_gc: CanGc) {
-    ScriptThread::pop_current_element_queue(can_gc);
-}
-
-pub(crate) fn push_new_element_queue() {
-    ScriptThread::push_new_element_queue();
 }
 
 pub(crate) fn call_html_constructor<T: DerivedFrom<Element> + DomObject>(

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -19,9 +19,7 @@ use script_bindings::settings_stack::StackEntry;
 
 use crate::DomTypes;
 use crate::dom::bindings::codegen::{InterfaceObjectMap, PrototypeList};
-use crate::dom::bindings::constructor::{
-    call_html_constructor, pop_current_element_queue, push_new_element_queue,
-};
+use crate::dom::bindings::constructor::call_html_constructor;
 use crate::dom::bindings::conversions::DerivedFrom;
 use crate::dom::bindings::error::{Error, report_pending_exception, throw_dom_exception};
 use crate::dom::bindings::principals::PRINCIPALS_CALLBACKS;
@@ -33,6 +31,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::windowproxy::WindowProxyHandler;
 use crate::realms::InRealm;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+use crate::script_thread::ScriptThread;
 
 #[derive(JSTraceable, MallocSizeOf)]
 /// Static data associated with a global object.
@@ -185,10 +184,10 @@ impl DomHelpers<crate::DomTypeHolder> for crate::DomTypeHolder {
     }
 
     fn push_new_element_queue() {
-        push_new_element_queue()
+        ScriptThread::custom_element_reaction_stack().push_new_element_queue()
     }
     fn pop_current_element_queue(can_gc: CanGc) {
-        pop_current_element_queue(can_gc)
+        ScriptThread::custom_element_reaction_stack().pop_current_element_queue(can_gc)
     }
 
     fn reflect_dom_object<T, U>(obj: Box<T>, global: &U, can_gc: CanGc) -> DomRoot<T>

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -1044,8 +1044,12 @@ enum BackupElementQueueFlag {
 }
 
 /// <https://html.spec.whatwg.org/multipage/#custom-element-reactions-stack>
+/// # Safety
+/// This can be shared inside an Rc because one of those Rc copies lives
+/// inside ScriptThread, so the GC can always reach this structure.
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::allow_unrooted_in_rc)]
 pub(crate) struct CustomElementReactionStack {
     stack: DomRefCell<Vec<ElementQueue>>,
     backup_queue: ElementQueue,

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -117,6 +117,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             loader,
             Some(self.document.insecure_requests_policy()),
             self.document.has_trustworthy_ancestor_or_current_origin(),
+            self.document.custom_element_reaction_stack(),
             can_gc,
         );
 
@@ -184,6 +185,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             self.document.allow_declarative_shadow_roots(),
             Some(self.document.insecure_requests_policy()),
             self.document.has_trustworthy_ancestor_or_current_origin(),
+            self.document.custom_element_reaction_stack(),
             can_gc,
         );
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -104,6 +104,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     false,
                     Some(doc.insecure_requests_policy()),
                     doc.has_trustworthy_ancestor_or_current_origin(),
+                    doc.custom_element_reaction_stack(),
                     can_gc,
                 );
                 // Step switch-1. Parse HTML from a string given document and compliantString.
@@ -131,6 +132,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     false,
                     Some(doc.insecure_requests_policy()),
                     doc.has_trustworthy_ancestor_or_current_origin(),
+                    doc.custom_element_reaction_stack(),
                     can_gc,
                 );
                 // Step switch-1. Create an XML parser parser, associated with document,

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -326,7 +326,7 @@ impl Node {
 
     /// Implements the "unsafely set HTML" algorithm as specified in:
     /// <https://html.spec.whatwg.org/multipage/#concept-unsafely-set-html>
-    pub fn unsafely_set_html(
+    pub(crate) fn unsafely_set_html(
         target: &Node,
         context_element: &Element,
         html: DOMString,
@@ -2926,6 +2926,7 @@ impl Node {
                     document.allow_declarative_shadow_roots(),
                     Some(document.insecure_requests_policy()),
                     document.has_trustworthy_ancestor_or_current_origin(),
+                    document.custom_element_reaction_stack(),
                     can_gc,
                 );
                 DomRoot::upcast::<Node>(document)

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::collections::vec_deque::VecDeque;
+use std::rc::Rc;
 use std::thread;
 
 use crossbeam_channel::{Receiver, Sender, unbounded};
@@ -29,6 +30,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::comment::Comment;
+use crate::dom::customelementregistry::CustomElementReactionStack;
 use crate::dom::document::Document;
 use crate::dom::documenttype::DocumentType;
 use crate::dom::element::{Element, ElementCreator};
@@ -228,6 +230,8 @@ pub(crate) struct Tokenizer {
     #[no_trace]
     url: ServoUrl,
     parsing_algorithm: ParsingAlgorithm,
+    #[conditional_malloc_size_of]
+    custom_element_reaction_stack: Rc<CustomElementReactionStack>,
 }
 
 impl Tokenizer {
@@ -246,6 +250,7 @@ impl Tokenizer {
             None => ParsingAlgorithm::Normal,
         };
 
+        let custom_element_reaction_stack = document.custom_element_reaction_stack();
         let tokenizer = Tokenizer {
             document: Dom::from_ref(document),
             receiver: tokenizer_receiver,
@@ -253,6 +258,7 @@ impl Tokenizer {
             nodes: RefCell::new(HashMap::new()),
             url,
             parsing_algorithm: algorithm,
+            custom_element_reaction_stack,
         };
         tokenizer.insert_node(0, Dom::from_ref(document.upcast()));
 
@@ -397,7 +403,14 @@ impl Tokenizer {
             .GetParentNode()
             .expect("append_before_sibling called on node without parent");
 
-        super::insert(parent, Some(sibling), node, self.parsing_algorithm, can_gc);
+        super::insert(
+            parent,
+            Some(sibling),
+            node,
+            self.parsing_algorithm,
+            &self.custom_element_reaction_stack,
+            can_gc,
+        );
     }
 
     fn append(&self, parent: ParseNodeId, node: NodeOrText, can_gc: CanGc) {
@@ -409,7 +422,14 @@ impl Tokenizer {
         };
 
         let parent = &**self.get_node(&parent);
-        super::insert(parent, None, node, self.parsing_algorithm, can_gc);
+        super::insert(
+            parent,
+            None,
+            node,
+            self.parsing_algorithm,
+            &self.custom_element_reaction_stack,
+            can_gc,
+        );
     }
 
     fn has_parent_node(&self, node: ParseNodeId) -> bool {
@@ -454,6 +474,7 @@ impl Tokenizer {
                     &self.document,
                     ElementCreator::ParserCreated(current_line),
                     ParsingAlgorithm::Normal,
+                    &self.custom_element_reaction_stack,
                     can_gc,
                 );
                 self.insert_node(node, Dom::from_ref(element.upcast()));

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -52,12 +52,14 @@ impl Tokenizer {
         fragment_context: Option<super::FragmentContext>,
         parsing_algorithm: ParsingAlgorithm,
     ) -> Self {
+        let custom_element_reaction_stack = document.custom_element_reaction_stack();
         let sink = Sink {
             base_url: url,
             document: Dom::from_ref(document),
             current_line: Cell::new(1),
             script: Default::default(),
             parsing_algorithm,
+            custom_element_reaction_stack,
         };
 
         let quirks_mode = match document.quirks_mode() {

--- a/components/script/dom/servoparser/xml.rs
+++ b/components/script/dom/servoparser/xml.rs
@@ -35,6 +35,7 @@ impl Tokenizer {
             current_line: Cell::new(1),
             script: Default::default(),
             parsing_algorithm: ParsingAlgorithm::Normal,
+            custom_element_reaction_stack: document.custom_element_reaction_stack(),
         };
 
         let tb = XmlTreeBuilder::new(sink, Default::default());

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::rc::Rc;
+
 use data_url::mime::Mime;
 use dom_struct::dom_struct;
 use net_traits::request::InsecureRequestsPolicy;
@@ -17,6 +19,7 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::customelementregistry::CustomElementReactionStack;
 use crate::dom::document::{Document, DocumentSource, HasBrowsingContext, IsHTMLDocument};
 use crate::dom::location::Location;
 use crate::dom::node::Node;
@@ -44,6 +47,7 @@ impl XMLDocument {
         doc_loader: DocumentLoader,
         inherited_insecure_requests_policy: Option<InsecureRequestsPolicy>,
         has_trustworthy_ancestor_origin: bool,
+        custom_element_reaction_stack: Rc<CustomElementReactionStack>,
     ) -> XMLDocument {
         XMLDocument {
             document: Document::new_inherited(
@@ -64,6 +68,7 @@ impl XMLDocument {
                 false,
                 inherited_insecure_requests_policy,
                 has_trustworthy_ancestor_origin,
+                custom_element_reaction_stack,
             ),
         }
     }
@@ -82,6 +87,7 @@ impl XMLDocument {
         doc_loader: DocumentLoader,
         inherited_insecure_requests_policy: Option<InsecureRequestsPolicy>,
         has_trustworthy_ancestor_origin: bool,
+        custom_element_reaction_stack: Rc<CustomElementReactionStack>,
         can_gc: CanGc,
     ) -> DomRoot<XMLDocument> {
         let doc = reflect_dom_object(
@@ -98,6 +104,7 @@ impl XMLDocument {
                 doc_loader,
                 inherited_insecure_requests_policy,
                 has_trustworthy_ancestor_origin,
+                custom_element_reaction_stack,
             )),
             window,
             can_gc,

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1535,6 +1535,7 @@ impl XMLHttpRequest {
             false,
             Some(doc.insecure_requests_policy()),
             doc.has_trustworthy_ancestor_origin(),
+            doc.custom_element_reaction_stack(),
             can_gc,
         )
     }

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -453,7 +453,9 @@ impl ScriptThreadReceivers {
                 .ok()?;
             return MixedMessage::FromConstellation(message).into();
         }
-        if let Ok(message) = task_queue.take_tasks_and_recv(script_thread.get_fully_active_document_ids()) {
+        if let Ok(message) =
+            task_queue.take_tasks_and_recv(script_thread.get_fully_active_document_ids())
+        {
             return MixedMessage::FromScript(message).into();
         }
         if let Ok(message) = self.devtools_server_receiver.try_recv() {

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -33,6 +33,7 @@ use crate::dom::dedicatedworkerglobalscope::DedicatedWorkerScriptMsg;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerScriptMsg;
 use crate::dom::worker::TrustedWorkerAddress;
 use crate::script_runtime::ScriptThreadEventCategory;
+use crate::script_thread::ScriptThread;
 use crate::task::TaskBox;
 use crate::task_queue::{QueuedTask, QueuedTaskConversion, TaskQueue};
 use crate::task_source::TaskSourceName;
@@ -397,10 +398,12 @@ impl ScriptThreadReceivers {
         &self,
         task_queue: &TaskQueue<MainThreadScriptMsg>,
         timer_scheduler: &TimerScheduler,
+        script_thread: &ScriptThread,
     ) -> MixedMessage {
         select! {
             recv(task_queue.select()) -> msg => {
-                task_queue.take_tasks(msg.unwrap());
+                let fully_active = script_thread.get_fully_active_document_ids();
+                task_queue.take_tasks(msg.unwrap(), fully_active);
                 let event = task_queue
                     .recv()
                     .expect("Spurious wake-up of the event-loop, task-queue has no tasks available");
@@ -437,6 +440,7 @@ impl ScriptThreadReceivers {
     pub(crate) fn try_recv(
         &self,
         task_queue: &TaskQueue<MainThreadScriptMsg>,
+        script_thread: &ScriptThread,
     ) -> Option<MixedMessage> {
         if let Ok(message) = self.constellation_receiver.try_recv() {
             let message = message
@@ -449,7 +453,7 @@ impl ScriptThreadReceivers {
                 .ok()?;
             return MixedMessage::FromConstellation(message).into();
         }
-        if let Ok(message) = task_queue.take_tasks_and_recv() {
+        if let Ok(message) = task_queue.take_tasks_and_recv(script_thread.get_fully_active_document_ids()) {
             return MixedMessage::FromScript(message).into();
         }
         if let Ok(message) = self.devtools_server_receiver.try_recv() {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1343,9 +1343,12 @@ impl ScriptThread {
 
         // Receive at least one message so we don't spinloop.
         debug!("Waiting for event.");
-        let mut event = self
-            .receivers
-            .recv(&self.task_queue, &self.timer_scheduler.borrow(), self);
+        let fully_active = self.get_fully_active_document_ids();
+        let mut event = self.receivers.recv(
+            &self.task_queue,
+            &self.timer_scheduler.borrow(),
+            &fully_active,
+        );
 
         loop {
             debug!("Handling event: {event:?}");
@@ -1455,7 +1458,7 @@ impl ScriptThread {
             // If any of our input sources has an event pending, we'll perform another iteration
             // and check for more resize events. If there are no events pending, we'll move
             // on and execute the sequential non-resize events we've seen.
-            match self.receivers.try_recv(&self.task_queue, self) {
+            match self.receivers.try_recv(&self.task_queue, &fully_active) {
                 Some(new_event) => event = new_event,
                 None => break,
             }

--- a/components/script/task_queue.rs
+++ b/components/script/task_queue.rs
@@ -196,18 +196,18 @@ impl<T: QueuedTaskConversion> TaskQueue<T> {
     }
 
     /// Take all tasks again and then run `recv()`.
-    pub(crate) fn take_tasks_and_recv(&self, fully_active: HashSet<PipelineId>) -> Result<T, ()> {
+    pub(crate) fn take_tasks_and_recv(&self, fully_active: &HashSet<PipelineId>) -> Result<T, ()> {
         self.take_tasks(T::wake_up_msg(), fully_active);
         self.recv()
     }
 
     /// Drain the queue for the current iteration of the event-loop.
     /// Holding-back throttles above a given high-water mark.
-    pub(crate) fn take_tasks(&self, first_msg: T, fully_active: HashSet<PipelineId>) {
+    pub(crate) fn take_tasks(&self, first_msg: T, fully_active: &HashSet<PipelineId>) {
         // High-watermark: once reached, throttled tasks will be held-back.
         const PER_ITERATION_MAX: u64 = 5;
         // Always first check for new tasks, but don't reset 'taken_task_counter'.
-        self.process_incoming_tasks(first_msg, &fully_active);
+        self.process_incoming_tasks(first_msg, fully_active);
         let mut throttled = self.throttled.borrow_mut();
         let mut throttled_length: usize = throttled.values().map(|queue| queue.len()).sum();
         let mut task_source_cycler = TaskSourceName::VARIANTS.iter().cycle();


### PR DESCRIPTION
We store a pointer to the ScriptThread singleton for a thread in thread-local storage. While we don't have yet have profiles pointing to this TLS access as a hot spot, we can remove a potential performance footgun without a lot of effort by passing around small pieces of data that we otherwise need to fetch from the ScriptThread.

Testing: Existing WPT is sufficient
Fixes: part of #37969
