### PR TITLE
ci: Stop using `python3 ./mach`

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -qy --no-install-recommends mesa-vulkan-drivers
-          python3 ./mach bootstrap --skip-lints
+          ./mach bootstrap --skip-lints
       - uses: bencherdev/bencher@main
       - name: File size
         if: ${{ inputs.file-size == true }}
@@ -101,12 +101,12 @@ jobs:
       - name: Speedometer
         if: ${{ inputs.speedometer == true }}
         run: |
-            python3 ./mach test-speedometer -r --bmf-output speedometer.json
+            ./mach test-speedometer -r --bmf-output speedometer.json
             echo "SERVO_SPEEDOMETER_RESULT=speedometer.json" >> "$GITHUB_ENV"
       - name: Dromaeo
         if: ${{ inputs.dromaeo == true }}
         run: |
-            python3 ./mach test-dromaeo -r dom --bmf-output dromaeo.json
+            ./mach test-dromaeo -r dom --bmf-output dromaeo.json
             echo "SERVO_DROMAEO_RESULT=dromaeo.json" >> "$GITHUB_ENV"
       # set options
       - name: Set bencher opts for PRs (label try run)

--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -289,7 +289,7 @@ jobs:
         continue-on-error: true
       - name: Run speedometer
         id: BencherRun
-        run: python3 ./mach test-speedometer-ohos --bmf-output speedometer.json --profile ${{ inputs.profile }}
+        run: ./mach test-speedometer-ohos --bmf-output speedometer.json --profile ${{ inputs.profile }}
         continue-on-error: true
       - name: Create empty speedometer.json if failed
         run: touch speedometer.json


### PR DESCRIPTION
this way of invoking mach is incorrect now that we use uv, and it will prevent us from running bencher builds on self-hosted runners (#39269), where the system Python is too old (3.10 vs 3.11).

Testing:
- mach try bencher <https://github.com/servo/servo/actions/runs/17675086579>

Fixes: part of #39269
