### PR TITLE
script: Skip running layout when only updating images or canvas

### DIFF
--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -8,7 +8,6 @@ use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use ipc_channel::ipc;
 use pixels::Snapshot;
-use script_bindings::inheritance::Castable;
 use servo_url::ServoUrl;
 use webrender_api::ImageKey;
 
@@ -37,7 +36,7 @@ use crate::dom::dommatrix::DOMMatrix;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlcanvaselement::HTMLCanvasElement;
 use crate::dom::imagedata::ImageData;
-use crate::dom::node::{Node, NodeDamage, NodeTraits};
+use crate::dom::node::NodeTraits;
 use crate::dom::path2d::Path2D;
 use crate::dom::textmetrics::TextMetrics;
 use crate::script_runtime::CanGc;
@@ -158,7 +157,6 @@ impl CanvasContext for CanvasRenderingContext2D {
 
     fn mark_as_dirty(&self) {
         if let Some(canvas) = self.canvas.canvas() {
-            canvas.upcast::<Node>().dirty(NodeDamage::Other);
             canvas.owner_document().add_dirty_2d_canvas(self);
         }
     }

--- a/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
@@ -100,6 +100,8 @@ impl CanvasContext for OffscreenCanvasRenderingContext2D {
     fn image_key(&self) -> Option<webrender_api::ImageKey> {
         None
     }
+
+    fn mark_as_dirty(&self) {}
 }
 
 impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>

--- a/components/script/dom/canvas/canvas_context.rs
+++ b/components/script/dom/canvas/canvas_context.rs
@@ -12,7 +12,7 @@ use webrender_api::ImageKey;
 
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::node::{Node, NodeDamage};
+use crate::dom::node::Node;
 #[cfg(feature = "webgpu")]
 use crate::dom::types::GPUCanvasContext;
 use crate::dom::types::{
@@ -95,13 +95,7 @@ pub(crate) trait CanvasContext {
             .unwrap_or_default()
     }
 
-    fn mark_as_dirty(&self) {
-        if let Some(RootedHTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(canvas)) =
-            self.canvas()
-        {
-            canvas.upcast::<Node>().dirty(NodeDamage::Other);
-        }
-    }
+    fn mark_as_dirty(&self);
 
     /// The WebRender [`ImageKey`] of this [`CanvasContext`] if any.
     fn image_key(&self) -> Option<ImageKey>;

--- a/components/script/dom/canvas/imagebitmaprenderingcontext.rs
+++ b/components/script/dom/canvas/imagebitmaprenderingcontext.rs
@@ -160,6 +160,8 @@ impl CanvasContext for ImageBitmapRenderingContext {
     fn image_key(&self) -> Option<ImageKey> {
         None
     }
+
+    fn mark_as_dirty(&self) {}
 }
 
 impl ImageBitmapRenderingContextMethods<crate::DomTypeHolder> for ImageBitmapRenderingContext {

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -209,8 +209,12 @@ impl HTMLCanvasElement {
         let window = self.owner_window();
         let size = self.get_size();
         let context = CanvasRenderingContext2D::new(window.as_global_scope(), self, size, can_gc)?;
-        *self.context_mode.borrow_mut() =
-            Some(RenderingContext::Context2d(Dom::from_ref(&*context)));
+
+        self.context_mode
+            .borrow_mut()
+            .replace(RenderingContext::Context2d(Dom::from_ref(&*context)));
+        self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
+
         Some(context)
     }
 
@@ -237,8 +241,10 @@ impl HTMLCanvasElement {
         let context = ImageBitmapRenderingContext::new(&self.owner_global(), &canvas, can_gc);
 
         // Step 2. Set this's context mode to bitmaprenderer.
-        *self.context_mode.borrow_mut() =
-            Some(RenderingContext::BitmapRenderer(Dom::from_ref(&*context)));
+        self.context_mode
+            .borrow_mut()
+            .replace(RenderingContext::BitmapRenderer(Dom::from_ref(&*context)));
+        self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
 
         // Step 3. Return context.
         Some(context)
@@ -269,7 +275,12 @@ impl HTMLCanvasElement {
             attrs,
             can_gc,
         )?;
-        *self.context_mode.borrow_mut() = Some(RenderingContext::WebGL(Dom::from_ref(&*context)));
+
+        self.context_mode
+            .borrow_mut()
+            .replace(RenderingContext::WebGL(Dom::from_ref(&*context)));
+        self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
+
         Some(context)
     }
 
@@ -295,7 +306,12 @@ impl HTMLCanvasElement {
         let size = self.get_size();
         let attrs = Self::get_gl_attributes(cx, options, can_gc)?;
         let context = WebGL2RenderingContext::new(&window, &canvas, size, attrs, can_gc)?;
-        *self.context_mode.borrow_mut() = Some(RenderingContext::WebGL2(Dom::from_ref(&*context)));
+
+        self.context_mode
+            .borrow_mut()
+            .replace(RenderingContext::WebGL2(Dom::from_ref(&*context)));
+        self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
+
         Some(context)
     }
 
@@ -322,8 +338,12 @@ impl HTMLCanvasElement {
             .expect("Failed to get WebGPU channel")
             .map(|channel| {
                 let context = GPUCanvasContext::new(&global_scope, self, channel, can_gc);
-                *self.context_mode.borrow_mut() =
-                    Some(RenderingContext::WebGPU(Dom::from_ref(&*context)));
+
+                self.context_mode
+                    .borrow_mut()
+                    .replace(RenderingContext::WebGPU(Dom::from_ref(&*context)));
+                self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
+
                 context
             })
     }

--- a/components/script/dom/webgpu/gpucanvascontext.rs
+++ b/components/script/dom/webgpu/gpucanvascontext.rs
@@ -11,7 +11,6 @@ use dom_struct::dom_struct;
 use ipc_channel::ipc::{self};
 use pixels::Snapshot;
 use script_bindings::codegen::GenericBindings::WebGPUBinding::GPUTextureFormat;
-use script_bindings::inheritance::Castable;
 use webgpu_traits::{
     ContextConfiguration, PRESENTATION_BUFFER_COUNT, PendingTexture, WebGPU, WebGPUContextId,
     WebGPURequest,
@@ -37,8 +36,8 @@ use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::USVString;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::html::htmlcanvaselement::HTMLCanvasElement;
-use crate::dom::node::{Node, NodeDamage, NodeTraits};
+use crate::dom::htmlcanvaselement::HTMLCanvasElement;
+use crate::dom::node::NodeTraits;
 use crate::script_runtime::CanGc;
 
 /// <https://gpuweb.github.io/gpuweb/#supported-context-formats>
@@ -298,7 +297,6 @@ impl CanvasContext for GPUCanvasContext {
 
     fn mark_as_dirty(&self) {
         if let HTMLCanvasElementOrOffscreenCanvas::HTMLCanvasElement(ref canvas) = self.canvas {
-            canvas.upcast::<Node>().dirty(NodeDamage::Other);
             canvas.owner_document().add_dirty_webgpu_context(self);
         }
     }

--- a/components/script/image_animation.rs
+++ b/components/script/image_animation.rs
@@ -70,12 +70,11 @@ impl ImageAnimationManager {
             return;
         }
 
-        let rooted_nodes = self.rooted_nodes.borrow();
         let updates = self
             .node_to_image_map
             .write()
-            .iter_mut()
-            .filter_map(|(node, state)| {
+            .values_mut()
+            .filter_map(|state| {
                 if !state.update_frame_for_animation_timeline_value(now) {
                     return None;
                 }
@@ -85,9 +84,6 @@ impl ImageAnimationManager {
                     .frame(state.active_frame)
                     .expect("active_frame should within range of frames");
 
-                if let Some(node) = rooted_nodes.get(&NoTrace(*node)) {
-                    node.dirty(crate::dom::node::NodeDamage::Other);
-                }
                 Some(ImageUpdate::UpdateImage(
                     image.id.unwrap(),
                     ImageDescriptor {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -516,14 +516,17 @@ bitflags! {
         const BuiltStackingContextTree = 1 << 2;
         const BuiltDisplayList = 1 << 3;
         const UpdatedScrollNodeOffset = 1 << 4;
-        const UpdatedCanvasContents = 1 << 5;
+        /// Image data for a WebRender image key has been updated, without necessarily
+        /// updating style or layout. This is used when updating canvas contents and
+        /// progressing to a new animated image frame.
+        const UpdatedImageData = 1 << 5;
     }
 }
 
 impl ReflowPhasesRun {
     pub fn needs_frame(&self) -> bool {
         self.intersects(
-            Self::BuiltDisplayList | Self::UpdatedScrollNodeOffset | Self::UpdatedCanvasContents,
+            Self::BuiltDisplayList | Self::UpdatedScrollNodeOffset | Self::UpdatedImageData,
         )
     }
 }


### PR DESCRIPTION
Add a new super-lightweight layout mode that avoids any layout when
canvas is updated or animated images progress to the next frame. In the
future this can also be used for video elements.

Testing: This is a performance optimization, so shouldn't change any
WPT test results.
