### PR TITLE
Add scroll tree measurement in IOCompositor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,6 +1407,7 @@ dependencies = [
  "servo_allocator",
  "servo_config",
  "servo_geometry",
+ "servo_malloc_size_of",
  "stylo_traits",
  "surfman",
  "timers",

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -48,6 +48,7 @@ webrender = { workspace = true }
 webrender_api = { workspace = true }
 webxr = { path = "../webxr", optional = true }
 wr_malloc_size_of = { workspace = true }
+malloc_size_of = { workspace = true }
 
 [dev-dependencies]
 surfman = { workspace = true }

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -35,6 +35,7 @@ gleam = { workspace = true }
 ipc-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
+malloc_size_of = { workspace = true }
 pixels = { path = "../pixels" }
 profile_traits = { workspace = true }
 servo_allocator = { path = "../allocator" }
@@ -48,7 +49,6 @@ webrender = { workspace = true }
 webrender_api = { workspace = true }
 webxr = { path = "../webxr", optional = true }
 wr_malloc_size_of = { workspace = true }
-malloc_size_of = { workspace = true }
 
 [dev-dependencies]
 surfman = { workspace = true }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -443,7 +443,7 @@ impl IOCompositor {
 
                 perform_memory_report(|ops| {
                     reports.push(Report {
-                        path: path!["webrender", "scroll-tree"],
+                        path: path!["compositor", "scroll-tree"],
                         kind: ReportKind::ExplicitJemallocHeapSize,
                         size: self.webview_renderers.scroll_trees_memory_usage(ops),
                     });

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -29,7 +29,9 @@ use euclid::{Point2D, Rect, Scale, Size2D, Transform3D};
 use ipc_channel::ipc::{self, IpcSender, IpcSharedMemory};
 use log::{debug, info, trace, warn};
 use pixels::{CorsStatus, ImageFrame, ImageMetadata, PixelFormat, RasterImage};
-use profile_traits::mem::{ProcessReports, ProfilerRegistration, Report, ReportKind};
+use profile_traits::mem::{
+    ProcessReports, ProfilerRegistration, Report, ReportKind, perform_memory_report,
+};
 use profile_traits::time::{self as profile_time, ProfilerCategory};
 use profile_traits::{path, time_profile};
 use servo_config::{opts, pref};
@@ -421,7 +423,7 @@ impl IOCompositor {
                 let ops =
                     wr_malloc_size_of::MallocSizeOfOps::new(servo_allocator::usable_size, None);
                 let report = self.global.borrow().webrender_api.report_memory(ops);
-                let reports = vec![
+                let mut reports = vec![
                     Report {
                         path: path!["webrender", "fonts"],
                         kind: ReportKind::ExplicitJemallocHeapSize,
@@ -438,6 +440,15 @@ impl IOCompositor {
                         size: report.display_list,
                     },
                 ];
+
+                perform_memory_report(|ops| {
+                    reports.push(Report {
+                        path: path!["webrender", "scroll-tree"],
+                        kind: ReportKind::ExplicitJemallocHeapSize,
+                        size: self.webview_renderers.scroll_trees_memory_usage(ops),
+                    });
+                });
+
                 sender.send(ProcessReports::new(reports));
             },
 

--- a/components/compositing/webview_manager.rs
+++ b/components/compositing/webview_manager.rs
@@ -7,7 +7,7 @@ use std::collections::hash_map::{Entry, Values, ValuesMut};
 
 use base::id::WebViewId;
 
-use crate::webview_renderer::UnknownWebView;
+use crate::webview_renderer::{UnknownWebView, WebViewRenderer};
 
 #[derive(Debug)]
 pub struct WebViewManager<WebView> {
@@ -106,6 +106,17 @@ impl<WebView> WebViewManager<WebView> {
 
     pub fn iter_mut(&mut self) -> ValuesMut<'_, WebViewId, WebView> {
         self.webviews.values_mut()
+    }
+}
+
+impl WebViewManager<WebViewRenderer> {
+    pub(crate) fn scroll_trees_memory_usage(
+        &self,
+        ops: &mut malloc_size_of::MallocSizeOfOps,
+    ) -> usize {
+        self.iter()
+            .map(|renderer| renderer.scroll_trees_memory_usage(ops))
+            .sum::<usize>()
     }
 }
 

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -22,6 +22,7 @@ use embedder_traits::{
 use euclid::{Point2D, Scale, Vector2D};
 use fnv::FnvHashSet;
 use log::{debug, warn};
+use malloc_size_of::MallocSizeOf;
 use servo_geometry::DeviceIndependentPixel;
 use style_traits::{CSSPixel, PinchZoomFactor};
 use webrender_api::units::{DeviceIntPoint, DevicePixel, DevicePoint, DeviceRect, LayoutVector2D};
@@ -1000,6 +1001,16 @@ impl WebViewRenderer {
                     .clamp_zoom(viewport_description.initial_scale.get()),
             ));
         self.viewport_description = Some(viewport_description);
+    }
+
+    pub(crate) fn scroll_trees_memory_usage(
+        &self,
+        ops: &mut malloc_size_of::MallocSizeOfOps,
+    ) -> usize {
+        self.pipelines
+            .values()
+            .map(|pipeline| pipeline.scroll_tree.size_of(ops))
+            .sum::<usize>()
     }
 }
 


### PR DESCRIPTION
Adds a new memory report that aggregates the size of all scroll trees from within all pipelines for each web view.

Testing: Acessing `about:memory`
Fixes: #38726