### PR TITLE
layout: Convert animated image delays < 10ms into 100 ms delays

### DIFF
--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -640,7 +640,7 @@ impl ImageAnimationState {
                 .frames
                 .get(self.active_frame)
                 .unwrap()
-                .delay
+                .delay()
                 .unwrap()
                 .as_secs_f64();
         let mut next_active_frame_id = self.active_frame;
@@ -650,7 +650,7 @@ impl ImageAnimationState {
                 .frames
                 .get(next_active_frame_id)
                 .unwrap()
-                .delay
+                .delay()
                 .unwrap()
                 .as_secs_f64();
         }


### PR DESCRIPTION
Some animated images in the wild have delays <10ms and browsers usually change them into 100ms as such small timings are unusual.

Relevant code in FF: https://searchfox.org/firefox-main/source/image/FrameTimeout.h#35

Testing: Manually tested
Fixes: #39187
