### PR TITLE
script: Use xpath ns resolver to resolve namespace prefixes

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1812,16 +1812,16 @@ impl Element {
         Ref::map(self.attrs.borrow(), |attrs| &**attrs)
     }
 
-    // Element branch of https://dom.spec.whatwg.org/#locate-a-namespace
+    /// Element branch of <https://dom.spec.whatwg.org/#locate-a-namespace>
     pub(crate) fn locate_namespace(&self, prefix: Option<DOMString>) -> Namespace {
         let namespace_prefix = prefix.clone().map(|s| Prefix::from(&*s));
 
-        // "1. If prefix is "xml", then return the XML namespace."
+        // Step 1. If prefix is "xml", then return the XML namespace.
         if namespace_prefix == Some(namespace_prefix!("xml")) {
             return ns!(xml);
         }
 
-        // "2. If prefix is "xmlns", then return the XMLNS namespace."
+        // Step 2. If prefix is "xmlns", then return the XMLNS namespace.
         if namespace_prefix == Some(namespace_prefix!("xmlns")) {
             return ns!(xmlns);
         }
@@ -1833,21 +1833,20 @@ impl Element {
             .inclusive_ancestors(ShadowIncluding::No)
             .filter_map(DomRoot::downcast::<Self>);
 
-        // "5. If its parent element is null, then return null."
-        // "6. Return the result of running locate a namespace on its parent element using prefix."
+        // Step 5. If its parent element is null, then return null.
+        // Step 6. Return the result of running locate a namespace on its parent element using prefix.
         for element in inclusive_ancestor_elements {
-            // "3. If its namespace is non-null and its namespace prefix is prefix, then return
-            // namespace."
+            // Step 3. If its namespace is non-null and its namespace prefix is prefix, then return namespace.
             if element.namespace() != &ns!() &&
-                element.prefix().as_ref().map(|p| &**p) == prefix.as_deref()
+                dbg!(element.prefix()).as_ref().map(|p| &**p) == prefix.as_deref()
             {
                 return element.namespace().clone();
             }
 
-            // "4. If it has an attribute whose namespace is the XMLNS namespace, namespace prefix
+            // Step 4. If it has an attribute whose namespace is the XMLNS namespace, namespace prefix
             // is "xmlns", and local name is prefix, or if prefix is null and it has an attribute
             // whose namespace is the XMLNS namespace, namespace prefix is null, and local name is
-            // "xmlns", then return its value if it is not the empty string, and null otherwise."
+            // "xmlns", then return its value if it is not the empty string, and null otherwise.
             let attr = Ref::filter_map(self.attrs(), |attrs| {
                 attrs.iter().find(|attr| {
                     if attr.namespace() != &ns!(xmlns) {
@@ -3088,18 +3087,18 @@ impl Element {
 
 #[allow(non_snake_case)]
 impl ElementMethods<crate::DomTypeHolder> for Element {
-    // https://dom.spec.whatwg.org/#dom-element-namespaceuri
+    /// <https://dom.spec.whatwg.org/#dom-element-namespaceuri>
     fn GetNamespaceURI(&self) -> Option<DOMString> {
         Node::namespace_to_string(self.namespace.clone())
     }
 
-    // https://dom.spec.whatwg.org/#dom-element-localname
+    /// <https://dom.spec.whatwg.org/#dom-element-localname>
     fn LocalName(&self) -> DOMString {
         // FIXME(ajeffrey): Convert directly from LocalName to DOMString
         DOMString::from(&*self.local_name)
     }
 
-    // https://dom.spec.whatwg.org/#dom-element-prefix
+    /// <https://dom.spec.whatwg.org/#dom-element-prefix>
     fn GetPrefix(&self) -> Option<DOMString> {
         self.prefix.borrow().as_ref().map(|p| DOMString::from(&**p))
     }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -1838,7 +1838,7 @@ impl Element {
         for element in inclusive_ancestor_elements {
             // Step 3. If its namespace is non-null and its namespace prefix is prefix, then return namespace.
             if element.namespace() != &ns!() &&
-                dbg!(element.prefix()).as_ref().map(|p| &**p) == prefix.as_deref()
+                element.prefix().as_ref().map(|p| &**p) == prefix.as_deref()
             {
                 return element.namespace().clone();
             }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3986,13 +3986,10 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
 
     /// <https://dom.spec.whatwg.org/#dom-node-lookupnamespaceuri>
     fn LookupNamespaceURI(&self, prefix: Option<DOMString>) -> Option<DOMString> {
-        // Step 1.
-        let prefix = match prefix {
-            Some(ref p) if p.is_empty() => None,
-            pre => pre,
-        };
+        // Step 1. If prefix is the empty string, then set it to null.
+        let prefix = prefix.filter(|prefix| !prefix.is_empty());
 
-        // Step 2.
+        // Step 2. Return the result of running locate a namespace for this using prefix.
         Node::namespace_to_string(Node::locate_namespace(self, prefix))
     }
 

--- a/components/script/dom/xpathevaluator.rs
+++ b/components/script/dom/xpathevaluator.rs
@@ -9,7 +9,6 @@ use js::rust::HandleObject;
 
 use super::bindings::error::Error;
 use crate::dom::bindings::codegen::Bindings::XPathEvaluatorBinding::XPathEvaluatorMethods;
-use crate::dom::bindings::codegen::Bindings::XPathExpressionBinding::XPathExpression_Binding::XPathExpressionMethods;
 use crate::dom::bindings::codegen::Bindings::XPathNSResolverBinding::XPathNSResolver;
 use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object_with_proto};
@@ -91,7 +90,7 @@ impl XPathEvaluatorMethods<crate::DomTypeHolder> for XPathEvaluator {
         &self,
         expression_str: DOMString,
         context_node: &Node,
-        _resolver: Option<Rc<XPathNSResolver>>,
+        resolver: Option<Rc<XPathNSResolver>>,
         result_type: u16,
         result: Option<&XPathResult>,
         can_gc: CanGc,
@@ -101,12 +100,6 @@ impl XPathEvaluatorMethods<crate::DomTypeHolder> for XPathEvaluator {
         let parsed_expression =
             crate::xpath::parse(&expression_str).map_err(|_| Error::Syntax(None))?;
         let expression = XPathExpression::new(window, None, can_gc, parsed_expression);
-        XPathExpressionMethods::<crate::DomTypeHolder>::Evaluate(
-            &*expression,
-            context_node,
-            result_type,
-            result,
-            can_gc,
-        )
+        expression.evaluate_internal(context_node, result_type, result, resolver, can_gc)
     }
 }

--- a/components/script/xpath/context.rs
+++ b/components/script/xpath/context.rs
@@ -2,26 +2,33 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::fmt;
 use std::iter::Enumerate;
+use std::rc::Rc;
 use std::vec::IntoIter;
 
+use script_bindings::error::Fallible;
+use script_bindings::script_runtime::CanGc;
 use script_bindings::str::DOMString;
 
 use super::Node;
+use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::codegen::Bindings::NodeBinding::NodeMethods;
+use crate::dom::bindings::codegen::Bindings::XPathNSResolverBinding::XPathNSResolver;
 use crate::dom::bindings::root::DomRoot;
 
 /// The context during evaluation of an XPath expression.
-#[derive(Debug)]
 pub(crate) struct EvaluationCtx {
-    /// Where we started at
+    /// Where we started at.
     pub(crate) starting_node: DomRoot<Node>,
-    /// The "current" node in the evaluation
+    /// The "current" node in the evaluation.
     pub(crate) context_node: DomRoot<Node>,
-    /// Details needed for evaluating a predicate list
+    /// Details needed for evaluating a predicate list.
     pub(crate) predicate_ctx: Option<PredicateCtx>,
-    /// The nodes we're currently matching against
+    /// The nodes we're currently matching against.
     pub(crate) predicate_nodes: Option<Vec<DomRoot<Node>>>,
+    /// A list of known namespace prefixes.
+    pub(crate) resolver: Option<Rc<XPathNSResolver>>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -32,12 +39,13 @@ pub(crate) struct PredicateCtx {
 
 impl EvaluationCtx {
     /// Prepares the context used while evaluating the XPath expression
-    pub(crate) fn new(context_node: &Node) -> EvaluationCtx {
+    pub(crate) fn new(context_node: &Node, resolver: Option<Rc<XPathNSResolver>>) -> EvaluationCtx {
         EvaluationCtx {
             starting_node: DomRoot::from_ref(context_node),
             context_node: DomRoot::from_ref(context_node),
             predicate_ctx: None,
             predicate_nodes: None,
+            resolver,
         }
     }
 
@@ -48,6 +56,7 @@ impl EvaluationCtx {
             context_node: DomRoot::from_ref(node),
             predicate_ctx: self.predicate_ctx,
             predicate_nodes: self.predicate_nodes.clone(),
+            resolver: self.resolver.clone(),
         }
     }
 
@@ -57,6 +66,7 @@ impl EvaluationCtx {
             context_node: self.context_node.clone(),
             predicate_ctx: None,
             predicate_nodes: Some(nodes.into_iter().map(DomRoot::from_ref).collect()),
+            resolver: self.resolver.clone(),
         }
     }
 
@@ -74,9 +84,26 @@ impl EvaluationCtx {
     }
 
     /// Resolve a namespace prefix using the context node's document
-    pub(crate) fn resolve_namespace(&self, prefix: Option<&str>) -> Option<DOMString> {
-        self.context_node
-            .LookupNamespaceURI(prefix.map(DOMString::from))
+    pub(crate) fn resolve_namespace(
+        &self,
+        prefix: Option<&str>,
+        can_gc: CanGc,
+    ) -> Fallible<Option<DOMString>> {
+        // First check if the prefix is known by our resolver function
+        if let Some(resolver) = self.resolver.as_ref() {
+            if let Some(namespace_uri) = resolver.LookupNamespaceURI__(
+                prefix.map(DOMString::from),
+                ExceptionHandling::Rethrow,
+                can_gc,
+            )? {
+                return Ok(Some(namespace_uri));
+            }
+        }
+
+        // Then, see if it's defined on the context node
+        Ok(self
+            .context_node
+            .LookupNamespaceURI(prefix.map(DOMString::from)))
     }
 }
 
@@ -100,6 +127,19 @@ impl Iterator for EvalNodesetIter<'_> {
                 index: idx + 1,
                 size: self.size,
             }),
+            resolver: self.ctx.resolver.clone(),
         })
+    }
+}
+
+impl fmt::Debug for EvaluationCtx {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EvaluationCtx")
+            .field("starting_node", &self.starting_node)
+            .field("context_node", &self.context_node)
+            .field("predicate_ctx", &self.predicate_ctx)
+            .field("predicate_nodes", &self.predicate_nodes)
+            .field("resolver", &"<callback function>")
+            .finish()
     }
 }

--- a/components/script/xpath/mod.rs
+++ b/components/script/xpath/mod.rs
@@ -26,11 +26,11 @@ mod parser;
 pub(crate) fn parse(xpath: &str) -> Fallible<Expr> {
     match parse_impl(xpath) {
         Ok(expr) => {
-            debug!("Parsed XPath: {:?}", expr);
+            debug!("Parsed XPath: {expr:?}");
             Ok(expr)
         },
         Err(error) => {
-            debug!("Unable to parse XPath: {}", error);
+            debug!("Unable to parse XPath: {error}");
             Err(Error::Operation)
         },
     }
@@ -45,11 +45,11 @@ pub(crate) fn evaluate_parsed_xpath(
     let context = EvaluationCtx::new(context_node, resolver);
     match expr.evaluate(&context) {
         Ok(value) => {
-            debug!("Evaluated XPath: {:?}", value);
+            debug!("Evaluated XPath: {value:?}");
             Ok(value)
         },
         Err(error) => {
-            debug!("Unable to evaluate XPath: {}", error);
+            debug!("Unable to evaluate XPath: {error}");
 
             let error = match error {
                 EvaluationError::JsException(exception) => exception,

--- a/components/script/xpath/mod.rs
+++ b/components/script/xpath/mod.rs
@@ -2,13 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::rc::Rc;
+
 use context::EvaluationCtx;
-use eval::Evaluatable;
+use eval::{Error as EvaluationError, Evaluatable};
 pub(crate) use eval_value::{NodesetHelpers, Value};
-use parser::OwnedParserError;
 pub(crate) use parser::{Expr, parse as parse_impl};
 
 use super::dom::node::Node;
+use crate::dom::bindings::codegen::Bindings::XPathNSResolverBinding::XPathNSResolver;
+use crate::dom::bindings::error::{Error as JsError, Error, Fallible};
 
 mod context;
 #[allow(dead_code)]
@@ -19,58 +22,41 @@ mod eval_value;
 #[allow(dead_code)]
 mod parser;
 
-/// The failure modes of executing an XPath.
-#[derive(Debug, PartialEq)]
-pub(crate) enum Error {
-    /// The XPath was syntactically invalid
-    Parsing { source: OwnedParserError },
-    /// The XPath could not be executed
-    Evaluating { source: eval::Error },
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Error::Parsing { source } => write!(f, "Unable to parse XPath: {}", source),
-            Error::Evaluating { source } => write!(f, "Unable to evaluate XPath: {}", source),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Error::Parsing { source } => Some(source),
-            Error::Evaluating { source } => Some(source),
-        }
-    }
-}
-
 /// Parse an XPath expression from a string
-pub(crate) fn parse(xpath: &str) -> Result<Expr, Error> {
+pub(crate) fn parse(xpath: &str) -> Fallible<Expr> {
     match parse_impl(xpath) {
         Ok(expr) => {
             debug!("Parsed XPath: {:?}", expr);
             Ok(expr)
         },
-        Err(e) => {
-            debug!("Unable to parse XPath: {}", e);
-            Err(Error::Parsing { source: e })
+        Err(error) => {
+            debug!("Unable to parse XPath: {}", error);
+            Err(Error::Operation)
         },
     }
 }
 
 /// Evaluate an already-parsed XPath expression
-pub(crate) fn evaluate_parsed_xpath(expr: &Expr, context_node: &Node) -> Result<Value, Error> {
-    let context = EvaluationCtx::new(context_node);
+pub(crate) fn evaluate_parsed_xpath(
+    expr: &Expr,
+    context_node: &Node,
+    resolver: Option<Rc<XPathNSResolver>>,
+) -> Fallible<Value> {
+    let context = EvaluationCtx::new(context_node, resolver);
     match expr.evaluate(&context) {
-        Ok(v) => {
-            debug!("Evaluated XPath: {:?}", v);
-            Ok(v)
+        Ok(value) => {
+            debug!("Evaluated XPath: {:?}", value);
+            Ok(value)
         },
-        Err(e) => {
-            debug!("Unable to evaluate XPath: {}", e);
-            Err(Error::Evaluating { source: e })
+        Err(error) => {
+            debug!("Unable to evaluate XPath: {}", error);
+
+            let error = match error {
+                EvaluationError::JsException(exception) => exception,
+                _ => JsError::Operation,
+            };
+
+            Err(error)
         },
     }
 }

--- a/tests/wpt/meta/domxpath/text-html-attributes.html.ini
+++ b/tests/wpt/meta/domxpath/text-html-attributes.html.ini
@@ -11,9 +11,6 @@
   [Select HTML element with non-ascii attribute 3]
     expected: FAIL
 
-  [Select SVG element based on mixed case attribute]
-    expected: FAIL
-
   [Select both HTML and SVG elements based on mixed case attribute]
     expected: FAIL
 
@@ -21,7 +18,4 @@
     expected: FAIL
 
   [Select SVG element with non-ascii attribute 2]
-    expected: FAIL
-
-  [svg element with XLink attribute]
     expected: FAIL

--- a/tests/wpt/meta/domxpath/text-html-elements.html.ini
+++ b/tests/wpt/meta/domxpath/text-html-elements.html.ini
@@ -1,17 +1,5 @@
 [text-html-elements.html]
-  [HTML elements namespace prefix]
-    expected: FAIL
-
-  [HTML elements mixed use of prefix]
-    expected: FAIL
-
-  [SVG elements namespace prefix]
-    expected: FAIL
-
   [HTML elements mixed case]
-    expected: FAIL
-
-  [SVG elements mixed case selector]
     expected: FAIL
 
   [Non-ascii HTML element]


### PR DESCRIPTION
The xpath resolver is a function provided by the user to resolve namespace prefixes. Previously, we were ignoring the argument.

Testing: New web platform tests start to pass
Part of https://github.com/servo/servo/issues/34527
