### PR TITLE
libservo: Remove `Opts::webrender_stats` and `-Z wr-stats`

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -134,9 +134,6 @@ pub struct DebugOptions {
     /// Log GC passes and their durations.
     pub gc_profile: bool,
 
-    /// Show webrender profiling stats on screen.
-    pub webrender_stats: bool,
-
     /// True to use OS native signposting facilities. This makes profiling events (script activity,
     /// reflow, compositing, etc.) appear in Instruments.app on macOS.
     pub signpost: bool,
@@ -160,7 +157,6 @@ impl DebugOptions {
                 "relayout-event" => self.relayout_event = true,
                 "signpost" => self.signpost = true,
                 "dump-style-stats" => self.dump_style_statistics = true,
-                "wr-stats" => self.webrender_stats = true,
                 "" => {},
                 _ => return Err(String::from(option)),
             };

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -315,12 +315,6 @@ impl Servo {
         };
 
         let (mut webrender, webrender_api_sender) = {
-            let mut debug_flags = webrender::DebugFlags::empty();
-            debug_flags.set(
-                webrender::DebugFlags::PROFILER_DBG,
-                opts.debug.webrender_stats,
-            );
-
             rendering_context.prepare_for_rendering();
             let render_notifier = Box::new(RenderNotifier::new(compositor_proxy.clone()));
             let clear_color = servo_config::pref!(shell_background_color_rgba);
@@ -359,7 +353,7 @@ impl Servo {
                     // See: https://github.com/servo/servo/issues/31726
                     use_optimized_shaders: true,
                     resource_override_path: opts.shaders_dir.clone(),
-                    debug_flags,
+                    debug_flags: webrender::DebugFlags::empty(),
                     precache_flags: if pref!(gfx_precache_shaders) {
                         ShaderPrecacheFlags::FULL_COMPILE
                     } else {

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -793,7 +793,6 @@ fn print_debug_options_usage(app: &str) {
         "signpost",
         "Emit native OS signposts for profile events (currently macOS only)",
     );
-    print_option("wr-stats", "Show WebRender profiler on screen.");
 
     println!();
 


### PR DESCRIPTION
This option is supported via the WebView API now and you can enable it
in servoshell by pressing `Ctrl` + `F12`. The command-line argument and
`Opts` field are older and I believe are no longer necessary.

Testing: This just removes a redundant command-line option, so no tests.
