### PR TITLE
webdriver: Improve parsing of Frame and Window

### DIFF
--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -151,7 +151,7 @@ partial interface Window {
   undefined webdriverException(optional any result);
   undefined webdriverTimeout();
   Element? webdriverElement(DOMString id);
-  Element? webdriverFrame(DOMString id);
+  WindowProxy? webdriverFrame(DOMString id);
   WindowProxy? webdriverWindow(DOMString id);
   ShadowRoot? webdriverShadowRoot(DOMString id);
 };

--- a/tests/wpt/meta/webdriver/tests/classic/execute_async_script/arguments.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_async_script/arguments.py.ini
@@ -31,9 +31,3 @@
 
   [test_no_such_window_for_window_with_invalid_value]
     expected: FAIL
-
-  [test_element_reference[frame\]]
-    expected: FAIL
-
-  [test_element_reference[window\]]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/arguments.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/arguments.py.ini
@@ -31,9 +31,3 @@
 
   [test_no_such_window_for_window_with_invalid_value]
     expected: FAIL
-
-  [test_element_reference[frame\]]
-    expected: FAIL
-
-  [test_element_reference[window\]]
-    expected: FAIL


### PR DESCRIPTION
In #38745, we changed the id of Frame and Window as the result of `ToString` trait. This PR
- adapts the parsing of frame/window accordingly.
- for frame, return the [WindowProxy](https://developer.mozilla.org/en-US/docs/Web/API/WindowProxy) object of the iframe as it's supposed to do.

Testing: `execute_{async_}script/arguments.py`
