### PR TITLE
Refactor loading methods to align with specification

### DIFF
--- a/components/shared/net/mime_classifier.rs
+++ b/components/shared/net/mime_classifier.rs
@@ -240,13 +240,13 @@ impl MimeClassifier {
     /// <https://mimesniff.spec.whatwg.org/#xml-mime-type>
     fn is_xml(mt: &Mime) -> bool {
         mt.suffix() == Some(mime::XML) ||
-            *mt == mime::TEXT_XML ||
-            (mt.type_() == mime::APPLICATION && mt.subtype() == mime::XML)
+            mt.essence_str() == "text/xml" ||
+            mt.essence_str() == "application/xml"
     }
 
     /// <https://mimesniff.spec.whatwg.org/#html-mime-type>
     fn is_html(mt: &Mime) -> bool {
-        *mt == mime::TEXT_HTML
+        mt.essence_str() == "text/html"
     }
 
     /// <https://mimesniff.spec.whatwg.org/#image-mime-type>
@@ -258,7 +258,7 @@ impl MimeClassifier {
     fn is_audio_video(mt: &Mime) -> bool {
         mt.type_() == mime::AUDIO ||
             mt.type_() == mime::VIDEO ||
-            mt.type_() == mime::APPLICATION && mt.subtype() == mime::OGG
+            mt.essence_str() == "application/ogg"
     }
 
     fn is_explicit_unknown(mt: &Mime) -> bool {
@@ -318,7 +318,7 @@ impl MimeClassifier {
     }
 
     fn is_css(mt: &Mime) -> bool {
-        *mt == mime::TEXT_CSS
+        mt.essence_str() == "text/css"
     }
 
     pub fn get_media_type(mime: &Mime) -> Option<MediaType> {


### PR DESCRIPTION
This is in preparation of being able to do mime sniffing on the response data. For that, we first need to introduce separate methods so that we can decouple them from process_response. In doing so, we introduce a NavigationParams which mimics what the spec intents. The spec stores different data (policy container instead of csp list and response instead of content-type), but it is similar enough.

Part of #14024
