### PR TITLE
script: Migrate swmanager to GenericChannel

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -155,7 +155,7 @@ pub struct InitialPipelineState {
     pub bluetooth_thread: IpcSender<BluetoothRequest>,
 
     /// A channel to the service worker manager thread
-    pub swmanager_thread: IpcSender<SWManagerMsg>,
+    pub swmanager_thread: GenericSender<SWManagerMsg>,
 
     /// A proxy to the system font service, responsible for managing the list of system fonts.
     pub system_font_service: Arc<SystemFontServiceProxy>,
@@ -481,7 +481,7 @@ pub struct UnprivilegedPipelineContent {
     devtools_ipc_sender: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
     #[cfg(feature = "bluetooth")]
     bluetooth_thread: IpcSender<BluetoothRequest>,
-    swmanager_thread: IpcSender<SWManagerMsg>,
+    swmanager_thread: GenericSender<SWManagerMsg>,
     system_font_service: SystemFontServiceProxySender,
     resource_threads: ResourceThreads,
     time_profiler_chan: time::ProfilerChan,

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::AtomicBool;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
+use base::generic_channel::GenericSender;
 use base::id::PipelineId;
 use constellation_traits::{
     ScopeThings, ServiceWorkerMsg, WorkerGlobalScopeInit, WorkerScriptLoadOrigin,
@@ -15,7 +16,7 @@ use crossbeam_channel::{Receiver, Sender, after, unbounded};
 use devtools_traits::DevtoolScriptControlMsg;
 use dom_struct::dom_struct;
 use fonts::FontContext;
-use ipc_channel::ipc::{IpcReceiver, IpcSender};
+use ipc_channel::ipc::IpcReceiver;
 use ipc_channel::router::ROUTER;
 use js::jsapi::{JS_AddInterruptCallback, JSContext};
 use js::jsval::UndefinedValue;
@@ -161,7 +162,7 @@ pub(crate) struct ServiceWorkerGlobalScope {
 
     #[ignore_malloc_size_of = "Defined in std"]
     #[no_trace]
-    swmanager_sender: IpcSender<ServiceWorkerMsg>,
+    swmanager_sender: GenericSender<ServiceWorkerMsg>,
 
     #[no_trace]
     scope_url: ServoUrl,
@@ -224,7 +225,7 @@ impl ServiceWorkerGlobalScope {
         own_sender: Sender<ServiceWorkerScriptMsg>,
         receiver: Receiver<ServiceWorkerScriptMsg>,
         time_out_port: Receiver<Instant>,
-        swmanager_sender: IpcSender<ServiceWorkerMsg>,
+        swmanager_sender: GenericSender<ServiceWorkerMsg>,
         scope_url: ServoUrl,
         control_receiver: Receiver<ServiceWorkerControlMsg>,
         closing: Arc<AtomicBool>,
@@ -263,7 +264,7 @@ impl ServiceWorkerGlobalScope {
         own_sender: Sender<ServiceWorkerScriptMsg>,
         receiver: Receiver<ServiceWorkerScriptMsg>,
         time_out_port: Receiver<Instant>,
-        swmanager_sender: IpcSender<ServiceWorkerMsg>,
+        swmanager_sender: GenericSender<ServiceWorkerMsg>,
         scope_url: ServoUrl,
         control_receiver: Receiver<ServiceWorkerControlMsg>,
         closing: Arc<AtomicBool>,
@@ -293,7 +294,7 @@ impl ServiceWorkerGlobalScope {
         own_sender: Sender<ServiceWorkerScriptMsg>,
         receiver: Receiver<ServiceWorkerScriptMsg>,
         devtools_receiver: IpcReceiver<DevtoolScriptControlMsg>,
-        swmanager_sender: IpcSender<ServiceWorkerMsg>,
+        swmanager_sender: GenericSender<ServiceWorkerMsg>,
         scope_url: ServoUrl,
         control_receiver: Receiver<ServiceWorkerControlMsg>,
         context_sender: Sender<ThreadSafeJSContext>,

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 use base::Epoch;
-use base::generic_channel::{GenericCallback, GenericSender, SendResult};
+use base::generic_channel::{GenericCallback, GenericReceiver, GenericSender, SendResult};
 use base::id::{
     BroadcastChannelRouterId, BrowsingContextId, HistoryStateId, MessagePortId,
     MessagePortRouterId, PipelineId, ServiceWorkerId, ServiceWorkerRegistrationId, WebViewId,
@@ -24,7 +24,7 @@ use embedder_traits::{
 use euclid::default::Size2D as UntypedSize2D;
 use fonts_traits::SystemFontServiceProxySender;
 use http::{HeaderMap, Method};
-use ipc_channel::ipc::{IpcReceiver, IpcSender};
+use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{Destination, InsecureRequestsPolicy, Referrer, RequestBody};
@@ -206,7 +206,7 @@ pub struct DOMMessage {
 #[derive(Deserialize, Serialize)]
 pub struct SWManagerSenders {
     /// Sender of messages to the constellation.
-    pub swmanager_sender: IpcSender<SWManagerMsg>,
+    pub swmanager_sender: GenericSender<SWManagerMsg>,
     /// [`ResourceThreads`] for initating fetches or using i/o.
     pub resource_threads: ResourceThreads,
     /// [`CrossProcessCompositorApi`] for communicating with the compositor.
@@ -214,9 +214,9 @@ pub struct SWManagerSenders {
     /// The [`SystemFontServiceProxy`] used to communicate with the `SystemFontService`.
     pub system_font_service_sender: SystemFontServiceProxySender,
     /// Sender of messages to the manager.
-    pub own_sender: IpcSender<ServiceWorkerMsg>,
+    pub own_sender: GenericSender<ServiceWorkerMsg>,
     /// Receiver of messages from the constellation.
-    pub receiver: IpcReceiver<ServiceWorkerMsg>,
+    pub receiver: GenericReceiver<ServiceWorkerMsg>,
 }
 
 /// Messages sent to Service Worker Manager thread


### PR DESCRIPTION
Migrate `ServiceWorkerMsg` and `SWManagerMsg` to GenericChannel

Testing: Covered by service worker wpt tests
Part of #38912
