### PR TITLE
cargo: Remove unused workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ cookie = { package = "cookie", version = "0.18" }
 crossbeam-channel = "0.5"
 cssparser = { version = "0.35", features = ["serde"] }
 ctr = "0.9.2"
-darling = { version = "0.20", default-features = false }
 data-url = "0.3"
 devtools_traits = { path = "components/shared/devtools" }
 dpi = "0.1"
@@ -66,7 +65,6 @@ freetype-sys = "0.20"
 fxhash = "0.2"
 getopts = "0.2.11"
 gleam = "0.15"
-glib = "0.19"
 glow = "0.16"
 gstreamer = { version = "0.23", features = ["v1_18"] }
 gstreamer-base = "0.23"
@@ -139,10 +137,8 @@ servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
 servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
 skrifa = "0.35.0"
-smallbitvec = "2.6.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 string_cache = "0.8"
-string_cache_codegen = "0.5"
 strum = "0.26"
 strum_macros = "0.26"
 stylo = { git = "https://github.com/servo/stylo", branch = "2025-08-01" }
@@ -165,7 +161,6 @@ tracing = "0.1.41"
 tracing-perfetto = "0.1.5"
 tracing-subscriber = "0.3.19"
 tungstenite = "0.26"
-uluru = "3.0"
 unicode-bidi = "0.3.18"
 unicode-properties = { version = "0.1.3", features = ["emoji"] }
 unicode-script = "0.5"


### PR DESCRIPTION
These aren't referenced anywhere, so they needlessly clutter the `workspace.dependencies` section.

Testing: N/A
Fixes: None