### PR TITLE
Seperate freetype face and named instance indices

### DIFF
--- a/components/fonts/platform/freetype/android/font_list.rs
+++ b/components/fonts/platform/freetype/android/font_list.rs
@@ -432,7 +432,8 @@ where
     let mut produce_font = |font: &Font| {
         let local_font_identifier = LocalFontIdentifier {
             path: Atom::from(FontList::font_absolute_path(&font.filename)),
-            variation_index: 0,
+            face_index: 0,
+            named_instance_index: 0,
         };
         let stretch = StyleFontStretch::NORMAL;
         let weight = font

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -96,7 +96,11 @@ impl PlatformFontMethods for PlatformFont {
         let library = FreeTypeLibraryHandle::get().lock();
         let filename = CString::new(&*font_identifier.path).expect("filename contains NUL byte!");
 
-        let face = FreeTypeFace::new_from_file(&library, &filename, font_identifier.index())?;
+        let face = FreeTypeFace::new_from_file(
+            &library,
+            &filename,
+            font_identifier.face_index_for_freetype(),
+        )?;
 
         let normalized_variations = face.set_variations_for_font(variations, &library)?;
 

--- a/components/fonts/platform/freetype/font_list.rs
+++ b/components/fonts/platform/freetype/font_list.rs
@@ -123,7 +123,8 @@ where
 
             let local_font_identifier = LocalFontIdentifier {
                 path: Atom::from(c_str_to_string(path as *const c_char)),
-                variation_index: index as i32,
+                face_index: (index & 0xFFFF) as u16,
+                named_instance_index: (index >> 16) as u16,
             };
             let descriptor = FontTemplateDescriptor::new(weight, stretch, style);
 

--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -444,7 +444,8 @@ where
     let mut produce_font = |font: &Font| {
         let local_font_identifier = LocalFontIdentifier {
             path: Atom::from(font.filepath.clone()),
-            variation_index: 0,
+            face_index: 0,
+            named_instance_index: 0,
         };
         let stretch = font.width.into();
         let weight = font

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -186,7 +186,8 @@ mod font_context {
 
             let local_font_identifier = LocalFontIdentifier {
                 path: path.to_str().expect("Could not load test font").into(),
-                variation_index: 0,
+                face_index: 0,
+                named_instance_index: 0,
             };
             let handle = PlatformFont::new_from_local_font_identifier(
                 local_font_identifier.clone(),


### PR DESCRIPTION
In servo, each `LocalFontIdentifier` has an `fn index() -> u32`, which returns the index of the font within the font file in case it is a font collection (`.ttc` instead of `.ttf`). The way this index is obtained is platform-dependent.

On systems using `fontconfig`, we get the index by querying `FC_INDEX`:

https://github.com/servo/servo/blob/d2c78db981a508fab67f01ecb1a4eb90061c2e94/components/fonts/platform/freetype/font_list.rs#L109-L112

There is a sneaky bug here: In addition to the aforementioned face index, the value for `FC_INDEX` contains the index of the named instance of the face in the upper 16 bits. This behaviour is completely undocumented, but FreeType uses the same format: https://freetype.org/freetype2/docs/reference/ft2-face_creation.html#ft_open_face.

This wasn't a problem for the longest time, because the only consumer of the `index` value coming from fontconfig was FreeType. However, sometime after https://github.com/servo/servo/commit/29e618dcf779c424301c70c15270e8a7cda7aaa0, we started also passing it to`read-fonts` . `read-fonts` expects only the face index, causing it to return errors as seen in https://github.com/servo/servo/issues/39209.

The fix is to seperate the two indices when storing them in a `LocalFontDescriptor` and pass only the lower 16 bits to `read-fonts`. I'm unsure whether we should continue passing the named instance index to FreeType since we don't actually support variable fonts, but I've opted to keep the current behaviour for now.

Fixes: https://github.com/servo/servo/issues/39209

 