### PR TITLE
webdriver: Focus WebView asynchronously

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -131,10 +131,10 @@ use devtools_traits::{
 use embedder_traits::resources::{self, Resource};
 use embedder_traits::user_content_manager::UserContentManager;
 use embedder_traits::{
-    AnimationState, CompositorHitTestResult, EmbedderMsg, EmbedderProxy, FocusId,
-    FocusSequenceNumber, InputEvent, JSValue, JavaScriptEvaluationError, JavaScriptEvaluationId,
-    KeyboardEvent, MediaSessionActionType, MediaSessionEvent, MediaSessionPlaybackState,
-    MouseButton, MouseButtonAction, MouseButtonEvent, ScriptToEmbedderChan, Theme, ViewportDetails,
+    AnimationState, CompositorHitTestResult, EmbedderMsg, EmbedderProxy, FocusSequenceNumber,
+    InputEvent, JSValue, JavaScriptEvaluationError, JavaScriptEvaluationId, KeyboardEvent,
+    MediaSessionActionType, MediaSessionEvent, MediaSessionPlaybackState, MouseButton,
+    MouseButtonAction, MouseButtonEvent, ScriptToEmbedderChan, Theme, ViewportDetails,
     WebDriverCommandMsg, WebDriverCommandResponse, WebDriverLoadStatus, WebDriverScriptCommand,
 };
 use euclid::Size2D;
@@ -1432,8 +1432,8 @@ where
                 }
                 self.handle_panic(webview_id, error, None);
             },
-            EmbedderToConstellationMessage::FocusWebView(webview_id, focus_id) => {
-                self.handle_focus_web_view(webview_id, focus_id);
+            EmbedderToConstellationMessage::FocusWebView(webview_id) => {
+                self.handle_focus_web_view(webview_id);
             },
             EmbedderToConstellationMessage::BlurWebView => {
                 self.webviews.unfocus();
@@ -2871,13 +2871,13 @@ where
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn handle_focus_web_view(&mut self, webview_id: WebViewId, focus_id: FocusId) {
+    fn handle_focus_web_view(&mut self, webview_id: WebViewId) {
         let focused = self.webviews.focus(webview_id).is_ok();
         if !focused {
             warn!("{webview_id}: FocusWebView on unknown top-level browsing context");
         }
         self.embedder_proxy
-            .send(EmbedderMsg::WebViewFocused(webview_id, focus_id, focused));
+            .send(EmbedderMsg::WebViewFocused(webview_id, focused));
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -4235,11 +4235,8 @@ where
 
         // Focus the top-level browsing context.
         let focused = self.webviews.focus(webview_id);
-        self.embedder_proxy.send(EmbedderMsg::WebViewFocused(
-            webview_id,
-            FocusId::new(),
-            focused.is_ok(),
-        ));
+        self.embedder_proxy
+            .send(EmbedderMsg::WebViewFocused(webview_id, focused.is_ok()));
 
         // If a container with a non-null nested browsing context is focused,
         // the nested browsing context's active document becomes the focused

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -738,7 +738,7 @@ impl Servo {
                     webview.delegate().notify_closed(webview);
                 }
             },
-            EmbedderMsg::WebViewFocused(webview_id, focus_id, focus_result) => {
+            EmbedderMsg::WebViewFocused(webview_id, focus_result) => {
                 if focus_result {
                     for id in self.webviews.borrow().keys() {
                         if let Some(webview) = self.get_webview_handle(*id) {
@@ -746,9 +746,6 @@ impl Servo {
                             webview.set_focused(focused);
                         }
                     }
-                }
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview.complete_focus(focus_id);
                 }
             },
             EmbedderMsg::WebViewBlurred => {

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -13,7 +13,7 @@ use compositing_traits::WebViewTrait;
 use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use dpi::PhysicalSize;
 use embedder_traits::{
-    Cursor, FocusId, Image, InputEvent, JSValue, JavaScriptEvaluationError, LoadStatus,
+    Cursor, Image, InputEvent, JSValue, JavaScriptEvaluationError, LoadStatus,
     MediaSessionActionType, ScreenGeometry, Theme, TraversalId, ViewportDetails,
 };
 use euclid::{Point2D, Scale, Size2D};
@@ -287,10 +287,6 @@ impl WebView {
         self.delegate().notify_focus_changed(self, new_value);
     }
 
-    pub(crate) fn complete_focus(self, focus_id: FocusId) {
-        self.delegate().notify_focus_complete(self, focus_id);
-    }
-
     pub fn cursor(&self) -> Cursor {
         self.inner().cursor
     }
@@ -303,15 +299,10 @@ impl WebView {
         self.delegate().notify_cursor_changed(self, new_value);
     }
 
-    pub fn focus(&self) -> FocusId {
-        let focus_id = FocusId::new();
+    pub fn focus(&self) {
         self.inner()
             .constellation_proxy
-            .send(EmbedderToConstellationMessage::FocusWebView(
-                self.id(),
-                focus_id.clone(),
-            ));
-        focus_id
+            .send(EmbedderToConstellationMessage::FocusWebView(self.id()));
     }
 
     pub fn blur(&self) {
@@ -413,10 +404,9 @@ impl WebView {
             .expect("BUG: invalid WebView instance");
     }
 
-    pub fn focus_and_raise_to_top(&self, hide_others: bool) -> FocusId {
-        let focus_id = self.focus();
+    pub fn focus_and_raise_to_top(&self, hide_others: bool) {
+        self.focus();
         self.raise_to_top(hide_others);
-        focus_id
     }
 
     pub fn notify_theme_change(&self, theme: Theme) {

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -8,7 +8,7 @@ use base::generic_channel::{GenericSender, SendResult};
 use base::id::PipelineId;
 use constellation_traits::EmbedderToConstellationMessage;
 use embedder_traits::{
-    AllowOrDeny, AuthenticationResponse, ContextMenuResult, Cursor, FilterPattern, FocusId,
+    AllowOrDeny, AuthenticationResponse, ContextMenuResult, Cursor, FilterPattern,
     GamepadHapticEffectType, InputMethodType, KeyboardEvent, LoadStatus, MediaSessionEvent,
     Notification, PermissionFeature, RgbColor, ScreenGeometry, SelectElementOptionOrOptgroup,
     SimpleDialog, TraversalId, WebResourceRequest, WebResourceResponse, WebResourceResponseMsg,
@@ -419,9 +419,6 @@ pub trait WebViewDelegate {
     /// This [`WebView`] has either become focused or lost focus. Whether or not the
     /// [`WebView`] is focused can be accessed via [`WebView::focused`].
     fn notify_focus_changed(&self, _webview: WebView, _focused: bool) {}
-    /// A focus operation that was initiated by this webview has completed.
-    /// The current focus status of this [`WebView`] can be accessed via [`WebView::focused`].
-    fn notify_focus_complete(&self, _webview: WebView, _focus_id: FocusId) {}
     /// This [`WebView`] has either started to animate or stopped animating. When a
     /// [`WebView`] is animating, it is up to the embedding application ensure that
     /// `Servo::spin_event_loop` is called at regular intervals in order to update the

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -19,8 +19,8 @@ use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{MessagePortId, PipelineId, WebViewId};
 use embedder_traits::{
-    CompositorHitTestResult, FocusId, InputEvent, JavaScriptEvaluationId, MediaSessionActionType,
-    Theme, TraversalId, ViewportDetails, WebDriverCommandMsg, WebDriverCommandResponse,
+    CompositorHitTestResult, InputEvent, JavaScriptEvaluationId, MediaSessionActionType, Theme,
+    TraversalId, ViewportDetails, WebDriverCommandMsg, WebDriverCommandResponse,
 };
 use fnv::FnvHashMap;
 pub use from_script_message::*;
@@ -76,7 +76,7 @@ pub enum EmbedderToConstellationMessage {
     SendError(Option<WebViewId>, String),
     /// Make a webview focused. [EmbedderMsg::WebViewFocused] will be sent with
     /// the result of this operation.
-    FocusWebView(WebViewId, FocusId),
+    FocusWebView(WebViewId),
     /// Make none of the webviews focused.
     BlurWebView,
     /// Forward an input event to an appropriate ScriptTask.

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -338,17 +338,6 @@ pub struct ScreenMetrics {
     pub available_size: DeviceIndependentIntSize,
 }
 
-/// An opaque identifier for a single webview focus operation.
-#[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct FocusId(String);
-
-impl FocusId {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        Self(Uuid::new_v4().to_string())
-    }
-}
-
 /// An opaque identifier for a single history traversal operation.
 #[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct TraversalId(String);
@@ -448,7 +437,7 @@ pub enum EmbedderMsg {
     /// A webview potentially gained focus for keyboard events, as initiated
     /// by the provided focus id. If the boolean value is false, the webiew
     /// could not be focused.
-    WebViewFocused(WebViewId, FocusId, bool),
+    WebViewFocused(WebViewId, bool),
     /// All webviews lost focus for keyboard events.
     WebViewBlurred,
     /// Wether or not to unload a document

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -434,9 +434,8 @@ pub enum EmbedderMsg {
     ),
     /// A webview was destroyed.
     WebViewClosed(WebViewId),
-    /// A webview potentially gained focus for keyboard events, as initiated
-    /// by the provided focus id. If the boolean value is false, the webiew
-    /// could not be focused.
+    /// A webview potentially gained focus for keyboard events.
+    /// If the boolean value is false, the webiew could not be focused.
     WebViewFocused(WebViewId, bool),
     /// All webviews lost focus for keyboard events.
     WebViewBlurred,

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -155,7 +155,6 @@ pub enum WebDriverCommandMsg {
     /// Close the webview associated with the provided id.
     CloseWebView(WebViewId, IpcSender<()>),
     /// Focus the webview associated with the provided id.
-    /// Sends back a bool indicating whether the focus was successfully set.
     FocusWebView(WebViewId),
     /// Get focused webview. For now, this is only used when start new session.
     GetFocusedWebView(IpcSender<Option<WebViewId>>),

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -22,7 +22,7 @@ use style_traits::CSSPixel;
 use webdriver::error::ErrorStatus;
 use webrender_api::units::DevicePixel;
 
-use crate::{FocusId, JSValue, MouseButton, MouseButtonAction, TraversalId};
+use crate::{JSValue, MouseButton, MouseButtonAction, TraversalId};
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct WebDriverMessageId(pub usize);
@@ -156,7 +156,7 @@ pub enum WebDriverCommandMsg {
     CloseWebView(WebViewId, IpcSender<()>),
     /// Focus the webview associated with the provided id.
     /// Sends back a bool indicating whether the focus was successfully set.
-    FocusWebView(WebViewId, IpcSender<bool>),
+    FocusWebView(WebViewId),
     /// Get focused webview. For now, this is only used when start new session.
     GetFocusedWebView(IpcSender<Option<WebViewId>>),
     /// Get webviews state
@@ -298,5 +298,4 @@ pub struct WebDriverSenders {
     pub load_status_senders: HashMap<WebViewId, GenericSender<WebDriverLoadStatus>>,
     pub script_evaluation_interrupt_sender: Option<IpcSender<WebDriverJSResult>>,
     pub pending_traversals: HashMap<TraversalId, GenericSender<WebDriverLoadStatus>>,
-    pub pending_focus: HashMap<FocusId, IpcSender<bool>>,
 }

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2515,15 +2515,8 @@ impl Handler {
         }
     }
 
-    fn focus_webview(&self, webview_id: WebViewId) -> Result<(), WebDriverError> {
-        let (sender, receiver) = ipc::channel().unwrap();
-        self.send_message_to_embedder(WebDriverCommandMsg::FocusWebView(webview_id, sender))?;
-        if wait_for_ipc_response(receiver)? {
-            debug!("Focus new webview {webview_id} successfully");
-        } else {
-            debug!("Focus new webview failed, it may not exist anymore");
-        }
-        Ok(())
+    fn focus_webview(&self, webview_id: WebViewId) -> WebDriverResult<()> {
+        self.send_message_to_embedder(WebDriverCommandMsg::FocusWebView(webview_id))
     }
 
     fn focus_browsing_context(&self, browsing_cotext_id: BrowsingContextId) -> WebDriverResult<()> {

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -381,10 +381,9 @@ impl App {
                         warn!("Failed to send response of CloseWebView: {error}");
                     }
                 },
-                WebDriverCommandMsg::FocusWebView(webview_id, response_sender) => {
+                WebDriverCommandMsg::FocusWebView(webview_id) => {
                     if let Some(webview) = running_state.webview_by_id(webview_id) {
-                        let focus_id = webview.focus_and_raise_to_top(true);
-                        running_state.set_pending_focus(focus_id, response_sender);
+                        webview.focus_and_raise_to_top(true);
                     }
                 },
                 WebDriverCommandMsg::FocusBrowsingContext(..) => {

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -21,10 +21,10 @@ use servo::ipc_channel::ipc::IpcSender;
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 use servo::{
-    AllowOrDenyRequest, AuthenticationRequest, FilterPattern, FocusId, FormControl,
-    GamepadHapticEffectType, JSValue, KeyboardEvent, LoadStatus, PermissionRequest, Servo,
-    ServoDelegate, ServoError, SimpleDialog, TraversalId, WebDriverCommandMsg, WebDriverJSResult,
-    WebDriverLoadStatus, WebDriverUserPrompt, WebView, WebViewBuilder, WebViewDelegate,
+    AllowOrDenyRequest, AuthenticationRequest, FilterPattern, FormControl, GamepadHapticEffectType,
+    JSValue, KeyboardEvent, LoadStatus, PermissionRequest, Servo, ServoDelegate, ServoError,
+    SimpleDialog, TraversalId, WebDriverCommandMsg, WebDriverJSResult, WebDriverLoadStatus,
+    WebDriverUserPrompt, WebView, WebViewBuilder, WebViewDelegate,
 };
 use url::Url;
 
@@ -466,13 +466,6 @@ impl RunningAppState {
             });
     }
 
-    pub(crate) fn set_pending_focus(&self, focus_id: FocusId, sender: IpcSender<bool>) {
-        self.webdriver_senders
-            .borrow_mut()
-            .pending_focus
-            .insert(focus_id, sender);
-    }
-
     pub(crate) fn set_pending_traversal(
         &self,
         traversal_id: TraversalId,
@@ -666,14 +659,6 @@ impl WebViewDelegate for RunningAppState {
 
     fn notify_closed(&self, webview: servo::WebView) {
         self.close_webview(webview.id());
-    }
-
-    fn notify_focus_complete(&self, webview: servo::WebView, focus_id: FocusId) {
-        let mut webdriver_state = self.webdriver_senders.borrow_mut();
-        if let Entry::Occupied(entry) = webdriver_state.pending_focus.entry(focus_id) {
-            let sender = entry.remove();
-            let _ = sender.send(webview.focused());
-        }
     }
 
     fn notify_focus_changed(&self, webview: servo::WebView, focused: bool) {

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -24,10 +24,10 @@ use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntRect, DeviceIntSize, DevicePixel};
 use servo::{
-    AllowOrDenyRequest, FocusId, ImeEvent, InputEvent, LoadStatus, MouseButtonEvent,
-    MouseMoveEvent, NavigationRequest, PermissionRequest, RenderingContext, Servo, ServoDelegate,
-    ServoError, SimpleDialog, TraversalId, WebDriverCommandMsg, WebDriverLoadStatus,
-    WebDriverScriptCommand, WebView, WebViewBuilder, WebViewDelegate, WindowRenderingContext,
+    AllowOrDenyRequest, ImeEvent, InputEvent, LoadStatus, MouseButtonEvent, MouseMoveEvent,
+    NavigationRequest, PermissionRequest, RenderingContext, Servo, ServoDelegate, ServoError,
+    SimpleDialog, TraversalId, WebDriverCommandMsg, WebDriverLoadStatus, WebDriverScriptCommand,
+    WebView, WebViewBuilder, WebViewDelegate, WindowRenderingContext,
 };
 use url::Url;
 
@@ -625,7 +625,7 @@ impl RunningAppState {
                     WebDriverCommandMsg::CloseWebView(webview_id, response_sender) => {
                         info!("(Not Implemented) Closing webview {}", webview_id);
                     },
-                    WebDriverCommandMsg::FocusWebView(webview_id, response_sender) => {
+                    WebDriverCommandMsg::FocusWebView(webview_id) => {
                         if let Some(webview) = self.webview_by_id(webview_id) {
                             let focus_id = webview.focus();
                             info!("Successfully focused webview {}", webview_id);

--- a/tests/wpt/meta/webdriver/tests/classic/send_alert_text/send.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/send_alert_text/send.py.ini
@@ -15,4 +15,4 @@
     expected: FAIL
 
   [test_chained_alert_element_not_interactable[confirm\]]
-    expected: FAIL
+    expected: [PASS, FAIL]


### PR DESCRIPTION
#38160 added a webdriver-specific API to support waiting on focus operations to complete. Later, #38243 added a unique id to track each focus operation. 

Back then we wait on focusing webview in webdriver hoping to improve stability, but it does not matter as it turns out later. #39086 also focuses browsing context asynchronously.

This PR would make webdriver's focusing-webview behaviour same as human interaction.

Testing: 
[Before 1](https://github.com/yezhizhen/servo/actions/runs/17598288280), [Before 2](https://github.com/yezhizhen/servo/actions/runs/17598289360), [Before 3](https://github.com/yezhizhen/servo/actions/runs/17598290532)
[After 1](https://github.com/yezhizhen/servo/actions/runs/17598282988), [After 2](https://github.com/yezhizhen/servo/actions/runs/17598280603), [After 3](https://github.com/yezhizhen/servo/actions/runs/17589228530)
