### PR TITLE
Disable scripting when sandbox flag is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1650,7 +1650,7 @@ dependencies = [
 [[package]]
 name = "content-security-policy"
 version = "0.5.4"
-source = "git+https://github.com/servo/rust-content-security-policy?branch=servo-csp#fc927dfefb1fdc052fa4fa18c2ca3c3f6b87047b"
+source = "git+https://github.com/servo/rust-content-security-policy?branch=servo-csp#b437ae2001616161ce4729b49408e7785b2f6960"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.4",

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -357,9 +357,6 @@ pub(crate) struct Document {
     asap_in_order_scripts_list: PendingInOrderScriptVec,
     /// <https://html.spec.whatwg.org/multipage/#set-of-scripts-that-will-execute-as-soon-as-possible>
     asap_scripts_set: DomRefCell<Vec<Dom<HTMLScriptElement>>>,
-    /// <https://html.spec.whatwg.org/multipage/#concept-n-noscript>
-    /// True if scripting is enabled for all scripts in this document
-    scripting_enabled: bool,
     /// <https://html.spec.whatwg.org/multipage/#animation-frame-callback-identifier>
     /// Current identifier of animation frame callback
     animation_frame_ident: Cell<u32>,
@@ -1115,14 +1112,17 @@ impl Document {
     }
 
     /// Return whether scripting is enabled or not
-    pub(crate) fn is_scripting_enabled(&self) -> bool {
-        self.scripting_enabled
-    }
-
-    /// Return whether scripting is enabled or not
-    /// <https://html.spec.whatwg.org/multipage/#concept-n-noscript>
+    /// <https://html.spec.whatwg.org/multipage/#concept-n-script>
     pub(crate) fn scripting_enabled(&self) -> bool {
-        self.has_browsing_context()
+        // Scripting is enabled for a node node if node's node document's browsing context is non-null,
+        // and scripting is enabled for node's relevant settings object.
+        self.has_browsing_context() &&
+        // Either settings's global object is not a Window object,
+        // or settings's global object's associated Document's active sandboxing flag
+        // set does not have its sandboxed scripts browsing context flag set.
+            !self.has_active_sandboxing_flag(
+                SandboxingFlagSet::SANDBOXED_SCRIPTS_BROWSING_CONTEXT_FLAG,
+            )
     }
 
     /// Return the element that currently has focus.
@@ -3365,7 +3365,6 @@ impl Document {
             deferred_scripts: Default::default(),
             asap_in_order_scripts_list: Default::default(),
             asap_scripts_set: Default::default(),
-            scripting_enabled: has_browsing_context,
             animation_frame_ident: Cell::new(0),
             animation_frame_list: DomRefCell::new(VecDeque::new()),
             running_animation_callbacks: Cell::new(false),

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -720,7 +720,7 @@ impl EventTarget {
         };
 
         // Step 3.2
-        if !document.is_scripting_enabled() {
+        if !document.scripting_enabled() {
             return None;
         }
 

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -688,7 +688,7 @@ impl HTMLScriptElement {
         }
 
         // Step 17. If scripting is disabled for el, then return.
-        if !doc.is_scripting_enabled() {
+        if !doc.scripting_enabled() {
             return;
         }
 
@@ -1093,7 +1093,7 @@ impl HTMLScriptElement {
         // TODO use a settings object rather than this element's document/window
         // Step 2
         let document = self.owner_document();
-        if !document.is_fully_active() || !document.is_scripting_enabled() {
+        if !document.is_fully_active() || !document.scripting_enabled() {
             return;
         }
 
@@ -1130,7 +1130,7 @@ impl HTMLScriptElement {
         // TODO use a settings object rather than this element's document/window
         // Step 2
         let document = self.owner_document();
-        if !document.is_fully_active() || !document.is_scripting_enabled() {
+        if !document.is_fully_active() || !document.scripting_enabled() {
             return;
         }
 

--- a/tests/wpt/meta/content-security-policy/sandbox/sandbox-empty.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/sandbox/sandbox-empty.sub.html.ini
@@ -1,0 +1,3 @@
+[sandbox-empty.sub.html]
+  [Expecting logs: ["PASS2"\]]
+    expected: FAIL

--- a/tests/wpt/meta/trusted-types/trusted-types-sandbox-no-allow-scripts.html.ini
+++ b/tests/wpt/meta/trusted-types/trusted-types-sandbox-no-allow-scripts.html.ini
@@ -1,3 +1,0 @@
-[trusted-types-sandbox-no-allow-scripts.html]
-  [Trusted Types CSP directives don't affect the behavior of sandboxed page without allow-scripts.]
-    expected: FAIL

--- a/tests/wpt/tests/content-security-policy/sandbox/autoplay-disabled-by-csp.html
+++ b/tests/wpt/tests/content-security-policy/sandbox/autoplay-disabled-by-csp.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/#eligible-for-autoplay" />
+  <title>Test that autoplay is blocked by a document's active sandboxing flags</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src='../support/logTest.sub.js?logs=["Loaded iframe"]'></script>
+  <script src="/common/media.js"></script>
+  </head>
+  <body>
+    <iframe id="iframe" src="support/autoplay.html"></iframe>
+    <script>
+      async_test((t) => {
+        iframe.addEventListener('load', () => {
+          log('Loaded iframe');
+          var v = iframe.contentWindow.document.getElementById('v');
+
+          v.addEventListener('playing', t.unreached_func(
+            'video should not autoplay due to sandboxing flags'
+          ));
+
+          v.src = getVideoURI('/media/movie_5') + '?' + new Date() + Math.random()
+          t.step_timeout(() => t.done(), 500);
+        });
+      }, 'csp-derived sandboxing flags prevent autoplay.')
+    </script>
+  </body>
+</html>

--- a/tests/wpt/tests/content-security-policy/sandbox/sandbox-empty.sub.html
+++ b/tests/wpt/tests/content-security-policy/sandbox/sandbox-empty.sub.html
@@ -18,7 +18,7 @@
        }
     </script>
 
-    <iframe src="support/sandboxed-post-message-to-parent.sub.html?sandbox="
+    <iframe src="support/sandboxed-post-message-to-parent.html"
             onload="log('PASS2')"></iframe>
 </body>
 

--- a/tests/wpt/tests/content-security-policy/sandbox/sandbox-last-directive-csp.html
+++ b/tests/wpt/tests/content-security-policy/sandbox/sandbox-last-directive-csp.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+    <!-- Programmatically converted from a WebKit Reftest, please forgive resulting idiosyncracies.-->
+    <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline' 'self'; connect-src 'self';">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["PASS (1/2): Script can execute","PASS (2/2): Eval works"]'></script>
+    <script src='../support/alertAssert.sub.js?alerts=[]'></script>
+</head>
+<body>
+  <script>
+    window.onmessage = function(e) {
+      log(e.data);
+    }
+  </script>
+  <iframe src="support/sandboxed-last-directive-csp.html"></iframe>
+</body>
+</html>

--- a/tests/wpt/tests/content-security-policy/sandbox/support/autoplay.html
+++ b/tests/wpt/tests/content-security-policy/sandbox/support/autoplay.html
@@ -1,0 +1,1 @@
+<video id="v" autoplay></video>

--- a/tests/wpt/tests/content-security-policy/sandbox/support/autoplay.html.headers
+++ b/tests/wpt/tests/content-security-policy/sandbox/support/autoplay.html.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox

--- a/tests/wpt/tests/content-security-policy/sandbox/support/sandboxed-last-directive-csp.headers
+++ b/tests/wpt/tests/content-security-policy/sandbox/support/sandboxed-last-directive-csp.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox; sandbox allow-scripts

--- a/tests/wpt/tests/content-security-policy/sandbox/support/sandboxed-last-directive-csp.html
+++ b/tests/wpt/tests/content-security-policy/sandbox/support/sandboxed-last-directive-csp.html
@@ -1,0 +1,4 @@
+<script>
+  window.parent.postMessage('PASS (1/2): Script can execute', '*');
+  eval("window.parent.postMessage('PASS (2/2): Eval works', '*')");
+</script>

--- a/tests/wpt/tests/content-security-policy/sandbox/support/sandboxed-post-message-to-parent.headers
+++ b/tests/wpt/tests/content-security-policy/sandbox/support/sandboxed-post-message-to-parent.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox


### PR DESCRIPTION
While I adding spec comments to the CSP crate, I discovered two issues:
1. We should only use the last sandbox value (WPT test added)
2. We weren't checking for the scripting sandbox flag in document

Also, the autoplay test should have allowed scripts to run, otherwise the test doesn't run. Since we weren't checking the flag before, the test ran fine for Servo. However, it wouldn't run for other browsers.

Also realized that an existing test was pointing to a non-existent file (since it doesn't have `.sub`). Updated that and confirmed that in other browsers it now properly works (it no longer shows a 404). However, Servo now fails that test as we don't fire an load event.

Part of #913