### PR TITLE
servoshell: Move touch event simulation to servoshell

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -117,9 +117,6 @@ pub struct ServoRenderer {
     /// Some XR devices want to run on the main thread.
     webxr_main_thread: webxr::MainThreadRegistry,
 
-    /// True to translate mouse input into touch events.
-    pub(crate) convert_mouse_to_touch: bool,
-
     /// The last position in the rendered view that the mouse moved over. This becomes `None`
     /// when the mouse leaves the rendered view.
     pub(crate) last_mouse_move_position: Option<DevicePoint>,
@@ -306,7 +303,7 @@ impl ServoRenderer {
 }
 
 impl IOCompositor {
-    pub fn new(state: InitialCompositorState, convert_mouse_to_touch: bool) -> Self {
+    pub fn new(state: InitialCompositorState) -> Self {
         let registration = state.mem_profiler_chan.prepare_memory_reporting(
             "compositor".into(),
             state.sender.clone(),
@@ -327,7 +324,6 @@ impl IOCompositor {
                 webrender_gl: state.webrender_gl,
                 #[cfg(feature = "webxr")]
                 webxr_main_thread: state.webxr_main_thread,
-                convert_mouse_to_touch,
                 last_mouse_move_position: None,
                 frame_delayer: Default::default(),
             })),

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -283,10 +283,6 @@ impl TouchHandler {
         debug_assert!(old.is_some(), "Sequence already removed?");
     }
 
-    pub fn try_get_current_touch_sequence(&self) -> Option<&TouchSequenceInfo> {
-        self.touch_sequence_map.get(&self.current_sequence_id)
-    }
-
     pub fn get_current_touch_sequence_mut(&mut self) -> &mut TouchSequenceInfo {
         self.touch_sequence_map
             .get_mut(&self.current_sequence_id)

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -128,9 +128,6 @@ pub struct DebugOptions {
     /// Whether to show in stdout style sharing cache stats after a restyle.
     pub dump_style_statistics: bool,
 
-    /// Translate mouse input into touch events.
-    pub convert_mouse_to_touch: bool,
-
     /// Log GC passes and their durations.
     pub gc_profile: bool,
 
@@ -144,7 +141,6 @@ impl DebugOptions {
         for option in debug_string.split(',') {
             match option {
                 "help" => self.help = true,
-                "convert-mouse-to-touch" => self.convert_mouse_to_touch = true,
                 "disable-share-style-cache" => self.disable_share_style_cache = true,
                 "dump-display-list" => self.dump_display_list = true,
                 "dump-stacking-context-tree" => self.dump_stacking_context_tree = true,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -463,25 +463,22 @@ impl Servo {
         // The compositor coordinates with the client window to create the final
         // rendered page and display it somewhere.
         let shutdown_state = Rc::new(Cell::new(ShutdownState::NotShuttingDown));
-        let compositor = IOCompositor::new(
-            InitialCompositorState {
-                sender: compositor_proxy,
-                receiver: compositor_receiver,
-                constellation_chan: constellation_chan.clone(),
-                time_profiler_chan,
-                mem_profiler_chan,
-                webrender,
-                webrender_document,
-                webrender_api,
-                rendering_context,
-                webrender_gl,
-                #[cfg(feature = "webxr")]
-                webxr_main_thread,
-                shutdown_state: shutdown_state.clone(),
-                event_loop_waker,
-            },
-            opts.debug.convert_mouse_to_touch,
-        );
+        let compositor = IOCompositor::new(InitialCompositorState {
+            sender: compositor_proxy,
+            receiver: compositor_receiver,
+            constellation_chan: constellation_chan.clone(),
+            time_profiler_chan,
+            mem_profiler_chan,
+            webrender,
+            webrender_document,
+            webrender_api,
+            rendering_context,
+            webrender_gl,
+            #[cfg(feature = "webxr")]
+            webxr_main_thread,
+            shutdown_state: shutdown_state.clone(),
+            event_loop_waker,
+        });
 
         let constellation_proxy = ConstellationProxy::new(constellation_chan);
         Self {


### PR DESCRIPTION
This change removes the `DebugOption` (`-Z`) for touch event simulation
and moves the implementation of the feature to servoshell. The resaoning
for this is:

 - This is really a servoshell feature and can be implemented on top of
   the API. This moves more code out of the already too-complicated
   renderer.
 - I would like to consolidate `DebugOptions` into a `ServoLogOptions`
   to collect all options for configuring Servo logging. This requires
   moving away all of the non-logging options.
 - Eventually touch event simulation will be able to reuse the fling
   implementation from servoshell as we are actually simulating touch
   events sent to the `WebView`.

Testing: This changes a conditional feature that's used for manual debugging.
It is difficult to write tests for this as there are no servoshell tests that
verify input handling.
