### PR TITLE
fonts: Use `Helvetica` as the `system-ui` font on macOS

### DIFF
--- a/components/fonts/platform/macos/font_list.rs
+++ b/components/fonts/platform/macos/font_list.rs
@@ -182,7 +182,7 @@ pub fn default_system_generic_font_family(generic: GenericFontFamily) -> Lowerca
         GenericFontFamily::Monospace => "Menlo",
         GenericFontFamily::Cursive => "Apple Chancery",
         GenericFontFamily::Fantasy => "Papyrus",
-        GenericFontFamily::SystemUi => "Menlo",
+        GenericFontFamily::SystemUi => "Helvetica",
     }
     .into()
 }


### PR DESCRIPTION
Helvetica isn't quite right but it's a better default choice than a monospaced font like Menlo (it should be some variant of Apple's San Francisco font, but that isn't easily exposed)

Testing: Untested, but matches the font family used for `sans-serif` so it should be safe
