### PR TITLE
layout: Lay out collapsed table rows and columns, but don't paint them

### DIFF
--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -849,6 +849,13 @@ impl Fragment {
         mode: StackingContextBuildMode,
         text_decorations: &Arc<Vec<FragmentTextDecoration>>,
     ) {
+        if self
+            .base()
+            .is_some_and(|base| base.flags.contains(FragmentFlags::IS_COLLAPSED))
+        {
+            return;
+        }
+
         let containing_block = containing_block_info.get_containing_block_for_fragment(self);
         let fragment_clone = self.clone();
         match self {

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -178,6 +178,9 @@ bitflags! {
         const IS_ROOT_ELEMENT = 1 << 9;
         /// If element has propagated the overflow value to viewport.
         const PROPAGATED_OVERFLOW_TO_VIEWPORT = 1 << 10;
+        /// Whether or not this is a table cell that is part of a collapsed row or column.
+        /// In that case it should not be painted.
+        const IS_COLLAPSED = 1 << 11;
 
     }
 }

--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -6,6 +6,7 @@ use app_units::{Au, MAX_AU, MIN_AU};
 use atomic_refcell::AtomicRefCell;
 use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
+use euclid::Rect;
 use malloc_size_of_derive::MallocSizeOf;
 use servo_arc::Arc as ServoArc;
 use servo_geometry::f32_rect_to_au_rect;
@@ -290,6 +291,15 @@ impl BoxFragment {
                     );
                 acc.union(&scrollable_overflow_from_child)
             });
+
+        // Fragments with `IS_COLLAPSED` (currently only table cells that are part of
+        // table tracks with `visibility: collapse`) should not contribute to scrollable
+        // overflow. This behavior matches Chrome, but not Firefox.
+        // See https://github.com/w3c/csswg-drafts/issues/12689
+        if self.base.flags.contains(FragmentFlags::IS_COLLAPSED) {
+            self.scrollable_overflow = Some(Rect::zero());
+            return;
+        }
 
         self.scrollable_overflow = Some(scrollable_overflow)
     }

--- a/tests/wpt/tests/css/css-tables/table-collapsed-row-or-column-crash.html
+++ b/tests/wpt/tests/css/css-tables/table-collapsed-row-or-column-crash.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<link rel="help" href="https://github.com/servo/servo/issues/37421">
+
+<div style="display: table; visibility: collapse">
+  <div id="scroller" style="overflow: scroll"></div>
+</div>
+
+<table>
+    <colgroup>
+        <col style="background: green; visibility: collapse">
+    </colgroup>
+    <tr>
+        <td><div id="scroller2" style="overflow: scroll"></div></td>
+    </tr>
+</table>
+
+<script>
+    scroller.scrollTo();
+    scroller2.scrollTo();
+</script>
+


### PR DESCRIPTION
It's expected that script queries be able to interact with collapsed
table rows and columns, so this change starts laying them out. They
still do not affect table dimensions, nor are they painted.

This does not fix all interaction with collapsed rows and columns. For
instance, setting scroll offsets of contained scrolling nodes does not
work properly. It does fix the panic though, which is the most important
thing.


Testing: this change includes a new WPT crash test.
Fixes: #37421.
