### PR TITLE
ci: Bump workflows to macOS 14

### DIFF
--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   mac-wpt:
     name: WPT
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       max_chunk_id: 5
     strategy:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -100,8 +100,8 @@ jobs:
         uses: ./.github/actions/runner-select
         with:
           monitor-api-token: ${{ secrets.SERVO_CI_MONITOR_API_TOKEN }}
-          github-hosted-runner-label: macos-13
-          self-hosted-image-name: servo-macos13
+          github-hosted-runner-label: macos-14
+          self-hosted-image-name: servo-macos14
           # You can disable self-hosted runners globally by creating a repository variable named
           # NO_SELF_HOSTED_RUNNERS with any non-empty value.
           # <https://github.com/servo/servo/settings/variables/actions>


### PR DESCRIPTION
with servo/ci-runners#50, we now have self-hosted runner images for macOS 14 and 15. bumping our workflows is the easiest way to fix mozjs source builds (servo/ci-runners#47), and GitHub will start phasing out macOS 13 [in november](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/), so it would be good to move off macOS 13.

this patch bumps our macOS workflows to macOS 14.

Testing:
- GitHub-hosted <https://github.com/servo/servo/actions/runs/17947747030/job/51038357603>
- self-hosted <https://github.com/servo/servo/actions/runs/17947674971/job/51038109547>

Fixes: servo/ci-runners#47
