### PR TITLE
script: Support decomposing ShadowRoot from mozjs `HandleValue`

### DIFF
--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -617,7 +617,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         // Note: the element can pass this check without yet being a custom
         // element, as long as there is a registered definition
         // that could upgrade it to one later.
-        let registry = self.owner_document().window().CustomElements();
+        let registry = self.owner_window().CustomElements();
         let definition = registry.lookup_definition(self.as_element().local_name(), None);
 
         // Step 3: If definition is null, then throw an "NotSupportedError" DOMException

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1282,7 +1282,7 @@ impl Node {
     pub(crate) fn summarize(&self, can_gc: CanGc) -> NodeInfo {
         let USVString(base_uri) = self.BaseURI();
         let node_type = self.NodeType();
-        let pipeline = self.owner_document().window().pipeline_id();
+        let pipeline = self.owner_window().pipeline_id();
 
         let maybe_shadow_root = self.downcast::<ShadowRoot>();
         let shadow_root_mode = maybe_shadow_root

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -403,18 +403,22 @@ unsafe fn jsval_to_webdriver_inner(
             if is_stale(&element) {
                 Err(WebDriverJSError::StaleElementReference)
             } else {
-                Ok(JSValue::Element(element.upcast::<Node>().unique_id(
-                    element.owner_document().window().pipeline_id(),
-                )))
+                Ok(JSValue::Element(
+                    element
+                        .upcast::<Node>()
+                        .unique_id(element.owner_window().pipeline_id()),
+                ))
             }
         } else if let Ok(shadow_root) = root_from_object::<ShadowRoot>(*object, cx) {
             // If the shadow root is detached, return error with error code detached shadow root.
             if is_detached(&shadow_root) {
                 Err(WebDriverJSError::DetachedShadowRoot)
             } else {
-                Ok(JSValue::ShadowRoot(shadow_root.upcast::<Node>().unique_id(
-                    shadow_root.owner_document().window().pipeline_id(),
-                )))
+                Ok(JSValue::ShadowRoot(
+                    shadow_root
+                        .upcast::<Node>()
+                        .unique_id(shadow_root.owner_window().pipeline_id()),
+                ))
             }
         } else if let Ok(window) = root_from_object::<Window>(*object, cx) {
             let window_proxy = window.window_proxy();

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -83,6 +83,16 @@ fn test_evaluate_javascript_basic(servo_test: &ServoTest) -> Result<(), anyhow::
     let result = evaluate_javascript(
         servo_test,
         webview.clone(),
+        "document.body.attachShadow({mode: 'open'})",
+    );
+    ensure!(matches!(result, Ok(JSValue::ShadowRoot(..))));
+
+    let result = evaluate_javascript(servo_test, webview.clone(), "document.body.shadowRoot");
+    ensure!(matches!(result, Ok(JSValue::ShadowRoot(..))));
+
+    let result = evaluate_javascript(
+        servo_test,
+        webview.clone(),
         "document.body.innerHTML += '<iframe>'; frames[0]",
     );
     ensure!(matches!(result, Ok(JSValue::Frame(..))));

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -1047,6 +1047,7 @@ pub enum JSValue {
     Number(f64),
     String(String),
     Element(String),
+    ShadowRoot(String),
     Frame(String),
     Window(String),
     Array(Vec<JSValue>),

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -256,6 +256,7 @@ pub enum WebDriverJSError {
     /// Occurs when handler received an event message for a layout channel that is not
     /// associated with the current script thread
     BrowsingContextNotFound,
+    DetachedShadowRoot,
     JSException(JSValue),
     JSError,
     StaleElementReference,

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -260,6 +260,7 @@ impl Serialize for SendableJSValue {
             JSValue::Number(x) => serializer.serialize_f64(x),
             JSValue::String(ref x) => serializer.serialize_str(x),
             JSValue::Element(ref x) => WebElement(x.clone()).serialize(serializer),
+            JSValue::ShadowRoot(ref x) => ShadowRoot(x.clone()).serialize(serializer),
             JSValue::Frame(ref x) => WebFrame(x.clone()).serialize(serializer),
             JSValue::Window(ref x) => WebWindow(x.clone()).serialize(serializer),
             JSValue::Array(ref x) => x
@@ -2065,6 +2066,10 @@ impl Handler {
             Err(WebDriverJSError::StaleElementReference) => Err(WebDriverError::new(
                 ErrorStatus::StaleElementReference,
                 "Stale element",
+            )),
+            Err(WebDriverJSError::DetachedShadowRoot) => Err(WebDriverError::new(
+                ErrorStatus::DetachedShadowRoot,
+                "Detached shadow root",
             )),
             Err(WebDriverJSError::Timeout) => {
                 Err(WebDriverError::new(ErrorStatus::ScriptTimeout, ""))

--- a/tests/wpt/meta/webdriver/tests/classic/execute_async_script/arguments.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_async_script/arguments.py.ini
@@ -35,8 +35,5 @@
   [test_element_reference[frame\]]
     expected: FAIL
 
-  [test_element_reference[shadow-root\]]
-    expected: FAIL
-
   [test_element_reference[window\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/execute_async_script/node.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_async_script/node.py.ini
@@ -1,13 +1,4 @@
 [node.py]
-  [test_detached_shadow_root[top_context\]]
-    expected: FAIL
-
-  [test_detached_shadow_root[child_context\]]
-    expected: FAIL
-
-  [test_element_reference[shadow-root\]]
-    expected: FAIL
-
   [test_not_supported_nodes[attribute\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/arguments.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/arguments.py.ini
@@ -35,8 +35,5 @@
   [test_element_reference[frame\]]
     expected: FAIL
 
-  [test_element_reference[shadow-root\]]
-    expected: FAIL
-
   [test_element_reference[window\]]
     expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/node.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/node.py.ini
@@ -1,13 +1,4 @@
 [node.py]
-  [test_detached_shadow_root[top_context\]]
-    expected: FAIL
-
-  [test_detached_shadow_root[child_context\]]
-    expected: FAIL
-
-  [test_web_reference[shadow-root\]]
-    expected: FAIL
-
   [test_not_supported_nodes[attribute\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/get_element_property/get.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/get_element_property/get.py.ini
@@ -1,6 +1,3 @@
 [get.py]
   [test_no_browsing_context]
     expected: FAIL
-
-  [test_web_reference[shadowRoot-ShadowRoot\]]
-    expected: FAIL


### PR DESCRIPTION
- Add `ShadowRoot` to `JSValue` to avoid `WebDriverJSError::UnknownType`, and `JavaScriptEvaluationError::SerializationError` when execute JS from embedder.
- Add unit test.
- Move [is_detached](https://w3c.github.io/webdriver/#dfn-is-detached) to `fn is_detached` to be reused.
- Other random simplification.

Testing: WebDriver conformance tests.