### PR TITLE
canvas: Implement `strokeText`

### DIFF
--- a/components/canvas/backend.rs
+++ b/components/canvas/backend.rs
@@ -78,6 +78,14 @@ pub(crate) trait GenericDrawTarget {
         composition_options: CompositionOptions,
         transform: Transform2D<f64>,
     );
+    fn stroke_text(
+        &mut self,
+        text_runs: Vec<TextRun>,
+        style: FillOrStrokeStyle,
+        line_options: LineOptions,
+        composition_options: CompositionOptions,
+        transform: Transform2D<f64>,
+    );
     fn stroke_rect(
         &mut self,
         rect: &Rect<f32>,

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -119,6 +119,33 @@ impl<DrawTarget: GenericDrawTarget> CanvasData<DrawTarget> {
         );
     }
 
+    pub(crate) fn stroke_text(
+        &mut self,
+        text_bounds: Rect<f64>,
+        text_runs: Vec<TextRun>,
+        fill_or_stroke_style: FillOrStrokeStyle,
+        line_options: LineOptions,
+        _shadow_options: ShadowOptions,
+        composition_options: CompositionOptions,
+        transform: Transform2D<f64>,
+    ) {
+        self.maybe_bound_shape_with_pattern(
+            fill_or_stroke_style,
+            composition_options,
+            &text_bounds,
+            transform,
+            |self_, style| {
+                self_.drawtarget.stroke_text(
+                    text_runs,
+                    style,
+                    line_options,
+                    composition_options,
+                    transform,
+                );
+            },
+        );
+    }
+
     pub(crate) fn fill_rect(
         &mut self,
         rect: &Rect<f32>,

--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -124,6 +124,25 @@ impl CanvasPaintThread {
                     transform,
                 );
             },
+            Canvas2dMsg::StrokeText(
+                text_bounds,
+                text_runs,
+                fill_or_stroke_style,
+                line_options,
+                shadow_options,
+                composition_options,
+                transform,
+            ) => {
+                self.canvas(canvas_id).stroke_text(
+                    text_bounds,
+                    text_runs,
+                    fill_or_stroke_style,
+                    line_options,
+                    shadow_options,
+                    composition_options,
+                    transform,
+                );
+            },
             Canvas2dMsg::FillRect(rect, style, shadow_options, composition_options, transform) => {
                 self.canvas(canvas_id).fill_rect(
                     &rect,
@@ -308,6 +327,40 @@ impl Canvas {
             Canvas::Vello(canvas_data) => canvas_data.pop_clips(clips),
             #[cfg(feature = "vello_cpu")]
             Canvas::VelloCPU(canvas_data) => canvas_data.pop_clips(clips),
+        }
+    }
+
+    fn stroke_text(
+        &mut self,
+        text_bounds: Rect<f64>,
+        text_runs: Vec<TextRun>,
+        fill_or_stroke_style: FillOrStrokeStyle,
+        line_options: LineOptions,
+        shadow_options: ShadowOptions,
+        composition_options: CompositionOptions,
+        transform: Transform2D<f64>,
+    ) {
+        match self {
+            #[cfg(feature = "vello")]
+            Canvas::Vello(canvas_data) => canvas_data.stroke_text(
+                text_bounds,
+                text_runs,
+                fill_or_stroke_style,
+                line_options,
+                shadow_options,
+                composition_options,
+                transform,
+            ),
+            #[cfg(feature = "vello_cpu")]
+            Canvas::VelloCPU(canvas_data) => canvas_data.stroke_text(
+                text_bounds,
+                text_runs,
+                fill_or_stroke_style,
+                line_options,
+                shadow_options,
+                composition_options,
+                transform,
+            ),
         }
     }
 

--- a/components/canvas/lib.rs
+++ b/components/canvas/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #![deny(unsafe_code)]
+#![allow(clippy::too_many_arguments)]
 
 mod backend;
 

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -384,6 +384,50 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
         })
     }
 
+    fn stroke_text(
+        &mut self,
+        text_runs: Vec<TextRun>,
+        style: FillOrStrokeStyle,
+        line_options: LineOptions,
+        composition_options: CompositionOptions,
+        transform: Transform2D<f64>,
+    ) {
+        self.ensure_drawing();
+        self.ctx.set_paint(paint(style, composition_options.alpha));
+        self.ctx.set_stroke(line_options.convert());
+        self.ctx.set_transform(transform.cast().into());
+        self.with_composition(composition_options.composition_operation, |self_| {
+            for text_run in text_runs.iter() {
+                SHARED_FONT_CACHE.with(|font_cache| {
+                    let identifier = &text_run.font.identifier;
+                    if !font_cache.borrow().contains_key(identifier) {
+                        let Some(font_data_and_index) = text_run.font.font_data_and_index() else {
+                            return;
+                        };
+                        let font = font_data_and_index.convert();
+                        font_cache.borrow_mut().insert(identifier.clone(), font);
+                    }
+
+                    let font_cache = font_cache.borrow();
+                    let Some(font) = font_cache.get(identifier) else {
+                        return;
+                    };
+                    self_
+                        .ctx
+                        .glyph_run(font)
+                        .font_size(text_run.pt_size)
+                        .stroke_glyphs(text_run.glyphs_and_positions.iter().map(
+                            |glyph_and_position| vello_cpu::Glyph {
+                                id: glyph_and_position.id,
+                                x: glyph_and_position.point.x,
+                                y: glyph_and_position.point.y,
+                            },
+                        ));
+                });
+            }
+        })
+    }
+
     fn stroke_rect(
         &mut self,
         rect: &Rect<f32>,

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -350,6 +350,19 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
         self.mark_as_dirty();
     }
 
+    // https://html.spec.whatwg.org/multipage/#dom-context-2d-stroketext
+    fn StrokeText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>) {
+        self.canvas_state.stroke_text(
+            &self.global(),
+            self.canvas.canvas().as_deref(),
+            text,
+            x,
+            y,
+            max_width,
+        );
+        self.mark_as_dirty();
+    }
+
     // https://html.spec.whatwg.org/multipage/#textmetrics
     fn MeasureText(&self, text: DOMString, can_gc: CanGc) -> DomRoot<TextMetrics> {
         self.canvas_state.measure_text(

--- a/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
@@ -276,6 +276,11 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
         self.context.FillText(text, x, y, max_width)
     }
 
+    // https://html.spec.whatwg.org/multipage/#dom-context-2d-stroketext
+    fn StrokeText(&self, text: DOMString, x: f64, y: f64, max_width: Option<f64>) {
+        self.context.StrokeText(text, x, y, max_width)
+    }
+
     // https://html.spec.whatwg.org/multipage/#textmetrics
     fn MeasureText(&self, text: DOMString, can_gc: CanGc) -> DomRoot<TextMetrics> {
         self.context.MeasureText(text, can_gc)

--- a/components/script_bindings/webidls/CanvasRenderingContext2D.webidl
+++ b/components/script_bindings/webidls/CanvasRenderingContext2D.webidl
@@ -149,8 +149,9 @@ interface mixin CanvasText {
   [Pref="dom_canvas_text_enabled"]
   undefined fillText(DOMString text, unrestricted double x, unrestricted double y,
                 optional unrestricted double maxWidth);
-  //void strokeText(DOMString text, unrestricted double x, unrestricted double y,
-  //                optional unrestricted double maxWidth);
+  [Pref="dom_canvas_text_enabled"]
+  undefined strokeText(DOMString text, unrestricted double x, unrestricted double y,
+                  optional unrestricted double maxWidth);
   [Pref="dom_canvas_text_enabled"]
   TextMetrics measureText(DOMString text);
 };

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -492,6 +492,15 @@ pub enum Canvas2dMsg {
         CompositionOptions,
         Transform2D<f64>,
     ),
+    StrokeText(
+        Rect<f64>,
+        Vec<TextRun>,
+        FillOrStrokeStyle,
+        LineOptions,
+        ShadowOptions,
+        CompositionOptions,
+        Transform2D<f64>,
+    ),
     FillRect(
         Rect<f32>,
         FillOrStrokeStyle,

--- a/tests/wpt/meta/html/canvas/element/2d.conformance.requirements.basics.html.ini
+++ b/tests/wpt/meta/html/canvas/element/2d.conformance.requirements.basics.html.ini
@@ -1,3 +1,0 @@
-[2d.conformance.requirements.basics.html]
-  [void methods return undefined]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/conformance-requirements/2d.conformance.requirements.basics.html.ini
+++ b/tests/wpt/meta/html/canvas/element/conformance-requirements/2d.conformance.requirements.basics.html.ini
@@ -1,3 +1,0 @@
-[2d.conformance.requirements.basics.html]
-  [void methods return undefined]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.draw.stroke.unaffected.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.draw.stroke.unaffected.html.ini
@@ -1,3 +1,0 @@
-[2d.text.draw.stroke.unaffected.html]
-  [strokeText does not start a new path or subpath]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.measure.strokeTextCluster-align.tentative.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.measure.strokeTextCluster-align.tentative.html.ini
@@ -1,0 +1,2 @@
+[2d.text.measure.strokeTextCluster-align.tentative.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.measure.strokeTextCluster-baseline.tentative.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.measure.strokeTextCluster-baseline.tentative.html.ini
@@ -1,0 +1,2 @@
+[2d.text.measure.strokeTextCluster-baseline.tentative.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/text/2d.text.measure.strokeTextCluster-drawing-styles-change.tentative.html.ini
+++ b/tests/wpt/meta/html/canvas/element/text/2d.text.measure.strokeTextCluster-drawing-styles-change.tentative.html.ini
@@ -1,0 +1,2 @@
+[2d.text.measure.strokeTextCluster-drawing-styles-change.tentative.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/2d.conformance.requirements.basics.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/2d.conformance.requirements.basics.html.ini
@@ -1,3 +1,0 @@
-[2d.conformance.requirements.basics.html]
-  [void methods return undefined]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/2d.conformance.requirements.basics.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/2d.conformance.requirements.basics.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.conformance.requirements.basics.worker.html]
-  [void methods return undefined]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/conformance-requirements/2d.conformance.requirements.basics.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/conformance-requirements/2d.conformance.requirements.basics.html.ini
@@ -1,3 +1,0 @@
-[2d.conformance.requirements.basics.html]
-  [void methods return undefined]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/conformance-requirements/2d.conformance.requirements.basics.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/conformance-requirements/2d.conformance.requirements.basics.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.conformance.requirements.basics.worker.html]
-  [void methods return undefined]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/text/2d.text.draw.stroke.unaffected.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/text/2d.text.draw.stroke.unaffected.html.ini
@@ -1,4 +1,0 @@
-[2d.text.draw.stroke.unaffected.html]
-  [strokeText does not start a new path or subpath]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/text/2d.text.draw.stroke.unaffected.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/text/2d.text.draw.stroke.unaffected.worker.js.ini
@@ -1,4 +1,0 @@
-[2d.text.draw.stroke.unaffected.worker.html]
-  [strokeText does not start a new path or subpath]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-align.tentative.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-align.tentative.html.ini
@@ -1,0 +1,2 @@
+[2d.text.measure.strokeTextCluster-align.tentative.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-baseline.tentative.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-baseline.tentative.html.ini
@@ -1,0 +1,2 @@
+[2d.text.measure.strokeTextCluster-baseline.tentative.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-drawing-styles-change.tentative.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/text/2d.text.measure.strokeTextCluster-drawing-styles-change.tentative.html.ini
@@ -1,0 +1,2 @@
+[2d.text.measure.strokeTextCluster-drawing-styles-change.tentative.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/dom/idlharness.any.js.ini
+++ b/tests/wpt/meta/html/dom/idlharness.any.js.ini
@@ -26,9 +26,6 @@
   [OffscreenCanvasRenderingContext2D interface: operation isPointInStroke(Path2D, unrestricted double, unrestricted double)]
     expected: FAIL
 
-  [OffscreenCanvasRenderingContext2D interface: operation strokeText(DOMString, unrestricted double, unrestricted double, optional unrestricted double)]
-    expected: FAIL
-
   [OffscreenCanvasRenderingContext2D interface: attribute letterSpacing]
     expected: FAIL
 

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -4247,9 +4247,6 @@
   [CanvasRenderingContext2D interface: operation drawFocusIfNeeded(Path2D, Element)]
     expected: FAIL
 
-  [CanvasRenderingContext2D interface: operation strokeText(DOMString, unrestricted double, unrestricted double, optional unrestricted double)]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: attribute letterSpacing]
     expected: FAIL
 
@@ -4313,12 +4310,6 @@
   [CanvasRenderingContext2D interface: calling drawFocusIfNeeded(Path2D, Element) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
     expected: FAIL
 
-  [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "strokeText(DOMString, unrestricted double, unrestricted double, optional unrestricted double)" with the proper type]
-    expected: FAIL
-
-  [CanvasRenderingContext2D interface: calling strokeText(DOMString, unrestricted double, unrestricted double, optional unrestricted double) on document.createElement("canvas").getContext("2d") with too few arguments must throw TypeError]
-    expected: FAIL
-
   [CanvasRenderingContext2D interface: document.createElement("canvas").getContext("2d") must inherit property "letterSpacing" with the proper type]
     expected: FAIL
 
@@ -4368,9 +4359,6 @@
     expected: FAIL
 
   [OffscreenCanvasRenderingContext2D interface: operation isPointInStroke(Path2D, unrestricted double, unrestricted double)]
-    expected: FAIL
-
-  [OffscreenCanvasRenderingContext2D interface: operation strokeText(DOMString, unrestricted double, unrestricted double, optional unrestricted double)]
     expected: FAIL
 
   [OffscreenCanvasRenderingContext2D interface: attribute letterSpacing]


### PR DESCRIPTION
Mostly it's just reusing/copy&edit fillText stuff.

Testing: Existing WPT tests
Fixes: #29973

Try run: https://github.com/sagudev/servo/actions/runs/17511337550
