### PR TITLE
html: Add the reflected 'sizes' IDL attribute for <image>

### DIFF
--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1670,6 +1670,12 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
     // https://html.spec.whatwg.org/multipage/#dom-img-src
     make_url_setter!(SetSrcset, "srcset");
 
+    // <https://html.spec.whatwg.org/multipage/#dom-img-sizes>
+    make_getter!(Sizes, "sizes");
+
+    // <https://html.spec.whatwg.org/multipage/#dom-img-sizes>
+    make_setter!(SetSizes, "sizes");
+
     // https://html.spec.whatwg.org/multipage/#dom-img-crossOrigin
     fn GetCrossOrigin(&self) -> Option<DOMString> {
         reflect_cross_origin_attribute(self.upcast::<Element>())

--- a/components/script_bindings/webidls/HTMLImageElement.webidl
+++ b/components/script_bindings/webidls/HTMLImageElement.webidl
@@ -13,6 +13,7 @@ interface HTMLImageElement : HTMLElement {
            attribute USVString src;
   [CEReactions]
            attribute USVString srcset;
+  [CEReactions] attribute DOMString sizes;
   [CEReactions]
            attribute DOMString? crossOrigin;
   [CEReactions]

--- a/tests/wpt/meta/custom-elements/reactions/customized-builtins/HTMLImageElement.html.ini
+++ b/tests/wpt/meta/custom-elements/reactions/customized-builtins/HTMLImageElement.html.ini
@@ -1,10 +1,4 @@
 [HTMLImageElement.html]
-  [sizes on HTMLImageElement must enqueue an attributeChanged reaction when adding a new attribute]
-    expected: FAIL
-
-  [sizes on HTMLImageElement must enqueue an attributeChanged reaction when replacing an existing attribute]
-    expected: FAIL
-
   [decoding on HTMLImageElement must enqueue an attributeChanged reaction when adding a new attribute]
     expected: FAIL
 

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -5473,9 +5473,6 @@
   [HTMLSourceElement interface: document.createElement("source") must inherit property "height" with the proper type]
     expected: FAIL
 
-  [HTMLImageElement interface: attribute sizes]
-    expected: FAIL
-
   [HTMLImageElement interface: attribute decoding]
     expected: FAIL
 
@@ -5488,9 +5485,6 @@
   [HTMLImageElement interface: attribute lowsrc]
     expected: FAIL
 
-  [HTMLImageElement interface: document.createElement("img") must inherit property "sizes" with the proper type]
-    expected: FAIL
-
   [HTMLImageElement interface: document.createElement("img") must inherit property "decoding" with the proper type]
     expected: FAIL
 
@@ -5501,9 +5495,6 @@
     expected: FAIL
 
   [HTMLImageElement interface: document.createElement("img") must inherit property "lowsrc" with the proper type]
-    expected: FAIL
-
-  [HTMLImageElement interface: new Image() must inherit property "sizes" with the proper type]
     expected: FAIL
 
   [HTMLImageElement interface: new Image() must inherit property "decoding" with the proper type]

--- a/tests/wpt/meta/html/semantics/embedded-content/the-img-element/relevant-mutations.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-img-element/relevant-mutations.html.ini
@@ -7,6 +7,3 @@
 
   [crossorigin state not changed: anonymous to foobar]
     expected: FAIL
-
-  [sizes is set to same value]
-    expected: FAIL


### PR DESCRIPTION
Add the reflected 'sizes' IDL attribute for <image> element's DOM interface which defines image sizes for different page layouts.

See https://html.spec.whatwg.org/multipage/#dom-img-sizes

Testing: Improvements in the following tests
- custom-elements/reactions/customized-builtins/HTMLImageElement.html
- html/dom/idlharness.https.html
- html/semantics/embedded-content/the-img-element/relevant-mutations.html