### PR TITLE
CODEOWNERS: add sagudev for canvas and WebGPU components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,11 @@
 
 # Reviewers for Minibrowser related code
 /ports/servoshell/desktop @atbrakhi
+
+# Reviewers for 2D canvas related code
+/components/canvas @sagudev
+/components/shared/canvas @sagudev
+
+# Reviewers for WebGPU related code
+/components/webgpu @sagudev
+/components/script/dom/webgpu @sagudev


### PR DESCRIPTION
Not sure how useful it is given that I usually deal with these two components, but at least it will keep stuff from other people on my radar.

Testing: Not needed, just github stuff
