### PR TITLE
Remove `test-content` subcommand from mach

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -268,11 +268,6 @@ class MachCommands(CommandBase):
         assert isinstance(result, int)
         return result
 
-    @Command("test-content", description="Run the content tests", category="testing")
-    def test_content(self) -> int:
-        print("Content tests have been replaced by web-platform-tests under tests/wpt/mozilla/.")
-        return 0
-
     @Command("test-tidy", description="Run the source code tidiness check", category="testing")
     @CommandArgument(
         "--all",


### PR DESCRIPTION
Content tests have been replaced by web platform tests 10 years ago (see https://github.com/servo/servo/commit/9be71b941fc43b15d4f5b50ebba772c8430c601c). I think it is fair to assume that no one is going to run the relevant subcommand anymore. Let's remove it.
