### PR TITLE
script: do not update `Document` rendering when waiting on asynchronous canvas image updates

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -570,6 +570,10 @@ pub(crate) struct Document {
 
 #[allow(non_snake_case)]
 impl Document {
+    pub(crate) fn waiting_on_canvas_image_updates(&self) -> bool {
+        self.waiting_on_canvas_image_updates.get()
+    }
+
     pub(crate) fn note_node_with_dirty_descendants(&self, node: &Node) {
         debug_assert!(*node.owner_doc() == *self);
         if !node.is_connected() {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -570,10 +570,6 @@ pub(crate) struct Document {
 
 #[allow(non_snake_case)]
 impl Document {
-    pub(crate) fn waiting_on_canvas_image_updates(&self) -> bool {
-        self.waiting_on_canvas_image_updates.get()
-    }
-
     pub(crate) fn note_node_with_dirty_descendants(&self, node: &Node) {
         debug_assert!(*node.owner_doc() == *self);
         if !node.is_connected() {
@@ -2746,6 +2742,10 @@ impl Document {
 
     pub(crate) fn handle_no_longer_waiting_on_asynchronous_image_updates(&self) {
         self.waiting_on_canvas_image_updates.set(false);
+    }
+
+    pub(crate) fn waiting_on_canvas_image_updates(&self) -> bool {
+        self.waiting_on_canvas_image_updates.get()
     }
 
     /// From <https://drafts.csswg.org/css-font-loading/#fontfaceset-pending-on-the-environment>:

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1158,6 +1158,10 @@ impl ScriptThread {
                 continue;
             }
 
+            if document.waiting_on_canvas_image_updates() {
+                continue;
+            }
+
             // TODO(#31581): The steps in the "Revealing the document" section need to be implemented
             // `process_pending_input_events` handles the focusing steps as well as other events
             // from the compositor.


### PR DESCRIPTION
This is fixup for #37776. We forget to skip documents with waiting_on_canvas_image_updates flag.

Testing: Existing WPT tests and manual testing
Fixes: #39021 
