### PR TITLE
CI: Change APT mirror priorities

### DIFF
--- a/.github/actions/apt-mirrors/action.yml
+++ b/.github/actions/apt-mirrors/action.yml
@@ -1,0 +1,12 @@
+# Based on https://github.com/CrowdStrike/glide-core/pull/1113
+name: Change Mirror Priorities
+runs:
+  using: "composite"
+  steps:
+    # https://github.com/actions/runner-images/issues/7048
+    - name: Change Mirror Priorities
+      run: |
+        sudo sed -i '/archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:2/priority:0/' /etc/apt/apt-mirrors.txt
+        sudo sed -i '/azure.archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:0/priority:1/' /etc/apt/apt-mirrors.txt
+        sudo sed -i '/security.ubuntu.com\/ubuntu\/\tpriority/ s/priority:3/priority:2/' /etc/apt/apt-mirrors.txt
+        sudo cat /etc/apt/apt-mirrors.txt

--- a/.github/actions/apt-mirrors/action.yml
+++ b/.github/actions/apt-mirrors/action.yml
@@ -5,6 +5,7 @@ runs:
   steps:
     # https://github.com/actions/runner-images/issues/7048
     - name: Change Mirror Priorities
+      shell: bash
       run: |
         sudo sed -i '/archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:2/priority:0/' /etc/apt/apt-mirrors.txt
         sudo sed -i '/azure.archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:0/priority:1/' /etc/apt/apt-mirrors.txt

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -64,6 +64,8 @@ jobs:
         run: tar -xzf ${{ inputs.profile }}-binary-linux/target.tar.gz
       - name: Setup Python
         uses: ./.github/actions/setup-python
+      - name: Change Mirror Priorities
+        uses: ./.github/actions/apt-mirrors
       - name: Bootstrap dependencies
         timeout-minutes: 60
         run: |

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Change Mirror Priorities
         uses: ./.github/actions/apt-mirrors
       - name: Bootstrap dependencies
-        timeout-minutes: 60
+        timeout-minutes: 10
         run: |
           sudo apt update
           sudo apt install -qy --no-install-recommends mesa-vulkan-drivers fonts-noto-cjk

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -168,6 +168,7 @@ jobs:
         uses: ./.github/actions/apt-mirrors
       - name: Bootstrap dependencies
         if: ${{ runner.environment != 'self-hosted' }}
+        timeout-minutes: 10
         run: |
           sudo apt update
           ./mach bootstrap --skip-lints

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -163,6 +163,9 @@ jobs:
       - name: Setup Python
         if: ${{ runner.environment != 'self-hosted' }}
         uses: ./.github/actions/setup-python
+      - name: Change Mirror Priorities
+        if: ${{ runner.environment != 'self-hosted' }}
+        uses: ./.github/actions/apt-mirrors
       - name: Bootstrap dependencies
         if: ${{ runner.environment != 'self-hosted' }}
         run: |


### PR DESCRIPTION
We noticed many times that bootstrap sometimes takes a lot of time due to slow download speed: [#general > Bootstrap is slow in CI @ 💬](https://servo.zulipchat.com/#narrow/channel/263398-general/topic/Bootstrap.20is.20slow.20in.20CI/near/537610373). We [reported this to github](https://github.com/actions/runner-images/issues/12949) and they said we should just use different mirrors. Based on https://github.com/CrowdStrike/glide-core/pull/1113 we change Ubuntu's mirror priorities from:
```
http://azure.archive.ubuntu.com/ubuntu priority:0
https://archive.ubuntu.com/ubuntu priority:1
https://security.ubuntu.com/ubuntu priority:2
```
to:
```
https://archive.ubuntu.com/ubuntu priority:0
http://azure.archive.ubuntu.com/ubuntu priority:1
https://security.ubuntu.com/ubuntu priority:2
```
I also set more strict timeout (10 min; usually it takes 2-3 min but always less then 4 min) for bootstrap to alert us on problems.

Testing: Manual CI run: https://github.com/sagudev/servo/actions/runs/17527791255
