### PR TITLE
script: mark image-related node dirty only when image resource loaded

### DIFF
--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -559,8 +559,6 @@ impl HTMLImageElement {
             self.upcast::<EventTarget>()
                 .fire_event(atom!("loadend"), can_gc);
         }
-
-        self.upcast::<Node>().dirty(NodeDamage::Other);
     }
 
     fn process_image_response_for_environment_change(

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -646,8 +646,10 @@ impl Window {
             Entry::Occupied(nodes) => nodes,
             Entry::Vacant(_) => return,
         };
-        for node in nodes.get() {
-            node.dirty(NodeDamage::Other);
+        if matches!(response.response, ImageResponse::Loaded(_, _)) {
+            for node in nodes.get() {
+                node.dirty(NodeDamage::Other);
+            }
         }
         match response.response {
             ImageResponse::MetadataLoaded(_) => {},


### PR DESCRIPTION
Previously, we would always mark the image-related nodes as dirty whenever the fetch status of the image resources changed. However, the corresponding `ImageDisplayItem`s for these image resources are only generated after the image resources have been fully fetched and decoded. Therefore, we only mark the corresponding DOM nodes as dirty when the image resources are completely loaded, thereby reducing the occurrence of reflows.