### PR TITLE
script: Do not root nodes with animating images

### DIFF
--- a/components/layout/fragment_tree/fragment_tree.rs
+++ b/components/layout/fragment_tree/fragment_tree.rs
@@ -59,12 +59,10 @@ impl FragmentTree {
         // them. Create a set of all elements that used to be animating.
         let mut animations = layout_context.style_context.animations.sets.write();
         let mut invalid_animating_nodes: FxHashSet<_> = animations.keys().cloned().collect();
-        let mut image_animations = layout_context
-            .image_resolver
-            .node_to_animating_image_map
-            .write()
-            .to_owned();
-        let mut invalid_image_animating_nodes: FxHashSet<_> = image_animations
+
+        let mut animating_images = layout_context.image_resolver.animating_images.write();
+        let mut invalid_image_animating_nodes: FxHashSet<_> = animating_images
+            .node_to_state_map
             .keys()
             .cloned()
             .map(|node| AnimationSetKey::new(node, None))
@@ -95,7 +93,7 @@ impl FragmentTree {
             }
         }
         for node in &invalid_image_animating_nodes {
-            image_animations.remove(&node.node);
+            animating_images.remove(node.node);
         }
 
         fragment_tree

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -825,7 +825,7 @@ impl LayoutThread {
             pending_images: Mutex::default(),
             pending_rasterization_images: Mutex::default(),
             pending_svg_elements_for_serialization: Mutex::default(),
-            node_to_animating_image_map: reflow_request.node_to_animating_image_map.clone(),
+            animating_images: reflow_request.animating_images.clone(),
             animation_timeline_value: reflow_request.animation_timeline_value,
         });
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4290,11 +4290,17 @@ impl Document {
             .do_post_reflow_update(&self.window, self.current_animation_timeline_value());
         self.image_animation_manager
             .borrow()
-            .update_rooted_dom_nodes(&self.window, self.current_animation_timeline_value());
+            .maybe_schedule_update_after_layout(
+                &self.window,
+                self.current_animation_timeline_value(),
+            );
     }
 
     pub(crate) fn cancel_animations_for_node(&self, node: &Node) {
         self.animations.borrow().cancel_animations_for_node(node);
+        self.image_animation_manager
+            .borrow()
+            .cancel_animations_for_node(node);
     }
 
     /// An implementation of <https://drafts.csswg.org/web-animations-1/#update-animations-and-send-events>.

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2325,7 +2325,7 @@ impl Window {
             dom_count: document.dom_count(),
             animation_timeline_value: document.current_animation_timeline_value(),
             animations: document.animations().sets.clone(),
-            node_to_animating_image_map: document.image_animation_manager().node_to_image_map(),
+            animating_images: document.image_animation_manager().animating_images(),
             theme: self.theme.get(),
             highlighted_dom_node: document.highlighted_dom_node().map(|node| node.to_opaque()),
         };

--- a/components/script/image_animation.rs
+++ b/components/script/image_animation.rs
@@ -7,37 +7,27 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use compositing_traits::{ImageUpdate, SerializableImageData};
-use embedder_traits::UntrustedNodeAddress;
 use ipc_channel::ipc::IpcSharedMemory;
-use layout_api::ImageAnimationState;
-use libc::c_void;
+use layout_api::AnimatingImages;
 use malloc_size_of::MallocSizeOf;
 use parking_lot::RwLock;
-use rustc_hash::FxHashMap;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
-use script_bindings::root::Dom;
-use style::dom::OpaqueNode;
 use timers::{TimerEventRequest, TimerId};
 use webrender_api::units::DeviceIntSize;
 use webrender_api::{ImageDescriptor, ImageDescriptorFlags, ImageFormat};
 
-use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::refcounted::Trusted;
-use crate::dom::bindings::trace::NoTrace;
-use crate::dom::node::{Node, from_untrusted_node_address};
+use crate::dom::node::Node;
 use crate::dom::window::Window;
 use crate::script_thread::with_script_thread;
 
 #[derive(Clone, Default, JSTraceable)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub struct ImageAnimationManager {
+    /// The set of [`AnimatingImages`] which is used to communicate the addition
+    /// and removal of animating images from layout.
     #[no_trace]
-    node_to_image_map: Arc<RwLock<FxHashMap<OpaqueNode, ImageAnimationState>>>,
-
-    /// A list of nodes with in-progress image animations.
-    ///
-    /// TODO(mrobinson): This does not properly handle animating images that are in pseudo-elements.
-    rooted_nodes: DomRefCell<FxHashMap<NoTrace<OpaqueNode>, Dom<Node>>>,
+    animating_images: Arc<RwLock<AnimatingImages>>,
 
     /// The [`TimerId`] of the currently scheduled animated image update callback.
     #[no_trace]
@@ -46,33 +36,33 @@ pub struct ImageAnimationManager {
 
 impl MallocSizeOf for ImageAnimationManager {
     fn size_of(&self, ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
-        (*self.node_to_image_map.read()).size_of(ops) + self.rooted_nodes.size_of(ops)
+        (*self.animating_images.read()).size_of(ops)
     }
 }
 
 impl ImageAnimationManager {
-    pub(crate) fn node_to_image_map(
-        &self,
-    ) -> Arc<RwLock<FxHashMap<OpaqueNode, ImageAnimationState>>> {
-        self.node_to_image_map.clone()
+    pub(crate) fn animating_images(&self) -> Arc<RwLock<AnimatingImages>> {
+        self.animating_images.clone()
     }
 
     fn duration_to_next_frame(&self, now: f64) -> Option<Duration> {
-        self.node_to_image_map
+        self.animating_images
             .read()
+            .node_to_state_map
             .values()
             .map(|state| state.duration_to_next_frame(now))
             .min()
     }
 
     pub(crate) fn update_active_frames(&self, window: &Window, now: f64) {
-        if self.node_to_image_map.read().is_empty() {
+        if self.animating_images.read().is_empty() {
             return;
         }
 
         let updates = self
-            .node_to_image_map
+            .animating_images
             .write()
+            .node_to_state_map
             .values_mut()
             .filter_map(|state| {
                 if !state.update_frame_for_animation_timeline_value(now) {
@@ -103,43 +93,18 @@ impl ImageAnimationManager {
             .collect();
         window.compositor_api().update_images(updates);
 
-        self.maybe_schedule_animated_image_update_callback(window, now);
+        self.maybe_schedule_update(window, now);
     }
 
-    /// Ensure that all nodes with animating images are rooted and unroots any nodes that
-    /// no longer have an animating image. This should be called immediately after a
-    /// restyle, to ensure that these addresses are still valid.
-    #[allow(unsafe_code)]
-    pub(crate) fn update_rooted_dom_nodes(&self, window: &Window, now: f64) {
-        let mut rooted_nodes = self.rooted_nodes.borrow_mut();
-        let node_to_image_map = self.node_to_image_map.read();
-
-        let mut added_node = false;
-        for opaque_node in node_to_image_map.keys() {
-            let opaque_node = *opaque_node;
-            if rooted_nodes.contains_key(&NoTrace(opaque_node)) {
-                continue;
-            }
-
-            added_node = true;
-            let address = UntrustedNodeAddress(opaque_node.0 as *const c_void);
-            unsafe {
-                rooted_nodes.insert(
-                    NoTrace(opaque_node),
-                    Dom::from_ref(&*from_untrusted_node_address(address)),
-                )
-            };
-        }
-
-        let length_before = rooted_nodes.len();
-        rooted_nodes.retain(|node, _| node_to_image_map.contains_key(&node.0));
-
-        if added_node || length_before != rooted_nodes.len() {
-            self.maybe_schedule_animated_image_update_callback(window, now);
+    /// After doing a layout, if the set of animating images was updated in some way,
+    /// schedule a new animation update.
+    pub(crate) fn maybe_schedule_update_after_layout(&self, window: &Window, now: f64) {
+        if self.animating_images().write().clear_dirty() {
+            self.maybe_schedule_update(window, now);
         }
     }
 
-    fn maybe_schedule_animated_image_update_callback(&self, window: &Window, now: f64) {
+    fn maybe_schedule_update(&self, window: &Window, now: f64) {
         with_script_thread(|script_thread| {
             if let Some(current_timer_id) = self.callback_timer_id.take() {
                 self.callback_timer_id.set(None);
@@ -158,5 +123,9 @@ impl ImageAnimationManager {
                 self.callback_timer_id.set(Some(timer_id));
             }
         })
+    }
+
+    pub(crate) fn cancel_animations_for_node(&self, node: &Node) {
+        self.animating_images().write().remove(node.to_opaque());
     }
 }


### PR DESCRIPTION
Now that we do not need to call `Node::dirty` when an image frame
changes, we no longer have to keep a map of rooted nodes. Instead,
expose a new `AnimatingImages` type that also tracks when the set of
animating images is diryt and new image animation update should maybe be
scheduled.

In addition, cancel any ongoing image animations eagerly when they are
removed from the DOM like we do for CSS animations.

Testing: This should not change behavior and thus is covered by existing WPT tests.
