### PR TITLE
canvas: Update vello_cpu to use SIMD on x86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "fearless_simd"
 version = "0.2.0"
-source = "git+https://github.com/linebender/fearless_simd?rev=3d1a77c#3d1a77cfb4515c0da307d50dc782c08840b90c70"
+source = "git+https://github.com/linebender/fearless_simd?rev=f25206a#f25206a4fe58a8f6daae157d63b1abdafb3a1be2"
 dependencies = [
  "bytemuck",
 ]
@@ -9422,7 +9422,7 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 [[package]]
 name = "vello"
 version = "0.5.0"
-source = "git+https://github.com/linebender/vello?rev=472c43ccc80c731d32d167c9e9748c78df1977f4#472c43ccc80c731d32d167c9e9748c78df1977f4"
+source = "git+https://github.com/linebender/vello?rev=5e3e12559781891b204553161aee761900c7e92d#5e3e12559781891b204553161aee761900c7e92d"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
@@ -9440,7 +9440,7 @@ dependencies = [
 [[package]]
 name = "vello_common"
 version = "0.0.1"
-source = "git+https://github.com/linebender/vello?rev=472c43ccc80c731d32d167c9e9748c78df1977f4#472c43ccc80c731d32d167c9e9748c78df1977f4"
+source = "git+https://github.com/linebender/vello?rev=5e3e12559781891b204553161aee761900c7e92d#5e3e12559781891b204553161aee761900c7e92d"
 dependencies = [
  "bytemuck",
  "fearless_simd",
@@ -9454,7 +9454,7 @@ dependencies = [
 [[package]]
 name = "vello_cpu"
 version = "0.0.1"
-source = "git+https://github.com/linebender/vello?rev=472c43ccc80c731d32d167c9e9748c78df1977f4#472c43ccc80c731d32d167c9e9748c78df1977f4"
+source = "git+https://github.com/linebender/vello?rev=5e3e12559781891b204553161aee761900c7e92d#5e3e12559781891b204553161aee761900c7e92d"
 dependencies = [
  "bytemuck",
  "vello_common",
@@ -9463,7 +9463,7 @@ dependencies = [
 [[package]]
 name = "vello_encoding"
 version = "0.5.0"
-source = "git+https://github.com/linebender/vello?rev=472c43ccc80c731d32d167c9e9748c78df1977f4#472c43ccc80c731d32d167c9e9748c78df1977f4"
+source = "git+https://github.com/linebender/vello?rev=5e3e12559781891b204553161aee761900c7e92d#5e3e12559781891b204553161aee761900c7e92d"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -9475,7 +9475,7 @@ dependencies = [
 [[package]]
 name = "vello_shaders"
 version = "0.5.0"
-source = "git+https://github.com/linebender/vello?rev=472c43ccc80c731d32d167c9e9748c78df1977f4#472c43ccc80c731d32d167c9e9748c78df1977f4"
+source = "git+https://github.com/linebender/vello?rev=5e3e12559781891b204553161aee761900c7e92d#5e3e12559781891b204553161aee761900c7e92d"
 dependencies = [
  "bytemuck",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,8 +169,8 @@ unicode-segmentation = "1.12.0"
 url = "2.5"
 urlpattern = "0.3"
 uuid = { version = "1.18.0", features = ["v4", "v5"] }
-vello = { git = "https://github.com/linebender/vello", rev = "472c43ccc80c731d32d167c9e9748c78df1977f4" }
-vello_cpu = { git = "https://github.com/linebender/vello", rev = "472c43ccc80c731d32d167c9e9748c78df1977f4" }
+vello = { git = "https://github.com/linebender/vello", rev = "5e3e12559781891b204553161aee761900c7e92d" }
+vello_cpu = { git = "https://github.com/linebender/vello", rev = "5e3e12559781891b204553161aee761900c7e92d" }
 webdriver = "0.53.0"
 webgpu_traits = { path = "components/shared/webgpu" }
 webpki-roots = "1.0"


### PR DESCRIPTION
Set vello commit to https://github.com/linebender/vello/commit/5e3e12559781891b204553161aee761900c7e92d. This improves performance: [#vello > Servo 2D canvas backend @ 💬](https://xi.zulipchat.com/#narrow/channel/197075-vello/topic/Servo.202D.20canvas.20backend/near/536745909).

Testing: Existing WPT tests.
