### PR TITLE
Abort fetch controller when signal is aborted

### DIFF
--- a/tests/wpt/meta/fetch/api/abort/general.any.js.ini
+++ b/tests/wpt/meta/fetch/api/abort/general.any.js.ini
@@ -5,7 +5,6 @@
   expected: ERROR
 
 [general.any.html]
-  expected: TIMEOUT
   [Request is still 'used' if signal is aborted before fetching]
     expected: FAIL
 
@@ -27,48 +26,11 @@
   [Call text() twice on aborted response]
     expected: FAIL
 
-  [Underlying connection is closed when aborting after receiving response]
-    expected: FAIL
-
-  [Underlying connection is closed when aborting after receiving response - no-cors]
-    expected: FAIL
-
-  [Fetch aborted & connection closed when aborted after calling response.arrayBuffer()]
-    expected: TIMEOUT
-
-  [Fetch aborted & connection closed when aborted after calling response.blob()]
-    expected: NOTRUN
-
-  [Fetch aborted & connection closed when aborted after calling response.formData()]
-    expected: NOTRUN
-
-  [Fetch aborted & connection closed when aborted after calling response.json()]
-    expected: NOTRUN
-
-  [Fetch aborted & connection closed when aborted after calling response.text()]
-    expected: NOTRUN
-
-  [Stream errors once aborted. Underlying connection closed.]
-    expected: NOTRUN
-
-  [Stream errors once aborted, after reading. Underlying connection closed.]
-    expected: NOTRUN
-
-  [Stream will not error if body is empty. It's closed with an empty queue before it errors.]
-    expected: NOTRUN
-
-  [Readable stream synchronously cancels with AbortError if aborted before reading]
-    expected: NOTRUN
-
   [response.bytes() rejects if already aborted]
     expected: FAIL
-
-  [Fetch aborted & connection closed when aborted after calling response.bytes()]
-    expected: NOTRUN
 
 
 [general.any.worker.html]
-  expected: TIMEOUT
   [Request is still 'used' if signal is aborted before fetching]
     expected: FAIL
 
@@ -90,41 +52,5 @@
   [Call text() twice on aborted response]
     expected: FAIL
 
-  [Underlying connection is closed when aborting after receiving response]
-    expected: FAIL
-
-  [Underlying connection is closed when aborting after receiving response - no-cors]
-    expected: FAIL
-
-  [Fetch aborted & connection closed when aborted after calling response.arrayBuffer()]
-    expected: TIMEOUT
-
-  [Fetch aborted & connection closed when aborted after calling response.blob()]
-    expected: NOTRUN
-
-  [Fetch aborted & connection closed when aborted after calling response.formData()]
-    expected: NOTRUN
-
-  [Fetch aborted & connection closed when aborted after calling response.json()]
-    expected: NOTRUN
-
-  [Fetch aborted & connection closed when aborted after calling response.text()]
-    expected: NOTRUN
-
-  [Stream errors once aborted. Underlying connection closed.]
-    expected: NOTRUN
-
-  [Stream errors once aborted, after reading. Underlying connection closed.]
-    expected: NOTRUN
-
-  [Stream will not error if body is empty. It's closed with an empty queue before it errors.]
-    expected: NOTRUN
-
-  [Readable stream synchronously cancels with AbortError if aborted before reading]
-    expected: NOTRUN
-
   [response.bytes() rejects if already aborted]
     expected: FAIL
-
-  [Fetch aborted & connection closed when aborted after calling response.bytes()]
-    expected: NOTRUN

--- a/tests/wpt/meta/fetch/api/abort/keepalive.html.ini
+++ b/tests/wpt/meta/fetch/api/abort/keepalive.html.ini
@@ -1,7 +1,0 @@
-[keepalive.html]
-  expected: TIMEOUT
-  [aborting a keepalive fetch should work]
-    expected: TIMEOUT
-
-  [aborting a detached keepalive fetch should not do anything]
-    expected: NOTRUN


### PR DESCRIPTION
Does not all tests pass because of a mismatch in microtask timing. The promises are resolved/rejected in the wrong order.

Part of #34866