### PR TITLE
script: Empty pending mutation observers when notifying mutation observers

### DIFF
--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -232,6 +232,7 @@ impl MutationObserver {
             };
             // Step 4.8
             observer.record_queue.borrow_mut().push(record);
+            ScriptThread::mutation_observers().add_mutation_observer(&observer);
         }
 
         // Step 5

--- a/components/script/script_mutation_observers.rs
+++ b/components/script/script_mutation_observers.rs
@@ -43,8 +43,8 @@ impl ScriptMutationObservers {
         self.mutation_observer_microtask_queued.set(false);
 
         // Step 2. Let notifySet be a clone of the surrounding agent’s pending mutation observers.
-        // TODO Step 3. Empty the surrounding agent’s pending mutation observers.
-        let notify_list = self.mutation_observers.borrow();
+        // Step 3. Empty the surrounding agent’s pending mutation observers.
+        let notify_list = self.take_mutation_observers();
 
         // Step 4. Let signalSet be a clone of the surrounding agent’s signal slots.
         // Step 5. Empty the surrounding agent’s signal slots.
@@ -108,6 +108,14 @@ impl ScriptMutationObservers {
                 slot.remove_from_signal_slots();
             })
             .map(|slot| slot.as_rooted())
+            .collect()
+    }
+
+    pub(crate) fn take_mutation_observers(&self) -> Vec<DomRoot<MutationObserver>> {
+        self.mutation_observers
+            .take()
+            .iter()
+            .map(|mo| mo.as_rooted())
             .collect()
     }
 }

--- a/tests/wpt/tests/dom/nodes/MutationObserver-nested-crash.html
+++ b/tests/wpt/tests/dom/nodes/MutationObserver-nested-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>MutationObservers: observer inside another observer's callback</title>
+
+<div id="target"></div>
+<script>
+  var observer = new MutationObserver(_ => {
+    var otherObserver = new MutationObserver(_ => {});
+    otherObserver.observe(target, {characterData: true});
+  });
+  observer.observe(target, {subtree: true, attributeOldValue: true});
+  target.setAttribute("foo", "bar");
+</script>


### PR DESCRIPTION
Empty the surrounding agent’s pending mutation observers when notifying mutation observers according to the spec. Also, the code in the method MutationObserver::queue_a_mutation_record and the corresponding specification have diverged over the years. These changes bring the code into conformity with the specification.

Testing: Added a new crash test
Fixes: #39434 #39531
