### PR TITLE
layout: Skip adding `ScrollFrameHitTestItem` to stacking context tree if the `BoxFragment` has inherited style `pointer-events: none`

### DIFF
--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -1480,14 +1480,19 @@ impl BoxFragment {
             sensitivity,
         );
 
-        stacking_context_tree
-            .hit_test_items
-            .push(ScrollFrameHitTestItem {
-                scroll_node_id: *parent_scroll_node_id,
-                clip_id,
-                rect: scroll_frame_rect,
-                external_scroll_id,
-            });
+        use style::computed_values::pointer_events::T as PointerEvents;
+
+        let inherited_ui = self.style.get_inherited_ui();
+        if inherited_ui.pointer_events != PointerEvents::None {
+            stacking_context_tree
+                .hit_test_items
+                .push(ScrollFrameHitTestItem {
+                    scroll_node_id: *parent_scroll_node_id,
+                    clip_id,
+                    rect: scroll_frame_rect,
+                    external_scroll_id,
+                });
+        }
 
         Some(OverflowFrameData {
             clip_id,

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -1482,8 +1482,7 @@ impl BoxFragment {
 
         use style::computed_values::pointer_events::T as PointerEvents;
 
-        let inherited_ui = self.style.get_inherited_ui();
-        if inherited_ui.pointer_events != PointerEvents::None {
+        if self.style.get_inherited_ui().pointer_events != PointerEvents::None {
             stacking_context_tree
                 .hit_test_items
                 .push(ScrollFrameHitTestItem {


### PR DESCRIPTION
**fix some page cannot slide**
In the refactoring of https://github.com/servo/servo/pull/38480, a segment of logic was missing.
https://github.com/servo/servo/blob/11844ca5af97999f35b12d082ea9bfda9d18a74a/components/layout/display_list/mod.rs#L405-L410
Testing: The page can be scrolled on the OpenHarmony device.
Fixes: https://github.com/servo/servo/pull/38480#issuecomment-3213734994
