### PR TITLE
layout: Avoid ClipId, ExternalScrollId and ScrollTreeNodeId references

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -851,7 +851,7 @@ impl WebViewRenderer {
                 Some(&hit_test_result.pipeline_id)
             {
                 let scroll_result = pipeline_details.scroll_tree.scroll_node_or_ancestor(
-                    &hit_test_result.external_scroll_id,
+                    hit_test_result.external_scroll_id,
                     scroll_location,
                     ScrollType::InputEvents,
                 );

--- a/components/layout/display_list/clip.rs
+++ b/components/layout/display_list/clip.rs
@@ -69,8 +69,8 @@ impl StackingContextTreeClipStore {
     pub(super) fn add_for_clip_path(
         &mut self,
         clip_path: ClipPath,
-        parent_scroll_node_id: &ScrollTreeNodeId,
-        parent_clip_chain_id: &ClipId,
+        parent_scroll_node_id: ScrollTreeNodeId,
+        parent_clip_chain_id: ClipId,
         fragment_builder: BuilderForBoxFragment,
     ) -> Option<ClipId> {
         let geometry_box = match clip_path {
@@ -108,8 +108,8 @@ impl StackingContextTreeClipStore {
                     _ => fragment_builder.border_radius,
                 },
                 layout_rect,
-                *parent_scroll_node_id,
-                *parent_clip_chain_id,
+                parent_scroll_node_id,
+                parent_clip_chain_id,
             ))
         }
     }
@@ -119,8 +119,8 @@ impl StackingContextTreeClipStore {
         &mut self,
         shape: BasicShape,
         layout_box: LayoutRect,
-        parent_scroll_node_id: &ScrollTreeNodeId,
-        parent_clip_chain_id: &ClipId,
+        parent_scroll_node_id: ScrollTreeNodeId,
+        parent_clip_chain_id: ClipId,
     ) -> Option<ClipId> {
         match shape {
             BasicShape::Rect(rect) => {
@@ -159,8 +159,8 @@ impl StackingContextTreeClipStore {
                 Some(self.add(
                     radii,
                     shape_rect,
-                    *parent_scroll_node_id,
-                    *parent_clip_chain_id,
+                    parent_scroll_node_id,
+                    parent_clip_chain_id,
                 ))
             },
             BasicShape::Circle(circle) => {
@@ -207,7 +207,7 @@ impl StackingContextTreeClipStore {
                 let start = center.add_size(&-radius);
                 let rect = LayoutRect::from_origin_and_size(start, radius * 2.);
                 normalize_radii(&layout_box, &mut radii);
-                Some(self.add(radii, rect, *parent_scroll_node_id, *parent_clip_chain_id))
+                Some(self.add(radii, rect, parent_scroll_node_id, parent_clip_chain_id))
             },
             BasicShape::Ellipse(ellipse) => {
                 let center = match ellipse.position {
@@ -247,7 +247,7 @@ impl StackingContextTreeClipStore {
                 let start = center.add_size(&-size);
                 let rect = LayoutRect::from_origin_and_size(start, size * 2.);
                 normalize_radii(&rect, &mut radii);
-                Some(self.add(radii, rect, *parent_scroll_node_id, *parent_clip_chain_id))
+                Some(self.add(radii, rect, parent_scroll_node_id, parent_clip_chain_id))
             },
             _ => None,
         }

--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -103,7 +103,7 @@ impl<'a> HitTest<'a> {
             .stacking_context_tree
             .compositor_info
             .scroll_tree
-            .cumulative_root_to_node_transform(&scroll_tree_node_id)?;
+            .cumulative_root_to_node_transform(scroll_tree_node_id)?;
 
         let projected_point = transform.project_point2d(self.point_to_test)?;
 

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -238,7 +238,7 @@ impl DisplayListBuilder<'_> {
     }
 
     fn spatial_id(&self, id: ScrollTreeNodeId) -> SpatialId {
-        self.compositor_info.scroll_tree.webrender_id(&id)
+        self.compositor_info.scroll_tree.webrender_id(id)
     }
 
     fn clip_chain_id(&self, id: ClipId) -> ClipChainId {

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -204,7 +204,7 @@ impl StackingContextTree {
         &mut self,
         origin: LayoutPoint,
         frame_origin_for_query: LayoutPoint,
-        parent_scroll_node_id: &ScrollTreeNodeId,
+        parent_scroll_node_id: ScrollTreeNodeId,
         transform_style: wr::TransformStyle,
         transform: LayoutTransform,
         kind: wr::ReferenceFrameKind,
@@ -223,7 +223,7 @@ impl StackingContextTree {
 
     fn define_scroll_frame(
         &mut self,
-        parent_scroll_node_id: &ScrollTreeNodeId,
+        parent_scroll_node_id: ScrollTreeNodeId,
         external_id: wr::ExternalScrollId,
         content_rect: LayoutRect,
         clip_rect: LayoutRect,
@@ -244,7 +244,7 @@ impl StackingContextTree {
 
     fn define_sticky_frame(
         &mut self,
-        parent_scroll_node_id: &ScrollTreeNodeId,
+        parent_scroll_node_id: ScrollTreeNodeId,
         frame_rect: LayoutRect,
         margins: SideOffsets2D<Option<f32>, LayoutPixel>,
         vertical_offset_bounds: StickyOffsetBounds,
@@ -1018,7 +1018,7 @@ impl BoxFragment {
         let new_spatial_id = stacking_context_tree.push_reference_frame(
             reference_frame_data.origin.to_webrender(),
             frame_origin_for_query,
-            &containing_block.scroll_node_id,
+            containing_block.scroll_node_id,
             self.style.get_box().transform_style.to_webrender(),
             reference_frame_data.transform,
             reference_frame_data.kind,
@@ -1100,8 +1100,8 @@ impl BoxFragment {
             .clip_store
             .add_for_clip_path(
                 self.style.clone_clip_path(),
-                &containing_block.scroll_node_id,
-                &containing_block.clip_id,
+                containing_block.scroll_node_id,
+                containing_block.clip_id,
                 BuilderForBoxFragment::new(
                     self,
                     &containing_block.rect,
@@ -1166,7 +1166,7 @@ impl BoxFragment {
 
         if let Some(scroll_node_id) = self.build_sticky_frame_if_necessary(
             stacking_context_tree,
-            &new_scroll_node_id,
+            new_scroll_node_id,
             &containing_block.rect,
             &new_scroll_frame_size,
         ) {
@@ -1175,7 +1175,7 @@ impl BoxFragment {
 
         if let Some(clip_id) = self.build_clip_frame_if_necessary(
             stacking_context_tree,
-            &new_scroll_node_id,
+            new_scroll_node_id,
             new_clip_id,
             &containing_block.rect,
         ) {
@@ -1184,8 +1184,8 @@ impl BoxFragment {
 
         if let Some(clip_id) = stacking_context_tree.clip_store.add_for_clip_path(
             self.style.clone_clip_path(),
-            &new_scroll_node_id,
-            &new_clip_id,
+            new_scroll_node_id,
+            new_clip_id,
             BuilderForBoxFragment::new(
                 self,
                 &containing_block.rect,
@@ -1243,7 +1243,7 @@ impl BoxFragment {
         // they shouldn't scroll with the rest of the box content.
         if let Some(overflow_frame_data) = self.build_overflow_frame_if_necessary(
             stacking_context_tree,
-            &new_scroll_node_id,
+            new_scroll_node_id,
             new_clip_id,
             &containing_block.rect,
         ) {
@@ -1371,7 +1371,7 @@ impl BoxFragment {
     fn build_clip_frame_if_necessary(
         &self,
         stacking_context_tree: &mut StackingContextTree,
-        parent_scroll_node_id: &ScrollTreeNodeId,
+        parent_scroll_node_id: ScrollTreeNodeId,
         parent_clip_id: ClipId,
         containing_block_rect: &PhysicalRect<Au>,
     ) -> Option<ClipId> {
@@ -1396,7 +1396,7 @@ impl BoxFragment {
         Some(stacking_context_tree.clip_store.add(
             BorderRadius::zero(),
             clip_rect,
-            *parent_scroll_node_id,
+            parent_scroll_node_id,
             parent_clip_id,
         ))
     }
@@ -1404,7 +1404,7 @@ impl BoxFragment {
     fn build_overflow_frame_if_necessary(
         &self,
         stacking_context_tree: &mut StackingContextTree,
-        parent_scroll_node_id: &ScrollTreeNodeId,
+        parent_scroll_node_id: ScrollTreeNodeId,
         parent_clip_id: ClipId,
         containing_block_rect: &PhysicalRect<Au>,
     ) -> Option<OverflowFrameData> {
@@ -1448,7 +1448,7 @@ impl BoxFragment {
             let clip_id = stacking_context_tree.clip_store.add(
                 radii,
                 overflow_clip_rect,
-                *parent_scroll_node_id,
+                parent_scroll_node_id,
                 parent_clip_id,
             );
 
@@ -1466,7 +1466,7 @@ impl BoxFragment {
         let clip_id = stacking_context_tree.clip_store.add(
             BuilderForBoxFragment::new(self, containing_block_rect, false, false).border_radius,
             scroll_frame_rect,
-            *parent_scroll_node_id,
+            parent_scroll_node_id,
             parent_clip_id,
         );
 
@@ -1501,7 +1501,7 @@ impl BoxFragment {
     fn build_sticky_frame_if_necessary(
         &self,
         stacking_context_tree: &mut StackingContextTree,
-        parent_scroll_node_id: &ScrollTreeNodeId,
+        parent_scroll_node_id: ScrollTreeNodeId,
         containing_block_rect: &PhysicalRect<Au>,
         scroll_frame_size: &Option<LayoutSize>,
     ) -> Option<ScrollTreeNodeId> {

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -66,7 +66,7 @@ fn root_transform_for_layout_node(
         .borrow();
     let scroll_tree_node_id = box_fragment.spatial_tree_node.borrow();
     let scroll_tree_node_id = (*scroll_tree_node_id)?;
-    Some(scroll_tree.cumulative_node_to_root_transform(&scroll_tree_node_id))
+    Some(scroll_tree.cumulative_node_to_root_transform(scroll_tree_node_id))
 }
 
 pub(crate) fn process_box_area_request(


### PR DESCRIPTION
Changes function signatures to accept `ClipId`, `ExternalScrollId` and `ScrollTreeNodeId` instead of `&ClipId`, `&ExternalScrollId` and `&ScrollTreeNodeId`. This avoids several `&` and `*`.

Testing: not needed, no behavior change.
