### PR TITLE
mach: Configure `uv` using `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,6 @@ project-excludes = [
     "python/mach/**/*.py",
     "python/servo/mutation/**/*.py",
 ]
+
+[tool.uv]
+native-tls = true

--- a/uv.toml
+++ b/uv.toml
@@ -1,1 +1,0 @@
-native-tls = true


### PR DESCRIPTION
We have been consolidating all of our Python configuration in
`pyproject.toml`, so we can move our one `uv` specific setting there as
well.

Testing: There is no easy way to write an automated test for this but I
confirmed it work by running `uv run --show-settings`.
