### PR TITLE
layout: Correctly handle margins in sticky positioning

### DIFF
--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-margins.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-margins.html.ini
@@ -1,3 +1,0 @@
-[position-sticky-margins.html]
-  [The margin is taken into account when making sure the sticky element does not escape its container]
-    expected: FAIL


### PR DESCRIPTION
This fixes the logic that computes sticky offset bounds in order to correctly take margins into account.

Testing: One test passes
Fixes: #39389
