### PR TITLE
script: Calculate proper border box for resizeobserver

### DIFF
--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -320,9 +320,7 @@ fn calculate_box_size(target: &Element, observed_box: &ResizeObserverBoxOptions)
             // but the spec will expand to cover all fragments.
             target
                 .upcast::<Node>()
-                .border_boxes()
-                .pop()
-                .unwrap_or_else(Rect::zero)
+                .border_box()
         },
         // TODO(#31182): add support for device pixel size calculations.
         _ => Rect::zero(),

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -311,8 +311,7 @@ fn calculate_box_size(target: &Element, observed_box: &ResizeObserverBoxOptions)
             // but the spec will expand to cover all fragments.
             target
                 .upcast::<Node>()
-                .border_boxes()
-                .pop()
+                .content_box()
                 .unwrap_or_else(Rect::zero)
         },
         ResizeObserverBoxOptions::Border_box => {
@@ -321,6 +320,7 @@ fn calculate_box_size(target: &Element, observed_box: &ResizeObserverBoxOptions)
             target
                 .upcast::<Node>()
                 .border_box()
+                .unwrap_or_else(Rect::zero)
         },
         // TODO(#31182): add support for device pixel size calculations.
         _ => Rect::zero(),

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -315,7 +315,16 @@ fn calculate_box_size(target: &Element, observed_box: &ResizeObserverBoxOptions)
                 .pop()
                 .unwrap_or_else(Rect::zero)
         },
-        // TODO(#31182): add support for border box, and device pixel size, calculations.
+        ResizeObserverBoxOptions::Border_box => {
+            // Note: only taking first fragment,
+            // but the spec will expand to cover all fragments.
+            target
+                .upcast::<Node>()
+                .border_boxes()
+                .pop()
+                .unwrap_or_else(Rect::zero)
+        },
+        // TODO(#31182): add support for device pixel size calculations.
         _ => Rect::zero(),
     }
 }

--- a/tests/wpt/meta/resize-observer/observe.html.ini
+++ b/tests/wpt/meta/resize-observer/observe.html.ini
@@ -1,8 +1,4 @@
 [observe.html]
-  expected: TIMEOUT
-  [guard]
-    expected: NOTRUN
-
   [test8: simple content-box observation]
     expected: [PASS, FAIL]
 
@@ -11,3 +7,27 @@
 
   [test10: simple border-box observation]
     expected: [PASS, FAIL]
+
+  [test11: simple observation with vertical writing mode]
+    expected: FAIL
+
+  [test12: no observation is fired after the change of writing mode when box's specified size comes from logical size properties.]
+    expected: FAIL
+
+  [test13: an observation is fired after the change of writing mode when box's specified size comes from physical size properties.]
+    expected: FAIL
+
+  [test14: observe the same target but using a different box should override the previous one]
+    expected: FAIL
+
+  [test15: an observation is fired with box dimensions 0 when element's display property is set to inline]
+    expected: FAIL
+
+  [test16: observations fire once with 0x0 size for non-replaced inline elements]
+    expected: FAIL
+
+  [test17: Box sizing snd Resize Observer notifications]
+    expected: FAIL
+
+  [test18: an observation is fired when device-pixel-content-box is being observed]
+    expected: FAIL


### PR DESCRIPTION
Implements more of calculate_box_size, ensuring that the proper rectangle is returned when the border box is requested.

Testing: WPT
Fixes: Partially #38811 