### PR TITLE
Enable abort controller preference for fetch/api/abort

### DIFF
--- a/tests/wpt/meta/fetch/api/abort/__dir__.ini
+++ b/tests/wpt/meta/fetch/api/abort/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "dom_abort_controller_enabled:true",
+]

--- a/tests/wpt/meta/fetch/api/abort/destroyed-context.html.ini
+++ b/tests/wpt/meta/fetch/api/abort/destroyed-context.html.ini
@@ -1,2 +1,0 @@
-[destroyed-context.html]
-  expected: ERROR

--- a/tests/wpt/meta/fetch/api/abort/general.any.js.ini
+++ b/tests/wpt/meta/fetch/api/abort/general.any.js.ini
@@ -5,6 +5,7 @@
   expected: ERROR
 
 [general.any.html]
+  expected: TIMEOUT
   [Aborting rejects with AbortError]
     expected: FAIL
 
@@ -69,31 +70,31 @@
     expected: FAIL
 
   [Fetch aborted & connection closed when aborted after calling response.arrayBuffer()]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Fetch aborted & connection closed when aborted after calling response.blob()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch aborted & connection closed when aborted after calling response.formData()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch aborted & connection closed when aborted after calling response.json()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch aborted & connection closed when aborted after calling response.text()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream errors once aborted. Underlying connection closed.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream errors once aborted, after reading. Underlying connection closed.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream will not error if body is empty. It's closed with an empty queue before it errors.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Readable stream synchronously cancels with AbortError if aborted before reading]
-    expected: FAIL
+    expected: NOTRUN
 
   [Signal state is cloned]
     expected: FAIL
@@ -111,61 +112,11 @@
     expected: FAIL
 
   [Fetch aborted & connection closed when aborted after calling response.bytes()]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's window is not null]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Input URL is not valid]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Input URL has credentials]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's mode is navigate]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's referrer is invalid]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's method is invalid]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's method is forbidden]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's mode is no-cors and method is not simple]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's cache mode is only-if-cached and mode is not same-origin]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Request with cache mode: only-if-cached and fetch mode cors]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Request with cache mode: only-if-cached and fetch mode no-cors]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad referrerPolicy init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad mode init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad credentials init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad cache init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad redirect init parameter value]
-    expected: FAIL
-
-  [Signal removed by setting to null]
-    expected: FAIL
+    expected: NOTRUN
 
 
 [general.any.worker.html]
+  expected: TIMEOUT
   [Aborting rejects with AbortError]
     expected: FAIL
 
@@ -230,31 +181,31 @@
     expected: FAIL
 
   [Fetch aborted & connection closed when aborted after calling response.arrayBuffer()]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Fetch aborted & connection closed when aborted after calling response.blob()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch aborted & connection closed when aborted after calling response.formData()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch aborted & connection closed when aborted after calling response.json()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Fetch aborted & connection closed when aborted after calling response.text()]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream errors once aborted. Underlying connection closed.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream errors once aborted, after reading. Underlying connection closed.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Stream will not error if body is empty. It's closed with an empty queue before it errors.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Readable stream synchronously cancels with AbortError if aborted before reading]
-    expected: FAIL
+    expected: NOTRUN
 
   [Signal state is cloned]
     expected: FAIL
@@ -272,55 +223,4 @@
     expected: FAIL
 
   [Fetch aborted & connection closed when aborted after calling response.bytes()]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's window is not null]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Input URL is not valid]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Input URL has credentials]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's mode is navigate]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's referrer is invalid]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's method is invalid]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's method is forbidden]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's mode is no-cors and method is not simple]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - RequestInit's cache mode is only-if-cached and mode is not same-origin]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Request with cache mode: only-if-cached and fetch mode cors]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Request with cache mode: only-if-cached and fetch mode no-cors]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad referrerPolicy init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad mode init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad credentials init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad cache init parameter value]
-    expected: FAIL
-
-  [TypeError from request constructor takes priority - Bad redirect init parameter value]
-    expected: FAIL
-
-  [Signal removed by setting to null]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/fetch/api/abort/keepalive.html.ini
+++ b/tests/wpt/meta/fetch/api/abort/keepalive.html.ini
@@ -1,5 +1,5 @@
 [keepalive.html]
-  expected: ERROR
+  expected: TIMEOUT
   [aborting a keepalive fetch should work]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/fetch/api/abort/request.any.js.ini
+++ b/tests/wpt/meta/fetch/api/abort/request.any.js.ini
@@ -17,42 +17,6 @@
   [Calling text() on an aborted consumed nonempty request]
     expected: FAIL
 
-  [Calling arrayBuffer() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling arrayBuffer()]
-    expected: FAIL
-
-  [Calling arrayBuffer() on an aborted consumed empty request]
-    expected: FAIL
-
-  [Calling blob() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling blob()]
-    expected: FAIL
-
-  [Calling blob() on an aborted consumed empty request]
-    expected: FAIL
-
-  [Calling formData() on an aborted consumed nonempty request]
-    expected: FAIL
-
-  [Calling json() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling json()]
-    expected: FAIL
-
-  [Calling text() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling text()]
-    expected: FAIL
-
-  [Calling text() on an aborted consumed empty request]
-    expected: FAIL
-
 
 [request.any.serviceworker.html]
   expected: ERROR
@@ -77,40 +41,4 @@
     expected: FAIL
 
   [Calling text() on an aborted consumed nonempty request]
-    expected: FAIL
-
-  [Calling arrayBuffer() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling arrayBuffer()]
-    expected: FAIL
-
-  [Calling arrayBuffer() on an aborted consumed empty request]
-    expected: FAIL
-
-  [Calling blob() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling blob()]
-    expected: FAIL
-
-  [Calling blob() on an aborted consumed empty request]
-    expected: FAIL
-
-  [Calling formData() on an aborted consumed nonempty request]
-    expected: FAIL
-
-  [Calling json() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling json()]
-    expected: FAIL
-
-  [Calling text() on an aborted request]
-    expected: FAIL
-
-  [Aborting a request after calling text()]
-    expected: FAIL
-
-  [Calling text() on an aborted consumed empty request]
     expected: FAIL


### PR DESCRIPTION
This sets a baseline of tests for fetch-related implementation of AbortController.

Part of #34866