### PR TITLE
script: Add remaining unique element event listeners

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -70,8 +70,10 @@ use crate::script_runtime::CanGc;
 
 /// <https://html.spec.whatwg.org/multipage/#event-handler-content-attributes>
 /// containing the values from
-/// <https://html.spec.whatwg.org/multipage/#globaleventhandlers>
-static CONTENT_EVENT_HANDLER_NAMES: [&str; 85] = [
+/// <https://html.spec.whatwg.org/multipage/#globaleventhandlers> and
+/// <https://html.spec.whatwg.org/multipage/#windoweventhandlers> as well as
+/// specific attributes for elements
+static CONTENT_EVENT_HANDLER_NAMES: [&str; 108] = [
     "onabort",
     "onauxclick",
     "onbeforeinput",
@@ -160,6 +162,32 @@ static CONTENT_EVENT_HANDLER_NAMES: [&str; 85] = [
     // https://w3c.github.io/selection-api/#extensions-to-globaleventhandlers-interface
     "onselectstart",
     "onselectionchange",
+    // https://html.spec.whatwg.org/multipage/#windoweventhandlers
+    "onafterprint",
+    "onbeforeprint",
+    "onbeforeunload",
+    "onhashchange",
+    "onlanguagechange",
+    "onmessage",
+    "onmessageerror",
+    "onoffline",
+    "ononline",
+    "onpagehide",
+    "onpagereveal",
+    "onpageshow",
+    "onpageswap",
+    "onpopstate",
+    "onrejectionhandled",
+    "onstorage",
+    "onunhandledrejection",
+    "onunload",
+    // https://w3c.github.io/encrypted-media/#attributes-3
+    "onencrypted",
+    "onwaitingforkey",
+    // https://svgwg.org/svg2-draft/interact.html#AnimationEvents
+    "onbegin",
+    "onend",
+    "onrepeat",
 ];
 
 #[derive(Clone, JSTraceable, MallocSizeOf, PartialEq)]

--- a/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html.ini
+++ b/tests/wpt/meta/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html.ini
@@ -1,2 +1,0 @@
-[TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative.html]
-  expected: ERROR

--- a/tests/wpt/meta/trusted-types/set-event-handlers-content-attributes.tentative.html.ini
+++ b/tests/wpt/meta/trusted-types/set-event-handlers-content-attributes.tentative.html.ini
@@ -1,2 +1,0 @@
-[set-event-handlers-content-attributes.tentative.html]
-  expected: ERROR

--- a/tests/wpt/tests/trusted-types/support/event-handler-attributes.mjs
+++ b/tests/wpt/tests/trusted-types/support/event-handler-attributes.mjs
@@ -35,13 +35,17 @@ export async function getEventHandlerAttributeWithInterfaceNames() {
     addOnAttributes(htmlIDL, interfaceName);
   });
 
-  const encryptedMediaIDL = await (await fetch("/interfaces/encrypted-media.idl")).text();
-  // HTMLMediaElement (the parent for <audio> and <video>) has extra event handlers.
-  addOnAttributes(encryptedMediaIDL, "HTMLMediaElement");
+  if ("HTMLMediaElement" in self) {
+    const encryptedMediaIDL = await (await fetch("/interfaces/encrypted-media.idl")).text();
+    // HTMLMediaElement (the parent for <audio> and <video>) has extra event handlers.
+    addOnAttributes(encryptedMediaIDL, "HTMLMediaElement");
+  }
 
-  const svgAnimationsIDL = await (await fetch("/interfaces/svg-animations.idl")).text();
-  // SVGAnimationElement has extra event handlers.
-  addOnAttributes(svgAnimationsIDL, "SVGAnimationElement");
+  if ("SVGAnimationElement" in self) {
+    const svgAnimationsIDL = await (await fetch("/interfaces/svg-animations.idl")).text();
+    // SVGAnimationElement has extra event handlers.
+    addOnAttributes(svgAnimationsIDL, "SVGAnimationElement");
+  }
 
   return attributeNamesWithInterfaceName;
 }


### PR DESCRIPTION
This adds the remaining window as well as specific svg and animation listeners. The test suite was erroring before, as we don't implement `SVGAnimationElement` yet. Now, the test gracefully checks if the interface exists before doing a lookup.

Part of #36258