### PR TITLE
git: Mark `tests/blink_perf_tests` as linguist-vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto eol=lf
+tests/blink_perf_tests/** linguist-vendored
 tests/wpt/** linguist-vendored
 support/openharmony/**/*.ets linguist-language=ts
 


### PR DESCRIPTION
Hopefully this will make repo rust again.

Testing: No tests for .gitattributes
Fixes:
<img width="386" height="229" alt="slika" src="https://github.com/user-attachments/assets/7ad62390-21ef-4e66-ab71-ff26dddf22a1" />
