### PR TITLE
constellation: send EmbedderMsg::ShutdownComplete as last

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -760,6 +760,13 @@ where
         join_handle
             .join()
             .expect("Failed to join on the fetch thread in the constellation");
+
+        // Note: the last thing the constellation does,
+        // is asking the embedder to shutdown.
+        // This helps ensure we've shutdown all our internal threads before
+        // de-initializing Servo(see the `thread_count` warning on MacOS).
+        debug!("Asking embedding layer to complete shutdown.");
+        self.embedder_proxy.send(EmbedderMsg::ShutdownComplete);
     }
 
     /// Generate a new pipeline id namespace.
@@ -2710,9 +2717,6 @@ where
                 warn!("Exit WebGL thread failed ({:?})", e);
             }
         }
-
-        debug!("Asking embedding layer to complete shutdown.");
-        self.embedder_proxy.send(EmbedderMsg::ShutdownComplete);
 
         debug!("Shutting-down IPC router thread in constellation.");
         ROUTER.shutdown();

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -761,10 +761,9 @@ where
             .join()
             .expect("Failed to join on the fetch thread in the constellation");
 
-        // Note: the last thing the constellation does,
-        // is asking the embedder to shutdown.
-        // This helps ensure we've shutdown all our internal threads before
-        // de-initializing Servo(see the `thread_count` warning on MacOS).
+        // Note: the last thing the constellation does, is asking the embedder to
+        // shut down. This helps ensure we've shut down all our internal threads before
+        // de-initializing Servo (see the `thread_count` warning on MacOS).
         debug!("Asking embedding layer to complete shutdown.");
         self.embedder_proxy.send(EmbedderMsg::ShutdownComplete);
     }


### PR DESCRIPTION
To help ensure our internal threads have shut-down before we deinit Servo, the last thing the constellation should do, is sending the `EmbedderMsg::ShutdownComplete`. 

Testing: Manual testing by starting Servo and then closing the window. 
Fixes: Part of https://github.com/servo/servo/issues/30849
