### PR TITLE
cargo: Ignore advisory for deprecated crate 'fxhash'

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,8 @@ feature-depth = 1
 ignore = [
     # The crate `paste` is no longer maintained.
     "RUSTSEC-2024-0436",
+    # The crate `fxhash` is no longer maintained.
+    "RUSTSEC-2025-0057",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
Unblock CI, we will do migration slowly (because stylo).