### PR TITLE
mach: Improve test-speedometer error reporting

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -713,6 +713,10 @@ class MachCommands(CommandBase):
                 sleep(2)
                 whole_file = read_log_file(hdc_path)
                 break
+        else:
+            print("Error failed to find console logs in log file")
+            print(f"log-file contents: `{whole_file}`")
+            exit(1)
         start_index: int = whole_file.index("[INFO script::dom::console]") + len("[INFO script::dom::console]") + 1
         json_string = whole_file[start_index:]
         try:

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -113,15 +113,19 @@ def format_with_rustfmt(check_only: bool = True) -> int:
     )
 
 
-def pretty_print_json_decode_error(e: json.decoder.JSONDecodeError) -> None:
-    print(f"json decode error: {e}")
+def pretty_print_json_decode_error(error: json.decoder.JSONDecodeError) -> None:
+    print(f"json decode error: {error}")
     # Print section around that character that raised the json decode error.
-    start, stop = max(0, e.pos - 25), e.pos + 25
-    snippet = e.doc[start:stop]
+    snippet_radius = 25
+    start, stop = max(0, error.pos - snippet_radius), error.pos + snippet_radius
+    snippet = error.doc[start:stop]
     print("```")
-    print("... " if start != 0 else "", snippet, " ..." if stop < len(e.doc) else "", sep="")
+    prefix = "... " if start != 0 else ""
+    suffix = " ..." if stop < len(error.doc) else ""
+    print(prefix, snippet, suffix, sep="")
     # If the snippet is multiline, this won't work as expected, but it's a best effort.
-    print("^ Offending character".rjust(26 if not start else 30))
+    right_justification = snippet_radius + 1 + len(suffix)
+    print("^ Offending character".rjust(right_justification))
     print("```")
 
 


### PR DESCRIPTION
Currently speedometer results are parsed by parsing the console output from stdout (or a file in the case of ohos). Currently json decode errors just cause mach to crash. Instead print an error message, point to the problematic location and exit.
A crash can happen if something else also prints, e.g. on macos, we have the `xx threads are still running` message at shutdown. Hence this PR doesn't really fix the unreliable nature of the current implementation, but at least adds a helpful error message, which would point people in the right direction.

Testing: test-speedometer is run in CI

