### PR TITLE
compositor: Port GenerateFontKeys result sender to generic channel

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -13,6 +13,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
+use base::generic_channel::GenericSender;
 use base::id::{PipelineId, WebViewId};
 use bitflags::bitflags;
 use compositing_traits::display_list::{CompositorDisplayListInfo, ScrollTree, ScrollType};
@@ -26,7 +27,7 @@ use crossbeam_channel::{Receiver, Sender};
 use dpi::PhysicalSize;
 use embedder_traits::{CompositorHitTestResult, InputEvent, ShutdownState, ViewportDetails};
 use euclid::{Point2D, Rect, Scale, Size2D, Transform3D};
-use ipc_channel::ipc::{self, IpcSender, IpcSharedMemory};
+use ipc_channel::ipc::{self, IpcSharedMemory};
 use log::{debug, info, trace, warn};
 use pixels::{CorsStatus, ImageFrame, ImageMetadata, PixelFormat, RasterImage};
 use profile_traits::mem::{
@@ -814,7 +815,7 @@ impl IOCompositor {
         &self,
         number_of_font_keys: usize,
         number_of_font_instance_keys: usize,
-        result_sender: IpcSender<(Vec<FontKey>, Vec<FontInstanceKey>)>,
+        result_sender: GenericSender<(Vec<FontKey>, Vec<FontInstanceKey>)>,
     ) {
         let font_keys = (0..number_of_font_keys)
             .map(|_| self.global.borrow().webrender_api.generate_font_key())

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -23,6 +23,7 @@ pub mod viewport_description;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+use base::generic_channel::{self, GenericSender};
 use bitflags::bitflags;
 use display_list::CompositorDisplayListInfo;
 use embedder_traits::ScreenGeometry;
@@ -128,7 +129,7 @@ pub enum CompositorMsg {
     GenerateFontKeys(
         usize,
         usize,
-        IpcSender<(Vec<FontKey>, Vec<FontInstanceKey>)>,
+        GenericSender<(Vec<FontKey>, Vec<FontInstanceKey>)>,
     ),
     /// Add a font with the given data and font key.
     AddFont(FontKey, Arc<IpcSharedMemory>, u32),
@@ -343,7 +344,7 @@ impl CrossProcessCompositorApi {
         number_of_font_keys: usize,
         number_of_font_instance_keys: usize,
     ) -> (Vec<FontKey>, Vec<FontInstanceKey>) {
-        let (sender, receiver) = ipc_channel::ipc::channel().expect("Could not create IPC channel");
+        let (sender, receiver) = generic_channel::channel().expect("Could not create IPC channel");
         let _ = self.0.send(CompositorMsg::GenerateFontKeys(
             number_of_font_keys,
             number_of_font_instance_keys,


### PR DESCRIPTION
Ports the channel returning the result of `GenerateFontKeys` to generic channel

Testing: No functional changes - Covered by existing tests
Part of https://github.com/servo/servo/issues/38912
