### PR TITLE
webdriver: Update `.ini` to mark unstable subtests in `accept_alert/accept.py`, `forward/forward.py`, `perform_actions/pointer_mouse.py`, `send_alert_text/send.py`

### DIFF
--- a/tests/wpt/meta/webdriver/tests/classic/accept_alert/accept.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/accept_alert/accept.py.ini
@@ -1,0 +1,3 @@
+[accept.py]
+  [test_accept_in_popup_window]
+    expected: [PASS, FAIL]

--- a/tests/wpt/meta/webdriver/tests/classic/forward/forward.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/forward/forward.py.ini
@@ -12,4 +12,4 @@
     expected: FAIL
 
   [test_removed_iframe]
-    expected: FAIL
+    expected: [PASS, FAIL]

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_mouse.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_mouse.py.ini
@@ -5,6 +5,9 @@
   [test_pointer_down_closes_browsing_context]
     expected: FAIL
 
+  [test_click_navigation]
+    expected: [PASS, FAIL]
+
   [test_click_element_in_shadow_tree[outer-open\]]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/send_alert_text/send.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/send_alert_text/send.py.ini
@@ -1,6 +1,6 @@
 [send.py]
   [test_chained_alert_element_not_interactable[alert\]]
-    expected: FAIL
+    expected: [PASS, FAIL]
 
   [test_send_alert_text[\]]
     expected: FAIL


### PR DESCRIPTION
Few webdriver subtests are quite unstable. But it is an overkill to mark the entire test as intermittent, as the CI would permit buggy PRs that sabotage other stable subtests. This PR mark these subtests and closes the related intermittent issues.

Fixes: #39158
Fixes: #39117
Fixes: #39121
Fixes: #39154