### PR TITLE
indexeddb: Implement `openCursor` and `openKeyCursor` for object store

### DIFF
--- a/components/net/indexeddb/engines/sqlite.rs
+++ b/components/net/indexeddb/engines/sqlite.rs
@@ -8,8 +8,8 @@ use ipc_channel::ipc::IpcSender;
 use log::{error, info};
 use net_traits::indexeddb_thread::{
     AsyncOperation, AsyncReadOnlyOperation, AsyncReadWriteOperation, BackendError, BackendResult,
-    CreateObjectResult, IndexedDBKeyRange, IndexedDBKeyType, IndexedDBTxnMode, KeyPath,
-    PutItemResult,
+    CreateObjectResult, IndexedDBKeyRange, IndexedDBKeyType, IndexedDBRecord, IndexedDBTxnMode,
+    KeyPath, PutItemResult,
 };
 use rusqlite::{Connection, Error, OptionalExtension, params};
 use sea_query::{Condition, Expr, ExprTrait, IntoCondition, SqliteQueryBuilder};
@@ -223,6 +223,23 @@ impl SqliteEngine {
     ) -> Result<Vec<Vec<u8>>, Error> {
         Self::get_all(connection, store, key_range, count)
             .map(|models| models.into_iter().map(|m| m.data).collect())
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn get_all_records(
+        connection: &Connection,
+        store: object_store_model::Model,
+        key_range: IndexedDBKeyRange,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Error> {
+        // TODO: Rebase after PR 38885, which provides Self::get_all, is merged.
+        //
+        // Self::get_all(connection, store, key_range, None).map(|models| {
+        //     models
+        //         .into_iter()
+        //         .map(|model| (model.key, model.data))
+        //         .collect()
+        // })
+        todo!()
     }
 
     fn put_item(
@@ -504,6 +521,28 @@ impl KvsEngine for SqliteEngine {
                         let _ = sender.send(
                             Self::count(&connection, object_store, key_range)
                                 .map(|r| r as u64)
+                                .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
+                        );
+                    },
+                    AsyncOperation::ReadOnly(AsyncReadOnlyOperation::Iterate {
+                        sender,
+                        key_range,
+                    }) => {
+                        let Ok(object_store) = process_object_store(object_store, &sender) else {
+                            continue;
+                        };
+                        let _ = sender.send(
+                            Self::get_all_records(&connection, object_store, key_range)
+                                .map(|records| {
+                                    records
+                                        .into_iter()
+                                        .map(|(key, data)| IndexedDBRecord {
+                                            key: bincode::deserialize(&key).unwrap(),
+                                            primary_key: bincode::deserialize(&key).unwrap(),
+                                            value: data,
+                                        })
+                                        .collect()
+                                })
                                 .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
                         );
                     },

--- a/components/net/indexeddb/engines/sqlite.rs
+++ b/components/net/indexeddb/engines/sqlite.rs
@@ -231,15 +231,8 @@ impl SqliteEngine {
         store: object_store_model::Model,
         key_range: IndexedDBKeyRange,
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Error> {
-        // TODO: Rebase after PR 38885, which provides Self::get_all, is merged.
-        //
-        // Self::get_all(connection, store, key_range, None).map(|models| {
-        //     models
-        //         .into_iter()
-        //         .map(|model| (model.key, model.data))
-        //         .collect()
-        // })
-        todo!()
+        Self::get_all(connection, store, key_range, None)
+            .map(|models| models.into_iter().map(|m| (m.key, m.data)).collect())
     }
 
     fn put_item(

--- a/components/script/dom/idbcursor.rs
+++ b/components/script/dom/idbcursor.rs
@@ -4,19 +4,22 @@
 
 use std::cell::Cell;
 
+use constellation_traits::StructuredSerializedData;
 use dom_struct::dom_struct;
 use js::jsapi::Heap;
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::MutableHandleValue;
-use net_traits::indexeddb_thread::{IndexedDBKeyRange, IndexedDBKeyType};
+use net_traits::indexeddb_thread::{IndexedDBKeyRange, IndexedDBKeyType, IndexedDBRecord};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::IDBCursorBinding::{
     IDBCursorDirection, IDBCursorMethods,
 };
 use crate::dom::bindings::codegen::UnionTypes::IDBObjectStoreOrIDBIndex;
+use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+use crate::dom::bindings::structuredclone;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::idbindex::IDBIndex;
 use crate::dom::idbobjectstore::IDBObjectStore;
@@ -120,6 +123,21 @@ impl IDBCursor {
         )
     }
 
+    fn set_position(&self, position: Option<IndexedDBKeyType>) {
+        *self.position.borrow_mut() = position;
+    }
+
+    fn set_key(&self, key: Option<IndexedDBKeyType>) {
+        *self.key.borrow_mut() = key;
+    }
+
+    fn set_object_store_position(
+        &self,
+        object_store_position: Option<IndexedDBKeyType>,
+    ) {
+        *self.object_store_position.borrow_mut() = object_store_position;
+    }
+
     pub(crate) fn value(&self, mut out: MutableHandleValue) {
         out.set(self.value.get());
     }
@@ -173,4 +191,312 @@ impl IDBCursorMethods<crate::DomTypeHolder> for IDBCursor {
             .get()
             .expect("IDBCursor.request should be set when cursor is opened")
     }
+}
+
+/// A struct containing parameters for
+/// <https://www.w3.org/TR/IndexedDB-2/#iterate-a-cursor>
+#[derive(Clone)]
+pub(crate) struct IterationParam {
+    pub(crate) cursor: Trusted<IDBCursor>,
+    pub(crate) key: Option<IndexedDBKeyType>,
+    pub(crate) primary_key: Option<IndexedDBKeyType>,
+    pub(crate) count: Option<u32>,
+}
+
+/// <https://www.w3.org/TR/IndexedDB-2/#iterate-a-cursor>
+///
+/// NOTE: Be cautious: this part of the specification seems to assume the cursor’s source is an
+/// index. Therefore,
+///   "record’s key" means the key of the record,
+///   "record’s value" means the primary key of the record, and
+///   "record’s referenced value" means the value of the record.
+pub(crate) fn iterate_cursor(
+    global: &GlobalScope,
+    cx: SafeJSContext,
+    param: &IterationParam,
+    records: Vec<IndexedDBRecord>,
+) -> Option<DomRoot<IDBCursor>> {
+    // Unpack IterationParam
+    let cursor = param.cursor.root();
+    let key = param.key.clone();
+    let primary_key = param.primary_key.clone();
+    let count = param.count;
+
+    // Step 1. Let source be cursor’s source.
+    let source = &cursor.source;
+
+    // Step 2. Let direction be cursor’s direction.
+    let direction = cursor.direction;
+
+    // Step 3. Assert: if primaryKey is given, source is an index and direction is "next" or "prev".
+    if primary_key.is_some() {
+        assert!(matches!(source, ObjectStoreOrIndex::Index( .. )));
+        assert!(matches!(
+            direction,
+            IDBCursorDirection::Next | IDBCursorDirection::Prev
+        ));
+    }
+
+    // Step 4. Let records be the list of records in source.
+    // NOTE: It is given as a function parameter.
+
+    // Step 5. Let range be cursor’s range.
+    let range = &cursor.range;
+
+    // Step 6. Let position be cursor’s position.
+    let mut position = cursor.position.borrow().clone();
+
+    // Step 7. Let object store position be cursor’s object store position.
+    let object_store_position = cursor.object_store_position.borrow().clone();
+
+    // Step 8. If count is not given, let count be 1.
+    let mut count = count.unwrap_or(1);
+
+    let mut found_record: Option<&IndexedDBRecord> = None;
+
+    // Step 9. While count is greater than 0:
+    while count > 0 {
+        // Step 9.1. Switch on direction:
+        found_record = match direction {
+            // "next"
+            IDBCursorDirection::Next => records.iter().find(|record| {
+                // Let found record be the first record in records which satisfy all of the
+                // following requirements:
+
+                // If key is defined, the record’s key is greater than or equal to key.
+                let requirement1 = || match &key {
+                    Some(key) => &record.key >= key,
+                    None => true,
+                };
+
+                // If primaryKey is defined, the record’s key is equal to key and the record’s
+                // value is greater than or equal to primaryKey, or the record’s key is greater
+                // than key.
+                let requirement2 = || match &primary_key {
+                    Some(primary_key) => key.as_ref().is_some_and(|key| {
+                        (&record.key == key && &record.primary_key >= primary_key) ||
+                            &record.key > key
+                    }),
+                    _ => true,
+                };
+
+                // If position is defined, and source is an object store, the record’s key is
+                // greater than position.
+                let requirement3 = || match (&position, source) {
+                    (Some(position), ObjectStoreOrIndex::ObjectStore(_)) => &record.key > position,
+                    _ => true,
+                };
+
+                // If position is defined, and source is an index, the record’s key is equal to
+                // position and the record’s value is greater than object store position or the
+                // record’s key is greater than position.
+                let requirement4 = || match (&position, source) {
+                    (Some(position), ObjectStoreOrIndex::Index(_)) => {
+                        (&record.key == position &&
+                            object_store_position.as_ref().is_some_and(
+                                |object_store_position| &record.primary_key > object_store_position,
+                            )) ||
+                            &record.key > position
+                    },
+                    _ => true,
+                };
+
+                // The record’s key is in range.
+                let requirement5 = || range.contains(&record.key);
+
+                // NOTE: Use closures here for lazy computation on requirements.
+                requirement1() &&
+                    requirement2() &&
+                    requirement3() &&
+                    requirement4() &&
+                    requirement5()
+            }),
+            // "nextunique"
+            IDBCursorDirection::Nextunique => records.iter().find(|record| {
+                // Let found record be the first record in records which satisfy all of the
+                // following requirements:
+
+                // If key is defined, the record’s key is greater than or equal to key.
+                let requirement1 = || match &key {
+                    Some(key) => &record.key >= key,
+                    None => true,
+                };
+
+                // If position is defined, the record’s key is greater than position.
+                let requirement2 = || match &position {
+                    Some(position) => &record.key > position,
+                    None => true,
+                };
+
+                // The record’s key is in range.
+                let requirement3 = || range.contains(&record.key);
+
+                // NOTE: Use closures here for lazy computation on requirements.
+                requirement1() && requirement2() && requirement3()
+            }),
+            // "prev"
+            IDBCursorDirection::Prev => {
+                records.iter().rev().find(|&record| {
+                    // Let found record be the last record in records which satisfy all of the
+                    // following requirements:
+
+                    // If key is defined, the record’s key is less than or equal to key.
+                    let requirement1 = || match &key {
+                        Some(key) => &record.key <= key,
+                        None => true,
+                    };
+
+                    // If primaryKey is defined, the record’s key is equal to key and the record’s
+                    // value is less than or equal to primaryKey, or the record’s key is less than
+                    // key.
+                    let requirement2 = || match &primary_key {
+                        Some(primary_key) => key.as_ref().is_some_and(|key| {
+                            (&record.key == key && &record.primary_key <= primary_key) ||
+                                &record.key < key
+                        }),
+                        _ => true,
+                    };
+
+                    // If position is defined, and source is an object store, the record’s key is
+                    // less than position.
+                    let requirement3 = || match (&position, source) {
+                        (Some(position), ObjectStoreOrIndex::ObjectStore(_)) => {
+                            &record.key < position
+                        },
+                        _ => true,
+                    };
+
+                    // If position is defined, and source is an index, the record’s key is equal to
+                    // position and the record’s value is less than object store position or the
+                    // record’s key is less than position.
+                    let requirement4 = || match (&position, source) {
+                        (Some(position), ObjectStoreOrIndex::Index(_)) => {
+                            (&record.key == position &&
+                                object_store_position.as_ref().is_some_and(
+                                    |object_store_position| {
+                                        &record.primary_key < object_store_position
+                                    },
+                                )) ||
+                                &record.key < position
+                        },
+                        _ => true,
+                    };
+
+                    // The record’s key is in range.
+                    let requirement5 = || range.contains(&record.key);
+
+                    // NOTE: Use closures here for lazy computation on requirements.
+                    requirement1() &&
+                        requirement2() &&
+                        requirement3() &&
+                        requirement4() &&
+                        requirement5()
+                })
+            },
+            // "prevunique"
+            IDBCursorDirection::Prevunique => records
+                .iter()
+                .rev()
+                .find(|&record| {
+                    // Let temp record be the last record in records which satisfy all of the
+                    // following requirements:
+
+                    // If key is defined, the record’s key is less than or equal to key.
+                    let requirement1 = || match &key {
+                        Some(key) => &record.key <= key,
+                        None => true,
+                    };
+
+                    // If position is defined, the record’s key is less than position.
+                    let requirement2 = || match &position {
+                        Some(position) => &record.key < position,
+                        None => true,
+                    };
+
+                    // The record’s key is in range.
+                    let requirement3 = || range.contains(&record.key);
+
+                    // NOTE: Use closures here for lazy computation on requirements.
+                    requirement1() && requirement2() && requirement3()
+                })
+                // If temp record is defined, let found record be the first record in records
+                // whose key is equal to temp record’s key.
+                .map(|temp_record| {
+                    records
+                        .iter()
+                        .find(|&record| record.key == temp_record.key)
+                        .expect(
+                            "Record with key equal to temp record's key should exist in records",
+                        )
+                }),
+        };
+
+        match found_record {
+            // Step 9.2. If found record is not defined, then:
+            None => {
+                // Step 9.2.1. Set cursor’s key to undefined.
+                cursor.set_key(None);
+
+                // Step 9.2.2. If source is an index, set cursor’s object store position to undefined.
+                if matches!(source, ObjectStoreOrIndex::Index(_)) {
+                    cursor.set_object_store_position(None);
+                }
+
+                // Step 9.2.3. If cursor’s key only flag is unset, set cursor’s value to undefined.
+                if !cursor.key_only {
+                    cursor.value.set(UndefinedValue());
+                }
+
+                // Step 9.2.4. Return null.
+                return None;
+            },
+            Some(found_record) => {
+                // Step 9.3. Let position be found record’s key.
+                position = Some(found_record.key.clone());
+
+                // Step 9.4. If source is an index, let object store position be found record’s value.
+                if matches!(source, ObjectStoreOrIndex::Index(_)) {
+                    cursor.set_object_store_position(Some(found_record.primary_key.clone()));
+                }
+
+                // Step 9.5. Decrease count by 1.
+                count -= 1;
+            },
+        }
+    }
+    let found_record =
+        found_record.expect("The while loop above guarantees found_record is defined");
+
+    // Step 10. Set cursor’s position to position.
+    cursor.set_position(position);
+
+    // Step 11. If source is an index, set cursor’s object store position to object store position.
+    if let ObjectStoreOrIndex::Index(_) = source {
+        cursor.set_object_store_position(object_store_position);
+    }
+
+    // Step 12. Set cursor’s key to found record’s key.
+    cursor.set_key(Some(found_record.key.clone()));
+
+    // Step 13. If cursor’s key only flag is unset, then:
+    if !cursor.key_only {
+        // Step 13.1. Let serialized be found record’s referenced value.
+        let serialized = StructuredSerializedData {
+            serialized: found_record.value.clone(),
+            ..Default::default()
+        };
+
+        // Step 13.2. Set cursor’s value to ! StructuredDeserialize(serialized, targetRealm)
+        rooted!(in(*cx) let mut new_cursor_value: JSVal);
+        if structuredclone::read(global, serialized, new_cursor_value.handle_mut()).is_err() {
+            warn!("Error reading structuredclone data");
+        }
+        cursor.value.set(new_cursor_value.get());
+    }
+
+    // Step 14. Set cursor’s got value flag.
+    cursor.got_value.set(true);
+
+    // Step 15. Return cursor.
+    Some(cursor)
 }

--- a/components/script/dom/idbcursor.rs
+++ b/components/script/dom/idbcursor.rs
@@ -96,7 +96,6 @@ impl IDBCursor {
         }
     }
 
-    #[expect(unused)]
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -131,11 +130,12 @@ impl IDBCursor {
         *self.key.borrow_mut() = key;
     }
 
-    fn set_object_store_position(
-        &self,
-        object_store_position: Option<IndexedDBKeyType>,
-    ) {
+    fn set_object_store_position(&self, object_store_position: Option<IndexedDBKeyType>) {
         *self.object_store_position.borrow_mut() = object_store_position;
+    }
+
+    pub(crate) fn set_request(&self, request: &IDBRequest) {
+        self.request.set(Some(request));
     }
 
     pub(crate) fn value(&self, mut out: MutableHandleValue) {
@@ -230,7 +230,7 @@ pub(crate) fn iterate_cursor(
 
     // Step 3. Assert: if primaryKey is given, source is an index and direction is "next" or "prev".
     if primary_key.is_some() {
-        assert!(matches!(source, ObjectStoreOrIndex::Index( .. )));
+        assert!(matches!(source, ObjectStoreOrIndex::Index(..)));
         assert!(matches!(
             direction,
             IDBCursorDirection::Next | IDBCursorDirection::Prev

--- a/components/script/dom/idbcursorwithvalue.rs
+++ b/components/script/dom/idbcursorwithvalue.rs
@@ -42,7 +42,6 @@ impl IDBCursorWithValue {
         }
     }
 
-    #[expect(unused)]
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -8,8 +8,8 @@ use js::jsval::NullValue;
 use js::rust::HandleValue;
 use net_traits::IpcSend;
 use net_traits::indexeddb_thread::{
-    AsyncOperation, AsyncReadOnlyOperation, AsyncReadWriteOperation, IndexedDBKeyRange,
-    IndexedDBKeyType, IndexedDBThreadMsg, SyncOperation,
+    AsyncOperation, AsyncReadOnlyOperation, AsyncReadWriteOperation, IndexedDBKeyType,
+    IndexedDBThreadMsg, SyncOperation,
 };
 use profile_traits::ipc;
 use script_bindings::conversions::SafeToJSValConvertible;
@@ -281,12 +281,7 @@ impl IDBObjectStore {
         //
         // The query parameter may be a key or an IDBKeyRange to use as the cursor's range. If null
         // or not given, an unbounded key range is used.
-        // FIXME:
-        let range = if query.is_null_or_undefined() {
-            IndexedDBKeyRange::new(None, None, false, false)
-        } else {
-            convert_value_to_key_range(cx, query, Some(false))?
-        };
+        let range = convert_value_to_key_range(cx, query, Some(false))?;
 
         // Step 6. Let cursor be a new cursor with transaction set to transaction, an undefined
         // position, direction set to direction, got value flag unset, and undefined key and value.

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -274,19 +274,18 @@ impl IDBObjectStore {
         self.verify_not_deleted()?;
 
         // Step 4. If transaction is not active, throw a "TransactionInactiveError" DOMException.
-        if !self.transaction.is_active() {
-            return Err(Error::TransactionInactive);
-        }
+        self.check_transaction_active()?;
 
         // Step 5. Let range be the result of running the steps to convert a value to a key range
         // with query. Rethrow any exceptions.
         //
         // The query parameter may be a key or an IDBKeyRange to use as the cursor's range. If null
         // or not given, an unbounded key range is used.
+        // FIXME:
         let range = if query.is_null_or_undefined() {
             IndexedDBKeyRange::new(None, None, false, false)
         } else {
-            convert_value_to_key_range(cx, query, None)?
+            convert_value_to_key_range(cx, query, Some(false))?
         };
 
         // Step 6. Let cursor be a new cursor with transaction set to transaction, an undefined
@@ -515,6 +514,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
                 }),
                 receiver,
                 None,
+                None,
                 CanGc::note(),
             )
         })
@@ -551,6 +551,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
                     count,
                 }),
                 receiver,
+                None,
                 None,
                 CanGc::note(),
             )

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -298,7 +298,7 @@ impl IDBObjectStore {
                 ObjectStoreOrIndex::ObjectStore(Dom::from_ref(self)),
                 range.clone(),
                 key_only,
-                CanGc::note(),
+                can_gc,
             )
         } else {
             DomRoot::upcast(IDBCursorWithValue::new(
@@ -309,7 +309,7 @@ impl IDBObjectStore {
                 ObjectStoreOrIndex::ObjectStore(Dom::from_ref(self)),
                 range.clone(),
                 key_only,
-                CanGc::note(),
+                can_gc,
             ))
         };
 

--- a/components/script/dom/idbobjectstore.rs
+++ b/components/script/dom/idbobjectstore.rs
@@ -8,14 +8,15 @@ use js::jsval::NullValue;
 use js::rust::HandleValue;
 use net_traits::IpcSend;
 use net_traits::indexeddb_thread::{
-    AsyncOperation, AsyncReadOnlyOperation, AsyncReadWriteOperation, IndexedDBKeyType,
-    IndexedDBThreadMsg, SyncOperation,
+    AsyncOperation, AsyncReadOnlyOperation, AsyncReadWriteOperation, IndexedDBKeyRange,
+    IndexedDBKeyType, IndexedDBThreadMsg, SyncOperation,
 };
 use profile_traits::ipc;
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::error::ErrorResult;
 
 use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::codegen::Bindings::IDBCursorBinding::IDBCursorDirection;
 use crate::dom::bindings::codegen::Bindings::IDBDatabaseBinding::IDBObjectStoreParameters;
 use crate::dom::bindings::codegen::Bindings::IDBObjectStoreBinding::IDBObjectStoreMethods;
 use crate::dom::bindings::codegen::Bindings::IDBTransactionBinding::{
@@ -24,12 +25,15 @@ use crate::dom::bindings::codegen::Bindings::IDBTransactionBinding::{
 // We need to alias this name, otherwise test-tidy complains at &String reference.
 use crate::dom::bindings::codegen::UnionTypes::StringOrStringSequence as StrOrStringSequence;
 use crate::dom::bindings::error::{Error, Fallible};
+use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::domstringlist::DOMStringList;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::idbcursor::{IDBCursor, IterationParam, ObjectStoreOrIndex};
+use crate::dom::idbcursorwithvalue::IDBCursorWithValue;
 use crate::dom::idbrequest::IDBRequest;
 use crate::dom::idbtransaction::IDBTransaction;
 use crate::indexed_db::{
@@ -248,8 +252,96 @@ impl IDBObjectStore {
             }),
             receiver,
             None,
+            None,
             can_gc,
         )
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-opencursor>
+    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-openkeycursor>
+    fn open_cursor(
+        &self,
+        cx: SafeJSContext,
+        query: HandleValue,
+        direction: IDBCursorDirection,
+        key_only: bool,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<IDBRequest>> {
+        // Step 1. Let transaction be this object store handle's transaction.
+        // Step 2. Let store be this object store handle's object store.
+
+        // Step 3. If store has been deleted, throw an "InvalidStateError" DOMException.
+        self.verify_not_deleted()?;
+
+        // Step 4. If transaction is not active, throw a "TransactionInactiveError" DOMException.
+        if !self.transaction.is_active() {
+            return Err(Error::TransactionInactive);
+        }
+
+        // Step 5. Let range be the result of running the steps to convert a value to a key range
+        // with query. Rethrow any exceptions.
+        //
+        // The query parameter may be a key or an IDBKeyRange to use as the cursor's range. If null
+        // or not given, an unbounded key range is used.
+        let range = if query.is_null_or_undefined() {
+            IndexedDBKeyRange::new(None, None, false, false)
+        } else {
+            convert_value_to_key_range(cx, query, None)?
+        };
+
+        // Step 6. Let cursor be a new cursor with transaction set to transaction, an undefined
+        // position, direction set to direction, got value flag unset, and undefined key and value.
+        // The source of cursor is store. The range of cursor is range.
+        //
+        // NOTE: A cursor that has the key only flag unset implements the IDBCursorWithValue
+        // interface as well.
+        let cursor = if key_only {
+            IDBCursor::new(
+                &self.global(),
+                &self.transaction,
+                direction,
+                false,
+                ObjectStoreOrIndex::ObjectStore(Dom::from_ref(self)),
+                range.clone(),
+                key_only,
+                CanGc::note(),
+            )
+        } else {
+            DomRoot::upcast(IDBCursorWithValue::new(
+                &self.global(),
+                &self.transaction,
+                direction,
+                false,
+                ObjectStoreOrIndex::ObjectStore(Dom::from_ref(self)),
+                range.clone(),
+                key_only,
+                CanGc::note(),
+            ))
+        };
+
+        // Step 7. Run the steps to asynchronously execute a request and return the IDBRequest
+        // created by these steps. The steps are run with this object store handle as source and
+        // the steps to iterate a cursor as operation, using the current Realm as targetRealm, and
+        // cursor.
+        let iteration_param = IterationParam {
+            cursor: Trusted::new(&cursor),
+            key: None,
+            primary_key: None,
+            count: None,
+        };
+        let (sender, receiver) = indexed_db::create_channel(self.global());
+        IDBRequest::execute_async(
+            self,
+            AsyncOperation::ReadOnly(AsyncReadOnlyOperation::Iterate {
+                sender,
+                key_range: range,
+            }),
+            receiver,
+            None,
+            Some(iteration_param),
+            can_gc,
+        )
+        .inspect(|request| cursor.set_request(request))
     }
 }
 
@@ -297,6 +389,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
                 AsyncOperation::ReadWrite(AsyncReadWriteOperation::RemoveItem { sender, key: q }),
                 receiver,
                 None,
+                None,
                 CanGc::note(),
             )
         })
@@ -321,6 +414,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
             self,
             AsyncOperation::ReadWrite(AsyncReadWriteOperation::Clear(sender)),
             receiver,
+            None,
             None,
             CanGc::note(),
         )
@@ -350,6 +444,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
                     key_range: q,
                 }),
                 receiver,
+                None,
                 None,
                 CanGc::note(),
             )
@@ -381,6 +476,7 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
                     key_range: q,
                 }),
                 receiver,
+                None,
                 None,
                 CanGc::note(),
             )
@@ -486,9 +582,30 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
                 }),
                 receiver,
                 None,
+                None,
                 CanGc::note(),
             )
         })
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-opencursor>
+    fn OpenCursor(
+        &self,
+        cx: SafeJSContext,
+        query: HandleValue,
+        direction: IDBCursorDirection,
+    ) -> Fallible<DomRoot<IDBRequest>> {
+        self.open_cursor(cx, query, direction, false, CanGc::note())
+    }
+
+    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-openkeycursor>
+    fn OpenKeyCursor(
+        &self,
+        cx: SafeJSContext,
+        query: HandleValue,
+        direction: IDBCursorDirection,
+    ) -> Fallible<DomRoot<IDBRequest>> {
+        self.open_cursor(cx, query, direction, true, CanGc::note())
     }
 
     /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-name>

--- a/components/script/dom/idbrequest.rs
+++ b/components/script/dom/idbrequest.rs
@@ -185,7 +185,15 @@ impl RequestListener {
                     let param = self.iteration_param.as_ref().expect(
                         "iteration_param must be provided by IDBRequest::execute_async for Iterate",
                     );
-                    if let Some(cursor) = iterate_cursor(&global, cx, param, records) {
+                    let cursor = match iterate_cursor(&global, cx, param, records) {
+                        Ok(cursor) => cursor,
+                        Err(e) => {
+                            warn!("Error reading structuredclone data");
+                            Self::handle_async_request_error(&global, cx, request, e);
+                            return;
+                        },
+                    };
+                    if let Some(cursor) = cursor {
                         match cursor.downcast::<IDBCursorWithValue>() {
                             Some(cursor_with_value) => {
                                 answer.handle_mut().set(ObjectValue(

--- a/components/script/dom/idbrequest.rs
+++ b/components/script/dom/idbrequest.rs
@@ -8,12 +8,12 @@ use std::iter::repeat_n;
 use dom_struct::dom_struct;
 use ipc_channel::router::ROUTER;
 use js::jsapi::Heap;
-use js::jsval::{DoubleValue, JSVal, UndefinedValue};
+use js::jsval::{DoubleValue, JSVal, ObjectValue, UndefinedValue};
 use js::rust::HandleValue;
 use net_traits::IpcSend;
 use net_traits::indexeddb_thread::{
-    AsyncOperation, BackendError, BackendResult, IndexedDBKeyType, IndexedDBThreadMsg,
-    IndexedDBTxnMode, PutItemResult,
+    AsyncOperation, AsyncReadOnlyOperation, BackendError, BackendResult, IndexedDBKeyType,
+    IndexedDBRecord, IndexedDBThreadMsg, IndexedDBTxnMode, PutItemResult,
 };
 use profile_traits::ipc::IpcReceiver;
 use script_bindings::conversions::SafeToJSValConvertible;
@@ -27,13 +27,15 @@ use crate::dom::bindings::codegen::Bindings::IDBTransactionBinding::IDBTransacti
 use crate::dom::bindings::error::{Error, Fallible, create_dom_exception};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
-use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
+use crate::dom::bindings::reflector::{DomGlobal, DomObject, reflect_dom_object};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::structuredclone;
 use crate::dom::domexception::DOMException;
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::idbcursor::{IterationParam, iterate_cursor};
+use crate::dom::idbcursorwithvalue::IDBCursorWithValue;
 use crate::dom::idbobjectstore::IDBObjectStore;
 use crate::dom::idbtransaction::IDBTransaction;
 use crate::indexed_db::key_type_to_jsval;
@@ -43,6 +45,7 @@ use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 #[derive(Clone)]
 struct RequestListener {
     request: Trusted<IDBRequest>,
+    iteration_param: Option<IterationParam>,
 }
 
 pub enum IdbResult {
@@ -51,6 +54,7 @@ pub enum IdbResult {
     Value(Vec<u8>),
     Values(Vec<Vec<u8>>),
     Count(u64),
+    Iterate(Vec<IndexedDBRecord>),
     Error(Error),
     None,
 }
@@ -85,6 +89,12 @@ impl From<PutItemResult> for IdbResult {
             PutItemResult::Success => Self::None,
             PutItemResult::CannotOverwrite => Self::Error(Error::Constraint),
         }
+    }
+}
+
+impl From<Vec<IndexedDBRecord>> for IdbResult {
+    fn from(value: Vec<IndexedDBRecord>) -> Self {
+        Self::Iterate(value)
     }
 }
 
@@ -170,6 +180,25 @@ impl RequestListener {
                 },
                 IdbResult::Count(count) => {
                     answer.handle_mut().set(DoubleValue(count as f64));
+                },
+                IdbResult::Iterate(records) => {
+                    let param = self.iteration_param.as_ref().expect(
+                        "iteration_param must be provided by IDBRequest::execute_async for Iterate",
+                    );
+                    if let Some(cursor) = iterate_cursor(&global, cx, param, records) {
+                        match cursor.downcast::<IDBCursorWithValue>() {
+                            Some(cursor_with_value) => {
+                                answer.handle_mut().set(ObjectValue(
+                                    *cursor_with_value.reflector().get_jsobject(),
+                                ));
+                            },
+                            None => {
+                                answer
+                                    .handle_mut()
+                                    .set(ObjectValue(*cursor.reflector().get_jsobject()));
+                            },
+                        }
+                    }
                 },
                 IdbResult::None => {
                     // no-op
@@ -313,6 +342,7 @@ impl IDBRequest {
         operation: AsyncOperation,
         receiver: IpcReceiver<BackendResult<T>>,
         request: Option<DomRoot<IDBRequest>>,
+        iteration_param: Option<IterationParam>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<IDBRequest>>
     where
@@ -346,8 +376,24 @@ impl IDBRequest {
             IDBTransactionMode::Versionchange => IndexedDBTxnMode::Versionchange,
         };
 
+        if matches!(
+            operation,
+            AsyncOperation::ReadOnly(AsyncReadOnlyOperation::Iterate { .. })
+        ) {
+            assert!(
+                iteration_param.is_some(),
+                "iteration_param must be provided for Iterate"
+            );
+        } else {
+            assert!(
+                iteration_param.is_none(),
+                "iteration_param should not be provided for operation other than Iterate"
+            );
+        }
+
         let response_listener = RequestListener {
             request: Trusted::new(&request),
+            iteration_param,
         };
 
         let task_source = global

--- a/components/script_bindings/webidls/IDBObjectStore.webidl
+++ b/components/script_bindings/webidls/IDBObjectStore.webidl
@@ -28,10 +28,10 @@ interface IDBObjectStore {
                                     optional [EnforceRange] unsigned long count);
   [NewObject, Throws] IDBRequest count(optional any query);
 
-  // [NewObject] IDBRequest openCursor(optional any query,
-  //                                   optional IDBCursorDirection direction = "next");
-  // [NewObject] IDBRequest openKeyCursor(optional any query,
-  //                                      optional IDBCursorDirection direction = "next");
+  [NewObject, Throws] IDBRequest openCursor(optional any query,
+                                    optional IDBCursorDirection direction = "next");
+  [NewObject, Throws] IDBRequest openKeyCursor(optional any query,
+                                       optional IDBCursorDirection direction = "next");
 
   // IDBIndex index(DOMString name);
 

--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -289,6 +289,10 @@ pub enum AsyncReadOnlyOperation {
         sender: IpcSender<BackendResult<u64>>,
         key_range: IndexedDBKeyRange,
     },
+    Iterate {
+        sender: IpcSender<BackendResult<Vec<IndexedDBRecord>>>,
+        key_range: IndexedDBKeyRange,
+    },
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -233,6 +233,14 @@ impl IndexedDBKeyRange {
     }
 }
 
+/// <https://w3c.github.io/IndexedDB/#record-snapshot>
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub struct IndexedDBRecord {
+    pub key: IndexedDBKeyType,
+    pub primary_key: IndexedDBKeyType,
+    pub value: Vec<u8>,
+}
+
 #[test]
 fn test_as_singleton() {
     let key = IndexedDBKeyType::Number(1.0);

--- a/tests/wpt/meta/IndexedDB/idbcursor-advance-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbcursor-advance-exception-order.any.js.ini
@@ -1,7 +1,4 @@
 [idbcursor-advance-exception-order.any.worker.html]
-  [IDBCursor.advance exception order: TypeError vs. TransactionInactiveError]
-    expected: FAIL
-
   [IDBCursor.advance exception order: TransactionInactiveError vs. InvalidStateError #1]
     expected: FAIL
 
@@ -13,9 +10,6 @@
   expected: ERROR
 
 [idbcursor-advance-exception-order.any.html]
-  [IDBCursor.advance exception order: TypeError vs. TransactionInactiveError]
-    expected: FAIL
-
   [IDBCursor.advance exception order: TransactionInactiveError vs. InvalidStateError #1]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbcursor-direction.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbcursor-direction.any.js.ini
@@ -1,39 +1,9 @@
 [idbcursor-direction.any.worker.html]
-  [IDBCursor.direction - undefined]
-    expected: FAIL
-
-  [IDBCursor.direction - next]
-    expected: FAIL
-
-  [IDBCursor.direction - prev]
-    expected: FAIL
-
-  [IDBCursor.direction - nextunique]
-    expected: FAIL
-
-  [IDBCursor.direction - prevunique]
-    expected: FAIL
-
 
 [idbcursor-direction.any.serviceworker.html]
   expected: ERROR
 
 [idbcursor-direction.any.html]
-  [IDBCursor.direction - undefined]
-    expected: FAIL
-
-  [IDBCursor.direction - next]
-    expected: FAIL
-
-  [IDBCursor.direction - prev]
-    expected: FAIL
-
-  [IDBCursor.direction - nextunique]
-    expected: FAIL
-
-  [IDBCursor.direction - prevunique]
-    expected: FAIL
-
 
 [idbcursor-direction.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbcursor-key.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbcursor-key.any.js.ini
@@ -2,23 +2,11 @@
   expected: ERROR
 
 [idbcursor-key.any.worker.html]
-  [IDBCursor.key]
-    expected: FAIL
-
-  [IDBCursor.key 1]
-    expected: FAIL
-
   [IDBCursor.key 2]
     expected: FAIL
 
 
 [idbcursor-key.any.html]
-  [IDBCursor.key]
-    expected: FAIL
-
-  [IDBCursor.key 1]
-    expected: FAIL
-
   [IDBCursor.key 2]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbcursor_advance_objectstore.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbcursor_advance_objectstore.any.js.ini
@@ -5,9 +5,6 @@
   [object store - iterate cursor number of times specified by count]
     expected: FAIL
 
-  [Calling advance() with count argument 0 should throw TypeError.]
-    expected: FAIL
-
   [Calling advance() should throws an exception TransactionInactiveError when the transaction is not active]
     expected: FAIL
 
@@ -20,9 +17,6 @@
 
 [idbcursor_advance_objectstore.any.worker.html]
   [object store - iterate cursor number of times specified by count]
-    expected: FAIL
-
-  [Calling advance() with count argument 0 should throw TypeError.]
     expected: FAIL
 
   [Calling advance() should throws an exception TransactionInactiveError when the transaction is not active]

--- a/tests/wpt/meta/IndexedDB/idbcursor_update_objectstore.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbcursor_update_objectstore.any.js.ini
@@ -20,9 +20,6 @@
   [Throw DataCloneError]
     expected: FAIL
 
-  [No argument]
-    expected: FAIL
-
   [Throw DataError]
     expected: FAIL
 
@@ -47,9 +44,6 @@
     expected: FAIL
 
   [Throw DataCloneError]
-    expected: FAIL
-
-  [No argument]
     expected: FAIL
 
   [Throw DataError]

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-cross-realm-methods.html.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-cross-realm-methods.html.ini
@@ -5,18 +5,3 @@
 
   [Cross-realm IDBObjectStore::add() method from detached <iframe> works as expected]
     expected: FAIL
-
-  [Cross-realm IDBObjectStore::delete() method from detached <iframe> works as expected]
-    expected: FAIL
-
-  [Cross-realm IDBObjectStore::clear() method from detached <iframe> works as expected]
-    expected: FAIL
-
-  [Cross-realm IDBObjectStore::count() method from detached <iframe> works as expected]
-    expected: FAIL
-
-  [Cross-realm IDBObjectStore::openCursor() method from detached <iframe> works as expected]
-    expected: FAIL
-
-  [Cross-realm IDBObjectStore::openKeyCursor() method from detached <iframe> works as expected]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-query-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-query-exception-order.any.js.ini
@@ -11,13 +11,7 @@
   [IDBObjectStore.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
-  [IDBObjectStore.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
   [IDBObjectStore.openCursor exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
-  [IDBObjectStore.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBObjectStore.openKeyCursor exception order: TransactionInactiveError vs. DataError]
@@ -40,13 +34,7 @@
   [IDBObjectStore.count exception order: TransactionInactiveError vs. DataError]
     expected: FAIL
 
-  [IDBObjectStore.openCursor exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
   [IDBObjectStore.openCursor exception order: TransactionInactiveError vs. DataError]
-    expected: FAIL
-
-  [IDBObjectStore.openKeyCursor exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
   [IDBObjectStore.openKeyCursor exception order: TransactionInactiveError vs. DataError]

--- a/tests/wpt/meta/IndexedDB/idbobjectstore-request-source.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore-request-source.any.js.ini
@@ -2,37 +2,8 @@
   expected: ERROR
 
 [idbobjectstore-request-source.any.worker.html]
-  [The source of the request from store => store.getAll() is the object store itself]
-    expected: FAIL
-
-  [The source of the request from store => store.getAllKeys() is the object store itself]
-    expected: FAIL
-
-  [The source of the request from store => store.count() is the object store itself]
-    expected: FAIL
-
-  [The source of the request from store => store.openCursor() is the object store itself]
-    expected: FAIL
-
-  [The source of the request from store => store.openKeyCursor() is the object store itself]
-    expected: FAIL
-
 
 [idbobjectstore-request-source.any.sharedworker.html]
   expected: ERROR
 
 [idbobjectstore-request-source.any.html]
-  [The source of the request from store => store.getAll() is the object store itself]
-    expected: FAIL
-
-  [The source of the request from store => store.getAllKeys() is the object store itself]
-    expected: FAIL
-
-  [The source of the request from store => store.count() is the object store itself]
-    expected: FAIL
-
-  [The source of the request from store => store.openCursor() is the object store itself]
-    expected: FAIL
-
-  [The source of the request from store => store.openKeyCursor() is the object store itself]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_count.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_count.any.js.ini
@@ -1,7 +1,4 @@
 [idbobjectstore_count.any.worker.html]
-  [Returns the number of records in the object store ]
-    expected: FAIL
-
   [Returns the number of records that have keys with the key]
     expected: FAIL
 
@@ -10,9 +7,6 @@
   expected: ERROR
 
 [idbobjectstore_count.any.html]
-  [Returns the number of records in the object store ]
-    expected: FAIL
-
   [Returns the number of records that have keys with the key]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_get.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_get.any.js.ini
@@ -2,8 +2,13 @@
   expected: ERROR
 
 [idbobjectstore_get.any.html]
+  [When an invalid key is used, throw DataError]
+    expected: FAIL
+
 
 [idbobjectstore_get.any.serviceworker.html]
   expected: ERROR
 
 [idbobjectstore_get.any.worker.html]
+  [When an invalid key is used, throw DataError]
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAll.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAll.any.js.ini
@@ -2,16 +2,7 @@
   [Single item get (generated key)]
     expected: FAIL
 
-  [getAll on empty object store]
-    expected: FAIL
-
-  [Get all values]
-    expected: FAIL
-
   [Get all with large values]
-    expected: FAIL
-
-  [Test maxCount]
     expected: FAIL
 
   [Get upper excluded]
@@ -21,12 +12,6 @@
     expected: FAIL
 
   [Get bound range (generated) with maxCount]
-    expected: FAIL
-
-  [zero maxCount]
-    expected: FAIL
-
-  [Max value count]
     expected: FAIL
 
   [Get all values with transaction.commit()]
@@ -43,16 +28,7 @@
   [Single item get (generated key)]
     expected: FAIL
 
-  [getAll on empty object store]
-    expected: FAIL
-
-  [Get all values]
-    expected: FAIL
-
   [Get all with large values]
-    expected: FAIL
-
-  [Test maxCount]
     expected: FAIL
 
   [Get upper excluded]
@@ -62,12 +38,6 @@
     expected: FAIL
 
   [Get bound range (generated) with maxCount]
-    expected: FAIL
-
-  [zero maxCount]
-    expected: FAIL
-
-  [Max value count]
     expected: FAIL
 
   [Get all values with transaction.commit()]

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAll.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAll.any.js.ini
@@ -14,9 +14,6 @@
   [Get bound range (generated) with maxCount]
     expected: FAIL
 
-  [Get all values with transaction.commit()]
-    expected: FAIL
-
   [Get all values with invalid query keys]
     expected: FAIL
 
@@ -38,9 +35,6 @@
     expected: FAIL
 
   [Get bound range (generated) with maxCount]
-    expected: FAIL
-
-  [Get all values with transaction.commit()]
     expected: FAIL
 
   [Get all values with invalid query keys]

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys-options.tentative.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys-options.tentative.any.js.ini
@@ -5,12 +5,6 @@
   [Single item get (generated key)]
     expected: FAIL
 
-  [getAllKeys on empty object store]
-    expected: FAIL
-
-  [Get all keys]
-    expected: FAIL
-
   [Test maxCount]
     expected: FAIL
 
@@ -74,12 +68,6 @@
     expected: FAIL
 
   [Single item get (generated key)]
-    expected: FAIL
-
-  [getAllKeys on empty object store]
-    expected: FAIL
-
-  [Get all keys]
     expected: FAIL
 
   [Test maxCount]

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getAllKeys.any.js.ini
@@ -5,25 +5,10 @@
   expected: ERROR
 
 [idbobjectstore_getAllKeys.any.worker.html]
-  [getAllKeys on empty object store]
-    expected: FAIL
-
-  [Get all keys]
-    expected: FAIL
-
-  [Test maxCount]
-    expected: FAIL
-
   [Get upper excluded]
     expected: FAIL
 
   [Get lower excluded]
-    expected: FAIL
-
-  [zero maxCount]
-    expected: FAIL
-
-  [Max value count]
     expected: FAIL
 
   [Get all keys with invalid query keys]
@@ -31,25 +16,10 @@
 
 
 [idbobjectstore_getAllKeys.any.html]
-  [getAllKeys on empty object store]
-    expected: FAIL
-
-  [Get all keys]
-    expected: FAIL
-
-  [Test maxCount]
-    expected: FAIL
-
   [Get upper excluded]
     expected: FAIL
 
   [Get lower excluded]
-    expected: FAIL
-
-  [zero maxCount]
-    expected: FAIL
-
-  [Max value count]
     expected: FAIL
 
   [Get all keys with invalid query keys]

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_getKey.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_getKey.any.js.ini
@@ -48,6 +48,9 @@
   [IDBObjectStore.getKey() - key generator and key path - range - no match]
     expected: FAIL
 
+  [IDBObjectStore.getKey() - invalid parameters]
+    expected: FAIL
+
 
 [idbobjectstore_getKey.any.html]
   expected: TIMEOUT
@@ -97,4 +100,7 @@
     expected: FAIL
 
   [IDBObjectStore.getKey() - key generator and key path - range - no match]
+    expected: FAIL
+
+  [IDBObjectStore.getKey() - invalid parameters]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
@@ -5,12 +5,6 @@
   [IDBFactory interface: operation databases()]
     expected: FAIL
 
-  [IDBObjectStore interface: operation openCursor(optional any, optional IDBCursorDirection)]
-    expected: FAIL
-
-  [IDBObjectStore interface: operation openKeyCursor(optional any, optional IDBCursorDirection)]
-    expected: FAIL
-
   [IDBObjectStore interface: operation index(DOMString)]
     expected: FAIL
 
@@ -107,12 +101,6 @@
 
 [idlharness.any.worker.html]
   [IDBFactory interface: operation databases()]
-    expected: FAIL
-
-  [IDBObjectStore interface: operation openCursor(optional any, optional IDBCursorDirection)]
-    expected: FAIL
-
-  [IDBObjectStore interface: operation openKeyCursor(optional any, optional IDBCursorDirection)]
     expected: FAIL
 
   [IDBObjectStore interface: operation index(DOMString)]

--- a/tests/wpt/meta/IndexedDB/nested-cloning-basic.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/nested-cloning-basic.any.js.ini
@@ -2,19 +2,8 @@
   expected: ERROR
 
 [nested-cloning-basic.any.worker.html]
-  [small typed array]
-    expected: FAIL
-
-  [blob]
-    expected: FAIL
-
 
 [nested-cloning-basic.any.serviceworker.html]
   expected: ERROR
 
 [nested-cloning-basic.any.html]
-  [small typed array]
-    expected: FAIL
-
-  [blob]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/nested-cloning-large.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/nested-cloning-large.any.js.ini
@@ -2,19 +2,10 @@
   [large typed array]
     expected: FAIL
 
-  [blob with large typed array]
-    expected: FAIL
-
   [blob with large typed array with key generator]
     expected: FAIL
 
-  [array of blobs and large typed arrays]
-    expected: FAIL
-
   [array of blobs and large typed arrays with key generator]
-    expected: FAIL
-
-  [object with blobs and large typed arrays]
     expected: FAIL
 
   [object with blobs and large typed arrays with key generator]
@@ -28,19 +19,10 @@
   [large typed array]
     expected: FAIL
 
-  [blob with large typed array]
-    expected: FAIL
-
   [blob with large typed array with key generator]
     expected: FAIL
 
-  [array of blobs and large typed arrays]
-    expected: FAIL
-
   [array of blobs and large typed arrays with key generator]
-    expected: FAIL
-
-  [object with blobs and large typed arrays]
     expected: FAIL
 
   [object with blobs and large typed arrays with key generator]

--- a/tests/wpt/meta/IndexedDB/nested-cloning-small.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/nested-cloning-small.any.js.ini
@@ -1,17 +1,8 @@
 [nested-cloning-small.any.html]
-  [blob with small typed array]
-    expected: FAIL
-
   [blob with small typed array with key generator]
     expected: FAIL
 
-  [blob array]
-    expected: FAIL
-
   [blob array with key generator]
-    expected: FAIL
-
-  [array of blobs and small typed arrays]
     expected: FAIL
 
   [array of blobs and small typed arrays with key generator]
@@ -25,19 +16,10 @@
   expected: ERROR
 
 [nested-cloning-small.any.worker.html]
-  [blob with small typed array]
-    expected: FAIL
-
   [blob with small typed array with key generator]
     expected: FAIL
 
-  [blob array]
-    expected: FAIL
-
   [blob array with key generator]
-    expected: FAIL
-
-  [array of blobs and small typed arrays]
     expected: FAIL
 
   [array of blobs and small typed arrays with key generator]

--- a/tests/wpt/meta/IndexedDB/transaction-deactivation-timing.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/transaction-deactivation-timing.any.js.ini
@@ -16,12 +16,6 @@
   [Deactivation of new transactions happens at end of invocation]
     expected: FAIL
 
-  [New transactions are deactivated before next task]
-    expected: FAIL
-
-  [New transactions from microtask are deactivated before next task]
-    expected: FAIL
-
 
 [transaction-deactivation-timing.any.sharedworker.html]
   expected: ERROR


### PR DESCRIPTION
Continue on implementing indexeddb's cursor.

This patch focuses on implementing the `openCursor` [1] and `openKeyCursor` [2] methods of the `IDBObjectStore` interface, which create and initialize cursors by running the iterate-a-cursor algorithm [3].

It also adds struct `IndexedDBRecord` to `components/shared/net/indexeddb_thread.rs`. This struct can later be used to implement the new `IDBRecord` interface [4].

[1] https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-opencursor
[2] https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-openkeycursor
[3] https://www.w3.org/TR/IndexedDB-2/#iterate-a-cursor
[4] https://w3c.github.io/IndexedDB/#record-interface

Testing: Pass WPT tests that were expected to fail.
Fixes: Part of #38111