### PR TITLE
Prevent infinite recursion in convert_value_to_key

### DIFF
--- a/components/script/indexed_db.rs
+++ b/components/script/indexed_db.rs
@@ -164,7 +164,7 @@ pub fn convert_value_to_key(
     // Step 2: If seen contains input, then return invalid.
     for s in &seen {
         if s.get() == input.get() {
-            return Err(Error::Data);
+            return Ok(ConversionResult::Invalid);
         }
     }
 

--- a/components/script/indexed_db.rs
+++ b/components/script/indexed_db.rs
@@ -162,10 +162,11 @@ pub fn convert_value_to_key(
     let mut seen = seen.unwrap_or_default();
 
     // Step 2: If seen contains input, then return invalid.
-    // FIXME:(arihant2math) implement this
-    // Check if we have seen this key
-    // Does not currently work with HandleValue,
-    // as it does not implement PartialEq
+    for s in &seen {
+        if s.get() == input.get() {
+            return Err(Error::Data);
+        }
+    }
 
     // Step 3
     // FIXME:(arihant2math) Accept array as well


### PR DESCRIPTION
Checks if the seen set already contains the value; this prevents hangs if an array is being serialized into a key and the array  for some reason is self-referential.

Testing: WPT
Fixes: None
