### PR TITLE
script: Use `HTMLElement.scrollParent` to implement `Element.scrollIntoView`

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -29,8 +29,8 @@ use layout_api::wrapper_traits::LayoutNode;
 use layout_api::{
     BoxAreaType, IFrameSizes, Layout, LayoutConfig, LayoutDamage, LayoutFactory,
     OffsetParentResponse, PropertyRegistration, QueryMsg, ReflowGoal, ReflowPhasesRun,
-    ReflowRequest, ReflowRequestRestyle, ReflowResult, RegisterPropertyError, ScrollParentResponse,
-    TrustedNodeAddress,
+    ReflowRequest, ReflowRequestRestyle, ReflowResult, RegisterPropertyError,
+    ScrollContainerQueryType, ScrollContainerResponse, TrustedNodeAddress,
 };
 use log::{debug, error, warn};
 use malloc_size_of::{MallocConditionalSizeOf, MallocSizeOf, MallocSizeOfOps};
@@ -92,8 +92,8 @@ use crate::display_list::{DisplayListBuilder, HitTest, StackingContextTree};
 use crate::query::{
     get_the_text_steps, process_box_area_request, process_box_areas_request,
     process_client_rect_request, process_node_scroll_area_request, process_offset_parent_query,
-    process_resolved_font_style_query, process_resolved_style_request, process_scroll_parent_query,
-    process_text_index_request,
+    process_resolved_font_style_query, process_resolved_style_request,
+    process_scroll_container_query, process_text_index_request,
 };
 use crate::traversal::{RecalcStyle, compute_damage_and_repair_style};
 use crate::{BoxTree, FragmentTree};
@@ -326,9 +326,13 @@ impl Layout for LayoutThread {
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn query_scroll_parent(&self, node: TrustedNodeAddress) -> Option<ScrollParentResponse> {
+    fn query_scroll_container(
+        &self,
+        node: TrustedNodeAddress,
+        query_type: ScrollContainerQueryType,
+    ) -> Option<ScrollContainerResponse> {
         let node = unsafe { ServoLayoutNode::new(&node) };
-        process_scroll_parent_query(node)
+        process_scroll_container_query(node, query_type)
     }
 
     #[servo_tracing::instrument(skip_all)]

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -669,9 +669,8 @@ pub(crate) fn process_scroll_container_query(
     // - The element is the root element.
     // - The element is the body element.
     //
-    // Note: We only do this for `scrollParent`, as `scrollIntoView` on the `<body>` element should
-    // scroll the body by scrolling the viewport, but the `scrollParent` of the body is `null`. in
-    // `HTMLElement`.
+    // Note: We only do this for `scrollParent`, which needs to be null. But `scrollIntoView` on the
+    // `<body>` or root element should still bring it into view by scrolling the viewport.
     if query_type == ScrollContainerQueryType::ForScrollParent &&
         flags.intersects(
             FragmentFlags::IS_ROOT_ELEMENT | FragmentFlags::IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -56,8 +56,8 @@ use js::rust::{
 use layout_api::{
     BoxAreaType, ElementsFromPointFlags, ElementsFromPointResult, FragmentType, Layout,
     PendingImage, PendingImageState, PendingRasterizationImage, QueryMsg, ReflowGoal,
-    ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle, RestyleReason, ScrollParentResponse,
-    TrustedNodeAddress, combine_id_with_fragment_type,
+    ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle, RestyleReason, ScrollContainerQueryType,
+    ScrollContainerResponse, TrustedNodeAddress, combine_id_with_fragment_type,
 };
 use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
@@ -2599,21 +2599,15 @@ impl Window {
         (element, response.rect)
     }
 
-    #[allow(unsafe_code)]
-    pub(crate) fn scroll_parent_query(&self, node: &Node) -> Option<DomRoot<Element>> {
+    pub(crate) fn scroll_container_query(
+        &self,
+        node: &Node,
+        query_type: ScrollContainerQueryType,
+    ) -> Option<ScrollContainerResponse> {
         self.layout_reflow(QueryMsg::ScrollParentQuery);
         self.layout
             .borrow()
-            .query_scroll_parent(node.to_trusted_node_address())
-            .and_then(|response| match response {
-                ScrollParentResponse::DocumentScrollingElement => {
-                    self.Document().GetScrollingElement()
-                },
-                ScrollParentResponse::Element(parent_node_address) => {
-                    let node = unsafe { from_untrusted_node_address(parent_node_address) };
-                    DomRoot::downcast(node)
-                },
-            })
+            .query_scroll_container(node.to_trusted_node_address(), query_type)
     }
 
     pub(crate) fn text_index_query(

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -295,7 +295,11 @@ pub trait Layout {
     fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32>;
     fn query_element_inner_outer_text(&self, node: TrustedNodeAddress) -> String;
     fn query_offset_parent(&self, node: TrustedNodeAddress) -> OffsetParentResponse;
-    fn query_scroll_parent(&self, node: TrustedNodeAddress) -> Option<ScrollParentResponse>;
+    fn query_scroll_container(
+        &self,
+        node: TrustedNodeAddress,
+        query_type: ScrollContainerQueryType,
+    ) -> Option<ScrollContainerResponse>;
     fn query_resolved_style(
         &self,
         node: TrustedNodeAddress,
@@ -352,9 +356,15 @@ pub struct OffsetParentResponse {
     pub rect: Rect<Au>,
 }
 
+#[derive(PartialEq)]
+pub enum ScrollContainerQueryType {
+    ForScrollParent,
+    ForScrollIntoView,
+}
+
 #[derive(Clone)]
-pub enum ScrollParentResponse {
-    DocumentScrollingElement,
+pub enum ScrollContainerResponse {
+    Viewport,
     Element(UntrustedNodeAddress),
 }
 

--- a/tests/wpt/meta/css/cssom-view/scrollIntoView-fixed.html.ini
+++ b/tests/wpt/meta/css/cssom-view/scrollIntoView-fixed.html.ini
@@ -1,11 +1,5 @@
 [scrollIntoView-fixed.html]
-  [[Box A\] scrollIntoView from unscrollable position:fixed]
-    expected: FAIL
-
   [[Box B\] scrollIntoView from unscrollable position:fixed in iframe]
-    expected: FAIL
-
-  [[Box C\] scrollIntoView from scrollable position:fixed]
     expected: FAIL
 
   [[Box D\] scrollIntoView from scrollable position:fixed in iframe]

--- a/tests/wpt/tests/css/cssom-view/scrollIntoView-should-treat-slot-as-scroll-container.html
+++ b/tests/wpt/tests/css/cssom-view/scrollIntoView-should-treat-slot-as-scroll-container.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#overflow-control">
+<meta name="assert" content="scrollIntoView called on the descendant of shadow host with a slot should treat the slot as a pontential scroll container.">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="host">
+  <div style="height: 200px"></div>
+  <div id="target" style="height: 100px; width: 100px; background: green"></div>
+</div>
+<script>
+    var shadow = host.attachShadow({mode: "open"});
+    var slot = document.createElement("slot");
+    slot.style="display: block; overflow: hidden; width: 100px; height: 100px; background: red";
+    shadow.appendChild(slot);
+    target.scrollIntoView();
+</script>


### PR DESCRIPTION
To find scrolling ancestors, we need to walk up the flat tree and only
consider the elements that are in the chain of containing block
ancestors of an element. `scrollParent` now does this so we can use it
to properly implement `scrollIntoView`.

Testing: There are WPT tests for this change.
