### PR TITLE
cargo: Bump MSRV to 1.86.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ publish = false
 # why we should consider increasing our minimum supported rust version.
 # Please also note, that the **default** rust version in rust-toolchain.toml may be
 # bumped freely.
-rust-version = "1.85.0"
+rust-version = "1.86.0"
 
 [workspace.dependencies]
 accountable-refcell = "0.2.2"


### PR DESCRIPTION
Per discussions in [#general > RFC: Bump MSRV to 1.86 @ 💬](https://servo.zulipchat.com/#narrow/channel/263398-general/topic/RFC.3A.20Bump.20MSRV.20to.201.2E86/near/537822241) it's okay to do this. LLVM/clang used by this rust version is still 19, so there should be no problems on that front.

This will be needed for future vello bumps: https://github.com/linebender/vello/blob/65eea2c43b7f90f0159615731348defb4eb602bd/Cargo.toml#L45 

Testing: CI MSRV check