### PR TITLE
Get the Rc to the custom_reaction_stack outside the loop instead of using the thread_local inside.

### DIFF
--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -816,11 +816,12 @@ pub(crate) fn upgrade_element(
     // Step 4. For each attribute in element's attribute list, in order, enqueue a custom element callback reaction
     // with element, callback name "attributeChangedCallback", and « attribute's local name, null, attribute's value,
     // attribute's namespace ».
+    let custom_element_reaction_stack = ScriptThread::custom_element_reaction_stack();
     for attr in element.attrs().iter() {
         let local_name = attr.local_name().clone();
         let value = DOMString::from(&**attr.value());
         let namespace = attr.namespace().clone();
-        ScriptThread::enqueue_callback_reaction(
+        custom_element_reaction_stack.enqueue_callback_reaction(
             element,
             CallbackReaction::AttributeChanged(local_name, None, Some(value), namespace),
             Some(definition.clone()),


### PR DESCRIPTION
This uses the ScriptThread::custom_element_reaction_stack to call the enqueue_callback_reaction on the Rc instead of in the loop.
Potentially saving access to thread_local variables.


Testing: Should not change functionality and should be covered by wpt tests.
