### PR TITLE
layout: Set baseline even if line box has no fragment

### DIFF
--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -986,17 +986,17 @@ impl InlineFormattingContextLayout<'_> {
             justification_adjustment,
         );
 
+        if line_to_layout.has_content {
+            let baseline = baseline_offset + block_start_position;
+            self.baselines.first.get_or_insert(baseline);
+            self.baselines.last = Some(baseline);
+        }
+
         // If the line doesn't have any fragments, we don't need to add a containing fragment for it.
         if fragments.is_empty() &&
             self.positioning_context.len() == start_positioning_context_length
         {
             return;
-        }
-
-        if line_to_layout.has_content {
-            let baseline = baseline_offset + block_start_position;
-            self.baselines.first.get_or_insert(baseline);
-            self.baselines.last = Some(baseline);
         }
 
         // The inline part of this start offset was taken into account when determining

--- a/tests/wpt/tests/css/CSS2/visudet/inline-block-baseline-016.html
+++ b/tests/wpt/tests/css/CSS2/visudet/inline-block-baseline-016.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<title>Vertical-align: baseline of inline-block with only forced line break</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css2/#leading">
+<link rel="help" href="https://drafts.csswg.org/css2/#inline-formatting">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="
+  From https://drafts.csswg.org/css2/#leading
+  > The baseline of an inline-block is the baseline of its last line box in the normal flow,
+  > unless it has either no in-flow line boxes or if its overflow property has a computed
+  > value other than visible, in which case the baseline is the bottom margin edge.
+
+  Here we have 2 inline-blocks. The 1st one is has some zero-sized text, so its baseline is
+  at its top content edge. The 2nd one only has a preserved line break.
+
+  From https://drafts.csswg.org/css2/#inline-formatting
+  > Line boxes that contain no text, no preserved white space, no inline elements with
+  > non-zero margins, padding, or borders, and no other in-flow content (such as images,
+  > inline blocks or inline tables), and do not end with a preserved newline must be
+  > treated as zero-height line boxes for the purposes of determining the positions of
+  > any elements inside of them, and must be treated as not existing for any other purpose.
+
+  The forced line break prevents the line box from being phantom, so the baseline of the
+  2nd inline-block is also at its top content edge. If it weren't for the forced line break,
+  the line would be phanthom and then the baseline would be at the bottom margin edge.
+
+  Therefore, the inline-blocks should have their top content edges aligned.
+">
+
+<style>
+.wrapper {
+  width: 200px;
+  font-size: 0;
+  line-height: 0;
+  background: red;
+}
+.inline-block {
+  display: inline-block;
+  width: 100px;
+  height: 200px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div class="wrapper">
+  <div class="inline-block">text</div>
+  <div class="inline-block" style="white-space: pre">&#10;</div>
+</div>


### PR DESCRIPTION
`InlineFormattingContextLayout::finish_current_line_and_reset()` has an early return in case the line has no fragment. However, if the line only has a forced line break, then we still need to set the baseline.

Testing: Adding new test.
