### PR TITLE
ci: Make runner timeout jobs conditional, not the steps

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -111,6 +111,7 @@ jobs:
   runner-timeout:
     needs:
       - runner-select
+    if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -119,7 +120,6 @@ jobs:
           sparse-checkout: '.github'
       - name: Runner timeout
         uses: ./.github/actions/runner-timeout
-        if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           unique-id: '${{ needs.runner-select.outputs.unique-id }}'

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -94,6 +94,7 @@ jobs:
   runner-timeout:
     needs:
       - runner-select
+    if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -102,7 +103,6 @@ jobs:
           sparse-checkout: '.github'
       - name: Runner timeout
         uses: ./.github/actions/runner-timeout
-        if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           unique-id: '${{ needs.runner-select.outputs.unique-id }}'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,6 +85,7 @@ jobs:
   runner-timeout:
     needs:
       - runner-select
+    if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -93,7 +94,6 @@ jobs:
           sparse-checkout: '.github'
       - name: Runner timeout
         uses: ./.github/actions/runner-timeout
-        if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           unique-id: '${{ needs.runner-select.outputs.unique-id }}'


### PR DESCRIPTION
#38503 converted the self-hosted runner timeout from a [reusable workflow](https://docs.github.com/en/actions/concepts/workflows-and-actions/reusable-workflows) to a [composite action](https://docs.github.com/en/actions/tutorials/create-actions/create-a-composite-action), but in doing so, it changed from having a conditional job to having a conditional step. [This Update Broke My Workflow](https://xkcd.com/1172/), because i enjoyed being able to tell if a job ended up being GitHub-hosted or not by seeing if its timeout job was skipped, rather than having to click on the workload job then wait then scroll up then click “Set up job”.

this patch fixes that by making the job conditional.

Testing:
- self-hosted <https://github.com/servo/servo/actions/runs/17674214808/job/50232483209>
- GitHub-hosted <https://github.com/delan/servo/actions/runs/17674531369/job/50233465791>

Fixes: #39192
