### PR TITLE
Use more workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ fonts_traits = { path = "components/shared/fonts" }
 freetype-sys = "0.20"
 fxhash = "0.2"
 gleam = "0.15"
-glow = "0.16"
+glow = "0.16.0"
 gstreamer = { version = "0.23", features = ["v1_18"] }
 gstreamer-base = "0.23"
 gstreamer-gl = "0.23"
@@ -93,7 +93,7 @@ keyboard-types = { version = "0.8.1", features = ["serde", "webdriver"] }
 kurbo = { version = "0.11.3", features = ["euclid"] }
 layout_api = { path = "components/shared/layout" }
 libc = "0.2"
-log = "0.4"
+log = "0.4.27"
 mach2 = "0.4"
 malloc_size_of = { package = "servo_malloc_size_of", path = "components/malloc_size_of" }
 malloc_size_of_derive = "0.1"

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -26,7 +26,7 @@ rustc-hash = { workspace = true }
 serde_json = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mach2 = { version = "0.4", optional = true }
+mach2 = { workspace = true, optional = true }
 
 [target.'cfg(all(target_os = "linux", not(any(target_arch = "arm", target_arch = "aarch64", target_env = "ohos", target_env = "musl"))))'.dependencies]
 nix = { workspace = true, features = ["signal"], optional = true }

--- a/components/shared/compositing/Cargo.toml
+++ b/components/shared/compositing/Cargo.toml
@@ -19,7 +19,7 @@ base = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true }
 crossbeam-channel = { workspace = true }
-dpi = { version = "0.1" }
+dpi = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }
 gleam = { workspace = true }
@@ -30,7 +30,7 @@ log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 profile_traits = { path = '../profile' }
-raw-window-handle = "0.6"
+raw-window-handle = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 servo_geometry = { path = "../../geometry" }

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -28,7 +28,7 @@ embedder_traits = { workspace = true }
 euclid = { workspace = true }
 ipc-channel = { workspace = true }
 keyboard-types = { workspace = true }
-log = "0.4.27"
+log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 media = { path = "../../media" }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -115,7 +115,7 @@ egui-file-dialog = "0.11.0"
 egui-winit = { version = "0.32.3", default-features = false, features = ["accesskit", "clipboard", "wayland"] }
 egui_glow = { version = "0.32.3", features = ["winit"] }
 gilrs = "0.11.0"
-glow = "0.16.0"
+glow = { workspace = true }
 headers = { workspace = true }
 net = { path = "../../components/net" }
 net_traits = { workspace = true }


### PR DESCRIPTION
I noticed that there are various dependencies that are listed independently even though they are already in the Servo workspace. Is there any issue with converting these to workspace dependencies?

Testing: No tests for Cargo.toml edits.