### PR TITLE
script: Always dirty nodes when changing node state

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3773,17 +3773,6 @@ impl Document {
         })
     }
 
-    pub(crate) fn element_state_will_change(&self, element: &Element) {
-        let mut entry = self.ensure_pending_restyle(element);
-        if entry.snapshot.is_none() {
-            entry.snapshot = Some(Snapshot::new());
-        }
-        let snapshot = entry.snapshot.as_mut().unwrap();
-        if snapshot.state.is_none() {
-            snapshot.state = Some(element.state());
-        }
-    }
-
     pub(crate) fn element_attr_will_change(&self, el: &Element, attr: &Attr) {
         // FIXME(emilio): Kind of a shame we have to duplicate this.
         //


### PR DESCRIPTION
With incremental layout adding a restyle to a node isn't enough to force
its layout to update. We also need to explicitly mark the node as dirty
so that its contents are updated when layout is run. This change makes
this consistent for all node state changes. This might be a bit too
conservative as all node state may not affect layout, but should catch
issues in the future.

Testing: This is very hard to test as it requires moving the mouse over the
WebView, and the moving it away, and then testing the rendered contents. This
kind of coordination would be difficult to manage with unit tests.
Fixes: #38989.
