### PR TITLE
layout: Gracefully handle script queries on nodes with uninvertible transforms

### DIFF
--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -1026,6 +1026,7 @@ impl BoxFragment {
         // > If a transform function causes the current transformation matrix of an object
         // > to be non-invertible, the object and its content do not get displayed.
         if !reference_frame_data.transform.is_invertible() {
+            self.clear_spatial_tree_node_including_descendants();
             return;
         }
 
@@ -1716,6 +1717,29 @@ impl BoxFragment {
             },
             Perspective::None => None,
         }
+    }
+
+    fn clear_spatial_tree_node_including_descendants(&self) {
+        fn assign_spatial_tree_node_on_fragments(fragments: &[Fragment]) {
+            for fragment in fragments.iter() {
+                match fragment {
+                    Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
+                        box_fragment
+                            .borrow()
+                            .clear_spatial_tree_node_including_descendants();
+                    },
+                    Fragment::Positioning(positioning_fragment) => {
+                        assign_spatial_tree_node_on_fragments(
+                            &positioning_fragment.borrow().children,
+                        );
+                    },
+                    _ => {},
+                }
+            }
+        }
+
+        *self.spatial_tree_node.borrow_mut() = None;
+        assign_spatial_tree_node_on_fragments(&self.children);
     }
 }
 

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -60,10 +60,8 @@ fn root_transform_for_layout_node(
         .first()
         .and_then(Fragment::retrieve_box_fragment)?
         .borrow();
-    let scroll_tree_node_id = box_fragment
-        .spatial_tree_node
-        .borrow()
-        .expect("Should always have a scroll tree node when querying bounding box.");
+    let scroll_tree_node_id = box_fragment.spatial_tree_node.borrow();
+    let scroll_tree_node_id = (*scroll_tree_node_id)?;
     Some(scroll_tree.cumulative_node_to_root_transform(&scroll_tree_node_id))
 }
 
@@ -87,7 +85,7 @@ pub(crate) fn process_box_area_request(
     let Some(transform) =
         root_transform_for_layout_node(&stacking_context_tree.compositor_info.scroll_tree, node)
     else {
-        return Some(rect_union);
+        return Some(Rect::new(rect_union.origin, Size2D::zero()));
     };
 
     transform_au_rectangle(rect_union, transform)
@@ -107,7 +105,9 @@ pub(crate) fn process_box_areas_request(
     let Some(transform) =
         root_transform_for_layout_node(&stacking_context_tree.compositor_info.scroll_tree, node)
     else {
-        return box_areas.collect();
+        return box_areas
+            .map(|rect| Rect::new(rect.origin, Size2D::zero()))
+            .collect();
     };
 
     box_areas

--- a/tests/wpt/tests/css/css-transforms/crashtests/uninvertible-transform-and-script-queries.html
+++ b/tests/wpt/tests/css/css-transforms/crashtests/uninvertible-transform-and-script-queries.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+
+<link rel="help" href="https://github.com/servo/servo/issues/38848">
+
+<div style="transform: scale(0)">
+    <img style="height: 200px; width: 200px; border: solid;" id="img">
+    <div style="height: 200px; width: 200px; border: solid;" id="div"></div>
+</div>
+<script>
+    div.getBoundingClientRect();
+    div.getClientRects();
+    img.getBoundingClientRect();
+    img.getClientRects();
+    img.height;
+    img.width;
+</script>


### PR DESCRIPTION
Instead of panicking when doing a geometry script query on a node with
an uninvertible transform, return a zero-sized rectangle at the
untransformed position. This is similar to what Gecko and Blink do
(though it seems there are some differences in positioning this
zero-sized rectangle). Mostly importantly, do not panic.

Testing: This change adds a new WPT crash test.
Fixes: #38848.
