### PR TITLE
Implement `SnapshotData::Ipc` and use it for `Canvas2dMsg::DrawImage`

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -210,6 +210,7 @@ impl CanvasPaintThread {
                 self.canvas(canvas_id)
                     .clip_path(&path, fill_rule, transform);
             },
+            #[allow(unsafe_code)]
             Canvas2dMsg::DrawImage(
                 snapshot,
                 dest_rect,
@@ -219,7 +220,7 @@ impl CanvasPaintThread {
                 composition_options,
                 transform,
             ) => self.canvas(canvas_id).draw_image(
-                snapshot.to_owned(),
+                unsafe { snapshot.to_data() },
                 dest_rect,
                 source_rect,
                 smoothing_enabled,

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -459,15 +459,18 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
         (image_desc, data)
     }
 
+    #[allow(unsafe_code)]
     fn snapshot(&mut self) -> pixels::Snapshot {
-        Snapshot::from_vec(
-            self.size().cast(),
-            SnapshotPixelFormat::RGBA,
-            SnapshotAlphaMode::Transparent {
-                premultiplied: true,
-            },
-            self.pixmap().to_vec(),
-        )
+        unsafe {
+            Snapshot::from_shared_memory(
+                self.size().cast(),
+                SnapshotPixelFormat::RGBA,
+                SnapshotAlphaMode::Transparent {
+                    premultiplied: true,
+                },
+                IpcSharedMemory::from_bytes(self.pixmap()),
+            )
+        }
     }
 
     fn surface(&mut self) -> Self::SourceSurface {


### PR DESCRIPTION
This partially addresses #36594 as well as #39292 by implementing the plumbing for `SnapshotData::Ipc` and using it in order to avoid some copying in the meantime.

As mentioned in #39292, I suspected that a major refactor on the way image frames are obtained is indeed necessary, since it is the biggest bottleneck so far. In order to get a performance boost now, the image's `IpcSharedMemory` will be directly used if it isn't an animated image, else it will try to create a new instance from the frame slice. While this greatly improves the test case's performance, it doesn't really affect Cookie Clicker itself, which is a shame. I'd dig deeper into this, but this is all I can do for now.

This PR needs some extra attention since the use of `unsafe` code was required here.

Testing: This test has been tested using #39292's specialized test case as well as the official mirror for Cookie Clicker (https://cookieclicker.eu/cookieclicker). `./mach test-wpt -r` has been executed for precaution.
Fixes (partially): #36594 and #39292