### PR TITLE
layout: Clamp sticky positioning offset bounds by zero

### DIFF
--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -1558,12 +1558,12 @@ impl BoxFragment {
         // This is the minimum negative offset and then the maximum positive offset. We just
         // specify every edge, but if the corresponding margin is None, that offset has no effect.
         let vertical_offset_bounds = wr::StickyOffsetBounds::new(
-            containing_block_rect.min.y - frame_rect.min.y,
-            containing_block_rect.max.y - frame_rect.max.y,
+            (containing_block_rect.min.y - frame_rect.min.y).min(0.),
+            (containing_block_rect.max.y - frame_rect.max.y).max(0.),
         );
         let horizontal_offset_bounds = wr::StickyOffsetBounds::new(
-            containing_block_rect.min.x - frame_rect.min.x,
-            containing_block_rect.max.x - frame_rect.max.x,
+            (containing_block_rect.min.x - frame_rect.min.x).min(0.),
+            (containing_block_rect.max.x - frame_rect.max.x).max(0.),
         );
 
         let margins = SideOffsets2D::new(

--- a/tests/wpt/tests/css/css-position/sticky/position-sticky-bottom-004.html
+++ b/tests/wpt/tests/css/css-position/sticky/position-sticky-bottom-004.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>CSS Position Test: sticky element with bottom offset</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-position/#stickypos-insets">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The static position of #sticky is outside (below) of its containing block.
+  Sticky positioning doesn't force it to move up into the containing block.
+">
+
+<style>
+#scroll-container {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+#sticky {
+  position: sticky;
+  bottom: 0;
+  height: 100px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="scroll-container">
+  <div style="height: 100px; margin-top: -100px">
+    <div style="height: 100px"></div>
+    <div id="sticky"></div>
+  </div>
+</div>

--- a/tests/wpt/tests/css/css-position/sticky/position-sticky-bottom-005.html
+++ b/tests/wpt/tests/css/css-position/sticky/position-sticky-bottom-005.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>CSS Position Test: sticky element with bottom offset</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-position/#stickypos-insets">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The static position of #sticky is outside (above) of its containing block.
+  Sticky positioning doesn't force it to move down into the containing block.
+">
+
+<style>
+#scroll-container {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+#sticky {
+  position: sticky;
+  bottom: 0;
+  height: 100px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="scroll-container">
+  <div style="padding-top: 200px">
+    <div style="margin-top: -200px"></div>
+    <div id="sticky"></div>
+  </div>
+</div>

--- a/tests/wpt/tests/css/css-position/sticky/position-sticky-bottom-006.html
+++ b/tests/wpt/tests/css/css-position/sticky/position-sticky-bottom-006.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>CSS Position Test: sticky element with bottom offset</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-position/#stickypos-insets">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  The static position of #sticky is outside (above) of its nearest scrollport.
+  Sticky positioning doesn't force it to move down into the scrollport.
+">
+
+<style>
+#scroll-container {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+  background: green;
+}
+#sticky {
+  position: sticky;
+  bottom: 0;
+  height: 100px;
+  background: red;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="scroll-container">
+  <div style="margin-top: -100px"></div>
+  <div id="sticky"></div>
+</div>

--- a/tests/wpt/tests/css/css-position/sticky/position-sticky-bottom-007.html
+++ b/tests/wpt/tests/css/css-position/sticky/position-sticky-bottom-007.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<title>CSS Position Test: sticky element with bottom offset</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-position/#stickypos-insets">
+<link rel="match" href="../../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="
+  When the scroll container is scrolled to the top, then #sticky is visible.
+  If we scroll 100px down, then #sticky should update its sticky offsets
+  to still be visible.
+">
+
+<style>
+#scroll-container {
+  overflow: hidden;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+#sticky {
+  position: sticky;
+  bottom: 0;
+  height: 100px;
+  background: green;
+}
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="scroll-container">
+  <div style="height: 500px"></div>
+  <div id="sticky"></div>
+</div>
+
+<script>
+scroller.scrollTop = 100;
+</script>


### PR DESCRIPTION
Sticky positioning tries to keep an element visible within the nearest scrollport. However, the element can't be offset to go beyond its containing block. We implement this as offset bounds.

The problem was that, if the element would already be overflowing its containing block before applying the sticky positioning, then we were forcing it to move inside the containing block. That was wrong, and is solved by flooring or ceiling the offset bounds by zero.

Testing: Adding new tests
