### PR TITLE
Ensure test_multiprocess_preference_observer waits for reload to complete.

### DIFF
--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -143,6 +143,7 @@ pub(crate) struct WebViewDelegateImpl {
     pub(crate) url_changed: Cell<bool>,
     pub(crate) cursor_changed: Cell<bool>,
     pub(crate) new_frame_ready: Cell<bool>,
+    pub(crate) load_status_changed: Cell<bool>,
 }
 
 impl WebViewDelegateImpl {
@@ -165,6 +166,12 @@ impl WebViewDelegate for WebViewDelegateImpl {
     fn notify_new_frame_ready(&self, webview: WebView) {
         self.new_frame_ready.set(true);
         webview.paint();
+    }
+
+    fn notify_load_status_changed(&self, _webview: WebView, status: LoadStatus) {
+        if status == LoadStatus::Complete {
+            self.load_status_changed.set(true);
+        }
     }
 }
 

--- a/components/servo/tests/multiprocess.rs
+++ b/components/servo/tests/multiprocess.rs
@@ -32,7 +32,9 @@ fn test_multiprocess_preference_observer(servo_test: &ServoTest) -> Result<(), a
     prefs.dom_servo_helpers_enabled = true;
     prefs::set(prefs);
 
+    delegate.load_status_changed.set(false);
     webview.reload();
+    let _ = servo_test.spin(move || Ok(!delegate.load_status_changed.get()));
 
     let result = evaluate_javascript(servo_test, webview.clone(), "window.gc");
     ensure!(matches!(result, Ok(JSValue::Object(..))));


### PR DESCRIPTION
The test could intermittently fail if the second evaluate_javascript() command was received in the script thread before the reloaded page actually existed. By serializing the steps so that the page is completely loaded after the reload command is issued, we avoid this race.

Testing: Locally reproduced, could not reproduce after the changes.
Fixes: #38920
