### PR TITLE
profile: Remove integration with Instruments.app "Points of Interest"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6721,7 +6721,6 @@ dependencies = [
  "servo_allocator",
  "servo_config",
  "servo_malloc_size_of",
- "signpost",
  "time",
  "tracing",
 ]
@@ -8095,11 +8094,6 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "signpost"
-version = "0.1.0"
-source = "git+https://github.com/pcwalton/signpost.git#7ed712507f343c38646b9d1fefd049166f9c9a18"
 
 [[package]]
 name = "simd-adler32"

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -133,10 +133,6 @@ pub struct DebugOptions {
 
     /// Log GC passes and their durations.
     pub gc_profile: bool,
-
-    /// True to use OS native signposting facilities. This makes profiling events (script activity,
-    /// reflow, compositing, etc.) appear in Instruments.app on macOS.
-    pub signpost: bool,
 }
 
 impl DebugOptions {
@@ -156,7 +152,6 @@ impl DebugOptions {
                 "gc-profile" => self.gc_profile = true,
                 "profile-script-events" => self.profile_script_events = true,
                 "relayout-event" => self.relayout_event = true,
-                "signpost" => self.signpost = true,
                 "" => {},
                 _ => return Err(String::from(option)),
             };

--- a/components/shared/profile/Cargo.toml
+++ b/components/shared/profile/Cargo.toml
@@ -24,6 +24,5 @@ malloc_size_of_derive = { workspace = true }
 serde = { workspace = true }
 servo_allocator = { path = "../../allocator" }
 servo_config = { path = "../../config" }
-signpost = { git = "https://github.com/pcwalton/signpost.git" }
 time = { workspace = true }
 tracing = { workspace = true, optional = true }

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -7,7 +7,6 @@ use ipc_channel::ipc::IpcSender;
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
-use servo_config::opts;
 use time::Duration;
 
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
@@ -197,9 +196,6 @@ pub fn profile<T, F>(
 where
     F: FnOnce() -> T,
 {
-    if opts::get().debug.signpost {
-        signpost::start(category as u32, &[0, 0, 0, (category as usize) >> 4]);
-    }
     let start_time = CrossProcessInstant::now();
     let val = {
         #[cfg(feature = "tracing")]
@@ -207,10 +203,6 @@ where
         callback()
     };
     let end_time = CrossProcessInstant::now();
-
-    if opts::get().debug.signpost {
-        signpost::end(category as u32, &[0, 0, 0, (category as usize) >> 4]);
-    }
 
     send_profile_data(category, meta, &profiler_chan, start_time, end_time);
     val

--- a/deny.toml
+++ b/deny.toml
@@ -205,4 +205,4 @@ skip = [
 
 # github.com organizations to allow git sources for
 [sources.allow-org]
-github = ["pcwalton", "servo", "linebender"]
+github = ["servo", "linebender"]

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -769,10 +769,6 @@ fn print_debug_options_usage(app: &str) {
         "relayout-event",
         "Print notifications when there is a relayout.",
     );
-    print_option(
-        "signpost",
-        "Emit native OS signposts for profile events (currently macOS only)",
-    );
 
     println!();
 


### PR DESCRIPTION
This changes removes the integration with Instruments.app "Points of
Interest" track for a variety of reasons:

 - This functionality is made somewhat redundant by Servo's support for
   Perfetto traces.
 - This functionality depends on the `signpost` crate which hasn't seen
   activity for 9 years and only supports macOS.

Testing: This removes some functionality that is only observable via
Instruments.app, so testing it is difficult.
