### PR TITLE
constellation: Migrate namespace channel to GenericChannel

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -132,7 +132,7 @@ pub struct InitialPipelineState {
     pub script_to_constellation_chan: ScriptToConstellationChan,
 
     /// A sender to request pipeline namespace ids.
-    pub namespace_request_sender: IpcSender<PipelineNamespaceRequest>,
+    pub namespace_request_sender: GenericSender<PipelineNamespaceRequest>,
 
     /// A handle to register components for hang monitoring.
     /// None when in multiprocess mode.
@@ -470,7 +470,7 @@ pub struct UnprivilegedPipelineContent {
     browsing_context_id: BrowsingContextId,
     parent_pipeline_id: Option<PipelineId>,
     opener: Option<BrowsingContextId>,
-    namespace_request_sender: IpcSender<PipelineNamespaceRequest>,
+    namespace_request_sender: GenericSender<PipelineNamespaceRequest>,
     script_to_constellation_chan: ScriptToConstellationChan,
     background_hang_monitor_to_constellation_chan: IpcSender<HangMonitorAlert>,
     bhm_control_port: Option<IpcReceiver<BackgroundHangMonitorControlMsg>>,

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -19,6 +19,8 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use webrender_api::{ExternalScrollId, PipelineId as WebRenderPipelineId};
 
+use crate::generic_channel::GenericSender;
+
 /// Asserts the size of a type at compile time.
 macro_rules! size_of_test {
     ($t: ty, $expected_size: expr) => {
@@ -119,7 +121,7 @@ pub struct PipelineNamespaceRequest(pub IpcSender<PipelineNamespaceId>);
 
 /// A per-process installer of pipeline-namespaces.
 pub struct PipelineNamespaceInstaller {
-    request_sender: Option<IpcSender<PipelineNamespaceRequest>>,
+    request_sender: Option<GenericSender<PipelineNamespaceRequest>>,
     namespace_sender: IpcSender<PipelineNamespaceId>,
     namespace_receiver: IpcReceiver<PipelineNamespaceId>,
 }
@@ -138,7 +140,7 @@ impl Default for PipelineNamespaceInstaller {
 
 impl PipelineNamespaceInstaller {
     /// Provide a request sender to send requests to the constellation.
-    pub fn set_sender(&mut self, sender: IpcSender<PipelineNamespaceRequest>) {
+    pub fn set_sender(&mut self, sender: GenericSender<PipelineNamespaceRequest>) {
         self.request_sender = Some(sender);
     }
 
@@ -207,7 +209,7 @@ impl PipelineNamespace {
 
     /// Setup the pipeline-namespace-installer, by providing it with a sender to the constellation.
     /// Idempotent in single-process mode.
-    pub fn set_installer_sender(sender: IpcSender<PipelineNamespaceRequest>) {
+    pub fn set_installer_sender(sender: GenericSender<PipelineNamespaceRequest>) {
         PIPELINE_NAMESPACE_INSTALLER.lock().set_sender(sender);
     }
 


### PR DESCRIPTION
Migrates the namespace sender and receiver to use GenericChannel

Testing: Covered by existing tests
Part of #38912
