### PR TITLE
ci: Reland run devtools tests whenever we run unit tests from #38614

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -194,6 +194,9 @@ jobs:
           timeout_minutes: 20
           max_attempts: 2 # https://github.com/servo/servo/issues/30683
           command: ./mach test-unit --${{ inputs.profile }}
+      - name: Devtools tests
+        if: ${{ inputs.unit-tests }}
+        run: ./mach test-devtools --${{ inputs.profile }}
       - name: Archive build timing
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -174,6 +174,9 @@ jobs:
           timeout_minutes: 40 # https://github.com/servo/servo/issues/30275
           max_attempts: 3 # https://github.com/servo/servo/issues/30683
           command: ./mach test-unit --${{ inputs.profile }}
+      - name: Devtools tests
+        if: ${{ inputs.unit-tests }}
+        run: ./mach test-devtools --${{ inputs.profile }}
       - name: Build mach package
         run: ./mach package --${{ inputs.profile }}
       - name: Run DMG smoketest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -187,6 +187,9 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3 # https://github.com/servo/servo/issues/30683
           command: .\mach test-unit --${{ inputs.profile }} -- -- --test-threads=1
+      - name: Devtools tests
+        if: ${{ inputs.unit-tests }}
+        run: .\mach test-devtools --${{ inputs.profile }}
       - name: Archive build timing
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This patch updates `linux.yml`, `mac.yml`, and `windows.yml` to run the devtools test suite (https://github.com/servo/servo/issues/36325).


Testing: this patch effectively adds all devtools tests to CI
Fixes: https://github.com/servo/servo/issues/36325