### PR TITLE
script: Move operations in `window_named_properties::get_own_property_descriptor` & `webdriver_handlers::clone_an_object` into unsafe blocks

### DIFF
--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -312,7 +312,11 @@ pub unsafe fn set_dictionary_property(
     Ok(())
 }
 
-/// Returns whether `proxy` has a property `id` on its prototype.
+/// Computes whether `proxy` has a property `id` on its prototype and stores
+/// the result in `found`.
+///
+/// Returns a boolean indicating whether the check succeeded.
+/// If `false` is returned then the value of `found` is unspecified.
 ///
 /// # Safety
 /// `cx` must point to a valid, non-null JSContext.


### PR DESCRIPTION


Testing: Covered by existing tests
Part of https://github.com/servo/servo/issues/35955
