### PR TITLE
webdriver: Focus when "switch to window"

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1067,7 +1067,7 @@ impl Handler {
     /// <https://w3c.github.io/webdriver/#get-window-handles>
     fn handle_window_handles(&mut self) -> WebDriverResult<WebDriverResponse> {
         let mut handles = self.get_window_handles();
-        handles.sort();
+        handles.sort_unstable();
 
         Ok(WebDriverResponse::Generic(ValueResponse(
             serde_json::to_value(handles)?,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1266,6 +1266,12 @@ impl Handler {
         let session = self.session_mut()?;
         session.set_webview_id(webview_id);
         session.set_browsing_context_id(BrowsingContextId::from(webview_id));
+
+        // Step 5. Update any implementation-specific state that would result
+        // from the user selecting session's current browsing context for interaction,
+        // without altering OS-level focus.
+        self.focus_webview(webview_id)?;
+
         Ok(WebDriverResponse::Void)
     }
 

--- a/tests/wpt/meta/webdriver/tests/classic/back/back.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/back/back.py.ini
@@ -7,6 +7,3 @@
 
   [test_seen_nodes[https coop\]]
     expected: FAIL
-
-  [test_history_pushstate]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/forward/forward.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/forward/forward.py.ini
@@ -13,6 +13,3 @@
 
   [test_removed_iframe]
     expected: FAIL
-
-  [test_history_pushstate]
-    expected: FAIL


### PR DESCRIPTION
Add logic that was accidentally removed in #38745. Otherwise it is very weird when using webdriver as a human, as we still stays on the original tab.

Testing: ~this should not affect any test. Even if the tab is not "visible" previously, all programmatic interaction works fine.~ Stably pass `test_history_pushstate` in `back.py` and `forward.py`.