### PR TITLE
Add signal to request

### DIFF
--- a/components/script/dom/abortsignal.rs
+++ b/components/script/dom/abortsignal.rs
@@ -2,18 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
 use dom_struct::dom_struct;
+use indexmap::IndexSet;
 use js::jsapi::{ExceptionStackBehavior, Heap, JS_SetPendingException};
 use js::jsval::{JSVal, UndefinedValue};
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
 use script_bindings::inheritance::Castable;
+use script_bindings::trace::CustomTraceable;
 
+use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::AbortSignalBinding::AbortSignalMethods;
 use crate::dom::bindings::error::{Error, ErrorToJsval};
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::readablestream::PipeTo;
@@ -48,6 +51,15 @@ pub(crate) struct AbortSignal {
 
     /// <https://dom.spec.whatwg.org/#abortsignal-abort-algorithms>
     abort_algorithms: RefCell<Vec<AbortAlgorithm>>,
+
+    /// <https://dom.spec.whatwg.org/#abortsignal-dependent>
+    dependent: Cell<bool>,
+
+    /// <https://dom.spec.whatwg.org/#abortsignal-source-signals>
+    source_signals: DomRefCell<IndexSet<Dom<AbortSignal>>>,
+
+    /// <https://dom.spec.whatwg.org/#abortsignal-dependent-signals>
+    dependent_signals: DomRefCell<IndexSet<Dom<AbortSignal>>>,
 }
 
 impl AbortSignal {
@@ -56,6 +68,9 @@ impl AbortSignal {
             eventtarget: EventTarget::new_inherited(),
             abort_reason: Default::default(),
             abort_algorithms: Default::default(),
+            dependent: Default::default(),
+            source_signals: Default::default(),
+            dependent_signals: Default::default(),
         }
     }
 
@@ -73,6 +88,7 @@ impl AbortSignal {
     }
 
     /// <https://dom.spec.whatwg.org/#abortsignal-signal-abort>
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))] // TODO(39333): Remove when all iterators are marked as safe
     pub(crate) fn signal_abort(
         &self,
         cx: SafeJSContext,
@@ -99,21 +115,25 @@ impl AbortSignal {
         }
 
         // Step 3. Let dependentSignalsToAbort be a new list.
-        // TODO
+        let mut dependent_signals_to_abort = vec![];
         // Step 4. For each dependentSignal of signal’s dependent signals:
-        // TODO
-        // Step 4.1. If dependentSignal is not aborted:
-        // TODO
-        // Step 4.1.1. Set dependentSignal’s abort reason to signal’s abort reason.
-        // TODO
-        // Step 4.1.2. Append dependentSignal to dependentSignalsToAbort.
-        // TODO
+        for dependent_signal in self.dependent_signals.borrow().iter() {
+            // Step 4.1. If dependentSignal is not aborted:
+            if !dependent_signal.aborted() {
+                // Step 4.1.1. Set dependentSignal’s abort reason to signal’s abort reason.
+                dependent_signal.abort_reason.set(self.abort_reason.get());
+                // Step 4.1.2. Append dependentSignal to dependentSignalsToAbort.
+                dependent_signals_to_abort.push(dependent_signal.as_rooted());
+            }
+        }
 
         // Step 5. Run the abort steps for signal.
         self.run_the_abort_steps(cx, &global, realm, can_gc);
 
         // Step 6. For each dependentSignal of dependentSignalsToAbort, run the abort steps for dependentSignal.
-        // TODO
+        for dependent_signal in dependent_signals_to_abort.iter() {
+            dependent_signal.run_the_abort_steps(cx, &global, realm, can_gc);
+        }
     }
 
     /// <https://dom.spec.whatwg.org/#abortsignal-add>
@@ -174,6 +194,61 @@ impl AbortSignal {
         // An AbortSignal object is aborted when its abort reason is not undefined.
         !self.abort_reason.get().is_undefined()
     }
+
+    /// <https://dom.spec.whatwg.org/#create-a-dependent-abort-signal>
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))] // TODO(39333): Remove when all iterators are marked as safe
+    pub(crate) fn create_dependent_abort_signal(
+        signals: Vec<DomRoot<AbortSignal>>,
+        global: &GlobalScope,
+        can_gc: CanGc,
+    ) -> DomRoot<AbortSignal> {
+        // Step 1. Let resultSignal be a new object implementing signalInterface using realm.
+        let result_signal = Self::new_with_proto(global, None, can_gc);
+        // Step 2. For each signal of signals: if signal is aborted,
+        // then set resultSignal’s abort reason to signal’s abort reason and return resultSignal.
+        for signal in signals.iter() {
+            if signal.aborted() {
+                result_signal.abort_reason.set(signal.abort_reason.get());
+                return result_signal;
+            }
+        }
+        // Step 3. Set resultSignal’s dependent to true.
+        result_signal.dependent.set(true);
+        // Step 4. For each signal of signals:
+        for signal in signals.iter() {
+            // Step 4.1. If signal’s dependent is false:
+            if !signal.dependent.get() {
+                // Step 4.1.1. Append signal to resultSignal’s source signals.
+                result_signal
+                    .source_signals
+                    .borrow_mut()
+                    .insert(Dom::from_ref(signal));
+                // Step 4.1.2. Append resultSignal to signal’s dependent signals.
+                signal
+                    .dependent_signals
+                    .borrow_mut()
+                    .insert(Dom::from_ref(&result_signal));
+            } else {
+                // Step 4.2. Otherwise, for each sourceSignal of signal’s source signals:
+                for source_signal in signal.source_signals.borrow().iter() {
+                    // Step 4.2.1. Assert: sourceSignal is not aborted and not dependent.
+                    assert!(!source_signal.aborted() && !source_signal.dependent.get());
+                    // Step 4.2.2. Append sourceSignal to resultSignal’s source signals.
+                    result_signal
+                        .source_signals
+                        .borrow_mut()
+                        .insert(source_signal.clone());
+                    // Step 4.2.3. Append resultSignal to sourceSignal’s dependent signals.
+                    source_signal
+                        .dependent_signals
+                        .borrow_mut()
+                        .insert(Dom::from_ref(&result_signal));
+                }
+            }
+        }
+        // Step 5. Return resultSignal.
+        result_signal
+    }
 }
 
 impl AbortSignalMethods<crate::DomTypeHolder> for AbortSignal {
@@ -206,6 +281,17 @@ impl AbortSignalMethods<crate::DomTypeHolder> for AbortSignal {
 
         // Step 3. Return signal.
         signal
+    }
+
+    /// <https://dom.spec.whatwg.org/#dom-abortsignal-any>
+    fn Any(
+        global: &GlobalScope,
+        signals: Vec<DomRoot<AbortSignal>>,
+        can_gc: CanGc,
+    ) -> DomRoot<AbortSignal> {
+        // The static any(signals) method steps are to return the result
+        // of creating a dependent abort signal from signals using AbortSignal and the current realm.
+        Self::create_dependent_abort_signal(signals, global, can_gc)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-abortsignal-reason>

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -20,7 +20,7 @@ DOMInterfaces = {
 },
 
 'AbortSignal': {
-    'canGc':['Abort'],
+    'canGc':['Abort', 'Any'],
 },
 
 'AbstractRange': {

--- a/components/script_bindings/webidls/AbortSignal.webidl
+++ b/components/script_bindings/webidls/AbortSignal.webidl
@@ -7,6 +7,8 @@
 [Exposed=*, Pref="dom_abort_controller_enabled"]
 interface AbortSignal : EventTarget {
   [NewObject] static AbortSignal abort(optional any reason);
+  // [Exposed=(Window,Worker), NewObject] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
+  [NewObject] static AbortSignal _any(sequence<AbortSignal> signals);
   readonly attribute boolean aborted;
   readonly attribute any reason;
   undefined throwIfAborted();

--- a/components/script_bindings/webidls/Request.webidl
+++ b/components/script_bindings/webidls/Request.webidl
@@ -6,6 +6,7 @@
 
 typedef (Request or USVString) RequestInfo;
 
+// https://fetch.spec.whatwg.org/#request
 [Exposed=(Window,Worker)]
 interface Request {
   [Throws] constructor(RequestInfo input, optional RequestInit init = {});
@@ -21,12 +22,18 @@ interface Request {
   readonly attribute RequestCache cache;
   readonly attribute RequestRedirect redirect;
   readonly attribute DOMString integrity;
+  // readonly attribute boolean keepalive;
+  // readonly attribute boolean isReloadNavigation;
+  // readonly attribute boolean isHistoryNavigation;
+  readonly attribute AbortSignal signal;
+  // readonly attribute RequestDuplex duplex;
 
   [NewObject, Throws] Request clone();
 };
 
 Request includes Body;
 
+// https://fetch.spec.whatwg.org/#requestinit
 dictionary RequestInit {
   ByteString method;
   HeadersInit headers;
@@ -38,9 +45,14 @@ dictionary RequestInit {
   RequestCache cache;
   RequestRedirect redirect;
   DOMString integrity;
+  // boolean keepalive;
+  AbortSignal? signal;
+  // RequestDuplex duplex;
+  // RequestPriority priority;
   any window; // can only be set to null
 };
 
+// https://fetch.spec.whatwg.org/#requestdestination
 enum RequestDestination {
   "",
   "audio",
@@ -63,6 +75,7 @@ enum RequestDestination {
   "xslt"
 };
 
+// https://fetch.spec.whatwg.org/#requestmode
 enum RequestMode {
   "navigate",
   "same-origin",
@@ -70,12 +83,14 @@ enum RequestMode {
   "cors"
 };
 
+// https://fetch.spec.whatwg.org/#requestcredentials
 enum RequestCredentials {
   "omit",
   "same-origin",
   "include"
 };
 
+// https://fetch.spec.whatwg.org/#requestcache
 enum RequestCache {
   "default",
   "no-store",
@@ -85,12 +100,14 @@ enum RequestCache {
   "only-if-cached"
 };
 
+// https://fetch.spec.whatwg.org/#requestredirect
 enum RequestRedirect {
   "follow",
   "error",
   "manual"
 };
 
+// https://w3c.github.io/webappsec-referrer-policy/#enumdef-referrerpolicy
 enum ReferrerPolicy {
   "",
   "no-referrer",

--- a/tests/wpt/meta/dom/abort/abort-signal-any-crash.html.ini
+++ b/tests/wpt/meta/dom/abort/abort-signal-any-crash.html.ini
@@ -1,2 +1,0 @@
-[abort-signal-any-crash.html]
-    expected: TIMEOUT

--- a/tests/wpt/meta/dom/abort/abort-signal-any.any.js.ini
+++ b/tests/wpt/meta/dom/abort/abort-signal-any.any.js.ini
@@ -1,86 +1,8 @@
 [abort-signal-any.any.worker.html]
-  [AbortSignal.any() works with an empty array of signals]
-    expected: FAIL
-
-  [AbortSignal.any() follows a single signal (using AbortController)]
-    expected: FAIL
-
-  [AbortSignal.any() follows multiple signals (using AbortController)]
-    expected: FAIL
-
-  [AbortSignal.any() returns an aborted signal if passed an aborted signal (using AbortController)]
-    expected: FAIL
-
-  [AbortSignal.any() can be passed the same signal more than once (using AbortController)]
-    expected: FAIL
-
-  [AbortSignal.any() uses the first instance of a duplicate signal (using AbortController)]
-    expected: FAIL
-
-  [AbortSignal.any() signals are composable (using AbortController)]
-    expected: FAIL
-
   [AbortSignal.any() works with signals returned by AbortSignal.timeout() (using AbortController)]
-    expected: FAIL
-
-  [AbortSignal.any() works with intermediate signals (using AbortController)]
-    expected: FAIL
-
-  [Abort events for AbortSignal.any() signals fire in the right order (using AbortController)]
-    expected: FAIL
-
-  [Dependent signals for AbortSignal.any() are marked aborted before abort events fire (using AbortController)]
-    expected: FAIL
-
-  [Dependent signals for AbortSignal.any() are aborted correctly for reentrant aborts (using AbortController)]
-    expected: FAIL
-
-  [Dependent signals for AbortSignal.any() should use the same DOMException instance from the already aborted source signal (using AbortController)]
-    expected: FAIL
-
-  [Dependent signals for AbortSignal.any() should use the same DOMException instance from the source signal being aborted later (using AbortController)]
     expected: FAIL
 
 
 [abort-signal-any.any.html]
-  [AbortSignal.any() works with an empty array of signals]
-    expected: FAIL
-
-  [AbortSignal.any() follows a single signal (using AbortController)]
-    expected: FAIL
-
-  [AbortSignal.any() follows multiple signals (using AbortController)]
-    expected: FAIL
-
-  [AbortSignal.any() returns an aborted signal if passed an aborted signal (using AbortController)]
-    expected: FAIL
-
-  [AbortSignal.any() can be passed the same signal more than once (using AbortController)]
-    expected: FAIL
-
-  [AbortSignal.any() uses the first instance of a duplicate signal (using AbortController)]
-    expected: FAIL
-
-  [AbortSignal.any() signals are composable (using AbortController)]
-    expected: FAIL
-
   [AbortSignal.any() works with signals returned by AbortSignal.timeout() (using AbortController)]
-    expected: FAIL
-
-  [AbortSignal.any() works with intermediate signals (using AbortController)]
-    expected: FAIL
-
-  [Abort events for AbortSignal.any() signals fire in the right order (using AbortController)]
-    expected: FAIL
-
-  [Dependent signals for AbortSignal.any() are marked aborted before abort events fire (using AbortController)]
-    expected: FAIL
-
-  [Dependent signals for AbortSignal.any() are aborted correctly for reentrant aborts (using AbortController)]
-    expected: FAIL
-
-  [Dependent signals for AbortSignal.any() should use the same DOMException instance from the already aborted source signal (using AbortController)]
-    expected: FAIL
-
-  [Dependent signals for AbortSignal.any() should use the same DOMException instance from the source signal being aborted later (using AbortController)]
     expected: FAIL

--- a/tests/wpt/meta/dom/idlharness.any.js.ini
+++ b/tests/wpt/meta/dom/idlharness.any.js.ini
@@ -17,31 +17,7 @@
   [AbortController interface: new AbortController() must inherit property "abort()" with the proper type]
     expected: FAIL
 
-  [AbortSignal interface: existence and properties of interface object]
-    expected: FAIL
-
-  [AbortSignal interface object length]
-    expected: FAIL
-
-  [AbortSignal interface object name]
-    expected: FAIL
-
-  [AbortSignal interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [AbortSignal interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [AbortSignal interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
   [AbortSignal interface: operation abort()]
-    expected: FAIL
-
-  [AbortSignal interface: attribute aborted]
-    expected: FAIL
-
-  [AbortSignal interface: attribute onabort]
     expected: FAIL
 
   [AbortSignal must be primary interface of new AbortController().signal]
@@ -77,15 +53,6 @@
   [EventTarget interface: calling dispatchEvent(Event) on new AbortController().signal with too few arguments must throw TypeError]
     expected: FAIL
 
-  [AbortSignal interface: operation abort(optional any)]
-    expected: FAIL
-
-  [AbortSignal interface: attribute reason]
-    expected: FAIL
-
-  [AbortSignal interface: operation throwIfAborted()]
-    expected: FAIL
-
   [AbortSignal interface: new AbortController().signal must inherit property "abort(optional any)" with the proper type]
     expected: FAIL
 
@@ -105,9 +72,6 @@
     expected: FAIL
 
   [AbortSignal interface: calling timeout(unsigned long long) on new AbortController().signal with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [AbortSignal interface: operation any(sequence<AbortSignal>)]
     expected: FAIL
 
   [AbortSignal interface: new AbortController().signal must inherit property "any(sequence<AbortSignal>)" with the proper type]

--- a/tests/wpt/meta/dom/idlharness.window.js.ini
+++ b/tests/wpt/meta/dom/idlharness.window.js.ini
@@ -2,12 +2,6 @@
   [AbortSignal must be primary interface of new AbortController().signal]
     expected: FAIL
 
-  [AbortSignal interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [AbortSignal interface: existence and properties of interface object]
-    expected: FAIL
-
   [EventTarget interface: calling removeEventListener(DOMString, EventListener?, optional (EventListenerOptions or boolean)) on new AbortController().signal with too few arguments must throw TypeError]
     expected: FAIL
 
@@ -17,9 +11,6 @@
   [EventTarget interface: new AbortController().signal must inherit property "dispatchEvent(Event)" with the proper type]
     expected: FAIL
 
-  [AbortSignal interface object name]
-    expected: FAIL
-
   [EventTarget interface: new AbortController().signal must inherit property "removeEventListener(DOMString, EventListener?, optional (EventListenerOptions or boolean))" with the proper type]
     expected: FAIL
 
@@ -27,9 +18,6 @@
     expected: FAIL
 
   [AbortController interface: attribute signal]
-    expected: FAIL
-
-  [AbortSignal interface: attribute aborted]
     expected: FAIL
 
   [AbortController interface: new AbortController() must inherit property "signal" with the proper type]
@@ -47,19 +35,7 @@
   [EventTarget interface: calling addEventListener(DOMString, EventListener?, optional (AddEventListenerOptions or boolean)) on new AbortController().signal with too few arguments must throw TypeError]
     expected: FAIL
 
-  [AbortSignal interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
   [AbortSignal interface: new AbortController().signal must inherit property "onabort" with the proper type]
-    expected: FAIL
-
-  [AbortSignal interface: attribute onabort]
-    expected: FAIL
-
-  [AbortSignal interface object length]
-    expected: FAIL
-
-  [AbortSignal interface: existence and properties of interface prototype object]
     expected: FAIL
 
   [NodeFilter interface: existence and properties of interface object]
@@ -173,15 +149,6 @@
   [XSLTProcessor interface: new XSLTProcessor() must inherit property "reset()" with the proper type]
     expected: FAIL
 
-  [AbortSignal interface: operation abort(optional any)]
-    expected: FAIL
-
-  [AbortSignal interface: attribute reason]
-    expected: FAIL
-
-  [AbortSignal interface: operation throwIfAborted()]
-    expected: FAIL
-
   [AbortSignal interface: new AbortController().signal must inherit property "abort(optional any)" with the proper type]
     expected: FAIL
 
@@ -225,9 +192,6 @@
     expected: FAIL
 
   [Element interface: element must inherit property "onfullscreenerror" with the proper type]
-    expected: FAIL
-
-  [AbortSignal interface: operation any(sequence<AbortSignal>)]
     expected: FAIL
 
   [AbortSignal interface: new AbortController().signal must inherit property "any(sequence<AbortSignal>)" with the proper type]
@@ -373,3 +337,6 @@
 
   [Element interface: element must inherit property "customElementRegistry" with the proper type]
     expected: FAIL
+
+
+[idlharness.window.html?include=Node]

--- a/tests/wpt/meta/fetch/api/abort/general.any.js.ini
+++ b/tests/wpt/meta/fetch/api/abort/general.any.js.ini
@@ -12,9 +12,6 @@
   [Aborting rejects with AbortError - no-cors]
     expected: FAIL
 
-  [Request objects have a signal property]
-    expected: FAIL
-
   [Signal on request object]
     expected: FAIL
 
@@ -95,12 +92,6 @@
 
   [Readable stream synchronously cancels with AbortError if aborted before reading]
     expected: NOTRUN
-
-  [Signal state is cloned]
-    expected: FAIL
-
-  [Clone aborts with original controller]
-    expected: FAIL
 
   [Aborting rejects with abort reason]
     expected: FAIL
@@ -123,9 +114,6 @@
   [Aborting rejects with AbortError - no-cors]
     expected: FAIL
 
-  [Request objects have a signal property]
-    expected: FAIL
-
   [Signal on request object]
     expected: FAIL
 
@@ -206,12 +194,6 @@
 
   [Readable stream synchronously cancels with AbortError if aborted before reading]
     expected: NOTRUN
-
-  [Signal state is cloned]
-    expected: FAIL
-
-  [Clone aborts with original controller]
-    expected: FAIL
 
   [Aborting rejects with abort reason]
     expected: FAIL

--- a/tests/wpt/meta/fetch/api/idlharness.any.js.ini
+++ b/tests/wpt/meta/fetch/api/idlharness.any.js.ini
@@ -8,9 +8,6 @@
   [Request interface: attribute isHistoryNavigation]
     expected: FAIL
 
-  [Request interface: attribute signal]
-    expected: FAIL
-
   [Request interface: attribute duplex]
     expected: FAIL
 
@@ -21,9 +18,6 @@
     expected: FAIL
 
   [Request interface: new Request('about:blank') must inherit property "isHistoryNavigation" with the proper type]
-    expected: FAIL
-
-  [Request interface: new Request('about:blank') must inherit property "signal" with the proper type]
     expected: FAIL
 
   [Request interface: new Request('about:blank') must inherit property "duplex" with the proper type]
@@ -43,9 +37,6 @@
   [Request interface: attribute isHistoryNavigation]
     expected: FAIL
 
-  [Request interface: attribute signal]
-    expected: FAIL
-
   [Request interface: attribute duplex]
     expected: FAIL
 
@@ -56,9 +47,6 @@
     expected: FAIL
 
   [Request interface: new Request('about:blank') must inherit property "isHistoryNavigation" with the proper type]
-    expected: FAIL
-
-  [Request interface: new Request('about:blank') must inherit property "signal" with the proper type]
     expected: FAIL
 
   [Request interface: new Request('about:blank') must inherit property "duplex" with the proper type]


### PR DESCRIPTION
The signal taken from the requestinit is now passed into
the request object with the relevant steps. I added all
spec comments to this method, as I had trouble figuring
out which steps I had to add.

This required implementing the algorithm to create
dependent signals, which is used in the `any()` method.
So that's now implemented as well.

All of that required the machinery to have dependent and
source signals on an AbortSignal. It uses an IndexSet
as the spec requires it to be an ordered set.

Part of #34866