### PR TITLE
Move unsafe to the wrap method for global objects

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -325,7 +325,6 @@ impl DedicatedWorkerGlobalScope {
         control_receiver: Receiver<DedicatedWorkerControlMsg>,
         insecure_requests_policy: InsecureRequestsPolicy,
     ) -> DomRoot<DedicatedWorkerGlobalScope> {
-        let cx = runtime.cx();
         let scope = Box::new(DedicatedWorkerGlobalScope::new_inherited(
             init,
             worker_name,
@@ -344,12 +343,10 @@ impl DedicatedWorkerGlobalScope {
             control_receiver,
             insecure_requests_policy,
         ));
-        unsafe {
-            DedicatedWorkerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(
-                SafeJSContext::from_ptr(cx),
-                scope,
-            )
-        }
+        DedicatedWorkerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(
+            GlobalScope::get_cx(),
+            scope,
+        )
     }
 
     /// <https://html.spec.whatwg.org/multipage/#run-a-worker>
@@ -430,7 +427,6 @@ impl DedicatedWorkerGlobalScope {
                     Runtime::new_with_parent(Some(parent), Some(task_source))
                 };
                 let debugger_global = DebuggerGlobalScope::new(
-                    &runtime,
                     pipeline_id,
                     init.to_devtools_sender.clone(),
                     init.from_devtools_sender

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -73,7 +73,7 @@ impl DissimilarOriginWindow {
             window_proxy: Dom::from_ref(window_proxy),
             location: Default::default(),
         });
-        unsafe { DissimilarOriginWindowBinding::Wrap::<crate::DomTypeHolder>(cx, win) }
+        DissimilarOriginWindowBinding::Wrap::<crate::DomTypeHolder>(cx, win)
     }
 
     pub(crate) fn window_proxy(&self) -> DomRoot<WindowProxy> {

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -19,8 +19,8 @@ use js::jsapi::{
     JS_IsExceptionPending, JSAutoRealm, JSObject, NewArrayObject, Value,
 };
 use js::jsval::{JSVal, ObjectValue, UndefinedValue};
+use js::rust::HandleValue;
 use js::rust::wrappers::{Call, Construct1};
-use js::rust::{HandleValue, Runtime};
 use net_traits::image_cache::ImageCache;
 use pixels::PixelFormat;
 use script_traits::{DrawAPaintImageResult, PaintWorkletError, Painter};
@@ -43,12 +43,13 @@ use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::cssstylevalue::CSSStyleValue;
+use crate::dom::globalscope::GlobalScope;
 use crate::dom::paintrenderingcontext2d::PaintRenderingContext2D;
 use crate::dom::paintsize::PaintSize;
 use crate::dom::stylepropertymapreadonly::StylePropertyMapReadOnly;
 use crate::dom::worklet::WorkletExecutor;
 use crate::dom::workletglobalscope::{WorkletGlobalScope, WorkletGlobalScopeInit, WorkletTask};
-use crate::script_runtime::{CanGc, JSContext};
+use crate::script_runtime::CanGc;
 
 /// <https://drafts.css-houdini.org/css-paint-api/#paintworkletglobalscope>
 #[dom_struct]
@@ -86,7 +87,6 @@ pub(crate) struct PaintWorkletGlobalScope {
 impl PaintWorkletGlobalScope {
     #[allow(unsafe_code)]
     pub(crate) fn new(
-        runtime: &Runtime,
         pipeline_id: PipelineId,
         base_url: ServoUrl,
         executor: WorkletExecutor,
@@ -119,12 +119,7 @@ impl PaintWorkletGlobalScope {
                 missing_image_urls: Vec::new(),
             }),
         });
-        unsafe {
-            PaintWorkletGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(
-                JSContext::from_ptr(runtime.cx()),
-                global,
-            )
-        }
+        PaintWorkletGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(GlobalScope::get_cx(), global)
     }
 
     pub(crate) fn image_cache(&self) -> Arc<dyn ImageCache> {

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -265,7 +265,6 @@ impl ServiceWorkerGlobalScope {
         control_receiver: Receiver<ServiceWorkerControlMsg>,
         closing: Arc<AtomicBool>,
     ) -> DomRoot<ServiceWorkerGlobalScope> {
-        let cx = runtime.cx();
         let scope = Box::new(ServiceWorkerGlobalScope::new_inherited(
             init,
             worker_url,
@@ -279,12 +278,7 @@ impl ServiceWorkerGlobalScope {
             control_receiver,
             closing,
         ));
-        unsafe {
-            ServiceWorkerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(
-                SafeJSContext::from_ptr(cx),
-                scope,
-            )
-        }
+        ServiceWorkerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(GlobalScope::get_cx(), scope)
     }
 
     /// <https://w3c.github.io/ServiceWorker/#run-service-worker-algorithm>

--- a/components/script/dom/testworkletglobalscope.rs
+++ b/components/script/dom/testworkletglobalscope.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use base::id::PipelineId;
 use crossbeam_channel::Sender;
 use dom_struct::dom_struct;
-use js::rust::Runtime;
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::cell::DomRefCell;
@@ -15,9 +14,9 @@ use crate::dom::bindings::codegen::Bindings::TestWorkletGlobalScopeBinding;
 use crate::dom::bindings::codegen::Bindings::TestWorkletGlobalScopeBinding::TestWorkletGlobalScopeMethods;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::globalscope::GlobalScope;
 use crate::dom::worklet::WorkletExecutor;
 use crate::dom::workletglobalscope::{WorkletGlobalScope, WorkletGlobalScopeInit};
-use crate::script_runtime::JSContext;
 
 // check-tidy: no specs after this line
 
@@ -32,7 +31,6 @@ pub(crate) struct TestWorkletGlobalScope {
 impl TestWorkletGlobalScope {
     #[allow(unsafe_code)]
     pub(crate) fn new(
-        runtime: &Runtime,
         pipeline_id: PipelineId,
         base_url: ServoUrl,
         executor: WorkletExecutor,
@@ -51,12 +49,7 @@ impl TestWorkletGlobalScope {
             ),
             lookup_table: Default::default(),
         });
-        unsafe {
-            TestWorkletGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(
-                JSContext::from_ptr(runtime.cx()),
-                global,
-            )
-        }
+        TestWorkletGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(GlobalScope::get_cx(), global)
     }
 
     pub(crate) fn perform_a_worklet_task(&self, task: TestWorkletTask) {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -3202,9 +3202,7 @@ impl Window {
             endpoints_list: Default::default(),
         });
 
-        unsafe {
-            WindowBinding::Wrap::<crate::DomTypeHolder>(JSContext::from_ptr(runtime.cx()), win)
-        }
+        WindowBinding::Wrap::<crate::DomTypeHolder>(GlobalScope::get_cx(), win)
     }
 
     pub(crate) fn pipeline_id(&self) -> PipelineId {

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -629,7 +629,6 @@ impl WorkletThread {
                 let executor = WorkletExecutor::new(worklet_id, self.primary_sender.clone());
                 let result = WorkletGlobalScope::new(
                     global_type,
-                    &self.runtime,
                     pipeline_id,
                     base_url,
                     executor,

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -13,7 +13,6 @@ use dom_struct::dom_struct;
 use embedder_traits::JavaScriptEvaluationError;
 use ipc_channel::ipc::IpcSender;
 use js::jsval::UndefinedValue;
-use js::rust::Runtime;
 use net_traits::ResourceThreads;
 use net_traits::image_cache::ImageCache;
 use profile_traits::{mem, time};
@@ -56,7 +55,6 @@ impl WorkletGlobalScope {
     /// Create a new heap-allocated `WorkletGlobalScope`.
     pub(crate) fn new(
         scope_type: WorkletGlobalScopeType,
-        runtime: &Runtime,
         pipeline_id: PipelineId,
         base_url: ServoUrl,
         executor: WorkletExecutor,
@@ -65,14 +63,12 @@ impl WorkletGlobalScope {
         let scope: DomRoot<WorkletGlobalScope> = match scope_type {
             #[cfg(feature = "testbinding")]
             WorkletGlobalScopeType::Test => DomRoot::upcast(TestWorkletGlobalScope::new(
-                runtime,
                 pipeline_id,
                 base_url,
                 executor,
                 init,
             )),
             WorkletGlobalScopeType::Paint => DomRoot::upcast(PaintWorkletGlobalScope::new(
-                runtime,
                 pipeline_id,
                 base_url,
                 executor,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -939,7 +939,6 @@ impl ScriptThread {
             pipeline_id,
         };
         let debugger_global = DebuggerGlobalScope::new(
-            &js_runtime.clone(),
             PipelineId::new(),
             senders.devtools_server_sender.clone(),
             senders.devtools_client_to_script_thread_sender.clone(),


### PR DESCRIPTION
The method now doesn't need unsafe in its signature because it no longer accepts unsafe pointers as arguments. We move the unsafe marker to the method itself.

Testing: I opened the browser and went to google.com; I ran some WPT (IndexedDB) tests.
Fixes: #38361 