### PR TITLE
devtools: Add scaffolding for `Debugger.Script` and setbreakpoint in SM

### DIFF
--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -239,6 +239,7 @@ impl Actor for SourceActor {
                         tx,
                     ))
                     .map_err(|_| ActorError::Internal)?;
+
                 let result = rx.recv().map_err(|_| ActorError::Internal)?;
                 let mut positions: BTreeMap<u32, BTreeSet<u32>> = BTreeMap::default();
                 for entry in result {
@@ -250,6 +251,20 @@ impl Actor for SourceActor {
                         .or_default()
                         .insert(entry.column_number - 1);
                 }
+
+                // set-breakpoint
+                let (tx, rx) = channel().map_err(|_| ActorError::Internal)?;
+                println!("----: before");
+                self.script_sender
+                    .send(DevtoolScriptControlMsg::SetBreakpoint(
+                        self.spidermonkey_id,
+                        5,
+                        tx,
+                    ))
+                    .map_err(|_| ActorError::Internal)?;
+                println!("----: sent");
+                let result_setbreakpoint = rx.recv().map_err(|_| ActorError::Internal)?;
+                println!("----: received");
                 let reply = GetBreakpointPositionsCompressedReply {
                     from: self.name(),
                     positions,

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -252,9 +252,7 @@ impl Actor for SourceActor {
                         .insert(entry.column_number - 1);
                 }
 
-                // set-breakpoint
-                let (tx, rx) = channel().map_err(|_| ActorError::Internal)?;
-                println!("----: before");
+                let (tx, _rx) = channel().map_err(|_| ActorError::Internal)?;
                 self.script_sender
                     .send(DevtoolScriptControlMsg::SetBreakpoint(
                         self.spidermonkey_id,
@@ -262,9 +260,7 @@ impl Actor for SourceActor {
                         tx,
                     ))
                     .map_err(|_| ActorError::Internal)?;
-                println!("----: sent");
-                let result_setbreakpoint = rx.recv().map_err(|_| ActorError::Internal)?;
-                println!("----: received");
+
                 let reply = GetBreakpointPositionsCompressedReply {
                     from: self.name(),
                     positions,

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -28,6 +28,7 @@ use crate::dom::bindings::error::report_pending_exception;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
+use crate::dom::debuggersetbreakpointevent::DebuggerSetBreakpointEvent;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::types::{DebuggerAddDebuggeeEvent, DebuggerGetPossibleBreakpointsEvent, Event};
 #[cfg(feature = "testbinding")]
@@ -48,6 +49,8 @@ pub(crate) struct DebuggerGlobalScope {
     #[no_trace]
     get_possible_breakpoints_result_sender:
         RefCell<Option<IpcSender<Vec<devtools_traits::RecommendedBreakpointLocation>>>>,
+    #[no_trace]
+    set_breakpoint_result_sender: RefCell<Option<IpcSender<bool>>>,
 }
 
 impl DebuggerGlobalScope {
@@ -93,6 +96,7 @@ impl DebuggerGlobalScope {
             ),
             devtools_to_script_sender,
             get_possible_breakpoints_result_sender: RefCell::new(None),
+            set_breakpoint_result_sender: RefCell::new(None),
         });
         let global =
             DebuggerGlobalScopeBinding::Wrap::<crate::DomTypeHolder>(GlobalScope::get_cx(), global);
@@ -183,6 +187,30 @@ impl DebuggerGlobalScope {
         assert!(
             DomRoot::upcast::<Event>(event).fire(self.upcast(), can_gc),
             "Guaranteed by DebuggerGetPossibleBreakpointsEvent::new"
+        );
+    }
+
+    pub(crate) fn fire_set_breakpoint(
+        &self,
+        can_gc: CanGc,
+        spidermonkey_id: u32,
+        offset: u32,
+        result_sender: IpcSender<bool>,
+    ) {
+        assert!(
+            self.set_breakpoint_result_sender
+                .replace(Some(result_sender))
+                .is_none()
+        );
+        let event = DomRoot::upcast::<Event>(DebuggerSetBreakpointEvent::new(
+            self.upcast(),
+            spidermonkey_id,
+            offset,
+            can_gc,
+        ));
+        assert!(
+            DomRoot::upcast::<Event>(event).fire(self.upcast(), can_gc),
+            "Guaranteed by DebuggerSetBreakpointEvent::new"
         );
     }
 }
@@ -304,5 +332,14 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                 })
                 .collect(),
         );
+    }
+
+    fn SetBreakpointResult(&self, event: &DebuggerSetBreakpointEvent, result: bool) {
+        info!("SetBreakpointResult: {event:?} {result:?}");
+        let sender = self
+            .set_breakpoint_result_sender
+            .take()
+            .expect("Guaranteed by Self::fire_set_breakpoint()");
+        let _ = sender.send(result);
     }
 }

--- a/components/script/dom/debuggersetbreakpointevent.rs
+++ b/components/script/dom/debuggersetbreakpointevent.rs
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::fmt::Debug;
+
+use dom_struct::dom_struct;
+
+use crate::dom::bindings::codegen::Bindings::DebuggerSetBreakpointEventBinding::DebuggerSetBreakpointEventMethods;
+use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
+use crate::dom::bindings::reflector::reflect_dom_object;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::event::Event;
+use crate::dom::types::GlobalScope;
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+/// Event for Rust → JS calls in [`crate::dom::DebuggerGlobalScope`].
+pub(crate) struct DebuggerSetBreakpointEvent {
+    event: Event,
+    spidermonkey_id: u32,
+    offset: u32,
+}
+
+impl DebuggerSetBreakpointEvent {
+    pub(crate) fn new(
+        debugger_global: &GlobalScope,
+        spidermonkey_id: u32,
+        offset: u32,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        let result = Box::new(Self {
+            event: Event::new_inherited(),
+            spidermonkey_id,
+            offset,
+        });
+        let result = reflect_dom_object(result, debugger_global, can_gc);
+        result
+            .event
+            .init_event("setBreakpoint".into(), false, false);
+
+        result
+    }
+}
+
+impl DebuggerSetBreakpointEventMethods<crate::DomTypeHolder> for DebuggerSetBreakpointEvent {
+    // check-tidy: no specs after this line
+    fn SpidermonkeyId(&self) -> u32 {
+        self.spidermonkey_id
+    }
+
+    fn Offset(&self) -> u32 {
+        self.offset
+    }
+
+    fn IsTrusted(&self) -> bool {
+        self.event.IsTrusted()
+    }
+}
+
+impl Debug for DebuggerSetBreakpointEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DebuggerSetBreakpointEvent")
+            .field("spidermonkey_id", &self.spidermonkey_id)
+            .field("offset", &self.offset)
+            .finish()
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -277,6 +277,7 @@ pub(crate) mod datatransferitemlist;
 pub(crate) mod debuggeradddebuggeeevent;
 pub(crate) mod debuggergetpossiblebreakpointsevent;
 pub(crate) mod debuggerglobalscope;
+pub(crate) mod debuggersetbreakpointevent;
 pub(crate) mod dedicatedworkerglobalscope;
 pub(crate) mod defaultteereadrequest;
 pub(crate) mod defaultteeunderlyingsource;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2139,6 +2139,14 @@ impl ScriptThread {
                     result_sender,
                 );
             },
+            DevtoolScriptControlMsg::SetBreakpoint(spidermonkey_id, offset, result_sender) => {
+                self.debugger_global.fire_set_breakpoint(
+                    can_gc,
+                    spidermonkey_id,
+                    offset,
+                    result_sender,
+                );
+            },
         }
     }
 

--- a/components/script_bindings/webidls/DebuggerSetBreakpointEvent.webidl
+++ b/components/script_bindings/webidls/DebuggerSetBreakpointEvent.webidl
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+[Exposed=DebuggerGlobalScope]
+interface DebuggerSetBreakpointEvent : Event {
+    readonly attribute unsigned long spidermonkeyId;
+    readonly attribute unsigned long offset;
+};
+
+partial interface DebuggerGlobalScope {
+    undefined setBreakpointResult(
+        DebuggerSetBreakpointEvent event,
+        boolean result);
+};

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -286,6 +286,7 @@ pub enum DevtoolScriptControlMsg {
     HighlightDomNode(PipelineId, Option<String>),
 
     GetPossibleBreakpoints(u32, IpcSender<Vec<RecommendedBreakpointLocation>>),
+    SetBreakpoint(u32, u32, IpcSender<bool>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -48,5 +48,26 @@ addEventListener("getPossibleBreakpoints", event => {
         }
         return result;
     }
+
     getPossibleBreakpointsResult(event, getPossibleBreakpointsRecursive(script));
+});
+
+addEventListener("setBreakpoint", event => {
+    const {spidermonkeyId, offset} = event;
+    const script = sourceIdsToScripts.get(spidermonkeyId);
+    function breakpointHandler(...args) {
+        // todo: notify script tp pause
+        // tell spidermonkey to pause
+       return {throw: "1"}
+    }
+
+    function getPossibleBreakpointsRecursive(script) {
+        script.setBreakpoint(offset, { hit: breakpointHandler })
+        for (const child of script.getChildScripts()) {
+            getPossibleBreakpointsRecursive(child)
+        }
+    }
+
+    getPossibleBreakpointsRecursive(script);
+    setBreakpointResult(event, true)
 });

--- a/resources/debugger.js
+++ b/resources/debugger.js
@@ -55,10 +55,13 @@ addEventListener("getPossibleBreakpoints", event => {
 addEventListener("setBreakpoint", event => {
     const {spidermonkeyId, offset} = event;
     const script = sourceIdsToScripts.get(spidermonkeyId);
+
+    // The hit method’s return value should be a resumption value, determining how execution should continue.
+    // <https://firefox-source-docs.mozilla.org/js/Debugger/Conventions.html#resumption-values>
     function breakpointHandler(...args) {
-        // todo: notify script tp pause
-        // tell spidermonkey to pause
-       return {throw: "1"}
+        // TODO: Notify script to pause and handle different resumption values
+        // <https://firefox-source-docs.mozilla.org/js/Debugger/Debugger.Script.html#setbreakpoint-offset-handler>
+        return {throw: "1"}
     }
 
     function getPossibleBreakpointsRecursive(script) {


### PR DESCRIPTION
With the current implementation, the user on the client side is able to see where they can set breakpoints, but we never inform SpiderMonkey about where the user has set them, see #37667 . In this patch, we add scaffolding for `Debugger.Script` for `setBreakpoint` and set the breakpoints in SpiderMonkey,so that when a breakpoint is set on the client side, it is also set in SpiderMonkey.

Testing: We already have test that verifies where the user can set breakpoints.
Fixes: part of https://github.com/servo/servo/issues/36027
