### PR TITLE
script: Do not start `Fetch` operations if they have been aborted by the `AbortController`

### DIFF
--- a/tests/wpt/meta/fetch/api/abort/general.any.js.ini
+++ b/tests/wpt/meta/fetch/api/abort/general.any.js.ini
@@ -6,30 +6,6 @@
 
 [general.any.html]
   expected: TIMEOUT
-  [Aborting rejects with AbortError]
-    expected: FAIL
-
-  [Aborting rejects with AbortError - no-cors]
-    expected: FAIL
-
-  [Signal on request object]
-    expected: FAIL
-
-  [Signal on request object created from request object]
-    expected: FAIL
-
-  [Signal on request object created from request object, with signal on second request]
-    expected: FAIL
-
-  [Signal on request object created from request object, with signal on second request overriding another]
-    expected: FAIL
-
-  [Signal retained after unrelated properties are overridden by fetch]
-    expected: FAIL
-
-  [Already aborted signal rejects immediately]
-    expected: FAIL
-
   [Request is still 'used' if signal is aborted before fetching]
     expected: FAIL
 
@@ -49,15 +25,6 @@
     expected: FAIL
 
   [Call text() twice on aborted response]
-    expected: FAIL
-
-  [Already aborted signal does not make request]
-    expected: FAIL
-
-  [Already aborted signal can be used for many fetches]
-    expected: FAIL
-
-  [Signal can be used to abort other fetches, even if another fetch succeeded before aborting]
     expected: FAIL
 
   [Underlying connection is closed when aborting after receiving response]
@@ -92,12 +59,6 @@
 
   [Readable stream synchronously cancels with AbortError if aborted before reading]
     expected: NOTRUN
-
-  [Aborting rejects with abort reason]
-    expected: FAIL
-
-  [Signal on request object should also have abort reason]
-    expected: FAIL
 
   [response.bytes() rejects if already aborted]
     expected: FAIL
@@ -108,30 +69,6 @@
 
 [general.any.worker.html]
   expected: TIMEOUT
-  [Aborting rejects with AbortError]
-    expected: FAIL
-
-  [Aborting rejects with AbortError - no-cors]
-    expected: FAIL
-
-  [Signal on request object]
-    expected: FAIL
-
-  [Signal on request object created from request object]
-    expected: FAIL
-
-  [Signal on request object created from request object, with signal on second request]
-    expected: FAIL
-
-  [Signal on request object created from request object, with signal on second request overriding another]
-    expected: FAIL
-
-  [Signal retained after unrelated properties are overridden by fetch]
-    expected: FAIL
-
-  [Already aborted signal rejects immediately]
-    expected: FAIL
-
   [Request is still 'used' if signal is aborted before fetching]
     expected: FAIL
 
@@ -151,15 +88,6 @@
     expected: FAIL
 
   [Call text() twice on aborted response]
-    expected: FAIL
-
-  [Already aborted signal does not make request]
-    expected: FAIL
-
-  [Already aborted signal can be used for many fetches]
-    expected: FAIL
-
-  [Signal can be used to abort other fetches, even if another fetch succeeded before aborting]
     expected: FAIL
 
   [Underlying connection is closed when aborting after receiving response]
@@ -194,12 +122,6 @@
 
   [Readable stream synchronously cancels with AbortError if aborted before reading]
     expected: NOTRUN
-
-  [Aborting rejects with abort reason]
-    expected: FAIL
-
-  [Signal on request object should also have abort reason]
-    expected: FAIL
 
   [response.bytes() rejects if already aborted]
     expected: FAIL


### PR DESCRIPTION
The first step for aborting fetch calls. It only
has the case where the signal was already aborted
prior to fetch starting.

Part of #34866