### PR TITLE
constellation: Optimize tracing of maybe_close_random_pipeline

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -5539,7 +5539,6 @@ where
     }
 
     // Randomly close a pipeline -if --random-pipeline-closure-probability is set
-    #[servo_tracing::instrument(skip_all)]
     fn maybe_close_random_pipeline(&mut self) {
         match self.random_pipeline_closure {
             Some((ref mut rng, probability)) => {


### PR DESCRIPTION
Most of the time this function does nothing and returns immediately, so there isn't really a point in tracing it.
If one wanted to know when a pipeline is closed, one could add a trace point **after** the early return.
However, during review it was suggested that we currently don't need this information and thus just remove the trace.

Testing: Not required.

