### PR TITLE
Update to Stylo with icu range dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7542,7 +7542,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.31.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#64d8521f1b8509a0160a89e24d0ace2883fa3269"
+source = "git+https://github.com/servo/stylo?branch=2025-09-02#c4caa30eebad573590222d4f76b8939b41dc186a"
 dependencies = [
  "bitflags 2.9.4",
  "cssparser",
@@ -7874,7 +7874,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#64d8521f1b8509a0160a89e24d0ace2883fa3269"
+source = "git+https://github.com/servo/stylo?branch=2025-09-02#c4caa30eebad573590222d4f76b8939b41dc186a"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8348,7 +8348,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#64d8521f1b8509a0160a89e24d0ace2883fa3269"
+source = "git+https://github.com/servo/stylo?branch=2025-09-02#c4caa30eebad573590222d4f76b8939b41dc186a"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8405,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#64d8521f1b8509a0160a89e24d0ace2883fa3269"
+source = "git+https://github.com/servo/stylo?branch=2025-09-02#c4caa30eebad573590222d4f76b8939b41dc186a"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8414,12 +8414,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#64d8521f1b8509a0160a89e24d0ace2883fa3269"
+source = "git+https://github.com/servo/stylo?branch=2025-09-02#c4caa30eebad573590222d4f76b8939b41dc186a"
 
 [[package]]
 name = "stylo_derive"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#64d8521f1b8509a0160a89e24d0ace2883fa3269"
+source = "git+https://github.com/servo/stylo?branch=2025-09-02#c4caa30eebad573590222d4f76b8939b41dc186a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8431,7 +8431,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#64d8521f1b8509a0160a89e24d0ace2883fa3269"
+source = "git+https://github.com/servo/stylo?branch=2025-09-02#c4caa30eebad573590222d4f76b8939b41dc186a"
 dependencies = [
  "bitflags 2.9.4",
  "stylo_malloc_size_of",
@@ -8440,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#64d8521f1b8509a0160a89e24d0ace2883fa3269"
+source = "git+https://github.com/servo/stylo?branch=2025-09-02#c4caa30eebad573590222d4f76b8939b41dc186a"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8457,12 +8457,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#64d8521f1b8509a0160a89e24d0ace2883fa3269"
+source = "git+https://github.com/servo/stylo?branch=2025-09-02#c4caa30eebad573590222d4f76b8939b41dc186a"
 
 [[package]]
 name = "stylo_traits"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#64d8521f1b8509a0160a89e24d0ace2883fa3269"
+source = "git+https://github.com/servo/stylo?branch=2025-09-02#c4caa30eebad573590222d4f76b8939b41dc186a"
 dependencies = [
  "app_units",
  "bitflags 2.9.4",
@@ -8876,7 +8876,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#64d8521f1b8509a0160a89e24d0ace2883fa3269"
+source = "git+https://github.com/servo/stylo?branch=2025-09-02#c4caa30eebad573590222d4f76b8939b41dc186a"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8889,7 +8889,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#64d8521f1b8509a0160a89e24d0ace2883fa3269"
+source = "git+https://github.com/servo/stylo?branch=2025-09-02#c4caa30eebad573590222d4f76b8939b41dc186a"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
Updates Stylo to:
- https://github.com/servo/stylo/pull/242

Testing: This is a no-op for Servo. So if it builds without non-stylo lockfile changes it should be good.
