### PR TITLE
script: Fix wrong procedure when deserializing `JSValue` from mozjs `HandleValue`

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -410,14 +410,12 @@ unsafe fn jsval_to_webdriver_inner(
             let window_proxy = window.window_proxy();
             if window_proxy.is_browsing_context_discarded() {
                 Err(WebDriverJSError::StaleElementReference)
+            } else if window_proxy.browsing_context_id() == window_proxy.webview_id() {
+                Ok(JSValue::Window(window.webview_id().to_string()))
             } else {
-                if window_proxy.browsing_context_id() == window_proxy.webview_id() {
-                    Ok(JSValue::Window(window.webview_id().to_string()))
-                } else {
-                    Ok(JSValue::Frame(
-                        window_proxy.browsing_context_id().to_string(),
-                    ))
-                }
+                Ok(JSValue::Frame(
+                    window_proxy.browsing_context_id().to_string(),
+                ))
             }
         } else if object_has_to_json_property(cx, global_scope, object.handle()) {
             let name = CString::new("toJSON").unwrap();

--- a/tests/wpt/meta/webdriver/tests/classic/execute_async_script/node.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_async_script/node.py.ini
@@ -5,12 +5,6 @@
   [test_detached_shadow_root[child_context\]]
     expected: FAIL
 
-  [test_stale_element[top_context\]]
-    expected: FAIL
-
-  [test_stale_element[child_context\]]
-    expected: FAIL
-
   [test_element_reference[shadow-root\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/node.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/node.py.ini
@@ -5,12 +5,6 @@
   [test_detached_shadow_root[child_context\]]
     expected: FAIL
 
-  [test_stale_element[top_context\]]
-    expected: FAIL
-
-  [test_stale_element[child_context\]]
-    expected: FAIL
-
   [test_web_reference[shadow-root\]]
     expected: FAIL
 


### PR DESCRIPTION
Spec: https://w3c.github.io/webdriver/#dfn-internal-json-clone

This PR 
1. moves [clone an object](https://w3c.github.io/webdriver/#dfn-clone-an-object) to `fn clone_an_object` to make things clearer.
2. Fixes the bug where we wrongly put `element` and `WindowProxy` as part of [clone an object](https://w3c.github.io/webdriver/#dfn-clone-an-object), which leads to false-positive `JSError` before.
3. Update spec links to correct ones.

Testing: New passing in `{execute_async_script,execute_script}/node.py`