### PR TITLE
script: Fix bluetooth module clippy lint position to be consistent

### DIFF
--- a/components/script/dom/bluetooth/mod.rs
+++ b/components/script/dom/bluetooth/mod.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 pub(crate) use self::bluetooth::*;
+#[allow(clippy::module_inception, reason = "The interface name is Bluetooth")]
 pub(crate) mod bluetooth;
 pub(crate) mod bluetoothadvertisingevent;
 pub(crate) mod bluetoothcharacteristicproperties;

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -225,7 +225,6 @@ pub(crate) mod beforeunloadevent;
 pub(crate) mod bindings;
 pub(crate) mod blob;
 #[cfg(feature = "bluetooth")]
-#[allow(clippy::module_inception)]
 pub(crate) mod bluetooth;
 #[cfg(feature = "bluetooth")]
 pub(crate) use self::bluetooth::*;


### PR DESCRIPTION
As per discussion in #38900 

Testing: None, minor refactor
