### PR TITLE
layout: allow skip restyle when only replaced contents changed

### DIFF
--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -269,6 +269,7 @@ fn traverse_pseudo_element_contents<'dom>(
                     Display::from(anonymous_info.style.get_box().display) ==
                         Display::GeneratingBox(display_inline)
                 );
+
                 handler.handle_element(
                     anonymous_info,
                     display_inline,

--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -25,6 +25,7 @@ use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::BaseFragmentInfo;
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::AbsolutelyPositionedBox;
+use crate::replaced::ReplacedContents;
 
 mod geom;
 mod layout;
@@ -174,6 +175,18 @@ impl FlexLevelBox {
                 .borrow_mut()
                 .context
                 .repair_style(context, node, new_style),
+        }
+    }
+
+    pub(crate) fn repair_replaced_contents(&mut self, new_contents: ReplacedContents) {
+        match self {
+            FlexLevelBox::FlexItem(flex_item_box) => flex_item_box
+                .independent_formatting_context
+                .repair_replaced_contents(new_contents),
+            FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(positioned_box) => positioned_box
+                .borrow_mut()
+                .context
+                .repair_replaced_contents(new_contents),
         }
     }
 

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -127,6 +127,7 @@ use crate::fragment_tree::{
 use crate::geom::{LogicalRect, LogicalVec2, ToLogical};
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
+use crate::replaced::ReplacedContents;
 use crate::sizing::{ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult};
 use crate::style_ext::{ComputedValuesExt, PaddingBorderMargin};
 use crate::{ConstraintSpace, ContainingBlock, SharedStyle};
@@ -243,6 +244,24 @@ impl InlineItem {
                 .repair_style(context, node, new_style),
             InlineItem::Atomic(atomic, ..) => {
                 atomic.borrow_mut().repair_style(context, node, new_style)
+            },
+        }
+    }
+
+    pub(crate) fn repair_replaced_contents(&self, new_contents: ReplacedContents) {
+        match self {
+            InlineItem::StartInlineBox(..) | InlineItem::EndInlineBox | InlineItem::TextRun(..) => {
+            },
+            InlineItem::OutOfFlowAbsolutelyPositionedBox(positioned_box, ..) => positioned_box
+                .borrow_mut()
+                .context
+                .repair_replaced_contents(new_contents),
+            InlineItem::OutOfFlowFloatBox(float_box) => float_box
+                .borrow_mut()
+                .contents
+                .repair_replaced_contents(new_contents),
+            InlineItem::Atomic(atomic, ..) => {
+                atomic.borrow_mut().repair_replaced_contents(new_contents)
             },
         }
     }

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -39,6 +39,7 @@ use crate::geom::{
 };
 use crate::layout_box_base::{CacheableLayoutResult, LayoutBoxBase};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext, PositioningContextLength};
+use crate::replaced::ReplacedContents;
 use crate::sizing::{
     self, ComputeInlineContentSizes, ContentSizes, InlineContentSizesResult, LazySize, Size,
     SizeConstraint, Sizes,
@@ -132,6 +133,22 @@ impl BlockLevelBox {
                 base.repair_style(new_style);
                 contents.repair_style(node, new_style);
             },
+        }
+    }
+
+    pub(crate) fn repair_replaced_contents(&mut self, new_contents: ReplacedContents) {
+        match self {
+            BlockLevelBox::Independent(independent_formatting_context) => {
+                independent_formatting_context.repair_replaced_contents(new_contents);
+            },
+            BlockLevelBox::OutOfFlowAbsolutelyPositionedBox(positioned_box) => positioned_box
+                .borrow_mut()
+                .context
+                .repair_replaced_contents(new_contents),
+            BlockLevelBox::OutOfFlowFloatBox(float_box) => {
+                float_box.contents.repair_replaced_contents(new_contents);
+            },
+            _ => unreachable!("Called repair_replaced_contents on a non-replaced block-level box"),
         }
     }
 

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -238,6 +238,14 @@ impl IndependentFormattingContext {
         }
     }
 
+    pub(crate) fn repair_replaced_contents(&mut self, new_contents: ReplacedContents) {
+        if let IndependentFormattingContextContents::Replaced(contents) = &mut self.contents {
+            *contents = new_contents;
+        } else {
+            unreachable!("Called repair_replaced_contents on a non-replaced IFC");
+        }
+    }
+
     #[inline]
     pub(crate) fn is_block_container(&self) -> bool {
         matches!(self.contents, IndependentFormattingContextContents::Flow(_))

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -181,7 +181,6 @@ bitflags! {
         /// Whether or not this is a table cell that is part of a collapsed row or column.
         /// In that case it should not be painted.
         const IS_COLLAPSED = 1 << 11;
-
     }
 }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -924,7 +924,7 @@ impl LayoutThread {
         image_resolver: &Arc<ImageResolver>,
     ) -> (ReflowPhasesRun, RestyleDamage, IFrameSizes) {
         let mut snapshot_map = SnapshotMap::new();
-        let _snapshot_setter = match reflow_request.restyle.as_mut() {
+        let snapshot_setter = match reflow_request.restyle.as_mut() {
             Some(restyle) => SnapshotSetter::new(restyle, &mut snapshot_map),
             None => return Default::default(),
         };
@@ -1005,11 +1005,19 @@ impl LayoutThread {
             };
 
             if !token.should_traverse() {
-                layout_context.style_context.stylist.rule_tree().maybe_gc();
-                return Default::default();
+                dirty_root = None;
+            } else {
+                dirty_root = Some(
+                    driver::traverse_dom(&recalc_style_traversal, token, rayon_pool).as_node(),
+                );
             }
+        }
 
-            dirty_root = driver::traverse_dom(&recalc_style_traversal, token, rayon_pool).as_node();
+        // If we don't run restyle and there is no damage from DOM mutations, then there is
+        // nothing to do.
+        if dirty_root.is_none() && !snapshot_setter.has_damage_from_dom_mutation {
+            layout_context.style_context.stylist.rule_tree().maybe_gc();
+            return Default::default();
         }
 
         let root_node = root_element.as_node();
@@ -1019,7 +1027,7 @@ impl LayoutThread {
             Default::default()
         };
         let damage = compute_damage_and_repair_style(
-            &layout_context.style_context,
+            &layout_context,
             root_node.to_threadsafe(),
             damage_from_environment,
         );
@@ -1032,9 +1040,9 @@ impl LayoutThread {
         let mut box_tree = self.box_tree.borrow_mut();
         let box_tree = &mut *box_tree;
         let layout_damage: LayoutDamage = damage.into();
-        if box_tree.is_none() || layout_damage.has_box_damage() {
+        if dirty_root.is_some() && (box_tree.is_none() || layout_damage.has_box_damage()) {
             let mut build_box_tree = || {
-                if !BoxTree::update(recalc_style_traversal.context(), dirty_root) {
+                if !BoxTree::update(recalc_style_traversal.context(), dirty_root.unwrap()) {
                     *box_tree = Some(Arc::new(BoxTree::construct(
                         recalc_style_traversal.context(),
                         root_node,
@@ -1539,6 +1547,7 @@ impl Debug for LayoutFontMetricsProvider {
 
 struct SnapshotSetter<'dom> {
     elements_with_snapshot: Vec<ServoLayoutElement<'dom>>,
+    has_damage_from_dom_mutation: bool,
 }
 
 impl SnapshotSetter<'_> {
@@ -1551,6 +1560,7 @@ impl SnapshotSetter<'_> {
             .filter(|r| r.1.snapshot.is_some())
             .map(|r| unsafe { ServoLayoutNode::new(&r.0).as_element().unwrap() })
             .collect();
+        let mut has_damage_from_dom_mutation = false;
 
         for (element, restyle) in restyles {
             let element = unsafe { ServoLayoutNode::new(&element).as_element().unwrap() };
@@ -1571,9 +1581,11 @@ impl SnapshotSetter<'_> {
             // Stash the data on the element for processing by the style system.
             style_data.hint.insert(restyle.hint);
             style_data.damage = restyle.damage;
+            has_damage_from_dom_mutation |= !restyle.damage.is_empty();
         }
         Self {
             elements_with_snapshot,
+            has_damage_from_dom_mutation,
         }
     }
 }

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -23,6 +23,7 @@ use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::Fragment;
 use crate::layout_box_base::LayoutBoxBase;
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
+use crate::replaced::ReplacedContents;
 
 #[derive(Debug, MallocSizeOf)]
 pub(crate) struct TaffyContainer {
@@ -184,6 +185,18 @@ impl TaffyItemBox {
                 .borrow_mut()
                 .context
                 .repair_style(context, node, new_style),
+        }
+    }
+
+    pub(crate) fn repair_replaced_contents(&mut self, new_contents: ReplacedContents) {
+        match &mut self.taffy_level_box {
+            TaffyItemBoxInner::InFlowBox(independent_formatting_context) => {
+                independent_formatting_context.repair_replaced_contents(new_contents)
+            },
+            TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(positioned_box) => positioned_box
+                .borrow_mut()
+                .context
+                .repair_replaced_contents(new_contents),
         }
     }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -938,7 +938,7 @@ impl Document {
 
         // FIXME(emilio): This is very inefficient, ideally the flag above would
         // be enough and incremental layout could figure out from there.
-        node.dirty(NodeDamage::ContentOrHeritage);
+        node.dirty(NodeDamage::NonReplacedContentsOrHeritage);
     }
 
     /// Remove any existing association between the provided id and any elements in this document.
@@ -4165,7 +4165,9 @@ impl Document {
                 if !node.get_flag(NodeFlags::IS_CONNECTED) {
                     return None;
                 }
-                node.note_dirty_descendants();
+                if !restyle.0.hint.is_empty() || restyle.0.snapshot.is_some() {
+                    node.note_dirty_descendants();
+                }
                 Some((node.to_trusted_node_address(), restyle.0))
             })
             .collect()

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -494,7 +494,7 @@ impl HTMLImageElement {
         self.current_request.borrow_mut().state = State::CompletelyAvailable;
         LoadBlocker::terminate(&self.current_request.borrow().blocker, can_gc);
         // Mark the node dirty
-        self.upcast::<Node>().dirty(NodeDamage::Other);
+        self.upcast::<Node>().dirty(NodeDamage::ReplacedContents);
         self.resolve_image_decode_promises();
     }
 

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -3230,7 +3230,8 @@ impl VirtualMethods for HTMLInputElement {
                     );
             }
             if !reaction.is_empty() {
-                self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
+                self.upcast::<Node>()
+                    .dirty(NodeDamage::NonReplacedContentsOrHeritage);
             }
         }
 

--- a/components/script/dom/html/htmlslotelement.rs
+++ b/components/script/dom/html/htmlslotelement.rs
@@ -346,7 +346,8 @@ impl HTMLSlotElement {
 
     /// <https://dom.spec.whatwg.org/#signal-a-slot-change>
     pub(crate) fn signal_a_slot_change(&self) {
-        self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
+        self.upcast::<Node>()
+            .dirty(NodeDamage::NonReplacedContentsOrHeritage);
 
         if self.is_in_agents_signal_slots.get() {
             return;

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -719,7 +719,8 @@ impl VirtualMethods for HTMLTextAreaElement {
                     );
             }
             if !reaction.is_empty() {
-                self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
+                self.upcast::<Node>()
+                    .dirty(NodeDamage::NonReplacedContentsOrHeritage);
             }
         }
 

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -821,12 +821,12 @@ impl Node {
         match self.type_id() {
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(TextTypeId::Text)) => {
                 // For content changes in text nodes, we should accurately use
-                // [`NodeDamage::ContentOrHeritage`] to mark the parent node, thereby
+                // [`NodeDamage::NonReplacedContentsOrHeritage`] to mark the parent node, thereby
                 // reducing the scope of incremental box tree construction.
                 self.parent_node
                     .get()
                     .unwrap()
-                    .dirty(NodeDamage::ContentOrHeritage)
+                    .dirty(NodeDamage::NonReplacedContentsOrHeritage)
             },
             NodeTypeId::Element(_) => self.downcast::<Element>().unwrap().restyle(damage),
             NodeTypeId::DocumentFragment(DocumentFragmentTypeId::ShadowRoot) => self
@@ -4092,9 +4092,12 @@ impl VirtualMethods for Node {
 pub(crate) enum NodeDamage {
     /// The node's `style` attribute changed.
     Style,
-    /// The node's content or heritage changed, such as the addition or removal of
-    /// children.
-    ContentOrHeritage,
+    /// The node's replaced content changed, such as an image element's image
+    /// data status changed from pending to loaded.
+    ReplacedContents,
+    /// The node's non replaced content or heritage changed, such as the addition
+    /// or removal of children.
+    NonReplacedContentsOrHeritage,
     /// Other parts of a node changed; attributes, text content, etc.
     Other,
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -643,7 +643,10 @@ impl Window {
             Entry::Occupied(nodes) => nodes,
             Entry::Vacant(_) => return,
         };
-        if matches!(response.response, ImageResponse::Loaded(_, _)) {
+        if matches!(
+            response.response,
+            ImageResponse::Loaded(_, _) | ImageResponse::PlaceholderLoaded(_, _)
+        ) {
             for node in nodes.get() {
                 node.dirty(NodeDamage::Other);
             }

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -10,6 +10,9 @@ bitflags! {
     /// of `RestyleDamage` from stylo, which only uses the 4 lower bits.
     #[derive(Clone, Copy, Default, Eq, PartialEq)]
     pub struct LayoutDamage: u16 {
+        /// Repair the replaced contents for this element, becase its replaced contents
+        /// have been changed.
+        const REPAIR_REPLACED_CONTENTS = 0b0011_1111_1111 << 4;
         /// Recollect the box children for this element, because some of the them will be
         /// rebuilt.
         const RECOLLECT_BOX_TREE_CHILDREN = 0b0111_1111_1111 << 4;
@@ -20,6 +23,10 @@ bitflags! {
 }
 
 impl LayoutDamage {
+    pub fn repair_replaced_contents() -> RestyleDamage {
+        RestyleDamage::from_bits_retain(LayoutDamage::REPAIR_REPLACED_CONTENTS.bits())
+    }
+
     pub fn recollect_box_tree_children() -> RestyleDamage {
         RestyleDamage::from_bits_retain(LayoutDamage::RECOLLECT_BOX_TREE_CHILDREN.bits())
     }
@@ -29,7 +36,7 @@ impl LayoutDamage {
     }
 
     pub fn has_box_damage(&self) -> bool {
-        self.intersects(Self::REBUILD_BOX)
+        self.contains(Self::RECOLLECT_BOX_TREE_CHILDREN)
     }
 }
 
@@ -45,6 +52,8 @@ impl std::fmt::Debug for LayoutDamage {
             f.write_str("REBUILD_BOX")
         } else if self.contains(Self::RECOLLECT_BOX_TREE_CHILDREN) {
             f.write_str("RECOLLECT_BOX_TREE_CHILDREN")
+        } else if self.contains(Self::REPAIR_REPLACED_CONTENTS) {
+            f.write_str("REPAIR_REPLACED_CONTENTS")
         } else {
             f.write_str("EMPTY")
         }


### PR DESCRIPTION
This change add an slight-weight layout mode, which allows skip restyle and box tree reconstruction when only replaced contents changed. 
- Add new `NodeDamage` type, `NodeDamage::ReplacedContents`, to indicate that the dom node's replaced contents have changed.
- Add new `LayoutDamage` type, `LayoutDamage::REPAIR_REPLACED_CONTENTS`, to indicate that the node maybe not need box tree reconstruction.
- Execute reparing of replaced contents if the computed damage doesn't contains other `LayoutDamage` bits except for `LayoutDamage::REPAIR_REPLACED_CONTENTS`

As the first step, this PR only cover the image node.

Testing: This PR doesn't change any behavior so covered by existing WPT tests.
