### PR TITLE
Move attribute related methods from Element to Attr

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2200,22 +2200,6 @@ impl Element {
         }
     }
 
-    /// <https://dom.spec.whatwg.org/#concept-element-attributes-change>
-    pub(crate) fn change_attribute(&self, attr: &Attr, mut value: AttrValue, can_gc: CanGc) {
-        // Step 1. Let oldValue be attribute’s value.
-        //
-        // Clone to avoid double borrow
-        let old_value = &attr.value().clone();
-        // Step 2. Set attribute’s value to value.
-        self.will_mutate_attr(attr);
-        attr.swap_value(&mut value);
-        // Step 3. Handle attribute changes for attribute with attribute’s element, oldValue, and value.
-        //
-        // Put on a separate line to avoid double borrow
-        let new_value = DOMString::from(&**attr.value());
-        self.handle_attribute_changes(attr, Some(old_value), Some(new_value), can_gc);
-    }
-
     pub(crate) fn get_attribute(
         &self,
         namespace: &Namespace,
@@ -2344,8 +2328,7 @@ impl Element {
             .map(|js| DomRoot::from_ref(&**js));
         if let Some(attr) = attr {
             // Step 3. Change attribute to value.
-            self.will_mutate_attr(&attr);
-            self.change_attribute(&attr, value, can_gc);
+            attr.change(self, value, can_gc);
         } else {
             // Step 2. If attribute is null, create an attribute whose namespace is namespace,
             // namespace prefix is prefix, local name is localName, value is value,


### PR DESCRIPTION
`element.rs` is large (over 5k lines) and these methods
are related to attributes. To keep things manageable,
we can move these to `attr.rs`, which handles other
attribute handling.

It also ensures that whenever attributes are mutated
(we call `self.attrs.borrow_mut()`), we now also call
`will_mutate_attr`. In my previous attribute related
changes, I sometimes forgot that and ran into
several difficult-to-debug test failures.

Testing: refactoring, no observable differences