### PR TITLE
script: Report module evaluation errors async.

### DIFF
--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -259,7 +259,7 @@ impl GlobalScope {
 
         // Step 4. Prepare to run script given settings.
         run_a_script::<DomTypeHolder, _>(self, || {
-            let cx = GlobalScope::get_cx();
+            let safe_cx = GlobalScope::get_cx();
 
             // Step 6. If script's error to rethrow is not null, then set evaluationPromise to a
             // promise rejected with script's error to rethrow.
@@ -269,21 +269,21 @@ impl GlobalScope {
                     //module_tree.report_error(self, CanGc::from_cx(cx));
                     let evaluation_promise = Promise::new_rejected(
                         self,
-                        cx,
+                        safe_cx,
                         error.handle(),
-                        can_gc,
+                        CanGc::from_cx(cx),
                     );
                     let handler = PromiseNativeHandler::new(
                         self,
                         None,
                         Some(Box::new(ReportErrorRejectionHandler)),
-                        can_gc,
+                        CanGc::from_cx(cx),
                     );
-                    let realm = AlreadyInRealm::assert_for_cx(cx);
+                    let realm = AlreadyInRealm::assert_for_cx(safe_cx);
                     evaluation_promise.append_native_handler(
                         &handler,
                         (&realm).into(),
-                        can_gc,
+                        CanGc::from_cx(cx),
                     );
                     return;
                 }
@@ -303,19 +303,19 @@ impl GlobalScope {
                 // global object.
                 //if evaluated.is_err() {
                     assert!(rval.is_object());
-                    rooted!(in(*cx) let evaluation_promise_obj = rval.to_object());
-                    let evaluation_promise = Promise::new_with_js_promise(evaluation_promise_obj.handle(), cx);
+                    rooted!(&in(cx) let evaluation_promise_obj = rval.to_object());
+                    let evaluation_promise = Promise::new_with_js_promise(evaluation_promise_obj.handle(), safe_cx);
                     let handler = PromiseNativeHandler::new(
                         self,
                         None,
                         Some(Box::new(ReportErrorRejectionHandler)),
-                        can_gc,
+                        CanGc::from_cx(cx),
                     );
-                    let realm = AlreadyInRealm::assert_for_cx(cx);
+                    let realm = AlreadyInRealm::assert_for_cx(safe_cx);
                     evaluation_promise.append_native_handler(
                         &handler,
                         (&realm).into(),
-                        can_gc,
+                        CanGc::from_cx(cx),
                     );
 
                     //module_tree.set_rethrow_error(exception);

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -295,13 +295,13 @@ impl GlobalScope {
             if let Some(record) = record {
                 // Step 7.2. Set evaluationPromise to record.Evaluate().
                 rooted!(&in(cx) let mut rval = UndefinedValue());
-                let evaluated =
+                let _evaluated =
                     module_tree.execute_module(self, record, rval.handle_mut(), CanGc::from_cx(cx));
 
                 // Step 8. If preventErrorReporting is false, then upon rejection of evaluationPromise
                 // with reason, report an exception given by reason for script's settings object's
                 // global object.
-                if evaluated.is_err() {
+                //if evaluated.is_err() {
                     assert!(rval.is_object());
                     rooted!(in(*cx) let evaluation_promise_obj = rval.to_object());
                     let evaluation_promise = Promise::new_with_js_promise(evaluation_promise_obj.handle(), cx);
@@ -320,7 +320,7 @@ impl GlobalScope {
 
                     //module_tree.set_rethrow_error(exception);
                     //module_tree.report_error(self, CanGc::from_cx(cx));
-                }
+                //}
             }
         });
     }

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -9,9 +9,11 @@ use std::rc::Rc;
 
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use js::context::JSContext;
+use js::gc::HandleValue;
 use js::jsapi::{ExceptionStackBehavior, JSScript, SetScriptPrivate};
 use js::jsval::{PrivateValue, UndefinedValue};
 use js::panic::maybe_resume_unwind;
+use js::realm::CurrentRealm;
 use js::rust::wrappers2::{
     Compile1, JS_ClearPendingException, JS_ExecuteScript, JS_GetPendingException,
     JS_GetScriptPrivate, JS_SetPendingException,
@@ -23,11 +25,14 @@ use servo_url::ServoUrl;
 
 use crate::DomTypeHolder;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
-use crate::dom::bindings::error::{Error, ErrorResult};
+use crate::dom::bindings::error::{Error, ErrorResult, report_pending_exception};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::promise::Promise;
+use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::window::Window;
+use crate::realms::AlreadyInRealm;
 use crate::script_module::{
     ModuleScript, ModuleSource, ModuleTree, RethrowError, ScriptFetchOptions,
 };
@@ -239,7 +244,6 @@ impl GlobalScope {
         &self,
         cx: &mut JSContext,
         module_tree: Rc<ModuleTree>,
-        _rethrow_errors: bool,
     ) {
         // Step 1. Let settings be the settings object of script.
         // NOTE(pylbrecht): "settings" is `self` here.
@@ -255,12 +259,32 @@ impl GlobalScope {
 
         // Step 4. Prepare to run script given settings.
         run_a_script::<DomTypeHolder, _>(self, || {
+            let cx = GlobalScope::get_cx();
+
             // Step 6. If script's error to rethrow is not null, then set evaluationPromise to a
             // promise rejected with script's error to rethrow.
             {
                 let module_error = module_tree.get_rethrow_error().borrow();
-                if module_error.is_some() {
-                    module_tree.report_error(self, CanGc::from_cx(cx));
+                if let Some(error) = &*module_error {
+                    //module_tree.report_error(self, CanGc::from_cx(cx));
+                    let evaluation_promise = Promise::new_rejected(
+                        self,
+                        cx,
+                        error.handle(),
+                        can_gc,
+                    );
+                    let handler = PromiseNativeHandler::new(
+                        self,
+                        None,
+                        Some(Box::new(ReportErrorRejectionHandler)),
+                        can_gc,
+                    );
+                    let realm = AlreadyInRealm::assert_for_cx(cx);
+                    evaluation_promise.append_native_handler(
+                        &handler,
+                        (&realm).into(),
+                        can_gc,
+                    );
                     return;
                 }
             }
@@ -277,9 +301,25 @@ impl GlobalScope {
                 // Step 8. If preventErrorReporting is false, then upon rejection of evaluationPromise
                 // with reason, report an exception given by reason for script's settings object's
                 // global object.
-                if let Err(exception) = evaluated {
-                    module_tree.set_rethrow_error(exception);
-                    module_tree.report_error(self, CanGc::from_cx(cx));
+                if evaluated.is_err() {
+                    assert!(rval.is_object());
+                    rooted!(in(*cx) let evaluation_promise_obj = rval.to_object());
+                    let evaluation_promise = Promise::new_with_js_promise(evaluation_promise_obj.handle(), cx);
+                    let handler = PromiseNativeHandler::new(
+                        self,
+                        None,
+                        Some(Box::new(ReportErrorRejectionHandler)),
+                        can_gc,
+                    );
+                    let realm = AlreadyInRealm::assert_for_cx(cx);
+                    evaluation_promise.append_native_handler(
+                        &handler,
+                        (&realm).into(),
+                        can_gc,
+                    );
+
+                    //module_tree.set_rethrow_error(exception);
+                    //module_tree.report_error(self, CanGc::from_cx(cx));
                 }
             }
         });
@@ -379,4 +419,23 @@ pub(crate) fn evaluate_script(
     }
 
     unsafe { JS_ExecuteScript(cx, record.handle(), rval) }
+}
+
+#[derive(Clone, JSTraceable, MallocSizeOf)]
+struct ReportErrorRejectionHandler;
+
+impl Callback for ReportErrorRejectionHandler {
+    #[expect(unsafe_code)]
+    fn callback(&self, realm: &mut CurrentRealm, v: HandleValue) {
+        let cx = GlobalScope::get_cx();
+        unsafe {
+            JS_SetPendingException(
+                *cx,
+                v,
+                ExceptionStackBehavior::Capture,
+            );
+        }
+        let in_realm = AlreadyInRealm::from(&mut *realm);
+        report_pending_exception(cx, (&in_realm).into(), CanGc::from_cx(&mut *realm));
+    }
 }

--- a/components/script/dom/global_scope_script_execution.rs
+++ b/components/script/dom/global_scope_script_execution.rs
@@ -428,13 +428,13 @@ impl Callback for ReportErrorRejectionHandler {
     #[expect(unsafe_code)]
     fn callback(&self, realm: &mut CurrentRealm, v: HandleValue) {
         let cx = GlobalScope::get_cx();
-        unsafe {
+        /*unsafe {
             JS_SetPendingException(
                 *cx,
                 v,
                 ExceptionStackBehavior::Capture,
             );
-        }
+        }*/
         let in_realm = AlreadyInRealm::from(&mut *realm);
         report_pending_exception(cx, (&in_realm).into(), CanGc::from_cx(&mut *realm));
     }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1063,7 +1063,7 @@ impl HTMLScriptElement {
                 // Step 6."module".2. Run the module script given by el's result.
                 self.owner_window()
                     .as_global_scope()
-                    .run_a_module_script(cx, module_tree, false);
+                    .run_a_module_script(cx, module_tree);
             },
             Script::ImportMap(script) => {
                 // Step 6."importmap".1. Register an import map given el's relevant global object and el's result.

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -604,7 +604,7 @@ impl WorkerGlobalScope {
                         .run_a_classic_script(cx, script, RethrowErrors::No);
                 },
                 Script::Module(module_tree) => {
-                    self.globalscope.run_a_module_script(cx, module_tree, false);
+                    self.globalscope.run_a_module_script(cx, module_tree);
                 },
                 _ => unreachable!(),
             }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -452,7 +452,7 @@ impl ModuleTree {
             let throw_result = ThrowOnModuleEvaluationFailure(
                 *cx,
                 evaluation_promise.handle().into(),
-                ModuleErrorBehaviour::ThrowModuleErrorsSync,
+                ModuleErrorBehaviour::ReportModuleErrorsAsync,
             );
             if !throw_result {
                 warn!("fail to evaluate module");

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -436,7 +436,7 @@ impl ModuleTree {
         module_record: js::gc::HandleObject,
         mut eval_result: MutableHandleValue,
         _can_gc: CanGc,
-    ) -> Result<(), RethrowError> {
+    ) -> Result<(), ()> {
         let cx = GlobalScope::get_cx();
         let _ac = JSAutoRealm::new(*cx, *global.reflector().get_jsobject());
 
@@ -457,13 +457,14 @@ impl ModuleTree {
             if !throw_result {
                 warn!("fail to evaluate module");
 
-                rooted!(in(*cx) let mut exception = UndefinedValue());
+                /*rooted!(in(*cx) let mut exception = UndefinedValue());
                 assert!(JS_GetPendingException(*cx, exception.handle_mut()));
                 JS_ClearPendingException(*cx);
 
                 Err(RethrowError(RootedTraceableBox::from_box(Heap::boxed(
                     exception.get(),
-                ))))
+            ))))*/
+                Err(())
             } else {
                 debug!("module evaluated successfully");
                 Ok(())

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -67,7 +67,7 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::Window_Binding::WindowMethods;
 use crate::dom::bindings::conversions::SafeToJSValConvertible;
 use crate::dom::bindings::error::{
-    Error, ErrorToJsval, report_pending_exception, throw_dom_exception,
+    Error, ErrorToJsval, throw_dom_exception,
 };
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
@@ -472,7 +472,7 @@ impl ModuleTree {
         }
     }
 
-    #[expect(unsafe_code)]
+    /*#[expect(unsafe_code)]
     pub(crate) fn report_error(&self, global: &GlobalScope, can_gc: CanGc) {
         let module_error = self.rethrow_error.borrow();
 
@@ -487,7 +487,7 @@ impl ModuleTree {
             }
             report_pending_exception(GlobalScope::get_cx(), InRealm::Entered(&ar), can_gc);
         }
-    }
+    }*/
 
     /// <https://html.spec.whatwg.org/multipage/#resolve-a-module-specifier>
     pub(crate) fn resolve_module_specifier(

--- a/tests/wpt/meta/html/browsers/history/the-location-interface/same-hash.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-location-interface/same-hash.html.ini
@@ -1,2 +1,0 @@
-[same-hash.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/semantics/embedded-content/bfcache/embedded-html.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/bfcache/embedded-html.html.ini
@@ -1,2 +1,0 @@
-[embedded-html.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/semantics/embedded-content/bfcache/embedded-img.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/bfcache/embedded-img.html.ini
@@ -1,2 +1,0 @@
-[embedded-img.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/semantics/embedded-content/bfcache/embedded-js.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/bfcache/embedded-js.html.ini
@@ -1,2 +1,0 @@
-[embedded-js.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/semantics/embedded-content/bfcache/embedded-mp4.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/bfcache/embedded-mp4.html.ini
@@ -1,2 +1,0 @@
-[embedded-mp4.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/semantics/embedded-content/bfcache/embedded-not-found.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/bfcache/embedded-not-found.html.ini
@@ -1,2 +1,0 @@
-[embedded-not-found.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/semantics/embedded-content/bfcache/embedded-type-only.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/bfcache/embedded-type-only.html.ini
@@ -1,2 +1,0 @@
-[embedded-type-only.html]
-  expected: ERROR

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-events.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-events.html.ini
@@ -1,3 +1,4 @@
 [dialog-cancel-events.html]
+  expected: TIMEOUT
   [Test cancel event is fired when the dialog is closed by user close requests]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-preventDefault.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-dialog-element/dialog-cancel-preventDefault.html.ini
@@ -1,3 +1,4 @@
 [dialog-cancel-preventDefault.html]
+  expected: TIMEOUT
   [Test cancel event with preventDefault on cancel event for dialog element]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/choice-of-error-3.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/choice-of-error-3.html.ini
@@ -1,0 +1,3 @@
+[choice-of-error-3.html]
+  [Evaluation errors are cached in intermediate module scripts]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/error-type-3.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/error-type-3.html.ini
@@ -1,0 +1,3 @@
+[error-type-3.html]
+  [instantiation error has higher priority than evaluation error]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/evaluation-error-1.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/evaluation-error-1.html.ini
@@ -1,0 +1,3 @@
+[evaluation-error-1.html]
+  [Test that exceptions during evaluation lead to error events on window, and that exceptions are remembered.\n]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/evaluation-error-1.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/evaluation-error-1.html.ini
@@ -1,3 +1,3 @@
-[evaluation-error-1.html]
+[sevaluation-error-1.html]
   [Test that exceptions during evaluation lead to error events on window, and that exceptions are remembered.\n]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/evaluation-error-2.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/evaluation-error-2.html.ini
@@ -1,0 +1,3 @@
+[evaluation-error-2.html]
+  [Test that ill-founded cyclic dependencies cause ReferenceError during evaluation, which leads to error events on window, and that exceptions are remembered.\n]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/evaluation-error-3.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/evaluation-error-3.html.ini
@@ -1,0 +1,3 @@
+[evaluation-error-3.html]
+  [Test that exceptions during evaluation lead to error events on window, and that exceptions are remembered.\n]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/evaluation-error-4.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/evaluation-error-4.html.ini
@@ -1,0 +1,3 @@
+[evaluation-error-4.html]
+  [Test that exceptions during evaluation lead to error events on window, and that exceptions are remembered.\n]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/module-import-referrer.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/module-import-referrer.html.ini
@@ -1,2 +1,0 @@
-[module-import-referrer.html]
-  expected: ERROR

--- a/tests/wpt/meta/import-maps/not-overridden/failed-resolution.html.ini
+++ b/tests/wpt/meta/import-maps/not-overridden/failed-resolution.html.ini
@@ -1,2 +1,0 @@
-[failed-resolution.html]
-  expected: ERROR

--- a/tests/wpt/tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-1.html
+++ b/tests/wpt/tests/html/semantics/scripting-1/the-script-element/module/evaluation-error-1.html
@@ -8,7 +8,7 @@
 
     window.log = [];
 
-    window.addEventListener("error", ev => log.push(ev.error));
+  window.addEventListener("error", ev => {console.log("error handler");log.push(ev.error)});
     window.addEventListener("unhandledrejection", unreachable);
 
     const test_load = async_test(
@@ -21,7 +21,7 @@
       assert_true(exn.foo);
     }));
 
-    function logLoad() { log.push("load") }
+  function logLoad() { console.log("load handler");log.push("load") }
 
     function unreachable() { log.push("unexpected"); }
 </script>


### PR DESCRIPTION
Per the documentation in https://searchfox.org/firefox-main/rev/36ebbdf6fbbfd0b40a607212ec843992b5d43e92/js/public/Modules.h#255-257, this setting is the expected one for web content.

Testing: This allows a bunch of automated tests to run to completion in debug mozjs builds. Sadly, we don't run those in CI.
Fixes: #34726
