### PR TITLE
script: Clean-up IpcSend .sender().send() pattern

### DIFF
--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -128,7 +128,6 @@ impl IDBObjectStore {
 
         self.global()
             .resource_threads()
-            .sender()
             .send(IndexedDBThreadMsg::Sync(operation))
             .unwrap();
 

--- a/components/script/dom/idbopendbrequest.rs
+++ b/components/script/dom/idbopendbrequest.rs
@@ -288,7 +288,6 @@ impl IDBOpenDBRequest {
 
         global
             .resource_threads()
-            .sender()
             .send(IndexedDBThreadMsg::Sync(open_operation))
             .unwrap();
     }
@@ -320,7 +319,6 @@ impl IDBOpenDBRequest {
 
         global
             .resource_threads()
-            .sender()
             .send(IndexedDBThreadMsg::Sync(delete_operation))
             .unwrap();
     }

--- a/components/script/dom/idbrequest.rs
+++ b/components/script/dom/idbrequest.rs
@@ -308,7 +308,6 @@ impl IDBRequest {
         transaction
             .global()
             .resource_threads()
-            .sender()
             .send(IndexedDBThreadMsg::Async(
                 global.origin().immutable().clone(),
                 transaction.get_db_name().to_string(),

--- a/components/script/dom/idbtransaction.rs
+++ b/components/script/dom/idbtransaction.rs
@@ -105,7 +105,6 @@ impl IDBTransaction {
 
         global
             .resource_threads()
-            .sender()
             .send(IndexedDBThreadMsg::Sync(SyncOperation::RegisterNewTxn(
                 sender,
                 global.origin().immutable().clone(),

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -356,12 +356,7 @@ impl WindowProxy {
                 dest: response.new_webview_id,
             };
 
-            document
-                .global()
-                .resource_threads()
-                .sender()
-                .send(msg)
-                .unwrap();
+            document.global().resource_threads().send(msg).unwrap();
             receiver.recv().unwrap();
         }
         Some(new_window_proxy)


### PR DESCRIPTION
The IpcSend trait defines a `send()` method, so doing .sender().send() seems like it just adds a useless clone of the sender, when we could just `send()` directly.
This only cleans up the direct usages of this pattern, there are more instances, where a helper method is defined, which returns the IpcSender, and the only usages also just directly call send.

Testing: No functional changes

