### PR TITLE
script: Registration retrieval methods for service workers

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1863,6 +1863,34 @@ where
             ScriptToConstellationMessage::ScheduleJob(job) => {
                 self.handle_schedule_serviceworker_job(source_pipeline_id, job);
             },
+            ScriptToConstellationMessage::MatchRegistration {
+                url,
+                storage_key,
+                sender,
+            } => {
+                if let Some(mgr) = self.sw_managers.get(&storage_key.0) {
+                    let _ = mgr.send(ServiceWorkerMsg::MatchRegistration {
+                        storage_key,
+                        url,
+                        sender,
+                    });
+                } else {
+                    let _ = sender.send(None);
+                }
+            },
+            ScriptToConstellationMessage::GetRegistrations {
+                storage_key,
+                sender,
+            } => {
+                if let Some(mgr) = self.sw_managers.get(&storage_key.0) {
+                    let _ = mgr.send(ServiceWorkerMsg::GetRegistrations {
+                        storage_key,
+                        sender,
+                    });
+                } else {
+                    let _ = sender.send(vec![]);
+                }
+            },
             ScriptToConstellationMessage::ForwardDOMMessage(msg_vec, scope_url) => {
                 if let Some(mgr) = self.sw_managers.get(&scope_url.origin()) {
                     let _ = mgr.send(ServiceWorkerMsg::ForwardDOMMessage(msg_vec, scope_url));

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -170,6 +170,8 @@ mod from_script {
                 Self::PipelineExited => target!("PipelineExited"),
                 Self::ForwardDOMMessage(..) => target!("ForwardDOMMessage"),
                 Self::ScheduleJob(..) => target!("ScheduleJob"),
+                Self::MatchRegistration { .. } => target!("MatchRegistration"),
+                Self::GetRegistrations { .. } => target!("GetRegistrations"),
                 Self::MediaSessionEvent(..) => target!("MediaSessionEvent"),
                 #[cfg(feature = "webgpu")]
                 Self::RequestAdapter(..) => target!("RequestAdapter"),

--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -5,7 +5,7 @@
 use std::default::Default;
 
 use dom_struct::dom_struct;
-use servo_url::ServoUrl;
+use servo_url::{ImmutableOrigin, ServoUrl};
 use uuid::Uuid;
 
 use crate::dom::bindings::codegen::Bindings::ClientBinding::{ClientMethods, FrameType};
@@ -21,7 +21,7 @@ pub(crate) struct Client {
     reflector_: Reflector,
     active_worker: MutNullableDom<ServiceWorker>,
     #[no_trace]
-    url: ServoUrl,
+    pub(crate) url: ServoUrl,
     frame_type: FrameType,
     #[ignore_malloc_size_of = "Defined in uuid"]
     #[no_trace]
@@ -58,6 +58,30 @@ impl Client {
     #[expect(dead_code)]
     pub(crate) fn set_controller(&self, worker: &ServiceWorker) {
         self.active_worker.set(Some(worker));
+    }
+
+    /// <https://storage.spec.whatwg.org/#obtain-a-storage-key-for-non-storage-purposes>
+    #[expect(dead_code)]
+    pub(crate) fn obtain_storage_key_for_non_storage_purposes(&self) -> (ImmutableOrigin,) {
+        // Step 1. Let origin be environment’s origin if environment is an environment settings object;
+        // otherwise environment’s creation URL’s origin.
+        let origin = self.url.origin();
+        // Return a tuple consisting of origin.
+        (origin,)
+    }
+
+    /// <https://storage.spec.whatwg.org/#obtain-a-storage-key>
+    #[expect(dead_code)]
+    pub(crate) fn obtain_storage_key(&self) -> Result<(ImmutableOrigin,), ()> {
+        // Step 1. Let key be the result of running obtain a storage key for non-storage purposes with environment.
+        let key = self.obtain_storage_key_for_non_storage_purposes();
+        // Step 2. If key’s origin is an opaque origin, then return failure.
+        if matches!(key.0, ImmutableOrigin::Opaque(..)) {
+            return Err(());
+        }
+        // TODO: Step 3. If the user has disabled storage, then return failure.
+        // Step 4. Return key.
+        Ok(key)
     }
 }
 

--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -21,7 +21,7 @@ pub(crate) struct Client {
     reflector_: Reflector,
     active_worker: MutNullableDom<ServiceWorker>,
     #[no_trace]
-    pub(crate) url: ServoUrl,
+    url: ServoUrl,
     frame_type: FrameType,
     #[ignore_malloc_size_of = "Defined in uuid"]
     #[no_trace]

--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -61,7 +61,6 @@ impl Client {
     }
 
     /// <https://storage.spec.whatwg.org/#obtain-a-storage-key-for-non-storage-purposes>
-    #[expect(dead_code)]
     pub(crate) fn obtain_storage_key_for_non_storage_purposes(&self) -> (ImmutableOrigin,) {
         // Step 1. Let origin be environment’s origin if environment is an environment settings object;
         // otherwise environment’s creation URL’s origin.
@@ -71,7 +70,6 @@ impl Client {
     }
 
     /// <https://storage.spec.whatwg.org/#obtain-a-storage-key>
-    #[expect(dead_code)]
     pub(crate) fn obtain_storage_key(&self) -> Result<(ImmutableOrigin,), ()> {
         // Step 1. Let key be the result of running obtain a storage key for non-storage purposes with environment.
         let key = self.obtain_storage_key_for_non_storage_purposes();

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -13,8 +13,6 @@ use dom_struct::dom_struct;
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use js::jsval::UndefinedValue;
-
-use script_bindings::codegen::GenericBindings::ClientBinding::ClientMethods;
 use js::realm::CurrentRealm;
 
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerContainerBinding::{
@@ -203,8 +201,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
             },
         };
         // Step 3. Let clientURL be the result of parsing clientURL with this’s relevant settings object’s API base URL.
-        // FIXME(arihant2math): This should be the API base of the settings object, but that's not implemented yet.
-        let mut client_url = match global.creation_url().join(client_url.0.as_str()) {
+        let mut client_url = match global.api_base_url().join(client_url.0.as_str()) {
             Ok(url) => url,
             Err(_) => {
                 // Step 4. If clientURL is failure, return a promise rejected with a TypeError.

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -189,7 +189,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
     }
 
     /// <https://w3c.github.io/ServiceWorker/#navigator-service-worker-getRegistration>
-    fn GetRegistration(&self, client_url: USVString) -> Rc<Promise> {
+    fn GetRegistration(&self, _client_url: USVString) -> Rc<Promise> {
         let global = self.global();
         // Step 1. Let client be this’s service worker client.
         // self.client is the client.
@@ -197,7 +197,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
         let storage_key = match self.client.obtain_storage_key() {
             Ok(key) => key,
             Err(()) => {
-                let promise = Promise::new(&*global, CanGc::note());
+                let promise = Promise::new(&global, CanGc::note());
                 promise.reject_error(Error::InvalidAccess, CanGc::note());
                 return promise;
             },
@@ -209,7 +209,7 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
         // TODO: Step 5. Set clientURL’s fragment to null.
         // TODO: Step 6. If the origin of clientURL is not client’s origin, return a promise rejected with a "SecurityError" DOMException.
         // Step 7. Let promise be a new promise.
-        let promise = Promise::new(&*global, CanGc::note());
+        let promise = Promise::new(&global, CanGc::note());
         // Step 8. Run the following substeps in parallel:
         let script_to_constellation_chan = global.script_to_constellation_chan();
         let (sender, receiver) = ipc::channel().unwrap();
@@ -276,13 +276,13 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
         let storage_key = match self.client.obtain_storage_key() {
             Ok(key) => key,
             Err(()) => {
-                let promise = Promise::new(&*global, CanGc::note());
+                let promise = Promise::new(&global, CanGc::note());
                 promise.reject_error(Error::InvalidAccess, CanGc::note());
                 return promise;
             },
         };
         // Step 3. Let promise be a new promise.
-        let promise = Promise::new(&*global, CanGc::note());
+        let promise = Promise::new(&global, CanGc::note());
         // Step 4. Run the following steps in parallel:
         let (sender, receiver) = ipc::channel().unwrap();
         let task_source = global

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -10,11 +10,13 @@ use constellation_traits::{
     Job, JobError, JobResult, JobResultValue, JobType, ScriptToConstellationMessage,
 };
 use dom_struct::dom_struct;
+use script_bindings::codegen::GenericBindings::ClientBinding::ClientMethods;
 use js::realm::CurrentRealm;
 
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerContainerBinding::{
     RegistrationOptions, ServiceWorkerContainerMethods,
 };
+use crate::dom::bindings::codegen::DomTypeHolder::DomTypeHolder;
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::refcounted::TrustedPromise;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
@@ -180,6 +182,54 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
             .send(ScriptToConstellationMessage::ScheduleJob(job));
 
         // A: Step 7
+        promise
+    }
+
+    /// <https://w3c.github.io/ServiceWorker/#navigator-service-worker-getRegistration>
+    // fn GetRegistration(&self) -> Rc<Promise> {
+    //     // Step 1. Let client be this’s service worker client.
+    //     // self.client is the client.
+    //     // Step 2. Let storage key be the result of running obtain a storage key given client.
+    //     let storage_key = match self.client.obtain_storage_key() {
+    //         Ok(key) => key,
+    //         Err(()) => {
+    //             let promise = Promise::new(&*self.global(), CanGc::note());
+    //             promise.reject_error(Error::InvalidAccess, CanGc::note());
+    //             return promise;
+    //         },
+    //     };
+    //     // Step 3. Let clientURL be the result of parsing clientURL with this’s relevant settings object’s API base URL.
+    //     let client_url = self.client.url;
+    //     // TODO: Step 4. If clientURL is failure, return a promise rejected with a TypeError.
+    //     // TODO: Step 5. Set clientURL’s fragment to null.
+    //     // TODO: Step 6. If the origin of clientURL is not client’s origin, return a promise rejected with a "SecurityError" DOMException.
+    //     // Step 7. Let promise be a new promise.
+    //     let promise = Promise::new(&*self.global(), CanGc::note());
+    //     // Step 8. Run the following substeps in parallel:
+    //     // TODO: do in parallel
+    //     // Step 8.1. Let registration be the result of running Match Service Worker Registration given storage key and clientURL.
+    //     let registration = self.global().
+    //     // Step 8.2. If registration is null, resolve promise with undefined and abort these steps.
+    //     // Step 8.3. Resolve promise with the result of getting the service worker registration object that represents registration in promise’s relevant settings object.
+    //     // Step 9. Return promise.
+    //     promise
+    // }
+
+    /// <https://w3c.github.io/ServiceWorker/#navigator-service-worker-getRegistrations>
+    fn GetRegistrations(&self) -> Rc<Promise> {
+        // Step 1. Let client be this’s service worker client.
+        // Step 2. Let client storage key be the result of running obtain a storage key given client.
+        let storage_key = match self.client.obtain_storage_key() {
+            Ok(key) => key,
+            Err(()) => {
+                let promise = Promise::new(&*self.global(), CanGc::note());
+                promise.reject_error(Error::InvalidAccess, CanGc::note());
+                return promise;
+            },
+        };
+        // Step 3. Let promise be a new promise.
+        let promise = Promise::new(&*self.global(), CanGc::note());
+        // Step 4. Run the following steps in parallel:
         promise
     }
 }

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -476,7 +476,6 @@ impl ServiceWorkerManager {
     }
 
     /// <https://w3c.github.io/ServiceWorker/#match-service-worker-registration>
-    #[expect(dead_code)]
     fn match_service_worker_registration(
         &self,
         storage_key: (ImmutableOrigin,),

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -497,10 +497,8 @@ impl ServiceWorkerManager {
         }
         // Step 6. Set matchingScopeString to the longest value in scopeStringSet which the value of clientURLString starts with, if it exists.
         for scope in scope_string_set {
-            if client_url_string.starts_with(scope) {
-                if scope.len() > matching_scope_string.len() {
-                    matching_scope_string = scope.to_owned();
-                }
+            if client_url_string.starts_with(scope) && scope.len() > matching_scope_string.len() {
+                matching_scope_string = scope.to_owned();
             }
         }
         // Step 7. Let matchingScope be null.

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -449,6 +449,49 @@ impl ServiceWorkerManager {
                 .send(JobResult::RejectPromise(JobError::TypeError));
         }
     }
+
+    /// <https://w3c.github.io/ServiceWorker/#match-service-worker-registration>
+    #[expect(dead_code)]
+    fn match_service_worker_registration(&self, storage_key: (ImmutableOrigin,), client_url: ServoUrl) -> Option<&ServiceWorkerRegistration> {
+        // Step 1. Run the following steps atomically.
+        // Step 2. Let clientURLString be serialized clientURL.
+        let client_url_string = client_url.as_str();
+        // Step 3. Let matchingScopeString be the empty string.
+        let mut matching_scope_string = String::new();
+        // Step 4. Let scopeStringSet be an empty list.
+        let mut scope_string_set = Vec::new();
+        // Step 5. For each (entry storage key, entry scope) of registration map’s keys:
+        for (entry_storage_key, entry_scope) in self.registrations.keys().map(|k| (k.origin(), k)) {
+            // Step 5.1. If storage key equals entry storage key, then append entry scope to the end of scopeStringSet.
+            if storage_key == (entry_storage_key,) {
+                scope_string_set.push(entry_scope.as_str());
+            }
+        }
+        // Step 6. Set matchingScopeString to the longest value in scopeStringSet which the value of clientURLString starts with, if it exists.
+        for scope in scope_string_set {
+            if client_url_string.starts_with(scope) {
+                if scope.len() > matching_scope_string.len() {
+                    matching_scope_string = scope.to_owned();
+                }
+            }
+        }
+        // Step 7. Let matchingScope be null.
+        let mut matching_scope = None;
+        // Step 8. If matchingScopeString is not the empty string, then:
+        if !matching_scope_string.is_empty() {
+            // Step 8.1. Set matchingScope to the result of parsing matchingScopeString.
+            matching_scope = Some(ServoUrl::parse(&matching_scope_string).ok()?);
+            // Step 8.2. Assert: matchingScope’s origin and clientURL’s origin are same origin.
+            assert_eq!(matching_scope.as_ref().unwrap().origin(), client_url.origin());
+        }
+        // Step 9. Return the result of running Get Registration given storage key and matchingScope.
+        // TODO: implement https://w3c.github.io/ServiceWorker/#get-registration
+        if let Some(matching_scope) = matching_scope {
+            self.registrations.get(&matching_scope)
+        } else {
+            None
+        }
+    }
 }
 
 /// <https://w3c.github.io/ServiceWorker/#update-algorithm>

--- a/components/script_bindings/webidls/ServiceWorkerContainer.webidl
+++ b/components/script_bindings/webidls/ServiceWorkerContainer.webidl
@@ -11,7 +11,7 @@ interface ServiceWorkerContainer : EventTarget {
   [NewObject] Promise<ServiceWorkerRegistration> register(USVString scriptURL,
                                                           optional RegistrationOptions options = {});
 
-  //[NewObject] Promise<any> getRegistration(optional USVString clientURL = "");
+  [NewObject] Promise<any> getRegistration(optional USVString clientURL = "");
   // TODO: Replace this when FrozenArray is supported, using sequence like firefox
   //[NewObject] Promise<FrozenArray<ServiceWorkerRegistration>> getRegistrations();
   [NewObject] Promise<sequence<ServiceWorkerRegistration>> getRegistrations();

--- a/components/script_bindings/webidls/ServiceWorkerContainer.webidl
+++ b/components/script_bindings/webidls/ServiceWorkerContainer.webidl
@@ -12,7 +12,9 @@ interface ServiceWorkerContainer : EventTarget {
                                                           optional RegistrationOptions options = {});
 
   //[NewObject] Promise<any> getRegistration(optional USVString clientURL = "");
+  // TODO: Replace this when FrozenArray is supported, using sequence like firefox
   //[NewObject] Promise<FrozenArray<ServiceWorkerRegistration>> getRegistrations();
+  [NewObject] Promise<sequence<ServiceWorkerRegistration>> getRegistrations();
 
   //void startMessages();
 

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -252,6 +252,16 @@ pub enum ServiceWorkerMsg {
     ForwardDOMMessage(DOMMessage, ServoUrl),
     /// <https://w3c.github.io/ServiceWorker/#schedule-job-algorithm>
     ScheduleJob(Job),
+    MatchRegistration {
+        storage_key: (ImmutableOrigin,),
+        url: ServoUrl,
+        sender: IpcSender<Option<ServiceWorkerRegistrationId>>,
+    },
+    GetRegistrations {
+        /// The origin to get registrations for.
+        storage_key: (ImmutableOrigin,),
+        sender: IpcSender<Vec<ServiceWorkerRegistrationId>>,
+    },
     /// Exit the service worker manager
     Exit,
 }
@@ -682,6 +692,16 @@ pub enum ScriptToConstellationMessage {
     ForwardDOMMessage(DOMMessage, ServoUrl),
     /// <https://w3c.github.io/ServiceWorker/#schedule-job-algorithm>
     ScheduleJob(Job),
+    MatchRegistration {
+        storage_key: (ImmutableOrigin,),
+        url: ServoUrl,
+        sender: IpcSender<Option<ServiceWorkerRegistrationId>>,
+    },
+    GetRegistrations {
+        /// The origin to get registrations for.
+        storage_key: (ImmutableOrigin,),
+        sender: IpcSender<Vec<ServiceWorkerRegistrationId>>,
+    },
     /// Notifies the constellation about media session events
     /// (i.e. when there is metadata for the active media session, playback state changes...).
     MediaSessionEvent(PipelineId, MediaSessionEvent),


### PR DESCRIPTION
Implements `getRegistrations`, and `getRegistration`, mainly for the sake of WPT tests.

Testing: WPT