### PR TITLE
script: Implement document's active sandboxing flag set

### DIFF
--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -6,6 +6,7 @@ use std::borrow::ToOwned;
 use std::cell::Cell;
 
 use constellation_traits::{LoadData, LoadOrigin, NavigationHistoryBehavior};
+use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use dom_struct::dom_struct;
 use encoding_rs::{Encoding, UTF_8};
 use headers::{ContentType, HeaderMapExt};
@@ -739,10 +740,18 @@ impl HTMLFormElement {
         if self.constructing_entry_list.get() {
             return;
         }
-        // Step 3
+        // Step 3. Let form document be form's node document.
         let doc = self.owner_document();
+
+        // Step 4. If form document's active sandboxing flag set has its sandboxed forms browsing
+        // context flag set, then return.
+        if doc.has_active_sandboxing_flag(SandboxingFlagSet::SANDBOXED_FORMS_BROWSING_CONTEXT_FLAG)
+        {
+            return;
+        }
+
         let base = doc.base_url();
-        // TODO: Handle browsing contexts (Step 4, 5)
+        // TODO: Handle browsing contexts (Step 5)
         // Step 6
         if submit_method_flag == SubmittedFrom::NotFromForm {
             // Step 6.1

--- a/tests/wpt/meta/html/browsers/origin/relaxing-the-same-origin-restriction/sandboxed-document_domain.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/relaxing-the-same-origin-restriction/sandboxed-document_domain.html.ini
@@ -1,3 +1,0 @@
-[sandboxed-document_domain.html]
-  [Sandboxed document.domain]
-    expected: FAIL

--- a/tests/wpt/tests/content-security-policy/sandbox/autoplay-disabled-by-csp.html
+++ b/tests/wpt/tests/content-security-policy/sandbox/autoplay-disabled-by-csp.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/#eligible-for-autoplay" />
+  <title>Test that autoplay is blocked by a document's active sandboxing flags</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/common/media.js"></script>
+  </head>
+  <body>
+    <video id="v" autoplay></video>
+    <script>
+      async_test((t) => {
+        var v = document.getElementById('v')
+
+        v.addEventListener('playing', t.unreached_func('video should not autoplay due to sandboxing flags'));
+
+        v.src = getVideoURI('/media/movie_5') + '?' + new Date() + Math.random()
+        t.step_timeout(() => t.done(), 500);
+      }, 'csp-derived sandboxing flags prevent autoplay.')
+    </script>
+  </body>
+</html>

--- a/tests/wpt/tests/content-security-policy/sandbox/autoplay-disabled-by-csp.html.headers
+++ b/tests/wpt/tests/content-security-policy/sandbox/autoplay-disabled-by-csp.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-forms

--- a/tests/wpt/tests/content-security-policy/sandbox/form-submission-blocked-by-sandboxing.html
+++ b/tests/wpt/tests/content-security-policy/sandbox/form-submission-blocked-by-sandboxing.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/#concept-form-submit">
+  <title>Test that form submission is blocked by a document's active sandboxing flags</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <form id="f">
+      <input type="hidden" value="test" />
+    </form>
+    <script>
+      async_test((t) => {
+        var f = document.getElementById('f')
+
+        f.addEventListener('submit', t.unreached_func('form should not be submitted due to sandboxing flags'));
+
+        f.submit();
+        t.step_timeout(() => t.done(), 500);
+      }, 'csp-derived sandboxing flags prevent form submission.')
+    </script>
+  </body>
+</html>

--- a/tests/wpt/tests/content-security-policy/sandbox/form-submission-blocked-by-sandboxing.html.headers
+++ b/tests/wpt/tests/content-security-policy/sandbox/form-submission-blocked-by-sandboxing.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts


### PR DESCRIPTION
Implements document's active sandboxing flags. These are currently populated only from CSP-derived sandboxing flags for a new document, when defined in the CSP.

Testing: 1 new pass, and some new wpt's are added to test points in the spec where these flags influence behaviour. 