### PR TITLE
devtools: Reland test improvements from #38614 minus CI changes

### DIFF
--- a/components/devtools/protocol.rs
+++ b/components/devtools/protocol.rs
@@ -5,7 +5,7 @@
 //! Low-level wire protocol implementation. Currently only supports
 //! [JSON packets](https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#json-packets).
 
-use std::io::{Read, Write};
+use std::io::{ErrorKind, Read, Write};
 use std::net::TcpStream;
 
 use log::debug;
@@ -49,7 +49,8 @@ impl JsonPacketStream for TcpStream {
         loop {
             let mut buf = [0];
             let byte = match self.read(&mut buf) {
-                Ok(0) => return Ok(None), // EOF
+                Ok(0) => return Ok(None),                                            // EOF
+                Err(e) if e.kind() == ErrorKind::ConnectionReset => return Ok(None), // EOF
                 Ok(1) => buf[0],
                 Ok(_) => unreachable!(),
                 Err(e) => return Err(e.to_string()),

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -50,13 +50,13 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
     # /path/to/servo/python/servo
     script_path = None
     build_type: Optional[BuildType] = None
+    base_urls = None
+    web_servers = None
+    web_server_threads = None
 
     def __init__(self, methodName="runTest"):
         super().__init__(methodName)
         self.servoshell = None
-        self.base_urls = None
-        self.web_servers = None
-        self.web_server_threads = None
 
     # Watcher tests
 
@@ -78,22 +78,21 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
     # Worker script sources can be external or blob.
 
     def test_sources_list(self):
-        self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))
-        self.run_servoshell()
+        self.run_servoshell(url=f"{self.base_urls[0]}/sources/test.html")
         self.assert_sources_list(
             set(
                 [
                     # TODO: update expectations when we fix ES modules
                     tuple(
                         [
-                            Source("srcScript", f"{self.base_urls[0]}/classic.js"),
-                            Source("inlineScript", f"{self.base_urls[0]}/test.html"),
-                            Source("inlineScript", f"{self.base_urls[0]}/test.html"),
-                            Source("srcScript", f"{self.base_urls[1]}/classic.js"),
-                            Source("importedModule", f"{self.base_urls[0]}/module.js"),
+                            Source("srcScript", f"{self.base_urls[0]}/sources/classic.js"),
+                            Source("inlineScript", f"{self.base_urls[0]}/sources/test.html"),
+                            Source("inlineScript", f"{self.base_urls[0]}/sources/test.html"),
+                            Source("srcScript", f"{self.base_urls[1]}/sources/classic.js"),
+                            Source("importedModule", f"{self.base_urls[0]}/sources/module.js"),
                         ]
                     ),
-                    tuple([Source("Worker", f"{self.base_urls[0]}/classic_worker.js")]),
+                    tuple([Source("Worker", f"{self.base_urls[0]}/sources/classic_worker.js")]),
                 ]
             ),
         )
@@ -113,9 +112,8 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         self.assert_sources_list(set([tuple([Source("inlineScript", "data:text/html,<script>;</script>")])]))
 
     def test_sources_list_with_data_external_classic_script(self):
-        self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))
-        self.run_servoshell(url=f'data:text/html,<script src="{self.base_urls[0]}/classic.js"></script>')
-        self.assert_sources_list(set([tuple([Source("srcScript", f"{self.base_urls[0]}/classic.js")])]))
+        self.run_servoshell(url=f'data:text/html,<script src="{self.base_urls[0]}/sources/classic.js"></script>')
+        self.assert_sources_list(set([tuple([Source("srcScript", f"{self.base_urls[0]}/sources/classic.js")])]))
 
     def test_sources_list_with_data_empty_inline_module_script(self):
         self.run_servoshell(url="data:text/html,<script type=module></script>")
@@ -128,24 +126,23 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         )
 
     def test_sources_list_with_data_external_module_script(self):
-        self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))
-        self.run_servoshell(url=f"{self.base_urls[0]}/test_sources_list_with_data_external_module_script.html")
-        self.assert_sources_list(set([tuple([Source("srcScript", f"{self.base_urls[0]}/module.js")])]))
+        self.run_servoshell(url=f"{self.base_urls[0]}/sources/test_sources_list_with_data_external_module_script.html")
+        self.assert_sources_list(set([tuple([Source("srcScript", f"{self.base_urls[0]}/sources/module.js")])]))
 
     # Sources list for `introductionType` = `importedModule`
 
     def test_sources_list_with_static_import_module(self):
-        self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))
-        self.run_servoshell(url=f"{self.base_urls[0]}/test_sources_list_with_static_import_module.html")
+        self.run_servoshell(url=f"{self.base_urls[0]}/sources/test_sources_list_with_static_import_module.html")
         self.assert_sources_list(
             set(
                 [
                     tuple(
                         [
                             Source(
-                                "inlineScript", f"{self.base_urls[0]}/test_sources_list_with_static_import_module.html"
+                                "inlineScript",
+                                f"{self.base_urls[0]}/sources/test_sources_list_with_static_import_module.html",
                             ),
-                            Source("importedModule", f"{self.base_urls[0]}/module.js"),
+                            Source("importedModule", f"{self.base_urls[0]}/sources/module.js"),
                         ]
                     )
                 ]
@@ -153,17 +150,17 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         )
 
     def test_sources_list_with_dynamic_import_module(self):
-        self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))
-        self.run_servoshell(url=f"{self.base_urls[0]}/test_sources_list_with_dynamic_import_module.html")
+        self.run_servoshell(url=f"{self.base_urls[0]}/sources/test_sources_list_with_dynamic_import_module.html")
         self.assert_sources_list(
             set(
                 [
                     tuple(
                         [
                             Source(
-                                "inlineScript", f"{self.base_urls[0]}/test_sources_list_with_dynamic_import_module.html"
+                                "inlineScript",
+                                f"{self.base_urls[0]}/sources/test_sources_list_with_dynamic_import_module.html",
                             ),
-                            Source("importedModule", f"{self.base_urls[0]}/module.js"),
+                            Source("importedModule", f"{self.base_urls[0]}/sources/module.js"),
                         ]
                     )
                 ]
@@ -173,19 +170,21 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
     # Sources list for `introductionType` = `Worker`
 
     def test_sources_list_with_classic_worker(self):
-        self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))
-        self.run_servoshell(url=f"{self.base_urls[0]}/test_sources_list_with_classic_worker.html")
+        self.run_servoshell(url=f"{self.base_urls[0]}/sources/test_sources_list_with_classic_worker.html")
         self.assert_sources_list(
             set(
                 [
                     tuple(
                         [
-                            Source("inlineScript", f"{self.base_urls[0]}/test_sources_list_with_classic_worker.html"),
+                            Source(
+                                "inlineScript",
+                                f"{self.base_urls[0]}/sources/test_sources_list_with_classic_worker.html",
+                            ),
                         ]
                     ),
                     tuple(
                         [
-                            Source("Worker", f"{self.base_urls[0]}/classic_worker.js"),
+                            Source("Worker", f"{self.base_urls[0]}/sources/classic_worker.js"),
                         ]
                     ),
                 ]
@@ -193,19 +192,20 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         )
 
     def test_sources_list_with_module_worker(self):
-        self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))
-        self.run_servoshell(url=f"{self.base_urls[0]}/test_sources_list_with_module_worker.html")
+        self.run_servoshell(url=f"{self.base_urls[0]}/sources/test_sources_list_with_module_worker.html")
         self.assert_sources_list(
             set(
                 [
                     tuple(
                         [
-                            Source("inlineScript", f"{self.base_urls[0]}/test_sources_list_with_module_worker.html"),
+                            Source(
+                                "inlineScript", f"{self.base_urls[0]}/sources/test_sources_list_with_module_worker.html"
+                            ),
                         ]
                     ),
                     tuple(
                         [
-                            Source("Worker", f"{self.base_urls[0]}/module_worker.js"),
+                            Source("Worker", f"{self.base_urls[0]}/sources/module_worker.js"),
                         ]
                     ),
                 ]
@@ -538,24 +538,20 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         self.assert_source_content(Source("inlineScript", f"data:text/html,{script_tag}"), script_tag)
 
     def test_source_content_external_script(self):
-        self.start_web_server(test_dir=os.path.join(DevtoolsTests.script_path, "devtools_tests/sources"))
-        self.run_servoshell(url=f'data:text/html,<script src="{self.base_urls[0]}/classic.js"></script>')
+        self.run_servoshell(url=f'data:text/html,<script src="{self.base_urls[0]}/sources/classic.js"></script>')
         expected_content = 'console.log("external classic");\n'
-        self.assert_source_content(Source("srcScript", f"{self.base_urls[0]}/classic.js"), expected_content)
+        self.assert_source_content(Source("srcScript", f"{self.base_urls[0]}/sources/classic.js"), expected_content)
 
     def test_source_content_html_file(self):
-        self.start_web_server(test_dir=self.get_test_path("sources"))
-        self.run_servoshell()
+        self.run_servoshell(url=f"{self.base_urls[0]}/sources/test.html")
         expected_content = open(self.get_test_path("sources/test.html")).read()
-        self.assert_source_content(Source("inlineScript", f"{self.base_urls[0]}/test.html"), expected_content)
+        self.assert_source_content(Source("inlineScript", f"{self.base_urls[0]}/sources/test.html"), expected_content)
 
     def test_source_content_with_inline_module_import_external(self):
-        self.start_web_server(test_dir=self.get_test_path("sources_content_with_inline_module_import_external"))
-        self.run_servoshell()
-        expected_content = open(
-            self.get_test_path("sources_content_with_inline_module_import_external/test.html")
-        ).read()
-        self.assert_source_content(Source("inlineScript", f"{self.base_urls[0]}/test.html"), expected_content)
+        self.run_servoshell(url=f"{self.base_urls[0]}/sources_content_with_inline_module_import_external/test.html")
+        path = "sources_content_with_inline_module_import_external/test.html"
+        expected_content = open(self.get_test_path(path)).read()
+        self.assert_source_content(Source("inlineScript", f"{self.base_urls[0]}/{path}"), expected_content)
 
     # Test case that uses innerHTML and would actually need the HTML parser
     # (innerHTML has a fast path for values that don’t contain b'&' | b'\0' | b'<' | b'\r')
@@ -581,16 +577,16 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
     # Test case that uses XMLHttpRequest#responseXML and would actually need the HTML parser
     # (innerHTML has a fast path for values that don’t contain b'&' | b'\0' | b'<' | b'\r')
     def test_source_content_inline_script_with_responsexml(self):
-        self.start_web_server(test_dir=self.get_test_path("sources_content_with_responsexml"))
-        self.run_servoshell()
+        self.run_servoshell(url=f"{self.base_urls[0]}/sources_content_with_responsexml/test.html")
         expected_content = open(self.get_test_path("sources_content_with_responsexml/test.html")).read()
-        self.assert_source_content(Source("inlineScript", f"{self.base_urls[0]}/test.html"), expected_content)
+        self.assert_source_content(
+            Source("inlineScript", f"{self.base_urls[0]}/sources_content_with_responsexml/test.html"), expected_content
+        )
 
     def test_source_breakable_lines_and_positions(self):
-        self.start_web_server(test_dir=self.get_test_path("sources_breakable_lines_and_positions"))
-        self.run_servoshell()
+        self.run_servoshell(url=f"{self.base_urls[0]}/sources_breakable_lines_and_positions/test.html")
         self.assert_source_breakable_lines_and_positions(
-            Source("inlineScript", f"{self.base_urls[0]}/test.html"),
+            Source("inlineScript", f"{self.base_urls[0]}/sources_breakable_lines_and_positions/test.html"),
             [4, 5, 6, 7],
             {
                 "4": [4, 12, 20, 28],
@@ -617,13 +613,14 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         )
 
     # Sets `base_url` and `web_server` and `web_server_thread`.
-    def start_web_server(self, *, test_dir=None, num_servers=2):
-        assert self.base_urls is None and self.web_servers is None and self.web_server_threads is None
-        if test_dir is None:
-            test_dir = os.path.join(DevtoolsTests.script_path, "devtools_tests")
+    @classmethod
+    def setUpClass(cls):
+        assert cls.base_urls is None and cls.web_servers is None and cls.web_server_threads is None
+        test_dir = os.path.join(DevtoolsTests.script_path, "devtools_tests")
+        num_servers = 2
         base_urls = [Future() for i in range(num_servers)]
-        self.web_servers = [None for i in range(num_servers)]
-        self.web_server_threads = [None for i in range(num_servers)]
+        cls.web_servers = [None for i in range(num_servers)]
+        cls.web_server_threads = [None for i in range(num_servers)]
 
         class Handler(http.server.SimpleHTTPRequestHandler):
             def __init__(self, *args, **kwargs):
@@ -642,24 +639,22 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
             web_server = socketserver.TCPServer(("127.0.0.1", 10000 + index), Handler)
             base_url = f"http://127.0.0.1:{web_server.server_address[1]}"
             base_urls[index].set_result(base_url)
-            self.web_servers[index] = web_server
+            cls.web_servers[index] = web_server
             web_server.serve_forever()
 
         # Start a web server for the test.
         for index in range(num_servers):
             thread = Thread(target=server_thread, args=[index])
-            self.web_server_threads[index] = thread
+            cls.web_server_threads[index] = thread
             thread.start()
-        self.base_urls = [base_url.result(1) for base_url in base_urls]
+        cls.base_urls = [base_url.result(1) for base_url in base_urls]
 
     # Sets `servoshell`.
-    def run_servoshell(self, *, url=None):
+    def run_servoshell(self, *, url):
         # Change this setting if you want to debug Servo.
         os.environ["RUST_LOG"] = "error,devtools=warn"
 
         # Run servoshell.
-        if url is None:
-            url = f"{self.base_urls[0]}/test.html"
         self.servoshell = subprocess.Popen([f"target/{self.build_type.directory_name()}/servo", "--devtools=6080", url])
 
         sleep_per_try = 1 / 8  # seconds
@@ -680,23 +675,25 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
                 continue
 
     def tearDown(self):
-        # Terminate servoshell.
+        # Terminate servoshell, but do not stop the web servers.
         if self.servoshell is not None:
             self.servoshell.terminate()
             self.servoshell = None
 
+    @classmethod
+    def tearDownClass(cls):
         # Stop the web servers.
-        if self.web_servers is not None:
-            for web_server in self.web_servers:
+        if cls.web_servers is not None:
+            for web_server in cls.web_servers:
                 web_server.shutdown()
                 web_server.server_close()
-            self.web_servers = None
-        if self.web_server_threads is not None:
-            for web_server_thread in self.web_server_threads:
+            cls.web_servers = None
+        if cls.web_server_threads is not None:
+            for web_server_thread in cls.web_server_threads:
                 web_server_thread.join()
-            self.web_server_threads = None
-        if self.base_urls is not None:
-            self.base_urls = None
+            cls.web_server_threads = None
+        if cls.base_urls is not None:
+            cls.base_urls = None
 
     def _setup_devtools_client(self, *, expected_targets=1) -> Devtools:
         client = RDPClient()

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -82,7 +82,6 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         self.assert_sources_list(
             set(
                 [
-                    # TODO: update expectations when we fix ES modules
                     tuple(
                         [
                             Source("srcScript", f"{self.base_urls[0]}/sources/classic.js"),

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -7,6 +7,7 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
+from __future__ import annotations
 from concurrent.futures import Future
 from dataclasses import dataclass
 import logging
@@ -24,7 +25,7 @@ import socketserver
 import subprocess
 import time
 from threading import Thread
-from typing import Optional
+from typing import Any, Optional
 import unittest
 
 from servo.command_base import BuildType
@@ -46,7 +47,7 @@ class Devtools:
     targets: list
     exited: bool = False
 
-    def connect(*, expected_targets=1):
+    def connect(*, expected_targets: int = 1) -> Devtools:
         """
         Connect to the Servo devtools server.
         You should use a `with` statement to ensure we disconnect unconditionally.
@@ -87,7 +88,7 @@ class Devtools:
 
         return Devtools(client, watcher, targets)
 
-    def __getattribute__(self, name):
+    def __getattribute__(self, name: str) -> Any:
         """
         Access a property, raising a ValueError if the instance was previously marked as exited.
         """
@@ -95,7 +96,7 @@ class Devtools:
             raise ValueError("Devtools instance must not be used after __exit__()")
         return object.__getattribute__(self, name)
 
-    def __enter__(self):
+    def __enter__(self) -> Devtools:
         """
         Enter the `with` context for this instance, raising a ValueError if it was previously marked as exited.
         """
@@ -103,7 +104,7 @@ class Devtools:
             raise ValueError("Devtools instance must not be used after __exit__()")
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
         """
         Exit the `with` context for this instance, disconnecting the client and marking it as exited.
         Does not raise a ValueError if it was previously marked as exited, so you can nest `with` statements.

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -654,7 +654,9 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         os.environ["RUST_LOG"] = "error,devtools=warn"
 
         # Run servoshell.
-        self.servoshell = subprocess.Popen([f"target/{self.build_type.directory_name()}/servo", "--devtools=6080", url])
+        self.servoshell = subprocess.Popen(
+            [f"target/{self.build_type.directory_name()}/servo", "--headless", "--devtools=6080", url]
+        )
 
         sleep_per_try = 1 / 8  # seconds
         remaining_tries = 5 / sleep_per_try  # 5 seconds

--- a/python/servo/devtools_tests/sources/test.html
+++ b/python/servo/devtools_tests/sources/test.html
@@ -8,4 +8,4 @@
     import module from "./module.js";
     console.log("inline module");
 </script>
-<script src="http://127.0.0.1:10001/classic.js"></script>
+<script src="http://127.0.0.1:10001/sources/classic.js"></script>


### PR DESCRIPTION
#38614 was reverted due to CI flakiness, but it also included several improvements to the devtools tests. this patch relands those improvements, described below.

we make three changes that speed up the devtools tests from 73 → 65 → 56 → 51 seconds:

- we replace the hardcoded sleep(1) after starting servoshell with a loop that waits until the devtools port is open (this also fixes intermittent failures when servoshell starts too slowly, especially on macOS)
- we start the internal web servers once, and reuse them across all tests
- we run servoshell in headless mode (this is also required because most CI runners have no GUI)

and we fix two bugs that cause very noisy but not very interesting error messages:

- in the test code, we use a [context manager](https://docs.python.org/3/reference/datamodel.html#context-managers) to ensure the devtools client is disconnected unconditionally, even if test methods or assert helper methods raise exceptions (this was causing errors on all platforms)
- in the devtools server, we treat “connection reset” errors when reading from the client like a normal EOF, rather than as a failure (this was causing errors on Windows)

on self-hosted linux builds, there are still spurious error messages like the following, but we can fix them later:

```
error: XDG_RUNTIME_DIR not set in the environment.
libEGL warning: egl: failed to create dri2 screen
```

Testing: this patch improves the devtools tests, but does not change their coverage
Fixes: part of #36325