### PR TITLE
script: optimize `Element::create` for uncustomized built-in elements

### DIFF
--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -243,7 +243,9 @@ fn create_html_element(
             if is_valid_custom_element_name(&name.local) {
                 result.set_custom_element_state(CustomElementState::Undefined);
             } else {
-                result.set_custom_element_state(CustomElementState::Uncustomized);
+                // Note: This is a performance optimization. See the doc comment of the method for
+                // more information.
+                result.set_initial_custom_element_state_to_uncustomized();
             }
         },
     };

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -395,6 +395,20 @@ impl Element {
         self.is.borrow().clone()
     }
 
+    /// This is a performance optimization. `Element::create` can simply call
+    /// `element.set_custom_element_state(CustomElementState::Uncustomized)` to initialize
+    /// uncustomized, built-in elements with the right state, which currently just means that the
+    /// `DEFINED` state should be `true` for styling. However `set_custom_element_state` has a high
+    /// performance cost and it is unnecessary if the element is being created as an uncustomized
+    /// built-in element.
+    ///
+    /// See <https://github.com/servo/servo/issues/37745> for more details.
+    pub(crate) fn set_initial_custom_element_state_to_uncustomized(&self) {
+        let mut state = self.state.get();
+        state.insert(ElementState::DEFINED);
+        self.state.set(state);
+    }
+
     /// <https://dom.spec.whatwg.org/#concept-element-custom-element-state>
     pub(crate) fn set_custom_element_state(&self, state: CustomElementState) {
         // no need to inflate rare data for uncustomized

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -412,7 +412,7 @@ impl Element {
     /// <https://dom.spec.whatwg.org/#concept-element-custom-element-state>
     pub(crate) fn set_custom_element_state(&self, state: CustomElementState) {
         // no need to inflate rare data for uncustomized
-        if state != CustomElementState::Uncustomized || self.rare_data().is_some() {
+        if state != CustomElementState::Uncustomized {
             self.ensure_rare_data().custom_element_state = state;
         }
 


### PR DESCRIPTION
The investigation in #37745 revealed that `Element::create` spends ~39%
of its runtime in `set_custom_element_state`. For uncustomized built-in
elements, this overhead is unnecessary as according to the spec, they
are equivalent to being initialized in the "uncustomized" state.
Although our rust implemention also initializes the elements in
"uncustomized" state, this particular call to `set_custom_element_state`
can't simply be removed as this call also ensures that the element's
DEFINED state is set to 'true', to match the `:defined` selector, based
on the custom element state.

So, introduce a new method that will only set the
`ElementState::DEFINED` flag by manipulating the state directly and call
it from `Element::create` when creating uncustomized, built-ins.

For more information about the peformance improvements, please refer to
[this comment][1].

[1]: https://github.com/servo/servo/issues/37745#issuecomment-3305477287

Testing: There should be no functional change, so this is covered by WPT suite.
