### PR TITLE
Enable viewport `<meta>` tag support for mobile platforms only

### DIFF
--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -64,7 +64,9 @@ impl HTMLMetaElement {
             if name == "referrer" {
                 self.apply_referrer();
             }
-            if name == "viewport" {
+            if (cfg!(target_os = "android") || cfg!(target_os = "ios") || cfg!(target_env = "ohos")) &&
+                name == "viewport"
+            {
                 self.parse_and_send_viewport_if_necessary();
             }
         // https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv


### PR DESCRIPTION
Enable viewport `<meta>` tag support for mobile platforms only.

_Reference:_ [web_preferences.h](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/common/web_preferences/web_preferences.h;l=158;drc=8900162810d457b64286ce653cb61bc2009c5068;bpv=1;bpt=1)
_Todo: Disable for when requested desktop site:_ [web_contents_impl.cc](https://source.chromium.org/chromium/chromium/src/+/main:content/browser/web_contents/web_contents_impl.cc;l=3788;drc=8900162810d457b64286ce653cb61bc2009c5068;bpv=1;bpt=1) 

Testing: Tested Manually
Fixes: #39002
