### PR TITLE
servoshell: Update the debug options (`-Z`) help to reflect current set of options

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -151,12 +151,12 @@ impl DebugOptions {
                 "dump-flow-tree" => self.dump_flow_tree = true,
                 "dump-rule-tree" => self.dump_rule_tree = true,
                 "dump-style-tree" => self.dump_style_tree = true,
+                "dump-style-stats" => self.dump_style_statistics = true,
                 "dump-scroll-tree" => self.dump_scroll_tree = true,
                 "gc-profile" => self.gc_profile = true,
                 "profile-script-events" => self.profile_script_events = true,
                 "relayout-event" => self.relayout_event = true,
                 "signpost" => self.signpost = true,
-                "dump-style-stats" => self.dump_style_statistics = true,
                 "" => {},
                 _ => return Err(String::from(option)),
             };

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -730,11 +730,6 @@ fn print_debug_options_usage(app: &str) {
         "Usage: {} debug option,[options,...]\n\twhere options include\n\nOptions:",
         app
     );
-
-    print_option(
-        "bubble-inline-sizes-separately",
-        "Bubble intrinsic widths separately like other engines.",
-    );
     print_option(
         "convert-mouse-to-touch",
         "Send touch events instead of mouse events",
@@ -752,10 +747,6 @@ fn print_debug_options_usage(app: &str) {
         "Print the display list after each layout.",
     );
     print_option(
-        "dump-display-list-json",
-        "Print the display list in JSON form.",
-    );
-    print_option(
         "dump-flow-tree",
         "Print the fragment tree after each layout.",
     );
@@ -768,11 +759,8 @@ fn print_debug_options_usage(app: &str) {
         "Print the DOM with computed styles after each restyle.",
     );
     print_option("dump-style-stats", "Print style statistics each restyle.");
+    print_option("dump-scroll-tree", "Print scroll tree after each layout.");
     print_option("gc-profile", "Log GC passes and their durations.");
-    print_option(
-        "parallel-display-list-building",
-        "Build display lists in parallel.",
-    );
     print_option(
         "profile-script-events",
         "Enable profiling of script-related events.",
@@ -780,14 +768,6 @@ fn print_debug_options_usage(app: &str) {
     print_option(
         "relayout-event",
         "Print notifications when there is a relayout.",
-    );
-    print_option(
-        "show-fragment-borders",
-        "Paint borders along fragment boundaries.",
-    );
-    print_option(
-        "show-parallel-layout",
-        "Mark which thread laid each flow out with colors.",
     );
     print_option(
         "signpost",


### PR DESCRIPTION
The command-line help output for `-Z` and `DebugOptions were out of sync again. This change makes sure they match again.

Testing: No tests necessary as this mainly just updates the help output.
Fixes: #39311
