### PR TITLE
renderer: Enhance desktop zooming with preset values

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -86,6 +86,12 @@ pub enum WebRenderDebugOption {
     RenderTargetDebug,
 }
 
+pub enum PageZoom {
+    ZoomOut,
+    ZoomReset,
+    ZoomIn,
+}
+
 /// Data that is shared by all WebView renderers.
 pub struct ServoRenderer {
     /// The [`RefreshDriver`] which manages the rythym of painting.
@@ -1144,24 +1150,13 @@ impl IOCompositor {
         self.set_needs_repaint(RepaintReason::Resize);
     }
 
-    pub fn on_zoom_reset_window_event(&mut self, webview_id: WebViewId) {
+    pub fn on_zoom_window_event(&mut self, webview_id: WebViewId, new_zoom: PageZoom) {
         if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
             return;
         }
 
         if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-            webview_renderer.set_page_zoom(Scale::new(1.0));
-        }
-    }
-
-    pub fn on_zoom_window_event(&mut self, webview_id: WebViewId, magnification: f32) {
-        if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
-            return;
-        }
-
-        if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-            let current_page_zoom = webview_renderer.page_zoom();
-            webview_renderer.set_page_zoom(current_page_zoom * Scale::new(magnification));
+            webview_renderer.process_and_set_page_zoom(new_zoom);
         }
     }
 

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -17,7 +17,7 @@ use profile_traits::{mem, time};
 use webrender::RenderApi;
 use webrender_api::DocumentId;
 
-pub use crate::compositor::{IOCompositor, WebRenderDebugOption};
+pub use crate::compositor::{IOCompositor, PageZoom, WebRenderDebugOption};
 
 #[macro_use]
 mod tracing;

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -41,8 +41,8 @@ use bluetooth::BluetoothThreadFactory;
 use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::{GlType, WebGLThreads};
 use clipboard_delegate::StringRequest;
-pub use compositing::WebRenderDebugOption;
 use compositing::{IOCompositor, InitialCompositorState};
+pub use compositing::{PageZoom, WebRenderDebugOption};
 pub use compositing_traits::rendering_context::{
     OffscreenRenderingContext, RenderingContext, SoftwareRenderingContext, WindowRenderingContext,
 };

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -8,7 +8,7 @@ use std::rc::{Rc, Weak};
 use std::time::Duration;
 
 use base::id::WebViewId;
-use compositing::IOCompositor;
+use compositing::{IOCompositor, PageZoom};
 use compositing_traits::WebViewTrait;
 use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use dpi::PhysicalSize;
@@ -495,18 +495,11 @@ impl WebView {
         self.inner().compositor.borrow_mut().on_vsync(self.id());
     }
 
-    pub fn set_zoom(&self, new_zoom: f32) {
+    pub fn apply_zoom(&self, new_zoom: PageZoom) {
         self.inner()
             .compositor
             .borrow_mut()
             .on_zoom_window_event(self.id(), new_zoom);
-    }
-
-    pub fn reset_zoom(&self) {
-        self.inner()
-            .compositor
-            .borrow_mut()
-            .on_zoom_reset_window_event(self.id());
     }
 
     pub fn set_pinch_zoom(&self, new_pinch_zoom: f32) {

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -22,9 +22,9 @@ use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 use servo::{
     AllowOrDenyRequest, AuthenticationRequest, FilterPattern, FormControl, GamepadHapticEffectType,
-    JSValue, KeyboardEvent, LoadStatus, PermissionRequest, Servo, ServoDelegate, ServoError,
-    SimpleDialog, TraversalId, WebDriverCommandMsg, WebDriverJSResult, WebDriverLoadStatus,
-    WebDriverUserPrompt, WebView, WebViewBuilder, WebViewDelegate,
+    JSValue, KeyboardEvent, LoadStatus, PageZoom, PermissionRequest, Servo, ServoDelegate,
+    ServoError, SimpleDialog, TraversalId, WebDriverCommandMsg, WebDriverJSResult,
+    WebDriverLoadStatus, WebDriverUserPrompt, WebView, WebViewBuilder, WebViewDelegate,
 };
 use url::Url;
 
@@ -416,17 +416,14 @@ impl RunningAppState {
     fn handle_overridable_key_bindings(&self, webview: ::servo::WebView, event: KeyboardEvent) {
         let origin = webview.rect().min.ceil().to_i32();
         ShortcutMatcher::from_event(event.event)
-            .shortcut(CMD_OR_CONTROL, '=', || {
-                webview.set_zoom(1.1);
-            })
             .shortcut(CMD_OR_CONTROL, '+', || {
-                webview.set_zoom(1.1);
+                webview.apply_zoom(PageZoom::ZoomIn);
             })
             .shortcut(CMD_OR_CONTROL, '-', || {
-                webview.set_zoom(1.0 / 1.1);
+                webview.apply_zoom(PageZoom::ZoomOut);
             })
             .shortcut(CMD_OR_CONTROL, '0', || {
-                webview.reset_zoom();
+                webview.apply_zoom(PageZoom::ZoomReset);
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::PageDown), || {
                 let scroll_location = ScrollLocation::Delta(Vector2D::new(


### PR DESCRIPTION
1. Add a set of preset values: `ZOOM_LEVELS`. (Reference: [kPresetBrowserZoomFactorsArray](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/common/page/page_zoom.cc;l=13;drc=594b36a7ac6a62fe2a1f78595ab9d2a0d8a371da))
2. Pass `PageZoom` instead of magnification.
3. Process the `PageZoom` in renderer and set `page_zoom`.

Testing: Tested Manually
Fixes: None
