### PR TITLE
Add AbortController to preferences enabled by --enable-experimental-web-platform-features

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -21,6 +21,7 @@ use servo::servo_url::ServoUrl;
 use url::Url;
 
 pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
+    "dom_abort_controller_enabled",
     "dom_async_clipboard_enabled",
     "dom_fontface_enabled",
     "dom_intersection_observer_enabled",

--- a/resources/resource_protocol/preferences.html
+++ b/resources/resource_protocol/preferences.html
@@ -26,10 +26,6 @@
           <label for="experimental">Experimental web platform features</label>
         </li>
         <li>
-          <input type="checkbox" class="bool-preference" id="more-experimental">
-          <label for="more-experimental">Even more experimental web platform features</label>
-        </li>
-        <li>
           <input type="checkbox" class="bool-preference" id="http-cache">
           <label for="http-cache">Disable HTTP cache</label>
         </li>
@@ -52,7 +48,6 @@
       const prefs = {
           "experimental": [],
           "http-cache": ["network_http_cache_disabled"],
-          "more-experimental": ["dom_abort_controller_enabled"],
           "user-agent": ["user_agent"],
       };
 

--- a/tests/wpt/meta/IndexedDB/back-forward-cache-open-connection.window.js.ini
+++ b/tests/wpt/meta/IndexedDB/back-forward-cache-open-connection.window.js.ini
@@ -1,3 +1,4 @@
 [back-forward-cache-open-connection.window.html]
+  expected: TIMEOUT
   [Testing BFCache support for page with open IndexedDB connection, and eviction behavior when receiving versionchange event.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/css/css-cascade/layer-cssom-order-reverse.html.ini
+++ b/tests/wpt/meta/css/css-cascade/layer-cssom-order-reverse.html.ini
@@ -1,3 +1,0 @@
-[layer-cssom-order-reverse.html]
-  [Delete layer invalidates @font-face]
-    expected: FAIL

--- a/tests/wpt/meta/dom/abort/__dir__.ini
+++ b/tests/wpt/meta/dom/abort/__dir__.ini
@@ -1,3 +1,0 @@
-prefs: [
-  "dom_abort_controller_enabled:true",
-]

--- a/tests/wpt/meta/dom/events/AddEventListenerOptions-signal.any.js.ini
+++ b/tests/wpt/meta/dom/events/AddEventListenerOptions-signal.any.js.ini
@@ -20,20 +20,9 @@
   [Passing null as the signal should throw (listener is also null)]
     expected: FAIL
 
-  [Passing an AbortSignal to addEventListener does not prevent removeEventListener]
-    expected: FAIL
-
-  [Removing a once listener works with a passed signal]
-    expected: FAIL
-
-  [Adding then aborting a listener in another listener does not call it]
-    expected: FAIL
-
-  [Aborting from a nested listener should remove it]
-    expected: FAIL
-
 
 [AddEventListenerOptions-signal.any.worker.html]
+  expected: ERROR
   [Passing an AbortSignal to addEventListener works with the once flag]
     expected: FAIL
 
@@ -53,16 +42,4 @@
     expected: FAIL
 
   [Passing null as the signal should throw (listener is also null)]
-    expected: FAIL
-
-  [Passing an AbortSignal to addEventListener does not prevent removeEventListener]
-    expected: FAIL
-
-  [Removing a once listener works with a passed signal]
-    expected: FAIL
-
-  [Adding then aborting a listener in another listener does not call it]
-    expected: FAIL
-
-  [Aborting from a nested listener should remove it]
     expected: FAIL

--- a/tests/wpt/meta/dom/idlharness.any.js.ini
+++ b/tests/wpt/meta/dom/idlharness.any.js.ini
@@ -5,103 +5,19 @@
   expected: ERROR
 
 [idlharness.any.worker.html]
-  [AbortController interface: attribute signal]
-    expected: FAIL
-
   [AbortController interface: operation abort()]
-    expected: FAIL
-
-  [AbortController interface: new AbortController() must inherit property "signal" with the proper type]
     expected: FAIL
 
   [AbortController interface: new AbortController() must inherit property "abort()" with the proper type]
     expected: FAIL
 
-  [AbortSignal interface: existence and properties of interface object]
-    expected: FAIL
-
-  [AbortSignal interface object length]
-    expected: FAIL
-
-  [AbortSignal interface object name]
-    expected: FAIL
-
-  [AbortSignal interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [AbortSignal interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [AbortSignal interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
   [AbortSignal interface: operation abort()]
-    expected: FAIL
-
-  [AbortSignal interface: attribute aborted]
-    expected: FAIL
-
-  [AbortSignal interface: attribute onabort]
-    expected: FAIL
-
-  [AbortSignal must be primary interface of new AbortController().signal]
-    expected: FAIL
-
-  [Stringification of new AbortController().signal]
     expected: FAIL
 
   [AbortSignal interface: new AbortController().signal must inherit property "abort()" with the proper type]
     expected: FAIL
 
-  [AbortSignal interface: new AbortController().signal must inherit property "aborted" with the proper type]
-    expected: FAIL
-
-  [AbortSignal interface: new AbortController().signal must inherit property "onabort" with the proper type]
-    expected: FAIL
-
-  [EventTarget interface: new AbortController().signal must inherit property "addEventListener(DOMString, EventListener?, optional (AddEventListenerOptions or boolean))" with the proper type]
-    expected: FAIL
-
-  [EventTarget interface: calling addEventListener(DOMString, EventListener?, optional (AddEventListenerOptions or boolean)) on new AbortController().signal with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [EventTarget interface: new AbortController().signal must inherit property "removeEventListener(DOMString, EventListener?, optional (EventListenerOptions or boolean))" with the proper type]
-    expected: FAIL
-
-  [EventTarget interface: calling removeEventListener(DOMString, EventListener?, optional (EventListenerOptions or boolean)) on new AbortController().signal with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [EventTarget interface: new AbortController().signal must inherit property "dispatchEvent(Event)" with the proper type]
-    expected: FAIL
-
-  [EventTarget interface: calling dispatchEvent(Event) on new AbortController().signal with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [AbortSignal interface: operation abort(optional any)]
-    expected: FAIL
-
-  [AbortSignal interface: attribute reason]
-    expected: FAIL
-
-  [AbortSignal interface: operation throwIfAborted()]
-    expected: FAIL
-
-  [AbortSignal interface: new AbortController().signal must inherit property "abort(optional any)" with the proper type]
-    expected: FAIL
-
-  [AbortSignal interface: calling abort(optional any) on new AbortController().signal with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [AbortSignal interface: new AbortController().signal must inherit property "reason" with the proper type]
-    expected: FAIL
-
-  [AbortSignal interface: new AbortController().signal must inherit property "throwIfAborted()" with the proper type]
-    expected: FAIL
-
   [AbortSignal interface: operation timeout(unsigned long long)]
-    expected: FAIL
-
-  [AbortSignal interface: new AbortController().signal must inherit property "timeout(unsigned long long)" with the proper type]
     expected: FAIL
 
   [AbortSignal interface: calling timeout(unsigned long long) on new AbortController().signal with too few arguments must throw TypeError]
@@ -110,43 +26,7 @@
   [AbortSignal interface: operation any(sequence<AbortSignal>)]
     expected: FAIL
 
-  [AbortSignal interface: new AbortController().signal must inherit property "any(sequence<AbortSignal>)" with the proper type]
-    expected: FAIL
-
   [AbortSignal interface: calling any(sequence<AbortSignal>) on new AbortController().signal with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [AbortController interface: existence and properties of interface object]
-    expected: FAIL
-
-  [AbortController interface object length]
-    expected: FAIL
-
-  [AbortController interface object name]
-    expected: FAIL
-
-  [AbortController interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [AbortController interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [AbortController interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [AbortController interface: operation abort(optional any)]
-    expected: FAIL
-
-  [AbortController must be primary interface of new AbortController()]
-    expected: FAIL
-
-  [Stringification of new AbortController()]
-    expected: FAIL
-
-  [AbortController interface: new AbortController() must inherit property "abort(optional any)" with the proper type]
-    expected: FAIL
-
-  [AbortController interface: calling abort(optional any) on new AbortController() with too few arguments must throw TypeError]
     expected: FAIL
 
 

--- a/tests/wpt/meta/dom/idlharness.window.js.ini
+++ b/tests/wpt/meta/dom/idlharness.window.js.ini
@@ -1,71 +1,11 @@
 [idlharness.window.html?exclude=Node]
-  [AbortSignal must be primary interface of new AbortController().signal]
-    expected: FAIL
-
-  [AbortSignal interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [AbortSignal interface: existence and properties of interface object]
-    expected: FAIL
-
-  [EventTarget interface: calling removeEventListener(DOMString, EventListener?, optional (EventListenerOptions or boolean)) on new AbortController().signal with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [EventTarget interface: new AbortController().signal must inherit property "addEventListener(DOMString, EventListener?, optional (AddEventListenerOptions or boolean))" with the proper type]
-    expected: FAIL
-
-  [EventTarget interface: new AbortController().signal must inherit property "dispatchEvent(Event)" with the proper type]
-    expected: FAIL
-
-  [AbortSignal interface object name]
-    expected: FAIL
-
-  [EventTarget interface: new AbortController().signal must inherit property "removeEventListener(DOMString, EventListener?, optional (EventListenerOptions or boolean))" with the proper type]
-    expected: FAIL
-
   [AbortController interface: operation abort()]
-    expected: FAIL
-
-  [AbortController interface: attribute signal]
-    expected: FAIL
-
-  [AbortSignal interface: attribute aborted]
-    expected: FAIL
-
-  [AbortController interface: new AbortController() must inherit property "signal" with the proper type]
     expected: FAIL
 
   [AbortController interface: new AbortController() must inherit property "abort()" with the proper type]
     expected: FAIL
 
-  [EventTarget interface: calling dispatchEvent(Event) on new AbortController().signal with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [AbortSignal interface: new AbortController().signal must inherit property "aborted" with the proper type]
-    expected: FAIL
-
-  [EventTarget interface: calling addEventListener(DOMString, EventListener?, optional (AddEventListenerOptions or boolean)) on new AbortController().signal with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [AbortSignal interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [AbortSignal interface: new AbortController().signal must inherit property "onabort" with the proper type]
-    expected: FAIL
-
-  [AbortSignal interface: attribute onabort]
-    expected: FAIL
-
-  [AbortSignal interface object length]
-    expected: FAIL
-
-  [AbortSignal interface: existence and properties of interface prototype object]
-    expected: FAIL
-
   [NodeFilter interface: existence and properties of interface object]
-    expected: FAIL
-
-  [Stringification of new AbortController().signal]
     expected: FAIL
 
   [XPathNSResolver interface: document.createNSResolver(document.body) must inherit property "lookupNamespaceURI(DOMString?)" with the proper type]
@@ -173,31 +113,7 @@
   [XSLTProcessor interface: new XSLTProcessor() must inherit property "reset()" with the proper type]
     expected: FAIL
 
-  [AbortSignal interface: operation abort(optional any)]
-    expected: FAIL
-
-  [AbortSignal interface: attribute reason]
-    expected: FAIL
-
-  [AbortSignal interface: operation throwIfAborted()]
-    expected: FAIL
-
-  [AbortSignal interface: new AbortController().signal must inherit property "abort(optional any)" with the proper type]
-    expected: FAIL
-
-  [AbortSignal interface: calling abort(optional any) on new AbortController().signal with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [AbortSignal interface: new AbortController().signal must inherit property "reason" with the proper type]
-    expected: FAIL
-
-  [AbortSignal interface: new AbortController().signal must inherit property "throwIfAborted()" with the proper type]
-    expected: FAIL
-
   [AbortSignal interface: operation timeout(unsigned long long)]
-    expected: FAIL
-
-  [AbortSignal interface: new AbortController().signal must inherit property "timeout(unsigned long long)" with the proper type]
     expected: FAIL
 
   [AbortSignal interface: calling timeout(unsigned long long) on new AbortController().signal with too few arguments must throw TypeError]
@@ -228,9 +144,6 @@
     expected: FAIL
 
   [AbortSignal interface: operation any(sequence<AbortSignal>)]
-    expected: FAIL
-
-  [AbortSignal interface: new AbortController().signal must inherit property "any(sequence<AbortSignal>)" with the proper type]
     expected: FAIL
 
   [AbortSignal interface: calling any(sequence<AbortSignal>) on new AbortController().signal with too few arguments must throw TypeError]
@@ -288,39 +201,6 @@
     expected: FAIL
 
   [CharacterData interface: operation replaceWith((Node or TrustedScript or DOMString)...)]
-    expected: FAIL
-
-  [AbortController interface: existence and properties of interface object]
-    expected: FAIL
-
-  [AbortController interface object length]
-    expected: FAIL
-
-  [AbortController interface object name]
-    expected: FAIL
-
-  [AbortController interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [AbortController interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [AbortController interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [AbortController interface: operation abort(optional any)]
-    expected: FAIL
-
-  [AbortController must be primary interface of new AbortController()]
-    expected: FAIL
-
-  [Stringification of new AbortController()]
-    expected: FAIL
-
-  [AbortController interface: new AbortController() must inherit property "abort(optional any)" with the proper type]
-    expected: FAIL
-
-  [AbortController interface: calling abort(optional any) on new AbortController() with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: operation moveBefore(Node, Node?)]

--- a/tests/wpt/meta/dom/interface-objects.html.ini
+++ b/tests/wpt/meta/dom/interface-objects.html.ini
@@ -1,6 +1,0 @@
-[interface-objects.html]
-  [Should be able to delete AbortSignal.]
-    expected: FAIL
-
-  [Should be able to delete AbortController.]
-    expected: FAIL

--- a/tests/wpt/meta/fetch/api/abort/destroyed-context.html.ini
+++ b/tests/wpt/meta/fetch/api/abort/destroyed-context.html.ini
@@ -1,2 +1,0 @@
-[destroyed-context.html]
-  expected: ERROR

--- a/tests/wpt/meta/fetch/api/abort/general.any.js.ini
+++ b/tests/wpt/meta/fetch/api/abort/general.any.js.ini
@@ -5,6 +5,7 @@
   expected: ERROR
 
 [general.any.html]
+  expected: TIMEOUT
   [Aborting rejects with AbortError]
     expected: FAIL
 
@@ -69,31 +70,31 @@
     expected: FAIL
 
   [Fetch aborted & connection closed when aborted after calling response.arrayBuffer()]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Fetch aborted & connection closed when aborted after calling response.blob()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch aborted & connection closed when aborted after calling response.formData()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch aborted & connection closed when aborted after calling response.json()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch aborted & connection closed when aborted after calling response.text()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream errors once aborted. Underlying connection closed.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream errors once aborted, after reading. Underlying connection closed.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream will not error if body is empty. It's closed with an empty queue before it errors.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Readable stream synchronously cancels with AbortError if aborted before reading]
-    expected: FAIL
+    expected: NOTRUN
 
   [Signal state is cloned]
     expected: FAIL
@@ -111,61 +112,11 @@
     expected: FAIL
 
   [Fetch aborted & connection closed when aborted after calling response.bytes()]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's window is not null]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Input URL is not valid]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Input URL has credentials]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's mode is navigate]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's referrer is invalid]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's method is invalid]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's method is forbidden]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's mode is no-cors and method is not simple]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's cache mode is only-if-cached and mode is not same-origin]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Request with cache mode: only-if-cached and fetch mode cors]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Request with cache mode: only-if-cached and fetch mode no-cors]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad referrerPolicy init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad mode init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad credentials init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad cache init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad redirect init parameter value]
-    expected: FAIL
-
-  [Signal removed by setting to null]
-    expected: FAIL
+    expected: NOTRUN
 
 
 [general.any.worker.html]
+  expected: TIMEOUT
   [Aborting rejects with AbortError]
     expected: FAIL
 
@@ -230,31 +181,31 @@
     expected: FAIL
 
   [Fetch aborted & connection closed when aborted after calling response.arrayBuffer()]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Fetch aborted & connection closed when aborted after calling response.blob()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch aborted & connection closed when aborted after calling response.formData()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch aborted & connection closed when aborted after calling response.json()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch aborted & connection closed when aborted after calling response.text()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream errors once aborted. Underlying connection closed.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream errors once aborted, after reading. Underlying connection closed.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream will not error if body is empty. It's closed with an empty queue before it errors.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Readable stream synchronously cancels with AbortError if aborted before reading]
-    expected: FAIL
+    expected: NOTRUN
 
   [Signal state is cloned]
     expected: FAIL
@@ -272,55 +223,4 @@
     expected: FAIL
 
   [Fetch aborted & connection closed when aborted after calling response.bytes()]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's window is not null]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Input URL is not valid]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Input URL has credentials]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's mode is navigate]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's referrer is invalid]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's method is invalid]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's method is forbidden]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's mode is no-cors and method is not simple]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's cache mode is only-if-cached and mode is not same-origin]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Request with cache mode: only-if-cached and fetch mode cors]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Request with cache mode: only-if-cached and fetch mode no-cors]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad referrerPolicy init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad mode init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad credentials init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad cache init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad redirect init parameter value]
-    expected: FAIL
-
-  [Signal removed by setting to null]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/fetch/api/abort/keepalive.html.ini
+++ b/tests/wpt/meta/fetch/api/abort/keepalive.html.ini
@@ -1,5 +1,5 @@
 [keepalive.html]
-  expected: ERROR
+  expected: TIMEOUT
   [aborting a keepalive fetch should work]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/fetch/api/abort/request.any.js.ini
+++ b/tests/wpt/meta/fetch/api/abort/request.any.js.ini
@@ -17,42 +17,6 @@
   [Calling text() on an aborted consumed nonempty request]
     expected: FAIL
 
-  [Calling arrayBuffer() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling arrayBuffer()]
-    expected: FAIL
-
-  [Calling arrayBuffer() on an aborted consumed empty request]
-    expected: FAIL
-
-  [Calling blob() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling blob()]
-    expected: FAIL
-
-  [Calling blob() on an aborted consumed empty request]
-    expected: FAIL
-
-  [Calling formData() on an aborted consumed nonempty request]
-    expected: FAIL
-
-  [Calling json() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling json()]
-    expected: FAIL
-
-  [Calling text() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling text()]
-    expected: FAIL
-
-  [Calling text() on an aborted consumed empty request]
-    expected: FAIL
-
 
 [request.any.serviceworker.html]
   expected: ERROR
@@ -77,40 +41,4 @@
     expected: FAIL
 
   [Calling text() on an aborted consumed nonempty request]
-    expected: FAIL
-
-  [Calling arrayBuffer() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling arrayBuffer()]
-    expected: FAIL
-
-  [Calling arrayBuffer() on an aborted consumed empty request]
-    expected: FAIL
-
-  [Calling blob() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling blob()]
-    expected: FAIL
-
-  [Calling blob() on an aborted consumed empty request]
-    expected: FAIL
-
-  [Calling formData() on an aborted consumed nonempty request]
-    expected: FAIL
-
-  [Calling json() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling json()]
-    expected: FAIL
-
-  [Calling text() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling text()]
-    expected: FAIL
-
-  [Calling text() on an aborted consumed empty request]
     expected: FAIL

--- a/tests/wpt/meta/fetch/fetch-later/quota/cross-origin-iframe/multiple-iframes.tentative.https.window.js.ini
+++ b/tests/wpt/meta/fetch/fetch-later/quota/cross-origin-iframe/multiple-iframes.tentative.https.window.js.ini
@@ -1,3 +1,4 @@
 [multiple-iframes.tentative.https.window.html]
+  expected: ERROR
   [fetchLater() request quota are delegated to cross-origin iframes and not shared, even if they are same origin.]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/dedicatedworker.tentative.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/dedicatedworker.tentative.window.js.ini
@@ -1,3 +1,4 @@
 [dedicatedworker.tentative.window.html]
+  expected: TIMEOUT
   [BroadcastChannel messages dispatched to dedicated worker in bfcache should be queued.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/evict-on-message.tentative.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/evict-on-message.tentative.window.js.ini
@@ -1,3 +1,4 @@
 [evict-on-message.tentative.window.html]
+  expected: TIMEOUT
   [BroadcastChannel message while in bfcache should evict the entry.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/document-state.https.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/document-state.https.html.ini
@@ -1,6 +1,7 @@
 [document-state.https.html]
+  expected: TIMEOUT
   [A navigation's initiator origin and referrer are stored in the document state and used in the document repopulation case]
-    expected: FAIL
+    expected: TIMEOUT
 
   [A navigation's initiator origin and referrer are stored in the document state and used on location.reload()]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigateToNew.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigateToNew.window.js.ini
@@ -1,3 +1,0 @@
-[navigateToNew.window.html]
-  [RemoteContextWrapper navigateToNew]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-bfcache.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-bfcache.window.js.ini
@@ -1,3 +1,4 @@
 [navigation-bfcache.window.html]
+  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-helpers.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-helpers.window.js.ini
@@ -1,3 +1,4 @@
 [navigation-helpers.window.html]
+  expected: TIMEOUT
   [RemoteContextHelper navigation helpers]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-same-document.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-same-document.window.js.ini
@@ -1,3 +1,0 @@
-[navigation-same-document.window.html]
-  [RemoteContextHelper navigation using BFCache]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-cross-origin.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-cross-origin.window.js.ini
@@ -1,3 +1,0 @@
-[unload-main-frame-cross-origin.window.html]
-  [Unload runs in main frame when navigating cross-origin.]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-same-origin.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-same-origin.window.js.ini
@@ -1,3 +1,0 @@
-[unload-main-frame-same-origin.window.html]
-  [Unload runs in main frame when navigating same-origin.]
-    expected: FAIL

--- a/tests/wpt/meta/html/browsers/history/the-history-interface/history-state-after-bfcache.window.js.ini
+++ b/tests/wpt/meta/html/browsers/history/the-history-interface/history-state-after-bfcache.window.js.ini
@@ -1,3 +1,4 @@
 [history-state-after-bfcache.window.html]
+  expected: TIMEOUT
   [Navigating back to a bfcached page does not reset history.state]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/windows/auxiliary-browsing-contexts/no-proactive-swap-when-other-contexts-in-group.html.ini
+++ b/tests/wpt/meta/html/browsers/windows/auxiliary-browsing-contexts/no-proactive-swap-when-other-contexts-in-group.html.ini
@@ -1,3 +1,0 @@
-[no-proactive-swap-when-other-contexts-in-group.html]
-  [no proactive browsing context group change when other contexts in group]
-    expected: FAIL

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-bfcache-reasons-stay.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-bfcache-reasons-stay.tentative.window.js.ini
@@ -1,3 +1,4 @@
 [performance-navigation-timing-bfcache-reasons-stay.tentative.window.html]
+  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-bfcache.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-bfcache.tentative.window.js.ini
@@ -1,3 +1,4 @@
 [performance-navigation-timing-bfcache.tentative.window.html]
+  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-cross-origin-bfcache.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-cross-origin-bfcache.tentative.window.js.ini
@@ -1,3 +1,4 @@
 [performance-navigation-timing-cross-origin-bfcache.tentative.window.html]
+  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-fetch.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-fetch.tentative.window.js.ini
@@ -1,3 +1,4 @@
 [performance-navigation-timing-fetch.tentative.window.html]
+  expected: TIMEOUT
   [Ensure that ongoing fetch upon entering bfcache blocks bfcache and recorded.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-navigation-failure.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-navigation-failure.tentative.window.js.ini
@@ -1,3 +1,4 @@
 [performance-navigation-timing-navigation-failure.tentative.window.html]
+  expected: TIMEOUT
   [Ensure that navigation failure blocks bfcache and gets recorded.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-redirect-on-history.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-redirect-on-history.tentative.window.js.ini
@@ -1,3 +1,4 @@
 [performance-navigation-timing-redirect-on-history.tentative.window.html]
+  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-same-origin-bfcache.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-same-origin-bfcache.tentative.window.js.ini
@@ -1,3 +1,4 @@
 [performance-navigation-timing-same-origin-bfcache.tentative.window.html]
+  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/streams/__dir__.ini
+++ b/tests/wpt/meta/streams/__dir__.ini
@@ -1,3 +1,0 @@
-prefs: [
-  "dom_abort_controller_enabled:true",
-]

--- a/tests/wpt/meta/streams/piping/abort.any.js.ini
+++ b/tests/wpt/meta/streams/piping/abort.any.js.ini
@@ -1,4 +1,3 @@
-prefs: [dom_abort_controller_enabled:true]
 [abort.https.any.shadowrealm-in-serviceworker.html]
   expected: ERROR
 

--- a/tests/wpt/meta/wasm/webapi/abort.any.js.ini
+++ b/tests/wpt/meta/wasm/webapi/abort.any.js.ini
@@ -11,12 +11,6 @@
   [instantiateStreaming() synchronously followed by abort should reject with AbortError]
     expected: FAIL
 
-  [compileStreaming() asynchronously racing with abort should succeed or reject with AbortError]
-    expected: FAIL
-
-  [instantiateStreaming() asynchronously racing with abort should succeed or reject with AbortError]
-    expected: FAIL
-
 
 [abort.any.worker.html]
   [compileStreaming() on an already-aborted request should reject with AbortError]

--- a/tests/wpt/meta/webmessaging/message-channels/close-event/document-destroyed.tentative.window.js.ini
+++ b/tests/wpt/meta/webmessaging/message-channels/close-event/document-destroyed.tentative.window.js.ini
@@ -1,5 +1,5 @@
 [document-destroyed.tentative.window.html]
-  expected: ERROR
+  expected: TIMEOUT
   [The context is navigated to a new document and a close event is fired.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/websockets/back-forward-cache-with-open-websocket-connection.window.js.ini
+++ b/tests/wpt/meta/websockets/back-forward-cache-with-open-websocket-connection.window.js.ini
@@ -1,3 +1,4 @@
 [back-forward-cache-with-open-websocket-connection.window.html]
+  expected: TIMEOUT
   [Testing BFCache support for page with open WebSocket connection.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13749,7 +13749,7 @@
      ]
     ],
     "interfaces.https.html": [
-     "1397b723a1cb001521ac1b2032c380f1e02cf1f0",
+     "5d000d8b71d1dfe268961bfc100dfdf8aa64257f",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -12,6 +12,8 @@
 // IMPORTANT: Do not change the list below without review from a DOM peer!
 test_interfaces([
   "AbstractRange",
+  "AbortController",
+  "AbortSignal",
   "AnalyserNode",
   "AnimationEvent",
   "Attr",


### PR DESCRIPTION
I think it's worth the new tests timing out to have this as part of the common option.

Testing: Existing tests