### PR TITLE
Change package.metadata.winres to package.metadata.winresource

### DIFF
--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -28,7 +28,7 @@ cc = "1.2"
 [target.'cfg(windows)'.build-dependencies]
 winresource = "0.1"
 
-[package.metadata.winres]
+[package.metadata.winresource]
 FileDescription = "Servo"
 LegalCopyright = "© The Servo Project Developers"
 OriginalFilename = "servo.exe"


### PR DESCRIPTION
Use `package.metadata.winresource` per: https://docs.rs/winresource/0.1.23/winresource/struct.WindowsResource.html#impl-WindowsResource

I think this was missed in #39344.

Testing: No tests for Cargo.toml edit.