### PR TITLE
Fix window title stuck on last opened webview

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -234,7 +234,9 @@ impl App {
                 need_window_redraw,
             } => {
                 let updated = match (update, &mut self.minibrowser) {
-                    (true, Some(minibrowser)) => minibrowser.update_webview_data(state),
+                    (true, Some(minibrowser)) => {
+                        minibrowser.update_webview_data(state, window.clone())
+                    },
                     _ => false,
                 };
 

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -34,6 +34,7 @@ use super::egui_glue::EguiGlow;
 use super::events_loop::EventLoopProxy;
 use super::geometry::winit_position_to_euclid_point;
 use super::headed_window::Window as ServoWindow;
+use crate::desktop::headed_window::INITIAL_WINDOW_TITLE;
 use crate::desktop::window_trait::WindowPortsMethods;
 use crate::prefs::{EXPERIMENTAL_PREFS, ServoShellPreferences};
 
@@ -545,16 +546,40 @@ impl Minibrowser {
         old_status != self.status_text
     }
 
+    fn update_title(
+        &mut self,
+        state: &RunningAppState,
+        window: Rc<dyn WindowPortsMethods>,
+    ) -> bool {
+        if let Some(webview) = state.focused_webview() {
+            let title = webview
+                .page_title()
+                .filter(|title| !title.is_empty())
+                .map(|title| title.to_string())
+                .or_else(|| webview.url().map(|url| url.to_string()))
+                .unwrap_or_else(|| INITIAL_WINDOW_TITLE.to_string());
+
+            window.set_title_if_changed(&title)
+        } else {
+            false
+        }
+    }
+
     /// Updates all fields taken from the given [WebViewManager], such as the location field.
     /// Returns true iff the egui needs an update.
-    pub fn update_webview_data(&mut self, state: &RunningAppState) -> bool {
+    pub fn update_webview_data(
+        &mut self,
+        state: &RunningAppState,
+        window: Rc<dyn WindowPortsMethods>,
+    ) -> bool {
         // Note: We must use the "bitwise OR" (|) operator here instead of "logical OR" (||)
         //       because logical OR would short-circuit if any of the functions return true.
         //       We want to ensure that all functions are called. The "bitwise OR" operator
         //       does not short-circuit.
         self.update_location_in_toolbar(state) |
             self.update_load_status(state) |
-            self.update_status_text(state)
+            self.update_status_text(state) |
+            self.update_title(state, window)
     }
 
     /// Returns true if a redraw is required after handling the provided event.

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -35,6 +35,9 @@ pub trait WindowPortsMethods {
     fn get_fullscreen(&self) -> bool;
     fn handle_winit_event(&self, state: Rc<RunningAppState>, event: winit::event::WindowEvent);
     fn set_title(&self, _title: &str) {}
+    fn set_title_if_changed(&self, _title: &str) -> bool {
+        false
+    }
     /// Request a new outer size for the window, including external decorations.
     /// This should be the same as `window.outerWidth` and `window.outerHeight``
     fn request_resize(&self, webview: &WebView, outer_size: DeviceIntSize)


### PR DESCRIPTION
Testing: tested manually switching between tabs and check if title changes.
Fixes: #39256
