### PR TITLE
layout: Make bottom table captions obey relative positioning offsets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4881,6 +4881,7 @@ dependencies = [
  "servo_malloc_size_of",
  "servo_url",
  "smallvec",
+ "strum",
  "stylo",
  "stylo_atoms",
  "stylo_traits",

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -54,6 +54,7 @@ servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
 servo_url = { path = "../url" }
 smallvec = { workspace = true }
+strum = { workspace = true }
 stylo = { workspace = true }
 stylo_atoms = { workspace = true }
 stylo_traits = { workspace = true }

--- a/tests/wpt/tests/css/css-tables/caption-relative-positioning.html
+++ b/tests/wpt/tests/css/css-tables/caption-relative-positioning.html
@@ -11,7 +11,7 @@
             position: relative;
             background: green;
             width: 100px;
-            height: 100px;
+            height: 50px;
             margin-left: 200px;
             left: -200px;
         }
@@ -20,7 +20,10 @@
     <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
     <div style="width: 100px; background: red;">
         <table>
-            <caption></caption>
+            <caption style="caption-side: top"></caption>
+        </table>
+        <table>
+            <caption style="caption-side: bottom"></caption>
         </table>
     </div>
 </html>


### PR DESCRIPTION
#33426 only added support for relative positioning on captions with `caption-side: top`, but forgot about `caption-side: bottom`. This unifies the logic for both kinds of captions to avoid divergences.

Testing: Modifying an existing test to also cover this case.
Fixes: #39386
