### PR TITLE
script: Remove redundant step in UnwrapKey method of SubtleCrypto

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -1168,23 +1168,14 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     KeyFormat::Jwk => {
                         // Let key be the result of executing the parse a JWK algorithm, with bytes
                         // as the data to be parsed.
-                        let jwk = match JsonWebKey::parse(cx, &bytes) {
-                            Ok(jwk) => jwk,
-                            Err(error) => {
-                                promise.reject_error(error, CanGc::note());
-                                return;
-                            },
-                        };
-
-                        // NOTE: Further convert the stringified JsonWebKey to the bytes so that we
-                        // can pass it to normialized algorithm.
-                        match jwk.stringify(cx) {
-                            Ok(stringified) => stringified.as_bytes().to_vec(),
-                            Err(error) => {
-                                promise.reject_error(error, CanGc::note());
-                                return;
-                            },
+                        if let Err(error) = JsonWebKey::parse(cx, &bytes) {
+                            promise.reject_error(error, CanGc::note());
+                            return;
                         }
+                        // NOTE: We can directly use bytes to perform the import key operation of
+                        // normailized key algorithm, instead of re-serializing the resultant
+                        // JsonWebKey dictionary.
+                        bytes
                     },
                 };
 


### PR DESCRIPTION
In Step 15, we are given the unwrapped key as bytes. If the format is "jwk", we execute parse-a-JWK algorithm to parse it (and deserialize it to a JsonWebKey dictionary).

In next step, we perform the import key operation on the unwrapped key. In our current implementation, we serialize the JsonWebKey dictionary (when format is "jwk") back to bytes, in order to perform the import key operation.

In fact, this serialization step is redundant since we have already been given the unwrapped key as bytes in Step 15. We can directly use it for perform the import key operation. This patch remove this redundant step of re-serializing the JsonWebKey dictionary.

Testing: Refactoring only. No change in tests.