### PR TITLE
Add resource header for mime sniffing

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1799,6 +1799,18 @@ impl Document {
         self.policy_container.borrow()
     }
 
+    pub(crate) fn set_policy_container(&self, policy_container: PolicyContainer) {
+        *self.policy_container.borrow_mut() = policy_container;
+    }
+
+    pub(crate) fn set_csp_list(&self, csp_list: Option<CspList>) {
+        self.policy_container.borrow_mut().set_csp_list(csp_list);
+    }
+
+    pub(crate) fn get_csp_list(&self) -> Option<CspList> {
+        self.policy_container.borrow().csp_list.clone()
+    }
+
     /// Add the policy container and HTTPS state to a given request.
     ///
     /// TODO: Can this hapen for all requests that go through the document?
@@ -3478,14 +3490,6 @@ impl Document {
 
     pub(crate) fn set_resize_observer_started_observing_target(&self, value: bool) {
         self.resize_observer_started_observing_target.set(value);
-    }
-
-    pub(crate) fn set_csp_list(&self, csp_list: Option<CspList>) {
-        self.policy_container.borrow_mut().set_csp_list(csp_list);
-    }
-
-    pub(crate) fn get_csp_list(&self) -> Option<CspList> {
-        self.policy_container.borrow().csp_list.clone()
     }
 
     /// Prevent any JS or layout from running until the corresponding call to

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3855,7 +3855,7 @@ impl ScriptThread {
 
         let dummy_request_id = RequestId::default();
         context.process_response(dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
-        context.append_parent_to_csp_list(policy_container.as_ref());
+        context.set_policy_container(policy_container.as_ref());
         context.process_response_chunk(dummy_request_id, chunk);
         context.process_response_eof(
             dummy_request_id,
@@ -3882,7 +3882,7 @@ impl ScriptThread {
         let dummy_request_id = RequestId::default();
 
         context.process_response(dummy_request_id, Ok(FetchMetadata::Unfiltered(meta)));
-        context.append_parent_to_csp_list(policy_container.as_ref());
+        context.set_policy_container(policy_container.as_ref());
         context.process_response_chunk(dummy_request_id, chunk);
         context.process_response_eof(
             dummy_request_id,

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -137,6 +137,19 @@ pub enum ReferrerPolicy {
     StrictOriginWhenCrossOrigin,
 }
 
+impl ReferrerPolicy {
+    /// <https://w3c.github.io/webappsec-referrer-policy/#parse-referrer-policy-from-header>
+    pub fn parse_header_for_response(headers: &Option<Serde<HeaderMap>>) -> Self {
+        // Step 4. Return policy.
+        headers
+            .as_ref()
+            // Step 1. Let policy-tokens be the result of extracting header list values given `Referrer-Policy` and response’s header list.
+            .and_then(|headers| headers.typed_get::<ReferrerPolicyHeader>())
+            // Step 2-3.
+            .into()
+    }
+}
+
 impl Display for ReferrerPolicy {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let string = match self {
@@ -154,8 +167,11 @@ impl Display for ReferrerPolicy {
     }
 }
 
+/// <https://w3c.github.io/webappsec-referrer-policy/#parse-referrer-policy-from-header>
 impl From<Option<ReferrerPolicyHeader>> for ReferrerPolicy {
     fn from(header: Option<ReferrerPolicyHeader>) -> Self {
+        // Step 2. Let policy be the empty string.
+        // Step 3. For each token in policy-tokens, if token is a referrer policy and token is not the empty string, then set policy to token.
         header.map_or(ReferrerPolicy::EmptyString, |policy| match policy {
             ReferrerPolicyHeader::NO_REFERRER => ReferrerPolicy::NoReferrer,
             ReferrerPolicyHeader::NO_REFERRER_WHEN_DOWNGRADE => {

--- a/components/shared/net/policy_container.rs
+++ b/components/shared/net/policy_container.rs
@@ -32,7 +32,7 @@ pub struct PolicyContainer {
     /// <https://html.spec.whatwg.org/multipage/#policy-container-csp-list>
     pub csp_list: Option<CspList>,
     /// <https://html.spec.whatwg.org/multipage/#policy-container-referrer-policy>
-    referrer_policy: ReferrerPolicy,
+    pub referrer_policy: ReferrerPolicy,
     // https://html.spec.whatwg.org/multipage/#policy-container-embedder-policy
     // TODO: Embedder Policy
 }

--- a/tests/wpt/meta/fetch/content-type/response.window.js.ini
+++ b/tests/wpt/meta/fetch/content-type/response.window.js.ini
@@ -49,9 +49,3 @@
 
   [Response: combined response Content-Type: text/html;" \\" text/plain ";charset=GBK]
     expected: FAIL
-
-  [<iframe>: separate response Content-Type: text/html;x=" text/plain]
-    expected: FAIL
-
-  [<iframe>: combined response Content-Type: text/html;x=" text/plain]
-    expected: FAIL

--- a/tests/wpt/meta/navigation-timing/navigation-type-post-backforward.html.ini
+++ b/tests/wpt/meta/navigation-timing/navigation-type-post-backforward.html.ini
@@ -1,3 +1,4 @@
 [navigation-type-post-backforward.html]
+  expected: TIMEOUT
   [Navigation type after posting and navigating away and back should be back_forward.]
-    expected: FAIL
+    expected: TIMEOUT


### PR DESCRIPTION
The concept of a "resource header" is not well specced, since it is unclear what a "resource" is. That said, it most closely matches a "response" as part of the navigation params.

With this change, we now delay loading the document until either two things happen:
1. We reached the end of the file
2. We processed 1445 bytes (as defined by spec)

We initially store bytes in the resource header and then after loading parse the stored bytes. Any subsequent loading will process as before.

Part of #14024
