### PR TITLE
layout: Ignore insets in Taffy for static and sticky positionings

### DIFF
--- a/components/layout/taffy/stylo_taffy/wrapper.rs
+++ b/components/layout/taffy/stylo_taffy/wrapper.rs
@@ -10,6 +10,7 @@ use style::values::computed::{GridTemplateAreas, LengthPercentage};
 use style::values::generics::grid::{TrackListValue, TrackRepeat, TrackSize};
 use style::values::specified::position::NamedArea;
 use style::{Atom, OwnedSlice};
+use taffy::prelude::TaffyAuto;
 
 use super::{convert, stylo};
 
@@ -73,6 +74,19 @@ impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> 
 
     #[inline]
     fn inset(&self) -> taffy::Rect<taffy::LengthPercentageAuto> {
+        // Taffy doesn't support static nor sticky positionings, they are treated
+        // as relative. As a workaround, ignore the insets.
+        if matches!(
+            self.style.get_box().position,
+            stylo::Position::Static | stylo::Position::Sticky
+        ) {
+            return taffy::Rect {
+                left: taffy::LengthPercentageAuto::AUTO,
+                right: taffy::LengthPercentageAuto::AUTO,
+                top: taffy::LengthPercentageAuto::AUTO,
+                bottom: taffy::LengthPercentageAuto::AUTO,
+            };
+        }
         let position_styles = self.style.get_position();
         taffy::Rect {
             left: convert::inset(&position_styles.left),

--- a/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-sticky-positioned-items-002.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-column-axis-alignment-sticky-positioned-items-002.html.ini
@@ -1,6 +1,0 @@
-[grid-column-axis-alignment-sticky-positioned-items-002.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-sticky-positioned-items-002.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-row-axis-alignment-sticky-positioned-items-002.html.ini
@@ -1,6 +1,0 @@
-[grid-row-axis-alignment-sticky-positioned-items-002.html]
-  [.grid 1]
-    expected: FAIL
-
-  [.grid 2]
-    expected: FAIL

--- a/tests/wpt/meta/css/css-position/sticky/position-sticky-grid.html.ini
+++ b/tests/wpt/meta/css/css-position/sticky/position-sticky-grid.html.ini
@@ -1,2 +1,0 @@
-[position-sticky-grid.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-position/position-static-001.html
+++ b/tests/wpt/tests/css/css-position/position-static-001.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-position/#insets">
+<link rel="help" href="https://github.com/servo/servo/issues/39399">
+<link rel="match" href="../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="Inset propeties do not apply to a statically positioned grid item.">
+
+<style>
+#grid {
+  display: grid;
+  width: 200px;
+  height: 200px;
+  background: red;
+}
+#item {
+  width: 200px;
+  height: 200px;
+  top: 200px;
+  left: 200px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="grid">
+  <div id="item"></div>
+</div>


### PR DESCRIPTION
Taffy treats static and sticky positionings as relative. So the inset properties shifted the element in the relpos way, which was no good. It's better to just treat them as `auto` instead.

Testing: 3 existing tests pass, and adding a new one.
Fixes: #39399
