### PR TITLE
renderer: Apply initial viewport scale to `page_zoom`.

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -45,8 +45,6 @@ struct ScrollEvent {
 enum ScrollZoomEvent {
     /// A pinch zoom event that magnifies the view by the given factor.
     PinchZoom(f32),
-    /// A zoom event that establishes the initial zoom from the viewport meta tag.
-    InitialViewportZoom(f32),
     /// A scroll event that scrolls the scroll node at the given location by the
     /// given amount.
     Scroll(ScrollEvent),
@@ -740,15 +738,11 @@ impl WebViewRenderer {
 
         // Batch up all scroll events into one, or else we'll do way too much painting.
         let mut combined_scroll_event: Option<ScrollEvent> = None;
-        let mut base_page_zoom = self.pinch_zoom_level().get();
         let mut combined_magnification = 1.0;
         for scroll_event in self.pending_scroll_zoom_events.drain(..) {
             match scroll_event {
                 ScrollZoomEvent::PinchZoom(magnification) => {
                     combined_magnification *= magnification
-                },
-                ScrollZoomEvent::InitialViewportZoom(magnification) => {
-                    base_page_zoom = magnification
                 },
                 ScrollZoomEvent::Scroll(scroll_event_info) => {
                     let combined_event = match combined_scroll_event.as_mut() {
@@ -806,11 +800,12 @@ impl WebViewRenderer {
             );
         }
 
-        let pinch_zoom_result =
-            match self.set_pinch_zoom_level(base_page_zoom * combined_magnification) {
-                true => PinchZoomResult::DidPinchZoom,
-                false => PinchZoomResult::DidNotPinchZoom,
-            };
+        let pinch_zoom_result = match self
+            .set_pinch_zoom_level(self.pinch_zoom_level().get() * combined_magnification)
+        {
+            true => PinchZoomResult::DidPinchZoom,
+            false => PinchZoomResult::DidNotPinchZoom,
+        };
 
         (pinch_zoom_result, scroll_result)
     }
@@ -994,12 +989,11 @@ impl WebViewRenderer {
     }
 
     pub fn set_viewport_description(&mut self, viewport_description: ViewportDescription) {
-        self.pending_scroll_zoom_events
-            .push(ScrollZoomEvent::InitialViewportZoom(
-                viewport_description
-                    .clone()
-                    .clamp_zoom(viewport_description.initial_scale.get()),
-            ));
+        self.set_page_zoom(Scale::new(
+            viewport_description
+                .clone()
+                .clamp_zoom(viewport_description.initial_scale.get()),
+        ));
         self.viewport_description = Some(viewport_description);
     }
 

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -86,7 +86,7 @@ pub(crate) struct WebViewRenderer {
     /// Touch input state machine
     touch_handler: TouchHandler,
     /// "Desktop-style" zoom that resizes the viewport to fit the window.
-    pub page_zoom: Scale<f32, CSSPixel, DeviceIndependentPixel>,
+    page_zoom: Scale<f32, CSSPixel, DeviceIndependentPixel>,
     /// "Mobile-style" zoom that does not reflow the page.
     pinch_zoom: PinchZoomFactor,
     /// The HiDPI scale factor for the `WebView` associated with this renderer. This is controlled
@@ -939,12 +939,7 @@ impl WebViewRenderer {
 
         // TODO: Scroll to keep the center in view?
         self.pending_scroll_zoom_events
-            .push(ScrollZoomEvent::PinchZoom(
-                self.viewport_description
-                    .clone()
-                    .unwrap_or_default()
-                    .clamp_zoom(magnification),
-            ));
+            .push(ScrollZoomEvent::PinchZoom(magnification));
     }
 
     fn send_window_size_message(&self) {


### PR DESCRIPTION
Attached scenario in issue highlights that applying viewport scale needs reflow.
Hence applying it to `page_zoom` because we reflow for `page_zoom`.

_**Follow-Up**: Ignore applying of viewport meta tag by default for desktop browsers._  
_Chromium and Firefox ignore in desktop browser, only enable in devtools._ #39133 

Testing: Manual Test Case using mobile size window dimensions.

> Another Scenario verified using devtools:  Page opened with `initial scale=0.5` have 2x the width as compared with the page with `initial-scale=1.0`

Fixes: #39002 
