### PR TITLE
compositor: Hide IpcSender as implementation detail

### DIFF
--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -4,7 +4,6 @@
 
 use std::str::FromStr;
 
-use compositing_traits::CompositorMsg;
 use compositing_traits::viewport_description::ViewportDescription;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
@@ -136,12 +135,7 @@ impl HTMLMetaElement {
         if let Ok(viewport) = ViewportDescription::from_str(&content.value()) {
             self.owner_window()
                 .compositor_api()
-                .sender()
-                .send(CompositorMsg::Viewport(
-                    self.owner_window().webview_id(),
-                    viewport,
-                ))
-                .unwrap();
+                .send_viewport(self.owner_window().webview_id(), viewport);
         }
     }
 

--- a/components/script/dom/htmlmetaelement.rs
+++ b/components/script/dom/htmlmetaelement.rs
@@ -135,7 +135,7 @@ impl HTMLMetaElement {
         if let Ok(viewport) = ViewportDescription::from_str(&content.value()) {
             self.owner_window()
                 .compositor_api()
-                .send_viewport(self.owner_window().webview_id(), viewport);
+                .viewport(self.owner_window().webview_id(), viewport);
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2956,7 +2956,7 @@ impl ScriptThread {
             .ok();
 
         self.compositor_api
-            .notify_pipeline_exit(webview_id, id, PipelineExitSource::Script);
+            .pipeline_exited(webview_id, id, PipelineExitSource::Script);
 
         debug!("{id}: Finished pipeline exit");
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -36,7 +36,7 @@ use base::cross_process_instant::CrossProcessInstant;
 use base::id::{BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespace, WebViewId};
 use canvas_traits::webgl::WebGLPipeline;
 use chrono::{DateTime, Local};
-use compositing_traits::{CompositorMsg, CrossProcessCompositorApi, PipelineExitSource};
+use compositing_traits::{CrossProcessCompositorApi, PipelineExitSource};
 use constellation_traits::{
     JsEvalResult, LoadData, LoadOrigin, NavigationHistoryBehavior, ScriptToConstellationChan,
     ScriptToConstellationMessage, StructuredSerializedData, WindowSizeType,
@@ -2956,13 +2956,7 @@ impl ScriptThread {
             .ok();
 
         self.compositor_api
-            .sender()
-            .send(CompositorMsg::PipelineExited(
-                webview_id,
-                id,
-                PipelineExitSource::Script,
-            ))
-            .ok();
+            .notify_pipeline_exit(webview_id, id, PipelineExitSource::Script);
 
         debug!("{id}: Finished pipeline exit");
     }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1101,7 +1101,7 @@ fn create_compositor_channel(
     let (compositor_ipc_sender, compositor_ipc_receiver) =
         ipc::channel().expect("ipc channel failure");
 
-    let cross_process_compositor_api = CrossProcessCompositorApi(compositor_ipc_sender);
+    let cross_process_compositor_api = CrossProcessCompositorApi::new(compositor_ipc_sender);
     let compositor_proxy = CompositorProxy {
         sender,
         cross_process_compositor_api,

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -352,13 +352,13 @@ impl CrossProcessCompositorApi {
         receiver.recv().unwrap()
     }
 
-    pub fn send_viewport(&self, webview_id: WebViewId, description: ViewportDescription) {
+    pub fn viewport(&self, webview_id: WebViewId, description: ViewportDescription) {
         let _ = self
             .0
             .send(CompositorMsg::Viewport(webview_id, description));
     }
 
-    pub fn notify_pipeline_exit(
+    pub fn pipeline_exited(
         &self,
         webview_id: WebViewId,
         pipeline_id: PipelineId,


### PR DESCRIPTION
The `CrossProcessCompositorApi` already provides methods for most messages.
Remove the `sender()` method, and hide the IpcSender as an implementation detail. This is a preparation for abstracting over the internal IpcSender.

Testing: No functional changes

