### PR TITLE
RFC: LazyDomString

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7402,6 +7408,7 @@ dependencies = [
 name = "script_bindings"
 version = "0.0.1"
 dependencies = [
+ "ascii",
  "bitflags 2.9.4",
  "crossbeam-channel",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rust-version = "1.86.0"
 accountable-refcell = "0.2.2"
 aes = "0.8.4"
 aes-gcm = "0.10.3"
+ascii = "1.1.0"
 aes-kw = { version = "0.2.1", features = ["alloc"] }
 app_units = "0.7"
 arboard = "3"
@@ -60,6 +61,7 @@ embedder_traits = { path = "components/shared/embedder" }
 encoding_rs = "0.8"
 env_logger = "0.11"
 euclid = "0.22"
+fnv = "1.0"
 fonts_traits = { path = "components/shared/fonts" }
 freetype-sys = "0.20"
 fxhash = "0.2"

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -6,11 +6,16 @@ use std::sync::LazyLock;
 
 use num_traits::Zero;
 use regex::Regex;
+use script_bindings::lazydomstring::StringTrait;
 pub use script_bindings::str::*;
 use time::{Date, Month, OffsetDateTime, Time, Weekday};
 
 /// <https://html.spec.whatwg.org/multipage/#parse-a-month-component>
-fn parse_month_component(value: &str) -> Option<(i32, u32)> {
+fn parse_month_component<'a, 'b, T>(value: T) -> Option<(i32, u32)>
+where
+    T: Copy + StringTrait<'b>,
+    'a: 'b,
+{
     // Step 3
     let mut iterator = value.split('-');
     let year = iterator.next()?;
@@ -33,7 +38,11 @@ fn parse_month_component(value: &str) -> Option<(i32, u32)> {
 }
 
 /// <https://html.spec.whatwg.org/multipage/#parse-a-date-component>
-fn parse_date_component(value: &str) -> Option<(i32, u32, u32)> {
+fn parse_date_component<'a, 'b, T>(value: T) -> Option<(i32, u32, u32)>
+where
+    T: Copy + StringTrait<'b>,
+    'a: 'b,
+{
     // Step 1
     let (year_int, month_int) = parse_month_component(value)?;
 
@@ -55,7 +64,11 @@ fn parse_date_component(value: &str) -> Option<(i32, u32, u32)> {
 }
 
 /// <https://html.spec.whatwg.org/multipage/#parse-a-time-component>
-fn parse_time_component(value: &str) -> Option<(u8, u8, u8, u16)> {
+fn parse_time_component<'a, 'b, T>(value: T) -> Option<(u8, u8, u8, u16)>
+where
+    T: Copy + StringTrait<'b>,
+    'a: 'b,
+{
     // Step 1: Collect a sequence of code points that are ASCII digits from input given
     // position. If the collected sequence is not exactly two characters long, then fail.
     // Otherwise, interpret the resulting sequence as a base-ten integer. Let that number
@@ -212,7 +225,10 @@ impl ToInputValueString for OffsetDateTime {
     }
 }
 
-pub(crate) trait FromInputValueString {
+pub(crate) trait FromInputValueString
+where
+    Self: Sized,
+{
     /// <https://html.spec.whatwg.org/multipage/#parse-a-date-string>
     ///
     /// Parse the date string and return an [`OffsetDateTime`] on midnight of the
@@ -221,7 +237,7 @@ pub(crate) trait FromInputValueString {
     /// A valid date string should be "YYYY-MM-DD"
     /// YYYY must be four or more digits, MM and DD both must be two digits
     /// <https://html.spec.whatwg.org/multipage/#valid-date-string>
-    fn parse_date_string(&self) -> Option<OffsetDateTime>;
+    fn parse_date_string(self) -> Option<OffsetDateTime>;
 
     /// <https://html.spec.whatwg.org/multipage/#parse-a-month-string>
     ///
@@ -230,7 +246,7 @@ pub(crate) trait FromInputValueString {
     ///
     /// A valid month string should be "YYYY-MM" YYYY must be four or more digits, MM both
     /// must be two digits <https://html.spec.whatwg.org/multipage/#valid-month-string>
-    fn parse_month_string(&self) -> Option<OffsetDateTime>;
+    fn parse_month_string(self) -> Option<OffsetDateTime>;
 
     /// <https://html.spec.whatwg.org/multipage/#parse-a-week-string>
     ///
@@ -240,52 +256,56 @@ pub(crate) trait FromInputValueString {
     /// A valid week string should be like {YYYY}-W{WW}, such as "2017-W52" YYYY must be
     /// four or more digits, WW both must be two digits
     /// <https://html.spec.whatwg.org/multipage/#valid-week-string>
-    fn parse_week_string(&self) -> Option<OffsetDateTime>;
+    fn parse_week_string(self) -> Option<OffsetDateTime>;
 
     /// Parse this value as a time string according to
     /// <https://html.spec.whatwg.org/multipage/#valid-time-string>.
-    fn parse_time_string(&self) -> Option<OffsetDateTime>;
+    fn parse_time_string(self) -> Option<OffsetDateTime>;
 
     /// <https://html.spec.whatwg.org/multipage/#parse-a-local-date-and-time-string>
     ///
     /// Parse the local date and time, returning an [`OffsetDateTime`] in UTC or None.
-    fn parse_local_date_time_string(&self) -> Option<OffsetDateTime>;
+    fn parse_local_date_time_string(self) -> Option<OffsetDateTime>;
 
     /// Validates whether or not this value is a valid date string according to
     /// <https://html.spec.whatwg.org/multipage/#valid-date-string>.
-    fn is_valid_date_string(&self) -> bool {
+    fn is_valid_date_string(self) -> bool {
         self.parse_date_string().is_some()
     }
 
     /// Validates whether or not this value is a valid month string according to
     /// <https://html.spec.whatwg.org/multipage/#valid-month-string>.
-    fn is_valid_month_string(&self) -> bool {
+    fn is_valid_month_string(self) -> bool {
         self.parse_month_string().is_some()
     }
     /// Validates whether or not this value is a valid week string according to
     /// <https://html.spec.whatwg.org/multipage/#valid-week-string>.
-    fn is_valid_week_string(&self) -> bool {
+    fn is_valid_week_string(self) -> bool {
         self.parse_week_string().is_some()
     }
     /// Validates whether or not this value is a valid time string according to
     /// <https://html.spec.whatwg.org/multipage/#valid-time-string>.
-    fn is_valid_time_string(&self) -> bool;
+    fn is_valid_time_string(self) -> bool;
 
     /// Validates whether or not this value is a valid local date time string according to
     /// <https://html.spec.whatwg.org/multipage/#valid-week-string>.
-    fn is_valid_local_date_time_string(&self) -> bool {
+    fn is_valid_local_date_time_string(self) -> bool {
         self.parse_local_date_time_string().is_some()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#valid-simple-colour>
-    fn is_valid_simple_color_string(&self) -> bool;
+    fn is_valid_simple_color_string(self) -> bool;
 
     /// <https://html.spec.whatwg.org/multipage/#valid-e-mail-address>
-    fn is_valid_email_address_string(&self) -> bool;
+    fn is_valid_email_address_string(self) -> bool;
 }
 
-impl FromInputValueString for &str {
-    fn parse_date_string(&self) -> Option<OffsetDateTime> {
+impl<'a, 'b, T> FromInputValueString for T
+where
+    T: StringTrait<'b> + Copy + std::cmp::PartialEq<&'a str>,
+    'b: 'a,
+{
+    fn parse_date_string(self) -> Option<OffsetDateTime> {
         // Step 1, 2, 3
         let (year_int, month_int, day_int) = parse_date_component(self)?;
 
@@ -300,7 +320,7 @@ impl FromInputValueString for &str {
         Some(OffsetDateTime::new_utc(date, Time::MIDNIGHT))
     }
 
-    fn parse_month_string(&self) -> Option<OffsetDateTime> {
+    fn parse_month_string(self) -> Option<OffsetDateTime> {
         // Step 1, 2, 3
         let (year_int, month_int) = parse_month_component(self)?;
 
@@ -314,7 +334,7 @@ impl FromInputValueString for &str {
         Some(OffsetDateTime::new_utc(date, Time::MIDNIGHT))
     }
 
-    fn parse_week_string(&self) -> Option<OffsetDateTime> {
+    fn parse_week_string(self) -> Option<OffsetDateTime> {
         // Step 1, 2, 3
         let mut iterator = self.split('-');
         let year = iterator.next()?;
@@ -356,7 +376,7 @@ impl FromInputValueString for &str {
         Some(OffsetDateTime::new_utc(date, Time::MIDNIGHT))
     }
 
-    fn parse_time_string(&self) -> Option<OffsetDateTime> {
+    fn parse_time_string(self) -> Option<OffsetDateTime> {
         // Step 1, 2, 3
         let (hour, minute, second, millisecond) = parse_time_component(self)?;
 
@@ -373,7 +393,7 @@ impl FromInputValueString for &str {
         ))
     }
 
-    fn parse_local_date_time_string(&self) -> Option<OffsetDateTime> {
+    fn parse_local_date_time_string(self) -> Option<OffsetDateTime> {
         // Step 1, 2, 4
         let mut iterator = if self.contains('T') {
             self.split('T')
@@ -402,7 +422,7 @@ impl FromInputValueString for &str {
         Some(OffsetDateTime::new_utc(date, time))
     }
 
-    fn is_valid_time_string(&self) -> bool {
+    fn is_valid_time_string(self) -> bool {
         enum State {
             HourHigh,
             HourLow09,
@@ -470,7 +490,7 @@ impl FromInputValueString for &str {
         }
     }
 
-    fn is_valid_simple_color_string(&self) -> bool {
+    fn is_valid_simple_color_string(self) -> bool {
         let mut chars = self.chars();
         if self.len() == 7 && chars.next() == Some('#') {
             chars.all(|c| c.is_ascii_hexdigit())
@@ -479,7 +499,7 @@ impl FromInputValueString for &str {
         }
     }
 
-    fn is_valid_email_address_string(&self) -> bool {
+    fn is_valid_email_address_string(self) -> bool {
         static RE: LazyLock<Regex> = LazyLock::new(|| {
             Regex::new(concat!(
                 r"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?",
@@ -487,6 +507,8 @@ impl FromInputValueString for &str {
             ))
             .unwrap()
         });
-        RE.is_match(self)
+        // This should be safe to use unchecked but better safe than sorry.
+        let s = String::from_utf8(self.chars().map(|c| c as u8).collect::<Vec<u8>>()).unwrap();
+        RE.is_match(&s)
     }
 }

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -2,10 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::sync::LazyLock;
-
 use num_traits::Zero;
-use regex::Regex;
 use script_bindings::lazydomstring::StringTrait;
 pub use script_bindings::str::*;
 use time::{Date, Month, OffsetDateTime, Time, Weekday};
@@ -295,9 +292,6 @@ where
 
     /// <https://html.spec.whatwg.org/multipage/#valid-simple-colour>
     fn is_valid_simple_color_string(self) -> bool;
-
-    /// <https://html.spec.whatwg.org/multipage/#valid-e-mail-address>
-    fn is_valid_email_address_string(self) -> bool;
 }
 
 impl<'a, 'b, T> FromInputValueString for T
@@ -497,18 +491,5 @@ where
         } else {
             false
         }
-    }
-
-    fn is_valid_email_address_string(self) -> bool {
-        static RE: LazyLock<Regex> = LazyLock::new(|| {
-            Regex::new(concat!(
-                r"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?",
-                r"(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
-            ))
-            .unwrap()
-        });
-        // This should be safe to use unchecked but better safe than sorry.
-        let s = String::from_utf8(self.chars().map(|c| c as u8).collect::<Vec<u8>>()).unwrap();
-        RE.is_match(&s)
     }
 }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1228,7 +1228,7 @@ impl HTMLFormElement {
                             data_set.push(FormDatum {
                                 ty: textarea.Type(),
                                 name,
-                                value: FormDatumValue::String(textarea.Value()),
+                                value: FormDatumValue::String(textarea.Value().to_domstring()),
                             });
                         }
                     },

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -9,6 +9,7 @@ use std::ops::Range;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::rust::HandleObject;
+use script_bindings::lazydomstring::LazyDOMString;
 use style::attr::AttrValue;
 use stylo_dom::ElementState;
 
@@ -75,6 +76,7 @@ impl<'dom> LayoutDom<'dom, HTMLTextAreaElement> {
                 .textinput
                 .borrow_for_layout()
                 .get_content()
+                .to_domstring()
         }
     }
 
@@ -322,12 +324,12 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-value
-    fn Value(&self) -> DOMString {
+    fn Value(&self) -> LazyDOMString {
         self.textinput.borrow().get_content()
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-value
-    fn SetValue(&self, value: DOMString) {
+    fn SetValue(&self, value: LazyDOMString) {
         {
             let mut textinput = self.textinput.borrow_mut();
 
@@ -454,13 +456,15 @@ impl HTMLTextAreaElement {
     /// Used by WebDriver to clear the textarea element.
     pub(crate) fn clear(&self) {
         self.value_dirty.set(false);
-        self.textinput.borrow_mut().set_content(DOMString::from(""));
+        self.textinput
+            .borrow_mut()
+            .set_content(LazyDOMString::from(""));
     }
 
     pub(crate) fn reset(&self) {
         // https://html.spec.whatwg.org/multipage/#the-textarea-element:concept-form-reset-control
         let mut textinput = self.textinput.borrow_mut();
-        textinput.set_content(self.DefaultValue());
+        textinput.set_content(LazyDOMString::from(self.DefaultValue().to_string()));
         self.value_dirty.set(false);
     }
 

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -350,6 +350,19 @@ macro_rules! make_atomic_setter(
 );
 
 #[macro_export]
+macro_rules! make_atomic_setter_lazy(
+    ( $attr:ident, $htmlname:tt ) => (
+        fn $attr(&self, value: LazyDOMString) {
+            use $crate::dom::bindings::inheritance::Castable;
+            use $crate::dom::element::Element;
+            use $crate::script_runtime::CanGc;
+            let element = self.upcast::<Element>();
+            element.set_atomic_attribute(&html5ever::local_name!($htmlname), value.to_domstring(), CanGc::note())
+        }
+    );
+);
+
+#[macro_export]
 macro_rules! make_legacy_color_setter(
     ( $attr:ident, $htmlname:tt ) => (
         fn $attr(&self, value: DOMString) {

--- a/components/script/dom/radionodelist.rs
+++ b/components/script/dom/radionodelist.rs
@@ -92,7 +92,7 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
                 node.downcast::<HTMLInputElement>().and_then(|input| {
                     if input.input_type() == InputType::Radio && input.Checked() {
                         // Step 3-4
-                        let value = input.Value();
+                        let value = input.Value().to_domstring();
                         Some(if value.is_empty() {
                             DOMString::from("on")
                         } else {
@@ -116,7 +116,7 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
                 match input.input_type() {
                     InputType::Radio if value == *"on" => {
                         // Step 2
-                        let val = input.Value();
+                        let val = input.Value().to_domstring();
                         if val.is_empty() || val == value {
                             input.SetChecked(true);
                             return;
@@ -124,7 +124,7 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
                     },
                     InputType::Radio => {
                         // Step 2
-                        if input.Value() == value {
+                        if input.Value().to_domstring() == value {
                             input.SetChecked(true);
                             return;
                         }

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -16,6 +16,7 @@ name = "script_bindings"
 path = "lib.rs"
 
 [dependencies]
+ascii = { workspace = true }
 bitflags = { workspace = true }
 crossbeam-channel = { workspace = true }
 cssparser = { workspace = true }

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -1071,7 +1071,10 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
             if type.nullable():
                 default = f"Some({default})"
 
-        declType = "DOMString"
+        if type.getExtendedAttribute("Lazy"):
+            declType = "LazyDOMString"
+        else:
+            declType = "DOMString"
         if type.nullable():
             declType = f"Option<{declType}>"
 
@@ -1550,6 +1553,8 @@ def getRetvalDeclarationForType(returnType: IDLType | None, descriptorProvider: 
         return builtin_return_type(returnType)
     if returnType.isDOMString():
         result = CGGeneric("DOMString")
+        if returnType.getExtendedAttribute("Lazy"):
+            result = CGGeneric("LazyDOMString")
         if returnType.nullable():
             result = CGWrapper(result, pre="Option<", post=">")
         return result

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -28,6 +28,7 @@ use num_traits::Float;
 use crate::JSTraceable;
 use crate::codegen::GenericBindings::EventModifierInitBinding::EventModifierInit;
 use crate::inheritance::Castable;
+use crate::lazydomstring::LazyDOMString;
 use crate::num::Finite;
 use crate::reflector::{DomObject, Reflector};
 use crate::root::DomRoot;
@@ -76,6 +77,23 @@ pub enum StringificationBehavior {
 impl ToJSValConvertible for DOMString {
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
         (**self).to_jsval(cx, rval);
+    }
+}
+
+impl FromJSValConvertible for LazyDOMString {
+    type Config = StringificationBehavior;
+    unsafe fn from_jsval(
+        cx: *mut JSContext,
+        value: HandleValue,
+        null_behavior: StringificationBehavior,
+    ) -> Result<ConversionResult<LazyDOMString>, ()> {
+        if null_behavior == StringificationBehavior::Empty && value.get().is_null() {
+            Ok(ConversionResult::Success(LazyDOMString::new()))
+        } else {
+            Ok(ConversionResult::Success(LazyDOMString::from_js_string(
+                cx, value,
+            )))
+        }
     }
 }
 

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -32,6 +32,7 @@ pub(crate) mod base {
     pub(crate) use crate::error::Error::JSFailed;
     pub(crate) use crate::error::Fallible;
     pub(crate) use crate::interfaces::*;
+    pub(crate) use crate::lazydomstring::LazyDOMString;
     pub(crate) use crate::lock::ThreadUnsafeOnceLock;
     pub(crate) use crate::num::Finite;
     pub(crate) use crate::proxyhandler::CrossOriginProperties;

--- a/components/script_bindings/lazydomstring.rs
+++ b/components/script_bindings/lazydomstring.rs
@@ -1,0 +1,575 @@
+use std::borrow::ToOwned;
+use std::cell::OnceCell;
+use std::default::Default;
+use std::ffi::CString;
+use std::ops::Deref;
+use std::ptr::{self, NonNull};
+use std::str::{EncodeUtf16, FromStr};
+use std::sync::LazyLock;
+use std::{fmt, slice, str};
+
+use ascii::ToAsciiChar;
+use html5ever::{LocalName, Namespace};
+use js::conversions::{ToJSValConvertible, jsstr_to_string};
+use js::gc::MutableHandleValue;
+use js::jsapi::{Heap, JS_GetLatin1StringCharsAndLength, JSContext, JSString};
+use js::rust::Trace;
+use malloc_size_of::MallocSizeOfOps;
+use regex::Regex;
+use style::Atom;
+use tendril::encoding_rs;
+
+use crate::str::DOMString;
+
+fn char_to_latin1_u8(c: char) -> u8 {
+    c.to_ascii_char().unwrap().into()
+}
+
+fn latin1_u8_to_char(c: u8) -> char {
+    c.to_ascii_char().unwrap().into()
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum EncodedBytes<'a> {
+    Latin1Bytes(&'a [u8]),
+    Utf8Bytes(&'a str),
+}
+
+impl<'a> EncodedBytes<'a> {
+    pub fn encode_utf16(self) -> EncodeUtf16<'a> {
+        match self {
+            EncodedBytes::Latin1Bytes(s) => {
+                String::from_iter(s.iter().map(|c| latin1_u8_to_char(*c))).encode_utf16()
+            },
+            EncodedBytes::Utf8Bytes(s) => s.encode_utf16(),
+        }
+    }
+
+    pub fn split_commas(self) -> Box<dyn Iterator<Item = EncodedBytes<'a>> + 'a> {
+        match self {
+            EncodedBytes::Latin1Bytes(s) => Box::new(
+                s.split(|byte| *byte == char_to_latin1_u8(','))
+                    .map(EncodedBytes::Latin1Bytes),
+            ),
+            EncodedBytes::Utf8Bytes(s) => Box::new(s.split(',').map(EncodedBytes::Utf8Bytes)),
+        }
+    }
+
+    pub fn char_indices(self) -> Box<dyn Iterator<Item = (usize, char)> + 'a> {
+        match self {
+            EncodedBytes::Latin1Bytes(items) => Box::new(
+                items
+                    .iter()
+                    .enumerate()
+                    .map(|(index, c)| (index, latin1_u8_to_char(*c))),
+            ),
+            EncodedBytes::Utf8Bytes(s) => Box::new(s.char_indices()),
+        }
+    }
+}
+
+impl<'a> PartialEq<str> for EncodedBytes<'a> {
+    fn eq(&self, other: &str) -> bool {
+        match self {
+            EncodedBytes::Utf8Bytes(s) => *s == other,
+            EncodedBytes::Latin1Bytes(s) => {
+                let v = s.iter().map(|c| *c as char as u8).collect::<Vec<u8>>();
+                v == *s
+            },
+        }
+    }
+}
+
+impl<'a> PartialEq<&str> for EncodedBytes<'a> {
+    fn eq(&self, other: &&str) -> bool {
+        match self {
+            EncodedBytes::Utf8Bytes(s) => s == other,
+            EncodedBytes::Latin1Bytes(s) => {
+                let v = s.iter().map(|c| *c as char as u8).collect::<Vec<u8>>();
+                &String::from_utf8(v).unwrap() == other
+            },
+        }
+    }
+}
+
+impl<'a> PartialEq<&str> for Box<EncodedBytes<'a>> {
+    fn eq(&self, other: &&str) -> bool {
+        match self.deref() {
+            EncodedBytes::Utf8Bytes(s) => s == other,
+            EncodedBytes::Latin1Bytes(s) => {
+                let v = s.iter().map(|c| *c as char as u8).collect::<Vec<u8>>();
+                &String::from_utf8(v).unwrap() == other
+            },
+        }
+    }
+}
+
+#[cfg_attr(crown, allow(crown::unrooted_must_root))]
+/// This string class will keep either the Reference toe the mozjs object alive
+/// or will have an internal rust string.
+/// We currently default to doing most of the string operation on the rust side.
+/// As this conversion was anyway needed, it does not much extra cost.
+/// You should assume that all the functions incur the conversion cost.
+pub struct LazyDOMString {
+    rust_string: OnceCell<String>,
+    js_context: Option<*mut JSContext>,
+    js_string: Option<std::boxed::Box<Heap<*mut JSString>>>,
+}
+
+impl std::fmt::Debug for LazyDOMString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LazyDOMString")
+            .field("rust_string", &self.rust_string)
+            .finish()
+    }
+}
+
+impl Clone for LazyDOMString {
+    fn clone(&self) -> Self {
+        self.make_me_string();
+        Self {
+            rust_string: self.rust_string.clone(),
+            js_context: None,
+            js_string: None,
+        }
+    }
+}
+
+unsafe impl Trace for LazyDOMString {
+    unsafe fn trace(&self, tracer: *mut js::jsapi::JSTracer) {
+        // We can safely delete the jsstring if we already converted to a rust string.
+        if self.rust_string.get().is_none() {
+            if let Some(ref s) = self.js_string {
+                unsafe { s.trace(tracer) }
+            }
+        }
+    }
+}
+
+impl LazyDOMString {
+    /// Creates a new `DOMString`.
+    pub fn new() -> LazyDOMString {
+        LazyDOMString {
+            rust_string: OnceCell::from(String::new()),
+            js_context: None,
+            js_string: None,
+        }
+    }
+
+    /// This method will do some work if necessary but not an allocation.
+    pub fn bytes<'a>(&'a self) -> EncodedBytes<'a> {
+        self.debug_js();
+        match self.rust_string.get() {
+            Some(s) => EncodedBytes::Utf8Bytes(s.as_str()),
+            None => {
+                let mut length = 0;
+                unsafe {
+                    let chars = JS_GetLatin1StringCharsAndLength(
+                        self.js_context.unwrap(),
+                        ptr::null(),
+                        self.js_string.as_ref().unwrap().get(),
+                        &mut length,
+                    );
+                    assert!(!chars.is_null());
+
+                    EncodedBytes::Latin1Bytes(slice::from_raw_parts(chars, length))
+                }
+            },
+        }
+    }
+
+    /// This method is here for compatibilities sake.
+    pub fn str(&self) -> EncodedBytes<'_> {
+        self.debug_js();
+        self.bytes()
+    }
+
+    /// Creates a new `DOMString` from a `String`.
+    pub fn from_string(s: String) -> LazyDOMString {
+        LazyDOMString {
+            rust_string: OnceCell::from(s),
+            js_context: None,
+            js_string: None,
+        }
+    }
+
+    /// Debug the current  state of the string
+    #[allow(unused)]
+    fn debug_js(&self) {
+        if self.js_string.is_some() && self.rust_string.get().is_none() {
+            unsafe {
+                println!(
+                    "jsstring {:?}",
+                    jsstr_to_string(
+                        self.js_context.unwrap(),
+                        ptr::NonNull::new(self.js_string.as_ref().unwrap().get()).unwrap()
+                    )
+                );
+            }
+        } else {
+            println!("only rust string {:?}", self.rust_string.get().unwrap());
+        }
+    }
+
+    pub fn from_js_string(cx: *mut JSContext, value: js::gc::HandleValue) -> LazyDOMString {
+        let string_ptr = unsafe { js::rust::ToString(cx, value) };
+        if !string_ptr.is_null() {
+            let latin1 = unsafe { js::jsapi::JS_DeprecatedStringHasLatin1Chars(string_ptr) };
+            if latin1 {
+                let h = Heap::boxed(string_ptr);
+                LazyDOMString {
+                    rust_string: OnceCell::new(),
+                    js_context: Some(cx),
+                    js_string: Some(h),
+                }
+            } else {
+                // We need to convert the string anyway as it is not just latin1
+                LazyDOMString::from_string(unsafe {
+                    jsstr_to_string(cx, ptr::NonNull::new(string_ptr).unwrap())
+                })
+            }
+        } else {
+            LazyDOMString::from_string(String::new())
+        }
+    }
+
+    fn make_me_string(&self) {
+        self.rust_string.get_or_init(|| unsafe {
+            info!("Converting js string to rust");
+            jsstr_to_string(
+                self.js_context.unwrap(),
+                NonNull::new(self.js_string.as_ref().unwrap().get()).unwrap(),
+            )
+        });
+    }
+
+    pub fn encode_utf16(&self) -> EncodeUtf16<'_> {
+        self.bytes().encode_utf16()
+    }
+
+    pub fn rust_str(&self) -> &str {
+        self.make_me_string();
+        self.rust_string.get().unwrap()
+    }
+
+    pub fn to_domstring(&self) -> DOMString {
+        self.make_me_string();
+        DOMString::from_string(self.rust_string.get().unwrap().to_owned())
+    }
+
+    pub fn clear(&mut self) {
+        if let Some(val) = self.rust_string.get_mut() {
+            val.clear();
+        } else {
+            self.debug_js();
+            self.rust_string
+                .set(String::new())
+                .expect("Error in clearing");
+        }
+    }
+
+    pub fn push_str(&mut self, s: &str) {
+        self.make_me_string();
+        self.rust_string.get_mut().unwrap().push_str(s)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.make_me_string();
+        self.rust_string.get().unwrap().is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.str().len()
+    }
+
+    pub fn strip_leading_and_trailing_ascii_whitespace(&mut self) {
+        if self.is_empty() {
+            return;
+        }
+
+        self.make_me_string();
+        let s = self.rust_string.get_mut().unwrap();
+
+        let trailing_whitespace_len = s
+            .trim_end_matches(|ref c| char::is_ascii_whitespace(c))
+            .len();
+        s.truncate(trailing_whitespace_len);
+        if s.is_empty() {
+            return;
+        }
+
+        let first_non_whitespace = s.find(|ref c| !char::is_ascii_whitespace(c)).unwrap();
+        s.replace_range(0..first_non_whitespace, "");
+    }
+
+    pub fn make_ascii_lowercase(&mut self) {
+        self.make_me_string();
+        self.rust_string.get_mut().unwrap().make_ascii_lowercase();
+    }
+
+    pub fn is_valid_floating_point_number_string(&self) -> bool {
+        static RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^-?(?:\d+\.\d+|\d+|\.\d+)(?:(e|E)(\+|\-)?\d+)?$").unwrap()
+        });
+
+        RE.is_match(self.rust_str()) && self.parse_floating_point_number().is_some()
+    }
+
+    pub fn parse<T: FromStr + std::fmt::Debug>(&self) -> Result<T, <T as FromStr>::Err> {
+        self.make_me_string();
+        self.str().parse::<T>()
+    }
+
+    /// <https://html.spec.whatwg.org/multipage/#rules-for-parsing-floating-point-number-values>
+    pub fn parse_floating_point_number(&self) -> Option<f64> {
+        self.to_domstring().parse_floating_point_number()
+    }
+
+    pub fn set_best_representation_of_the_floating_point_number(&mut self) {
+        self.to_domstring()
+            .set_best_representation_of_the_floating_point_number();
+    }
+
+    pub fn strip_newlines(&mut self) {
+        self.make_me_string();
+        self.rust_string
+            .get_mut()
+            .unwrap()
+            .retain(|c| c != '\r' && c != '\n');
+    }
+
+    pub fn replace(self, needle: &str, replace_char: &str) -> LazyDOMString {
+        self.make_me_string();
+        let new_string = self.rust_string.get().unwrap().to_owned();
+        LazyDOMString::from_string(new_string.replace(needle, replace_char))
+    }
+
+    pub fn split(&mut self, c: char) -> impl Iterator<Item = &str> {
+        self.make_me_string();
+        self.rust_string.get().unwrap().split(c)
+    }
+}
+
+impl ToJSValConvertible for LazyDOMString {
+    unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
+        self.make_me_string();
+        unsafe {
+            self.rust_str().to_jsval(cx, rval);
+        }
+    }
+}
+
+impl std::hash::Hash for LazyDOMString {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.make_me_string();
+        self.rust_string.hash(state);
+    }
+}
+
+impl From<&str> for LazyDOMString {
+    fn from(contents: &str) -> LazyDOMString {
+        LazyDOMString::from_string(String::from(contents))
+    }
+}
+
+impl From<LazyDOMString> for String {
+    fn from(val: LazyDOMString) -> Self {
+        val.make_me_string();
+        val.rust_str().to_owned()
+    }
+}
+
+impl From<LazyDOMString> for Vec<u8> {
+    fn from(mut value: LazyDOMString) -> Self {
+        value.make_me_string();
+        value.rust_string.take().unwrap().as_bytes().to_vec()
+    }
+}
+
+impl malloc_size_of::MallocSizeOf for LazyDOMString {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        if let Some(s) = self.rust_string.get() {
+            s.size_of(ops)
+        } else {
+            0
+        }
+    }
+}
+
+impl std::fmt::Display for LazyDOMString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.make_me_string();
+        fmt::Display::fmt(self.rust_string.get().unwrap(), f)
+    }
+}
+
+impl Default for LazyDOMString {
+    fn default() -> Self {
+        LazyDOMString::new()
+    }
+}
+
+impl std::cmp::PartialEq<&str> for LazyDOMString {
+    fn eq(&self, other: &&str) -> bool {
+        self.make_me_string();
+        self.rust_string.get().unwrap() == *other
+    }
+}
+
+impl std::cmp::PartialEq for LazyDOMString {
+    fn eq(&self, other: &Self) -> bool {
+        self.make_me_string();
+        other.make_me_string();
+        self.rust_str() == other.rust_str()
+    }
+}
+
+impl std::cmp::Eq for LazyDOMString {}
+
+impl From<std::string::String> for LazyDOMString {
+    fn from(value: String) -> Self {
+        LazyDOMString::from_string(value)
+    }
+}
+
+impl From<LazyDOMString> for LocalName {
+    fn from(contents: LazyDOMString) -> LocalName {
+        contents.make_me_string();
+        LocalName::from(contents.rust_str())
+    }
+}
+
+impl From<LazyDOMString> for Namespace {
+    fn from(contents: LazyDOMString) -> Namespace {
+        contents.make_me_string();
+        Namespace::from(contents.rust_str())
+    }
+}
+
+impl From<LazyDOMString> for Atom {
+    fn from(contents: LazyDOMString) -> Atom {
+        contents.make_me_string();
+        Atom::from(contents.rust_str())
+    }
+}
+
+impl From<EncodedBytes<'_>> for LazyDOMString {
+    fn from(value: EncodedBytes<'_>) -> Self {
+        match value {
+            EncodedBytes::Utf8Bytes(s) => LazyDOMString::from_string(s.to_string()),
+            EncodedBytes::Latin1Bytes(s) => {
+                LazyDOMString::from_string(encoding_rs::mem::decode_latin1(s).into_owned())
+            },
+        }
+    }
+}
+
+pub trait StringTrait<'a>
+where
+    Self: Sized,
+{
+    fn split(self, split_char: char) -> Box<dyn Iterator<Item = Self> + 'a>;
+    fn parse<T: FromStr + std::fmt::Debug>(self) -> Result<T, <T as FromStr>::Err>;
+    fn len(self) -> usize;
+    fn empty(self) -> bool;
+    fn split_at(self, index: usize) -> (Self, Self)
+    where
+        Self: Sized;
+    fn contains(self, char: char) -> bool;
+    fn split_commas(self) -> Box<dyn Iterator<Item = Self> + 'a> {
+        self.split(',')
+    }
+    /// You should assume this function is slow.
+    fn chars(self) -> Box<dyn Iterator<Item = char> + 'a>;
+}
+
+impl<'a> StringTrait<'a> for EncodedBytes<'a> {
+    fn split(self, split_char: char) -> Box<dyn Iterator<Item = EncodedBytes<'a>> + 'a> {
+        match self {
+            EncodedBytes::Utf8Bytes(s) => {
+                Box::new(s.split(split_char).map(EncodedBytes::Utf8Bytes))
+            },
+            EncodedBytes::Latin1Bytes(items) => Box::new(
+                items
+                    .split(move |c| *c == char_to_latin1_u8(split_char))
+                    .map(EncodedBytes::Latin1Bytes),
+            ),
+        }
+    }
+
+    fn parse<T: FromStr + std::fmt::Debug>(self) -> Result<T, <T as FromStr>::Err> {
+        match self {
+            EncodedBytes::Latin1Bytes(s) => {
+                let f = encoding_rs::mem::decode_latin1(s);
+                f.parse::<T>()
+            },
+            EncodedBytes::Utf8Bytes(s) => s.parse::<T>(),
+        }
+    }
+
+    fn len(self) -> usize {
+        match self {
+            EncodedBytes::Utf8Bytes(s) => s.len(),
+            EncodedBytes::Latin1Bytes(items) => items.len(),
+        }
+    }
+
+    fn empty(self) -> bool {
+        match self {
+            EncodedBytes::Latin1Bytes(items) => items.is_empty(),
+            EncodedBytes::Utf8Bytes(s) => s.is_empty(),
+        }
+    }
+
+    fn split_at(self, index: usize) -> (Self, Self) {
+        match self {
+            EncodedBytes::Utf8Bytes(s) => {
+                let (a, b) = s.split_at(index);
+                (EncodedBytes::Utf8Bytes(a), EncodedBytes::Utf8Bytes(b))
+            },
+            EncodedBytes::Latin1Bytes(items) => {
+                let (a, b) = items.split_at(index);
+                (EncodedBytes::Latin1Bytes(a), EncodedBytes::Latin1Bytes(b))
+            },
+        }
+    }
+
+    fn contains(self, char: char) -> bool {
+        match self {
+            EncodedBytes::Utf8Bytes(s) => s.contains(char),
+            EncodedBytes::Latin1Bytes(items) => items.contains(&char_to_latin1_u8(char)),
+        }
+    }
+
+    fn chars(self) -> Box<dyn Iterator<Item = char> + 'a> {
+        match self {
+            EncodedBytes::Utf8Bytes(s) => Box::new(s.chars()),
+            EncodedBytes::Latin1Bytes(s) => Box::new(s.iter().map(|c| latin1_u8_to_char(*c))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn latin1_u8_to_char_test_only_ascii() {
+        let latin1 = vec![
+            ' ', '!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', '+', ',', '-', '.', '/', '0',
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', ':', ';', '<', '=', '>', '?', '@', 'A',
+            'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+            'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '[', '\\', ']', '^', '_', '`', 'a', 'b', 'c',
+            'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
+            'u', 'v', 'w', 'x', 'y', 'z', '{', '|', '}', '~',
+        ];
+        for i in latin1 {
+            assert!(latin1_u8_to_char(i as u8) == i);
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn error_conversion_to_char() {
+        latin1_u8_to_char(b"\xA0"[0]);
+    }
+}

--- a/components/script_bindings/lazydomstring.rs
+++ b/components/script_bindings/lazydomstring.rs
@@ -36,12 +36,14 @@ pub enum EncodedBytes<'a> {
 }
 
 impl<'a> EncodedBytes<'a> {
-    pub fn encode_utf16(self) -> EncodeUtf16<'a> {
+    pub fn encode_utf16(self) -> Vec<u16> {
         match self {
             EncodedBytes::Latin1Bytes(s) => {
-                String::from_iter(s.iter().map(|c| latin1_u8_to_char(*c))).encode_utf16()
+                String::from_iter(s.iter().map(|c| latin1_u8_to_char(*c)))
+                    .encode_utf16()
+                    .collect()
             },
-            EncodedBytes::Utf8Bytes(s) => s.encode_utf16(),
+            EncodedBytes::Utf8Bytes(s) => s.encode_utf16().collect(),
         }
     }
 
@@ -244,7 +246,8 @@ impl LazyDOMString {
     }
 
     pub fn encode_utf16(&self) -> EncodeUtf16<'_> {
-        self.bytes().encode_utf16()
+        self.make_me_string();
+        self.rust_str().encode_utf16()
     }
 
     pub fn rust_str(&self) -> &str {
@@ -362,7 +365,7 @@ impl ToJSValConvertible for LazyDOMString {
 impl std::hash::Hash for LazyDOMString {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.make_me_string();
-        self.rust_string.hash(state);
+        self.rust_string.get().hash(state);
     }
 }
 

--- a/components/script_bindings/lazydomstring.rs
+++ b/components/script_bindings/lazydomstring.rs
@@ -1,7 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use std::borrow::ToOwned;
 use std::cell::OnceCell;
 use std::default::Default;
-use std::ffi::CString;
 use std::ops::Deref;
 use std::ptr::{self, NonNull};
 use std::str::{EncodeUtf16, FromStr};
@@ -36,17 +39,6 @@ pub enum EncodedBytes<'a> {
 }
 
 impl<'a> EncodedBytes<'a> {
-    pub fn encode_utf16(self) -> Vec<u16> {
-        match self {
-            EncodedBytes::Latin1Bytes(s) => {
-                String::from_iter(s.iter().map(|c| latin1_u8_to_char(*c)))
-                    .encode_utf16()
-                    .collect()
-            },
-            EncodedBytes::Utf8Bytes(s) => s.encode_utf16().collect(),
-        }
-    }
-
     pub fn split_commas(self) -> Box<dyn Iterator<Item = EncodedBytes<'a>> + 'a> {
         match self {
             EncodedBytes::Latin1Bytes(s) => Box::new(
@@ -347,7 +339,7 @@ impl LazyDOMString {
         LazyDOMString::from_string(new_string.replace(needle, replace_char))
     }
 
-    pub fn split(&mut self, c: char) -> impl Iterator<Item = &str> {
+    pub fn split(&self, c: char) -> impl Iterator<Item = &str> {
         self.make_me_string();
         self.rust_string.get().unwrap().split(c)
     }

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -27,6 +27,7 @@ pub mod inheritance;
 pub mod interface;
 pub mod interfaces;
 pub mod iterable;
+pub mod lazydomstring;
 pub mod like;
 mod lock;
 mod mem;

--- a/components/script_bindings/webidls/HTMLInputElement.webidl
+++ b/components/script_bindings/webidls/HTMLInputElement.webidl
@@ -67,11 +67,11 @@ interface HTMLInputElement : HTMLElement {
   [CEReactions]
            attribute DOMString step;
   [CEReactions]
-           attribute DOMString type;
+           attribute [Lazy] DOMString type;
   [CEReactions]
            attribute DOMString defaultValue;
   [CEReactions, SetterThrows]
-           attribute [LegacyNullToEmptyString] DOMString value;
+           attribute [LegacyNullToEmptyString, Lazy] DOMString value;
   [SetterThrows]
            attribute object? valueAsDate;
   [SetterThrows]

--- a/components/script_bindings/webidls/HTMLTextAreaElement.webidl
+++ b/components/script_bindings/webidls/HTMLTextAreaElement.webidl
@@ -40,7 +40,7 @@ interface HTMLTextAreaElement : HTMLElement {
   readonly attribute DOMString type;
   [CEReactions]
            attribute DOMString defaultValue;
-           attribute [LegacyNullToEmptyString] DOMString value;
+           attribute [LegacyNullToEmptyString, Lazy] DOMString value;
   readonly attribute unsigned long textLength;
 
   readonly attribute boolean willValidate;


### PR DESCRIPTION
The problem:
Currently whenever we have a string comming from the mozjs side we convert it to a rust string. This needs another allocation and
might not be necessary in some cases (like validation where we clear the string).

Solution: Allow the the type to keep the JS string around and only convert it if necessary. Try to do as many operations as possible on the JS
string itself.

This RFC:
This RFC introduces a new String class `LazyDOMString`. We hook into codegen.py and WebIDLParser to have a new attribute called Lazy which changes the string class
from DOMString to LazyDOMString. This was implemented for htmlinputelement and related.
The LazyDOMString class has most of the methods you expect. Somme mentions
- `make_me_string()`: performs the conversion and is used in many places.
- `bytes()/str()`: Gives the bytes of the underlying string in EncodedBytes enum.
- The Latin1Bytes comes from mozjs and is part of the native string type mozilla uses so it should be reasonably efficient.

What is missing:
- There are still a lot of functionality missing which I hope to implement.
- It would be good if we can replace the DOMString with LazyDOMString everywhere but it is a bit unclear to me how much functionality needs to be supported.
- A lot of methods just seem to assume DOMString can be dereferenced to a &str which makes it quite  difficult to do a complete conversion and implementing Deref<str> seems to defeat the point. Any pointers on how to handle this would be appreciated.

