### PR TITLE
webcrypto: implement raw hmac export

### DIFF
--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/hkdf.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/hkdf.https.any.js.ini
@@ -2,13 +2,7 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -755,25 +749,13 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -854,25 +836,13 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -1645,25 +1615,13 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -1744,25 +1702,13 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -2418,13 +2364,7 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -3171,25 +3111,13 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -3270,25 +3198,13 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -3461,25 +3377,13 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -3560,25 +3464,13 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -4325,25 +4217,13 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -4424,25 +4304,13 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -5491,25 +5359,13 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -5590,25 +5446,13 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -6399,25 +6243,13 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -6498,25 +6330,13 @@
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -7263,25 +7083,13 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -7362,25 +7170,13 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -8168,25 +7964,13 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -8267,25 +8051,13 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -9032,25 +8804,13 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -9131,13 +8891,7 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-512, with empty info with 0 length]
@@ -9658,25 +9412,13 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -9757,25 +9499,13 @@
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -10522,25 +10252,13 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -10621,13 +10339,7 @@
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
   [long derivedKey, empty salt, SHA-512, with empty info with 0 length]

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js.ini
@@ -1,17 +1,8 @@
 [pbkdf2.https.any.html?3001-4000]
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -74,25 +65,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -164,25 +143,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -245,25 +212,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -317,25 +272,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -398,25 +341,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -470,25 +401,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -542,25 +461,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -623,25 +530,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -695,25 +590,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -767,25 +650,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -848,25 +719,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -920,25 +779,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -1117,25 +964,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -1198,25 +1033,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -1270,25 +1093,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -1342,25 +1153,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -1423,25 +1222,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -1495,25 +1282,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -1576,25 +1351,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -1666,25 +1429,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -1747,25 +1498,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -1828,25 +1567,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -1918,25 +1645,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -1999,25 +1714,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -2080,25 +1783,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -2238,25 +1929,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -2319,25 +1998,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -2400,25 +2067,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -2490,25 +2145,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -2571,25 +2214,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -2652,25 +2283,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -2742,25 +2361,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -2823,25 +2430,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -2904,25 +2499,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -2994,25 +2577,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -3075,25 +2646,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -3156,25 +2715,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -3246,19 +2793,10 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [empty password, short salt, SHA-512, with 1000 iterations with 0 length]
@@ -3347,25 +2885,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -3428,25 +2954,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -3518,25 +3032,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -3599,25 +3101,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -3680,25 +3170,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -3770,25 +3248,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -3851,25 +3317,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -3932,25 +3386,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -4022,25 +3464,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -4103,25 +3533,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -4184,25 +3602,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -4274,25 +3680,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -4353,9 +3747,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -4432,25 +3823,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -4513,25 +3892,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -4603,25 +3970,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -4684,25 +4039,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -4765,25 +4108,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -4855,25 +4186,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -4936,25 +4255,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -5017,25 +4324,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -5115,25 +4410,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -5205,25 +4488,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -5286,25 +4557,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -5367,25 +4626,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -5457,25 +4704,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -5538,25 +4773,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -5619,25 +4842,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -5709,25 +4920,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -5790,25 +4989,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -5871,25 +5058,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -5961,25 +5136,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -6042,25 +5205,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -6123,25 +5274,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -6227,25 +5366,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -6308,25 +5435,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -6389,25 +5504,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -6479,25 +5582,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -6560,25 +5651,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -6641,25 +5720,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -6731,25 +5798,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -6812,25 +5867,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -6893,25 +5936,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -6983,25 +6014,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -7064,25 +6083,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -7145,25 +6152,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -7235,19 +6230,10 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [empty password, short salt, SHA-512, with 1000 iterations with 0 length]
@@ -7306,25 +6292,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -7387,25 +6361,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -7468,25 +6430,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -7558,25 +6508,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -7639,25 +6577,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -7720,25 +6646,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -7810,25 +6724,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -7891,25 +6793,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -7972,25 +6862,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -8062,25 +6940,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -8143,25 +7009,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -8224,25 +7078,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -8314,25 +7156,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -8409,25 +7239,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -8490,25 +7308,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -8571,25 +7377,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -8661,25 +7455,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -8742,25 +7524,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -8823,25 +7593,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -8913,25 +7671,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -8994,25 +7740,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -9075,25 +7809,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -9165,25 +7887,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -9246,25 +7956,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -9327,25 +8025,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -9417,25 +8103,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -9560,25 +8234,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -9641,25 +8303,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -9722,25 +8372,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -9812,25 +8450,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -9893,25 +8519,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -9974,25 +8588,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -10064,25 +8666,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -10145,25 +8735,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -10226,25 +8804,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -10316,25 +8882,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -10397,25 +8951,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -10478,25 +9020,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -10624,25 +9154,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -10705,25 +9223,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -10786,25 +9292,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -10876,25 +9370,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -10957,25 +9439,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -11038,25 +9508,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -11128,25 +9586,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -11209,25 +9655,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -11290,25 +9724,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -11380,25 +9802,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -11461,25 +9871,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -11542,25 +9940,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -11658,9 +10044,6 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -11721,25 +10104,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -11802,25 +10173,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -11892,25 +10251,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -11973,25 +10320,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -12054,25 +10389,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -12144,25 +10467,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -12225,25 +10536,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -12306,25 +10605,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -12396,25 +10683,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -12477,25 +10752,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -12558,25 +10821,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -12648,25 +10899,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -12740,9 +10979,6 @@
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -12803,25 +11039,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -12884,25 +11108,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -12974,25 +11186,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -13055,25 +11255,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -13136,25 +11324,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -13226,25 +11402,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -13307,25 +11471,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -13388,25 +11540,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -13478,25 +11618,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -13559,25 +11687,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -13640,25 +11756,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -13730,25 +11834,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -13819,19 +11911,10 @@
 
 
 [pbkdf2.https.any.worker.html?3001-4000]
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -13894,25 +11977,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -13984,25 +12055,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -14065,25 +12124,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -14146,25 +12193,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -14236,25 +12271,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -14317,25 +12340,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -14398,25 +12409,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -14488,25 +12487,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -14569,25 +12556,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -14650,25 +12625,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -14740,25 +12703,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -14821,25 +12772,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -14955,25 +12894,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -15036,25 +12963,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -15126,25 +13041,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -15207,25 +13110,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -15288,25 +13179,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -15378,25 +13257,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -15459,25 +13326,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -15540,25 +13395,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -15630,25 +13473,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -15711,25 +13542,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -15792,25 +13611,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -15882,25 +13689,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -15961,9 +13756,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -16040,25 +13832,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -16121,25 +13901,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -16211,25 +13979,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -16292,25 +14048,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -16373,25 +14117,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -16463,25 +14195,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -16544,25 +14264,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -16625,25 +14333,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -16750,25 +14446,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -16831,25 +14515,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -16912,25 +14584,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -17002,25 +14662,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -17083,25 +14731,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -17164,25 +14800,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -17254,25 +14878,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -17335,25 +14947,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -17416,25 +15016,13 @@
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -17506,25 +15094,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -17587,25 +15163,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -17668,25 +15232,13 @@
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -17814,25 +15366,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -17895,25 +15435,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -17976,25 +15504,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -18066,25 +15582,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -18147,25 +15651,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -18228,25 +15720,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -18318,25 +15798,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -18399,25 +15867,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -18480,25 +15936,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -18570,25 +16014,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -18651,25 +16083,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -18732,25 +16152,13 @@
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 100000 iterations]
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]


### PR DESCRIPTION
Implement raw export of HMAC keys. JWT export of HMAC keys will come in a separate PR.

Testing: WPT
Fixes: Partially #39060