### PR TITLE
script: Enable crypto task source at task manager

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -132,9 +132,7 @@ impl SubtleCrypto {
     pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<SubtleCrypto> {
         reflect_dom_object(Box::new(SubtleCrypto::new_inherited()), global, can_gc)
     }
-}
 
-impl SubtleCrypto {
     /// Queue a global task on the crypto task source, given realm's global object, to resolve
     /// promise with a CryptoKey.
     fn resolve_promise_with_key(&self, promise: Rc<Promise>, key: DomRoot<CryptoKey>) {

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -135,6 +135,7 @@ impl TaskManager {
     task_source_functions!(self, bitmap_task_source, Bitmap);
     task_source_functions!(self, canvas_blob_task_source, Canvas);
     task_source_functions!(self, clipboard_task_source, Clipboard);
+    task_source_functions!(self, crypto_task_source, Crypto);
     task_source_functions!(self, database_access_task_source, DatabaseAccess);
     task_source_functions!(self, dom_manipulation_task_source, DOMManipulation);
     task_source_functions!(self, file_reading_task_source, FileReading);

--- a/components/script/task_source.rs
+++ b/components/script/task_source.rs
@@ -26,6 +26,8 @@ pub(crate) enum TaskSourceName {
     Bitmap,
     Canvas,
     Clipboard,
+    /// <https://w3c.github.io/webcrypto/#dfn-crypto-task-source-0>
+    Crypto,
     DatabaseAccess,
     DOMManipulation,
     FileReading,
@@ -56,6 +58,7 @@ impl From<TaskSourceName> for ScriptThreadEventCategory {
             TaskSourceName::Bitmap => ScriptThreadEventCategory::ScriptEvent,
             TaskSourceName::Canvas => ScriptThreadEventCategory::ScriptEvent,
             TaskSourceName::Clipboard => ScriptThreadEventCategory::ScriptEvent,
+            TaskSourceName::Crypto => ScriptThreadEventCategory::ScriptEvent,
             TaskSourceName::DatabaseAccess => ScriptThreadEventCategory::ScriptEvent,
             TaskSourceName::DOMManipulation => ScriptThreadEventCategory::ScriptEvent,
             TaskSourceName::FileReading => ScriptThreadEventCategory::FileRead,

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits_curve25519.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits_curve25519.https.any.js.ini
@@ -50,6 +50,7 @@
 
 
 [cfrg_curves_bits_curve25519.https.any.worker.html]
+  expected: ERROR
   [X25519 key derivation checks for all-zero value result with a key of order 0]
     expected: FAIL
 

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits_curve448.tentative.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits_curve448.tentative.https.any.js.ini
@@ -47,6 +47,7 @@
 
 
 [cfrg_curves_bits_curve448.tentative.https.any.worker.html]
+  expected: ERROR
   [X448 key derivation checks for all-zero value result with a key of order 0]
     expected: FAIL
 

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys_curve25519.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys_curve25519.https.any.js.ini
@@ -1,4 +1,5 @@
 [cfrg_curves_keys_curve25519.https.any.worker.html]
+  expected: ERROR
   [X25519 deriveBits checks for all-zero value result with a key of order 0]
     expected: FAIL
 

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys_curve448.tentative.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/cfrg_curves_keys_curve448.tentative.https.any.js.ini
@@ -1,4 +1,5 @@
 [cfrg_curves_keys_curve448.tentative.https.any.worker.html]
+  expected: ERROR
   [X448 deriveBits checks for all-zero value result with a key of order 0]
     expected: FAIL
 


### PR DESCRIPTION
The Web Cryptography API has the "crypto task source" (https://w3c.github.io/webcrypto/#dfn-crypto-task-source-0) to queue tasks to resolve or reject promises created in response to calls to methods of `SubtleCrypto`.

This patch enables this task source at the script task manager, and queue tasks on this task source from existing steps.

A few WPT error expectations are also added to WPT meta. The related cryptographic algorithms have not yet implemented, so the errors are expected. I don't know why WPT test did not capture them before.

Testing: Existing tests suffice.