### PR TITLE
devtools: Fix `test_source_breakable_lines_and_positions_with_functions`

### DIFF
--- a/python/servo/devtools_tests.py
+++ b/python/servo/devtools_tests.py
@@ -669,10 +669,11 @@ class DevtoolsTests(unittest.IsolatedAsyncioTestCase):
         )
 
     def test_source_breakable_lines_and_positions_with_functions(self):
-        self.start_web_server(test_dir=self.get_test_path("sources_breakable_lines_and_positions"))
-        self.run_servoshell(url=f"{self.base_urls[0]}/test_with_functions.html")
+        self.run_servoshell(url=f"{self.base_urls[0]}/sources_breakable_lines_and_positions/test_with_functions.html")
         self.assert_source_breakable_lines_and_positions(
-            Source("inlineScript", f"{self.base_urls[0]}/test_with_functions.html"),
+            Source(
+                "inlineScript", f"{self.base_urls[0]}/sources_breakable_lines_and_positions/test_with_functions.html"
+            ),
             [5, 6, 7, 8, 9, 10],
             {
                 "5": [8, 18],


### PR DESCRIPTION
In #38933 we removed `start_web_server` but `test_source_breakable_lines_and_positions_with_functions` was not updated because it was added later. In this patch we remove `start_web_server` in that test as well.

Testing: fixes an existing test
Fixes: Part of #36325 
