### PR TITLE
net/fetch: Improve HTTP fetch error handling for gzip  content decompressions

### DIFF
--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -841,8 +841,8 @@ async fn wait_for_response(
                     }
                     target.process_response_chunk(request, vec);
                 },
-                Some(Data::Error(e)) => {
-                    response.set_network_error(e);
+                Some(Data::Error(network_error)) => {
+                    response.set_network_error(network_error);
                     break;
                 },
                 Some(Data::Done) => {

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -66,6 +66,7 @@ pub enum Data {
     Payload(Vec<u8>),
     Done,
     Cancelled,
+    Error(NetworkError),
 }
 
 pub struct WebSocketChannel {
@@ -839,6 +840,10 @@ async fn wait_for_response(
                         body.extend(&vec);
                     }
                     target.process_response_chunk(request, vec);
+                },
+                Some(Data::Error(e)) => {
+                    response.set_network_error(e);
+                    break;
                 },
                 Some(Data::Done) => {
                     send_response_to_devtools(request, context, response, devtools_body);

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2288,8 +2288,8 @@ async fn http_network_fetch(
                 let _ = done_sender2.send(Data::Done);
                 future::ready(Ok(()))
             })
-            .map_err(move |e| {
-                if let std::io::ErrorKind::InvalidData = e.kind() {
+            .map_err(move |error| {
+                if let std::io::ErrorKind::InvalidData = error.kind() {
                     debug!("Content decompression error for {:?}", url2);
                     let _ = done_sender3.send(Data::Error(NetworkError::DecompressionError));
                     let mut body = res_body2.lock();

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -55,7 +55,7 @@ use net_traits::request::{
     is_cors_safelisted_request_header,
 };
 use net_traits::response::{
-    CacheState, HttpsState, RedirectTaint, Response, ResponseBody, ResponseType,
+    CacheState, HttpsState, RedirectTaint, Response, ResponseBody, ResponseType, TerminationReason,
 };
 use net_traits::{
     CookieSource, DOCUMENT_ACCEPT_HEADER_VALUE, DebugVec, FetchMetadata, NetworkError,
@@ -2249,14 +2249,14 @@ async fn http_network_fetch(
 
     spawn_task(
         res.into_body()
-            .map_err(|e| {
-                warn!("Error streaming response body: {:?}", e);
-            })
             .try_fold(res_body, move |res_body, chunk| {
                 if cancellation_listener.cancelled() {
                     *res_body.lock() = ResponseBody::Done(vec![]);
                     let _ = done_sender.send(Data::Cancelled);
-                    return future::ready(Err(()));
+                    return future::ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::Interrupted,
+                        "Fetch aborted",
+                    )));
                 }
                 if let ResponseBody::Receiving(ref mut body) = *res_body.lock() {
                     let bytes = chunk;
@@ -2288,7 +2288,15 @@ async fn http_network_fetch(
                 let _ = done_sender2.send(Data::Done);
                 future::ready(Ok(()))
             })
-            .map_err(move |_| {
+            .map_err(move |e| {
+                if let std::io::ErrorKind::InvalidData = e.kind() {
+                    debug!("Content decompression error for {:?}", url2);
+                    let _ = done_sender3.send(Data::Error(NetworkError::DecompressionError));
+                    let mut body = res_body2.lock();
+                    response.termination_reason = Some(TerminationReason::Fatal);
+
+                    *body = ResponseBody::Done(vec![]);
+                }
                 debug!("finished response for {:?}", url2);
                 let mut body = res_body2.lock();
                 let completed_body = match *body {

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1344,7 +1344,8 @@ impl FetchResponseListener for ParserContext {
                 NetworkError::InvalidPort |
                 NetworkError::LocalDirectoryError |
                 NetworkError::PartialResponseToNonRangeRequestError |
-                NetworkError::ProtocolHandlerSubstitutionError => {
+                NetworkError::ProtocolHandlerSubstitutionError |
+                NetworkError::DecompressionError => {
                     let page = resources::read_string(Resource::NetErrorHTML);
                     page.replace("${reason}", &format!("{:?}", error))
                 },

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -626,8 +626,8 @@ impl FetchResponseListener for FetchContext {
     ) {
         let response_object = self.response_object.root();
         let _ac = enter_realm(&*response_object);
-        if let Err(error) = response.clone() {
-            if error == NetworkError::DecompressionError {
+        if let Err(ref error) = response {
+            if *error == NetworkError::DecompressionError {
                 response_object.error_stream(
                     Error::Type("Network error occurred".to_string()),
                     CanGc::note(),

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -626,6 +626,14 @@ impl FetchResponseListener for FetchContext {
     ) {
         let response_object = self.response_object.root();
         let _ac = enter_realm(&*response_object);
+        if let Err(e) = response.clone() {
+            if e == NetworkError::DecompressionError {
+                response_object.error_stream(
+                    Error::Type("Network error occurred".to_string()),
+                    CanGc::note(),
+                );
+            }
+        }
         response_object.finish(CanGc::note());
         // TODO
         // ... trailerObject is not supported in Servo yet.

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -626,8 +626,8 @@ impl FetchResponseListener for FetchContext {
     ) {
         let response_object = self.response_object.root();
         let _ac = enter_realm(&*response_object);
-        if let Err(e) = response.clone() {
-            if e == NetworkError::DecompressionError {
+        if let Err(error) = response.clone() {
+            if error == NetworkError::DecompressionError {
                 response_object.error_stream(
                     Error::Type("Network error occurred".to_string()),
                     CanGc::note(),

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -1169,6 +1169,7 @@ pub enum NetworkError {
     ProtocolHandlerSubstitutionError,
     BlobURLStoreError(String),
     HttpError(String),
+    DecompressionError,
 }
 
 impl fmt::Debug for NetworkError {
@@ -1216,6 +1217,7 @@ impl fmt::Debug for NetworkError {
                 write!(f, "Websocket connection failure: {}", s)
             },
             NetworkError::HttpError(s) => write!(f, "HTTP failure: {}", s),
+            NetworkError::DecompressionError => write!(f, "Decompression error"),
         }
     }
 }

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -218,6 +218,10 @@ impl Response {
         }
     }
 
+    pub fn set_network_error(&mut self, e: NetworkError) {
+        self.response_type = ResponseType::Error(e);
+    }
+
     pub fn actual_response(&self) -> &Response {
         if self.return_internal && self.internal_response.is_some() {
             self.internal_response.as_ref().unwrap()

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -218,8 +218,8 @@ impl Response {
         }
     }
 
-    pub fn set_network_error(&mut self, e: NetworkError) {
-        self.response_type = ResponseType::Error(e);
+    pub fn set_network_error(&mut self, network_error: NetworkError) {
+        self.response_type = ResponseType::Error(network_error);
     }
 
     pub fn actual_response(&self) -> &Response {

--- a/tests/wpt/meta/fetch/content-encoding/gzip/bad-gzip-body.any.js.ini
+++ b/tests/wpt/meta/fetch/content-encoding/gzip/bad-gzip-body.any.js.ini
@@ -1,36 +1,6 @@
 [bad-gzip-body.any.html]
-  [Consuming the body of a resource with bad gzip content with arrayBuffer() should reject]
-    expected: FAIL
-
-  [Consuming the body of a resource with bad gzip content with blob() should reject]
-    expected: FAIL
-
-  [Consuming the body of a resource with bad gzip content with json() should reject]
-    expected: FAIL
-
-  [Consuming the body of a resource with bad gzip content with text() should reject]
-    expected: FAIL
-
-  [Consuming the body of a resource with bad gzip content with bytes() should reject]
-    expected: FAIL
-
 
 [bad-gzip-body.any.worker.html]
-  [Consuming the body of a resource with bad gzip content with arrayBuffer() should reject]
-    expected: FAIL
-
-  [Consuming the body of a resource with bad gzip content with blob() should reject]
-    expected: FAIL
-
-  [Consuming the body of a resource with bad gzip content with json() should reject]
-    expected: FAIL
-
-  [Consuming the body of a resource with bad gzip content with text() should reject]
-    expected: FAIL
-
-  [Consuming the body of a resource with bad gzip content with bytes() should reject]
-    expected: FAIL
-
 
 [bad-gzip-body.any.serviceworker.html]
   expected: ERROR


### PR DESCRIPTION
This PR fixes error handling in Servo's HTTP fetch implementations to properly handle content decompression failures (e.g., bad gzip content) by treating them as  network errors as defined in WPT.

  - Fixed some previously failing tests in bad-gzip-body.any.js that now properly reject when consuming bodies with bad gzip content
  - Several fetch metadata tests now pass correctly