### PR TITLE
net: use `log::error!` to handle DevTools startup failures gracefully

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -430,9 +430,9 @@ pub fn send_request_to_devtools(
     msg: ChromeToDevtoolsControlMsg,
     devtools_chan: &Sender<DevtoolsControlMsg>,
 ) {
-    devtools_chan
-        .send(DevtoolsControlMsg::FromChrome(msg))
-        .unwrap();
+    if let Err(e) = devtools_chan.send(DevtoolsControlMsg::FromChrome(msg)) {
+        error!("DevTools send failed: {e}");
+    }
 }
 
 pub fn send_response_to_devtools(


### PR DESCRIPTION
Replace the `unwrap()` call with `log::error!()` in the `send_request_to_devtools()` function to enhance error handling.

---

Before:
```
╰─❯ ./servo --devtools=1
[2025-09-15T14:35:07Z ERROR servoshell::desktop::app_state] Saw Servo error: DevtoolsFailedToStart!
called `Result::unwrap()` on an `Err` value: "SendError(..)" (thread tokio-runtime-5, at components/net/http_loader.rs:435)
[2025-09-15T14:35:07Z ERROR servoshell::panic_hook] called `Result::unwrap()` on an `Err` value: "SendError(..)"
```

After:
```
╰─❯ ./servo --devtools=1
[2025-09-16T01:24:59Z ERROR servoshell::desktop::app_state] Saw Servo error: DevtoolsFailedToStart!
[2025-09-16T01:24:59Z ERROR net::http_loader] DevTools send failed: sending on a disconnected channel
[2025-09-16T01:24:59Z ERROR net::http_loader] DevTools send failed: sending on a disconnected channel
...
```