### PR TITLE
layout: Fix propagation of `overflow` to viewport

### DIFF
--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -202,7 +202,7 @@ impl FlexLevelBox {
         }
     }
 
-    pub(crate) fn with_base_mut<T>(&mut self, callback: impl Fn(&mut LayoutBoxBase) -> T) -> T {
+    pub(crate) fn with_base_mut<T>(&mut self, callback: impl FnOnce(&mut LayoutBoxBase) -> T) -> T {
         match self {
             FlexLevelBox::FlexItem(flex_item_box) => {
                 callback(&mut flex_item_box.independent_formatting_context.base)

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -290,11 +290,9 @@ impl InlineItem {
         }
     }
 
-    pub(crate) fn with_base_mut(&mut self, callback: impl Fn(&mut LayoutBoxBase)) {
+    pub(crate) fn with_base_mut<T>(&mut self, callback: impl FnOnce(&mut LayoutBoxBase) -> T) -> T {
         match self {
-            InlineItem::StartInlineBox(inline_box) => {
-                callback(&mut inline_box.borrow_mut().base);
-            },
+            InlineItem::StartInlineBox(inline_box) => callback(&mut inline_box.borrow_mut().base),
             InlineItem::EndInlineBox | InlineItem::TextRun(..) => {
                 unreachable!("Should never have these kind of fragments attached to a DOM node")
             },

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -153,7 +153,7 @@ impl BlockLevelBox {
         }
     }
 
-    pub(crate) fn with_base_mut<T>(&mut self, callback: impl Fn(&mut LayoutBoxBase) -> T) -> T {
+    pub(crate) fn with_base_mut<T>(&mut self, callback: impl FnOnce(&mut LayoutBoxBase) -> T) -> T {
         match self {
             BlockLevelBox::Independent(independent_formatting_context) => {
                 callback(&mut independent_formatting_context.base)

--- a/components/layout/table/mod.rs
+++ b/components/layout/table/mod.rs
@@ -421,7 +421,7 @@ impl TableLevelBox {
         }
     }
 
-    pub(crate) fn with_base_mut<T>(&mut self, callback: impl Fn(&mut LayoutBoxBase) -> T) -> T {
+    pub(crate) fn with_base_mut<T>(&mut self, callback: impl FnOnce(&mut LayoutBoxBase) -> T) -> T {
         match self {
             TableLevelBox::Caption(caption) => callback(&mut caption.borrow_mut().context.base),
             TableLevelBox::Cell(cell) => callback(&mut cell.borrow_mut().base),

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -158,7 +158,7 @@ impl TaffyItemBox {
         }
     }
 
-    pub(crate) fn with_base_mut<T>(&mut self, callback: impl Fn(&mut LayoutBoxBase) -> T) -> T {
+    pub(crate) fn with_base_mut<T>(&mut self, callback: impl FnOnce(&mut LayoutBoxBase) -> T) -> T {
         match &mut self.taffy_level_box {
             TaffyItemBoxInner::InFlowBox(independent_formatting_context) => {
                 callback(&mut independent_formatting_context.base)

--- a/tests/wpt/tests/css/css-overflow/overflow-body-propagation-013.html
+++ b/tests/wpt/tests/css/css-overflow/overflow-body-propagation-013.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: HTML with display:none and BODY with overflow:scroll</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#overflow-propagation">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12649">
+<meta name="assert" content="The <body> doesn't propagate overflow to the
+  viewport when the root element doesn't generate a box. Therefore, there
+  shouldn't be scrollbars.">
+<link rel="match" href="about:blank">
+<style>
+:root {
+  display: none;
+  scrollbar-color: red red;
+}
+body {
+  overflow: scroll;
+}
+</style>
+<body></body>

--- a/tests/wpt/tests/css/css-overflow/overflow-body-propagation-014.html
+++ b/tests/wpt/tests/css/css-overflow/overflow-body-propagation-014.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: two BODY elements</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#overflow-propagation">
+<meta name="assert" content="If there are multiple <body> elements, the
+  one that propagates `overflow` to the viewport is the first one.
+
+  Therefore, the first <body> should get `overflow: visible` and its
+  overflowing contents should be visible. And the second <body> should
+  be able to keep `overflow: hidden` and hide its overflowing contents.">
+<link rel="match" href="overflow-body-propagation-012-ref.html">
+<style>
+body {
+  overflow: hidden;
+  width: 0px;
+  height: 0px;
+  border: solid red;
+  border-width: 0 400px 200px 0;
+  margin-bottom: 0;
+}
+body > div {
+  background: green;
+  width: 400px;
+  height: 200px;
+}
+#clone {
+  border-color: green;
+  margin-top: 0;
+}
+#clone > div {
+  background: red;
+}
+</style>
+<body>
+  <div></div>
+</body>
+<script>
+let clone = document.body.cloneNode(true);
+clone.id = "clone";
+document.documentElement.appendChild(clone);
+</script>

--- a/tests/wpt/tests/css/css-overflow/overflow-body-propagation-015.html
+++ b/tests/wpt/tests/css/css-overflow/overflow-body-propagation-015.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: two BODY elements</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#overflow-propagation">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1987284">
+<meta name="assert" content="If there are multiple <body> elements, the
+  one that propagates `overflow` to the viewport is the first one.
+
+  Here we insert a cloned body before the original one, so the original
+  needs to stop propagating because the clone will do it instead.
+
+  Therefore, the cloned <body> should get `overflow: visible` and its
+  overflowing contents should be visible. And the original <body> should
+  be able to keep `overflow: hidden` and hide its overflowing contents.">
+<link rel="match" href="overflow-body-propagation-012-ref.html">
+<style>
+body {
+  overflow: hidden;
+  width: 0px;
+  height: 0px;
+  border: solid green;
+  border-width: 0 400px 200px 0;
+  margin-bottom: 0;
+}
+body:not(#clone) {
+  margin-top: 0;
+}
+body > div {
+  background: red;
+  width: 400px;
+  height: 200px;
+}
+#clone {
+  border-color: red;
+  margin-top: revert;
+}
+#clone > div {
+  background: green;
+}
+</style>
+<body>
+  <div></div>
+</body>
+<script>
+let clone = document.body.cloneNode(true);
+clone.id = "clone";
+document.documentElement.prepend(clone);
+</script>

--- a/tests/wpt/tests/css/css-overflow/overflow-body-propagation-016.html
+++ b/tests/wpt/tests/css/css-overflow/overflow-body-propagation-016.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: two BODY elements</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#overflow-propagation">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/12644">
+<meta name="assert" content="If there are multiple <body> elements, the
+  one that propagates `overflow` to the viewport would be the first one.
+
+  However, the first one has `display: none`, and overflow propagation
+  can only happen when the element generates a box. Therefore, the viewport
+  shouldn't get scrollbars from the `overflow: scroll` on the first body.
+
+  The second body doesn't propagate either, so it should be able to keep
+  `overflow: hidden` and hide its overflowing contents.">
+<link rel="match" href="overflow-body-propagation-012-ref.html">
+<style>
+html {
+  scrollbar-color: red red;
+}
+body {
+  overflow: scroll;
+  width: 0px;
+  height: 0px;
+  border: solid red;
+  border-width: 0 400px 400px 0;
+}
+body > div {
+  overflow: hidden;
+  background: green;
+  width: 400px;
+  height: 400px;
+}
+#clone {
+  border-color: green;
+}
+#clone > div {
+  background: red;
+}
+</style>
+<body>
+  <div></div>
+</body>
+<script>
+let clone = document.body.cloneNode(true);
+clone.id = "clone";
+document.documentElement.appendChild(clone);
+document.body.style.display = "none";
+</script>


### PR DESCRIPTION
This patch refactors the logic for propagating overflow to the viewport, fixing various issues:
- Now we won't propagate from the root element if it has no box. Note the fix isn't observable in Servo because we lack scrollbars.
- If the first `<body>` element has no box, we won't keep searching for other `<body>` elements. This deviates from the spec, but aligns us with other browsers.
- We won't propagate from the `<body>` if it has no box. We were already handling `display: none` but not `display: contents`. This deviates from the spec, but aligns us with other browsers.

Also, when we flag the root or `<body>` as having propagated `overflow` to the viewport, we retrieve the `LayoutBoxBase`. Therefore, now we get the computed style from the `LayoutBoxBase` in a single operation, instead of first retrieving the style from the DOM element and then getting the `LayoutBoxBase` from the box.

Testing: Adding more tests. We were only failing one of them, but it's hard to test the fixes given that we don't show scrollbars. The tests that were already passing are useful too, e.g. Firefox fails one of them.
