### PR TITLE
dependabot: Specify time and reduce PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,10 @@ updates:
     - "tests/wpt/**"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+    # default timezone is UTC
+    # CI is usually busiest during european daytime.
+    time: "00:00"
+  open-pull-requests-limit: 7
   allow:
   - dependency-type: direct
   - dependency-type: indirect


### PR DESCRIPTION
The merge queue today was greatly affected by many dependabot PRs in the European morning, which caused a long merge queue for the rest of the day.
Let's attempt to schedule dependabot updates during less busy times, and also reduce the limit of open PRs.
[Dependabot documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#schedule-)

Testing: No testing.

