### PR TITLE
layout: Refactor `InlineFormattingContextBuilder::is_empty`

### DIFF
--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -588,7 +588,7 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
         box_slot: BoxSlot<'dom>,
     ) {
         if let Some(builder) = self.inline_formatting_context_builder.as_mut() {
-            if !builder.is_empty() {
+            if !builder.is_empty {
                 let constructor = || {
                     ArcRefCell::new(AbsolutelyPositionedBox::construct(
                         self.context,
@@ -625,7 +625,7 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
         box_slot: BoxSlot<'dom>,
     ) {
         if let Some(builder) = self.inline_formatting_context_builder.as_mut() {
-            if !builder.is_empty() {
+            if !builder.is_empty {
                 let constructor = || {
                     ArcRefCell::new(FloatBox::construct(
                         self.context,


### PR DESCRIPTION
This method could iterate all the items in the inline formatting context that was being created. This patch turns it into a field, replacing `has_uncollapsible_text_content` (so this doesn't increase memory).

Testing: Not needed, no behavior change
