### PR TITLE
indexeddb: Return error instead of panicking on structured clone failure

### DIFF
--- a/components/script/indexed_db.rs
+++ b/components/script/indexed_db.rs
@@ -145,7 +145,7 @@ pub fn convert_value_to_key(
 
             if IsArrayBufferObject(*object) || JS_IsArrayBufferViewObject(*object) {
                 // FIXME:(arihant2math) implement it the correct way (is this correct?)
-                let key = structuredclone::write(cx, input, None).expect("Could not serialize key");
+                let key = structuredclone::write(cx, input, None)?;
                 return Ok(IndexedDBKeyType::Binary(key.serialized.clone()));
             }
 

--- a/tests/wpt/meta/IndexedDB/crashtests/create-index.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/crashtests/create-index.any.js.ini
@@ -5,7 +5,7 @@
 
 
 [create-index.any.worker.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Assure no crash when populating index]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/IndexedDB/idb-binary-key-detached.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idb-binary-key-detached.any.js.ini
@@ -1,5 +1,4 @@
 [idb-binary-key-detached.any.html]
-  expected: CRASH
   [Detached ArrayBuffers must throw DataError when used as a key]
     expected: FAIL
 
@@ -8,7 +7,6 @@
 
 
 [idb-binary-key-detached.any.worker.html]
-  expected: CRASH
   [Detached ArrayBuffers must throw DataError when used as a key]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
@@ -2,9 +2,6 @@
   [IDBFactory.open() - error in version change transaction aborts open]
     expected: FAIL
 
-  [Calling open() with version argument 1.5 should not throw.]
-    expected: FAIL
-
   [Calling open() with version argument undefined should not throw.]
     expected: FAIL
 
@@ -38,4 +35,7 @@
     expected: FAIL
 
   [Calling open() with version argument 9007199254740991 should not throw.]
+    expected: FAIL
+
+  [Calling open() with version argument 1.5 should not throw.]
     expected: FAIL


### PR DESCRIPTION
Related to failures in #38847

Testing: WPT
