### PR TITLE
Move LinkProcessingOptions into separate file

### DIFF
--- a/components/script/dom/linkprocessingoptions.rs
+++ b/components/script/dom/linkprocessingoptions.rs
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::str::FromStr;
+
+use base::id::WebViewId;
+use mime::Mime;
+use net_traits::ReferrerPolicy;
+use net_traits::mime_classifier::{MediaType, MimeClassifier};
+use net_traits::policy_container::PolicyContainer;
+use net_traits::request::{
+    CorsSettings, Destination, Initiator, InsecureRequestsPolicy, Referrer, RequestBuilder,
+};
+use servo_url::{ImmutableOrigin, ServoUrl};
+
+use crate::fetch::create_a_potential_cors_request;
+
+/// <https://html.spec.whatwg.org/multipage/#link-processing-options>
+pub(crate) struct LinkProcessingOptions {
+    pub(crate) href: String,
+    pub(crate) destination: Option<Destination>,
+    pub(crate) integrity: String,
+    pub(crate) link_type: String,
+    pub(crate) cryptographic_nonce_metadata: String,
+    pub(crate) cross_origin: Option<CorsSettings>,
+    pub(crate) referrer_policy: ReferrerPolicy,
+    pub(crate) policy_container: PolicyContainer,
+    pub(crate) source_set: Option<()>,
+    pub(crate) base_url: ServoUrl,
+    pub(crate) origin: ImmutableOrigin,
+    pub(crate) insecure_requests_policy: InsecureRequestsPolicy,
+    pub(crate) has_trustworthy_ancestor_origin: bool,
+    // Some fields that we don't need yet are missing
+}
+
+impl LinkProcessingOptions {
+    /// <https://html.spec.whatwg.org/multipage/#create-a-link-request>
+    pub(crate) fn create_link_request(self, webview_id: WebViewId) -> Option<RequestBuilder> {
+        // Step 1. Assert: options's href is not the empty string.
+        assert!(!self.href.is_empty());
+
+        // Step 2. If options's destination is null, then return null.
+        let destination = self.destination?;
+
+        // Step 3. Let url be the result of encoding-parsing a URL given options's href, relative to options's base URL.
+        let Ok(url) = ServoUrl::parse_with_base(Some(&self.base_url), &self.href) else {
+            // Step 4. If url is failure, then return null.
+            return None;
+        };
+
+        // Step 5. Let request be the result of creating a potential-CORS request given
+        //         url, options's destination, and options's crossorigin.
+        // Step 6. Set request's policy container to options's policy container.
+        // Step 7. Set request's integrity metadata to options's integrity.
+        // Step 8. Set request's cryptographic nonce metadata to options's cryptographic nonce metadata.
+        // Step 9. Set request's referrer policy to options's referrer policy.
+        // FIXME: Step 10. Set request's client to options's environment.
+        // FIXME: Step 11. Set request's priority to options's fetch priority.
+        // FIXME: Use correct referrer
+        let builder = create_a_potential_cors_request(
+            Some(webview_id),
+            url,
+            destination,
+            self.cross_origin,
+            None,
+            Referrer::NoReferrer,
+            self.insecure_requests_policy,
+            self.has_trustworthy_ancestor_origin,
+            self.policy_container,
+        )
+        .initiator(Initiator::Link)
+        .origin(self.origin)
+        .integrity_metadata(self.integrity)
+        .cryptographic_nonce_metadata(self.cryptographic_nonce_metadata)
+        .referrer_policy(self.referrer_policy);
+
+        // Step 12. Return request.
+        Some(builder)
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#match-preload-type>
+    pub(crate) fn type_matches_destination(&self) -> bool {
+        // Step 1. If type is an empty string, then return true.
+        if self.link_type.is_empty() {
+            return true;
+        }
+        // Step 2. If destination is "fetch", then return true.
+        //
+        // Fetch is handled as an empty string destination in the spec:
+        // https://fetch.spec.whatwg.org/#concept-potential-destination-translate
+        let Some(destination) = self.destination else {
+            return false;
+        };
+        if destination == Destination::None {
+            return true;
+        }
+        // Step 3. Let mimeTypeRecord be the result of parsing type.
+        let Ok(mime_type_record) = Mime::from_str(&self.link_type) else {
+            // Step 4. If mimeTypeRecord is failure, then return false.
+            return false;
+        };
+        // Step 5. If mimeTypeRecord is not supported by the user agent, then return false.
+        //
+        // We currently don't check if we actually support the mime type. Only if we can classify
+        // it according to the spec.
+        let Some(mime_type) = MimeClassifier::get_media_type(&mime_type_record) else {
+            return false;
+        };
+        // Step 6. If any of the following are true:
+        if
+        // destination is "audio" or "video", and mimeTypeRecord is an audio or video MIME type;
+        ((destination == Destination::Audio || destination == Destination::Video) &&
+            mime_type == MediaType::AudioVideo)
+            // destination is a script-like destination and mimeTypeRecord is a JavaScript MIME type;
+            || (destination.is_script_like() && mime_type == MediaType::JavaScript)
+            // destination is "image" and mimeTypeRecord is an image MIME type;
+            || (destination == Destination::Image && mime_type == MediaType::Image)
+            // destination is "font" and mimeTypeRecord is a font MIME type;
+            || (destination == Destination::Font && mime_type == MediaType::Font)
+            // destination is "json" and mimeTypeRecord is a JSON MIME type;
+            || (destination == Destination::Json && mime_type == MediaType::Json)
+            // destination is "style" and mimeTypeRecord's essence is text/css; or
+            || (destination == Destination::Style && mime_type_record == mime::TEXT_CSS)
+            // destination is "track" and mimeTypeRecord's essence is text/vtt,
+            || (destination == Destination::Track && mime_type_record.essence_str() == "text/vtt")
+        {
+            // then return true.
+            return true;
+        }
+        // Step 7. Return false.
+        false
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#preload>
+    pub(crate) fn preload(self, webview_id: WebViewId) -> Option<RequestBuilder> {
+        // Step 1. If options's type doesn't match options's destination, then return.
+        //
+        // Handled by callers, since we need to check the previous destination type
+        assert!(self.type_matches_destination());
+        // Step 2. If options's destination is "image" and options's source set is not null,
+        // then set options's href to the result of selecting an image source from options's source set.
+        // TODO
+        // Step 3. Let request be the result of creating a link request given options.
+        let Some(request) = self.create_link_request(webview_id) else {
+            // Step 4. If request is null, then return.
+            return None;
+        };
+        // Step 5. Let unsafeEndTime be 0.
+        // TODO
+        // Step 6. Let entry be a new preload entry whose integrity metadata is options's integrity.
+        // TODO
+        // Step 7. Let key be the result of creating a preload key given request.
+        // TODO
+        // Step 8. If options's document is "pending", then set request's initiator type to "early hint".
+        // TODO
+        // Step 9. Let controller be null.
+        // Step 10. Let reportTiming given a Document document be to report timing for controller
+        // given document's relevant global object.
+        // Step 11. Set controller to the result of fetching request, with processResponseConsumeBody
+        // set to the following steps given a response response and null, failure, or a byte sequence bodyBytes:
+        Some(request.clone())
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -350,6 +350,7 @@ pub(crate) mod inputevent;
 pub(crate) mod intersectionobserver;
 pub(crate) mod intersectionobserverentry;
 pub(crate) mod keyboardevent;
+pub(crate) mod linkprocessingoptions;
 pub(crate) mod location;
 pub(crate) mod mediadeviceinfo;
 pub(crate) mod mediadevices;

--- a/tests/wpt/meta/content-security-policy/resource-hints/prefetch-allowed-by-any-directive.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/resource-hints/prefetch-allowed-by-any-directive.sub.html.ini
@@ -1,10 +1,6 @@
 [prefetch-allowed-by-any-directive.sub.html]
-  expected: TIMEOUT
   [Prefetch should succeed when restricted by default-src but allowed by other directive]
-    expected: TIMEOUT
-
-  [Prefetch should fail when restricted by default-src and different origin allowed by other directive]
-    expected: NOTRUN
+    expected: FAIL
 
   [Prefetch should succeed when restricted by default-src but origin allowed by other directive]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/resource-hints/prefetch-allowed-by-default.html.ini
+++ b/tests/wpt/meta/content-security-policy/resource-hints/prefetch-allowed-by-default.html.ini
@@ -1,4 +1,3 @@
 [prefetch-allowed-by-default.html]
-  expected: TIMEOUT
   [Prefetch should succeed when allowed by default-src]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/resource-hints/prefetch-allowed-no-default.html.ini
+++ b/tests/wpt/meta/content-security-policy/resource-hints/prefetch-allowed-no-default.html.ini
@@ -1,4 +1,3 @@
 [prefetch-allowed-no-default.html]
-  expected: TIMEOUT
   [Prefetch should succeed when there is no default-src]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/resource-hints/prefetch-allowed-with-conflicting-permissive-policies.html.ini
+++ b/tests/wpt/meta/content-security-policy/resource-hints/prefetch-allowed-with-conflicting-permissive-policies.html.ini
@@ -1,4 +1,3 @@
 [prefetch-allowed-with-conflicting-permissive-policies.html]
-  expected: TIMEOUT
   [Prefetch should succeed when a directive in a policy is permissive, even if a subsequent policy overrides that.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/resource-hints/prefetch-blocked-by-default-multiple-policies.html.ini
+++ b/tests/wpt/meta/content-security-policy/resource-hints/prefetch-blocked-by-default-multiple-policies.html.ini
@@ -1,4 +1,0 @@
-[prefetch-blocked-by-default-multiple-policies.html]
-  expected: TIMEOUT
-  [Prefetch should fail when restricted by default-src]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/resource-hints/prefetch-blocked-by-default.html.ini
+++ b/tests/wpt/meta/content-security-policy/resource-hints/prefetch-blocked-by-default.html.ini
@@ -1,4 +1,0 @@
-[prefetch-blocked-by-default.html]
-  expected: TIMEOUT
-  [Prefetch should fail when restricted by default-src]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/resource-hints/prefetch-generate-directives.html.ini
+++ b/tests/wpt/meta/content-security-policy/resource-hints/prefetch-generate-directives.html.ini
@@ -1,79 +1,72 @@
 [prefetch-generate-directives.html]
-  expected: TIMEOUT
   [Test that script-src enabled with everything else disabled allows prefetching]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Test that script-src enabled with default-src disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that img-src enabled with everything else disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that img-src enabled with default-src disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that connect-src enabled with everything else disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that connect-src enabled with default-src disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that object-src enabled with everything else disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that object-src enabled with default-src disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that font-src enabled with everything else disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that font-src enabled with default-src disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that manifest-src enabled with everything else disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that manifest-src enabled with default-src disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that media-src enabled with everything else disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that media-src enabled with default-src disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that style-src enabled with everything else disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that style-src enabled with default-src disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that child-src enabled with everything else disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that child-src enabled with default-src disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that frame-src enabled with everything else disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that frame-src enabled with default-src disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that worker-src enabled with everything else disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that worker-src enabled with default-src disabled allows prefetching]
-    expected: NOTRUN
-
-  [Test that base-uri enabled with everything else disabled allows prefetching]
-    expected: NOTRUN
-
-  [Test that base-uri enabled with default-src disabled allows prefetching]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that permissive script-src-elem supersedes script-src]
-    expected: NOTRUN
+    expected: FAIL
 
   [Test that permissive script-src supersedes script-src-elem]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/resource-hints/prefetch-ignores-prefetch-src.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/resource-hints/prefetch-ignores-prefetch-src.sub.html.ini
@@ -1,4 +1,0 @@
-[prefetch-ignores-prefetch-src.sub.html]
-  expected: TIMEOUT
-  [Prefetch should fail when restricted by default-src and allowed by unsupported prefetch-src directive (prefetch-src should be ignored)]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/resource-hints/prefetch-no-csp.html.ini
+++ b/tests/wpt/meta/content-security-policy/resource-hints/prefetch-no-csp.html.ini
@@ -1,4 +1,3 @@
 [prefetch-no-csp.html]
-  expected: TIMEOUT
   [Prefetch succeeds when no CSP]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/preload/dynamic-adding-preload.html.ini
+++ b/tests/wpt/meta/preload/dynamic-adding-preload.html.ini
@@ -1,3 +1,0 @@
-[dynamic-adding-preload.html]
-  [Makes sure that a dynamically added preloaded resource is downloaded]
-    expected: FAIL

--- a/tests/wpt/meta/preload/preload-error.sub.html.ini
+++ b/tests/wpt/meta/preload/preload-error.sub.html.ini
@@ -1,4 +1,5 @@
 [preload-error.sub.html]
+  expected: TIMEOUT
   [404 (image): main]
     expected: FAIL
 
@@ -26,12 +27,6 @@
   [CSP-error (xhr): main]
     expected: FAIL
 
-  [success (fetch): main]
-    expected: FAIL
-
-  [404 (fetch): main]
-    expected: FAIL
-
   [CORS (fetch): main]
     expected: FAIL
 
@@ -54,22 +49,4 @@
     expected: FAIL
 
   [MIME-blocked-nosniff (script): main]
-    expected: FAIL
-
-  [success (xhr): main]
-    expected: FAIL
-
-  [CORS (style): main]
-    expected: FAIL
-
-  [success (style): main]
-    expected: FAIL
-
-  [404 (script): main]
-    expected: FAIL
-
-  [Decode-error (style): main]
-    expected: FAIL
-
-  [CORS (xhr): main]
     expected: FAIL

--- a/tests/wpt/meta/preload/preload-font-crossorigin.html.ini
+++ b/tests/wpt/meta/preload/preload-font-crossorigin.html.ini
@@ -1,11 +1,5 @@
 [preload-font-crossorigin.html]
-  [Same origin font preload with crossorigin attribute]
-    expected: FAIL
-
   [Same origin font preload without crossorigin attribute]
-    expected: FAIL
-
-  [Cross origin font preload with crossorigin attribute]
     expected: FAIL
 
   [Cross origin font preload without crossorigin attribute]

--- a/tests/wpt/meta/preload/preload-invalid-resources.html.ini
+++ b/tests/wpt/meta/preload/preload-invalid-resources.html.ini
@@ -1,0 +1,3 @@
+[preload-invalid-resources.html]
+  [Preloading an invalid image (invalid data) should preload and not re-fetch]
+    expected: FAIL

--- a/tests/wpt/meta/preload/preload-referrer-policy.html.ini
+++ b/tests/wpt/meta/preload/preload-referrer-policy.html.ini
@@ -1,11 +1,5 @@
 [preload-referrer-policy.html]
   expected: TIMEOUT
-  [referrer policy ( -> , element, cross-origin)]
-    expected: FAIL
-
-  [referrer policy ( -> , element, same-origin)]
-    expected: FAIL
-
   [referrer policy ( -> , header, cross-origin)]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/preload/preload-resource-match.https.html.ini
+++ b/tests/wpt/meta/preload/preload-resource-match.https.html.ini
@@ -1,45 +1,9 @@
 [preload-resource-match.https.html]
   expected: TIMEOUT
-  [Loading image (no-cors) with link (anonymous) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading image (no-cors) with link (use-credentials) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading image (anonymous) with link (no-cors) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading image (anonymous) with link (use-credentials) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading image (use-credentials) with link (no-cors) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading image (use-credentials) with link (anonymous) should discard the preloaded response]
-    expected: FAIL
-
   [Loading font (anonymous) with link (no-cors) should discard the preloaded response]
     expected: FAIL
 
-  [Loading font (anonymous) with link (anonymous) should reuse the preloaded response]
-    expected: FAIL
-
   [Loading font (anonymous) with link (use-credentials) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading font (same-origin) with link (same-origin) should reuse the preloaded response]
-    expected: FAIL
-
-  [Loading backgroundImage (no-cors) with link (anonymous) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading backgroundImage (no-cors) with link (use-credentials) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading fetch (same-origin) with link (same-origin) should reuse the preloaded response]
-    expected: FAIL
-
-  [Loading fetch (no-cors) with link (no-cors) should reuse the preloaded response]
     expected: FAIL
 
   [Loading fetch (no-cors) with link (anonymous) should discard the preloaded response]
@@ -51,9 +15,6 @@
   [Loading fetch (anonymous) with link (no-cors) should discard the preloaded response]
     expected: FAIL
 
-  [Loading fetch (anonymous) with link (anonymous) should reuse the preloaded response]
-    expected: FAIL
-
   [Loading fetch (anonymous) with link (use-credentials) should discard the preloaded response]
     expected: FAIL
 
@@ -63,53 +24,8 @@
   [Loading fetch (use-credentials) with link (anonymous) should discard the preloaded response]
     expected: FAIL
 
-  [Loading fetch (use-credentials) with link (use-credentials) should reuse the preloaded response]
-    expected: FAIL
-
-  [Loading script (no-cors) with link (anonymous) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading script (no-cors) with link (use-credentials) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading script (anonymous) with link (no-cors) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading script (anonymous) with link (use-credentials) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading script (use-credentials) with link (no-cors) should discard the preloaded response]
-    expected: FAIL
-
-  [Loading script (use-credentials) with link (anonymous) should discard the preloaded response]
-    expected: TIMEOUT
-
-  [Loading script (use-credentials) with link (use-credentials) should reuse the preloaded response]
-    expected: NOTRUN
-
-  [Loading module (same-origin) with link (same-origin) should reuse the preloaded response]
-    expected: NOTRUN
-
-  [Loading module (no-cors) with link (no-cors) should reuse the preloaded response]
-    expected: NOTRUN
-
-  [Loading module (no-cors) with link (anonymous) should discard the preloaded response]
-    expected: NOTRUN
-
-  [Loading module (no-cors) with link (use-credentials) should discard the preloaded response]
-    expected: NOTRUN
-
-  [Loading module (anonymous) with link (no-cors) should discard the preloaded response]
-    expected: NOTRUN
-
-  [Loading module (anonymous) with link (anonymous) should reuse the preloaded response]
-    expected: NOTRUN
-
-  [Loading module (anonymous) with link (use-credentials) should discard the preloaded response]
-    expected: NOTRUN
-
   [Loading module (use-credentials) with link (no-cors) should discard the preloaded response]
-    expected: NOTRUN
+    expected: TIMEOUT
 
   [Loading module (use-credentials) with link (anonymous) should discard the preloaded response]
     expected: NOTRUN
@@ -146,3 +62,21 @@
 
   [Loading style (use-credentials) with link (use-credentials) should reuse the preloaded response]
     expected: NOTRUN
+
+  [Loading image (same-origin) with link (same-origin) should reuse the preloaded response]
+    expected: FAIL
+
+  [Loading image (no-cors) with link (no-cors) should reuse the preloaded response]
+    expected: FAIL
+
+  [Loading image (anonymous) with link (anonymous) should reuse the preloaded response]
+    expected: FAIL
+
+  [Loading image (use-credentials) with link (use-credentials) should reuse the preloaded response]
+    expected: FAIL
+
+  [Loading backgroundImage (no-cors) with link (no-cors) should reuse the preloaded response]
+    expected: FAIL
+
+  [Loading backgroundImage (same-origin) with link (same-origin) should reuse the preloaded response]
+    expected: FAIL

--- a/tests/wpt/meta/preload/preload-xhr.html.ini
+++ b/tests/wpt/meta/preload/preload-xhr.html.ini
@@ -1,6 +1,3 @@
 [preload-xhr.html]
   [Make an XHR request immediately after creating link rel=preload.]
     expected: FAIL
-
-  [Make an XHR request after loading link rel=preload.]
-    expected: FAIL

--- a/tests/wpt/meta/preload/single-download-preload.html.ini
+++ b/tests/wpt/meta/preload/single-download-preload.html.ini
@@ -1,3 +1,0 @@
-[single-download-preload.html]
-  [Makes sure that preloaded resources are not downloaded again when used]
-    expected: FAIL

--- a/tests/wpt/meta/preload/subresource-integrity-font.html.ini
+++ b/tests/wpt/meta/preload/subresource-integrity-font.html.ini
@@ -8,19 +8,10 @@
   [<crossorigin="anonymous"> Same-origin with correct sha512 hash.]
     expected: FAIL
 
-  [<crossorigin="anonymous"> Same-origin with empty integrity.]
-    expected: FAIL
-
-  [<crossorigin="anonymous"> Same-origin with no integrity.]
-    expected: FAIL
-
   [<crossorigin="anonymous"> Same-origin with incorrect hash.]
     expected: FAIL
 
   [<crossorigin="anonymous"> Same-origin with correct sha256 hash, options.]
-    expected: FAIL
-
-  [<crossorigin="anonymous"> Same-origin with unknown algorithm only.]
     expected: FAIL
 
   [<crossorigin="anonymous"> Same-origin with multiple sha256 hashes, including correct.]
@@ -54,9 +45,6 @@
     expected: FAIL
 
   [Cross-origin, not CORS request, with incorrect sha256.]
-    expected: FAIL
-
-  [<crossorigin="anonymous"> Cross-origin with empty integrity.]
     expected: FAIL
 
   [Cross-origin, not CORS request, with empty integrity.]

--- a/tests/wpt/meta/preload/subresource-integrity.html.ini
+++ b/tests/wpt/meta/preload/subresource-integrity.html.ini
@@ -1,38 +1,11 @@
 [subresource-integrity.html]
-  [Same-origin script with correct sha256 hash.]
-    expected: FAIL
-
-  [Same-origin script with correct sha384 hash.]
-    expected: FAIL
-
-  [Same-origin script with correct sha512 hash.]
-    expected: FAIL
-
-  [Same-origin script with empty integrity.]
-    expected: FAIL
-
   [Same-origin script with incorrect hash.]
-    expected: FAIL
-
-  [Same-origin script with multiple sha256 hashes, including correct.]
-    expected: FAIL
-
-  [Same-origin script with multiple sha256 hashes, including unknown algorithm.]
-    expected: FAIL
-
-  [Same-origin script with sha256 mismatch, sha512 match]
     expected: FAIL
 
   [Same-origin script with sha256 match, sha512 mismatch]
     expected: FAIL
 
-  [<crossorigin='anonymous'> script with correct hash, ACAO: *]
-    expected: FAIL
-
   [<crossorigin='anonymous'> script with incorrect hash, ACAO: *]
-    expected: FAIL
-
-  [<crossorigin='use-credentials'> script with correct hash, CORS-eligible]
     expected: FAIL
 
   [<crossorigin='use-credentials'> script with incorrect hash CORS-eligible]
@@ -45,21 +18,6 @@
     expected: FAIL
 
   [Cross-origin script, not CORS request, with hash mismatch]
-    expected: FAIL
-
-  [Cross-origin script, empty integrity]
-    expected: FAIL
-
-  [Same-origin script with correct hash, options.]
-    expected: FAIL
-
-  [Same-origin script with unknown algorithm only.]
-    expected: FAIL
-
-  [Same-origin script with matching digest re-uses preload with matching digest.]
-    expected: FAIL
-
-  [Same-origin script with matching digest re-uses preload with matching digest and options.]
     expected: FAIL
 
   [Same-origin script with non-matching digest does not re-use preload with matching digest.]
@@ -86,40 +44,13 @@
   [Same-origin script with non-matching digest reuses preload with no digest but fails.]
     expected: FAIL
 
-  [Same-origin style with correct sha256 hash.]
-    expected: FAIL
-
-  [Same-origin style with correct sha384 hash.]
-    expected: FAIL
-
-  [Same-origin style with correct sha512 hash.]
-    expected: FAIL
-
-  [Same-origin style with empty integrity.]
-    expected: FAIL
-
   [Same-origin style with incorrect hash.]
-    expected: FAIL
-
-  [Same-origin style with multiple sha256 hashes, including correct.]
-    expected: FAIL
-
-  [Same-origin style with multiple sha256 hashes, including unknown algorithm.]
-    expected: FAIL
-
-  [Same-origin style with sha256 mismatch, sha512 match]
     expected: FAIL
 
   [Same-origin style with sha256 match, sha512 mismatch]
     expected: FAIL
 
-  [<crossorigin='anonymous'> style with correct hash, ACAO: *]
-    expected: FAIL
-
   [<crossorigin='anonymous'> style with incorrect hash, ACAO: *]
-    expected: FAIL
-
-  [<crossorigin='use-credentials'> style with correct hash, CORS-eligible]
     expected: FAIL
 
   [<crossorigin='use-credentials'> style with incorrect hash CORS-eligible]
@@ -132,21 +63,6 @@
     expected: FAIL
 
   [Cross-origin style, not CORS request, with hash mismatch]
-    expected: FAIL
-
-  [Cross-origin style, empty integrity]
-    expected: FAIL
-
-  [Same-origin style with correct hash, options.]
-    expected: FAIL
-
-  [Same-origin style with unknown algorithm only.]
-    expected: FAIL
-
-  [Same-origin style with matching digest re-uses preload with matching digest.]
-    expected: FAIL
-
-  [Same-origin style with matching digest re-uses preload with matching digest and options.]
     expected: FAIL
 
   [Same-origin style with non-matching digest does not re-use preload with matching digest.]
@@ -192,4 +108,40 @@
     expected: FAIL
 
   [Cross-origin image, not CORS request, with hash mismatch]
+    expected: FAIL
+
+  [Same-origin image with correct sha256 hash.]
+    expected: FAIL
+
+  [Same-origin image with correct sha384 hash.]
+    expected: FAIL
+
+  [Same-origin image with correct sha512 hash.]
+    expected: FAIL
+
+  [Same-origin image with empty integrity.]
+    expected: FAIL
+
+  [Same-origin image with multiple sha256 hashes, including correct.]
+    expected: FAIL
+
+  [Same-origin image with multiple sha256 hashes, including unknown algorithm.]
+    expected: FAIL
+
+  [Same-origin image with sha256 mismatch, sha512 match]
+    expected: FAIL
+
+  [<crossorigin='anonymous'> image with correct hash, ACAO: *]
+    expected: FAIL
+
+  [<crossorigin='use-credentials'> image with correct hash, CORS-eligible]
+    expected: FAIL
+
+  [Cross-origin image, empty integrity]
+    expected: FAIL
+
+  [Same-origin image with correct hash, options.]
+    expected: FAIL
+
+  [Same-origin image with unknown algorithm only.]
     expected: FAIL

--- a/tests/wpt/meta/resource-timing/initiator-type/link.html.ini
+++ b/tests/wpt/meta/resource-timing/initiator-type/link.html.ini
@@ -1,5 +1,4 @@
 [link.html]
-  expected: TIMEOUT
   [The initiator type for css resources embedded in css must be 'css']
     expected: FAIL
 
@@ -15,11 +14,8 @@
   [The initiator type for <link preload> must be 'link']
     expected: FAIL
 
-  [The initiator type for <link prerender> must be 'link']
-    expected: TIMEOUT
-
   [The initiator type for <link manifest> must be 'link']
-    expected: TIMEOUT
+    expected: FAIL
 
   [The initiator type for module preload must be 'other']
-    expected: NOTRUN
+    expected: FAIL


### PR DESCRIPTION
This makes future implementations easier where we will reuse most of this code to parse Link headers.

Part of #35035
