### PR TITLE
Remove unnecessary deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -185,11 +185,6 @@ skip = [
     # Can be removed if `icu_capi` exposes the C include dir via the `DEP_`
     # variable in the future.
     "ordered-float",
-
-    # duplicated by image 0.25
-    "cfg-expr",
-    "system-deps",
-    "target-lexicon",
 ]
 
 # github.com organizations to allow git sources for


### PR DESCRIPTION
I ran `cargo deny check` and these showed up as unnecessary.

Testing: None