### PR TITLE
compositor: Preserve CompositorMsg deserialization errors

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -13,7 +13,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
-use base::generic_channel::GenericSender;
+use base::generic_channel::{GenericSender, RoutedReceiver};
 use base::id::{PipelineId, WebViewId};
 use bitflags::bitflags;
 use compositing_traits::display_list::{CompositorDisplayListInfo, ScrollTree, ScrollType};
@@ -23,7 +23,7 @@ use compositing_traits::{
     WebViewTrait,
 };
 use constellation_traits::{EmbedderToConstellationMessage, PaintMetricEvent};
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam_channel::Sender;
 use dpi::PhysicalSize;
 use embedder_traits::{CompositorHitTestResult, InputEvent, ShutdownState, ViewportDetails};
 use euclid::{Point2D, Rect, Scale, Size2D, Transform3D};
@@ -93,7 +93,7 @@ pub struct ServoRenderer {
     shutdown_state: Rc<Cell<ShutdownState>>,
 
     /// The port on which we receive messages.
-    compositor_receiver: Receiver<CompositorMsg>,
+    compositor_receiver: RoutedReceiver<CompositorMsg>,
 
     /// The channel on which messages can be sent to the constellation.
     pub(crate) constellation_sender: Sender<EmbedderToConstellationMessage>,
@@ -1394,7 +1394,7 @@ impl IOCompositor {
     }
 
     /// Get the message receiver for this [`IOCompositor`].
-    pub fn receiver(&self) -> Ref<'_, Receiver<CompositorMsg>> {
+    pub fn receiver(&self) -> Ref<'_, RoutedReceiver<CompositorMsg>> {
         Ref::map(self.global.borrow(), |global| &global.compositor_receiver)
     }
 

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -7,10 +7,11 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
+use base::generic_channel::RoutedReceiver;
 use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::{CompositorMsg, CompositorProxy};
 use constellation_traits::EmbedderToConstellationMessage;
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam_channel::Sender;
 use embedder_traits::{EventLoopWaker, ShutdownState};
 use profile_traits::{mem, time};
 use webrender::RenderApi;
@@ -32,7 +33,7 @@ pub struct InitialCompositorState {
     /// A channel to the compositor.
     pub sender: CompositorProxy,
     /// A port on which messages inbound to the compositor can be received.
-    pub receiver: Receiver<CompositorMsg>,
+    pub receiver: RoutedReceiver<CompositorMsg>,
     /// A channel to the constellation.
     pub constellation_chan: Sender<EmbedderToConstellationMessage>,
     /// A channel to the time profiler thread.

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -33,6 +33,7 @@ use std::rc::{Rc, Weak};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+use base::generic_channel::RoutedReceiver;
 pub use base::id::WebViewId;
 use base::id::{PipelineNamespace, PipelineNamespaceId};
 #[cfg(feature = "bluetooth")]
@@ -544,7 +545,12 @@ impl Servo {
             let mut compositor = self.compositor.borrow_mut();
             let mut messages = Vec::new();
             while let Ok(message) = compositor.receiver().try_recv() {
-                messages.push(message);
+                match message {
+                    Ok(msg) => messages.push(msg),
+                    Err(e) => {
+                        warn!("Router deserialization error: {e}. Ignoring this CompositorMsg.")
+                    },
+                }
             }
             compositor.handle_messages(messages);
         }
@@ -1095,7 +1101,7 @@ fn create_embedder_channel(
 
 fn create_compositor_channel(
     event_loop_waker: Box<dyn EventLoopWaker>,
-) -> (CompositorProxy, Receiver<CompositorMsg>) {
+) -> (CompositorProxy, RoutedReceiver<CompositorMsg>) {
     let (sender, receiver) = unbounded();
 
     let (compositor_ipc_sender, compositor_ipc_receiver) =
@@ -1112,7 +1118,7 @@ fn create_compositor_channel(
     ROUTER.add_typed_route(
         compositor_ipc_receiver,
         Box::new(move |message| {
-            compositor_proxy_clone.send(message.expect("Could not convert Compositor message"));
+            compositor_proxy_clone.route_msg(message);
         }),
     );
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -546,9 +546,9 @@ impl Servo {
             let mut messages = Vec::new();
             while let Ok(message) = compositor.receiver().try_recv() {
                 match message {
-                    Ok(msg) => messages.push(msg),
-                    Err(e) => {
-                        warn!("Router deserialization error: {e}. Ignoring this CompositorMsg.")
+                    Ok(message) => messages.push(message),
+                    Err(error) => {
+                        warn!("Router deserialization error: {error}. Ignoring this CompositorMsg.")
                     },
                 }
             }


### PR DESCRIPTION
Forward any deserialization errors to the receiver, instead of panicking on the router thread. This change was previously part of #38782, which got reverted, since generic channels don't support custom router callbacks yet. Propagating the error is still something we want, and landing this separately will reduce the diff of the PR that introduces generic callbacks. 

Testing: Should be covered by existing tests. Also manually tested https://github.com/servo/servo/issues/38939

