### PR TITLE
net: Do not send `data` scheme requests to DevTools

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -260,10 +260,7 @@ pub async fn main_fetch(
 ) -> Response {
     // Step 1: Let request be fetchParam's request.
     let request = &mut fetch_params.request;
-    // send early HTTP request to DevTools if not data
-    if request.url().scheme() != "data" {
-        send_early_httprequest_to_devtools(request, context);
-    }
+    send_early_httprequest_to_devtools(request, context);
     // Step 2: Let response be null.
     let mut response = None;
 

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -260,8 +260,10 @@ pub async fn main_fetch(
 ) -> Response {
     // Step 1: Let request be fetchParam's request.
     let request = &mut fetch_params.request;
-    // send early HTTP request to DevTools
-    send_early_httprequest_to_devtools(request, context);
+    // send early HTTP request to DevTools if not data
+    if request.url().scheme() != "data" {
+        send_early_httprequest_to_devtools(request, context);
+    }
     // Step 2: Let response be null.
     let mut response = None;
 

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -430,6 +430,11 @@ pub fn send_request_to_devtools(
     msg: ChromeToDevtoolsControlMsg,
     devtools_chan: &Sender<DevtoolsControlMsg>,
 ) {
+    if let ChromeToDevtoolsControlMsg::NetworkEvent(_, ref network_event) = msg {
+        if !network_event.forward_to_devtools() {
+            return;
+        }
+    }
     if let Err(e) = devtools_chan.send(DevtoolsControlMsg::FromChrome(msg)) {
         error!("DevTools send failed: {e}");
     }

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -430,10 +430,9 @@ pub fn send_request_to_devtools(
     msg: ChromeToDevtoolsControlMsg,
     devtools_chan: &Sender<DevtoolsControlMsg>,
 ) {
-    if let ChromeToDevtoolsControlMsg::NetworkEvent(_, ref network_event) = msg {
-        if !network_event.forward_to_devtools() {
-            return;
-        }
+    if matches!(msg, ChromeToDevtoolsControlMsg::NetworkEvent(_, ref network_event) if !network_event.forward_to_devtools())
+    {
+        return;
     }
     if let Err(e) = devtools_chan.send(DevtoolsControlMsg::FromChrome(msg)) {
         error!("DevTools send failed: {e}");

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -498,6 +498,10 @@ pub fn send_response_values_to_devtools(
 }
 
 pub fn send_early_httprequest_to_devtools(request: &Request, context: &FetchContext) {
+    // Do not forward data requests to devtools
+    if request.url().scheme() == "data" {
+        return;
+    }
     if let (Some(devtools_chan), Some(browsing_context_id), Some(pipeline_id)) = (
         context.devtools_chan.as_ref(),
         request.target_webview_id.map(|id| id.into()),

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -475,11 +475,12 @@ pub enum NetworkEvent {
 
 impl NetworkEvent {
     pub fn forward_to_devtools(&self) -> bool {
-        match self {
-            NetworkEvent::HttpRequest(http_request) => http_request.url.scheme() != "data",
-            NetworkEvent::HttpRequestUpdate(..) => true,
-            NetworkEvent::HttpResponse(..) => true,
-        }
+        !matches!(self, NetworkEvent::HttpRequest(http_request) if http_request.url.scheme() == "data") ||
+            match self {
+                NetworkEvent::HttpRequest(http_request) => http_request.url.scheme() != "data",
+                NetworkEvent::HttpRequestUpdate(..) => true,
+                NetworkEvent::HttpResponse(..) => true,
+            }
     }
 }
 

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -473,6 +473,16 @@ pub enum NetworkEvent {
     HttpResponse(HttpResponse),
 }
 
+impl NetworkEvent {
+    pub fn forward_to_devtools(&self) -> bool {
+        match self {
+            NetworkEvent::HttpRequest(http_request) => http_request.url.scheme() != "data",
+            NetworkEvent::HttpRequestUpdate(..) => true,
+            NetworkEvent::HttpResponse(..) => true,
+        }
+    }
+}
+
 impl TimelineMarker {
     pub fn start(name: String) -> StartedTimelineMarker {
         StartedTimelineMarker {


### PR DESCRIPTION
Simple check to not send data urls to devtools.


Testing: Looked at reddit.com which sends data url and tested it with this fix.
Fixes: Should fix https://github.com/servo/servo/issues/39127.
