### PR TITLE
script: Remove a `println` statement in `canvas_state.rs`

### DIFF
--- a/components/script/canvas_state.rs
+++ b/components/script/canvas_state.rs
@@ -2265,8 +2265,6 @@ impl CanvasState {
                 .union(&text_run.bounds);
         }
 
-        println!("bounds: {bounds:?}");
-
         self.send_canvas_2d_msg(Canvas2dMsg::FillText(
             bounds
                 .unwrap_or_default()


### PR DESCRIPTION
This was (presumably accidentally) added in #38979, cc @mrobinson 