### PR TITLE
html: Properly count <image>/<source> insertion/removal steps as the relevant mutations

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -738,11 +738,7 @@ impl Element {
             .upcast::<Node>()
             .set_containing_shadow_root(Some(&shadow_root));
 
-        let bind_context = BindContext {
-            tree_connected: self.upcast::<Node>().is_connected(),
-            tree_is_in_a_document_tree: self.upcast::<Node>().is_in_a_document_tree(),
-            tree_is_in_a_shadow_tree: true,
-        };
+        let bind_context = BindContext::new(&self.node);
         shadow_root.bind_to_tree(&bind_context, can_gc);
 
         let node = self.upcast::<Node>();

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -300,6 +300,8 @@ impl Node {
         let parent_is_connected = self.is_connected();
         let parent_is_in_ua_widget = self.is_in_ua_widget();
 
+        let context = BindContext::new(self);
+
         for node in new_child.traverse_preorder(ShadowIncluding::No) {
             if parent_in_shadow_tree {
                 if let Some(shadow_root) = self.containing_shadow_root() {
@@ -317,14 +319,7 @@ impl Node {
 
             // Out-of-document elements never have the descendants flag set.
             debug_assert!(!node.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS));
-            vtable_for(&node).bind_to_tree(
-                &BindContext {
-                    tree_connected: parent_is_connected,
-                    tree_is_in_a_document_tree: parent_is_in_a_document_tree,
-                    tree_is_in_a_shadow_tree: parent_in_shadow_tree,
-                },
-                can_gc,
-            );
+            vtable_for(&node).bind_to_tree(&context, can_gc);
         }
     }
 
@@ -4254,7 +4249,10 @@ impl<'a> ChildrenMutation<'a> {
 }
 
 /// The context of the binding to tree of a node.
-pub(crate) struct BindContext {
+pub(crate) struct BindContext<'a> {
+    /// The parent of the inclusive ancestor that was inserted.
+    pub(crate) parent: &'a Node,
+
     /// Whether the tree is connected.
     ///
     /// <https://dom.spec.whatwg.org/#connected>
@@ -4269,7 +4267,17 @@ pub(crate) struct BindContext {
     pub(crate) tree_is_in_a_shadow_tree: bool,
 }
 
-impl BindContext {
+impl<'a> BindContext<'a> {
+    /// Create a new `BindContext` value.
+    pub(crate) fn new(parent: &'a Node) -> Self {
+        BindContext {
+            parent,
+            tree_connected: parent.is_connected(),
+            tree_is_in_a_document_tree: parent.is_in_a_document_tree(),
+            tree_is_in_a_shadow_tree: parent.is_in_a_shadow_tree(),
+        }
+    }
+
     /// Return true iff the tree is inside either a document- or a shadow tree.
     pub(crate) fn is_in_tree(&self) -> bool {
         self.tree_is_in_a_document_tree || self.tree_is_in_a_shadow_tree

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -586,20 +586,15 @@ impl VirtualMethods for ShadowRoot {
 
         shadow_root.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);
 
+        let context = BindContext::new(shadow_root);
+
         // avoid iterate over the shadow root itself
         for node in shadow_root.traverse_preorder(ShadowIncluding::Yes).skip(1) {
             node.set_flag(NodeFlags::IS_CONNECTED, context.tree_connected);
 
             // Out-of-document elements never have the descendants flag set
             debug_assert!(!node.get_flag(NodeFlags::HAS_DIRTY_DESCENDANTS));
-            vtable_for(&node).bind_to_tree(
-                &BindContext {
-                    tree_connected: context.tree_connected,
-                    tree_is_in_a_document_tree: false,
-                    tree_is_in_a_shadow_tree: true,
-                },
-                can_gc,
-            );
+            vtable_for(&node).bind_to_tree(&context, can_gc);
         }
     }
 

--- a/tests/wpt/meta/html/semantics/embedded-content/the-img-element/relevant-mutations.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-img-element/relevant-mutations.html.ini
@@ -1,29 +1,11 @@
 [relevant-mutations.html]
-  [ancestor picture; previous sibling source inserted]
-    expected: FAIL
-
-  [picture is inserted; img has previous sibling source]
-    expected: FAIL
-
-  [ancestor picture; previous sibling source removed]
-    expected: FAIL
-
   [crossorigin state not changed: empty to anonymous]
-    expected: FAIL
-
-  [picture is inserted; img has following sibling source]
-    expected: FAIL
-
-  [picture is inserted; img has src]
     expected: FAIL
 
   [crossorigin state not changed: use-credentials to USE-CREDENTIALS]
     expected: FAIL
 
   [crossorigin state not changed: anonymous to foobar]
-    expected: FAIL
-
-  [picture is inserted; img has srcset]
     expected: FAIL
 
   [sizes is set to same value]


### PR DESCRIPTION
Follow the HTML specification and take into account that the HTML `<image>/<source>` element inserting/removal steps should only be counted as relevant mutations for `<image>` element if the parent of the inclusive ancestor that was inserted/removed is the parent `<picture>` element.

See <https://html.spec.whatwg.org/multipage/#relevant-mutations>.

Testing: Improvements in the following tests
- html/semantics/embedded-content/the-img-element/relevant-mutations.html