### PR TITLE
Parse qualified names with non-alpha characters in xpath

### DIFF
--- a/components/script/xpath/parser.rs
+++ b/components/script/xpath/parser.rs
@@ -10,7 +10,8 @@ use nom::error::{Error as NomError, ErrorKind as NomErrorKind, ParseError as Nom
 use nom::multi::{many0, separated_list0};
 use nom::sequence::{delimited, pair, preceded};
 use nom::{AsChar, Finish, IResult, Input, Parser};
-use crate::dom::bindings::xmlname::{is_valid_start, is_valid_continuation};
+
+use crate::dom::bindings::xmlname::{is_valid_continuation, is_valid_start};
 
 pub(crate) fn parse(input: &str) -> Result<Expr, OwnedParserError> {
     let (_, ast) = expr(input).finish().map_err(OwnedParserError::from)?;
@@ -989,7 +990,7 @@ fn ncname(input: &str) -> IResult<&str, &str> {
         <T as Input>::Item: AsChar,
     {
         input.split_at_position1_complete(
-            |character| !is_valid_continuation(character.as_char())|| character.as_char() == ':',
+            |character| !is_valid_continuation(character.as_char()) || character.as_char() == ':',
             NomErrorKind::OneOf,
         )
     }

--- a/tests/wpt/meta/domxpath/text-html-attributes.html.ini
+++ b/tests/wpt/meta/domxpath/text-html-attributes.html.ini
@@ -2,20 +2,8 @@
   [Select html element based on attribute mixed case]
     expected: FAIL
 
-  [Select HTML element with non-ascii attribute 1]
-    expected: FAIL
-
-  [Select HTML element with non-ascii attribute 2]
-    expected: FAIL
-
   [Select HTML element with non-ascii attribute 3]
     expected: FAIL
 
   [Select both HTML and SVG elements based on mixed case attribute]
-    expected: FAIL
-
-  [Select SVG element with non-ascii attribute 1]
-    expected: FAIL
-
-  [Select SVG element with non-ascii attribute 2]
     expected: FAIL

--- a/tests/wpt/meta/domxpath/text-html-elements.html.ini
+++ b/tests/wpt/meta/domxpath/text-html-elements.html.ini
@@ -2,9 +2,6 @@
   [HTML elements mixed case]
     expected: FAIL
 
-  [Non-ascii HTML element]
-    expected: FAIL
-
   [Non-ascii HTML element3]
     expected: FAIL
 


### PR DESCRIPTION
The existing parsing rules are too strict and only allow alpha and alphanumeric characters. Instead, we should follow the production defined in https://www.w3.org/TR/REC-xml-names/#NT-NCName.

Testing: New tests start to pass
Part of https://github.com/servo/servo/issues/34527
