### PR TITLE
script_bindings: Remove Cell wrapper from thread-local RootCollection.

### DIFF
--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -27,7 +27,6 @@
 use std::cell::{OnceCell, UnsafeCell};
 use std::default::Default;
 use std::hash::{Hash, Hasher};
-use std::marker::PhantomData;
 use std::{mem, ptr};
 
 use js::jsapi::{Heap, JSObject, JSTracer, Value};
@@ -42,21 +41,6 @@ use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::trace::JSTraceable;
 use crate::dom::node::Node;
-
-pub(crate) struct ThreadLocalStackRoots<'a>(PhantomData<&'a u32>);
-
-impl<'a> ThreadLocalStackRoots<'a> {
-    pub(crate) fn new(roots: &'a RootCollection) -> Self {
-        STACK_ROOTS.with(|r| r.set(Some(roots)));
-        ThreadLocalStackRoots(PhantomData)
-    }
-}
-
-impl Drop for ThreadLocalStackRoots<'_> {
-    fn drop(&mut self) {
-        STACK_ROOTS.with(|r| r.set(None));
-    }
-}
 
 pub(crate) trait ToLayout<T> {
     /// Returns `LayoutDom<T>` containing the same pointer.

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -40,7 +40,7 @@ use crate::dom::bindings::codegen::Bindings::WorkerBinding::WorkerType;
 use crate::dom::bindings::error::{ErrorInfo, ErrorResult};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{DomRoot, RootCollection, ThreadLocalStackRoots};
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::bindings::trace::{CustomTraceable, RootedTraceableBox};
@@ -395,9 +395,6 @@ impl DedicatedWorkerGlobalScope {
                 if let Some(webview_id) = webview_id {
                     WebViewId::install(webview_id);
                 }
-
-                let roots = RootCollection::new();
-                let _stack_roots = ThreadLocalStackRoots::new(&roots);
 
                 let WorkerScriptLoadOrigin {
                     referrer_url,

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -35,7 +35,7 @@ use crate::dom::bindings::codegen::Bindings::ServiceWorkerGlobalScopeBinding;
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerGlobalScopeBinding::ServiceWorkerGlobalScopeMethods;
 use crate::dom::bindings::codegen::Bindings::WorkerBinding::WorkerType;
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::root::{DomRoot, RootCollection, ThreadLocalStackRoots};
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::bindings::trace::CustomTraceable;
@@ -316,9 +316,6 @@ impl ServiceWorkerGlobalScope {
                 let runtime = Runtime::new(None);
                 let context_for_interrupt = runtime.thread_safe_js_context();
                 let _ = context_sender.send(context_for_interrupt);
-
-                let roots = RootCollection::new();
-                let _stack_roots = ThreadLocalStackRoots::new(&roots);
 
                 let WorkerScriptLoadOrigin {
                     referrer_url,

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -38,7 +38,7 @@ use crate::dom::bindings::error::Error;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::TrustedPromise;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
-use crate::dom::bindings::root::{Dom, DomRoot, RootCollection, ThreadLocalStackRoots};
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::USVString;
 use crate::dom::bindings::trace::{CustomTraceable, JSTraceable, RootedTraceableBox};
 use crate::dom::csp::Violation;
@@ -495,8 +495,6 @@ impl WorkletThread {
                 // TODO: configure the JS runtime (e.g. discourage GC, encourage agressive JIT)
                 debug!("Initializing worklet thread.");
                 thread_state::initialize(ThreadState::SCRIPT | ThreadState::IN_WORKER);
-                let roots = RootCollection::new();
-                let _stack_roots = ThreadLocalStackRoots::new(&roots);
                 let mut thread = RootedTraceableBox::new(WorkletThread {
                     role,
                     control_receiver,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -111,7 +111,7 @@ use crate::dom::bindings::conversions::{
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
-use crate::dom::bindings::root::{Dom, DomRoot, RootCollection, ThreadLocalStackRoots};
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::{HashMapTracedValues, JSTraceable};
@@ -415,8 +415,6 @@ impl ScriptThreadFactory for ScriptThread {
                 thread_state::initialize(ThreadState::SCRIPT | ThreadState::LAYOUT);
                 PipelineNamespace::install(state.pipeline_namespace_id);
                 WebViewId::install(state.webview_id);
-                let roots = RootCollection::new();
-                let _stack_roots = ThreadLocalStackRoots::new(&roots);
                 let memory_profiler_sender = state.memory_profiler_sender.clone();
 
                 let in_progress_load = InProgressLoad::new(


### PR DESCRIPTION
This doesn't appear to make a big difference in speedometer results, but this removes some code from the hot path of creating DomRoot values.

Before: `Score: 30.381097406624708 ± 2.0393225244958018`
After: `Score: 30.344639420871395 ± 1.9359337921154696`

Testing: Existing WPT coverage