### PR TITLE
script: Set validation anchor to target element in `ElementInternals::SetValidity` when anchor is not given

### DIFF
--- a/tests/wpt/meta/custom-elements/form-associated/ElementInternals-validation.html.ini
+++ b/tests/wpt/meta/custom-elements/form-associated/ElementInternals-validation.html.ini
@@ -1,6 +1,3 @@
 [ElementInternals-validation.html]
   [Custom control affects :valid :invalid for FORM and FIELDSET]
     expected: FAIL
-
-  ["anchor" argument of setValidity(): passing self]
-    expected: FAIL

--- a/tests/wpt/meta/custom-elements/form-associated/form-disabled-callback.html.ini
+++ b/tests/wpt/meta/custom-elements/form-associated/form-disabled-callback.html.ini
@@ -1,3 +1,0 @@
-[form-disabled-callback.html]
-  [A disabled form-associated custom element should not submit an entry for it]
-    expected: FAIL


### PR DESCRIPTION


Testing: Covered by existing web platform tests

