### PR TITLE
script: Make `EventTarget::fire` return `bool` according to spec

### DIFF
--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -885,7 +885,7 @@ impl EventTarget {
     }
 
     // https://dom.spec.whatwg.org/#concept-event-fire
-    pub(crate) fn fire_event(&self, name: Atom, can_gc: CanGc) -> DomRoot<Event> {
+    pub(crate) fn fire_event(&self, name: Atom, can_gc: CanGc) -> bool {
         self.fire_event_with_params(
             name,
             EventBubbles::DoesNotBubble,
@@ -896,7 +896,7 @@ impl EventTarget {
     }
 
     // https://dom.spec.whatwg.org/#concept-event-fire
-    pub(crate) fn fire_bubbling_event(&self, name: Atom, can_gc: CanGc) -> DomRoot<Event> {
+    pub(crate) fn fire_bubbling_event(&self, name: Atom, can_gc: CanGc) -> bool {
         self.fire_event_with_params(
             name,
             EventBubbles::Bubbles,
@@ -907,7 +907,7 @@ impl EventTarget {
     }
 
     // https://dom.spec.whatwg.org/#concept-event-fire
-    pub(crate) fn fire_cancelable_event(&self, name: Atom, can_gc: CanGc) -> DomRoot<Event> {
+    pub(crate) fn fire_cancelable_event(&self, name: Atom, can_gc: CanGc) -> bool {
         self.fire_event_with_params(
             name,
             EventBubbles::DoesNotBubble,
@@ -918,11 +918,7 @@ impl EventTarget {
     }
 
     // https://dom.spec.whatwg.org/#concept-event-fire
-    pub(crate) fn fire_bubbling_cancelable_event(
-        &self,
-        name: Atom,
-        can_gc: CanGc,
-    ) -> DomRoot<Event> {
+    pub(crate) fn fire_bubbling_cancelable_event(&self, name: Atom, can_gc: CanGc) -> bool {
         self.fire_event_with_params(
             name,
             EventBubbles::Bubbles,
@@ -940,11 +936,10 @@ impl EventTarget {
         cancelable: EventCancelable,
         composed: EventComposed,
         can_gc: CanGc,
-    ) -> DomRoot<Event> {
+    ) -> bool {
         let event = Event::new(&self.global(), name, bubbles, cancelable, can_gc);
         event.set_composed(composed.into());
-        event.fire(self, can_gc);
-        event
+        event.fire(self, can_gc)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-eventtarget-addeventlistener>

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLElementBinding::HTMLElementMethods;
 use crate::dom::bindings::codegen::Bindings::HTMLOrSVGElementBinding::FocusOptions;
 use crate::dom::bindings::inheritance::Castable;
@@ -62,14 +61,15 @@ pub(crate) trait Validatable {
             return true;
         }
 
-        // Step 1.1.
-        let event = self
+        // Step 1.1: Let report be the result of firing an event named invalid at element,
+        // with the cancelable attribute initialized to true.
+        let report = self
             .as_element()
             .upcast::<EventTarget>()
             .fire_cancelable_event(atom!("invalid"), can_gc);
 
         // Step 1.2.
-        if !event.DefaultPrevented() {
+        if report {
             let flags = self.validity_state().invalid_flags();
             println!(
                 "Validation error: {}",


### PR DESCRIPTION
This is a continuation of #38566, newly discovered when fixing https://github.com/servo/servo/issues/38616#issuecomment-3261561671. 

We add more documentation and return `bool` for the function family of [event firing](https://dom.spec.whatwg.org/#concept-event-fire).

Testing: No behaviour change.
