### PR TITLE
webdriver: Focus browsing context when switch frame

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4524,6 +4524,9 @@ where
                 let is_open = self.browsing_contexts.contains_key(&browsing_context_id);
                 let _ = response_sender.send(is_open);
             },
+            WebDriverCommandMsg::FocusBrowsingContext(browsing_context_id) => {
+                self.handle_focus_remote_document_msg(browsing_context_id);
+            },
             // TODO: This should use the ScriptThreadMessage::EvaluateJavaScript command
             WebDriverCommandMsg::ScriptCommand(browsing_context_id, cmd) => {
                 let pipeline_id = if let Some(browsing_context) =

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -173,7 +173,6 @@ pub enum WebDriverCommandMsg {
     ),
     GetAlertText(WebViewId, IpcSender<Result<String, ()>>),
     SendAlertText(WebViewId, String),
-    // Focus the browsing context.
     FocusBrowsingContext(BrowsingContextId),
 }
 

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -173,6 +173,8 @@ pub enum WebDriverCommandMsg {
     ),
     GetAlertText(WebViewId, IpcSender<Result<String, ()>>),
     SendAlertText(WebViewId, String),
+    // Focus the browsing context.
+    FocusBrowsingContext(BrowsingContextId),
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -380,6 +380,9 @@ impl App {
                         running_state.set_pending_focus(focus_id, response_sender);
                     }
                 },
+                WebDriverCommandMsg::FocusBrowsingContext(..) => {
+                    running_state.servo().execute_webdriver_command(msg);
+                },
                 WebDriverCommandMsg::GetAllWebViews(response_sender) => {
                     let webviews = running_state.webviews().iter().map(|(id, _)| *id).collect();
 


### PR DESCRIPTION
#38889 adds back the mechanism to focus the window when [switch to window](https://w3c.github.io/webdriver/#switch-to-window). After that, it causes many flaky TIMEOUT. Turns out the real reason is same as the phenomenon which I thought was unrelated: https://github.com/servo/servo/pull/38889#issuecomment-3217512339: we need to focus the browsing context as well according to spec. This is important for Servo because it relies on https://github.com/servo/servo/blob/f4dd2960b89bcc6bae3f9dae5be8964c64c1c2c7/components/constellation/constellation_webview.rs#L64 to determine which pipeline to send `InputEvent` to.

Testing: Before, there are 9 ~ 13 flaky results. [Before 1](https://github.com/yezhizhen/servo/actions/runs/17379170889), [Before 2](https://github.com/yezhizhen/servo/actions/runs/17392219417), [Before 3](https://github.com/yezhizhen/servo/actions/runs/17379172612).
Now there are 2 ~ 4 flaky results. [After 1](https://github.com/yezhizhen/servo/actions/runs/17394359570), [After 2](https://github.com/yezhizhen/servo/actions/runs/17394358218), [After 3](https://github.com/yezhizhen/servo/actions/runs/17394357400).
Fixes: https://github.com/servo/servo/pull/38889#issuecomment-3218600566
Fixes: #38906, which is last blocking point to enable WebDriver CI.