### PR TITLE
indexeddb: Don't drop sender when registering txn if database doesn't exist

### DIFF
--- a/components/net/indexeddb/idb_thread.rs
+++ b/components/net/indexeddb/idb_thread.rs
@@ -432,7 +432,9 @@ impl IndexedDBManager {
             SyncOperation::RegisterNewTxn(sender, origin, db_name) => {
                 if let Some(db) = self.get_database_mut(origin, db_name) {
                     db.serial_number_counter += 1;
-                    let _ = sender.send(db.serial_number_counter);
+                    let _ = sender.send(Ok(db.serial_number_counter));
+                } else {
+                    let _ = sender.send(Err(BackendError::DbNotFound));
                 }
             },
             SyncOperation::Exit(sender) => {

--- a/components/script/dom/idbtransaction.rs
+++ b/components/script/dom/idbtransaction.rs
@@ -114,7 +114,7 @@ impl IDBTransaction {
             )))
             .unwrap();
 
-        receiver.recv().unwrap()
+        receiver.recv().unwrap().unwrap()
     }
 
     // Runs the transaction and waits for it to finish

--- a/components/shared/net/indexeddb_thread.rs
+++ b/components/shared/net/indexeddb_thread.rs
@@ -410,7 +410,7 @@ pub enum SyncOperation {
     /// Returns an unique identifier that is used to be able to
     /// commit/abort transactions.
     RegisterNewTxn(
-        IpcSender<u64>,
+        IpcSender<BackendResult<u64>>,
         ImmutableOrigin,
         String, // Database
     ),


### PR DESCRIPTION
Why a database that doesn't exist is being passed in as a parameter needs to be investigated.

Testing: WPT
Fixes: #39254
