### PR TITLE
net: Add spec comments to "cors_preflight_fetch"

### DIFF
--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -878,8 +878,8 @@ fn validate_range_header(value: &str) -> bool {
 }
 
 /// <https://fetch.spec.whatwg.org/#cors-safelisted-method>
-pub fn is_cors_safelisted_method(m: &Method) -> bool {
-    matches!(*m, Method::GET | Method::HEAD | Method::POST)
+pub fn is_cors_safelisted_method(method: &Method) -> bool {
+    matches!(*method, Method::GET | Method::HEAD | Method::POST)
 }
 
 /// <https://fetch.spec.whatwg.org/#cors-non-wildcard-request-header-name>


### PR DESCRIPTION
I added these comments while debugging `cors/request-headers.htm`. Ultimately the bug turned out to be outside of servo, so we have to wait for https://github.com/hyperium/headers/pull/219. 
Since that PR might take a while to merge I'd like to add these on their own.

