### PR TITLE
canvas: Use non rooted variant of HTMLCanvasElementOrOffscreenCanvas type

### DIFF
--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::codegen::Bindings::OffscreenCanvasBinding::{
     ImageEncodeOptions, OffscreenCanvasMethods,
     OffscreenRenderingContext as RootedOffscreenRenderingContext,
 };
-use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas;
+use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
@@ -135,7 +135,8 @@ impl OffscreenCanvas {
                 _ => None,
             };
         }
-        let context = OffscreenCanvasRenderingContext2D::new(&self.global(), self, can_gc)?;
+        let context =
+            OffscreenCanvasRenderingContext2D::new(&self.global(), self, self.get_size(), can_gc)?;
         *self.context.borrow_mut() = Some(OffscreenRenderingContext::Context2d(Dom::from_ref(
             &*context,
         )));
@@ -159,11 +160,10 @@ impl OffscreenCanvas {
         // Step 1. Let context be the result of running the
         // ImageBitmapRenderingContext creation algorithm given this and
         // options.
-        let context = ImageBitmapRenderingContext::new(
-            &self.global(),
-            HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(DomRoot::from_ref(self)),
-            can_gc,
-        );
+        let canvas =
+            RootedHTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(DomRoot::from_ref(self));
+
+        let context = ImageBitmapRenderingContext::new(&self.global(), &canvas, can_gc);
 
         // Step 2. Set this's context mode to bitmaprenderer.
         *self.context.borrow_mut() = Some(OffscreenRenderingContext::BitmapRenderer(

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -2,15 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base::Epoch;
 use dom_struct::dom_struct;
 use webrender_api::ImageKey;
 
+use crate::canvas_context::LayoutCanvasRenderingContextHelpers;
 use crate::dom::bindings::codegen::Bindings::GPUCanvasContextBinding::GPUCanvasContextMethods;
-use crate::dom::bindings::codegen::UnionTypes;
+use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
 use crate::dom::bindings::reflector::Reflector;
 use crate::dom::bindings::root::LayoutDom;
-use crate::dom::html::htmlcanvaselement::LayoutCanvasRenderingContextHelpers;
 
 #[dom_struct]
 pub(crate) struct GPUCanvasContext {
@@ -26,7 +25,7 @@ impl GPUCanvasContext {
 
 impl GPUCanvasContextMethods<crate::DomTypeHolder> for GPUCanvasContext {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-canvas>
-    fn Canvas(&self) -> UnionTypes::HTMLCanvasElementOrOffscreenCanvas {
+    fn Canvas(&self) -> RootedHTMLCanvasElementOrOffscreenCanvas {
         unimplemented!()
     }
 }

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -29,7 +29,7 @@ use url::Host;
 use webrender_api::ImageKey;
 
 use super::validations::types::TexImageTarget;
-use crate::canvas_context::CanvasContext;
+use crate::canvas_context::{CanvasContext, LayoutCanvasRenderingContextHelpers};
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::{
     WebGL2RenderingContextConstants as constants, WebGL2RenderingContextMethods,
 };
@@ -38,15 +38,14 @@ use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::{
 };
 use crate::dom::bindings::codegen::UnionTypes::{
     ArrayBufferViewOrArrayBuffer, Float32ArrayOrUnrestrictedFloatSequence,
-    HTMLCanvasElementOrOffscreenCanvas, Int32ArrayOrLongSequence,
-    Uint32ArrayOrUnsignedLongSequence,
+    HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas,
+    Int32ArrayOrLongSequence, Uint32ArrayOrUnsignedLongSequence,
 };
 use crate::dom::bindings::error::{ErrorResult, Fallible};
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom, ToLayout};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::html::htmlcanvaselement::LayoutCanvasRenderingContextHelpers;
 #[cfg(feature = "webxr")]
 use crate::dom::promise::Promise;
 use crate::dom::webgl::validations::WebGLValidator;
@@ -133,7 +132,7 @@ struct ReadPixelsSizes {
 impl WebGL2RenderingContext {
     fn new_inherited(
         window: &Window,
-        canvas: &HTMLCanvasElementOrOffscreenCanvas,
+        canvas: &RootedHTMLCanvasElementOrOffscreenCanvas,
         size: Size2D<u32>,
         attrs: GLContextAttributes,
         can_gc: CanGc,
@@ -179,10 +178,9 @@ impl WebGL2RenderingContext {
         })
     }
 
-    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn new(
         window: &Window,
-        canvas: &HTMLCanvasElementOrOffscreenCanvas,
+        canvas: &RootedHTMLCanvasElementOrOffscreenCanvas,
         size: Size2D<u32>,
         attrs: GLContextAttributes,
         can_gc: CanGc,
@@ -973,8 +971,8 @@ impl CanvasContext for WebGL2RenderingContext {
         self.base.context_id()
     }
 
-    fn canvas(&self) -> Option<HTMLCanvasElementOrOffscreenCanvas> {
-        self.base.canvas().clone()
+    fn canvas(&self) -> Option<RootedHTMLCanvasElementOrOffscreenCanvas> {
+        self.base.canvas()
     }
 
     fn resize(&self) {
@@ -1000,7 +998,7 @@ impl CanvasContext for WebGL2RenderingContext {
 
 impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingContext {
     /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.1>
-    fn Canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas {
+    fn Canvas(&self) -> RootedHTMLCanvasElementOrOffscreenCanvas {
         self.base.Canvas()
     }
 

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -20,7 +20,10 @@ use wgpu_core::id;
 
 use super::gpuconvert::convert_texture_descriptor;
 use super::gputexture::GPUTexture;
-use crate::canvas_context::{CanvasContext, CanvasHelpers};
+use crate::canvas_context::{
+    CanvasContext, CanvasHelpers, HTMLCanvasElementOrOffscreenCanvas,
+    LayoutCanvasRenderingContextHelpers,
+};
 use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::GPUCanvasContextBinding::GPUCanvasContextMethods;
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUTexture_Binding::GPUTextureMethods;
@@ -29,15 +32,15 @@ use crate::dom::bindings::codegen::Bindings::WebGPUBinding::{
     GPUObjectDescriptorBase, GPUTextureDescriptor, GPUTextureDimension, GPUTextureFormat,
     GPUTextureUsageConstants,
 };
-use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas;
+use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
-use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::USVString;
 use crate::dom::bindings::weakref::WeakRef;
 use crate::dom::document::WebGPUContextsMap;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::html::htmlcanvaselement::{HTMLCanvasElement, LayoutCanvasRenderingContextHelpers};
+use crate::dom::html::htmlcanvaselement::HTMLCanvasElement;
 use crate::dom::node::NodeTraits;
 use crate::script_runtime::CanGc;
 
@@ -91,6 +94,7 @@ pub(crate) struct GPUCanvasContext {
 }
 
 impl GPUCanvasContext {
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     fn new_inherited(
         global: &GlobalScope,
         canvas: HTMLCanvasElementOrOffscreenCanvas,
@@ -139,7 +143,7 @@ impl GPUCanvasContext {
         let this = reflect_dom_object(
             Box::new(GPUCanvasContext::new_inherited(
                 global,
-                HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(DomRoot::from_ref(canvas)),
+                HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(Dom::from_ref(canvas)),
                 channel,
                 document.webgpu_contexts(),
             )),
@@ -328,8 +332,8 @@ impl CanvasContext for GPUCanvasContext {
         })
     }
 
-    fn canvas(&self) -> Option<HTMLCanvasElementOrOffscreenCanvas> {
-        Some(self.canvas.clone())
+    fn canvas(&self) -> Option<RootedHTMLCanvasElementOrOffscreenCanvas> {
+        Some(RootedHTMLCanvasElementOrOffscreenCanvas::from(&self.canvas))
     }
 }
 
@@ -341,8 +345,8 @@ impl LayoutCanvasRenderingContextHelpers for LayoutDom<'_, GPUCanvasContext> {
 
 impl GPUCanvasContextMethods<crate::DomTypeHolder> for GPUCanvasContext {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-canvas>
-    fn Canvas(&self) -> HTMLCanvasElementOrOffscreenCanvas {
-        self.canvas.clone()
+    fn Canvas(&self) -> RootedHTMLCanvasElementOrOffscreenCanvas {
+        RootedHTMLCanvasElementOrOffscreenCanvas::from(&self.canvas)
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-configure>

--- a/components/script/dom/webxr/xrwebgllayer.rs
+++ b/components/script/dom/webxr/xrwebgllayer.rs
@@ -10,14 +10,13 @@ use euclid::{Rect, Size2D};
 use js::rust::HandleObject;
 use webxr_api::{ContextId as WebXRContextId, LayerId, LayerInit, Viewport};
 
-use crate::canvas_context::CanvasContext as _;
+use crate::canvas_context::CanvasContext;
 use crate::conversions::Convert;
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::WebGL2RenderingContextConstants as constants;
 use crate::dom::bindings::codegen::Bindings::WebGLRenderingContextBinding::WebGLRenderingContextMethods;
 use crate::dom::bindings::codegen::Bindings::XRWebGLLayerBinding::{
     XRWebGLLayerInit, XRWebGLLayerMethods, XRWebGLRenderingContext,
 };
-use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::num::Finite;
@@ -125,14 +124,7 @@ impl XRWebGLLayer {
                 size.1.try_into().unwrap_or(0),
             )
         } else {
-            let size = match self.context().Canvas() {
-                HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas) => canvas.get_size(),
-                HTMLCanvasElementOrOffscreenCanvas::OffscreenCanvas(canvas) => {
-                    let size = canvas.get_size();
-                    Size2D::new(size.width, size.height)
-                },
-            };
-            Size2D::from_untyped(size)
+            Size2D::from_untyped(self.context().size())
         }
     }
 


### PR DESCRIPTION
Any RenderingContext/OffscreenRenderingContext type has readonly "canvas" attribute
and associated native-code DOM context objects have reference to target DOM canvas objects. https://html.spec.whatwg.org/multipage/canvas.html#renderingcontext https://html.spec.whatwg.org/multipage/canvas.html#offscreenrenderingcontext

And currently the reference to DOM canvas object is the rooting pointer on the stack,
which leads to the circular reference problem.

The SpiderMonkey's (SM) garbage collector will not be able to free the DOM canvas and context
objects (unreacheble from JS) because of the rooting pointer on stack (see STACK_ROOTS).

And these objects will be stored until the associated script runtime/thread will be terminated.

SM -> JS Roots -> DOM Canvas* (on heap) -> DOM Context (on heap)
SM -> Rust Roots -> Dom Canvas* (on stack) <- as "canvas" member field

Let's replace the rooting pointer to the traceble pointer (DomRoot -> Dom)
in the "canvas" member field of DOM context object, which allows to broke circular referencing problem.

Testing: No changes in existed tests