### PR TITLE
layout: allow only repaint when css background and border image loaded

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -539,6 +539,10 @@ impl Layout for LayoutThread {
         self.need_new_display_list.get()
     }
 
+    fn set_needs_new_display_list(&self) {
+        self.need_new_display_list.set(true);
+    }
+
     /// <https://drafts.css-houdini.org/css-properties-values-api-1/#the-registerproperty-function>
     fn register_custom_property(
         &mut self,

--- a/components/layout/replaced.rs
+++ b/components/layout/replaced.rs
@@ -7,8 +7,8 @@ use base::id::{BrowsingContextId, PipelineId};
 use data_url::DataUrl;
 use embedder_traits::ViewportDetails;
 use euclid::{Scale, Size2D};
-use layout_api::IFrameSize;
 use layout_api::wrapper_traits::ThreadSafeLayoutNode;
+use layout_api::{IFrameSize, LayoutImageDestination};
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::image_cache::{Image, ImageOrMetadataAvailable, UsePlaceholder, VectorImage};
 use script::layout_dom::ServoThreadSafeLayoutNode;
@@ -189,7 +189,12 @@ impl ReplacedContents {
 
                 let result = context
                     .image_resolver
-                    .get_cached_image_for_url(node.opaque(), svg_source, UsePlaceholder::No)
+                    .get_cached_image_for_url(
+                        node.opaque(),
+                        svg_source,
+                        UsePlaceholder::No,
+                        LayoutImageDestination::BoxTreeConstruction,
+                    )
                     .ok();
 
                 let vector_image = result.map(|result| match result {
@@ -230,6 +235,7 @@ impl ReplacedContents {
                 node.opaque(),
                 image_url.clone().into(),
                 UsePlaceholder::No,
+                LayoutImageDestination::BoxTreeConstruction,
             ) {
                 LayoutImageCacheResult::DataAvailable(img_or_meta) => match img_or_meta {
                     ImageOrMetadataAvailable::ImageAvailable { image, .. } => {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -154,6 +154,13 @@ pub enum PendingImageState {
     PendingResponse,
 }
 
+/// The destination in layout where an image is needed.
+#[derive(Debug, MallocSizeOf)]
+pub enum LayoutImageDestination {
+    BoxTreeConstruction,
+    DisplayListBuilding,
+}
+
 /// The data associated with an image that is not yet present in the image cache.
 /// Used by the script thread to hold on to DOM elements that need to be repainted
 /// when an image fetch is complete.
@@ -163,6 +170,7 @@ pub struct PendingImage {
     pub node: UntrustedNodeAddress,
     pub id: PendingImageId,
     pub origin: ImmutableOrigin,
+    pub destination: LayoutImageDestination,
 }
 
 /// A data structure to tarck vector image that are fully loaded (i.e has a parsed SVG
@@ -289,6 +297,9 @@ pub trait Layout {
 
     /// Returns true if this layout needs to produce a new display list for rendering updates.
     fn needs_new_display_list(&self) -> bool;
+
+    /// Marks that this layout needs to produce a new display list for rendering updates.
+    fn set_needs_new_display_list(&self);
 
     fn query_box_area(&self, node: TrustedNodeAddress, area: BoxAreaType) -> Option<Rect<Au>>;
     fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> Vec<Rect<Au>>;


### PR DESCRIPTION
This change allows that only new display list is built when css background and border image loaded.

Testing: This change should not change any behaviors so covered by existing WPT tests.
