### PR TITLE
generic channel: Migrate background hang monitor to GenericChannel

### DIFF
--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -11,9 +11,9 @@ use background_hang_monitor_api::{
     BackgroundHangMonitorExitSignal, BackgroundHangMonitorRegister, HangAlert, HangAnnotation,
     HangMonitorAlert, MonitoredComponentId,
 };
+use base::generic_channel::{GenericReceiver, RoutedReceiver};
 use crossbeam_channel::{Receiver, Sender, after, never, select, unbounded};
-use ipc_channel::ipc::{IpcReceiver, IpcSender};
-use ipc_channel::router::ROUTER;
+use ipc_channel::ipc::IpcSender;
 use rustc_hash::FxHashMap;
 
 use crate::sampler::{NativeStack, Sampler};
@@ -29,7 +29,7 @@ impl HangMonitorRegister {
     /// as well as a join handle on the worker thread.
     pub fn init(
         constellation_chan: IpcSender<HangMonitorAlert>,
-        control_port: IpcReceiver<BackgroundHangMonitorControlMsg>,
+        control_port: GenericReceiver<BackgroundHangMonitorControlMsg>,
         monitoring_enabled: bool,
     ) -> (Box<dyn BackgroundHangMonitorRegister>, JoinHandle<()>) {
         let (sender, port) = unbounded();
@@ -213,7 +213,7 @@ struct BackgroundHangMonitorWorker {
     monitored_components: FxHashMap<MonitoredComponentId, MonitoredComponent>,
     constellation_chan: IpcSender<HangMonitorAlert>,
     port: Receiver<(MonitoredComponentId, MonitoredComponentMsg)>,
-    control_port: Receiver<BackgroundHangMonitorControlMsg>,
+    control_port: RoutedReceiver<BackgroundHangMonitorControlMsg>,
     sampling_duration: Option<Duration>,
     sampling_max_duration: Option<Duration>,
     last_sample: Instant,
@@ -230,11 +230,11 @@ type MonitoredComponentReceiver = Receiver<(MonitoredComponentId, MonitoredCompo
 impl BackgroundHangMonitorWorker {
     fn new(
         constellation_chan: IpcSender<HangMonitorAlert>,
-        control_port: IpcReceiver<BackgroundHangMonitorControlMsg>,
+        control_port: GenericReceiver<BackgroundHangMonitorControlMsg>,
         port: MonitoredComponentReceiver,
         monitoring_enabled: bool,
     ) -> Self {
-        let control_port = ROUTER.route_ipc_receiver_to_new_crossbeam_receiver(control_port);
+        let control_port = control_port.route_preserving_errors();
         Self {
             component_names: Default::default(),
             monitored_components: Default::default(),
@@ -318,7 +318,7 @@ impl BackgroundHangMonitorWorker {
             },
             recv(self.control_port) -> event => {
                 match event {
-                    Ok(BackgroundHangMonitorControlMsg::ToggleSampler(rate, max_duration)) => {
+                    Ok(Ok(BackgroundHangMonitorControlMsg::ToggleSampler(rate, max_duration))) => {
                         if self.sampling_duration.is_some() {
                             println!("Enabling profiler.");
                             self.finish_sampled_profile();
@@ -331,7 +331,7 @@ impl BackgroundHangMonitorWorker {
                         }
                         None
                     },
-                    Ok(BackgroundHangMonitorControlMsg::Exit) => {
+                    Ok(Ok(BackgroundHangMonitorControlMsg::Exit)) => {
                         for component in self.monitored_components.values_mut() {
                             component.exit_signal.signal_to_exit();
                         }
@@ -345,6 +345,10 @@ impl BackgroundHangMonitorWorker {
                         // Keep running; this worker thread will shutdown
                         // when the monitored components have shutdown,
                         // which we know has happened when `self.port` disconnects.
+                        None
+                    },
+                    Ok(Err(e)) => {
+                        log::warn!("BackgroundHangMonitorWorker control message deserialization error: {e:?}");
                         None
                     },
                     Err(_) => return false,

--- a/components/background_hang_monitor/tests/hang_monitor_tests.rs
+++ b/components/background_hang_monitor/tests/hang_monitor_tests.rs
@@ -14,6 +14,7 @@ use background_hang_monitor_api::{
     BackgroundHangMonitorControlMsg, BackgroundHangMonitorExitSignal, HangAlert, HangAnnotation,
     HangMonitorAlert, MonitoredComponentId, MonitoredComponentType, ScriptHangAnnotation,
 };
+use base::generic_channel;
 use base::id::TEST_PIPELINE_ID;
 use ipc_channel::ipc;
 
@@ -25,7 +26,8 @@ fn test_hang_monitoring() {
 
     let (background_hang_monitor_ipc_sender, background_hang_monitor_receiver) =
         ipc::channel().expect("ipc channel failure");
-    let (_sampler_sender, sampler_receiver) = ipc::channel().expect("ipc channel failure");
+    let (_sampler_sender, sampler_receiver) =
+        generic_channel::channel().expect("ipc channel failure");
 
     let (background_hang_monitor_register, join_handle) = HangMonitorRegister::init(
         background_hang_monitor_ipc_sender.clone(),
@@ -141,7 +143,8 @@ fn test_hang_monitoring_unregister() {
 
     let (background_hang_monitor_ipc_sender, background_hang_monitor_receiver) =
         ipc::channel().expect("ipc channel failure");
-    let (_sampler_sender, sampler_receiver) = ipc::channel().expect("ipc channel failure");
+    let (_sampler_sender, sampler_receiver) =
+        generic_channel::channel().expect("ipc channel failure");
 
     let (background_hang_monitor_register, join_handle) = HangMonitorRegister::init(
         background_hang_monitor_ipc_sender.clone(),
@@ -226,7 +229,8 @@ fn test_hang_monitoring_exit_signal_inner(op_order: fn(&mut dyn FnMut(), &mut dy
 
     let (background_hang_monitor_ipc_sender, _background_hang_monitor_receiver) =
         ipc::channel().expect("ipc channel failure");
-    let (control_sender, control_receiver) = ipc::channel().expect("ipc channel failure");
+    let (control_sender, control_receiver) =
+        generic_channel::channel().expect("ipc channel failure");
 
     struct BHMExitSignal {
         closing: Arc<AtomicBool>,

--- a/components/background_hang_monitor/tests/hang_monitor_tests.rs
+++ b/components/background_hang_monitor/tests/hang_monitor_tests.rs
@@ -25,7 +25,7 @@ fn test_hang_monitoring() {
     let _lock = SERIAL.lock().unwrap();
 
     let (background_hang_monitor_ipc_sender, background_hang_monitor_receiver) =
-        ipc::channel().expect("ipc channel failure");
+        generic_channel::channel().expect("ipc channel failure");
     let (_sampler_sender, sampler_receiver) =
         generic_channel::channel().expect("ipc channel failure");
 
@@ -142,7 +142,7 @@ fn test_hang_monitoring_unregister() {
     let _lock = SERIAL.lock().unwrap();
 
     let (background_hang_monitor_ipc_sender, background_hang_monitor_receiver) =
-        ipc::channel().expect("ipc channel failure");
+        generic_channel::channel().expect("ipc channel failure");
     let (_sampler_sender, sampler_receiver) =
         generic_channel::channel().expect("ipc channel failure");
 
@@ -228,7 +228,7 @@ fn test_hang_monitoring_exit_signal_inner(op_order: fn(&mut dyn FnMut(), &mut dy
     let _lock = SERIAL.lock().unwrap();
 
     let (background_hang_monitor_ipc_sender, _background_hang_monitor_receiver) =
-        ipc::channel().expect("ipc channel failure");
+        generic_channel::channel().expect("ipc channel failure");
     let (control_sender, control_receiver) =
         generic_channel::channel().expect("ipc channel failure");
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -309,7 +309,7 @@ pub struct Constellation<STF, SWF> {
     /// Channels to control all background-hang monitors.
     /// TODO: store them on the relevant BrowsingContextGroup,
     /// so that they could be controlled on a "per-tab/event-loop" basis.
-    background_monitor_control_senders: Vec<IpcSender<BackgroundHangMonitorControlMsg>>,
+    background_monitor_control_senders: Vec<GenericSender<BackgroundHangMonitorControlMsg>>,
 
     /// A channel for the background hang monitor to send messages
     /// to the constellation.
@@ -646,7 +646,7 @@ where
                     let (
                         background_hang_monitor_control_ipc_sender,
                         background_hang_monitor_control_ipc_receiver,
-                    ) = ipc::channel().expect("ipc channel failure");
+                    ) = generic_channel::channel().expect("ipc channel failure");
                     let (register, join_handle) = HangMonitorRegister::init(
                         background_hang_monitor_ipc_sender.clone(),
                         background_hang_monitor_control_ipc_receiver,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -313,7 +313,7 @@ pub struct Constellation<STF, SWF> {
 
     /// A channel for the background hang monitor to send messages
     /// to the constellation.
-    background_hang_monitor_sender: IpcSender<HangMonitorAlert>,
+    background_hang_monitor_sender: GenericSender<HangMonitorAlert>,
 
     /// A channel for the constellation to receiver messages
     /// from the background hang monitor.
@@ -627,11 +627,9 @@ where
                 let namespace_receiver = namespace_ipc_receiver.route_preserving_errors();
 
                 let (background_hang_monitor_ipc_sender, background_hang_monitor_ipc_receiver) =
-                    ipc::channel().expect("ipc channel failure");
+                    generic_channel::channel().expect("ipc channel failure");
                 let background_hang_monitor_receiver =
-                    route_ipc_receiver_to_new_crossbeam_receiver_preserving_errors(
-                        background_hang_monitor_ipc_receiver,
-                    );
+                    background_hang_monitor_ipc_receiver.route_preserving_errors();
 
                 // If we are in multiprocess mode,
                 // a dedicated per-process hang monitor will be initialized later inside the content process.

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -317,7 +317,7 @@ pub struct Constellation<STF, SWF> {
 
     /// A channel for the constellation to receiver messages
     /// from the background hang monitor.
-    background_hang_monitor_receiver: Receiver<Result<HangMonitorAlert, IpcError>>,
+    background_hang_monitor_receiver: RoutedReceiver<HangMonitorAlert>,
 
     /// A factory for creating layouts. This allows customizing the kind
     /// of layout created for a [`Constellation`] and prevents a circular crate

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -144,7 +144,7 @@ pub struct InitialPipelineState {
     pub background_monitor_register: Option<Box<dyn BackgroundHangMonitorRegister>>,
 
     /// A channel for the background hang monitor to send messages to the constellation.
-    pub background_hang_monitor_to_constellation_chan: IpcSender<HangMonitorAlert>,
+    pub background_hang_monitor_to_constellation_chan: GenericSender<HangMonitorAlert>,
 
     /// A fatory for creating layouts to be used by the ScriptThread.
     pub layout_factory: Arc<dyn LayoutFactory>,
@@ -487,7 +487,7 @@ pub struct UnprivilegedPipelineContent {
     namespace_request_sender: GenericSender<PipelineNamespaceRequest>,
     script_to_constellation_chan: ScriptToConstellationChan,
     script_to_embedder_chan: ScriptToEmbedderChan,
-    background_hang_monitor_to_constellation_chan: IpcSender<HangMonitorAlert>,
+    background_hang_monitor_to_constellation_chan: GenericSender<HangMonitorAlert>,
     bhm_control_port: Option<GenericReceiver<BackgroundHangMonitorControlMsg>>,
     devtools_ipc_sender: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
     #[cfg(feature = "bluetooth")]

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -12,7 +12,7 @@ use background_hang_monitor_api::{
     BackgroundHangMonitorControlMsg, BackgroundHangMonitorRegister, HangMonitorAlert,
 };
 use base::Epoch;
-use base::generic_channel::{GenericReceiver, GenericSender};
+use base::generic_channel::{self, GenericReceiver, GenericSender};
 use base::id::{
     BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespace, PipelineNamespaceId,
     PipelineNamespaceRequest, WebViewId,
@@ -219,7 +219,7 @@ pub struct InitialPipelineState {
 
 pub struct NewPipeline {
     pub pipeline: Pipeline,
-    pub bhm_control_chan: Option<IpcSender<BackgroundHangMonitorControlMsg>>,
+    pub bhm_control_chan: Option<GenericSender<BackgroundHangMonitorControlMsg>>,
     pub lifeline: Option<(IpcReceiver<()>, Process)>,
     pub join_handle: Option<JoinHandle<()>>,
 }
@@ -325,7 +325,7 @@ impl Pipeline {
                 // Yes, that's all there is to it!
                 let multiprocess_data = if opts::get().multiprocess {
                     let (bhm_control_chan, bhm_control_port) =
-                        ipc::channel().expect("Sampler chan");
+                        generic_channel::channel().expect("Sampler chan");
                     unprivileged_pipeline_content.bhm_control_port = Some(bhm_control_port);
                     let (sender, receiver) =
                         ipc::channel().expect("Failed to create lifeline channel");
@@ -488,7 +488,7 @@ pub struct UnprivilegedPipelineContent {
     script_to_constellation_chan: ScriptToConstellationChan,
     script_to_embedder_chan: ScriptToEmbedderChan,
     background_hang_monitor_to_constellation_chan: IpcSender<HangMonitorAlert>,
-    bhm_control_port: Option<IpcReceiver<BackgroundHangMonitorControlMsg>>,
+    bhm_control_port: Option<GenericReceiver<BackgroundHangMonitorControlMsg>>,
     devtools_ipc_sender: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
     #[cfg(feature = "bluetooth")]
     bluetooth_thread: IpcSender<BluetoothRequest>,


### PR DESCRIPTION
Refactor the background hang monitor channels to use GenericChannel. 
Deserialization errors of `BackgroundHangMonitorControlMsg` are now logged and ignored instead of causing a panic.

Testing: No major functional changes. Covered by BHM tests. GenericChannel is also already widely used in servo.
Part of #38912
