### PR TITLE
Assert that style element has an owner in `parse_own_css`

### DIFF
--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -97,7 +97,10 @@ impl HTMLStyleElement {
 
     pub(crate) fn parse_own_css(&self) {
         let node = self.upcast::<Node>();
-        assert!(node.is_connected());
+        assert!(
+            node.is_in_a_document_tree() || node.is_in_a_shadow_tree(),
+            "This stylesheet does not have an owner, so there's no reason to parse its contents"
+        );
 
         // Step 4. of <https://html.spec.whatwg.org/multipage/#the-style-element%3Aupdate-a-style-block>
         let mut type_attribute = self.Type();

--- a/tests/wpt/tests/shadow-dom/crashtests/modify-style-element-in-disconnected-shadow-crash.html
+++ b/tests/wpt/tests/shadow-dom/crashtests/modify-style-element-in-disconnected-shadow-crash.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Modifying a style element in a disconnected shadow tree should not crash</title>
+        <link rel="help" href="https://github.com/servo/servo/issues/37781">
+    </head>
+    <body>
+        <script>
+        let d = document.createElement('div');
+        let s = d.attachShadow({mode: "open"});
+        let s2 = document.createElement('style');
+        s.appendChild(s2);
+        s2.textContent = "lol";
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
The existing `assert!(node.is_connected())` is wrong. What it *wants* to assert is that the style element has an owner, which is either a Document or a ShadowRoot that the element is a descendant of. However, if the element is descendant of a ShadowRoot which is itself not connected to a document then the assertion would fail.

Instead, we use `node.is_in_a_document_tree() || node.is_in_a_shadow_tree()`, which more accurately reflects the intent.

Testing: This change adds the test case from https://github.com/servo/servo/issues/37781 as a crashtest
Fixes https://github.com/servo/servo/issues/39457
Fixes https://github.com/servo/servo/issues/37781
