### PR TITLE
Fix Response:bodyUsed behavior to return false if the body is null

### DIFF
--- a/tests/wpt/meta/fetch/api/response/response-consume-empty.any.js.ini
+++ b/tests/wpt/meta/fetch/api/response/response-consume-empty.any.js.ini
@@ -5,52 +5,10 @@
   expected: ERROR
 
 [response-consume-empty.any.worker.html]
-  [Consume response's body as text]
-    expected: FAIL
-
-  [Consume response's body as json (error case)]
-    expected: FAIL
-
-  [Consume response's body as blob]
-    expected: FAIL
-
-  [Consume response's body as formData without correct type (error case)]
-    expected: FAIL
-
-  [Consume response's body as arrayBuffer]
-    expected: FAIL
-
   [Consume empty FormData response body as text]
-    expected: FAIL
-
-  [Consume response's body as formData with correct multipart type (error case)]
-    expected: FAIL
-
-  [Consume response's body as formData with correct urlencoded type]
     expected: FAIL
 
 
 [response-consume-empty.any.html]
-  [Consume response's body as text]
-    expected: FAIL
-
-  [Consume response's body as json (error case)]
-    expected: FAIL
-
-  [Consume response's body as blob]
-    expected: FAIL
-
-  [Consume response's body as formData without correct type (error case)]
-    expected: FAIL
-
-  [Consume response's body as arrayBuffer]
-    expected: FAIL
-
   [Consume empty FormData response body as text]
-    expected: FAIL
-
-  [Consume response's body as formData with correct multipart type (error case)]
-    expected: FAIL
-
-  [Consume response's body as formData with correct urlencoded type]
     expected: FAIL


### PR DESCRIPTION
This PR fixes some test-cases in https://wpt.fyi/results/fetch/api/response/response-consume-empty.any.html?product=servo

Fetch standard indicates `Response:bodyUsed` should return `false` if the body content is null , even if the stream was disturbed.
https://fetch.spec.whatwg.org/#dom-body-bodyused

> The bodyUsed getter steps are to return true if [this](https://webidl.spec.whatwg.org/#this)’s [body](https://fetch.spec.whatwg.org/#concept-body-body) is non-null and [this](https://webidl.spec.whatwg.org/#this)’s [body](https://fetch.spec.whatwg.org/#concept-body-body)’s [stream](https://fetch.spec.whatwg.org/#concept-body-stream) is [disturbed](https://streams.spec.whatwg.org/#is-readable-stream-disturbed); otherwise false.