### PR TITLE
script: when fetching a worker script abort if response status is not ok

### DIFF
--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -505,6 +505,18 @@ impl DedicatedWorkerGlobalScope {
 
                 global_scope.set_https_state(current_global_https_state);
 
+                let send_error = || {
+                    parent_event_loop_sender
+                        .send(CommonScriptMsg::Task(
+                            WorkerEvent,
+                            Box::new(SimpleWorkerErrorHandler::new(worker.clone())),
+                            Some(pipeline_id),
+                            TaskSourceName::DOMManipulation,
+                        ))
+                        .unwrap();
+                    scope.clear_js_runtime();
+                };
+
                 let (metadata, bytes) = match load_whole_resource(
                     request,
                     &global_scope.resource_threads().sender(),
@@ -517,18 +529,16 @@ impl DedicatedWorkerGlobalScope {
                 ) {
                     Err(e) => {
                         error!("error loading script {} ({:?})", serialized_worker_url, e);
-                        parent_event_loop_sender
-                            .send(CommonScriptMsg::Task(
-                                WorkerEvent,
-                                Box::new(SimpleWorkerErrorHandler::new(worker)),
-                                Some(pipeline_id),
-                                TaskSourceName::DOMManipulation,
-                            ))
-                            .unwrap();
-                        scope.clear_js_runtime();
+                        send_error();
                         return;
                     },
-                    Ok((metadata, bytes)) => (metadata, bytes),
+                    Ok((metadata, bytes)) => {
+                        if !metadata.status.is_success() {
+                            send_error();
+                            return;
+                        }
+                        (metadata, bytes)
+                    },
                 };
                 scope.set_url(metadata.final_url.clone());
                 Self::initialize_policy_container_for_worker_global_scope(

--- a/tests/wpt/meta/resource-timing/initiator-type/workers.html.ini
+++ b/tests/wpt/meta/resource-timing/initiator-type/workers.html.ini
@@ -1,5 +1,4 @@
 [workers.html]
-  expected: ERROR
   [The initiator type for classic worker must be 'other']
     expected: FAIL
 


### PR DESCRIPTION
According to [spec](https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-classic-worker-script) we should abort if the response status is not ok.

Testing: Check tests listed inside issue are not intermittent anymore
Fixes: #39413
Fixes: #22991 
