### PR TITLE
libservo: Remove the `Opts::trace_layout`

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -122,11 +122,6 @@ pub struct DebugOptions {
     /// Periodically print out on which events script threads spend their processing time.
     pub profile_script_events: bool,
 
-    /// True if each step of layout is traced to an external JSON file
-    /// for debugging purposes. Setting this implies sequential layout
-    /// and paint.
-    pub trace_layout: bool,
-
     /// Disable the style sharing cache.
     pub disable_share_style_cache: bool,
 
@@ -165,7 +160,6 @@ impl DebugOptions {
                 "relayout-event" => self.relayout_event = true,
                 "signpost" => self.signpost = true,
                 "dump-style-stats" => self.dump_style_statistics = true,
-                "trace-layout" => self.trace_layout = true,
                 "wr-stats" => self.webrender_stats = true,
                 "" => {},
                 _ => return Err(String::from(option)),

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -793,10 +793,6 @@ fn print_debug_options_usage(app: &str) {
         "signpost",
         "Emit native OS signposts for profile events (currently macOS only)",
     );
-    print_option(
-        "trace-layout",
-        "Write layout trace to an external file for debugging.",
-    );
     print_option("wr-stats", "Show WebRender profiler on screen.");
 
     println!();


### PR DESCRIPTION
This is currently unused, so it can be removed.

Testing: This just removes an unused field, so does not require tests.
