### PR TITLE
devtools: Use correct servoshell path on Windows

### DIFF
--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -119,6 +119,7 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
     # /path/to/servo/python/servo
     script_path = None
     build_type: Optional[BuildType] = None
+    servo_binary: Optional[str] = None
     base_urls = None
     web_servers = None
     web_server_threads = None
@@ -727,9 +728,7 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         os.environ["RUST_LOG"] = "error,devtools=warn"
 
         # Run servoshell.
-        self.servoshell = subprocess.Popen(
-            [f"target/{self.build_type.directory_name()}/servo", "--headless", "--devtools=6080", url]
-        )
+        self.servoshell = subprocess.Popen([f"{DevtoolsTests.servo_binary}", "--headless", "--devtools=6080", url])
 
         sleep_per_try = 1 / 8  # seconds
         remaining_tries = 5 / sleep_per_try  # 5 seconds
@@ -899,9 +898,10 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         return os.path.join(DevtoolsTests.script_path, os.path.join("devtools_tests", path))
 
 
-def run_tests(script_path, build_type: BuildType, test_names: list[str]):
+def run_tests(script_path, build_type: BuildType, test_names: list[str], servo_binary: str):
     DevtoolsTests.script_path = script_path
     DevtoolsTests.build_type = build_type
+    DevtoolsTests.servo_binary = servo_binary
     verbosity = 1 if logging.getLogger().level >= logging.WARN else 2
     loader = unittest.TestLoader()
     if test_names:

--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -28,8 +28,6 @@ from threading import Thread
 from typing import Any, Optional
 import unittest
 
-from servo.command_base import BuildType
-
 # Set this to true to log requests in the internal web servers.
 LOG_REQUESTS = False
 
@@ -118,7 +116,6 @@ class Devtools:
 class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
     # /path/to/servo/python/servo
     script_path = None
-    build_type: Optional[BuildType] = None
     servo_binary: Optional[str] = None
     base_urls = None
     web_servers = None
@@ -898,9 +895,8 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         return os.path.join(DevtoolsTests.script_path, os.path.join("devtools_tests", path))
 
 
-def run_tests(script_path, build_type: BuildType, test_names: list[str], servo_binary: str):
+def run_tests(script_path, servo_binary: str, test_names: list[str]):
     DevtoolsTests.script_path = script_path
-    DevtoolsTests.build_type = build_type
     DevtoolsTests.servo_binary = servo_binary
     verbosity = 1 if logging.getLogger().level >= logging.WARN else 2
     loader = unittest.TestLoader()

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -378,10 +378,10 @@ class MachCommands(CommandBase):
 
     @Command("test-devtools", description="Run tests for devtools.", category="testing")
     @CommandArgument("test_names", nargs=argparse.REMAINDER, help="Only run tests that match these patterns")
-    @CommandBase.common_command_arguments(build_type=True, binary_selection=True)
-    def test_devtools(self, build_type: BuildType, test_names: list[str], servo_binary: str, **kwargs: Any) -> int:
+    @CommandBase.common_command_arguments(binary_selection=True)
+    def test_devtools(self, servo_binary: str, test_names: list[str], **kwargs: Any) -> int:
         print("Running devtools tests...")
-        passed = servo.devtools_tests.run_tests(SCRIPT_PATH, build_type, test_names, servo_binary)
+        passed = servo.devtools_tests.run_tests(SCRIPT_PATH, servo_binary, test_names)
         return 0 if passed else 1
 
     @Command(

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -378,10 +378,10 @@ class MachCommands(CommandBase):
 
     @Command("test-devtools", description="Run tests for devtools.", category="testing")
     @CommandArgument("test_names", nargs=argparse.REMAINDER, help="Only run tests that match these patterns")
-    @CommandBase.common_command_arguments(build_type=True)
-    def test_devtools(self, build_type: BuildType, test_names: list[str], **kwargs: Any) -> int:
+    @CommandBase.common_command_arguments(build_type=True, binary_selection=True)
+    def test_devtools(self, build_type: BuildType, test_names: list[str], servo_binary: str, **kwargs: Any) -> int:
         print("Running devtools tests...")
-        passed = servo.devtools_tests.run_tests(SCRIPT_PATH, build_type, test_names)
+        passed = servo.devtools_tests.run_tests(SCRIPT_PATH, build_type, test_names, servo_binary)
         return 0 if passed else 1
 
     @Command(


### PR DESCRIPTION
When we landed #38614, the devtools tests consistently failed on GitHub-hosted Windows builds, because we were hardcoding the target directory. This patch fixes that by taking the `CARGO_TARGET_DIR` into account.

- before: `[D:\a\servo\servo\]target/release/servo`
- after: `C:\a\servo\servo\target\release\servo.exe`

Testing (cherry picked onto #38614 so it runs in CI):
- GitHub-hosted, before: <https://github.com/atbrakhi/servo/actions/runs/17231549981/job/48886505825>
- GitHub-hosted, after: <https://github.com/atbrakhi/servo/actions/runs/17232856662/job/48890768590>
- self-hosted, after: <https://github.com/servo/servo/actions/runs/17234485907/job/48896322465>

Fixes: part of #38658
