### PR TITLE
Remove the `dom_trusted_types_enabled` preference

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -145,7 +145,6 @@ pub struct Preferences {
     pub dom_testperf_enabled: bool,
     // https://testutils.spec.whatwg.org#availability
     pub dom_testutils_enabled: bool,
-    pub dom_trusted_types_enabled: bool,
     pub dom_xpath_enabled: bool,
     /// Enable WebGL2 APIs.
     pub dom_webgl2_enabled: bool,
@@ -325,7 +324,6 @@ impl Preferences {
             dom_testing_html_input_element_select_files_enabled: false,
             dom_testperf_enabled: false,
             dom_testutils_enabled: false,
-            dom_trusted_types_enabled: false,
             dom_webgl2_enabled: false,
             dom_webgpu_enabled: false,
             dom_webgpu_wgpu_backend: String::new(),

--- a/components/script_bindings/webidls/TrustedHTML.webidl
+++ b/components/script_bindings/webidls/TrustedHTML.webidl
@@ -6,7 +6,7 @@
  * https://www.w3.org/TR/trusted-types/#trusted-html
  */
 
-[Exposed=(Window,Worker), Pref="dom_trusted_types_enabled"]
+[Exposed=(Window,Worker)]
 interface TrustedHTML {
   stringifier;
   DOMString toJSON();

--- a/components/script_bindings/webidls/TrustedScript.webidl
+++ b/components/script_bindings/webidls/TrustedScript.webidl
@@ -6,7 +6,7 @@
  * https://www.w3.org/TR/trusted-types/#trusted-script
  */
 
-[Exposed=(Window,Worker), Pref="dom_trusted_types_enabled"]
+[Exposed=(Window,Worker)]
 interface TrustedScript {
   stringifier;
   DOMString toJSON();

--- a/components/script_bindings/webidls/TrustedScriptURL.webidl
+++ b/components/script_bindings/webidls/TrustedScriptURL.webidl
@@ -6,7 +6,7 @@
  * https://www.w3.org/TR/trusted-types/#trused-script-url
  */
 
-[Exposed=(Window,Worker), Pref="dom_trusted_types_enabled"]
+[Exposed=(Window,Worker)]
 interface TrustedScriptURL {
   stringifier;
   DOMString toJSON();

--- a/components/script_bindings/webidls/TrustedTypePolicy.webidl
+++ b/components/script_bindings/webidls/TrustedTypePolicy.webidl
@@ -6,7 +6,7 @@
  * https://www.w3.org/TR/trusted-types/#trusted-type-policy
  */
 
-[Exposed=(Window,Worker), Pref="dom_trusted_types_enabled"]
+[Exposed=(Window,Worker)]
 interface TrustedTypePolicy {
   readonly attribute DOMString name;
   [Throws] TrustedHTML createHTML(DOMString input, any... arguments);

--- a/components/script_bindings/webidls/TrustedTypePolicyFactory.webidl
+++ b/components/script_bindings/webidls/TrustedTypePolicyFactory.webidl
@@ -6,7 +6,7 @@
  * https://www.w3.org/TR/trusted-types/#trusted-type-policy-factory
  */
 
-[Exposed=(Window,Worker), Pref="dom_trusted_types_enabled"]
+[Exposed=(Window,Worker)]
 interface TrustedTypePolicyFactory {
     [Throws]
     TrustedTypePolicy createPolicy(

--- a/components/script_bindings/webidls/WindowOrWorkerGlobalScope.webidl
+++ b/components/script_bindings/webidls/WindowOrWorkerGlobalScope.webidl
@@ -46,7 +46,6 @@ partial interface mixin WindowOrWorkerGlobalScope {
 
 // https://www.w3.org/TR/trusted-types/#extensions-to-the-windoworworkerglobalscope-interface
 partial interface mixin WindowOrWorkerGlobalScope {
-  [Pref="dom_trusted_types_enabled"]
   readonly attribute TrustedTypePolicyFactory trustedTypes;
 };
 

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -34,7 +34,6 @@ pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
     "dom_offscreen_canvas_enabled",
     "dom_permissions_enabled",
     "dom_resize_observer_enabled",
-    "dom_trusted_types_enabled",
     "dom_webgl2_enabled",
     "dom_webgpu_enabled",
     "dom_xpath_enabled",


### PR DESCRIPTION
Everything related to Trusted Types has been implemented. Failing WPT tests are related to other features such as SVG scripts.

Fixes #36258
