### PR TITLE
script: Document need for always sending an image update to compositor

### DIFF
--- a/components/script/dom/canvas/canvas_context.rs
+++ b/components/script/dom/canvas/canvas_context.rs
@@ -108,9 +108,11 @@ pub(crate) trait CanvasContext {
 
     /// Request that the [`CanvasContext`] update the rendering of its contents,
     /// returning `true` if new image was produced.
-    /// Note: If this function returns true, script will wait for all images to be updated
-    /// before calling next round of update the rendering, so be sure that image updates are always sent
-    /// even in case of failures by sending transparent black image.
+    ///
+    /// Note: If this function returns `true`, script will wait for all images to be updated
+    /// before updating the rendering again. Be sure that image updates are always sent
+    /// even in the failure case by sending transparent black image or return `false` in the
+    /// case of failure.
     fn update_rendering(&self, _canvas_epoch: Epoch) -> bool {
         false
     }

--- a/components/script/dom/canvas/canvas_context.rs
+++ b/components/script/dom/canvas/canvas_context.rs
@@ -108,6 +108,9 @@ pub(crate) trait CanvasContext {
 
     /// Request that the [`CanvasContext`] update the rendering of its contents,
     /// returning `true` if new image was produced.
+    /// Note: If this function returns true, script will wait for all images to be updated
+    /// before calling next round of update the rendering, so be sure that image updates are always sent
+    /// even in case of failures by sending transparent black image.
     fn update_rendering(&self, _canvas_epoch: Epoch) -> bool {
         false
     }


### PR DESCRIPTION
I hit this many times while working on #38717

Testing: Not needed because we just update the docs
