### PR TITLE
font: Remove unused `FontTable` constructor for Windows

### DIFF
--- a/components/fonts/platform/windows/font.rs
+++ b/components/fonts/platform/windows/font.rs
@@ -48,14 +48,6 @@ pub struct FontTable {
     data: Vec<u8>,
 }
 
-impl FontTable {
-    pub(crate) fn wrap(data: &[u8]) -> FontTable {
-        FontTable {
-            data: data.to_vec(),
-        }
-    }
-}
-
 impl FontTableMethods for FontTable {
     fn buffer(&self) -> &[u8] {
         &self.data


### PR DESCRIPTION
#39112 restricts accessibility for some font functions, exposing some functions that haven't been used for a long time. Now it is detected by Lint as dead code.