### PR TITLE
Move `Element::matches_environment` to `MediaList`

### DIFF
--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -75,6 +75,7 @@ use crate::dom::html::htmlformelement::{FormControl, HTMLFormElement};
 use crate::dom::html::htmlmapelement::HTMLMapElement;
 use crate::dom::html::htmlpictureelement::HTMLPictureElement;
 use crate::dom::html::htmlsourceelement::HTMLSourceElement;
+use crate::dom::medialist::MediaList;
 use crate::dom::mouseevent::MouseEvent;
 use crate::dom::node::{BindContext, Node, NodeDamage, NodeTraits, ShadowIncluding, UnbindContext};
 use crate::dom::performanceresourcetiming::InitiatorType;
@@ -713,7 +714,7 @@ impl HTMLImageElement {
 
             // Step 4.6
             if let Some(x) = element.get_attribute(&ns!(), &local_name!("media")) {
-                if !elem.matches_environment(&x.value()) {
+                if !MediaList::matches_environment(&elem.owner_document(), &x.value()) {
                     continue;
                 }
             }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -339,7 +339,7 @@ impl VirtualMethods for HTMLLinkElement {
                 }
 
                 let matches_media_environment =
-                    self.upcast::<Element>().matches_environment(&attr.value());
+                    MediaList::matches_environment(&self.owner_document(), &attr.value());
                 self.previous_media_environment_matched
                     .set(matches_media_environment);
             },
@@ -573,7 +573,7 @@ impl HTMLLinkElement {
             None => "",
         };
 
-        if !element.matches_environment(mq_str) {
+        if !MediaList::matches_environment(&document, mq_str) {
             return;
         }
 


### PR DESCRIPTION
It more logically matches `MediaList`, and it allows us to
call this method with a document. This is required when
parsing Link headers, as they don't have an associated
element, but they do have a document.

Part of #35035