### PR TITLE
indexeddb: Support enabling IndexedDB after startup

### DIFF
--- a/components/net/indexeddb/idb_thread.rs
+++ b/components/net/indexeddb/idb_thread.rs
@@ -224,9 +224,6 @@ impl IndexedDBManager {
 
 impl IndexedDBManager {
     fn start(&mut self) {
-        if !pref!(dom_indexeddb_enabled) {
-            return;
-        }
         loop {
             // FIXME:(arihant2math) No message *most likely* means that
             // the ipc sender has been dropped, so we break the look

--- a/components/script/dom/idbfactory.rs
+++ b/components/script/dom/idbfactory.rs
@@ -58,7 +58,9 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         let request = IDBOpenDBRequest::new(&self.global(), CanGc::note());
 
         // Step 5: Runs in parallel
-        request.open_database(name, version);
+        if request.open_database(name, version).is_err() {
+            return Err(Error::Operation);
+        }
 
         // Step 6
         Ok(request)
@@ -81,7 +83,9 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         let request = IDBOpenDBRequest::new(&self.global(), CanGc::note());
 
         // Step 4: Runs in parallel
-        request.delete_database(name.to_string());
+        if request.delete_database(name.to_string()).is_err() {
+            return Err(Error::Operation);
+        }
 
         // Step 5: Return request
         Ok(request)


### PR DESCRIPTION
The servodriver harness requires preference-gated web platform features to be toggleable at any point in the browsing session's lifetime, rather than at startup. To support toggling IndexedDB, we need to ensure the IDB manager thread is always started.

Testing: Verified when running `./mach test-wpt /IndexedDB --headless --product servodriver`. We don't run servodriver in CI yet.
Fixes: #39175
