### PR TITLE
storage: Port Reply senders to GenericSender

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2611,7 +2611,7 @@ where
         let (core_ipc_sender, core_ipc_receiver) =
             ipc::channel().expect("Failed to create IPC channel!");
         let (storage_ipc_sender, storage_ipc_receiver) =
-            ipc::channel().expect("Failed to create IPC channel!");
+            generic_channel::channel().expect("Failed to create IPC channel!");
         let mut webgl_threads_receiver = None;
 
         debug!("Exiting core resource threads.");

--- a/components/net/storage_thread.rs
+++ b/components/net/storage_thread.rs
@@ -9,7 +9,6 @@ use std::thread;
 
 use base::generic_channel::{self, GenericReceiver, GenericSender};
 use base::id::WebViewId;
-use ipc_channel::ipc::IpcSender;
 use malloc_size_of::MallocSizeOf;
 use net_traits::storage_thread::{StorageThreadMsg, StorageType};
 use profile_traits::mem::{
@@ -195,7 +194,7 @@ impl StorageManager {
 
     fn length(
         &self,
-        sender: IpcSender<usize>,
+        sender: GenericSender<usize>,
         storage_type: StorageType,
         webview_id: WebViewId,
         url: ServoUrl,
@@ -209,7 +208,7 @@ impl StorageManager {
 
     fn key(
         &self,
-        sender: IpcSender<Option<String>>,
+        sender: GenericSender<Option<String>>,
         storage_type: StorageType,
         webview_id: WebViewId,
         url: ServoUrl,
@@ -243,7 +242,7 @@ impl StorageManager {
     /// exceeding the quota limit
     fn set_item(
         &mut self,
-        sender: IpcSender<Result<(bool, Option<String>), ()>>,
+        sender: GenericSender<Result<(bool, Option<String>), ()>>,
         storage_type: StorageType,
         webview_id: WebViewId,
         url: ServoUrl,
@@ -292,7 +291,7 @@ impl StorageManager {
 
     fn request_item(
         &self,
-        sender: IpcSender<Option<String>>,
+        sender: GenericSender<Option<String>>,
         storage_type: StorageType,
         webview_id: WebViewId,
         url: ServoUrl,
@@ -308,7 +307,7 @@ impl StorageManager {
     /// Sends Some(old_value) in case there was a previous value with the key name, otherwise sends None
     fn remove_item(
         &mut self,
-        sender: IpcSender<Option<String>>,
+        sender: GenericSender<Option<String>>,
         storage_type: StorageType,
         webview_id: WebViewId,
         url: ServoUrl,
@@ -326,7 +325,7 @@ impl StorageManager {
 
     fn clear(
         &mut self,
-        sender: IpcSender<bool>,
+        sender: GenericSender<bool>,
         storage_type: StorageType,
         webview_id: WebViewId,
         url: ServoUrl,

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -6,7 +6,7 @@ use base::id::WebViewId;
 use constellation_traits::ScriptToConstellationMessage;
 use dom_struct::dom_struct;
 use net_traits::storage_thread::{StorageThreadMsg, StorageType};
-use profile_traits::{generic_channel, ipc};
+use profile_traits::generic_channel;
 use servo_url::ServoUrl;
 
 use crate::dom::bindings::codegen::Bindings::StorageBinding::StorageMethods;
@@ -64,7 +64,8 @@ impl Storage {
 impl StorageMethods<crate::DomTypeHolder> for Storage {
     // https://html.spec.whatwg.org/multipage/#dom-storage-length
     fn Length(&self) -> u32 {
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let (sender, receiver) =
+            generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
 
         self.send_storage_msg(StorageThreadMsg::Length(
             sender,
@@ -78,7 +79,8 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
 
     // https://html.spec.whatwg.org/multipage/#dom-storage-key
     fn Key(&self, index: u32) -> Option<DOMString> {
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let (sender, receiver) =
+            generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
 
         self.send_storage_msg(StorageThreadMsg::Key(
             sender,
@@ -93,7 +95,8 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
 
     // https://html.spec.whatwg.org/multipage/#dom-storage-getitem
     fn GetItem(&self, name: DOMString) -> Option<DOMString> {
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let (sender, receiver) =
+            generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
         let name = String::from(name);
 
         let msg = StorageThreadMsg::GetItem(
@@ -109,7 +112,8 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
 
     // https://html.spec.whatwg.org/multipage/#dom-storage-setitem
     fn SetItem(&self, name: DOMString, value: DOMString) -> ErrorResult {
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let (sender, receiver) =
+            generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
         let name = String::from(name);
         let value = String::from(value);
 
@@ -138,7 +142,8 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
 
     // https://html.spec.whatwg.org/multipage/#dom-storage-removeitem
     fn RemoveItem(&self, name: DOMString) {
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let (sender, receiver) =
+            generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
         let name = String::from(name);
 
         let msg = StorageThreadMsg::RemoveItem(
@@ -156,7 +161,8 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
 
     // https://html.spec.whatwg.org/multipage/#dom-storage-clear
     fn Clear(&self) {
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let (sender, receiver) =
+            generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
 
         self.send_storage_msg(StorageThreadMsg::Clear(
             sender,

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -5,6 +5,7 @@
 use std::cell::Cell;
 use std::ptr;
 
+use base::generic_channel;
 use base::generic_channel::GenericSend;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use constellation_traits::{
@@ -348,7 +349,7 @@ impl WindowProxy {
             // the session storage is copied over.
             // See https://html.spec.whatwg.org/multipage/#the-sessionstorage-attribute
 
-            let (sender, receiver) = ipc::channel().unwrap();
+            let (sender, receiver) = generic_channel::channel().unwrap();
 
             let msg = StorageThreadMsg::Clone {
                 sender,

--- a/components/shared/net/storage_thread.rs
+++ b/components/shared/net/storage_thread.rs
@@ -4,7 +4,6 @@
 
 use base::generic_channel::GenericSender;
 use base::id::WebViewId;
-use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
 use profile_traits::mem::ReportsChan;
 use serde::{Deserialize, Serialize};
@@ -20,11 +19,11 @@ pub enum StorageType {
 #[derive(Debug, Deserialize, Serialize)]
 pub enum StorageThreadMsg {
     /// gets the number of key/value pairs present in the associated storage data
-    Length(IpcSender<usize>, StorageType, WebViewId, ServoUrl),
+    Length(GenericSender<usize>, StorageType, WebViewId, ServoUrl),
 
     /// gets the name of the key at the specified index in the associated storage data
     Key(
-        IpcSender<Option<String>>,
+        GenericSender<Option<String>>,
         StorageType,
         WebViewId,
         ServoUrl,
@@ -36,7 +35,7 @@ pub enum StorageThreadMsg {
 
     /// gets the value associated with the given key in the associated storage data
     GetItem(
-        IpcSender<Option<String>>,
+        GenericSender<Option<String>>,
         StorageType,
         WebViewId,
         ServoUrl,
@@ -45,7 +44,7 @@ pub enum StorageThreadMsg {
 
     /// sets the value of the given key in the associated storage data
     SetItem(
-        IpcSender<Result<(bool, Option<String>), ()>>,
+        GenericSender<Result<(bool, Option<String>), ()>>,
         StorageType,
         WebViewId,
         ServoUrl,
@@ -55,7 +54,7 @@ pub enum StorageThreadMsg {
 
     /// removes the key/value pair for the given key in the associated storage data
     RemoveItem(
-        IpcSender<Option<String>>,
+        GenericSender<Option<String>>,
         StorageType,
         WebViewId,
         ServoUrl,
@@ -63,18 +62,18 @@ pub enum StorageThreadMsg {
     ),
 
     /// clears the associated storage data by removing all the key/value pairs
-    Clear(IpcSender<bool>, StorageType, WebViewId, ServoUrl),
+    Clear(GenericSender<bool>, StorageType, WebViewId, ServoUrl),
 
     /// clones all storage data of the given top-level browsing context for a new browsing context.
     /// should only be used for sessionStorage.
     Clone {
-        sender: IpcSender<()>,
+        sender: GenericSender<()>,
         src: WebViewId,
         dest: WebViewId,
     },
 
     /// send a reply when done cleaning up thread resources and then shut it down
-    Exit(IpcSender<()>),
+    Exit(GenericSender<()>),
 
     /// Measure memory used by this thread and send the report over the provided channel.
     CollectMemoryReport(ReportsChan),


### PR DESCRIPTION
Port the reply / back channels of StorageThreadMsg to GenericChannel.

Testing: No functional changes
Part of #38912
