### PR TITLE
html: Ignore a parse error on 'srcset' attribute parsing

### DIFF
--- a/tests/wpt/meta/html/semantics/embedded-content/the-img-element/srcset/parse-a-srcset-attribute.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-img-element/srcset/parse-a-srcset-attribute.html.ini
@@ -1,13 +1,4 @@
 [parse-a-srcset-attribute.html]
-  ["data:,a,, , "]
-    expected: FAIL
-
-  [",,,data:,a"]
-    expected: FAIL
-
-  [" , ,,data:,a"]
-    expected: FAIL
-
   ["data:,a 1.0w"]
     expected: FAIL
 


### PR DESCRIPTION
Parsing the 'srcset' attribute of an image element may result in a parse error
indicating a non-fatal mismatch between the input and the requirements.
https://html.spec.whatwg.org/multipage/#concept-microsyntax-parse-error
https://html.spec.whatwg.org/multipage/#parse-a-srcset-attribute

This error should not be a reason to stop parsing and may be used by the user agent to signal a syntax error.

Other browsers generally ignore this error, and we do the same.

Testing: Improvements in the following tests
- html/semantics/embedded-content/the-img-element/srcset/parse-a-srcset-attribute.html