### PR TITLE
layout: Shut down style thread-pool when exiting a content process / shutting down the Constellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,7 @@ dependencies = [
  "servo_config",
  "servo_rand",
  "servo_url",
+ "stylo",
  "stylo_traits",
  "tracing",
  "webgpu",

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -55,6 +55,7 @@ servo_config = { path = "../config" }
 servo_rand = { path = "../rand" }
 servo_url = { path = "../url" }
 stylo_traits = { workspace = true }
+stylo = { workspace = true }
 tracing = { workspace = true, optional = true }
 webgpu = { path = "../webgpu" }
 webgpu_traits = { workspace = true }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -144,7 +144,7 @@ use ipc_channel::Error as IpcError;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
 use keyboard_types::{Key, KeyState, Modifiers, NamedKey};
-use layout_api::{LayoutFactory, ScriptThreadFactory};
+use layout_api::{LayoutFactory, ScriptThreadFactory, shutdown_style_threads};
 use log::{debug, error, info, trace, warn};
 use media::WindowGLContext;
 use net_traits::pub_domains::reg_host;
@@ -754,6 +754,10 @@ where
             self.handle_request();
         }
         self.handle_shutdown();
+
+        if !opts::get().multiprocess {
+            shutdown_style_threads();
+        }
 
         // Shut down the fetch thread started above.
         exit_fetch_thread();

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -144,7 +144,7 @@ use ipc_channel::Error as IpcError;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
 use keyboard_types::{Key, KeyState, Modifiers, NamedKey};
-use layout_api::{LayoutFactory, ScriptThreadFactory, shutdown_style_threads};
+use layout_api::{LayoutFactory, ScriptThreadFactory};
 use log::{debug, error, info, trace, warn};
 use media::WindowGLContext;
 use net_traits::pub_domains::reg_host;
@@ -165,6 +165,7 @@ use servo_config::prefs::{self, PrefValue};
 use servo_config::{opts, pref};
 use servo_rand::{Rng, ServoRng, SliceRandom, random};
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
+use style::global_style_data::StyleThreadPool;
 #[cfg(feature = "webgpu")]
 use webgpu::swapchain::WGPUImageMap;
 #[cfg(feature = "webgpu")]
@@ -756,7 +757,7 @@ where
         self.handle_shutdown();
 
         if !opts::get().multiprocess {
-            shutdown_style_threads();
+            StyleThreadPool::shutdown();
         }
 
         // Shut down the fetch thread started above.

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -88,7 +88,6 @@ pub use keyboard_types::{
     Code, CompositionEvent, CompositionState, Key, KeyState, Location, Modifiers, NamedKey,
 };
 use layout::LayoutFactoryImpl;
-use layout_api::shutdown_style_threads;
 use log::{Log, Metadata, Record, debug, error, warn};
 use media::{GlApi, NativeDisplay, WindowGLContext};
 use net::protocols::ProtocolRegistry;
@@ -108,6 +107,7 @@ use servo_geometry::{
 use servo_media::ServoMedia;
 use servo_media::player::context::GlContext;
 use servo_url::ServoUrl;
+use style::global_style_data::StyleThreadPool;
 use webgl::WebGLComm;
 #[cfg(feature = "webgpu")]
 pub use webgpu;
@@ -1282,7 +1282,7 @@ pub fn run_content_process(token: String) {
                 .join()
                 .expect("Failed to join on the BHM background thread.");
 
-            shutdown_style_threads();
+            StyleThreadPool::shutdown();
 
             // Shut down the fetch thread started above.
             exit_fetch_thread();

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -88,6 +88,7 @@ pub use keyboard_types::{
     Code, CompositionEvent, CompositionState, Key, KeyState, Location, Modifiers, NamedKey,
 };
 use layout::LayoutFactoryImpl;
+use layout_api::shutdown_style_threads;
 use log::{Log, Metadata, Record, debug, error, warn};
 use media::{GlApi, NativeDisplay, WindowGLContext};
 use net::protocols::ProtocolRegistry;
@@ -1280,6 +1281,8 @@ pub fn run_content_process(token: String) {
             join_handle
                 .join()
                 .expect("Failed to join on the BHM background thread.");
+
+            shutdown_style_threads();
 
             // Shut down the fetch thread started above.
             exit_fetch_thread();

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -49,6 +49,7 @@ use style::animation::DocumentAnimationSet;
 use style::context::QuirksMode;
 use style::data::ElementData;
 use style::dom::OpaqueNode;
+use style::global_style_data::StyleThreadPool;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::media_queries::Device;
 use style::properties::PropertyId;
@@ -58,6 +59,10 @@ use style::stylesheets::{Stylesheet, UrlExtraData};
 use style_traits::CSSPixel;
 use webrender_api::units::{DeviceIntSize, LayoutPoint, LayoutVector2D};
 use webrender_api::{ExternalScrollId, ImageKey};
+
+pub fn shutdown_style_threads() {
+    StyleThreadPool::shutdown();
+}
 
 pub trait GenericLayoutDataTrait: Any + MallocSizeOfTrait {
     fn as_any(&self) -> &dyn Any;

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -49,7 +49,6 @@ use style::animation::DocumentAnimationSet;
 use style::context::QuirksMode;
 use style::data::ElementData;
 use style::dom::OpaqueNode;
-use style::global_style_data::StyleThreadPool;
 use style::invalidation::element::restyle_hints::RestyleHint;
 use style::media_queries::Device;
 use style::properties::PropertyId;
@@ -59,10 +58,6 @@ use style::stylesheets::{Stylesheet, UrlExtraData};
 use style_traits::CSSPixel;
 use webrender_api::units::{DeviceIntSize, LayoutPoint, LayoutVector2D};
 use webrender_api::{ExternalScrollId, ImageKey};
-
-pub fn shutdown_style_threads() {
-    StyleThreadPool::shutdown();
-}
 
 pub trait GenericLayoutDataTrait: Any + MallocSizeOfTrait {
     fn as_any(&self) -> &dyn Any;


### PR DESCRIPTION
To ensure a clean-shutdown of Servo, we need to shutdown our internal threading before deinit. This shuts down the style thread pool either using the constellation(in single-process mode), or when a content process exits.

Testing: Manual testing by opening a window, opening and closing multiple tabs, and closing the window, with a sleep added before deinit and a sample taken to ensure the loose threads previously noticed are gone.
Fixes: part of https://github.com/servo/servo/issues/30849
