### PR TITLE
compositor: Add hit test cache when swiping with a single finger

### DIFF
--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -603,10 +603,18 @@ impl TouchHandler {
                 }
             } else {
                 sequence.hit_test_result_cache = Some(HitTestResultCache {
-                    value: value,
+                    value,
                     // Only single touch points have a valid hit test result.
                     is_valid: sequence.touch_count() == 1,
                 });
+            }
+        }
+    }
+
+    pub(crate) fn set_hit_test_result_cache_invalid(&mut self, sequence_id: TouchSequenceId) {
+        if let Some(sequence) = self.touch_sequence_map.get_mut(&sequence_id) {
+            if let Some(ref mut hit_test_result_cache) = sequence.hit_test_result_cache {
+                hit_test_result_cache.is_valid = false;
             }
         }
     }

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -332,6 +332,7 @@ impl WebViewRenderer {
                                 self.touch_handler.set_hit_test_result_cache_value(
                                     self.touch_handler.current_sequence_id,
                                     value.clone(),
+                                    self.device_pixels_per_page_pixel(),
                                 );
                             }
                             hit_test_result


### PR DESCRIPTION
Add hit test cache when swiping witn a single finger.
The compositor's request for WebRender's hit testing requires synchronous waiting. This modification reduces the number of hit tests by adding a hit test cache, thereby improving the frame rate during scrolling.
Testing: Testing the Mosele [homepage](https://www.huaweimossel.com/) on mobile devices shows no issues.
Fixes: N/A
