### PR TITLE
fixup: Enable viewport <meta> tag support for mobile platforms only

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -264,7 +264,8 @@ pub struct Preferences {
     /// The user-agent to use for Servo. This can also be set via [`UserAgentPlatform`] in
     /// order to set the value to the default value for the given platform.
     pub user_agent: String,
-
+    /// Whether or not the viewport meta tag is enabled.
+    pub viewport_meta_enabled: bool,
     pub log_filter: String,
 }
 
@@ -431,6 +432,7 @@ impl Preferences {
             threadpools_webrender_workers_max: 4,
             webgl_testing_context_creation_error: false,
             user_agent: String::new(),
+            viewport_meta_enabled: false,
             log_filter: String::new(),
         }
     }

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -64,9 +64,7 @@ impl HTMLMetaElement {
             if name == "referrer" {
                 self.apply_referrer();
             }
-            if (cfg!(target_os = "android") || cfg!(target_os = "ios") || cfg!(target_env = "ohos")) &&
-                name == "viewport"
-            {
+            if name == "viewport" {
                 self.parse_and_send_viewport_if_necessary();
             }
         // https://html.spec.whatwg.org/multipage/#attr-meta-http-equiv

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -8,6 +8,7 @@ use compositing_traits::viewport_description::ViewportDescription;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::rust::HandleObject;
+use servo_config::pref;
 use style::str::HTML_SPACE_CHARACTERS;
 
 use crate::dom::attr::Attr;
@@ -123,6 +124,10 @@ impl HTMLMetaElement {
 
     /// <https://drafts.csswg.org/css-viewport/#parsing-algorithm>
     fn parse_and_send_viewport_if_necessary(&self) {
+        if !pref!(viewport_meta_enabled) {
+            return;
+        }
+
         // Skip processing if this isn't the top level frame
         if !self.owner_window().is_top_level() {
             return;

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -51,7 +51,7 @@ pub fn init(
     let mut args = mem::take(&mut init_opts.args);
     args.insert(0, "servo".to_string());
 
-    let (opts, preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
+    let (opts, mut preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
         ArgumentParsingResult::ContentProcess(..) => {
             unreachable!("Android does not have support for multiprocess yet.")
         },
@@ -63,6 +63,8 @@ pub fn init(
         },
         ArgumentParsingResult::ErrorParsing => std::process::exit(1),
     };
+
+    preferences.set_value("viewport_meta_enabled", servo::PrefValue::Bool(true));
 
     crate::init_tracing(servoshell_preferences.tracing_filter.as_deref());
 

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -146,7 +146,7 @@ pub fn init(
         });
     }
 
-    let (opts, preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
+    let (opts, mut preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
         ArgumentParsingResult::ContentProcess(..) => {
             unreachable!("OHOS does not have support for multiprocess yet.")
         },
@@ -156,6 +156,10 @@ pub fn init(
         ArgumentParsingResult::Exit => std::process::exit(0),
         ArgumentParsingResult::ErrorParsing => std::process::exit(1),
     };
+
+    if native_values.device_type == ohos_deviceinfo::OhosDeviceType::Phone {
+        preferences.set_value("viewport_meta_enabled", servo::PrefValue::Bool(true));
+    }
 
     if servoshell_preferences.log_to_file {
         let mut servo_log = PathBuf::from(&native_values.cache_dir);


### PR DESCRIPTION
1. Adds a pref viewport_meta_enabled.
2. Enable pref for mobile platforms.

Testing: Tested Manually
Fixes: #39157
Fixes: #39002 
