### PR TITLE
webdriver: Port WebDriverLoadStatus to Generic Channel

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -418,7 +418,7 @@ pub struct Constellation<STF, SWF> {
     next_pipeline_namespace_id: PipelineNamespaceId,
 
     /// An [`IpcSender`] to notify navigation events to webdriver.
-    webdriver_load_status_sender: Option<(IpcSender<WebDriverLoadStatus>, PipelineId)>,
+    webdriver_load_status_sender: Option<(GenericSender<WebDriverLoadStatus>, PipelineId)>,
 
     /// An [`IpcSender`] to forward responses from the `ScriptThread` to the WebDriver server.
     webdriver_input_command_reponse_sender: Option<IpcSender<WebDriverCommandResponse>>,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -326,7 +326,7 @@ pub(crate) struct Window {
 
     /// A channel to notify webdriver if there is a navigation
     #[no_trace]
-    webdriver_load_status_sender: RefCell<Option<IpcSender<WebDriverLoadStatus>>>,
+    webdriver_load_status_sender: RefCell<Option<GenericSender<WebDriverLoadStatus>>>,
 
     /// The current state of the window object
     current_state: Cell<WindowState>,
@@ -2861,7 +2861,7 @@ impl Window {
 
     pub(crate) fn set_webdriver_load_status_sender(
         &self,
-        sender: Option<IpcSender<WebDriverLoadStatus>>,
+        sender: Option<GenericSender<WebDriverLoadStatus>>,
     ) {
         *self.webdriver_load_status_sender.borrow_mut() = sender;
     }

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::CString;
 use std::ptr::NonNull;
 
+use base::generic_channel::GenericSender;
 use base::id::{BrowsingContextId, PipelineId};
 use cookie::Cookie;
 use embedder_traits::{
@@ -2066,7 +2067,7 @@ pub(crate) fn handle_is_selected(
 pub(crate) fn handle_add_load_status_sender(
     documents: &DocumentCollection,
     pipeline: PipelineId,
-    reply: IpcSender<WebDriverLoadStatus>,
+    reply: GenericSender<WebDriverLoadStatus>,
 ) {
     if let Some(document) = documents.find_document(pipeline) {
         let window = document.window();

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 
+use base::generic_channel::GenericSender;
 use base::id::{BrowsingContextId, WebViewId};
 use cookie::Cookie;
 use euclid::default::Rect as UntypedRect;
@@ -81,13 +82,13 @@ pub enum WebDriverCommandMsg {
     /// Get the viewport size.
     GetViewportSize(WebViewId, IpcSender<Size2D<u32, DevicePixel>>),
     /// Load a URL in the top-level browsing context with the given ID.
-    LoadUrl(WebViewId, ServoUrl, IpcSender<WebDriverLoadStatus>),
+    LoadUrl(WebViewId, ServoUrl, GenericSender<WebDriverLoadStatus>),
     /// Refresh the top-level browsing context with the given ID.
-    Refresh(WebViewId, IpcSender<WebDriverLoadStatus>),
+    Refresh(WebViewId, GenericSender<WebDriverLoadStatus>),
     /// Navigate the webview with the given ID to the previous page in the browsing context's history.
-    GoBack(WebViewId, IpcSender<WebDriverLoadStatus>),
+    GoBack(WebViewId, GenericSender<WebDriverLoadStatus>),
     /// Navigate the webview with the given ID to the next page in the browsing context's history.
-    GoForward(WebViewId, IpcSender<WebDriverLoadStatus>),
+    GoForward(WebViewId, GenericSender<WebDriverLoadStatus>),
     /// Pass a webdriver command to the script thread of the current pipeline
     /// of a browsing context.
     ScriptCommand(BrowsingContextId, WebDriverScriptCommand),
@@ -147,7 +148,10 @@ pub enum WebDriverCommandMsg {
     /// Create a new webview that loads about:blank. The embedder will use
     /// the provided channels to return the top level browsing context id
     /// associated with the new webview, and sets a "load status sender" if provided.
-    NewWebView(IpcSender<WebViewId>, Option<IpcSender<WebDriverLoadStatus>>),
+    NewWebView(
+        IpcSender<WebViewId>,
+        Option<GenericSender<WebDriverLoadStatus>>,
+    ),
     /// Close the webview associated with the provided id.
     CloseWebView(WebViewId, IpcSender<()>),
     /// Focus the webview associated with the provided id.
@@ -243,7 +247,7 @@ pub enum WebDriverScriptCommand {
     GetTitle(IpcSender<String>),
     /// Deal with the case of input element for Element Send Keys, which does not send keys.
     WillSendKeys(String, String, bool, IpcSender<Result<bool, ErrorStatus>>),
-    AddLoadStatusSender(WebViewId, IpcSender<WebDriverLoadStatus>),
+    AddLoadStatusSender(WebViewId, GenericSender<WebDriverLoadStatus>),
     RemoveLoadStatusSender(WebViewId),
 }
 
@@ -289,8 +293,8 @@ pub enum WebDriverLoadStatus {
 /// to a WebDriver server with information about application state.
 #[derive(Clone, Default)]
 pub struct WebDriverSenders {
-    pub load_status_senders: HashMap<WebViewId, IpcSender<WebDriverLoadStatus>>,
+    pub load_status_senders: HashMap<WebViewId, GenericSender<WebDriverLoadStatus>>,
     pub script_evaluation_interrupt_sender: Option<IpcSender<WebDriverJSResult>>,
-    pub pending_traversals: HashMap<TraversalId, IpcSender<WebDriverLoadStatus>>,
+    pub pending_traversals: HashMap<TraversalId, GenericSender<WebDriverLoadStatus>>,
     pub pending_focus: HashMap<FocusId, IpcSender<bool>>,
 }

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -13,6 +13,7 @@ use embedder_traits::webdriver::WebDriverSenders;
 use euclid::Vector2D;
 use keyboard_types::{Key, Modifiers, NamedKey, ShortcutMatcher};
 use log::{error, info};
+use servo::base::generic_channel::GenericSender;
 use servo::base::id::WebViewId;
 use servo::config::pref;
 use servo::ipc_channel::ipc::IpcSender;
@@ -456,7 +457,7 @@ impl RunningAppState {
     pub(crate) fn set_pending_traversal(
         &self,
         traversal_id: TraversalId,
-        sender: IpcSender<WebDriverLoadStatus>,
+        sender: GenericSender<WebDriverLoadStatus>,
     ) {
         self.webdriver_senders
             .borrow_mut()
@@ -467,7 +468,7 @@ impl RunningAppState {
     pub(crate) fn set_load_status_sender(
         &self,
         webview_id: WebViewId,
-        sender: IpcSender<WebDriverLoadStatus>,
+        sender: GenericSender<WebDriverLoadStatus>,
     ) {
         self.webdriver_senders
             .borrow_mut()


### PR DESCRIPTION
Ports the channel for WebDriverLoadStatus to GenericChannel.

Testing: No functional changes - Covered by existing webdriver tests
Part of #38912
