### PR TITLE
libservo: Make Servo (and servoshell) more resilient against extreme sizes

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -132,6 +132,7 @@ use crate::proxies::ConstellationProxy;
 use crate::responders::ServoErrorChannel;
 pub use crate::servo_delegate::{ServoDelegate, ServoError};
 use crate::webrender_api::FrameReadyParams;
+use crate::webview::MINIMUM_WEBVIEW_SIZE;
 pub use crate::webview::{WebView, WebViewBuilder};
 pub use crate::webview_delegate::{
     AllowOrDenyRequest, AuthenticationRequest, ColorPicker, FormControl, NavigationRequest,
@@ -693,7 +694,9 @@ impl Servo {
             },
             EmbedderMsg::ResizeTo(webview_id, size) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview.delegate().request_resize_to(webview, size);
+                    webview
+                        .delegate()
+                        .request_resize_to(webview, size.max(MINIMUM_WEBVIEW_SIZE));
                 }
             },
             EmbedderMsg::ShowSimpleDialog(webview_id, prompt_definition) => {

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -56,7 +56,7 @@ pub(crate) fn run_test(
 }
 
 pub struct ServoTest {
-    servo: Servo,
+    pub servo: Rc<Servo>,
     #[allow(dead_code)]
     pub rendering_context: Rc<dyn RenderingContext>,
 }
@@ -101,7 +101,7 @@ impl ServoTest {
         let builder = ServoBuilder::new(rendering_context.clone())
             .event_loop_waker(Box::new(EventLoopWakerImpl(user_event_triggered)));
         let builder = customize(builder);
-        let servo = builder.build();
+        let servo = Rc::new(builder.build());
         Self {
             servo,
             rendering_context,

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -474,7 +474,11 @@ pub trait WebViewDelegate {
     fn request_unload(&self, _webview: WebView, _unload_request: AllowOrDenyRequest) {}
     /// Move the window to a point.
     fn request_move_to(&self, _webview: WebView, _: DeviceIntPoint) {}
-    /// Try to resize the window that contains this [`WebView`] to the provided outer size.
+    /// Try to resize the window that contains this [`WebView`] to the provided outer
+    /// size. These resize requests can come from page content. Servo will ensure that the
+    /// values are greater than zero, but it is up to the embedder to limit the maximum
+    /// size. For instance, a reasonable limitation might be that the final size is no
+    /// larger than the screen size.
     fn request_resize_to(&self, _webview: WebView, _requested_outer_size: DeviceIntSize) {}
     /// Whether or not to allow script to open a new `WebView`. If not handled by the
     /// embedder, these requests are automatically denied.

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -24,8 +24,7 @@ pub(crate) const PIXEL_DELTA_FACTOR: f64 = 4.0;
 
 /// <https://github.com/web-platform-tests/wpt/blob/9320b1f724632c52929a3fdb11bdaf65eafc7611/webdriver/tests/classic/set_window_rect/set.py#L287-L290>
 /// "A window size of 10x10px shouldn't be supported by any browser."
-pub(crate) const MIN_INNER_WIDTH: i32 = 20;
-pub(crate) const MIN_INNER_HEIGHT: i32 = 20;
+pub(crate) const MIN_WINDOW_INNER_SIZE: DeviceIntSize = DeviceIntSize::new(100, 100);
 
 pub trait WindowPortsMethods {
     fn id(&self) -> winit::window::WindowId;

--- a/tests/wpt/meta/css/cssom-view/resizeTo-negative.html.ini
+++ b/tests/wpt/meta/css/cssom-view/resizeTo-negative.html.ini
@@ -1,2 +1,0 @@
-[resizeTo-negative.html]
-  expected: CRASH


### PR DESCRIPTION
Make several changes which should address panics and inconsistent
behavior around attempts to set extreme sizes:

1. Limit the minimum size of the `RenderingContext` to 1 pixel by 1
   pixel. This should address problems where users of the API try to
   directly set the size to a zero or negative dimension. In addition,
   improve the documentation around `WebView::resize` to mention this.
2. Clamp values sent in the `WebViewDelegate::request_resize_to` method
   to be at least 1x1. This prevents Servo from sending nonsense values
   to embedders. Improve documentation in this method.
3. In servoshell:
    - More consistently clamp inner and outer window size values.
    - Clamp all resize values to the available screen size, so that
      large screen sizes aren't processed directly.

Testing: This change fixes an existing WPT and adds two new API tests.
Fixes: #36763.
Fixes: #36841.
Fixes: #39141.
