### PR TITLE
layout: Ensure IFC for abspos with inline-level original display

### DIFF
--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -15,6 +15,7 @@ use servo_arc::Arc;
 use style::dom::{NodeInfo, TNode};
 use style::properties::ComputedValues;
 use style::values::computed::Overflow;
+use style::values::specified::box_::DisplayOutside;
 use style_traits::CSSPixel;
 
 use crate::cell::ArcRefCell;
@@ -338,6 +339,12 @@ impl<'dom> IncrementalBoxTreeUpdate<'dom> {
                     BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(_)
                         if box_style.position.is_absolutely_positioned() =>
                     {
+                        // If the outer type of its original display changed from block to inline,
+                        // a block-level abspos needs to be placed in an inline formatting context,
+                        // see [`BlockContainerBuilder::handle_absolutely_positioned_element()`].
+                        if box_style.original_display.outside() == DisplayOutside::Inline {
+                            return None;
+                        }
                         DirtyRootBoxTreeNode::AbsolutelyPositionedBlockLevelBox(
                             block_level_box.clone(),
                         )

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -615,6 +615,12 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
                 return true;
             }
 
+            if new_box.position.is_absolutely_positioned() &&
+                old_box.original_display != new_box.original_display
+            {
+                return true;
+            }
+
             if old.get_font() != new.get_font() {
                 return true;
             }

--- a/tests/wpt/meta/css/css-position/position-absolute-dynamic-static-position-floats-001.html.ini
+++ b/tests/wpt/meta/css/css-position/position-absolute-dynamic-static-position-floats-001.html.ini
@@ -1,2 +1,0 @@
-[position-absolute-dynamic-static-position-floats-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/position-absolute-dynamic-static-position-floats-002.html.ini
+++ b/tests/wpt/meta/css/css-position/position-absolute-dynamic-static-position-floats-002.html.ini
@@ -1,2 +1,0 @@
-[position-absolute-dynamic-static-position-floats-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/position-absolute-dynamic-static-position-floats-003.html.ini
+++ b/tests/wpt/meta/css/css-position/position-absolute-dynamic-static-position-floats-003.html.ini
@@ -1,2 +1,0 @@
-[position-absolute-dynamic-static-position-floats-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/position-absolute-dynamic-static-position-floats-004.html.ini
+++ b/tests/wpt/meta/css/css-position/position-absolute-dynamic-static-position-floats-004.html.ini
@@ -1,2 +1,0 @@
-[position-absolute-dynamic-static-position-floats-004.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-001.html.ini
+++ b/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-001.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-002.html.ini
+++ b/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-002.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-002.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-003.html.ini
+++ b/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-003.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-005.html.ini
+++ b/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-005.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-005.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-006.html.ini
+++ b/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-006.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-006.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-008.html.ini
+++ b/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-008.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-008.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-009.html.ini
+++ b/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-009.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-009.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-010.html.ini
+++ b/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-010.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-010.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-011.html.ini
+++ b/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-011.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-011.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-012.html.ini
+++ b/tests/wpt/meta/css/css-position/static-position/inline-level-absolute-in-block-level-context-012.html.ini
@@ -1,2 +1,0 @@
-[inline-level-absolute-in-block-level-context-012.html]
-  expected: FAIL


### PR DESCRIPTION
Absolutely positioned elements get blockified, but their static position still depends on the original display. Therefore, if we encounter an abspos with an inline-level original display, we will now ensure that it's handled in an inline formatting context. This way its static position will correctly take into account things like `text-align`.

Testing: Several WPT tests are now passing.
Fixes: #39017
