### PR TITLE
Split subtlecrypto.rs

### DIFF
--- a/components/script/crypto.rs
+++ b/components/script/crypto.rs
@@ -1,0 +1,930 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use aes::{Aes128, Aes192, Aes256};
+use aes_gcm::AesGcm;
+use aes_gcm::aead::consts::{U12, U16, U32};
+use aws_lc_rs::{digest, hmac};
+use base64::Engine;
+use js::conversions::ConversionResult;
+use js::gc::MutableHandleObject;
+use js::jsval::ObjectValue;
+use params::{
+    SubtleAesCbcParams, SubtleAesCtrParams, SubtleAesGcmParams, SubtleAesKeyGenParams,
+    SubtleHkdfParams, SubtleHmacImportParams, SubtleHmacKeyGenParams, SubtlePbkdf2Params,
+};
+use script_bindings::codegen::GenericBindings::CryptoKeyBinding::{CryptoKeyMethods, KeyUsage};
+use script_bindings::codegen::GenericBindings::SubtleCryptoBinding::KeyFormat;
+use script_bindings::error::Error;
+use script_bindings::root::DomRoot;
+use script_bindings::script_runtime::{CanGc, JSContext};
+use script_bindings::str::DOMString;
+
+use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::{
+    AesCbcParams, AesCtrParams, AesDerivedKeyParams, AesGcmParams, AesKeyAlgorithm,
+    AesKeyGenParams, Algorithm, AlgorithmIdentifier, HkdfParams, HmacImportParams,
+    HmacKeyAlgorithm, HmacKeyGenParams, KeyAlgorithm, Pbkdf2Params,
+};
+use crate::dom::cryptokey::CryptoKey;
+use crate::dom::subtlecrypto::SubtleCrypto;
+
+pub(crate) mod params;
+
+// String constants for algorithms/curves
+pub(crate) const ALG_AES_CBC: &str = "AES-CBC";
+pub(crate) const ALG_AES_CTR: &str = "AES-CTR";
+pub(crate) const ALG_AES_GCM: &str = "AES-GCM";
+pub(crate) const ALG_AES_KW: &str = "AES-KW";
+pub(crate) const ALG_SHA1: &str = "SHA-1";
+pub(crate) const ALG_SHA256: &str = "SHA-256";
+pub(crate) const ALG_SHA384: &str = "SHA-384";
+pub(crate) const ALG_SHA512: &str = "SHA-512";
+pub(crate) const ALG_HMAC: &str = "HMAC";
+pub(crate) const ALG_HKDF: &str = "HKDF";
+pub(crate) const ALG_PBKDF2: &str = "PBKDF2";
+pub(crate) const ALG_RSASSA_PKCS1: &str = "RSASSA-PKCS1-v1_5";
+pub(crate) const ALG_RSA_OAEP: &str = "RSA-OAEP";
+pub(crate) const ALG_RSA_PSS: &str = "RSA-PSS";
+pub(crate) const ALG_ECDH: &str = "ECDH";
+pub(crate) const ALG_ECDSA: &str = "ECDSA";
+
+#[allow(dead_code)]
+pub(crate) static SUPPORTED_ALGORITHMS: &[&str] = &[
+    ALG_AES_CBC,
+    ALG_AES_CTR,
+    ALG_AES_GCM,
+    ALG_AES_KW,
+    ALG_SHA1,
+    ALG_SHA256,
+    ALG_SHA384,
+    ALG_SHA512,
+    ALG_HMAC,
+    ALG_HKDF,
+    ALG_PBKDF2,
+    ALG_RSASSA_PKCS1,
+    ALG_RSA_OAEP,
+    ALG_RSA_PSS,
+    ALG_ECDH,
+    ALG_ECDSA,
+];
+
+pub(crate) const NAMED_CURVE_P256: &str = "P-256";
+pub(crate) const NAMED_CURVE_P384: &str = "P-384";
+pub(crate) const NAMED_CURVE_P521: &str = "P-521";
+#[allow(dead_code)]
+pub(crate) static SUPPORTED_CURVES: &[&str] =
+    &[NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521];
+
+pub(crate) type Aes128CbcEnc = cbc::Encryptor<Aes128>;
+pub(crate) type Aes128CbcDec = cbc::Decryptor<Aes128>;
+pub(crate) type Aes192CbcEnc = cbc::Encryptor<Aes192>;
+pub(crate) type Aes192CbcDec = cbc::Decryptor<Aes192>;
+pub(crate) type Aes256CbcEnc = cbc::Encryptor<Aes256>;
+pub(crate) type Aes256CbcDec = cbc::Decryptor<Aes256>;
+pub(crate) type Aes128Ctr = ctr::Ctr64BE<Aes128>;
+pub(crate) type Aes192Ctr = ctr::Ctr64BE<Aes192>;
+pub(crate) type Aes256Ctr = ctr::Ctr64BE<Aes256>;
+
+pub(crate) type Aes128Gcm96Iv = AesGcm<Aes128, U12>;
+pub(crate) type Aes128Gcm128Iv = AesGcm<Aes128, U16>;
+pub(crate) type Aes192Gcm96Iv = AesGcm<Aes192, U12>;
+pub(crate) type Aes256Gcm96Iv = AesGcm<Aes256, U12>;
+pub(crate) type Aes128Gcm256Iv = AesGcm<Aes128, U32>;
+pub(crate) type Aes192Gcm256Iv = AesGcm<Aes192, U32>;
+pub(crate) type Aes256Gcm256Iv = AesGcm<Aes256, U32>;
+
+// These "subtle" structs are proxies for the codegen'd dicts which don't hold a DOMString
+// so they can be sent safely when running steps in parallel.
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub(crate) struct SubtleAlgorithm {
+    #[allow(dead_code)]
+    pub(crate) name: String,
+}
+
+impl From<DOMString> for SubtleAlgorithm {
+    fn from(name: DOMString) -> Self {
+        SubtleAlgorithm {
+            name: name.to_string(),
+        }
+    }
+}
+
+pub(crate) enum GetKeyLengthAlgorithm {
+    Aes(u16),
+    Hmac(SubtleHmacImportParams),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum DigestAlgorithm {
+    /// <https://w3c.github.io/webcrypto/#sha>
+    Sha1,
+
+    /// <https://w3c.github.io/webcrypto/#sha>
+    Sha256,
+
+    /// <https://w3c.github.io/webcrypto/#sha>
+    Sha384,
+
+    /// <https://w3c.github.io/webcrypto/#sha>
+    Sha512,
+}
+
+/// A normalized algorithm returned by [`normalize_algorithm`] with operation `"importKey"`
+///
+/// [`normalize_algorithm`]: https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm
+#[derive(Clone)]
+pub(crate) enum ImportKeyAlgorithm {
+    AesCbc,
+    AesCtr,
+    AesKw,
+    AesGcm,
+    Hmac(SubtleHmacImportParams),
+    Pbkdf2,
+    Hkdf,
+}
+
+/// A normalized algorithm returned by [`normalize_algorithm`] with operation `"deriveBits"`
+///
+/// [`normalize_algorithm`]: https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm
+pub(crate) enum DeriveBitsAlgorithm {
+    Pbkdf2(SubtlePbkdf2Params),
+    Hkdf(SubtleHkdfParams),
+}
+
+/// A normalized algorithm returned by [`normalize_algorithm`] with operation `"encrypt"` or `"decrypt"`
+///
+/// [`normalize_algorithm`]: https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum EncryptionAlgorithm {
+    AesCbc(SubtleAesCbcParams),
+    AesCtr(SubtleAesCtrParams),
+    AesGcm(SubtleAesGcmParams),
+}
+
+/// A normalized algorithm returned by [`normalize_algorithm`] with operation `"sign"` or `"verify"`
+///
+/// [`normalize_algorithm`]: https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm
+pub(crate) enum SignatureAlgorithm {
+    Hmac,
+}
+
+/// A normalized algorithm returned by [`normalize_algorithm`] with operation `"generateKey"`
+///
+/// [`normalize_algorithm`]: https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm
+pub(crate) enum KeyGenerationAlgorithm {
+    Aes(SubtleAesKeyGenParams),
+    Hmac(SubtleHmacKeyGenParams),
+}
+
+/// A normalized algorithm returned by [`normalize_algorithm`] with operation `"wrapKey"` or `"unwrapKey"`
+///
+/// [`normalize_algorithm`]: https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum KeyWrapAlgorithm {
+    AesKw,
+    AesCbc(SubtleAesCbcParams),
+    AesCtr(SubtleAesCtrParams),
+    AesGcm(SubtleAesGcmParams),
+}
+
+macro_rules! value_from_js_object {
+    ($t: ty, $cx: ident, $value: ident) => {{
+        let params_result = <$t>::new($cx, $value.handle()).map_err(|_| Error::JSFailed)?;
+        let ConversionResult::Success(params) = params_result else {
+            return Err(Error::Syntax);
+        };
+        params
+    }};
+}
+
+pub(crate) trait AlgorithmFromName {
+    fn from_name(name: DOMString, out: MutableHandleObject, cx: JSContext);
+}
+
+impl AlgorithmFromName for KeyAlgorithm {
+    /// Fill the object referenced by `out` with an [KeyAlgorithm]
+    /// of the specified name and size.
+    #[allow(unsafe_code)]
+    fn from_name(name: DOMString, out: MutableHandleObject, cx: JSContext) {
+        let key_algorithm = Self { name };
+
+        unsafe {
+            key_algorithm.to_jsobject(*cx, out);
+        }
+    }
+}
+
+pub(crate) trait AlgorithmFromLengthAndHash {
+    fn from_length_and_hash(
+        length: u32,
+        hash: DigestAlgorithm,
+        out: MutableHandleObject,
+        cx: JSContext,
+    );
+}
+
+impl AlgorithmFromLengthAndHash for HmacKeyAlgorithm {
+    #[allow(unsafe_code)]
+    fn from_length_and_hash(
+        length: u32,
+        hash: DigestAlgorithm,
+        out: MutableHandleObject,
+        cx: JSContext,
+    ) {
+        let hmac_key_algorithm = Self {
+            parent: KeyAlgorithm {
+                name: ALG_HMAC.into(),
+            },
+            length,
+            hash: KeyAlgorithm { name: hash.name() },
+        };
+
+        unsafe {
+            hmac_key_algorithm.to_jsobject(*cx, out);
+        }
+    }
+}
+
+pub(crate) trait AlgorithmFromNameAndSize {
+    fn from_name_and_size(name: DOMString, size: u16, out: MutableHandleObject, cx: JSContext);
+}
+
+impl AlgorithmFromNameAndSize for AesKeyAlgorithm {
+    /// Fill the object referenced by `out` with an [AesKeyAlgorithm]
+    /// of the specified name and size.
+    #[allow(unsafe_code)]
+    fn from_name_and_size(name: DOMString, size: u16, out: MutableHandleObject, cx: JSContext) {
+        let key_algorithm = Self {
+            parent: KeyAlgorithm { name },
+            length: size,
+        };
+
+        unsafe {
+            key_algorithm.to_jsobject(*cx, out);
+        }
+    }
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-ctr-operations>
+pub(crate) fn get_key_length_for_aes(length: u16) -> Result<u32, Error> {
+    // Step 1. If the length member of normalizedDerivedKeyAlgorithm is not 128, 192 or 256,
+    // then throw an OperationError.
+    if !matches!(length, 128 | 192 | 256) {
+        return Err(Error::Operation);
+    }
+
+    // Step 2. Return the length member of normalizedDerivedKeyAlgorithm.
+    Ok(length as u32)
+}
+
+impl GetKeyLengthAlgorithm {
+    pub(crate) fn get_key_length(&self) -> Result<u32, Error> {
+        match self {
+            Self::Aes(length) => get_key_length_for_aes(*length),
+            Self::Hmac(params) => params.get_key_length(),
+        }
+    }
+}
+
+impl DigestAlgorithm {
+    /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
+    pub(crate) fn name(&self) -> DOMString {
+        match self {
+            Self::Sha1 => ALG_SHA1,
+            Self::Sha256 => ALG_SHA256,
+            Self::Sha384 => ALG_SHA384,
+            Self::Sha512 => ALG_SHA512,
+        }
+        .into()
+    }
+
+    pub(crate) fn digest(&self, data: &[u8]) -> Result<impl AsRef<[u8]>, Error> {
+        let algorithm = match self {
+            Self::Sha1 => &digest::SHA1_FOR_LEGACY_USE_ONLY,
+            Self::Sha256 => &digest::SHA256,
+            Self::Sha384 => &digest::SHA384,
+            Self::Sha512 => &digest::SHA512,
+        };
+        Ok(digest::digest(algorithm, data))
+    }
+
+    pub(crate) fn block_size_in_bits(&self) -> usize {
+        match self {
+            Self::Sha1 => 160,
+            Self::Sha256 => 256,
+            Self::Sha384 => 384,
+            Self::Sha512 => 512,
+        }
+    }
+}
+
+impl ImportKeyAlgorithm {
+    pub(crate) fn import_key(
+        &self,
+        subtle: &SubtleCrypto,
+        format: KeyFormat,
+        secret: &[u8],
+        extractable: bool,
+        key_usages: Vec<KeyUsage>,
+        can_gc: CanGc,
+    ) -> Result<DomRoot<CryptoKey>, Error> {
+        match self {
+            Self::AesCbc => {
+                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_CBC, can_gc)
+            },
+            Self::AesCtr => {
+                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_CTR, can_gc)
+            },
+            Self::AesKw => {
+                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_KW, can_gc)
+            },
+            Self::AesGcm => {
+                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_GCM, can_gc)
+            },
+            Self::Hmac(params) => {
+                subtle.import_key_hmac(params, format, secret, extractable, key_usages, can_gc)
+            },
+            Self::Pbkdf2 => {
+                subtle.import_key_pbkdf2(format, secret, extractable, key_usages, can_gc)
+            },
+            Self::Hkdf => subtle.import_key_hkdf(format, secret, extractable, key_usages, can_gc),
+        }
+    }
+}
+
+impl DeriveBitsAlgorithm {
+    pub(crate) fn derive_bits(
+        &self,
+        key: &CryptoKey,
+        length: Option<u32>,
+    ) -> Result<Vec<u8>, Error> {
+        match self {
+            Self::Pbkdf2(pbkdf2_params) => pbkdf2_params.derive_bits(key, length),
+            Self::Hkdf(hkdf_params) => hkdf_params.derive_bits(key, length),
+        }
+    }
+}
+
+impl EncryptionAlgorithm {
+    /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            Self::AesCbc(params) => &params.name,
+            Self::AesCtr(params) => &params.name,
+            Self::AesGcm(params) => &params.name,
+        }
+    }
+
+    // FIXME: This doesn't really need the "SubtleCrypto" argument
+    pub(crate) fn encrypt(
+        &self,
+        subtle: &SubtleCrypto,
+        key: &CryptoKey,
+        data: &[u8],
+        cx: JSContext,
+        result: MutableHandleObject,
+        can_gc: CanGc,
+    ) -> Result<Vec<u8>, Error> {
+        match self {
+            Self::AesCbc(params) => subtle.encrypt_aes_cbc(params, key, data, cx, result, can_gc),
+            Self::AesCtr(params) => {
+                subtle.encrypt_decrypt_aes_ctr(params, key, data, cx, result, can_gc)
+            },
+            Self::AesGcm(params) => subtle.encrypt_aes_gcm(params, key, data, cx, result, can_gc),
+        }
+    }
+
+    // FIXME: This doesn't really need the "SubtleCrypto" argument
+    pub(crate) fn decrypt(
+        &self,
+        subtle: &SubtleCrypto,
+        key: &CryptoKey,
+        data: &[u8],
+        cx: JSContext,
+        result: MutableHandleObject,
+        can_gc: CanGc,
+    ) -> Result<Vec<u8>, Error> {
+        match self {
+            Self::AesCbc(params) => subtle.decrypt_aes_cbc(params, key, data, cx, result, can_gc),
+            Self::AesCtr(params) => {
+                subtle.encrypt_decrypt_aes_ctr(params, key, data, cx, result, can_gc)
+            },
+            Self::AesGcm(params) => subtle.decrypt_aes_gcm(params, key, data, cx, result, can_gc),
+        }
+    }
+}
+
+impl SignatureAlgorithm {
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            Self::Hmac => ALG_HMAC,
+        }
+    }
+
+    pub(crate) fn sign(
+        &self,
+        cx: JSContext,
+        key: &CryptoKey,
+        data: &[u8],
+    ) -> Result<Vec<u8>, Error> {
+        match self {
+            Self::Hmac => sign_hmac(cx, key, data).map(|s| s.as_ref().to_vec()),
+        }
+    }
+
+    pub(crate) fn verify(
+        &self,
+        cx: JSContext,
+        key: &CryptoKey,
+        data: &[u8],
+        signature: &[u8],
+    ) -> Result<bool, Error> {
+        match self {
+            Self::Hmac => verify_hmac(cx, key, data, signature),
+        }
+    }
+}
+
+impl KeyGenerationAlgorithm {
+    // FIXME: This doesn't really need the "SubtleCrypto" argument
+    pub(crate) fn generate_key(
+        &self,
+        subtle: &SubtleCrypto,
+        usages: Vec<KeyUsage>,
+        extractable: bool,
+        can_gc: CanGc,
+    ) -> Result<DomRoot<CryptoKey>, Error> {
+        match self {
+            Self::Aes(params) => subtle.generate_key_aes(usages, params, extractable, can_gc),
+            Self::Hmac(params) => subtle.generate_key_hmac(usages, params, extractable, can_gc),
+        }
+    }
+}
+
+/// <https://w3c.github.io/webcrypto/#hmac-operations>
+pub(crate) fn sign_hmac(
+    cx: JSContext,
+    key: &CryptoKey,
+    data: &[u8],
+) -> Result<impl AsRef<[u8]>, Error> {
+    // Step 1. Let mac be the result of performing the MAC Generation operation described in Section 4 of [FIPS-198-1]
+    // using the key represented by [[handle]] internal slot of key, the hash function identified by the hash attribute
+    // of the [[algorithm]] internal slot of key and message as the input data text.
+    rooted!(in(*cx) let mut algorithm_slot = ObjectValue(key.Algorithm(cx).as_ptr()));
+    let params = value_from_js_object!(HmacKeyAlgorithm, cx, algorithm_slot);
+
+    let hash_algorithm = match params.hash.name.str() {
+        ALG_SHA1 => hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
+        ALG_SHA256 => hmac::HMAC_SHA256,
+        ALG_SHA384 => hmac::HMAC_SHA384,
+        ALG_SHA512 => hmac::HMAC_SHA512,
+        _ => return Err(Error::NotSupported),
+    };
+
+    let sign_key = hmac::Key::new(hash_algorithm, key.handle().as_bytes());
+    let mac = hmac::sign(&sign_key, data);
+
+    // Step 2. Return the result of creating an ArrayBuffer containing mac.
+    // NOTE: This is done by the caller
+    Ok(mac)
+}
+
+/// <https://w3c.github.io/webcrypto/#hmac-operations>
+pub(crate) fn verify_hmac(
+    cx: JSContext,
+    key: &CryptoKey,
+    data: &[u8],
+    signature: &[u8],
+) -> Result<bool, Error> {
+    // Step 1. Let mac be the result of performing the MAC Generation operation described in Section 4 of [FIPS-198-1]
+    // using the key represented by [[handle]] internal slot of key, the hash function identified by the hash attribute
+    // of the [[algorithm]] internal slot of key and message as the input data text.
+    let mac = sign_hmac(cx, key, data)?;
+
+    // Step 2. Return true if mac is equal to signature and false otherwise.
+    let is_valid = mac.as_ref() == signature;
+    Ok(is_valid)
+}
+
+impl KeyWrapAlgorithm {
+    /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            Self::AesKw => ALG_AES_KW,
+            Self::AesCbc(key_gen_params) => &key_gen_params.name,
+            Self::AesCtr(key_gen_params) => &key_gen_params.name,
+            Self::AesGcm(_) => ALG_AES_GCM,
+        }
+    }
+}
+
+/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"get key length"`
+pub(crate) fn normalize_algorithm_for_get_key_length(
+    cx: JSContext,
+    algorithm: &AlgorithmIdentifier,
+) -> Result<GetKeyLengthAlgorithm, Error> {
+    match algorithm {
+        AlgorithmIdentifier::Object(obj) => {
+            rooted!(in(*cx) let value = ObjectValue(obj.get()));
+            let algorithm = value_from_js_object!(Algorithm, cx, value);
+
+            let name = algorithm.name.str();
+            let normalized_algorithm = if name.eq_ignore_ascii_case(ALG_AES_CBC) ||
+                name.eq_ignore_ascii_case(ALG_AES_CTR) ||
+                name.eq_ignore_ascii_case(ALG_AES_GCM)
+            {
+                let params = value_from_js_object!(AesDerivedKeyParams, cx, value);
+                GetKeyLengthAlgorithm::Aes(params.length)
+            } else if name.eq_ignore_ascii_case(ALG_HMAC) {
+                let params = value_from_js_object!(HmacImportParams, cx, value);
+                let subtle_params = SubtleHmacImportParams::new(cx, params)?;
+                return Ok(GetKeyLengthAlgorithm::Hmac(subtle_params));
+            } else {
+                return Err(Error::NotSupported);
+            };
+
+            Ok(normalized_algorithm)
+        },
+        AlgorithmIdentifier::String(_) => {
+            // All algorithms that support "get key length" require additional parameters
+            Err(Error::NotSupported)
+        },
+    }
+}
+
+/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"digest"`
+pub(crate) fn normalize_algorithm_for_digest(
+    cx: JSContext,
+    algorithm: &AlgorithmIdentifier,
+) -> Result<DigestAlgorithm, Error> {
+    let name = match algorithm {
+        AlgorithmIdentifier::Object(obj) => {
+            rooted!(in(*cx) let value = ObjectValue(obj.get()));
+            let algorithm = value_from_js_object!(Algorithm, cx, value);
+
+            algorithm.name.str().to_uppercase()
+        },
+        AlgorithmIdentifier::String(name) => name.str().to_uppercase(),
+    };
+
+    let normalized_algorithm = match name.as_str() {
+        ALG_SHA1 => DigestAlgorithm::Sha1,
+        ALG_SHA256 => DigestAlgorithm::Sha256,
+        ALG_SHA384 => DigestAlgorithm::Sha384,
+        ALG_SHA512 => DigestAlgorithm::Sha512,
+        _ => return Err(Error::NotSupported),
+    };
+
+    Ok(normalized_algorithm)
+}
+
+/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"importKey"`
+pub(crate) fn normalize_algorithm_for_import_key(
+    cx: JSContext,
+    algorithm: &AlgorithmIdentifier,
+) -> Result<ImportKeyAlgorithm, Error> {
+    let name = match algorithm {
+        AlgorithmIdentifier::Object(obj) => {
+            rooted!(in(*cx) let value = ObjectValue(obj.get()));
+            let algorithm = value_from_js_object!(Algorithm, cx, value);
+
+            let name = algorithm.name.str().to_uppercase();
+            if name == ALG_HMAC {
+                let params = value_from_js_object!(HmacImportParams, cx, value);
+                let subtle_params = SubtleHmacImportParams::new(cx, params)?;
+                return Ok(ImportKeyAlgorithm::Hmac(subtle_params));
+            }
+
+            name
+        },
+        AlgorithmIdentifier::String(name) => name.str().to_uppercase(),
+    };
+
+    let normalized_algorithm = match name.as_str() {
+        ALG_AES_CBC => ImportKeyAlgorithm::AesCbc,
+        ALG_AES_CTR => ImportKeyAlgorithm::AesCtr,
+        ALG_AES_KW => ImportKeyAlgorithm::AesKw,
+        ALG_AES_GCM => ImportKeyAlgorithm::AesGcm,
+        ALG_PBKDF2 => ImportKeyAlgorithm::Pbkdf2,
+        ALG_HKDF => ImportKeyAlgorithm::Hkdf,
+        _ => return Err(Error::NotSupported),
+    };
+
+    Ok(normalized_algorithm)
+}
+
+/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"deriveBits"`
+pub(crate) fn normalize_algorithm_for_derive_bits(
+    cx: JSContext,
+    algorithm: &AlgorithmIdentifier,
+) -> Result<DeriveBitsAlgorithm, Error> {
+    let AlgorithmIdentifier::Object(obj) = algorithm else {
+        // All algorithms that support "deriveBits" require additional parameters
+        return Err(Error::NotSupported);
+    };
+
+    rooted!(in(*cx) let value = ObjectValue(obj.get()));
+    let algorithm = value_from_js_object!(Algorithm, cx, value);
+
+    let normalized_algorithm = if algorithm.name.str().eq_ignore_ascii_case(ALG_PBKDF2) {
+        let params = value_from_js_object!(Pbkdf2Params, cx, value);
+        let subtle_params = SubtlePbkdf2Params::new(cx, params)?;
+        DeriveBitsAlgorithm::Pbkdf2(subtle_params)
+    } else if algorithm.name.str().eq_ignore_ascii_case(ALG_HKDF) {
+        let params = value_from_js_object!(HkdfParams, cx, value);
+        let subtle_params = SubtleHkdfParams::new(cx, params)?;
+        DeriveBitsAlgorithm::Hkdf(subtle_params)
+    } else {
+        return Err(Error::NotSupported);
+    };
+
+    Ok(normalized_algorithm)
+}
+
+/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"deriveBits"`
+pub(crate) fn normalize_algorithm_for_encrypt_or_decrypt(
+    cx: JSContext,
+    algorithm: &AlgorithmIdentifier,
+) -> Result<EncryptionAlgorithm, Error> {
+    let AlgorithmIdentifier::Object(obj) = algorithm else {
+        // All algorithms that support "encrypt" or "decrypt" require additional parameters
+        return Err(Error::NotSupported);
+    };
+
+    rooted!(in(*cx) let value = ObjectValue(obj.get()));
+    let algorithm = value_from_js_object!(Algorithm, cx, value);
+
+    let name = algorithm.name.str();
+    let normalized_algorithm = if name.eq_ignore_ascii_case(ALG_AES_CBC) {
+        let params = value_from_js_object!(AesCbcParams, cx, value);
+        EncryptionAlgorithm::AesCbc(params.into())
+    } else if name.eq_ignore_ascii_case(ALG_AES_CTR) {
+        let params = value_from_js_object!(AesCtrParams, cx, value);
+        EncryptionAlgorithm::AesCtr(params.into())
+    } else if name.eq_ignore_ascii_case(ALG_AES_GCM) {
+        let params = value_from_js_object!(AesGcmParams, cx, value);
+        EncryptionAlgorithm::AesGcm(params.into())
+    } else {
+        return Err(Error::NotSupported);
+    };
+
+    Ok(normalized_algorithm)
+}
+
+/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"sign"`
+/// or `"verify"`
+pub(crate) fn normalize_algorithm_for_sign_or_verify(
+    cx: JSContext,
+    algorithm: &AlgorithmIdentifier,
+) -> Result<SignatureAlgorithm, Error> {
+    let name = match algorithm {
+        AlgorithmIdentifier::Object(obj) => {
+            rooted!(in(*cx) let value = ObjectValue(obj.get()));
+            let algorithm = value_from_js_object!(Algorithm, cx, value);
+
+            algorithm.name.str().to_uppercase()
+        },
+        AlgorithmIdentifier::String(name) => name.str().to_uppercase(),
+    };
+
+    let normalized_algorithm = match name.as_str() {
+        ALG_HMAC => SignatureAlgorithm::Hmac,
+        _ => return Err(Error::NotSupported),
+    };
+
+    Ok(normalized_algorithm)
+}
+
+/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"generateKey"`
+pub(crate) fn normalize_algorithm_for_generate_key(
+    cx: JSContext,
+    algorithm: &AlgorithmIdentifier,
+) -> Result<KeyGenerationAlgorithm, Error> {
+    let AlgorithmIdentifier::Object(obj) = algorithm else {
+        // All algorithms that support "generateKey" require additional parameters
+        return Err(Error::NotSupported);
+    };
+
+    rooted!(in(*cx) let value = ObjectValue(obj.get()));
+    let algorithm = value_from_js_object!(Algorithm, cx, value);
+
+    let name = algorithm.name.str();
+    let normalized_algorithm = if name.eq_ignore_ascii_case(ALG_AES_CBC) ||
+        name.eq_ignore_ascii_case(ALG_AES_CTR) ||
+        name.eq_ignore_ascii_case(ALG_AES_KW) ||
+        name.eq_ignore_ascii_case(ALG_AES_GCM)
+    {
+        let params = value_from_js_object!(AesKeyGenParams, cx, value);
+        KeyGenerationAlgorithm::Aes(params.into())
+    } else if name.eq_ignore_ascii_case(ALG_HMAC) {
+        let params = value_from_js_object!(HmacKeyGenParams, cx, value);
+        let subtle_params = SubtleHmacKeyGenParams::new(cx, params)?;
+        KeyGenerationAlgorithm::Hmac(subtle_params)
+    } else {
+        return Err(Error::NotSupported);
+    };
+
+    Ok(normalized_algorithm)
+}
+
+/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"wrapKey"` or `"unwrapKey"`
+pub(crate) fn normalize_algorithm_for_key_wrap(
+    cx: JSContext,
+    algorithm: &AlgorithmIdentifier,
+) -> Result<KeyWrapAlgorithm, Error> {
+    let name = match algorithm {
+        AlgorithmIdentifier::Object(obj) => {
+            rooted!(in(*cx) let value = ObjectValue(obj.get()));
+            let algorithm = value_from_js_object!(Algorithm, cx, value);
+
+            algorithm.name.str().to_uppercase()
+        },
+        AlgorithmIdentifier::String(name) => name.str().to_uppercase(),
+    };
+
+    let normalized_algorithm = match name.as_str() {
+        ALG_AES_KW => KeyWrapAlgorithm::AesKw,
+        ALG_AES_CBC => {
+            let AlgorithmIdentifier::Object(obj) = algorithm else {
+                return Err(Error::Syntax);
+            };
+            rooted!(in(*cx) let value = ObjectValue(obj.get()));
+            KeyWrapAlgorithm::AesCbc(value_from_js_object!(AesCbcParams, cx, value).into())
+        },
+        ALG_AES_CTR => {
+            let AlgorithmIdentifier::Object(obj) = algorithm else {
+                return Err(Error::Syntax);
+            };
+            rooted!(in(*cx) let value = ObjectValue(obj.get()));
+            KeyWrapAlgorithm::AesCtr(value_from_js_object!(AesCtrParams, cx, value).into())
+        },
+        ALG_AES_GCM => {
+            let AlgorithmIdentifier::Object(obj) = algorithm else {
+                return Err(Error::Syntax);
+            };
+            rooted!(in(*cx) let value = ObjectValue(obj.get()));
+            KeyWrapAlgorithm::AesGcm(value_from_js_object!(AesGcmParams, cx, value).into())
+        },
+        _ => return Err(Error::NotSupported),
+    };
+
+    Ok(normalized_algorithm)
+}
+
+/// <https://w3c.github.io/webcrypto/#concept-parse-a-jwk>
+pub(crate) fn parse_jwk(
+    bytes: &[u8],
+    import_alg: ImportKeyAlgorithm,
+    extractable: bool,
+    key_usages: &[KeyUsage],
+) -> Result<Vec<u8>, Error> {
+    let value = serde_json::from_slice(bytes)
+        .map_err(|_| Error::Type("Failed to parse JWK string".into()))?;
+    let serde_json::Value::Object(obj) = value else {
+        return Err(Error::Data);
+    };
+
+    let kty = get_jwk_string(&obj, "kty")?;
+    let ext = get_jwk_bool(&obj, "ext")?;
+    if !ext && extractable {
+        return Err(Error::Data);
+    }
+
+    // If the key_ops field of jwk is present, and is invalid according to the requirements of JSON Web Key [JWK]
+    // or does not contain all of the specified usages values, then throw a DataError.
+    if let Some(serde_json::Value::Array(key_ops)) = obj.get("key_ops") {
+        if key_ops.iter().any(|op| {
+            let op_string = match op {
+                serde_json::Value::String(op_string) => op_string,
+                _ => return true,
+            };
+            let usage = match usage_from_str(op_string) {
+                Ok(usage) => usage,
+                Err(_) => {
+                    return true;
+                },
+            };
+            !key_usages.contains(&usage)
+        }) {
+            return Err(Error::Data);
+        }
+    }
+
+    match import_alg {
+        ImportKeyAlgorithm::AesCbc |
+        ImportKeyAlgorithm::AesCtr |
+        ImportKeyAlgorithm::AesKw |
+        ImportKeyAlgorithm::AesGcm => {
+            if kty != "oct" {
+                return Err(Error::Data);
+            }
+            let k = get_jwk_string(&obj, "k")?;
+            let alg = get_jwk_string(&obj, "alg")?;
+
+            let data = base64::engine::general_purpose::STANDARD_NO_PAD
+                .decode(k.as_bytes())
+                .map_err(|_| Error::Data)?;
+
+            let expected_alg = match (data.len() * 8, &import_alg) {
+                (128, ImportKeyAlgorithm::AesCbc) => "A128CBC",
+                (128, ImportKeyAlgorithm::AesCtr) => "A128CTR",
+                (128, ImportKeyAlgorithm::AesKw) => "A128KW",
+                (128, ImportKeyAlgorithm::AesGcm) => "A128GCM",
+                (192, ImportKeyAlgorithm::AesCbc) => "A192CBC",
+                (192, ImportKeyAlgorithm::AesCtr) => "A192CTR",
+                (192, ImportKeyAlgorithm::AesKw) => "A192KW",
+                (192, ImportKeyAlgorithm::AesGcm) => "A192GCM",
+                (256, ImportKeyAlgorithm::AesCbc) => "A256CBC",
+                (256, ImportKeyAlgorithm::AesCtr) => "A256CTR",
+                (256, ImportKeyAlgorithm::AesKw) => "A256KW",
+                (256, ImportKeyAlgorithm::AesGcm) => "A256GCM",
+                _ => return Err(Error::Data),
+            };
+
+            if alg != expected_alg {
+                return Err(Error::Data);
+            }
+
+            if let Some(serde_json::Value::String(use_)) = obj.get("use") {
+                if use_ != "enc" {
+                    return Err(Error::Data);
+                }
+            }
+
+            Ok(data)
+        },
+        ImportKeyAlgorithm::Hmac(params) => {
+            if kty != "oct" {
+                return Err(Error::Data);
+            }
+            let k = get_jwk_string(&obj, "k")?;
+            let alg = get_jwk_string(&obj, "alg")?;
+
+            let expected_alg = match params.hash {
+                DigestAlgorithm::Sha1 => "HS1",
+                DigestAlgorithm::Sha256 => "HS256",
+                DigestAlgorithm::Sha384 => "HS384",
+                DigestAlgorithm::Sha512 => "HS512",
+            };
+
+            if alg != expected_alg {
+                return Err(Error::Data);
+            }
+
+            if let Some(serde_json::Value::String(use_)) = obj.get("use") {
+                if use_ != "sign" {
+                    return Err(Error::Data);
+                }
+            }
+
+            base64::engine::general_purpose::STANDARD_NO_PAD
+                .decode(k.as_bytes())
+                .map_err(|_| Error::Data)
+        },
+        _ => Err(Error::NotSupported),
+    }
+}
+
+fn get_jwk_string(
+    value: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<String, Error> {
+    let s = value
+        .get(key)
+        .ok_or(Error::Data)?
+        .as_str()
+        .ok_or(Error::Data)?;
+    Ok(s.to_string())
+}
+
+fn get_jwk_bool(
+    value: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<bool, Error> {
+    let b = value
+        .get(key)
+        .ok_or(Error::Data)?
+        .as_bool()
+        .ok_or(Error::Data)?;
+    Ok(b)
+}
+
+fn usage_from_str(op: &str) -> Result<KeyUsage, Error> {
+    let usage = match op {
+        "encrypt" => KeyUsage::Encrypt,
+        "decrypt" => KeyUsage::Decrypt,
+        "sign" => KeyUsage::Sign,
+        "verify" => KeyUsage::Verify,
+        "deriveKey" => KeyUsage::DeriveKey,
+        "deriveBits" => KeyUsage::DeriveBits,
+        "wrapKey" => KeyUsage::WrapKey,
+        "unwrapKey" => KeyUsage::UnwrapKey,
+        _ => {
+            return Err(Error::Data);
+        },
+    };
+    Ok(usage)
+}

--- a/components/script/crypto/params.rs
+++ b/components/script/crypto/params.rs
@@ -1,0 +1,346 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::num::NonZero;
+
+use aws_lc_rs::{hkdf, pbkdf2};
+use script_bindings::error::{Error, Fallible};
+use script_bindings::script_runtime::JSContext;
+use script_bindings::trace::RootedTraceableBox;
+
+use crate::crypto;
+use crate::crypto::DigestAlgorithm;
+use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::{
+    AesCbcParams, AesCtrParams, AesGcmParams, AesKeyGenParams, HkdfParams, HmacImportParams,
+    HmacKeyGenParams, Pbkdf2Params,
+};
+use crate::dom::bindings::codegen::UnionTypes::ArrayBufferViewOrArrayBuffer;
+use crate::dom::cryptokey::CryptoKey;
+
+#[derive(Clone, Debug)]
+pub(crate) struct SubtleAesCbcParams {
+    #[allow(dead_code)]
+    pub(crate) name: String,
+    pub(crate) iv: Vec<u8>,
+}
+
+impl From<RootedTraceableBox<AesCbcParams>> for SubtleAesCbcParams {
+    fn from(params: RootedTraceableBox<AesCbcParams>) -> Self {
+        let iv = match &params.iv {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
+        };
+        SubtleAesCbcParams {
+            name: params.parent.name.to_string(),
+            iv,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SubtleAesCtrParams {
+    pub(crate) name: String,
+    pub(crate) counter: Vec<u8>,
+    pub(crate) length: u8,
+}
+
+impl From<RootedTraceableBox<AesCtrParams>> for SubtleAesCtrParams {
+    fn from(params: RootedTraceableBox<AesCtrParams>) -> Self {
+        let counter = match &params.counter {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
+        };
+        SubtleAesCtrParams {
+            name: params.parent.name.to_string(),
+            counter,
+            length: params.length,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SubtleAesGcmParams {
+    pub(crate) name: String,
+    pub(crate) iv: Vec<u8>,
+    pub(crate) additional_data: Option<Vec<u8>>,
+    pub(crate) tag_length: Option<u8>,
+}
+
+impl From<RootedTraceableBox<AesGcmParams>> for SubtleAesGcmParams {
+    fn from(params: RootedTraceableBox<AesGcmParams>) -> Self {
+        let iv = match &params.iv {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
+        };
+        let additional_data = params.additionalData.as_ref().map(|data| match data {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
+        });
+
+        SubtleAesGcmParams {
+            name: params.parent.name.to_string(),
+            iv,
+            additional_data,
+            tag_length: params.tagLength,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SubtleAesKeyGenParams {
+    pub(crate) name: String,
+    pub(crate) length: u16,
+}
+
+impl From<AesKeyGenParams> for SubtleAesKeyGenParams {
+    fn from(params: AesKeyGenParams) -> Self {
+        SubtleAesKeyGenParams {
+            name: params.parent.name.to_string().to_uppercase(),
+            length: params.length,
+        }
+    }
+}
+
+/// <https://w3c.github.io/webcrypto/#dfn-HmacImportParams>
+#[derive(Clone)]
+pub(crate) struct SubtleHmacImportParams {
+    /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyAlgorithm-hash>
+    pub(crate) hash: DigestAlgorithm,
+
+    /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyGenParams-length>
+    pub(crate) length: Option<u32>,
+}
+
+impl SubtleHmacImportParams {
+    pub(crate) fn new(
+        cx: JSContext,
+        params: RootedTraceableBox<HmacImportParams>,
+    ) -> Fallible<Self> {
+        let hash = crypto::normalize_algorithm_for_digest(cx, &params.hash)?;
+        let params = Self {
+            hash,
+            length: params.length,
+        };
+        Ok(params)
+    }
+
+    /// <https://w3c.github.io/webcrypto/#hmac-operations>
+    pub(crate) fn get_key_length(&self) -> Result<u32, Error> {
+        // Step 1.
+        let length = match self.length {
+            // If the length member of normalizedDerivedKeyAlgorithm is not present:
+            None => {
+                // Let length be the block size in bits of the hash function identified by the hash member of
+                // normalizedDerivedKeyAlgorithm.
+                match self.hash {
+                    DigestAlgorithm::Sha1 => 160,
+                    DigestAlgorithm::Sha256 => 256,
+                    DigestAlgorithm::Sha384 => 384,
+                    DigestAlgorithm::Sha512 => 512,
+                }
+            },
+            // Otherwise, if the length member of normalizedDerivedKeyAlgorithm is non-zero:
+            Some(length) if length != 0 => {
+                // Let length be equal to the length member of normalizedDerivedKeyAlgorithm.
+                length
+            },
+            // Otherwise:
+            _ => {
+                // throw a TypeError.
+                return Err(Error::Type("[[length]] must not be zero".to_string()));
+            },
+        };
+
+        // Step 2. Return length.
+        Ok(length)
+    }
+}
+
+pub(crate) struct SubtleHmacKeyGenParams {
+    /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyGenParams-hash>
+    pub(crate) hash: DigestAlgorithm,
+
+    /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyGenParams-length>
+    pub(crate) length: Option<u32>,
+}
+
+impl SubtleHmacKeyGenParams {
+    pub(crate) fn new(
+        cx: JSContext,
+        params: RootedTraceableBox<HmacKeyGenParams>,
+    ) -> Fallible<Self> {
+        let hash = crypto::normalize_algorithm_for_digest(cx, &params.hash)?;
+        let params = Self {
+            hash,
+            length: params.length,
+        };
+        Ok(params)
+    }
+}
+
+/// <https://w3c.github.io/webcrypto/#hkdf-params>
+#[derive(Clone, Debug)]
+pub(crate) struct SubtleHkdfParams {
+    /// <https://w3c.github.io/webcrypto/#dfn-HkdfParams-hash>
+    pub(crate) hash: DigestAlgorithm,
+
+    /// <https://w3c.github.io/webcrypto/#dfn-HkdfParams-salt>
+    pub(crate) salt: Vec<u8>,
+
+    /// <https://w3c.github.io/webcrypto/#dfn-HkdfParams-info>
+    pub(crate) info: Vec<u8>,
+}
+
+impl SubtleHkdfParams {
+    pub(crate) fn new(cx: JSContext, params: RootedTraceableBox<HkdfParams>) -> Fallible<Self> {
+        let hash = crypto::normalize_algorithm_for_digest(cx, &params.hash)?;
+        let salt = match &params.salt {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
+        };
+        let info = match &params.info {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
+        };
+
+        let params = Self { hash, salt, info };
+
+        Ok(params)
+    }
+}
+
+/// <https://w3c.github.io/webcrypto/#dfn-Pbkdf2Params>
+#[derive(Clone, Debug)]
+pub(crate) struct SubtlePbkdf2Params {
+    /// <https://w3c.github.io/webcrypto/#dfn-Pbkdf2Params-salt>
+    pub(crate) salt: Vec<u8>,
+
+    /// <https://w3c.github.io/webcrypto/#dfn-Pbkdf2Params-iterations>
+    pub(crate) iterations: u32,
+
+    /// <https://w3c.github.io/webcrypto/#dfn-Pbkdf2Params-hash>
+    pub(crate) hash: DigestAlgorithm,
+}
+
+impl SubtlePbkdf2Params {
+    pub(crate) fn new(cx: JSContext, params: RootedTraceableBox<Pbkdf2Params>) -> Fallible<Self> {
+        let salt = match &params.salt {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
+        };
+
+        let params = Self {
+            salt,
+            iterations: params.iterations,
+            hash: crypto::normalize_algorithm_for_digest(cx, &params.hash)?,
+        };
+
+        Ok(params)
+    }
+}
+
+impl SubtleHkdfParams {
+    /// <https://w3c.github.io/webcrypto/#hkdf-operations>
+    pub(crate) fn derive_bits(
+        &self,
+        key: &CryptoKey,
+        length: Option<u32>,
+    ) -> Result<Vec<u8>, Error> {
+        // Step 1. If length is null or zero, or is not a multiple of 8, then throw an OperationError.
+        let Some(length) = length else {
+            return Err(Error::Operation);
+        };
+        if length == 0 || length % 8 != 0 {
+            return Err(Error::Operation);
+        };
+
+        // Step 3. Let keyDerivationKey be the secret represented by [[handle]] internal slot of key.
+        let key_derivation_key = key.handle().as_bytes();
+
+        // Step 4. Let result be the result of performing the HKDF extract and then the HKDF expand step described
+        // in Section 2 of [RFC5869] using:
+        // * the hash member of normalizedAlgorithm as Hash,
+        // * keyDerivationKey as the input keying material, IKM,
+        // * the contents of the salt member of normalizedAlgorithm as salt,
+        // * the contents of the info member of normalizedAlgorithm as info,
+        // * length divided by 8 as the value of L,
+        let mut result = vec![0; length as usize / 8];
+        let algorithm = match self.hash {
+            DigestAlgorithm::Sha1 => hkdf::HKDF_SHA1_FOR_LEGACY_USE_ONLY,
+            DigestAlgorithm::Sha256 => hkdf::HKDF_SHA256,
+            DigestAlgorithm::Sha384 => hkdf::HKDF_SHA384,
+            DigestAlgorithm::Sha512 => hkdf::HKDF_SHA512,
+        };
+        let salt = hkdf::Salt::new(algorithm, &self.salt);
+        let info = self.info.as_slice();
+        let pseudo_random_key = salt.extract(key_derivation_key);
+
+        let Ok(output_key_material) =
+            pseudo_random_key.expand(std::slice::from_ref(&info), algorithm)
+        else {
+            // Step 5. If the key derivation operation fails, then throw an OperationError.
+            return Err(Error::Operation);
+        };
+
+        if output_key_material.fill(&mut result).is_err() {
+            return Err(Error::Operation);
+        };
+
+        // Step 6. Return the result of creating an ArrayBuffer containing result.
+        // NOTE: The ArrayBuffer is created by the caller
+        Ok(result)
+    }
+}
+
+impl SubtlePbkdf2Params {
+    /// <https://w3c.github.io/webcrypto/#pbkdf2-operations>
+    pub(crate) fn derive_bits(
+        &self,
+        key: &CryptoKey,
+        length: Option<u32>,
+    ) -> Result<Vec<u8>, Error> {
+        // Step 1. If length is null or zero, or is not a multiple of 8, then throw an OperationError.
+        let Some(length) = length else {
+            return Err(Error::Operation);
+        };
+        if length == 0 || length % 8 != 0 {
+            return Err(Error::Operation);
+        };
+
+        // Step 2. If the iterations member of normalizedAlgorithm is zero, then throw an OperationError.
+        let Ok(iterations) = NonZero::<u32>::try_from(self.iterations) else {
+            return Err(Error::Operation);
+        };
+
+        // Step 3. Let prf be the MAC Generation function described in Section 4 of [FIPS-198-1]
+        // using the hash function described by the hash member of normalizedAlgorithm.
+        let prf = match self.hash {
+            DigestAlgorithm::Sha1 => pbkdf2::PBKDF2_HMAC_SHA1,
+            DigestAlgorithm::Sha256 => pbkdf2::PBKDF2_HMAC_SHA256,
+            DigestAlgorithm::Sha384 => pbkdf2::PBKDF2_HMAC_SHA384,
+            DigestAlgorithm::Sha512 => pbkdf2::PBKDF2_HMAC_SHA512,
+        };
+
+        // Step 4. Let result be the result of performing the PBKDF2 operation defined in Section 5.2 of [RFC8018] using
+        // prf as the pseudo-random function, PRF, the password represented by [[handle]] internal slot of key as
+        // the password, P, the contents of the salt attribute of normalizedAlgorithm as the salt, S, the value of
+        // the iterations attribute of normalizedAlgorithm as the iteration count, c, and length divided by 8 as the
+        // intended key length, dkLen.
+        let mut result = vec![0; length as usize / 8];
+        pbkdf2::derive(
+            prf,
+            iterations,
+            &self.salt,
+            key.handle().as_bytes(),
+            &mut result,
+        );
+
+        // Step 5. If the key derivation operation fails, then throw an OperationError.
+        // TODO: Investigate when key derivation can fail and how ring handles that case
+        // (pbkdf2::derive does not return a Result type)
+
+        // Step 6. Return result
+        Ok(result)
+    }
+}

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -2,114 +2,48 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::num::NonZero;
 use std::ptr;
 use std::rc::Rc;
 
 use aes::cipher::block_padding::Pkcs7;
 use aes::cipher::generic_array::GenericArray;
 use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit, StreamCipher};
-use aes::{Aes128, Aes192, Aes256};
-use aes_gcm::{AeadInPlace, AesGcm, KeyInit};
+use aes_gcm::{AeadInPlace, KeyInit};
 use aes_kw::{KekAes128, KekAes192, KekAes256};
-use aws_lc_rs::{digest, hkdf, hmac, pbkdf2};
 use base64::prelude::*;
-use cipher::consts::{U12, U16, U32};
 use dom_struct::dom_struct;
-use js::conversions::ConversionResult;
 use js::jsapi::{JS_NewObject, JSObject};
-use js::jsval::ObjectValue;
 use js::rust::MutableHandleObject;
 use js::typedarray::ArrayBufferU8;
 use servo_rand::{RngCore, ServoRng};
 
+use crate::crypto::params::{
+    SubtleAesCbcParams, SubtleAesCtrParams, SubtleAesGcmParams, SubtleAesKeyGenParams,
+    SubtleHmacImportParams, SubtleHmacKeyGenParams,
+};
+use crate::crypto::*;
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, KeyType, KeyUsage,
 };
 use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::{
-    AesCbcParams, AesCtrParams, AesDerivedKeyParams, AesGcmParams, AesKeyAlgorithm,
-    AesKeyGenParams, Algorithm, AlgorithmIdentifier, HkdfParams, HmacImportParams,
-    HmacKeyAlgorithm, HmacKeyGenParams, JsonWebKey, KeyAlgorithm, KeyFormat, Pbkdf2Params,
+    AesKeyAlgorithm, AlgorithmIdentifier, HmacKeyAlgorithm, JsonWebKey, KeyAlgorithm, KeyFormat,
     SubtleCryptoMethods,
 };
 use crate::dom::bindings::codegen::UnionTypes::{
     ArrayBufferViewOrArrayBuffer, ArrayBufferViewOrArrayBufferOrJsonWebKey,
 };
-use crate::dom::bindings::error::{Error, Fallible};
+use crate::dom::bindings::error::Error;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
-use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::realms::InRealm;
 use crate::script_runtime::{CanGc, JSContext};
-
-// String constants for algorithms/curves
-const ALG_AES_CBC: &str = "AES-CBC";
-const ALG_AES_CTR: &str = "AES-CTR";
-const ALG_AES_GCM: &str = "AES-GCM";
-const ALG_AES_KW: &str = "AES-KW";
-const ALG_SHA1: &str = "SHA-1";
-const ALG_SHA256: &str = "SHA-256";
-const ALG_SHA384: &str = "SHA-384";
-const ALG_SHA512: &str = "SHA-512";
-const ALG_HMAC: &str = "HMAC";
-const ALG_HKDF: &str = "HKDF";
-const ALG_PBKDF2: &str = "PBKDF2";
-const ALG_RSASSA_PKCS1: &str = "RSASSA-PKCS1-v1_5";
-const ALG_RSA_OAEP: &str = "RSA-OAEP";
-const ALG_RSA_PSS: &str = "RSA-PSS";
-const ALG_ECDH: &str = "ECDH";
-const ALG_ECDSA: &str = "ECDSA";
-
-#[allow(dead_code)]
-static SUPPORTED_ALGORITHMS: &[&str] = &[
-    ALG_AES_CBC,
-    ALG_AES_CTR,
-    ALG_AES_GCM,
-    ALG_AES_KW,
-    ALG_SHA1,
-    ALG_SHA256,
-    ALG_SHA384,
-    ALG_SHA512,
-    ALG_HMAC,
-    ALG_HKDF,
-    ALG_PBKDF2,
-    ALG_RSASSA_PKCS1,
-    ALG_RSA_OAEP,
-    ALG_RSA_PSS,
-    ALG_ECDH,
-    ALG_ECDSA,
-];
-
-const NAMED_CURVE_P256: &str = "P-256";
-const NAMED_CURVE_P384: &str = "P-384";
-const NAMED_CURVE_P521: &str = "P-521";
-#[allow(dead_code)]
-static SUPPORTED_CURVES: &[&str] = &[NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521];
-
-type Aes128CbcEnc = cbc::Encryptor<Aes128>;
-type Aes128CbcDec = cbc::Decryptor<Aes128>;
-type Aes192CbcEnc = cbc::Encryptor<Aes192>;
-type Aes192CbcDec = cbc::Decryptor<Aes192>;
-type Aes256CbcEnc = cbc::Encryptor<Aes256>;
-type Aes256CbcDec = cbc::Decryptor<Aes256>;
-type Aes128Ctr = ctr::Ctr64BE<Aes128>;
-type Aes192Ctr = ctr::Ctr64BE<Aes192>;
-type Aes256Ctr = ctr::Ctr64BE<Aes256>;
-
-type Aes128Gcm96Iv = AesGcm<Aes128, U12>;
-type Aes128Gcm128Iv = AesGcm<Aes128, U16>;
-type Aes192Gcm96Iv = AesGcm<Aes192, U12>;
-type Aes256Gcm96Iv = AesGcm<Aes256, U12>;
-type Aes128Gcm256Iv = AesGcm<Aes128, U32>;
-type Aes192Gcm256Iv = AesGcm<Aes192, U32>;
-type Aes256Gcm256Iv = AesGcm<Aes256, U32>;
 
 #[dom_struct]
 pub(crate) struct SubtleCrypto {
@@ -1089,583 +1023,9 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
     }
 }
 
-// These "subtle" structs are proxies for the codegen'd dicts which don't hold a DOMString
-// so they can be sent safely when running steps in parallel.
-
-#[allow(dead_code)]
-#[derive(Clone, Debug)]
-pub(crate) struct SubtleAlgorithm {
-    #[allow(dead_code)]
-    pub(crate) name: String,
-}
-
-impl From<DOMString> for SubtleAlgorithm {
-    fn from(name: DOMString) -> Self {
-        SubtleAlgorithm {
-            name: name.to_string(),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct SubtleAesCbcParams {
-    #[allow(dead_code)]
-    pub(crate) name: String,
-    pub(crate) iv: Vec<u8>,
-}
-
-impl From<RootedTraceableBox<AesCbcParams>> for SubtleAesCbcParams {
-    fn from(params: RootedTraceableBox<AesCbcParams>) -> Self {
-        let iv = match &params.iv {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
-        };
-        SubtleAesCbcParams {
-            name: params.parent.name.to_string(),
-            iv,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct SubtleAesCtrParams {
-    pub(crate) name: String,
-    pub(crate) counter: Vec<u8>,
-    pub(crate) length: u8,
-}
-
-impl From<RootedTraceableBox<AesCtrParams>> for SubtleAesCtrParams {
-    fn from(params: RootedTraceableBox<AesCtrParams>) -> Self {
-        let counter = match &params.counter {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
-        };
-        SubtleAesCtrParams {
-            name: params.parent.name.to_string(),
-            counter,
-            length: params.length,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct SubtleAesGcmParams {
-    pub(crate) name: String,
-    pub(crate) iv: Vec<u8>,
-    pub(crate) additional_data: Option<Vec<u8>>,
-    pub(crate) tag_length: Option<u8>,
-}
-
-impl From<RootedTraceableBox<AesGcmParams>> for SubtleAesGcmParams {
-    fn from(params: RootedTraceableBox<AesGcmParams>) -> Self {
-        let iv = match &params.iv {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
-        };
-        let additional_data = params.additionalData.as_ref().map(|data| match data {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
-        });
-
-        SubtleAesGcmParams {
-            name: params.parent.name.to_string(),
-            iv,
-            additional_data,
-            tag_length: params.tagLength,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct SubtleAesKeyGenParams {
-    pub(crate) name: String,
-    pub(crate) length: u16,
-}
-
-impl From<AesKeyGenParams> for SubtleAesKeyGenParams {
-    fn from(params: AesKeyGenParams) -> Self {
-        SubtleAesKeyGenParams {
-            name: params.parent.name.to_string().to_uppercase(),
-            length: params.length,
-        }
-    }
-}
-
-/// <https://w3c.github.io/webcrypto/#dfn-HmacImportParams>
-#[derive(Clone)]
-struct SubtleHmacImportParams {
-    /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyAlgorithm-hash>
-    hash: DigestAlgorithm,
-
-    /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyGenParams-length>
-    length: Option<u32>,
-}
-
-impl SubtleHmacImportParams {
-    fn new(cx: JSContext, params: RootedTraceableBox<HmacImportParams>) -> Fallible<Self> {
-        let hash = normalize_algorithm_for_digest(cx, &params.hash)?;
-        let params = Self {
-            hash,
-            length: params.length,
-        };
-        Ok(params)
-    }
-
-    /// <https://w3c.github.io/webcrypto/#hmac-operations>
-    fn get_key_length(&self) -> Result<u32, Error> {
-        // Step 1.
-        let length = match self.length {
-            // If the length member of normalizedDerivedKeyAlgorithm is not present:
-            None => {
-                // Let length be the block size in bits of the hash function identified by the hash member of
-                // normalizedDerivedKeyAlgorithm.
-                match self.hash {
-                    DigestAlgorithm::Sha1 => 160,
-                    DigestAlgorithm::Sha256 => 256,
-                    DigestAlgorithm::Sha384 => 384,
-                    DigestAlgorithm::Sha512 => 512,
-                }
-            },
-            // Otherwise, if the length member of normalizedDerivedKeyAlgorithm is non-zero:
-            Some(length) if length != 0 => {
-                // Let length be equal to the length member of normalizedDerivedKeyAlgorithm.
-                length
-            },
-            // Otherwise:
-            _ => {
-                // throw a TypeError.
-                return Err(Error::Type("[[length]] must not be zero".to_string()));
-            },
-        };
-
-        // Step 2. Return length.
-        Ok(length)
-    }
-}
-
-struct SubtleHmacKeyGenParams {
-    /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyGenParams-hash>
-    hash: DigestAlgorithm,
-
-    /// <https://w3c.github.io/webcrypto/#dfn-HmacKeyGenParams-length>
-    length: Option<u32>,
-}
-
-impl SubtleHmacKeyGenParams {
-    fn new(cx: JSContext, params: RootedTraceableBox<HmacKeyGenParams>) -> Fallible<Self> {
-        let hash = normalize_algorithm_for_digest(cx, &params.hash)?;
-        let params = Self {
-            hash,
-            length: params.length,
-        };
-        Ok(params)
-    }
-}
-/// <https://w3c.github.io/webcrypto/#hkdf-params>
-#[derive(Clone, Debug)]
-pub(crate) struct SubtleHkdfParams {
-    /// <https://w3c.github.io/webcrypto/#dfn-HkdfParams-hash>
-    hash: DigestAlgorithm,
-
-    /// <https://w3c.github.io/webcrypto/#dfn-HkdfParams-salt>
-    salt: Vec<u8>,
-
-    /// <https://w3c.github.io/webcrypto/#dfn-HkdfParams-info>
-    info: Vec<u8>,
-}
-
-impl SubtleHkdfParams {
-    fn new(cx: JSContext, params: RootedTraceableBox<HkdfParams>) -> Fallible<Self> {
-        let hash = normalize_algorithm_for_digest(cx, &params.hash)?;
-        let salt = match &params.salt {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
-        };
-        let info = match &params.info {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
-        };
-
-        let params = Self { hash, salt, info };
-
-        Ok(params)
-    }
-}
-
-/// <https://w3c.github.io/webcrypto/#dfn-Pbkdf2Params>
-#[derive(Clone, Debug)]
-pub(crate) struct SubtlePbkdf2Params {
-    /// <https://w3c.github.io/webcrypto/#dfn-Pbkdf2Params-salt>
-    salt: Vec<u8>,
-
-    /// <https://w3c.github.io/webcrypto/#dfn-Pbkdf2Params-iterations>
-    iterations: u32,
-
-    /// <https://w3c.github.io/webcrypto/#dfn-Pbkdf2Params-hash>
-    hash: DigestAlgorithm,
-}
-
-impl SubtlePbkdf2Params {
-    fn new(cx: JSContext, params: RootedTraceableBox<Pbkdf2Params>) -> Fallible<Self> {
-        let salt = match &params.salt {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
-        };
-
-        let params = Self {
-            salt,
-            iterations: params.iterations,
-            hash: normalize_algorithm_for_digest(cx, &params.hash)?,
-        };
-
-        Ok(params)
-    }
-}
-
-enum GetKeyLengthAlgorithm {
-    Aes(u16),
-    Hmac(SubtleHmacImportParams),
-}
-
-#[derive(Clone, Copy, Debug)]
-enum DigestAlgorithm {
-    /// <https://w3c.github.io/webcrypto/#sha>
-    Sha1,
-
-    /// <https://w3c.github.io/webcrypto/#sha>
-    Sha256,
-
-    /// <https://w3c.github.io/webcrypto/#sha>
-    Sha384,
-
-    /// <https://w3c.github.io/webcrypto/#sha>
-    Sha512,
-}
-
-/// A normalized algorithm returned by [`normalize_algorithm`] with operation `"importKey"`
-///
-/// [`normalize_algorithm`]: https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm
-#[derive(Clone)]
-enum ImportKeyAlgorithm {
-    AesCbc,
-    AesCtr,
-    AesKw,
-    AesGcm,
-    Hmac(SubtleHmacImportParams),
-    Pbkdf2,
-    Hkdf,
-}
-
-/// A normalized algorithm returned by [`normalize_algorithm`] with operation `"deriveBits"`
-///
-/// [`normalize_algorithm`]: https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm
-enum DeriveBitsAlgorithm {
-    Pbkdf2(SubtlePbkdf2Params),
-    Hkdf(SubtleHkdfParams),
-}
-
-/// A normalized algorithm returned by [`normalize_algorithm`] with operation `"encrypt"` or `"decrypt"`
-///
-/// [`normalize_algorithm`]: https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm
-#[allow(clippy::enum_variant_names)]
-enum EncryptionAlgorithm {
-    AesCbc(SubtleAesCbcParams),
-    AesCtr(SubtleAesCtrParams),
-    AesGcm(SubtleAesGcmParams),
-}
-
-/// A normalized algorithm returned by [`normalize_algorithm`] with operation `"sign"` or `"verify"`
-///
-/// [`normalize_algorithm`]: https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm
-enum SignatureAlgorithm {
-    Hmac,
-}
-
-/// A normalized algorithm returned by [`normalize_algorithm`] with operation `"generateKey"`
-///
-/// [`normalize_algorithm`]: https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm
-enum KeyGenerationAlgorithm {
-    Aes(SubtleAesKeyGenParams),
-    Hmac(SubtleHmacKeyGenParams),
-}
-
-/// A normalized algorithm returned by [`normalize_algorithm`] with operation `"wrapKey"` or `"unwrapKey"`
-///
-/// [`normalize_algorithm`]: https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm
-#[allow(clippy::enum_variant_names)]
-enum KeyWrapAlgorithm {
-    AesKw,
-    AesCbc(SubtleAesCbcParams),
-    AesCtr(SubtleAesCtrParams),
-    AesGcm(SubtleAesGcmParams),
-}
-
-macro_rules! value_from_js_object {
-    ($t: ty, $cx: ident, $value: ident) => {{
-        let params_result = <$t>::new($cx, $value.handle()).map_err(|_| Error::JSFailed)?;
-        let ConversionResult::Success(params) = params_result else {
-            return Err(Error::Syntax);
-        };
-        params
-    }};
-}
-
-/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"get key length"`
-fn normalize_algorithm_for_get_key_length(
-    cx: JSContext,
-    algorithm: &AlgorithmIdentifier,
-) -> Result<GetKeyLengthAlgorithm, Error> {
-    match algorithm {
-        AlgorithmIdentifier::Object(obj) => {
-            rooted!(in(*cx) let value = ObjectValue(obj.get()));
-            let algorithm = value_from_js_object!(Algorithm, cx, value);
-
-            let name = algorithm.name.str();
-            let normalized_algorithm = if name.eq_ignore_ascii_case(ALG_AES_CBC) ||
-                name.eq_ignore_ascii_case(ALG_AES_CTR) ||
-                name.eq_ignore_ascii_case(ALG_AES_GCM)
-            {
-                let params = value_from_js_object!(AesDerivedKeyParams, cx, value);
-                GetKeyLengthAlgorithm::Aes(params.length)
-            } else if name.eq_ignore_ascii_case(ALG_HMAC) {
-                let params = value_from_js_object!(HmacImportParams, cx, value);
-                let subtle_params = SubtleHmacImportParams::new(cx, params)?;
-                return Ok(GetKeyLengthAlgorithm::Hmac(subtle_params));
-            } else {
-                return Err(Error::NotSupported);
-            };
-
-            Ok(normalized_algorithm)
-        },
-        AlgorithmIdentifier::String(_) => {
-            // All algorithms that support "get key length" require additional parameters
-            Err(Error::NotSupported)
-        },
-    }
-}
-
-/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"digest"`
-fn normalize_algorithm_for_digest(
-    cx: JSContext,
-    algorithm: &AlgorithmIdentifier,
-) -> Result<DigestAlgorithm, Error> {
-    let name = match algorithm {
-        AlgorithmIdentifier::Object(obj) => {
-            rooted!(in(*cx) let value = ObjectValue(obj.get()));
-            let algorithm = value_from_js_object!(Algorithm, cx, value);
-
-            algorithm.name.str().to_uppercase()
-        },
-        AlgorithmIdentifier::String(name) => name.str().to_uppercase(),
-    };
-
-    let normalized_algorithm = match name.as_str() {
-        ALG_SHA1 => DigestAlgorithm::Sha1,
-        ALG_SHA256 => DigestAlgorithm::Sha256,
-        ALG_SHA384 => DigestAlgorithm::Sha384,
-        ALG_SHA512 => DigestAlgorithm::Sha512,
-        _ => return Err(Error::NotSupported),
-    };
-
-    Ok(normalized_algorithm)
-}
-
-/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"importKey"`
-fn normalize_algorithm_for_import_key(
-    cx: JSContext,
-    algorithm: &AlgorithmIdentifier,
-) -> Result<ImportKeyAlgorithm, Error> {
-    let name = match algorithm {
-        AlgorithmIdentifier::Object(obj) => {
-            rooted!(in(*cx) let value = ObjectValue(obj.get()));
-            let algorithm = value_from_js_object!(Algorithm, cx, value);
-
-            let name = algorithm.name.str().to_uppercase();
-            if name == ALG_HMAC {
-                let params = value_from_js_object!(HmacImportParams, cx, value);
-                let subtle_params = SubtleHmacImportParams::new(cx, params)?;
-                return Ok(ImportKeyAlgorithm::Hmac(subtle_params));
-            }
-
-            name
-        },
-        AlgorithmIdentifier::String(name) => name.str().to_uppercase(),
-    };
-
-    let normalized_algorithm = match name.as_str() {
-        ALG_AES_CBC => ImportKeyAlgorithm::AesCbc,
-        ALG_AES_CTR => ImportKeyAlgorithm::AesCtr,
-        ALG_AES_KW => ImportKeyAlgorithm::AesKw,
-        ALG_AES_GCM => ImportKeyAlgorithm::AesGcm,
-        ALG_PBKDF2 => ImportKeyAlgorithm::Pbkdf2,
-        ALG_HKDF => ImportKeyAlgorithm::Hkdf,
-        _ => return Err(Error::NotSupported),
-    };
-
-    Ok(normalized_algorithm)
-}
-
-/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"deriveBits"`
-fn normalize_algorithm_for_derive_bits(
-    cx: JSContext,
-    algorithm: &AlgorithmIdentifier,
-) -> Result<DeriveBitsAlgorithm, Error> {
-    let AlgorithmIdentifier::Object(obj) = algorithm else {
-        // All algorithms that support "deriveBits" require additional parameters
-        return Err(Error::NotSupported);
-    };
-
-    rooted!(in(*cx) let value = ObjectValue(obj.get()));
-    let algorithm = value_from_js_object!(Algorithm, cx, value);
-
-    let normalized_algorithm = if algorithm.name.str().eq_ignore_ascii_case(ALG_PBKDF2) {
-        let params = value_from_js_object!(Pbkdf2Params, cx, value);
-        let subtle_params = SubtlePbkdf2Params::new(cx, params)?;
-        DeriveBitsAlgorithm::Pbkdf2(subtle_params)
-    } else if algorithm.name.str().eq_ignore_ascii_case(ALG_HKDF) {
-        let params = value_from_js_object!(HkdfParams, cx, value);
-        let subtle_params = SubtleHkdfParams::new(cx, params)?;
-        DeriveBitsAlgorithm::Hkdf(subtle_params)
-    } else {
-        return Err(Error::NotSupported);
-    };
-
-    Ok(normalized_algorithm)
-}
-
-/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"deriveBits"`
-fn normalize_algorithm_for_encrypt_or_decrypt(
-    cx: JSContext,
-    algorithm: &AlgorithmIdentifier,
-) -> Result<EncryptionAlgorithm, Error> {
-    let AlgorithmIdentifier::Object(obj) = algorithm else {
-        // All algorithms that support "encrypt" or "decrypt" require additional parameters
-        return Err(Error::NotSupported);
-    };
-
-    rooted!(in(*cx) let value = ObjectValue(obj.get()));
-    let algorithm = value_from_js_object!(Algorithm, cx, value);
-
-    let name = algorithm.name.str();
-    let normalized_algorithm = if name.eq_ignore_ascii_case(ALG_AES_CBC) {
-        let params = value_from_js_object!(AesCbcParams, cx, value);
-        EncryptionAlgorithm::AesCbc(params.into())
-    } else if name.eq_ignore_ascii_case(ALG_AES_CTR) {
-        let params = value_from_js_object!(AesCtrParams, cx, value);
-        EncryptionAlgorithm::AesCtr(params.into())
-    } else if name.eq_ignore_ascii_case(ALG_AES_GCM) {
-        let params = value_from_js_object!(AesGcmParams, cx, value);
-        EncryptionAlgorithm::AesGcm(params.into())
-    } else {
-        return Err(Error::NotSupported);
-    };
-
-    Ok(normalized_algorithm)
-}
-
-/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"sign"`
-/// or `"verify"`
-fn normalize_algorithm_for_sign_or_verify(
-    cx: JSContext,
-    algorithm: &AlgorithmIdentifier,
-) -> Result<SignatureAlgorithm, Error> {
-    let name = match algorithm {
-        AlgorithmIdentifier::Object(obj) => {
-            rooted!(in(*cx) let value = ObjectValue(obj.get()));
-            let algorithm = value_from_js_object!(Algorithm, cx, value);
-
-            algorithm.name.str().to_uppercase()
-        },
-        AlgorithmIdentifier::String(name) => name.str().to_uppercase(),
-    };
-
-    let normalized_algorithm = match name.as_str() {
-        ALG_HMAC => SignatureAlgorithm::Hmac,
-        _ => return Err(Error::NotSupported),
-    };
-
-    Ok(normalized_algorithm)
-}
-
-/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"generateKey"`
-fn normalize_algorithm_for_generate_key(
-    cx: JSContext,
-    algorithm: &AlgorithmIdentifier,
-) -> Result<KeyGenerationAlgorithm, Error> {
-    let AlgorithmIdentifier::Object(obj) = algorithm else {
-        // All algorithms that support "generateKey" require additional parameters
-        return Err(Error::NotSupported);
-    };
-
-    rooted!(in(*cx) let value = ObjectValue(obj.get()));
-    let algorithm = value_from_js_object!(Algorithm, cx, value);
-
-    let name = algorithm.name.str();
-    let normalized_algorithm = if name.eq_ignore_ascii_case(ALG_AES_CBC) ||
-        name.eq_ignore_ascii_case(ALG_AES_CTR) ||
-        name.eq_ignore_ascii_case(ALG_AES_KW) ||
-        name.eq_ignore_ascii_case(ALG_AES_GCM)
-    {
-        let params = value_from_js_object!(AesKeyGenParams, cx, value);
-        KeyGenerationAlgorithm::Aes(params.into())
-    } else if name.eq_ignore_ascii_case(ALG_HMAC) {
-        let params = value_from_js_object!(HmacKeyGenParams, cx, value);
-        let subtle_params = SubtleHmacKeyGenParams::new(cx, params)?;
-        KeyGenerationAlgorithm::Hmac(subtle_params)
-    } else {
-        return Err(Error::NotSupported);
-    };
-
-    Ok(normalized_algorithm)
-}
-
-/// <https://w3c.github.io/webcrypto/#algorithm-normalization-normalize-an-algorithm> with operation `"wrapKey"` or `"unwrapKey"`
-fn normalize_algorithm_for_key_wrap(
-    cx: JSContext,
-    algorithm: &AlgorithmIdentifier,
-) -> Result<KeyWrapAlgorithm, Error> {
-    let name = match algorithm {
-        AlgorithmIdentifier::Object(obj) => {
-            rooted!(in(*cx) let value = ObjectValue(obj.get()));
-            let algorithm = value_from_js_object!(Algorithm, cx, value);
-
-            algorithm.name.str().to_uppercase()
-        },
-        AlgorithmIdentifier::String(name) => name.str().to_uppercase(),
-    };
-
-    let normalized_algorithm = match name.as_str() {
-        ALG_AES_KW => KeyWrapAlgorithm::AesKw,
-        ALG_AES_CBC => {
-            let AlgorithmIdentifier::Object(obj) = algorithm else {
-                return Err(Error::Syntax);
-            };
-            rooted!(in(*cx) let value = ObjectValue(obj.get()));
-            KeyWrapAlgorithm::AesCbc(value_from_js_object!(AesCbcParams, cx, value).into())
-        },
-        ALG_AES_CTR => {
-            let AlgorithmIdentifier::Object(obj) = algorithm else {
-                return Err(Error::Syntax);
-            };
-            rooted!(in(*cx) let value = ObjectValue(obj.get()));
-            KeyWrapAlgorithm::AesCtr(value_from_js_object!(AesCtrParams, cx, value).into())
-        },
-        ALG_AES_GCM => {
-            let AlgorithmIdentifier::Object(obj) = algorithm else {
-                return Err(Error::Syntax);
-            };
-            rooted!(in(*cx) let value = ObjectValue(obj.get()));
-            KeyWrapAlgorithm::AesGcm(value_from_js_object!(AesGcmParams, cx, value).into())
-        },
-        _ => return Err(Error::NotSupported),
-    };
-
-    Ok(normalized_algorithm)
-}
-
 impl SubtleCrypto {
     /// <https://w3c.github.io/webcrypto/#aes-cbc-operations>
-    fn encrypt_aes_cbc(
+    pub(crate) fn encrypt_aes_cbc(
         &self,
         params: &SubtleAesCbcParams,
         key: &CryptoKey,
@@ -1704,7 +1064,7 @@ impl SubtleCrypto {
     }
 
     /// <https://w3c.github.io/webcrypto/#aes-cbc-operations>
-    fn decrypt_aes_cbc(
+    pub(crate) fn decrypt_aes_cbc(
         &self,
         params: &SubtleAesCbcParams,
         key: &CryptoKey,
@@ -1749,7 +1109,7 @@ impl SubtleCrypto {
     }
 
     /// <https://w3c.github.io/webcrypto/#aes-ctr-operations>
-    fn encrypt_decrypt_aes_ctr(
+    pub(crate) fn encrypt_decrypt_aes_ctr(
         &self,
         params: &SubtleAesCtrParams,
         key: &CryptoKey,
@@ -1788,7 +1148,7 @@ impl SubtleCrypto {
     }
 
     /// <https://w3c.github.io/webcrypto/#aes-gcm-operations>
-    fn encrypt_aes_gcm(
+    pub(crate) fn encrypt_aes_gcm(
         &self,
         params: &SubtleAesGcmParams,
         key: &CryptoKey,
@@ -1909,7 +1269,7 @@ impl SubtleCrypto {
     }
 
     /// <https://w3c.github.io/webcrypto/#aes-gcm-operations>
-    fn decrypt_aes_gcm(
+    pub(crate) fn decrypt_aes_gcm(
         &self,
         params: &SubtleAesGcmParams,
         key: &CryptoKey,
@@ -2037,7 +1397,7 @@ impl SubtleCrypto {
     /// <https://w3c.github.io/webcrypto/#aes-ctr-operations>
     /// <https://w3c.github.io/webcrypto/#aes-kw-operations>
     #[allow(unsafe_code)]
-    fn generate_key_aes(
+    pub(crate) fn generate_key_aes(
         &self,
         usages: Vec<KeyUsage>,
         key_gen_params: &SubtleAesKeyGenParams,
@@ -2115,7 +1475,7 @@ impl SubtleCrypto {
 
     /// <https://w3c.github.io/webcrypto/#hmac-operations>
     #[allow(unsafe_code)]
-    fn generate_key_hmac(
+    pub(crate) fn generate_key_hmac(
         &self,
         usages: Vec<KeyUsage>,
         params: &SubtleHmacKeyGenParams,
@@ -2196,7 +1556,7 @@ impl SubtleCrypto {
     /// <https://w3c.github.io/webcrypto/#aes-cbc-operations>
     /// <https://w3c.github.io/webcrypto/#aes-ctr-operations>
     #[allow(unsafe_code)]
-    fn import_key_aes(
+    pub(crate) fn import_key_aes(
         &self,
         format: KeyFormat,
         data: &[u8],
@@ -2254,7 +1614,11 @@ impl SubtleCrypto {
 
     /// <https://w3c.github.io/webcrypto/#aes-cbc-operations>
     /// <https://w3c.github.io/webcrypto/#aes-ctr-operations>
-    fn export_key_aes(&self, format: KeyFormat, key: &CryptoKey) -> Result<AesExportedKey, Error> {
+    pub(crate) fn export_key_aes(
+        &self,
+        format: KeyFormat,
+        key: &CryptoKey,
+    ) -> Result<AesExportedKey, Error> {
         match format {
             KeyFormat::Raw => match key.handle() {
                 Handle::Aes128(key_data) => Ok(AesExportedKey::Raw(key_data.as_slice().to_vec())),
@@ -2308,7 +1672,7 @@ impl SubtleCrypto {
 
     /// <https://w3c.github.io/webcrypto/#hkdf-operations>
     #[allow(unsafe_code)]
-    fn import_key_hkdf(
+    pub(crate) fn import_key_hkdf(
         &self,
         format: KeyFormat,
         data: &[u8],
@@ -2365,7 +1729,7 @@ impl SubtleCrypto {
 
     /// <https://w3c.github.io/webcrypto/#hmac-operations>
     #[allow(unsafe_code)]
-    fn import_key_hmac(
+    pub(crate) fn import_key_hmac(
         &self,
         normalized_algorithm: &SubtleHmacImportParams,
         format: KeyFormat,
@@ -2560,7 +1924,7 @@ impl SubtleCrypto {
 
     /// <https://w3c.github.io/webcrypto/#pbkdf2-operations>
     #[allow(unsafe_code)]
-    fn import_key_pbkdf2(
+    pub(crate) fn import_key_pbkdf2(
         &self,
         format: KeyFormat,
         data: &[u8],
@@ -2629,564 +1993,4 @@ fn data_to_jwk_params(alg: &str, size: &str, key: &[u8]) -> (DOMString, DOMStrin
     };
     let data = base64::engine::general_purpose::STANDARD_NO_PAD.encode(key);
     (jwk_alg, DOMString::from(data))
-}
-
-trait AlgorithmFromName {
-    fn from_name(name: DOMString, out: MutableHandleObject, cx: JSContext);
-}
-
-impl AlgorithmFromName for KeyAlgorithm {
-    /// Fill the object referenced by `out` with an [KeyAlgorithm]
-    /// of the specified name and size.
-    #[allow(unsafe_code)]
-    fn from_name(name: DOMString, out: MutableHandleObject, cx: JSContext) {
-        let key_algorithm = Self { name };
-
-        unsafe {
-            key_algorithm.to_jsobject(*cx, out);
-        }
-    }
-}
-
-trait AlgorithmFromLengthAndHash {
-    fn from_length_and_hash(
-        length: u32,
-        hash: DigestAlgorithm,
-        out: MutableHandleObject,
-        cx: JSContext,
-    );
-}
-
-impl AlgorithmFromLengthAndHash for HmacKeyAlgorithm {
-    #[allow(unsafe_code)]
-    fn from_length_and_hash(
-        length: u32,
-        hash: DigestAlgorithm,
-        out: MutableHandleObject,
-        cx: JSContext,
-    ) {
-        let hmac_key_algorithm = Self {
-            parent: KeyAlgorithm {
-                name: ALG_HMAC.into(),
-            },
-            length,
-            hash: KeyAlgorithm { name: hash.name() },
-        };
-
-        unsafe {
-            hmac_key_algorithm.to_jsobject(*cx, out);
-        }
-    }
-}
-
-trait AlgorithmFromNameAndSize {
-    fn from_name_and_size(name: DOMString, size: u16, out: MutableHandleObject, cx: JSContext);
-}
-
-impl AlgorithmFromNameAndSize for AesKeyAlgorithm {
-    /// Fill the object referenced by `out` with an [AesKeyAlgorithm]
-    /// of the specified name and size.
-    #[allow(unsafe_code)]
-    fn from_name_and_size(name: DOMString, size: u16, out: MutableHandleObject, cx: JSContext) {
-        let key_algorithm = Self {
-            parent: KeyAlgorithm { name },
-            length: size,
-        };
-
-        unsafe {
-            key_algorithm.to_jsobject(*cx, out);
-        }
-    }
-}
-
-impl SubtleHkdfParams {
-    /// <https://w3c.github.io/webcrypto/#hkdf-operations>
-    fn derive_bits(&self, key: &CryptoKey, length: Option<u32>) -> Result<Vec<u8>, Error> {
-        // Step 1. If length is null or zero, or is not a multiple of 8, then throw an OperationError.
-        let Some(length) = length else {
-            return Err(Error::Operation);
-        };
-        if length == 0 || length % 8 != 0 {
-            return Err(Error::Operation);
-        };
-
-        // Step 3. Let keyDerivationKey be the secret represented by [[handle]] internal slot of key.
-        let key_derivation_key = key.handle().as_bytes();
-
-        // Step 4. Let result be the result of performing the HKDF extract and then the HKDF expand step described
-        // in Section 2 of [RFC5869] using:
-        // * the hash member of normalizedAlgorithm as Hash,
-        // * keyDerivationKey as the input keying material, IKM,
-        // * the contents of the salt member of normalizedAlgorithm as salt,
-        // * the contents of the info member of normalizedAlgorithm as info,
-        // * length divided by 8 as the value of L,
-        let mut result = vec![0; length as usize / 8];
-        let algorithm = match self.hash {
-            DigestAlgorithm::Sha1 => hkdf::HKDF_SHA1_FOR_LEGACY_USE_ONLY,
-            DigestAlgorithm::Sha256 => hkdf::HKDF_SHA256,
-            DigestAlgorithm::Sha384 => hkdf::HKDF_SHA384,
-            DigestAlgorithm::Sha512 => hkdf::HKDF_SHA512,
-        };
-        let salt = hkdf::Salt::new(algorithm, &self.salt);
-        let info = self.info.as_slice();
-        let pseudo_random_key = salt.extract(key_derivation_key);
-
-        let Ok(output_key_material) =
-            pseudo_random_key.expand(std::slice::from_ref(&info), algorithm)
-        else {
-            // Step 5. If the key derivation operation fails, then throw an OperationError.
-            return Err(Error::Operation);
-        };
-
-        if output_key_material.fill(&mut result).is_err() {
-            return Err(Error::Operation);
-        };
-
-        // Step 6. Return the result of creating an ArrayBuffer containing result.
-        // NOTE: The ArrayBuffer is created by the caller
-        Ok(result)
-    }
-}
-
-impl SubtlePbkdf2Params {
-    /// <https://w3c.github.io/webcrypto/#pbkdf2-operations>
-    fn derive_bits(&self, key: &CryptoKey, length: Option<u32>) -> Result<Vec<u8>, Error> {
-        // Step 1. If length is null or zero, or is not a multiple of 8, then throw an OperationError.
-        let Some(length) = length else {
-            return Err(Error::Operation);
-        };
-        if length == 0 || length % 8 != 0 {
-            return Err(Error::Operation);
-        };
-
-        // Step 2. If the iterations member of normalizedAlgorithm is zero, then throw an OperationError.
-        let Ok(iterations) = NonZero::<u32>::try_from(self.iterations) else {
-            return Err(Error::Operation);
-        };
-
-        // Step 3. Let prf be the MAC Generation function described in Section 4 of [FIPS-198-1]
-        // using the hash function described by the hash member of normalizedAlgorithm.
-        let prf = match self.hash {
-            DigestAlgorithm::Sha1 => pbkdf2::PBKDF2_HMAC_SHA1,
-            DigestAlgorithm::Sha256 => pbkdf2::PBKDF2_HMAC_SHA256,
-            DigestAlgorithm::Sha384 => pbkdf2::PBKDF2_HMAC_SHA384,
-            DigestAlgorithm::Sha512 => pbkdf2::PBKDF2_HMAC_SHA512,
-        };
-
-        // Step 4. Let result be the result of performing the PBKDF2 operation defined in Section 5.2 of [RFC8018] using
-        // prf as the pseudo-random function, PRF, the password represented by [[handle]] internal slot of key as
-        // the password, P, the contents of the salt attribute of normalizedAlgorithm as the salt, S, the value of
-        // the iterations attribute of normalizedAlgorithm as the iteration count, c, and length divided by 8 as the
-        // intended key length, dkLen.
-        let mut result = vec![0; length as usize / 8];
-        pbkdf2::derive(
-            prf,
-            iterations,
-            &self.salt,
-            key.handle().as_bytes(),
-            &mut result,
-        );
-
-        // Step 5. If the key derivation operation fails, then throw an OperationError.
-        // TODO: Investigate when key derivation can fail and how ring handles that case
-        // (pbkdf2::derive does not return a Result type)
-
-        // Step 6. Return result
-        Ok(result)
-    }
-}
-
-/// <https://w3c.github.io/webcrypto/#aes-ctr-operations>
-fn get_key_length_for_aes(length: u16) -> Result<u32, Error> {
-    // Step 1. If the length member of normalizedDerivedKeyAlgorithm is not 128, 192 or 256,
-    // then throw an OperationError.
-    if !matches!(length, 128 | 192 | 256) {
-        return Err(Error::Operation);
-    }
-
-    // Step 2. Return the length member of normalizedDerivedKeyAlgorithm.
-    Ok(length as u32)
-}
-
-impl GetKeyLengthAlgorithm {
-    fn get_key_length(&self) -> Result<u32, Error> {
-        match self {
-            Self::Aes(length) => get_key_length_for_aes(*length),
-            Self::Hmac(params) => params.get_key_length(),
-        }
-    }
-}
-
-impl DigestAlgorithm {
-    /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    fn name(&self) -> DOMString {
-        match self {
-            Self::Sha1 => ALG_SHA1,
-            Self::Sha256 => ALG_SHA256,
-            Self::Sha384 => ALG_SHA384,
-            Self::Sha512 => ALG_SHA512,
-        }
-        .into()
-    }
-
-    fn digest(&self, data: &[u8]) -> Result<impl AsRef<[u8]>, Error> {
-        let algorithm = match self {
-            Self::Sha1 => &digest::SHA1_FOR_LEGACY_USE_ONLY,
-            Self::Sha256 => &digest::SHA256,
-            Self::Sha384 => &digest::SHA384,
-            Self::Sha512 => &digest::SHA512,
-        };
-        Ok(digest::digest(algorithm, data))
-    }
-
-    fn block_size_in_bits(&self) -> usize {
-        match self {
-            Self::Sha1 => 160,
-            Self::Sha256 => 256,
-            Self::Sha384 => 384,
-            Self::Sha512 => 512,
-        }
-    }
-}
-
-impl ImportKeyAlgorithm {
-    fn import_key(
-        &self,
-        subtle: &SubtleCrypto,
-        format: KeyFormat,
-        secret: &[u8],
-        extractable: bool,
-        key_usages: Vec<KeyUsage>,
-        can_gc: CanGc,
-    ) -> Result<DomRoot<CryptoKey>, Error> {
-        match self {
-            Self::AesCbc => {
-                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_CBC, can_gc)
-            },
-            Self::AesCtr => {
-                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_CTR, can_gc)
-            },
-            Self::AesKw => {
-                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_KW, can_gc)
-            },
-            Self::AesGcm => {
-                subtle.import_key_aes(format, secret, extractable, key_usages, ALG_AES_GCM, can_gc)
-            },
-            Self::Hmac(params) => {
-                subtle.import_key_hmac(params, format, secret, extractable, key_usages, can_gc)
-            },
-            Self::Pbkdf2 => {
-                subtle.import_key_pbkdf2(format, secret, extractable, key_usages, can_gc)
-            },
-            Self::Hkdf => subtle.import_key_hkdf(format, secret, extractable, key_usages, can_gc),
-        }
-    }
-}
-
-impl DeriveBitsAlgorithm {
-    fn derive_bits(&self, key: &CryptoKey, length: Option<u32>) -> Result<Vec<u8>, Error> {
-        match self {
-            Self::Pbkdf2(pbkdf2_params) => pbkdf2_params.derive_bits(key, length),
-            Self::Hkdf(hkdf_params) => hkdf_params.derive_bits(key, length),
-        }
-    }
-}
-
-impl EncryptionAlgorithm {
-    /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    fn name(&self) -> &str {
-        match self {
-            Self::AesCbc(params) => &params.name,
-            Self::AesCtr(params) => &params.name,
-            Self::AesGcm(params) => &params.name,
-        }
-    }
-
-    // FIXME: This doesn't really need the "SubtleCrypto" argument
-    fn encrypt(
-        &self,
-        subtle: &SubtleCrypto,
-        key: &CryptoKey,
-        data: &[u8],
-        cx: JSContext,
-        result: MutableHandleObject,
-        can_gc: CanGc,
-    ) -> Result<Vec<u8>, Error> {
-        match self {
-            Self::AesCbc(params) => subtle.encrypt_aes_cbc(params, key, data, cx, result, can_gc),
-            Self::AesCtr(params) => {
-                subtle.encrypt_decrypt_aes_ctr(params, key, data, cx, result, can_gc)
-            },
-            Self::AesGcm(params) => subtle.encrypt_aes_gcm(params, key, data, cx, result, can_gc),
-        }
-    }
-
-    // FIXME: This doesn't really need the "SubtleCrypto" argument
-    fn decrypt(
-        &self,
-        subtle: &SubtleCrypto,
-        key: &CryptoKey,
-        data: &[u8],
-        cx: JSContext,
-        result: MutableHandleObject,
-        can_gc: CanGc,
-    ) -> Result<Vec<u8>, Error> {
-        match self {
-            Self::AesCbc(params) => subtle.decrypt_aes_cbc(params, key, data, cx, result, can_gc),
-            Self::AesCtr(params) => {
-                subtle.encrypt_decrypt_aes_ctr(params, key, data, cx, result, can_gc)
-            },
-            Self::AesGcm(params) => subtle.decrypt_aes_gcm(params, key, data, cx, result, can_gc),
-        }
-    }
-}
-
-impl SignatureAlgorithm {
-    fn name(&self) -> &str {
-        match self {
-            Self::Hmac => ALG_HMAC,
-        }
-    }
-
-    fn sign(&self, cx: JSContext, key: &CryptoKey, data: &[u8]) -> Result<Vec<u8>, Error> {
-        match self {
-            Self::Hmac => sign_hmac(cx, key, data).map(|s| s.as_ref().to_vec()),
-        }
-    }
-
-    fn verify(
-        &self,
-        cx: JSContext,
-        key: &CryptoKey,
-        data: &[u8],
-        signature: &[u8],
-    ) -> Result<bool, Error> {
-        match self {
-            Self::Hmac => verify_hmac(cx, key, data, signature),
-        }
-    }
-}
-
-impl KeyGenerationAlgorithm {
-    // FIXME: This doesn't really need the "SubtleCrypto" argument
-    fn generate_key(
-        &self,
-        subtle: &SubtleCrypto,
-        usages: Vec<KeyUsage>,
-        extractable: bool,
-        can_gc: CanGc,
-    ) -> Result<DomRoot<CryptoKey>, Error> {
-        match self {
-            Self::Aes(params) => subtle.generate_key_aes(usages, params, extractable, can_gc),
-            Self::Hmac(params) => subtle.generate_key_hmac(usages, params, extractable, can_gc),
-        }
-    }
-}
-
-/// <https://w3c.github.io/webcrypto/#hmac-operations>
-fn sign_hmac(cx: JSContext, key: &CryptoKey, data: &[u8]) -> Result<impl AsRef<[u8]>, Error> {
-    // Step 1. Let mac be the result of performing the MAC Generation operation described in Section 4 of [FIPS-198-1]
-    // using the key represented by [[handle]] internal slot of key, the hash function identified by the hash attribute
-    // of the [[algorithm]] internal slot of key and message as the input data text.
-    rooted!(in(*cx) let mut algorithm_slot = ObjectValue(key.Algorithm(cx).as_ptr()));
-    let params = value_from_js_object!(HmacKeyAlgorithm, cx, algorithm_slot);
-
-    let hash_algorithm = match params.hash.name.str() {
-        ALG_SHA1 => hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
-        ALG_SHA256 => hmac::HMAC_SHA256,
-        ALG_SHA384 => hmac::HMAC_SHA384,
-        ALG_SHA512 => hmac::HMAC_SHA512,
-        _ => return Err(Error::NotSupported),
-    };
-
-    let sign_key = hmac::Key::new(hash_algorithm, key.handle().as_bytes());
-    let mac = hmac::sign(&sign_key, data);
-
-    // Step 2. Return the result of creating an ArrayBuffer containing mac.
-    // NOTE: This is done by the caller
-    Ok(mac)
-}
-
-/// <https://w3c.github.io/webcrypto/#hmac-operations>
-fn verify_hmac(
-    cx: JSContext,
-    key: &CryptoKey,
-    data: &[u8],
-    signature: &[u8],
-) -> Result<bool, Error> {
-    // Step 1. Let mac be the result of performing the MAC Generation operation described in Section 4 of [FIPS-198-1]
-    // using the key represented by [[handle]] internal slot of key, the hash function identified by the hash attribute
-    // of the [[algorithm]] internal slot of key and message as the input data text.
-    let mac = sign_hmac(cx, key, data)?;
-
-    // Step 2. Return true if mac is equal to signature and false otherwise.
-    let is_valid = mac.as_ref() == signature;
-    Ok(is_valid)
-}
-
-impl KeyWrapAlgorithm {
-    /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
-    fn name(&self) -> &str {
-        match self {
-            Self::AesKw => ALG_AES_KW,
-            Self::AesCbc(key_gen_params) => &key_gen_params.name,
-            Self::AesCtr(key_gen_params) => &key_gen_params.name,
-            Self::AesGcm(_) => ALG_AES_GCM,
-        }
-    }
-}
-
-/// <https://w3c.github.io/webcrypto/#concept-parse-a-jwk>
-fn parse_jwk(
-    bytes: &[u8],
-    import_alg: ImportKeyAlgorithm,
-    extractable: bool,
-    key_usages: &[KeyUsage],
-) -> Result<Vec<u8>, Error> {
-    let value = serde_json::from_slice(bytes)
-        .map_err(|_| Error::Type("Failed to parse JWK string".into()))?;
-    let serde_json::Value::Object(obj) = value else {
-        return Err(Error::Data);
-    };
-
-    let kty = get_jwk_string(&obj, "kty")?;
-    let ext = get_jwk_bool(&obj, "ext")?;
-    if !ext && extractable {
-        return Err(Error::Data);
-    }
-
-    // If the key_ops field of jwk is present, and is invalid according to the requirements of JSON Web Key [JWK]
-    // or does not contain all of the specified usages values, then throw a DataError.
-    if let Some(serde_json::Value::Array(key_ops)) = obj.get("key_ops") {
-        if key_ops.iter().any(|op| {
-            let op_string = match op {
-                serde_json::Value::String(op_string) => op_string,
-                _ => return true,
-            };
-            let usage = match usage_from_str(op_string) {
-                Ok(usage) => usage,
-                Err(_) => {
-                    return true;
-                },
-            };
-            !key_usages.contains(&usage)
-        }) {
-            return Err(Error::Data);
-        }
-    }
-
-    match import_alg {
-        ImportKeyAlgorithm::AesCbc |
-        ImportKeyAlgorithm::AesCtr |
-        ImportKeyAlgorithm::AesKw |
-        ImportKeyAlgorithm::AesGcm => {
-            if kty != "oct" {
-                return Err(Error::Data);
-            }
-            let k = get_jwk_string(&obj, "k")?;
-            let alg = get_jwk_string(&obj, "alg")?;
-
-            let data = base64::engine::general_purpose::STANDARD_NO_PAD
-                .decode(k.as_bytes())
-                .map_err(|_| Error::Data)?;
-
-            let expected_alg = match (data.len() * 8, &import_alg) {
-                (128, ImportKeyAlgorithm::AesCbc) => "A128CBC",
-                (128, ImportKeyAlgorithm::AesCtr) => "A128CTR",
-                (128, ImportKeyAlgorithm::AesKw) => "A128KW",
-                (128, ImportKeyAlgorithm::AesGcm) => "A128GCM",
-                (192, ImportKeyAlgorithm::AesCbc) => "A192CBC",
-                (192, ImportKeyAlgorithm::AesCtr) => "A192CTR",
-                (192, ImportKeyAlgorithm::AesKw) => "A192KW",
-                (192, ImportKeyAlgorithm::AesGcm) => "A192GCM",
-                (256, ImportKeyAlgorithm::AesCbc) => "A256CBC",
-                (256, ImportKeyAlgorithm::AesCtr) => "A256CTR",
-                (256, ImportKeyAlgorithm::AesKw) => "A256KW",
-                (256, ImportKeyAlgorithm::AesGcm) => "A256GCM",
-                _ => return Err(Error::Data),
-            };
-
-            if alg != expected_alg {
-                return Err(Error::Data);
-            }
-
-            if let Some(serde_json::Value::String(use_)) = obj.get("use") {
-                if use_ != "enc" {
-                    return Err(Error::Data);
-                }
-            }
-
-            Ok(data)
-        },
-        ImportKeyAlgorithm::Hmac(params) => {
-            if kty != "oct" {
-                return Err(Error::Data);
-            }
-            let k = get_jwk_string(&obj, "k")?;
-            let alg = get_jwk_string(&obj, "alg")?;
-
-            let expected_alg = match params.hash {
-                DigestAlgorithm::Sha1 => "HS1",
-                DigestAlgorithm::Sha256 => "HS256",
-                DigestAlgorithm::Sha384 => "HS384",
-                DigestAlgorithm::Sha512 => "HS512",
-            };
-
-            if alg != expected_alg {
-                return Err(Error::Data);
-            }
-
-            if let Some(serde_json::Value::String(use_)) = obj.get("use") {
-                if use_ != "sign" {
-                    return Err(Error::Data);
-                }
-            }
-
-            base64::engine::general_purpose::STANDARD_NO_PAD
-                .decode(k.as_bytes())
-                .map_err(|_| Error::Data)
-        },
-        _ => Err(Error::NotSupported),
-    }
-}
-
-fn get_jwk_string(
-    value: &serde_json::Map<String, serde_json::Value>,
-    key: &str,
-) -> Result<String, Error> {
-    let s = value
-        .get(key)
-        .ok_or(Error::Data)?
-        .as_str()
-        .ok_or(Error::Data)?;
-    Ok(s.to_string())
-}
-
-fn get_jwk_bool(
-    value: &serde_json::Map<String, serde_json::Value>,
-    key: &str,
-) -> Result<bool, Error> {
-    let b = value
-        .get(key)
-        .ok_or(Error::Data)?
-        .as_bool()
-        .ok_or(Error::Data)?;
-    Ok(b)
-}
-
-fn usage_from_str(op: &str) -> Result<KeyUsage, Error> {
-    let usage = match op {
-        "encrypt" => KeyUsage::Encrypt,
-        "decrypt" => KeyUsage::Decrypt,
-        "sign" => KeyUsage::Sign,
-        "verify" => KeyUsage::Verify,
-        "deriveKey" => KeyUsage::DeriveKey,
-        "deriveBits" => KeyUsage::DeriveBits,
-        "wrapKey" => KeyUsage::WrapKey,
-        "unwrapKey" => KeyUsage::UnwrapKey,
-        _ => {
-            return Err(Error::Data);
-        },
-    };
-    Ok(usage)
 }

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -33,6 +33,7 @@ pub(crate) mod document_loader;
 mod dom;
 mod canvas_context;
 mod canvas_state;
+pub(crate) mod crypto;
 pub(crate) mod fetch;
 pub(crate) mod indexed_db;
 mod init;


### PR DESCRIPTION
Extract various helper functions to the `crypto` module to make it cleaner. Specifically the only thing left in `subtlecrypto.rs` now is the DOM interface implementation.

`params.rs` contains all the parameter structs. At some point splitting the algorithms into separate files in the `crypto` module might make readability better.

Testing: Covered by WPT, but is a refactor
Fixes: None