### PR TITLE
libservo: Allow embedders to drive frame updates via `RefreshDriver` trait

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -56,7 +56,7 @@ use webrender_api::{
 };
 
 use crate::InitialCompositorState;
-use crate::refresh_driver::RefreshDriver;
+use crate::refresh_driver::{AnimationRefreshDriverObserver, BaseRefreshDriver};
 use crate::screenshot::ScreenshotTaker;
 use crate::webview_manager::WebViewManager;
 use crate::webview_renderer::{PinchZoomResult, UnknownWebView, WebViewRenderer};
@@ -71,8 +71,11 @@ pub enum WebRenderDebugOption {
 
 /// Data that is shared by all WebView renderers.
 pub struct ServoRenderer {
-    /// The [`RefreshDriver`] which manages the rythym of painting.
-    refresh_driver: RefreshDriver,
+    /// The [`BaseRefreshDriver`] which manages the painting of `WebView`s during animations.
+    pub(crate) refresh_driver: Rc<BaseRefreshDriver>,
+
+    /// A [`RefreshDriverObserver`] for WebView content animations.
+    animation_refresh_driver_observer: Rc<AnimationRefreshDriverObserver>,
 
     /// Tracks whether we are in the process of shutting down, or have shut down and should close
     /// the compositor. This is shared with the `Servo` instance.
@@ -284,13 +287,19 @@ impl IOCompositor {
             state.sender.clone(),
             CompositorMsg::CollectMemoryReport,
         );
+
+        let refresh_driver = Rc::new(BaseRefreshDriver::new(
+            state.event_loop_waker,
+            state.refresh_driver,
+        ));
+        let animation_refresh_driver_observer = Rc::new(AnimationRefreshDriverObserver::new(
+            state.constellation_chan.clone(),
+        ));
+
         let compositor = IOCompositor {
             global: Rc::new(RefCell::new(ServoRenderer {
-                refresh_driver: RefreshDriver::new(
-                    state.constellation_chan.clone(),
-                    state.event_loop_waker,
-                    state.begin_frame_source,
-                ),
+                refresh_driver,
+                animation_refresh_driver_observer,
                 shutdown_state: state.shutdown_state,
                 compositor_receiver: state.receiver,
                 constellation_sender: state.constellation_chan,
@@ -351,6 +360,13 @@ impl IOCompositor {
 
     pub(crate) fn webview_renderer(&self, webview_id: WebViewId) -> Option<&WebViewRenderer> {
         self.webview_renderers.get(webview_id)
+    }
+
+    pub(crate) fn webview_renderer_mut(
+        &mut self,
+        webview_id: WebViewId,
+    ) -> Option<&mut WebViewRenderer> {
+        self.webview_renderers.get_mut(webview_id)
     }
 
     pub(crate) fn set_needs_repaint(&self, reason: RepaintReason) {
@@ -454,10 +470,15 @@ impl IOCompositor {
                 if webview_renderer
                     .change_pipeline_running_animations_state(pipeline_id, animation_state)
                 {
-                    self.global
-                        .borrow()
-                        .refresh_driver
-                        .notify_animation_state_changed(webview_renderer);
+                    let global = self.global.borrow();
+                    if global
+                        .animation_refresh_driver_observer
+                        .notify_animation_state_changed(webview_renderer)
+                    {
+                        global
+                            .refresh_driver
+                            .add_observer(global.animation_refresh_driver_observer.clone());
+                    }
                 }
             },
 
@@ -475,10 +496,15 @@ impl IOCompositor {
                 };
 
                 if webview_renderer.set_throttled(pipeline_id, throttled) {
-                    self.global
-                        .borrow()
-                        .refresh_driver
-                        .notify_animation_state_changed(webview_renderer);
+                    let global = self.global.borrow();
+                    if global
+                        .animation_refresh_driver_observer
+                        .notify_animation_state_changed(webview_renderer)
+                    {
+                        global
+                            .refresh_driver
+                            .add_observer(global.animation_refresh_driver_observer.clone());
+                    }
                 }
             },
 
@@ -1150,12 +1176,23 @@ impl IOCompositor {
             .any(WebViewRenderer::animation_callbacks_running)
     }
 
+    pub(crate) fn animating_webviews(&self) -> Vec<WebViewId> {
+        self.webview_renderers
+            .iter()
+            .filter_map(|webview_renderer| {
+                if webview_renderer.animating() {
+                    Some(webview_renderer.id)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     /// Render the WebRender scene to the active `RenderingContext`.
     pub fn render(&mut self) {
-        self.global
-            .borrow()
-            .refresh_driver
-            .notify_will_paint(self.webview_renderers.iter());
+        let refresh_driver = &self.global.borrow().refresh_driver.clone();
+        refresh_driver.notify_will_paint(self);
 
         self.render_inner();
 
@@ -1503,12 +1540,6 @@ impl IOCompositor {
     ) {
         if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
             webview_renderer.notify_scroll_event(scroll_location, cursor);
-        }
-    }
-
-    pub fn on_vsync(&mut self, webview_id: WebViewId) {
-        if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-            webview_renderer.on_vsync();
         }
     }
 

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -289,6 +289,7 @@ impl IOCompositor {
                 refresh_driver: RefreshDriver::new(
                     state.constellation_chan.clone(),
                     state.event_loop_waker,
+                    state.begin_frame_source,
                 ),
                 shutdown_state: state.shutdown_state,
                 compositor_receiver: state.receiver,

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -12,7 +12,7 @@ use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::{CompositorMsg, CompositorProxy};
 use constellation_traits::EmbedderToConstellationMessage;
 use crossbeam_channel::Sender;
-use embedder_traits::{EventLoopWaker, ShutdownState};
+use embedder_traits::{BeginFrameSource, EventLoopWaker, ShutdownState};
 use profile_traits::{mem, time};
 use webrender::RenderApi;
 use webrender_api::DocumentId;
@@ -55,4 +55,5 @@ pub struct InitialCompositorState {
     /// An [`EventLoopWaker`] used in order to wake up the embedder when it is
     /// time to paint.
     pub event_loop_waker: Box<dyn EventLoopWaker>,
+    pub begin_frame_source: Option<Rc<dyn BeginFrameSource>>,
 }

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -12,7 +12,7 @@ use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::{CompositorMsg, CompositorProxy};
 use constellation_traits::EmbedderToConstellationMessage;
 use crossbeam_channel::Sender;
-use embedder_traits::{BeginFrameSource, EventLoopWaker, ShutdownState};
+use embedder_traits::{EventLoopWaker, RefreshDriver, ShutdownState};
 use profile_traits::{mem, time};
 use webrender::RenderApi;
 use webrender_api::DocumentId;
@@ -55,5 +55,6 @@ pub struct InitialCompositorState {
     /// An [`EventLoopWaker`] used in order to wake up the embedder when it is
     /// time to paint.
     pub event_loop_waker: Box<dyn EventLoopWaker>,
-    pub begin_frame_source: Option<Rc<dyn BeginFrameSource>>,
+    /// An optional [`RefreshDriver`] provided by the embedder.
+    pub refresh_driver: Option<Rc<dyn RefreshDriver>>,
 }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -480,6 +480,7 @@ impl Servo {
             webxr_main_thread,
             shutdown_state: shutdown_state.clone(),
             event_loop_waker,
+            begin_frame_source: builder.begin_frame_source,
         });
 
         let constellation_proxy = ConstellationProxy::new(constellation_chan);
@@ -1366,6 +1367,7 @@ pub struct ServoBuilder {
     opts: Option<Box<Opts>>,
     preferences: Option<Box<Preferences>>,
     event_loop_waker: Box<dyn EventLoopWaker>,
+    begin_frame_source: Option<Rc<dyn BeginFrameSource>>,
     user_content_manager: UserContentManager,
     protocol_registry: ProtocolRegistry,
     #[cfg(feature = "webxr")]
@@ -1379,6 +1381,7 @@ impl ServoBuilder {
             opts: None,
             preferences: None,
             event_loop_waker: Box::new(DefaultEventLoopWaker),
+            begin_frame_source: None,
             user_content_manager: UserContentManager::default(),
             protocol_registry: ProtocolRegistry::default(),
             #[cfg(feature = "webxr")]
@@ -1402,6 +1405,11 @@ impl ServoBuilder {
 
     pub fn event_loop_waker(mut self, event_loop_waker: Box<dyn EventLoopWaker>) -> Self {
         self.event_loop_waker = event_loop_waker;
+        self
+    }
+
+    pub fn begin_frame_source(mut self, begin_frame_source: Rc<dyn BeginFrameSource>) -> Self {
+        self.begin_frame_source = Some(begin_frame_source);
         self
     }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -480,7 +480,7 @@ impl Servo {
             webxr_main_thread,
             shutdown_state: shutdown_state.clone(),
             event_loop_waker,
-            begin_frame_source: builder.begin_frame_source,
+            refresh_driver: builder.refresh_driver,
         });
 
         let constellation_proxy = ConstellationProxy::new(constellation_chan);
@@ -1367,9 +1367,9 @@ pub struct ServoBuilder {
     opts: Option<Box<Opts>>,
     preferences: Option<Box<Preferences>>,
     event_loop_waker: Box<dyn EventLoopWaker>,
-    begin_frame_source: Option<Rc<dyn BeginFrameSource>>,
     user_content_manager: UserContentManager,
     protocol_registry: ProtocolRegistry,
+    refresh_driver: Option<Rc<dyn RefreshDriver>>,
     #[cfg(feature = "webxr")]
     webxr_registry: Box<dyn webxr::WebXrRegistry>,
 }
@@ -1381,9 +1381,9 @@ impl ServoBuilder {
             opts: None,
             preferences: None,
             event_loop_waker: Box::new(DefaultEventLoopWaker),
-            begin_frame_source: None,
             user_content_manager: UserContentManager::default(),
             protocol_registry: ProtocolRegistry::default(),
+            refresh_driver: None,
             #[cfg(feature = "webxr")]
             webxr_registry: Box::new(DefaultWebXrRegistry),
         }
@@ -1408,8 +1408,8 @@ impl ServoBuilder {
         self
     }
 
-    pub fn begin_frame_source(mut self, begin_frame_source: Rc<dyn BeginFrameSource>) -> Self {
-        self.begin_frame_source = Some(begin_frame_source);
+    pub fn refresh_driver(mut self, refresh_driver: Rc<dyn RefreshDriver>) -> Self {
+        self.refresh_driver = Some(refresh_driver);
         self
     }
 

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -509,10 +509,6 @@ impl WebView {
             .send(EmbedderToConstellationMessage::MediaSessionAction(event));
     }
 
-    pub fn notify_vsync(&self) {
-        self.inner().compositor.borrow_mut().on_vsync(self.id());
-    }
-
     /// Set the page zoom of the [`WebView`]. This sets the final page zoom value of the
     /// [`WebView`]. Unlike [`WebView::pinch_zoom`] *it is not* multiplied by the current
     /// page zoom value, but overrides it.

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -134,22 +134,15 @@ impl Clone for EmbedderProxy {
     }
 }
 
-pub trait BeginFrameSource {
-    fn add_observer(&self, observer: Box<dyn BeginFrameSourceObserver>);
-    fn remove_observer(&self, id: u64);
-}
-
-pub trait BeginFrameSourceObserver: 'static + Send {
-    fn cloned_box(&self) -> Box<dyn BeginFrameSourceObserver>;
-    fn on_begin_frame(&self);
-    fn set_id(&self, id: u64);
-    fn id(&self) -> u64;
-}
-
-impl Clone for Box<dyn BeginFrameSourceObserver> {
-    fn clone(&self) -> Self {
-        self.cloned_box()
-    }
+/// A [`RefreshDriver`] is a trait that can be implemented by Servo embedders in
+/// order to drive let Servo know when to start preparing the next frame. For example,
+/// on systems that support Vsync notifications, an embedder may want to implement
+/// this trait to drive Servo animations via those notifications.
+pub trait RefreshDriver {
+    /// Servo will call this method when it wants to be informed of the next frame start
+    /// time. Implementors should call the callback when it is time to start preparing
+    /// the new frame.
+    fn observe_next_frame(&self, start_frame_callback: Box<dyn Fn() + Send + 'static>);
 }
 
 #[derive(Deserialize, Serialize)]

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -134,6 +134,24 @@ impl Clone for EmbedderProxy {
     }
 }
 
+pub trait BeginFrameSource {
+    fn add_observer(&self, observer: Box<dyn BeginFrameSourceObserver>);
+    fn remove_observer(&self, id: u64);
+}
+
+pub trait BeginFrameSourceObserver: 'static + Send {
+    fn cloned_box(&self) -> Box<dyn BeginFrameSourceObserver>;
+    fn on_begin_frame(&self);
+    fn set_id(&self, id: u64);
+    fn id(&self) -> u64;
+}
+
+impl Clone for Box<dyn BeginFrameSourceObserver> {
+    fn clone(&self) -> Self {
+        self.cloned_box()
+    }
+}
+
 #[derive(Deserialize, Serialize)]
 pub enum ContextMenuResult {
     Dismissed,

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -115,6 +115,7 @@ pub fn init(
             rendering_context,
             servo,
             window_callbacks,
+            None,
             servoshell_preferences,
             webdriver_receiver,
         );

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -20,7 +20,9 @@ use raw_window_handle::{
 use servo::{self, EventLoopWaker, ServoBuilder, WindowRenderingContext, resources};
 use xcomponent_sys::OH_NativeXComponent;
 
-use crate::egl::app_state::{Coordinates, RunningAppState, ServoWindowCallbacks};
+use crate::egl::app_state::{
+    Coordinates, RunningAppState, ServoWindowCallbacks, VsyncRefreshDriver,
+};
 use crate::egl::host_trait::HostTrait;
 use crate::egl::ohos::InitOpts;
 use crate::egl::ohos::resources::ResourceReaderInstance;
@@ -195,13 +197,12 @@ pub fn init(
         RefCell::new(coordinates),
     ));
 
-    let begin_frame_source = Rc::new(BeginFrameSourceImpl::new());
-
+    let refresh_driver = Rc::new(VsyncRefreshDriver::default());
     let servo = ServoBuilder::new(rendering_context.clone())
         .opts(opts)
         .preferences(preferences)
         .event_loop_waker(waker.clone())
-        .begin_frame_source(begin_frame_source.clone())
+        .refresh_driver(refresh_driver.clone())
         .build();
 
     // Initialize WebDriver server if port is specified
@@ -218,7 +219,7 @@ pub fn init(
         rendering_context,
         servo,
         window_callbacks,
-        Some(begin_frame_source),
+        Some(refresh_driver),
         servoshell_preferences,
         webdriver_receiver,
     );

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -195,10 +195,13 @@ pub fn init(
         RefCell::new(coordinates),
     ));
 
+    let begin_frame_source = Rc::new(BeginFrameSourceImpl::new());
+
     let servo = ServoBuilder::new(rendering_context.clone())
         .opts(opts)
         .preferences(preferences)
         .event_loop_waker(waker.clone())
+        .begin_frame_source(begin_frame_source.clone())
         .build();
 
     // Initialize WebDriver server if port is specified
@@ -215,6 +218,7 @@ pub fn init(
         rendering_context,
         servo,
         window_callbacks,
+        Some(begin_frame_source),
         servoshell_preferences,
         webdriver_receiver,
     );


### PR DESCRIPTION
Currently, the `RefreshDriver` creates a timer thread by default to limit the frame rate of animations to within 120fps. However, some platforms have already integrated `VSYNC` and even support `LTPO`, making the refresh rate of the current `RefreshDriver` mismatched with the display refresh rate of the platform. The main idea of this PR is to introduce the `BeginFrameSource` and `BeginFrameSourceObserver` types, allowing `VSYNC` to be integrated into the RefreshDriver.

Testing: It's hard to test rendering rate but some manual tests show that it takes effect on OHOS platform, and other behavior is covered by existing WPT tests.
