### PR TITLE
Allow whitespace around path expressions in xpath 

### DIFF
--- a/components/script/xpath/parser.rs
+++ b/components/script/xpath/parser.rs
@@ -512,7 +512,7 @@ fn union_expr(input: &str) -> IResult<&str, Expr> {
 }
 
 fn path_expr(input: &str) -> IResult<&str, Expr> {
-    alt((
+    ws(alt((
         // "//" RelativePathExpr
         map(
             pair(tag("//"), move |i| relative_path_expr(true, i)),
@@ -545,7 +545,7 @@ fn path_expr(input: &str) -> IResult<&str, Expr> {
         ),
         // RelativePathExpr
         move |i| relative_path_expr(false, i),
-    ))
+    )))
     .parse(input)
 }
 

--- a/tests/wpt/meta/domxpath/lexical-structure.html.ini
+++ b/tests/wpt/meta/domxpath/lexical-structure.html.ini
@@ -1,6 +1,0 @@
-[lexical-structure.html]
-  [Literal: Only ' and " should be handled as literal quotes.]
-    expected: FAIL
-
-  [ExprWhitespace: Only #x20 #x9 #xD or #xA must be handled as a whitespace.]
-    expected: FAIL


### PR DESCRIPTION
Previously servo would allow whitespace in between components of an xpath expression, but not around it.

Testing: New web platform tests start to pass 
Part of https://github.com/servo/servo/issues/34527
