### PR TITLE
layout: Add method to retrieve only the first LayoutBoxBase of a box

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -140,6 +140,22 @@ impl LayoutBox {
         }
     }
 
+    pub(crate) fn with_first_base<T>(
+        &self,
+        callback: impl FnOnce(&LayoutBoxBase) -> T,
+    ) -> Option<T> {
+        Some(match self {
+            LayoutBox::DisplayContents(..) => return None,
+            LayoutBox::BlockLevel(block_level_box) => block_level_box.borrow().with_base(callback),
+            LayoutBox::InlineLevel(inline_items) => {
+                inline_items.first()?.borrow().with_base(callback)
+            },
+            LayoutBox::FlexLevel(flex_level_box) => flex_level_box.borrow().with_base(callback),
+            LayoutBox::TaffyItemBox(taffy_item_box) => taffy_item_box.borrow().with_base(callback),
+            LayoutBox::TableLevelBox(table_box) => table_box.with_base(callback),
+        })
+    }
+
     pub(crate) fn with_base_flat<T>(&self, callback: impl Fn(&LayoutBoxBase) -> Vec<T>) -> Vec<T> {
         match self {
             LayoutBox::DisplayContents(..) => vec![],

--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -191,7 +191,7 @@ impl FlexLevelBox {
         }
     }
 
-    pub(crate) fn with_base<T>(&self, callback: impl Fn(&LayoutBoxBase) -> T) -> T {
+    pub(crate) fn with_base<T>(&self, callback: impl FnOnce(&LayoutBoxBase) -> T) -> T {
         match self {
             FlexLevelBox::FlexItem(flex_item_box) => {
                 callback(&flex_item_box.independent_formatting_context.base)

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -274,7 +274,7 @@ impl InlineItem {
         }
     }
 
-    pub(crate) fn with_base<T>(&self, callback: impl Fn(&LayoutBoxBase) -> T) -> T {
+    pub(crate) fn with_base<T>(&self, callback: impl FnOnce(&LayoutBoxBase) -> T) -> T {
         match self {
             InlineItem::StartInlineBox(inline_box) => callback(&inline_box.borrow().base),
             InlineItem::EndInlineBox | InlineItem::TextRun(..) => {

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -139,7 +139,7 @@ impl BlockLevelBox {
         self.with_base(|base| base.clear_fragment_layout_cache());
     }
 
-    pub(crate) fn with_base<T>(&self, callback: impl Fn(&LayoutBoxBase) -> T) -> T {
+    pub(crate) fn with_base<T>(&self, callback: impl FnOnce(&LayoutBoxBase) -> T) -> T {
         match self {
             BlockLevelBox::Independent(independent_formatting_context) => {
                 callback(&independent_formatting_context.base)

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -661,9 +661,7 @@ pub(crate) fn process_scroll_parent_query(
     let layout_box = layout_box.as_ref()?;
 
     let (mut current_position_value, flags) = layout_box
-        .with_base_flat(|base| vec![(base.style.clone_position(), base.base_fragment_info.flags)])
-        .first()
-        .cloned()?;
+        .with_first_base(|base| (base.style.clone_position(), base.base_fragment_info.flags))?;
 
     // - The element is the root element.
     // - The element is the body element.
@@ -702,9 +700,7 @@ pub(crate) fn process_scroll_parent_query(
         };
 
         let Some((ancestor_style, ancestor_flags)) = ancestor_layout_box
-            .with_base_flat(|base| vec![(base.style.clone(), base.base_fragment_info.flags)])
-            .first()
-            .cloned()
+            .with_first_base(|base| (base.style.clone(), base.base_fragment_info.flags))
         else {
             continue;
         };

--- a/components/layout/table/mod.rs
+++ b/components/layout/table/mod.rs
@@ -412,7 +412,7 @@ impl TableLevelBox {
         }
     }
 
-    pub(crate) fn with_base<T>(&self, callback: impl Fn(&LayoutBoxBase) -> T) -> T {
+    pub(crate) fn with_base<T>(&self, callback: impl FnOnce(&LayoutBoxBase) -> T) -> T {
         match self {
             TableLevelBox::Caption(caption) => callback(&caption.borrow().context.base),
             TableLevelBox::Cell(cell) => callback(&cell.borrow().base),

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -147,7 +147,7 @@ impl TaffyItemBox {
         }
     }
 
-    pub(crate) fn with_base<T>(&self, callback: impl Fn(&LayoutBoxBase) -> T) -> T {
+    pub(crate) fn with_base<T>(&self, callback: impl FnOnce(&LayoutBoxBase) -> T) -> T {
         match self.taffy_level_box {
             TaffyItemBoxInner::InFlowBox(ref independent_formatting_context) => {
                 callback(&independent_formatting_context.base)


### PR DESCRIPTION
A LayoutBox typically has one LayoutBoxBase, or none in the case of `LayoutBox::DisplayContents`. However, `LayoutBox::InlineLevel` can contain multiple inline items, each one with its base. But since things like the style or the fragment flags should be the same for all of them, getting the first base is sometimes enough.

Testing: not needed, no change in behavior.
