### PR TITLE
script: Allow reusing results from xpath queries

### DIFF
--- a/components/script/dom/xpathresult.rs
+++ b/components/script/dom/xpathresult.rs
@@ -137,11 +137,7 @@ impl XPathResult {
         )
     }
 
-    pub(crate) fn reinitialize_with(
-        &self,
-        result_type: XPathResultType,
-        value: XPathResultValue,
-    ) {
+    pub(crate) fn reinitialize_with(&self, result_type: XPathResultType, value: XPathResultValue) {
         self.result_type.set(result_type);
         *self.value.borrow_mut() = value;
         self.iterator_invalid.set(false);

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14613,6 +14613,13 @@
       {}
      ]
     ],
+    "xpath-result-out-parameter.html": [
+     "e4206aba44d2c4f6d299d9860d80b5f736094789",
+     [
+      null,
+      {}
+     ]
+    ],
     "zero_size_canvas_crash.html": [
      "45eb9b559e8d6105baca5ab4d336de520d33b36b",
      [

--- a/tests/wpt/mozilla/tests/mozilla/xpath-result-out-parameter.html
+++ b/tests/wpt/mozilla/tests/mozilla/xpath-result-out-parameter.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<head>
+    <link rel="help" href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathEvaluator-evaluate">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<script>
+const xmlString = `
+<root>
+  <section>
+    <item id="a"><name>Item A</name></item>
+    <item id="b"><name>Item B</name></item>
+  </section>
+</root>
+`;
+
+const parser = new DOMParser();
+const test_document = parser.parseFromString(xmlString, "application/xml");
+
+test(function () {
+    const first_result = test_document.evaluate(
+      "//section/item",
+      test_document,
+      null,
+      XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+      null
+    );
+
+    const second_result = test_document.evaluate(
+      "//section/item[@id='b']",
+      test_document,
+      null,
+      XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+      first_result
+    );
+
+    assert_equals(first_result, second_result);
+}, "Passing an existing xpath result as an out-parameter should overwrite the result");
+
+</script>


### PR DESCRIPTION
This behaviour is optional, but observable. Other browsers implement it, so we should do it too.

Testing: There are no WPT tests for this, which is fair since the spec explicitly states implementors may choose to not reuse the result. 
Fixes: Part of https://github.com/servo/servo/issues/34527
