### PR TITLE
minibrowser: for each tab, show a spinning wheel while loading

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -301,9 +301,7 @@ impl App {
                         warn!("failed to parse location");
                         break;
                     };
-                    if let Some(focused_webview) = state.focused_webview() {
-                        focused_webview.load(url.into_url());
-                    }
+                    state.load_focused_webview(url.into_url());
                 },
                 MinibrowserEvent::Back => {
                     if let Some(focused_webview) = state.focused_webview() {

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -230,18 +230,9 @@ impl Minibrowser {
             // Expansion would also show that they are 2 separate widgets
             visuals.widgets.active.expansion = 0.0;
             visuals.widgets.hovered.expansion = 0.0;
-
+            
             if webview.has_pending_load() {
-                // Show a spinner while the tab is loading.
                 tab_frame.content_ui.spinner();
-            }
-
-            if let Some(favicon) = favicon_texture {
-                tab_frame.content_ui.add(
-                    egui::Image::from_texture(favicon)
-                        .fit_to_exact_size(egui::vec2(16.0, 16.0))
-                        .bg_fill(egui::Color32::TRANSPARENT),
-                );
             }
 
             let tab = tab_frame

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -231,6 +231,11 @@ impl Minibrowser {
             visuals.widgets.active.expansion = 0.0;
             visuals.widgets.hovered.expansion = 0.0;
 
+            if webview.has_pending_load() {
+                // Show a spinner while the tab is loading.
+                tab_frame.content_ui.spinner();
+            }
+
             if let Some(favicon) = favicon_texture {
                 tab_frame.content_ui.add(
                     egui::Image::from_texture(favicon)


### PR DESCRIPTION
I think it's a good idea to follow standard browser practice, and show some visual indicator while a tab is still loading it's top-level document. This PR adds the visual element in the minibrowser and the backing state in webviews and app state, as well as a boolean used to request a redraw of the native UI(but not of the web page). 

Testing: Manual testing.
Fixes: N/A
