### PR TITLE
script: Remove three duplicated log functions from webgl

### DIFF
--- a/components/script/dom/webgl/validations/tex_image_2d.rs
+++ b/components/script/dom/webgl/validations/tex_image_2d.rs
@@ -85,10 +85,6 @@ impl fmt::Display for TexImageValidationError {
     }
 }
 
-fn log2(n: u32) -> u32 {
-    31 - n.leading_zeros()
-}
-
 pub(crate) struct CommonTexImage2DValidator<'a> {
     context: &'a WebGLRenderingContext,
     target: u32,
@@ -204,7 +200,7 @@ impl WebGLValidator for CommonTexImage2DValidator<'_> {
         // log_2(max), where max is the returned value of GL_MAX_TEXTURE_SIZE
         // when target is GL_TEXTURE_2D or GL_MAX_CUBE_MAP_TEXTURE_SIZE when
         // target is not GL_TEXTURE_2D.
-        if level > log2(max_size) {
+        if level > max_size.ilog2() {
             self.context.webgl_error(InvalidValue);
             return Err(TexImageValidationError::LevelTooHigh);
         }
@@ -772,7 +768,7 @@ impl WebGLValidator for TexStorageValidator<'_> {
             return Err(TexImageValidationError::InvalidTextureFormat);
         }
 
-        let max_level = log2(cmp::max(width, height)) + 1;
+        let max_level = cmp::max(width, height).ilog2() + 1;
         if level > max_level {
             context.webgl_error(InvalidOperation);
             return Err(TexImageValidationError::LevelTooHigh);

--- a/components/script/dom/webgl/validations/tex_image_3d.rs
+++ b/components/script/dom/webgl/validations/tex_image_3d.rs
@@ -14,10 +14,6 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::webgl::webglrenderingcontext::WebGLRenderingContext;
 use crate::dom::webgl::webgltexture::WebGLTexture;
 
-fn log2(n: u32) -> u32 {
-    31 - n.leading_zeros()
-}
-
 pub(crate) struct CommonTexImage3DValidator<'a> {
     context: &'a WebGLRenderingContext,
     target: u32,
@@ -107,7 +103,7 @@ impl WebGLValidator for CommonTexImage3DValidator<'_> {
             self.context.webgl_error(InvalidValue);
             return Err(TexImageValidationError::NegativeLevel);
         }
-        if level > log2(max_size) {
+        if level > max_size.ilog2() {
             self.context.webgl_error(InvalidValue);
             return Err(TexImageValidationError::LevelTooHigh);
         }

--- a/components/script/dom/webgl/webglframebuffer.rs
+++ b/components/script/dom/webgl/webglframebuffer.rs
@@ -37,10 +37,6 @@ pub(crate) enum CompleteForRendering {
     MissingColorAttachment,
 }
 
-fn log2(n: u32) -> u32 {
-    31 - n.leading_zeros()
-}
-
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 enum WebGLFramebufferAttachment {
@@ -786,7 +782,7 @@ impl WebGLFramebuffer {
             } else {
                 context.limits().max_tex_size
             };
-            if level < 0 || level as u32 > log2(max_tex_size) {
+            if level < 0 || level as u32 > max_tex_size.ilog2() {
                 return Err(WebGLError::InvalidValue);
             }
         }
@@ -856,11 +852,11 @@ impl WebGLFramebuffer {
             Some(texture) => {
                 let (max_level, max_layer) = match texture.target() {
                     Some(constants::TEXTURE_3D) => (
-                        log2(context.limits().max_3d_texture_size),
+                        context.limits().max_3d_texture_size.ilog2(),
                         context.limits().max_3d_texture_size - 1,
                     ),
                     Some(constants::TEXTURE_2D) => (
-                        log2(context.limits().max_tex_size),
+                        context.limits().max_tex_size.ilog2(),
                         context.limits().max_array_texture_layers - 1,
                     ),
                     _ => return Err(WebGLError::InvalidOperation),


### PR DESCRIPTION
We have the standard library at our disposal, let's use it.

Testing: Covered by existing tests

