### PR TITLE
script: Integrate animated image updates into `ScriptThread` event loop

### DIFF
--- a/components/script/animations.rs
+++ b/components/script/animations.rs
@@ -76,10 +76,6 @@ impl Animations {
         self.pending_events.borrow_mut().clear();
     }
 
-    pub(crate) fn animations_present(&self) -> bool {
-        self.has_running_animations.get() || !self.pending_events.borrow().is_empty()
-    }
-
     // Mark all animations dirty, if they haven't been marked dirty since the
     // specified `current_timeline_value`. Returns true if animations were marked
     // dirty or false otherwise.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -567,6 +567,12 @@ impl ScriptThread {
         self.timer_scheduler.borrow_mut().schedule_timer(request)
     }
 
+    /// Cancel a the [`TimerEventRequest`] for the given [`TimerId`] on this
+    /// [`ScriptThread`]'s [`TimerScheduler`].
+    pub(crate) fn cancel_timer(&self, timer_id: TimerId) {
+        self.timer_scheduler.borrow_mut().cancel_timer(timer_id)
+    }
+
     // https://html.spec.whatwg.org/multipage/#await-a-stable-state
     pub(crate) fn await_stable_state(task: Microtask) {
         with_script_thread(|script_thread| {

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -29,7 +29,7 @@ use crate::dom::bindings::reflector::{DomGlobal, DomObject};
 use crate::dom::bindings::root::{AsHandleValue, Dom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::csp::CspReporting;
-use crate::dom::document::{ImageAnimationUpdateCallback, RefreshRedirectDue};
+use crate::dom::document::RefreshRedirectDue;
 use crate::dom::eventsource::EventSourceTimeoutCallback;
 use crate::dom::globalscope::GlobalScope;
 #[cfg(feature = "testbinding")]
@@ -88,7 +88,6 @@ pub(crate) enum OneshotTimerCallback {
     #[cfg(feature = "testbinding")]
     TestBindingCallback(TestBindingCallback),
     RefreshRedirectDue(RefreshRedirectDue),
-    ImageAnimationUpdate(ImageAnimationUpdateCallback),
 }
 
 impl OneshotTimerCallback {
@@ -100,7 +99,6 @@ impl OneshotTimerCallback {
             #[cfg(feature = "testbinding")]
             OneshotTimerCallback::TestBindingCallback(callback) => callback.invoke(),
             OneshotTimerCallback::RefreshRedirectDue(callback) => callback.invoke(can_gc),
-            OneshotTimerCallback::ImageAnimationUpdate(callback) => callback.invoke(can_gc),
         }
     }
 }

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicIsize, AtomicU64, Ordering};
 use std::thread::JoinHandle;
+use std::time::Duration;
 
 use app_units::Au;
 use atomic_refcell::AtomicRefCell;
@@ -569,7 +570,7 @@ pub struct ImageAnimationState {
     #[ignore_malloc_size_of = "Arc is hard"]
     pub image: Arc<RasterImage>,
     pub active_frame: usize,
-    last_update_time: f64,
+    frame_start_time: f64,
 }
 
 impl ImageAnimationState {
@@ -577,7 +578,7 @@ impl ImageAnimationState {
         Self {
             image,
             active_frame: 0,
-            last_update_time,
+            frame_start_time: last_update_time,
         }
     }
 
@@ -585,15 +586,18 @@ impl ImageAnimationState {
         self.image.id
     }
 
-    pub fn time_to_next_frame(&self, now: f64) -> f64 {
+    pub fn duration_to_next_frame(&self, now: f64) -> Duration {
         let frame_delay = self
             .image
             .frames
             .get(self.active_frame)
             .expect("Image frame should always be valid")
             .delay
-            .map_or(0., |delay| delay.as_secs_f64());
-        (frame_delay - now + self.last_update_time).max(0.0)
+            .unwrap_or_default();
+
+        let time_since_frame_start = (now - self.frame_start_time).max(0.0) * 1000.0;
+        let time_since_frame_start = Duration::from_secs_f64(time_since_frame_start);
+        frame_delay - time_since_frame_start.min(frame_delay)
     }
 
     /// check whether image active frame need to be updated given current time,
@@ -604,7 +608,7 @@ impl ImageAnimationState {
             return false;
         }
         let image = &self.image;
-        let time_interval_since_last_update = now - self.last_update_time;
+        let time_interval_since_last_update = now - self.frame_start_time;
         let mut remain_time_interval = time_interval_since_last_update -
             image
                 .frames
@@ -628,7 +632,7 @@ impl ImageAnimationState {
             return false;
         }
         self.active_frame = next_active_frame_id;
-        self.last_update_time = now;
+        self.frame_start_time = now;
         true
     }
 }
@@ -689,18 +693,18 @@ mod test {
         let mut image_animation_state = ImageAnimationState::new(Arc::new(image), 0.0);
 
         assert_eq!(image_animation_state.active_frame, 0);
-        assert_eq!(image_animation_state.last_update_time, 0.0);
+        assert_eq!(image_animation_state.frame_start_time, 0.0);
         assert_eq!(
             image_animation_state.update_frame_for_animation_timeline_value(0.101),
             true
         );
         assert_eq!(image_animation_state.active_frame, 1);
-        assert_eq!(image_animation_state.last_update_time, 0.101);
+        assert_eq!(image_animation_state.frame_start_time, 0.101);
         assert_eq!(
             image_animation_state.update_frame_for_animation_timeline_value(0.116),
             false
         );
         assert_eq!(image_animation_state.active_frame, 1);
-        assert_eq!(image_animation_state.last_update_time, 0.101);
+        assert_eq!(image_animation_state.frame_start_time, 0.101);
     }
 }


### PR DESCRIPTION
Instead of manually triggering `ScriptThread::update_the_rendering`,
have animated images trigger rendering updates via the `ScriptThread`
event loop. This should result in fewer calls to
`ScriptThread::update_the_rendering`.

Testing: This should not change behavior and is thus covered by existing
tests.
