### PR TITLE
webdriver: Raise `WebView` to top when focus

### DIFF
--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -58,8 +58,7 @@ impl ::servo::WebViewDelegate for AppState {
             .hidpi_scale_factor(Scale::new(self.window.scale_factor() as f32))
             .delegate(parent_webview.delegate())
             .build();
-        webview.focus();
-        webview.raise_to_top(true);
+        webview.focus_and_raise_to_top(true);
 
         self.webviews.borrow_mut().push(webview.clone());
         Some(webview)
@@ -117,8 +116,7 @@ impl ApplicationHandler<WakerEvent> for App {
                 .delegate(app_state.clone())
                 .build();
 
-            webview.focus();
-            webview.raise_to_top(true);
+            webview.focus_and_raise_to_top(true);
 
             app_state.webviews.borrow_mut().push(webview);
             *self = Self::Running(app_state);

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -408,6 +408,12 @@ impl WebView {
             .expect("BUG: invalid WebView instance");
     }
 
+    pub fn focus_and_raise_to_top(&self, hide_others: bool) -> FocusId {
+        let focus_id = self.focus();
+        self.raise_to_top(hide_others);
+        focus_id
+    }
+
     pub fn notify_theme_change(&self, theme: Theme) {
         self.inner()
             .constellation_proxy

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2477,7 +2477,7 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
         self.send_message_to_embedder(WebDriverCommandMsg::FocusWebView(webview_id, sender))?;
         if wait_for_ipc_response(receiver)? {
-            debug!("Focus new webview {} successfully", webview_id);
+            debug!("Focus new webview {webview_id} successfully");
         } else {
             debug!("Focus new webview failed, it may not exist anymore");
         }

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2477,7 +2477,7 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
         self.send_message_to_embedder(WebDriverCommandMsg::FocusWebView(webview_id, sender))?;
         if wait_for_ipc_response(receiver)? {
-            debug!("Focus new webview successfully");
+            debug!("Focus new webview {} successfully", webview_id);
         } else {
             debug!("Focus new webview failed, it may not exist anymore");
         }

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -376,7 +376,7 @@ impl App {
                 },
                 WebDriverCommandMsg::FocusWebView(webview_id, response_sender) => {
                     if let Some(webview) = running_state.webview_by_id(webview_id) {
-                        let focus_id = webview.focus();
+                        let focus_id = webview.focus_and_raise_to_top(true);
                         running_state.set_pending_focus(focus_id, response_sender);
                     }
                 },

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -119,8 +119,7 @@ impl RunningAppState {
 
     pub(crate) fn create_and_focus_toplevel_webview(self: &Rc<Self>, url: Url) {
         let webview = self.create_toplevel_webview(url);
-        webview.focus();
-        webview.raise_to_top(true);
+        webview.focus_and_raise_to_top(true);
     }
 
     pub(crate) fn create_toplevel_webview(self: &Rc<Self>, url: Url) -> WebView {
@@ -633,8 +632,7 @@ impl WebViewDelegate for RunningAppState {
         // as that is what the specification expects. Otherwise, we would like `window.open()`
         // to create a new foreground tab
         if self.servoshell_preferences.webdriver_port.is_none() {
-            webview.focus();
-            webview.raise_to_top(true);
+            webview.focus_and_raise_to_top(true);
         }
         self.add(webview.clone());
         Some(webview)

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -406,12 +406,8 @@ impl Window {
             })
             .shortcut(Modifiers::CONTROL, Key::Named(NamedKey::PageUp), || {
                 if let Some(index) = state.get_focused_webview_index() {
-                    let new_index = if index == 0 {
-                        state.webviews().len() - 1
-                    } else {
-                        index - 1
-                    };
-                    state.focus_webview_by_index(new_index)
+                    let len = state.webviews().len();
+                    state.focus_webview_by_index((index + len - 1) % len);
                 }
             })
             .shortcut(CMD_OR_CONTROL, 'T', || {


### PR DESCRIPTION
- Add a helper function `focus_and_raise_to_top` to `WebView`.
- For webdriver, raise webview to top when focus, to make it consistent with user interaction.

Testing: Should reduce some flaky TIMEOUT when combined with another PR later.
Fixes: A small patch before the PR for #38906.