### PR TITLE
script: Load and rasterize favicons before passing them to the embedder

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -792,9 +792,9 @@ impl Servo {
                     webview.set_cursor(cursor);
                 }
             },
-            EmbedderMsg::NewFavicon(webview_id, url) => {
+            EmbedderMsg::NewFavicon(webview_id, image) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview.set_favicon_url(url.into_url());
+                    webview.set_favicon(image);
                 }
             },
             EmbedderMsg::NotifyLoadStatusChanged(webview_id, load_status) => {

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -13,7 +13,7 @@ use compositing_traits::WebViewTrait;
 use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use dpi::PhysicalSize;
 use embedder_traits::{
-    Cursor, FocusId, InputEvent, JSValue, JavaScriptEvaluationError, LoadStatus,
+    Cursor, FocusId, Image, InputEvent, JSValue, JavaScriptEvaluationError, LoadStatus,
     MediaSessionActionType, ScreenGeometry, Theme, TraversalId, ViewportDetails,
 };
 use euclid::{Point2D, Scale, Size2D};
@@ -84,7 +84,7 @@ pub(crate) struct WebViewInner {
     url: Option<Url>,
     status_text: Option<String>,
     page_title: Option<String>,
-    favicon_url: Option<Url>,
+    favicon: Option<Image>,
     focused: bool,
     animating: bool,
     cursor: Cursor,
@@ -126,7 +126,7 @@ impl WebView {
             url: None,
             status_text: None,
             page_title: None,
-            favicon_url: None,
+            favicon: None,
             focused: false,
             animating: false,
             cursor: Cursor::Pointer,
@@ -264,21 +264,13 @@ impl WebView {
         self.delegate().notify_page_title_changed(self, new_value);
     }
 
-    pub fn favicon_url(&self) -> Option<Url> {
-        self.inner().favicon_url.clone()
+    pub fn favicon(&self) -> Option<Ref<'_, Image>> {
+        Ref::filter_map(self.inner(), |inner| inner.favicon.as_ref()).ok()
     }
 
-    pub(crate) fn set_favicon_url(self, new_value: Url) {
-        if self
-            .inner()
-            .favicon_url
-            .as_ref()
-            .is_some_and(|url| url == &new_value)
-        {
-            return;
-        }
-        self.inner_mut().favicon_url = Some(new_value.clone());
-        self.delegate().notify_favicon_url_changed(self, new_value);
+    pub(crate) fn set_favicon(self, new_value: Image) {
+        self.inner_mut().favicon = Some(new_value);
+        self.delegate().notify_favicon_changed(self);
     }
 
     pub fn focused(&self) -> bool {

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -432,9 +432,9 @@ pub trait WebViewDelegate {
     /// The [`Cursor`] of the currently loaded page in this [`WebView`] has changed. The new
     /// cursor can accessed via [`WebView::cursor`].
     fn notify_cursor_changed(&self, _webview: WebView, _: Cursor) {}
-    /// The favicon [`Url`] of the currently loaded page in this [`WebView`] has changed. The new
-    /// favicon [`Url`] can accessed via [`WebView::favicon_url`].
-    fn notify_favicon_url_changed(&self, _webview: WebView, _: Url) {}
+    /// The favicon of the currently loaded page in this [`WebView`] has changed. The new
+    /// favicon [`Image`] can accessed via [`WebView::favicon`].
+    fn notify_favicon_changed(&self, _webview: WebView) {}
 
     /// Notify the embedder that it needs to present a new frame.
     fn notify_new_frame_ready(&self, _webview: WebView) {}

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -15,6 +15,7 @@ use std::hash::Hasher;
 use std::net::IpAddr;
 use std::ops::{Index, Range, RangeFrom, RangeFull, RangeTo};
 use std::path::Path;
+use std::str::FromStr;
 
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
@@ -305,5 +306,14 @@ impl From<Url> for ServoUrl {
 impl From<Arc<Url>> for ServoUrl {
     fn from(url: Arc<Url>) -> Self {
         ServoUrl(url)
+    }
+}
+
+impl FromStr for ServoUrl {
+    type Err = <Url as FromStr>::Err;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let url = Url::from_str(value)?;
+        Ok(url.into())
     }
 }

--- a/tests/wpt/meta/content-security-policy/img-src/icon-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/img-src/icon-blocked.sub.html.ini
@@ -1,4 +1,0 @@
-[icon-blocked.sub.html]
-  expected: TIMEOUT
-  [Test that spv event is fired]
-    expected: NOTRUN

--- a/tests/wpt/meta/fetch/metadata/generated/element-link-icon.https.sub.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/element-link-icon.https.sub.html.ini
@@ -1,67 +1,6 @@
 [element-link-icon.https.sub.html]
-  expected: TIMEOUT
-  [sec-fetch-site - Same origin no attributes]
-    expected: TIMEOUT
-
-  [sec-fetch-site - Cross-site no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Same site no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Same-Origin -> Cross-Site -> Same-Origin redirect no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Same-Origin -> Same-Site -> Same-Origin redirect no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Cross-Site -> Same Origin no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Cross-Site -> Same-Site no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Cross-Site -> Cross-Site no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Same-Origin -> Same Origin no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Same-Origin -> Same-Site no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Same-Origin -> Cross-Site no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Same-Site -> Same Origin no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Same-Site -> Same-Site no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Same-Site -> Cross-Site no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-mode no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-mode attributes: crossorigin]
-    expected: NOTRUN
-
-  [sec-fetch-mode attributes: crossorigin=anonymous]
-    expected: NOTRUN
-
-  [sec-fetch-mode attributes: crossorigin=use-credentials]
-    expected: NOTRUN
-
   [sec-fetch-dest no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-user no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-storage-access - Cross-site no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-storage-access - Same site no attributes]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/fetch/metadata/generated/element-link-icon.sub.html.ini
+++ b/tests/wpt/meta/fetch/metadata/generated/element-link-icon.sub.html.ini
@@ -1,55 +1,6 @@
 [element-link-icon.sub.html]
-  expected: TIMEOUT
-  [sec-fetch-site - Not sent to non-trustworthy same-origin destination no attributes]
-    expected: TIMEOUT
-
-  [sec-fetch-site - Not sent to non-trustworthy same-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - Not sent to non-trustworthy cross-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-mode - Not sent to non-trustworthy same-origin destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-mode - Not sent to non-trustworthy same-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-mode - Not sent to non-trustworthy cross-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-dest - Not sent to non-trustworthy same-origin destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-dest - Not sent to non-trustworthy same-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-dest - Not sent to non-trustworthy cross-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-user - Not sent to non-trustworthy same-origin destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-user - Not sent to non-trustworthy same-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-user - Not sent to non-trustworthy cross-site destination no attributes]
-    expected: NOTRUN
-
   [sec-fetch-site - HTTPS downgrade (header not sent) no attributes]
-    expected: NOTRUN
+    expected: FAIL
 
   [sec-fetch-site - HTTPS upgrade no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-site - HTTPS downgrade-upgrade no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-storage-access - Not sent to non-trustworthy same-origin destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-storage-access - Not sent to non-trustworthy same-site destination no attributes]
-    expected: NOTRUN
-
-  [sec-fetch-storage-access - Not sent to non-trustworthy cross-site destination no attributes]
-    expected: NOTRUN
+    expected: FAIL


### PR DESCRIPTION
Currently the embedding API only provides the embedder with the URL for a favicon. This is not great, for multiple reasons:
*  Loading the icon should happen according to the fetch spec which is not easy for the embedder to recreate (consider CSP, timing information etc)
* Rasterizing a svg favicon is not trivial

With this change, servo fetches and rasterizes the icon to a bitmap which is then passed to the embedder.

Testing: I'm not sure how I can write tests for the embedding api. I've tested the correctness manually using https://github.com/servo/servo/pull/36680.
Prepares for https://github.com/servo/servo/pull/36680
