### PR TITLE
servoshell: Hide information about outstanding threads by default.

### DIFF
--- a/ports/servoshell/platform/macos/mod.rs
+++ b/ports/servoshell/platform/macos/mod.rs
@@ -15,23 +15,23 @@ pub fn deinit(clean_shutdown: bool) {
     let thread_count = unsafe { macos_count_running_threads() };
 
     if thread_count != 1 {
-        println!(
+        log::debug!(
             "{} threads are still running after shutdown (bad).",
             thread_count
         );
         if clean_shutdown {
-            println!("Waiting until all threads have shutdown");
+            log::debug!("Waiting until all threads have shutdown");
             loop {
                 let thread_count = unsafe { macos_count_running_threads() };
                 if thread_count == 1 {
                     break;
                 }
                 thread::sleep(Duration::from_millis(1000));
-                println!("{} threads are still running.", thread_count);
+                log::debug!("{} threads are still running.", thread_count);
             }
         }
     } else {
-        println!("All threads have shutdown (good).");
+        log::debug!("All threads have shutdown (good).");
     }
 }
 


### PR DESCRIPTION
This output doesn't matter to most developers and testers, and it breaks `./mach test-speedometer`. Let's hide it by default and add a flag to opt in.

Testing: No testing for debug output.