### PR TITLE
Disallow invalid trusted type policy names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,7 +1630,7 @@ dependencies = [
 [[package]]
 name = "content-security-policy"
 version = "0.5.4"
-source = "git+https://github.com/servo/rust-content-security-policy?branch=servo-csp#cf67beb96db9244ab6956a4da61dbe83384d5cd7"
+source = "git+https://github.com/servo/rust-content-security-policy?branch=servo-csp#fc927dfefb1fdc052fa4fa18c2ca3c3f6b87047b"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.3",

--- a/components/script/dom/csp.rs
+++ b/components/script/dom/csp.rs
@@ -51,8 +51,8 @@ pub(crate) trait CspReporting {
     fn is_trusted_type_policy_creation_allowed(
         &self,
         global: &GlobalScope,
-        policy_name: String,
-        created_policy_names: Vec<String>,
+        policy_name: &str,
+        created_policy_names: &[&str],
     ) -> bool;
     fn does_sink_type_require_trusted_types(
         &self,
@@ -173,8 +173,8 @@ impl CspReporting for Option<CspList> {
     fn is_trusted_type_policy_creation_allowed(
         &self,
         global: &GlobalScope,
-        policy_name: String,
-        created_policy_names: Vec<String>,
+        policy_name: &str,
+        created_policy_names: &[&str],
     ) -> bool {
         let Some(csp_list) = self else {
             return true;

--- a/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-002.html.ini
+++ b/tests/wpt/meta/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-002.html.ini
@@ -1,17 +1,5 @@
 [should-trusted-type-policy-creation-be-blocked-by-csp-002.html]
   expected: TIMEOUT
-  [invalid tt-policy-name name "policy*name"]
-    expected: FAIL
-
-  [invalid tt-policy-name name "policy$name"]
-    expected: FAIL
-
-  [invalid tt-policy-name name "policy?name"]
-    expected: FAIL
-
-  [invalid tt-policy-name name "policy!name"]
-    expected: FAIL
-
   [directive "trusted-type _TTP1_%09_TTP2_%0C_TTP3_%0D_TTP4_%20_TTP5_" (required-ascii-whitespace)]
     expected: TIMEOUT
 


### PR DESCRIPTION
Actual fix is in the CSP crate.

Part of #36258