### PR TITLE
script: Avoid panic when scrolling area of window is larger than viewport

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2160,9 +2160,9 @@ impl Window {
         // the x-coordinate x of the viewport scrolling area with the left of the viewport
         // and aligning the y-coordinate y of the viewport scrolling area with the top of
         // the viewport.
-        let scrolling_area = self.scrolling_area_query(None);
-        let x = xfinite.clamp(0.0, scrolling_area.width() as f32 - viewport.width);
-        let y = yfinite.clamp(0.0, scrolling_area.height() as f32 - viewport.height);
+        let scrolling_area = self.scrolling_area_query(None).to_f32();
+        let x = xfinite.clamp(0.0, 0.0f32.max(scrolling_area.width() - viewport.width));
+        let y = yfinite.clamp(0.0, 0.0f32.max(scrolling_area.height() - viewport.height));
 
         // Step 10: If position is the same as the viewport’s current scroll position, and
         // the viewport does not have an ongoing smooth scroll, abort these steps.


### PR DESCRIPTION
Sometimes, the computed scrolling area of window is larger than viewport. This causes panics in `Window.scroll` with `f32::clamp(0.0, some negative number)`.

Eventually, we should find out why "computed scrolling area of window is larger than viewport". But let's avoid the panics first.

Testing: This avoids panic, so definitely not covered by existing tests. But it would be hard to write a automated test for this in headless mode.
Fixes: #39346