### PR TITLE
Allow hyper_serde to only depend on serde_core for potentially faster compile times.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,10 +31,6 @@ updates:
         - "glib*"
         - "gobject*"
         - "gstreamer*"
-    serde-related:
-      patterns:
-        - "serde"
-        - "serde_core"
     napi-ohos-related:
       patterns:
         - "napi-ohos*"
@@ -42,6 +38,10 @@ updates:
     objc2-related:
       patterns:
         - "objc2*"
+    serde-related:
+      patterns:
+        - "serde"
+        - "serde_core"
     servo-media-related:
       patterns:
         - "servo-media*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,10 @@ updates:
         - "glib*"
         - "gobject*"
         - "gstreamer*"
+    serde-related:
+      patterns:
+        - "serde"
+        - "serde_core"
     napi-ohos-related:
       patterns:
         - "napi-ohos*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,6 +4050,7 @@ dependencies = [
  "mime",
  "serde",
  "serde_bytes",
+ "serde_core",
  "serde_test",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,8 +129,8 @@ rustls-pki-types = "1.12"
 script_traits = { path = "components/shared/script" }
 selectors = { git = "https://github.com/servo/stylo", branch = "2025-09-02" }
 serde = "1.0.226"
-serde_core = "1.0.226"
 serde_bytes = "0.11"
+serde_core = "1.0.226"
 serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ rustls-pki-types = "1.12"
 script_traits = { path = "components/shared/script" }
 selectors = { git = "https://github.com/servo/stylo", branch = "2025-09-02" }
 serde = "1.0.226"
+serde_core = "1.0.226"
 serde_bytes = "0.11"
 serde_json = "1.0"
 servo-media = { git = "https://github.com/servo/media" }

--- a/components/hyper_serde/Cargo.toml
+++ b/components/hyper_serde/Cargo.toml
@@ -21,8 +21,8 @@ headers = { workspace = true }
 http = { workspace = true }
 hyper = { workspace = true }
 mime = { workspace = true }
-serde_core = { workspace = true }
 serde_bytes = { workspace = true }
+serde_core = { workspace = true }
 
 [dev-dependencies]
 serde = { workspace = true }

--- a/components/hyper_serde/Cargo.toml
+++ b/components/hyper_serde/Cargo.toml
@@ -21,8 +21,9 @@ headers = { workspace = true }
 http = { workspace = true }
 hyper = { workspace = true }
 mime = { workspace = true }
-serde = { workspace = true }
+serde_core = { workspace = true }
 serde_bytes = { workspace = true }
 
 [dev-dependencies]
+serde = { workspace = true }
 serde_test = "1.0"

--- a/components/hyper_serde/lib.rs
+++ b/components/hyper_serde/lib.rs
@@ -73,10 +73,10 @@ use http::HeaderMap;
 use hyper::header::{HeaderName, HeaderValue};
 use hyper::{Method, StatusCode, Uri};
 use mime::Mime;
-use serde::de::{self, Error, MapAccess, SeqAccess, Visitor};
-use serde::ser::{SerializeMap, SerializeSeq};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_bytes::{ByteBuf, Bytes};
+use serde_core::de::{self, Error, MapAccess, SeqAccess, Visitor};
+use serde_core::ser::{SerializeMap, SerializeSeq};
+use serde_core::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Deserialises a `T` value with a given deserializer.
 ///
@@ -164,7 +164,7 @@ pub struct Ser<'a, T: 'a> {
 
 impl<'a, T> Ser<'a, T>
 where
-    Ser<'a, T>: serde::Serialize,
+    Ser<'a, T>: serde_core::Serialize,
 {
     /// Returns a new `Ser` wrapper.
     #[inline(always)]


### PR DESCRIPTION
Serde_core was released which has all the traits and allows some crates to have parallel compile times.
More information can be found here: https://github.com/serde-rs/serde/tree/master/serde_core
serde_bytes already depends on on serde_core. Additionally added serde and serde_core to dependabot group.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Compilation is the test.
