### PR TITLE
script: Do not include fragments when comparing URLs in `CookieStore`

### DIFF
--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -116,6 +116,12 @@ impl ServoUrl {
             scheme == "wss"
     }
 
+    /// <https://url.spec.whatwg.org/#url-equivalence>
+    /// See <https://github.com/servo/rust-url/issues/1063>
+    pub fn is_equal_excluding_fragments(&self, other: &ServoUrl) -> bool {
+        self.0[..Position::AfterQuery] == other.0[..Position::AfterQuery]
+    }
+
     pub fn as_str(&self) -> &str {
         self.0.as_str()
     }

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -117,7 +117,8 @@ impl ServoUrl {
     }
 
     /// <https://url.spec.whatwg.org/#url-equivalence>
-    /// See <https://github.com/servo/rust-url/issues/1063>
+    /// In the future this may be removed if the helper is added upstream in rust-url
+    /// see <https://github.com/servo/rust-url/issues/1063> for details
     pub fn is_equal_excluding_fragments(&self, other: &ServoUrl) -> bool {
         self.0[..Position::AfterQuery] == other.0[..Position::AfterQuery]
     }

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_document_cookie.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_document_cookie.https.window.js.ini
@@ -1,18 +1,19 @@
 [change_eventhandler_for_document_cookie.https.window.html]
+  expected: TIMEOUT
   [document.cookie set/overwrite/delete observed by CookieStore]
-    expected: FAIL
+    expected: TIMEOUT
 
   [document.cookie set already-expired cookie should not be observed by CookieStore]
-    expected: FAIL
+    expected: NOTRUN
 
   [document.cookie duplicate cookie should not be observed by CookieStore]
-    expected: FAIL
+    expected: NOTRUN
 
   [CookieStore set/overwrite/delete observed by document.cookie]
-    expected: FAIL
+    expected: NOTRUN
 
   [CookieStore agrees with document.cookie on encoding non-ASCII cookies]
-    expected: FAIL
+    expected: NOTRUN
 
   [document.cookie agrees with CookieStore on encoding non-ASCII cookies]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.js.ini
@@ -1,21 +1,22 @@
 [change_eventhandler_for_http_cookie_and_set_cookie_headers.https.window.html]
+  expected: TIMEOUT
   [HTTP set/overwrite/delete observed in CookieStore]
-    expected: FAIL
+    expected: TIMEOUT
 
   [HTTP set already-expired cookie should not be observed by CookieStore]
-    expected: FAIL
+    expected: NOTRUN
 
   [HTTP duplicate cookie should not be observed by CookieStore]
-    expected: FAIL
+    expected: NOTRUN
 
   [CookieStore agreed with HTTP headers agree on encoding non-ASCII cookies]
-    expected: FAIL
+    expected: NOTRUN
 
   [CookieStore set/overwrite/delete observed in HTTP headers]
-    expected: FAIL
+    expected: NOTRUN
 
   [HTTP headers agreed with CookieStore on encoding non-ASCII cookies]
-    expected: FAIL
+    expected: NOTRUN
 
   [Binary HTTP set/overwrite/delete observed in CookieStore]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_no_change.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_no_change.https.window.js.ini
@@ -1,6 +1,7 @@
 [change_eventhandler_for_no_change.https.window.html]
+  expected: TIMEOUT
   [CookieStore duplicate cookie should not be observed]
-    expected: FAIL
+    expected: TIMEOUT
 
   [CookieStore duplicate partitioned cookie should not be observed]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_no_name_and_no_value.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_no_name_and_no_value.https.window.js.ini
@@ -1,3 +1,4 @@
 [change_eventhandler_for_no_name_and_no_value.https.window.html]
+  expected: TIMEOUT
   [Verify behavior of no-name and no-value cookies.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_no_name_equals_in_value.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_no_name_equals_in_value.https.window.js.ini
@@ -1,3 +1,4 @@
 [change_eventhandler_for_no_name_equals_in_value.https.window.html]
+  expected: TIMEOUT
   [Verify that attempting to set a cookie with no name and with '=' in the value does not work.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/cookiestore/change_eventhandler_for_no_name_multiple_values.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/change_eventhandler_for_no_name_multiple_values.https.window.js.ini
@@ -1,3 +1,4 @@
 [change_eventhandler_for_no_name_multiple_values.https.window.html]
+  expected: TIMEOUT
   [Verify behavior of multiple no-name cookies]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/cookiestore/cookieStore_getAll_arguments.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_getAll_arguments.https.any.js.ini
@@ -2,17 +2,5 @@
   expected: ERROR
 
 [cookieStore_getAll_arguments.https.any.html]
-  [cookieStore.getAll with no arguments]
-    expected: FAIL
-
-  [cookieStore.getAll with empty options]
-    expected: FAIL
-
-  [cookieStore.getAll with absolute url with fragment in options]
-    expected: FAIL
-
-  [cookieStore.getAll with absolute different url in options]
-    expected: FAIL
-
   [cookieStore.getAll with whitespace]
     expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_getAll_multiple.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_getAll_multiple.https.any.js.ini
@@ -1,7 +1,4 @@
 [cookieStore_getAll_multiple.https.any.html]
-  [cookieStore.getAll returns multiple cookies written by cookieStore.set]
-    expected: FAIL
-
 
 [cookieStore_getAll_multiple.https.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/cookiestore/cookieStore_getAll_set_creation_url.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_getAll_set_creation_url.https.any.js.ini
@@ -1,3 +1,0 @@
-[cookieStore_getAll_set_creation_url.https.any.html]
-  [cookieStore.set and cookieStore.getAll use the creation url]
-    expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_get_arguments.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_get_arguments.https.any.js.ini
@@ -2,11 +2,5 @@
   expected: ERROR
 
 [cookieStore_get_arguments.https.any.html]
-  [cookieStore.get with absolute url with fragment in options]
-    expected: FAIL
-
-  [cookieStore.get with absolute different url in options]
-    expected: FAIL
-
   [cookieStore.get with whitespace]
     expected: FAIL

--- a/tests/wpt/meta/cookiestore/cookieStore_opaque_origin.https.html.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_opaque_origin.https.html.ini
@@ -1,7 +1,4 @@
 [cookieStore_opaque_origin.https.html]
   expected: TIMEOUT
-  [cookieStore in non-sandboxed iframe should not throw]
-    expected: FAIL
-
   [cookieStore in sandboxed iframe should throw SecurityError]
     expected: TIMEOUT

--- a/tests/wpt/meta/cookiestore/httponly_cookies.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/httponly_cookies.https.window.js.ini
@@ -1,12 +1,13 @@
 [httponly_cookies.https.window.html]
+  expected: TIMEOUT
   [HttpOnly cookies are not observed]
-    expected: FAIL
+    expected: TIMEOUT
 
   [HttpOnly cookies can not be set by document.cookie]
-    expected: FAIL
+    expected: NOTRUN
 
   [HttpOnly cookies can not be set by CookieStore]
-    expected: FAIL
+    expected: NOTRUN
 
   [HttpOnly cookies are not deleted/overwritten]
-    expected: FAIL
+    expected: NOTRUN


### PR DESCRIPTION
Fixes a check for empty options in `getAll(options)` and makes url comparison with exclude fragments set to true.

Testing: New passing WPT tests
Part of #37674 
