### PR TITLE
script: Replace DomRefCell<bool> with Cell<bool> for Response::redirected

### DIFF
--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -48,7 +48,7 @@ pub(crate) struct Response {
     body_stream: MutNullableDom<ReadableStream>,
     #[ignore_malloc_size_of = "StreamConsumer"]
     stream_consumer: DomRefCell<Option<StreamConsumer>>,
-    redirected: DomRefCell<bool>,
+    redirected: Cell<bool>,
     is_body_empty: Cell<bool>,
 }
 
@@ -70,7 +70,7 @@ impl Response {
             url_list: DomRefCell::new(vec![]),
             body_stream: MutNullableDom::new(Some(&*stream)),
             stream_consumer: DomRefCell::new(None),
-            redirected: DomRefCell::new(false),
+            redirected: Cell::new(false),
             is_body_empty: Cell::new(true),
         }
     }
@@ -273,7 +273,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
 
     /// <https://fetch.spec.whatwg.org/#dom-response-redirected>
     fn Redirected(&self) -> bool {
-        return *self.redirected.borrow();
+        self.redirected.get()
     }
 
     /// <https://fetch.spec.whatwg.org/#dom-response-status>
@@ -487,7 +487,7 @@ impl Response {
     }
 
     pub(crate) fn set_redirected(&self, is_redirected: bool) {
-        *self.redirected.borrow_mut() = is_redirected;
+        self.redirected.set(is_redirected);
     }
 
     fn set_response_members_by_type(&self, response_type: DOMResponseType, can_gc: CanGc) {


### PR DESCRIPTION
Replace DomRefCell<bool> with Cell<bool> for Response::redirected field.

Changed redirected field from DomRefCell<bool> to Cell<bool> and updated all related methods:
- Struct field: redirected: DomRefCell<bool> → redirected: Cell<bool>
- Constructor: DomRefCell::new(false) → Cell::new(false)
- Getter method: *self.redirected.borrow() → self.redirected.get()
- Setter method: *self.redirected.borrow_mut() = value → self.redirected.set(value)

Testing: As noted in the issue, compilation is sufficient for this change.

Fixes: #39288
