### PR TITLE
CI: Enable webdriver classic on wpt workflow

### DIFF
--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -117,8 +117,6 @@ def handle_preset(s: str) -> Optional[JobConfig]:
             wpt_args=" ".join(
                 [
                     "./tests/wpt/tests/webdriver/tests/classic/",
-                    "--product servodriver",
-                    "--headless",
                     "--processes 1",
                 ]
             ),

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -299,7 +299,7 @@ skip: true
     [bidi]
       skip: true
     [classic]
-      skip: true
+      skip: false
     [interop]
       skip: true
 [webgl]

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/key_shortcuts.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/key_shortcuts.py.ini
@@ -1,0 +1,3 @@
+[key_shortcuts.py]
+  [test_mod_a_mod_c_right_mod_v_pastes_text]
+    expected: FAIL


### PR DESCRIPTION
Since WebDriver is quite stable now, enable the `webdriver/classic` tests on wpt CI.