### PR TITLE
script: Clear all associated event listeners when removing an event listener content attribute.

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -343,8 +343,8 @@ impl CompiledEventListener {
                                 );
                                 // Step 4
                                 if let Ok(()) = return_value {
-                                    if rooted_return_value.handle().is_boolean()
-                                        && rooted_return_value.handle().to_boolean()
+                                    if rooted_return_value.handle().is_boolean() &&
+                                        rooted_return_value.handle().to_boolean()
                                     {
                                         event.upcast::<Event>().PreventDefault();
                                     }
@@ -988,23 +988,21 @@ impl EventTarget {
         &self,
         ty: DOMString,
         listener: Option<Rc<EventListener>>,
-        options: Option<EventListenerOptions>,
+        options: EventListenerOptions,
     ) {
         let Some(ref listener) = listener else {
             return;
         };
         let mut handlers = self.handlers.borrow_mut();
         if let Some(entries) = handlers.get_mut(&Atom::from(ty)) {
-            let phase = options.map(|options| {
-                if options.capture {
-                    ListenerPhase::Capturing
-                } else {
-                    ListenerPhase::Bubbling
-                }
-            });
+            let phase = if options.capture {
+                ListenerPhase::Capturing
+            } else {
+                ListenerPhase::Bubbling
+            };
             if let Some(position) = entries.iter().position(|e| {
-                e.borrow().listener == EventListenerType::Additive(listener.clone())
-                    && phase.is_none_or(|phase| e.borrow().phase == phase)
+                e.borrow().listener == EventListenerType::Additive(listener.clone()) &&
+                    e.borrow().phase == phase
             }) {
                 entries.remove(position).borrow_mut().removed = true;
             }
@@ -1110,7 +1108,7 @@ impl EventTargetMethods<crate::DomTypeHolder> for EventTarget {
         listener: Option<Rc<EventListener>>,
         options: EventListenerOptionsOrBoolean,
     ) {
-        self.remove_event_listener(ty, listener, Some(options.convert()))
+        self.remove_event_listener(ty, listener, options.convert())
     }
 
     // https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -343,8 +343,8 @@ impl CompiledEventListener {
                                 );
                                 // Step 4
                                 if let Ok(()) = return_value {
-                                    if rooted_return_value.handle().is_boolean() &&
-                                        rooted_return_value.handle().to_boolean()
+                                    if rooted_return_value.handle().is_boolean()
+                                        && rooted_return_value.handle().to_boolean()
                                     {
                                         event.upcast::<Event>().PreventDefault();
                                     }
@@ -988,26 +988,24 @@ impl EventTarget {
         &self,
         ty: DOMString,
         listener: Option<Rc<EventListener>>,
-        options: EventListenerOptions,
+        options: Option<EventListenerOptions>,
     ) {
         let Some(ref listener) = listener else {
             return;
         };
         let mut handlers = self.handlers.borrow_mut();
         if let Some(entries) = handlers.get_mut(&Atom::from(ty)) {
-            let phase = if options.capture {
-                ListenerPhase::Capturing
-            } else {
-                ListenerPhase::Bubbling
-            };
-            let old_entry = Rc::new(RefCell::new(EventListenerEntry {
-                phase,
-                listener: EventListenerType::Additive(listener.clone()),
-                once: false,
-                passive: None,
-                removed: false,
-            }));
-            if let Some(position) = entries.iter().position(|e| *e == old_entry) {
+            let phase = options.map(|options| {
+                if options.capture {
+                    ListenerPhase::Capturing
+                } else {
+                    ListenerPhase::Bubbling
+                }
+            });
+            if let Some(position) = entries.iter().position(|e| {
+                e.borrow().listener == EventListenerType::Additive(listener.clone())
+                    && phase.is_none_or(|phase| e.borrow().phase == phase)
+            }) {
                 entries.remove(position).borrow_mut().removed = true;
             }
         }
@@ -1112,7 +1110,7 @@ impl EventTargetMethods<crate::DomTypeHolder> for EventTarget {
         listener: Option<Rc<EventListener>>,
         options: EventListenerOptionsOrBoolean,
     ) {
-        self.remove_event_listener(ty, listener, options.convert())
+        self.remove_event_listener(ty, listener, Some(options.convert()))
     }
 
     // https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -1131,10 +1131,7 @@ impl VirtualMethods for HTMLElement {
                     },
                     // https://html.spec.whatwg.org/multipage/#deactivate-an-event-handler
                     AttributeMutation::Removed => {
-                        evtarget.set_event_handler_common::<EventHandlerNonNull>(
-                            event_name.into(),
-                            None,
-                        );
+                        evtarget.set_event_handler_common::<EventHandlerNonNull>(event_name, None);
                     },
                 }
             },

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -1135,7 +1135,7 @@ impl VirtualMethods for HTMLElement {
                         evtarget.remove_event_listener(
                             event_name.into(),
                             evtarget.get_event_handler_common(event_name, can_gc),
-                            EventListenerOptions { capture: false },
+                            None,
                         );
                     },
                 }

--- a/components/script/dom/htmlelement.rs
+++ b/components/script/dom/htmlelement.rs
@@ -20,7 +20,6 @@ use crate::dom::bindings::codegen::Bindings::CharacterDataBinding::CharacterData
 use crate::dom::bindings::codegen::Bindings::EventHandlerBinding::{
     EventHandlerNonNull, OnErrorEventHandlerNonNull,
 };
-use crate::dom::bindings::codegen::Bindings::EventTargetBinding::EventListenerOptions;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLLabelElementBinding::HTMLLabelElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
@@ -1132,9 +1131,8 @@ impl VirtualMethods for HTMLElement {
                     },
                     // https://html.spec.whatwg.org/multipage/#deactivate-an-event-handler
                     AttributeMutation::Removed => {
-                        evtarget.remove_event_listener(
+                        evtarget.set_event_handler_common::<EventHandlerNonNull>(
                             event_name.into(),
-                            evtarget.get_event_handler_common(event_name, can_gc),
                             None,
                         );
                     },

--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -116,7 +116,7 @@ impl MediaQueryListMethods<crate::DomTypeHolder> for MediaQueryList {
         self.upcast::<EventTarget>().remove_event_listener(
             DOMString::from_string("change".to_owned()),
             listener,
-            EventListenerOptions { capture: false },
+            Some(EventListenerOptions { capture: false }),
         );
     }
 

--- a/components/script/dom/mediaquerylist.rs
+++ b/components/script/dom/mediaquerylist.rs
@@ -116,7 +116,7 @@ impl MediaQueryListMethods<crate::DomTypeHolder> for MediaQueryList {
         self.upcast::<EventTarget>().remove_event_listener(
             DOMString::from_string("change".to_owned()),
             listener,
-            Some(EventListenerOptions { capture: false }),
+            EventListenerOptions { capture: false },
         );
     }
 

--- a/tests/wpt/meta/html/webappapis/scripting/events/event-handler-removal.window.js.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/events/event-handler-removal.window.js.ini
@@ -1,3 +1,0 @@
-[event-handler-removal.window.html]
-  [Event handler set through content attribute should be deactivated when the content attribute is removed.]
-    expected: FAIL


### PR DESCRIPTION
This change allows callers of `remove_event_listener` to specify `None` for the `options` argument to skip phase (bubble/capture) checking (and remove either type of listener).

Notably, this changes the HTMLElement `attribute_mutated` code to remove all event listeners rather than ones with just `capture: false`, which should be [correct behavior](https://html.spec.whatwg.org/multipage/webappapis.html#deactivate-an-event-handler).

Testing: `mach try linux-wpt`: https://github.com/kotx/servo/actions/runs/17313405730
Fixes: https://github.com/servo/servo/issues/38742