### PR TITLE
webcrypto: Implement sign and verify for rsa_pkcs1

### DIFF
--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -17,9 +17,10 @@ pub(crate) mod base {
     pub(crate) use js::jsval::{JSVal, NullValue, ObjectOrNullValue, ObjectValue, UndefinedValue};
     pub(crate) use js::panic::maybe_resume_unwind;
     pub(crate) use js::rust::wrappers::Call;
-    pub(crate) use js::rust::{HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
+    pub(crate) use js::rust::{CustomTrace, HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
     pub(crate) use js::typedarray::{
-        ArrayBuffer, ArrayBufferView, Float32Array, Float64Array, Uint8Array, Uint8ClampedArray,
+        self, ArrayBuffer, ArrayBufferView, Float32Array, Float64Array, Uint8Array,
+        Uint8ClampedArray,
     };
 
     pub(crate) use crate::callback::{

--- a/components/script_bindings/webidls/SubtleCrypto.webidl
+++ b/components/script_bindings/webidls/SubtleCrypto.webidl
@@ -68,6 +68,36 @@ interface SubtleCrypto {
                          sequence<KeyUsage> keyUsages );
 };
 
+typedef Uint8Array BigInteger;
+
+// RSASSA-PKCS1-v1_5
+// https://w3c.github.io/webcrypto/#dfn-RsaKeyGenParams
+dictionary RsaKeyGenParams : Algorithm {
+  required [EnforceRange] unsigned long modulusLength;
+  required BigInteger publicExponent;
+};
+
+// https://w3c.github.io/webcrypto/#dfn-RsaHashedKeyGenParams
+dictionary RsaHashedKeyGenParams : RsaKeyGenParams {
+  required HashAlgorithmIdentifier hash;
+};
+
+// https://w3c.github.io/webcrypto/#RsaKeyAlgorithm-dictionary
+dictionary RsaKeyAlgorithm : KeyAlgorithm {
+  required unsigned long modulusLength;
+  required BigInteger publicExponent;
+};
+
+// https://w3c.github.io/webcrypto/#RsaHashedKeyAlgorithm-dictionary
+dictionary RsaHashedKeyAlgorithm : RsaKeyAlgorithm {
+  required KeyAlgorithm hash;
+};
+
+// http://w3c.github.io/webcrypto/#dfn-RsaHashedImportParams
+dictionary RsaHashedImportParams : Algorithm {
+  required HashAlgorithmIdentifier hash;
+};
+
 // AES shared
 dictionary AesKeyAlgorithm : KeyAlgorithm {
   required unsigned short length;


### PR DESCRIPTION
Adds sign and verify methods for rsa_pkcs1. If needed I'll add limited import or generation support so that WPT tests can pass.

Testing: WPT
Fixes: Partially #39060 
