### PR TITLE
WebGPU: expose GPUObjectBase to worker

### DIFF
--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -7,7 +7,6 @@
 // Source: WebGPU (https://gpuweb.github.io/gpuweb/)
 // Direct source: https://github.com/w3c/webref/blob/curated/ed/idl/webgpu.idl
 
-[Exposed=(Window)]
 interface mixin GPUObjectBase {
     attribute USVString label;
 };


### PR DESCRIPTION
Label attribute in several WebGPU object should be available to worker as well. [Firefox](https://searchfox.org/firefox-main/source/dom/webidl/WebGPU.webidl#10) doesn't limit it to window either.

Testing: CTS [try run](https://github.com/wusyong/servo/actions/runs/17942843000) from my fork