### PR TITLE
net: Ignore `pragma: no-cache` if cache-control is understood

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -146,7 +146,8 @@ fn response_is_cacheable(metadata: &Metadata) -> bool {
             directive.max_age().is_some() ||
             directive.no_cache()
         {
-            is_cacheable = true;
+            // If cache-control is understood, we can use it and ignore pragma.
+            return true;
         }
     }
     if let Some(pragma) = headers.typed_get::<Pragma>() {

--- a/tests/wpt/meta/fetch/http-cache/pragma-no-cache-with-cache-control.html.ini
+++ b/tests/wpt/meta/fetch/http-cache/pragma-no-cache-with-cache-control.html.ini
@@ -1,3 +1,2 @@
 [pragma-no-cache-with-cache-control.html]
   [Response with Cache-Control: max-age=2592000, public and Pragma: no-cache should be cached]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/http-cache/pragma-no-cache-with-cache-control.html.ini
+++ b/tests/wpt/meta/fetch/http-cache/pragma-no-cache-with-cache-control.html.ini
@@ -1,2 +1,0 @@
-[pragma-no-cache-with-cache-control.html]
-  [Response with Cache-Control: max-age=2592000, public and Pragma: no-cache should be cached]


### PR DESCRIPTION
This PR fixes a failed WPT: https://wpt.fyi/results/fetch/http-cache/pragma-no-cache-with-cache-control.html?product=servo

[As RFC9111 mentions,](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.4) the Pragma header field is deprecated. And, in WPT, it expects the Pragma header field is ignored if a cache-control header field is specified and understood by UA. 



Testing: running `./mach test-wpt fetch/http-cache/pragma-no-cache-with-cache-control.html`

