### PR TITLE
webgpu: Add the dedicated WebGPU task source

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3191,7 +3191,6 @@ impl GlobalScope {
         device: WebGPUDevice,
         reason: DeviceLostReason,
         msg: String,
-        can_gc: CanGc,
     ) {
         let reason = match reason {
             DeviceLostReason::Unknown => GPUDeviceLostReason::Unknown,
@@ -3205,7 +3204,7 @@ impl GlobalScope {
             .expect("GPUDevice should still be in devices hashmap")
             .root()
         {
-            device.lose(reason, msg, can_gc);
+            device.lose(reason, msg);
         }
     }
 
@@ -3214,7 +3213,6 @@ impl GlobalScope {
         &self,
         device: WebGPUDevice,
         error: webgpu_traits::Error,
-        can_gc: CanGc,
     ) {
         if let Some(gpu_device) = self
             .gpu_devices
@@ -3222,7 +3220,7 @@ impl GlobalScope {
             .get(&device)
             .and_then(|device| device.root())
         {
-            gpu_device.fire_uncaptured_error(error, can_gc);
+            gpu_device.fire_uncaptured_error(error);
         } else {
             warn!("Recived error for lost GPUDevice!")
         }

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -269,7 +269,7 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
                     can_gc,
                 );
                 // 2. Lose the device(device, "unknown").
-                device.lose(GPUDeviceLostReason::Unknown, e, can_gc);
+                device.lose(GPUDeviceLostReason::Unknown, e);
                 promise.resolve_native(&device, can_gc);
             },
         }

--- a/components/script/dom/webgpu/gpuuncapturederrorevent.rs
+++ b/components/script/dom/webgpu/gpuuncapturederrorevent.rs
@@ -62,10 +62,6 @@ impl GPUUncapturedErrorEvent {
         );
         ev
     }
-
-    pub(crate) fn event(&self) -> &Event {
-        &self.event
-    }
 }
 
 impl GPUUncapturedErrorEventMethods<crate::DomTypeHolder> for GPUUncapturedErrorEvent {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1512,7 +1512,7 @@ impl ScriptThread {
                     },
                     #[cfg(feature = "webgpu")]
                     MixedMessage::FromWebGPUServer(inner_msg) => {
-                        self.handle_msg_from_webgpu_server(inner_msg, can_gc)
+                        self.handle_msg_from_webgpu_server(inner_msg)
                     },
                     MixedMessage::TimerFired => {},
                 }
@@ -1947,7 +1947,7 @@ impl ScriptThread {
     }
 
     #[cfg(feature = "webgpu")]
-    fn handle_msg_from_webgpu_server(&self, msg: WebGPUMsg, can_gc: CanGc) {
+    fn handle_msg_from_webgpu_server(&self, msg: WebGPUMsg) {
         match msg {
             WebGPUMsg::FreeAdapter(id) => self.gpu_id_hub.free_adapter_id(id),
             WebGPUMsg::FreeDevice {
@@ -1985,7 +1985,7 @@ impl ScriptThread {
                 msg,
             } => {
                 let global = self.documents.borrow().find_global(pipeline_id).unwrap();
-                global.gpu_device_lost(device, reason, msg, can_gc);
+                global.gpu_device_lost(device, reason, msg);
             },
             WebGPUMsg::UncapturedError {
                 device,
@@ -1994,7 +1994,7 @@ impl ScriptThread {
             } => {
                 let global = self.documents.borrow().find_global(pipeline_id).unwrap();
                 let _ac = enter_realm(&*global);
-                global.handle_uncaptured_gpu_error(device, error, can_gc);
+                global.handle_uncaptured_gpu_error(device, error);
             },
             _ => {},
         }

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -153,4 +153,5 @@ impl TaskManager {
         intersection_observer_task_source,
         IntersectionObserver
     );
+    task_source_functions!(self, webgpu_task_source, WebGPU);
 }

--- a/components/script/task_source.rs
+++ b/components/script/task_source.rs
@@ -46,6 +46,8 @@ pub(crate) enum TaskSourceName {
     Gamepad,
     /// <https://w3c.github.io/IntersectionObserver/#intersectionobserver-task-source>
     IntersectionObserver,
+    /// <https://www.w3.org/TR/webgpu/#-webgpu-task-source>
+    WebGPU,
 }
 
 impl From<TaskSourceName> for ScriptThreadEventCategory {
@@ -72,6 +74,7 @@ impl From<TaskSourceName> for ScriptThreadEventCategory {
             TaskSourceName::Timer => ScriptThreadEventCategory::TimerEvent,
             TaskSourceName::Gamepad => ScriptThreadEventCategory::InputEvent,
             TaskSourceName::IntersectionObserver => ScriptThreadEventCategory::ScriptEvent,
+            TaskSourceName::WebGPU => ScriptThreadEventCategory::ScriptEvent,
         }
     }
 }


### PR DESCRIPTION
According to the WebGPU specification there are the dedicated task source
which is used to queue a global task for a GPUDevice on content timeline.
https://gpuweb.github.io/gpuweb/#-webgpu-task-source

Tasks on content timeline:
- to fire "uncaptureevent" event
- to resolve GPUDevice.lost promise

Also fixed the "isTrusted" attribute status (false -> true) of the
"uncaptureevent" event by using non JS version of event dispatching.

Testing: No changes in WebGPU CTS expectations
- webgpu:api,operation,uncapturederror:*
- webgpu:api,operation,device,lost:*
- webgpu:api,validation,state,device_lost,destroy:*