### PR TITLE
webcrypto: Reduce usage of standalone helper functions for JWK format

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -3150,6 +3150,7 @@ fn parse_jwk(
     }
 }
 
+#[expect(unused)]
 trait RsaOtherPrimesInfoExt {
     fn from_value(value: &serde_json::Value) -> Result<RsaOtherPrimesInfo, Error>;
 }

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -3267,6 +3267,6 @@ impl JsonWebKeyExt for JsonWebKey {
     }
 
     fn get_rsa_other_primes_info_from_oth(&self) -> Result<&[RsaOtherPrimesInfo], Error> {
-        self.oth.as_ref().map(Vec::as_slice).ok_or(Error::Data)
+        self.oth.as_deref().ok_or(Error::Data)
     }
 }

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -3202,6 +3202,7 @@ impl JsonWebKeyExt for JsonWebKey {
         // (It is given as a method paramter.)
 
         // Step 2. Let json be the Unicode string that results from interpreting data according to UTF-8.
+        #[allow(clippy::incompatible_msrv)]
         let json = str::from_utf8(data).map_err(|_| Error::Data)?;
 
         // Step 3. Convert json to UTF-16.

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -3202,8 +3202,7 @@ impl JsonWebKeyExt for JsonWebKey {
         // (It is given as a method paramter.)
 
         // Step 2. Let json be the Unicode string that results from interpreting data according to UTF-8.
-        #[allow(clippy::incompatible_msrv)]
-        let json = str::from_utf8(data).map_err(|_| Error::Data)?;
+        let json = String::from_utf8_lossy(data);
 
         // Step 3. Convert json to UTF-16.
         let json: Vec<_> = json.encode_utf16().collect();

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -3077,7 +3077,7 @@ fn parse_jwk(
                 serde_json::Value::String(op_string) => op_string,
                 _ => return true,
             };
-            let usage = match usage_from_str(op_string) {
+            let usage = match KeyUsage::from_str(op_string) {
                 Ok(usage) => usage,
                 Err(_) => {
                     return true;
@@ -3186,23 +3186,6 @@ fn get_jwk_bool(
         .as_bool()
         .ok_or(Error::Data)?;
     Ok(b)
-}
-
-fn usage_from_str(op: &str) -> Result<KeyUsage, Error> {
-    let usage = match op {
-        "encrypt" => KeyUsage::Encrypt,
-        "decrypt" => KeyUsage::Decrypt,
-        "sign" => KeyUsage::Sign,
-        "verify" => KeyUsage::Verify,
-        "deriveKey" => KeyUsage::DeriveKey,
-        "deriveBits" => KeyUsage::DeriveBits,
-        "wrapKey" => KeyUsage::WrapKey,
-        "unwrapKey" => KeyUsage::UnwrapKey,
-        _ => {
-            return Err(Error::Data);
-        },
-    };
-    Ok(usage)
 }
 
 trait RsaOtherPrimesInfoExt {


### PR DESCRIPTION
Reduce the reliance on standalone helper functions for handling JWK format. Instead, those functionalities are now integrated into the `JsonWebKey` type generated by script_binding, via the local trait `JsonWebKeyExt`, for internal use.

The `parse_jwk` function remains for now. It will be removed when once we refactor `SubtleCrypto::ImportKey` to support a more generic approach across different cryptographic algorithms.

Testing: Refactoring. Existing WPT tests should suffice.