### PR TITLE
servoshell: Add button to toggle experimental web platform features.

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -98,6 +98,7 @@ use profile_traits::mem::MemoryReportResult;
 use profile_traits::{mem, time};
 use script::{JSEngineSetup, ServiceWorkerManager};
 use servo_config::opts::Opts;
+pub use servo_config::prefs::PrefValue;
 use servo_config::prefs::Preferences;
 use servo_config::{opts, pref, prefs};
 use servo_delegate::DefaultServoDelegate;
@@ -1082,6 +1083,12 @@ impl Servo {
             self.constellation_proxy
                 .send(EmbedderToConstellationMessage::WebDriverCommand(command));
         }
+    }
+
+    pub fn set_preference(&self, name: &str, value: PrefValue) {
+        let mut preferences = prefs::get().clone();
+        preferences.set_value(name, value);
+        prefs::set(preferences);
     }
 }
 

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -119,6 +119,7 @@ impl App {
                     event_loop,
                     proxy,
                     self.initial_url.clone(),
+                    &self.servoshell_preferences,
                 ));
                 Rc::new(window)
             },
@@ -319,6 +320,12 @@ impl App {
                     minibrowser.update_location_dirty(false);
                     if let Some(focused_webview) = state.focused_webview() {
                         focused_webview.reload();
+                    }
+                },
+                MinibrowserEvent::ReloadAll => {
+                    minibrowser.update_location_dirty(false);
+                    for (_, webview) in state.webviews() {
+                        webview.reload();
                     }
                 },
                 MinibrowserEvent::NewWebView => {

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -88,6 +88,9 @@ pub(crate) struct ServoShellPreferences {
     /// Log also to a file
     #[cfg(target_env = "ohos")]
     pub log_to_file: bool,
+
+    /// Whether the CLI option to enable experimental prefs was present at startup.
+    pub experimental_prefs_enabled: bool,
 }
 
 impl Default for ServoShellPreferences {
@@ -111,6 +114,7 @@ impl Default for ServoShellPreferences {
             log_filter: None,
             #[cfg(target_env = "ohos")]
             log_to_file: false,
+            experimental_prefs_enabled: false,
         }
     }
 }
@@ -605,7 +609,9 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         })
         .collect();
 
-    if opt_match.opt_present("enable-experimental-web-platform-features") {
+    let experimental_prefs_enabled =
+        opt_match.opt_present("enable-experimental-web-platform-features");
+    if experimental_prefs_enabled {
         for pref in EXPERIMENTAL_PREFS {
             preferences.set_value(pref, PrefValue::Bool(true));
         }
@@ -677,6 +683,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         log_filter,
         #[cfg(target_env = "ohos")]
         log_to_file,
+        experimental_prefs_enabled,
         ..Default::default()
     };
 


### PR DESCRIPTION
This makes it easier to experiment with the impact of experimental features when browsing around in servoshell. The toggle is global and causes all webviews to reload with the new preference values.

Testing: Manually tested; no UI testing for servoshell.

Not enabled:
<img width="317" height="82" alt="Screenshot 2025-09-03 at 9 34 30 PM" src="https://github.com/user-attachments/assets/ca521ad5-ce1b-434e-a0c3-ea1b75d76d53" />

Enabled:
<img width="320" height="82" alt="Screenshot 2025-09-03 at 9 34 36 PM" src="https://github.com/user-attachments/assets/7b6529b5-1055-4ae0-924a-96d57e115714" />
