### PR TITLE
script: Chain up keyboard scrolling to parent `<iframe>`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,7 @@ dependencies = [
  "http 1.3.1",
  "hyper_serde",
  "ipc-channel",
+ "keyboard-types",
  "log",
  "malloc_size_of_derive",
  "net_traits",

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1985,6 +1985,20 @@ where
                     warn!("No webdriver_input_command_reponse_sender");
                 }
             },
+            ScriptToConstellationMessage::ForwardKeyboardScroll(pipeline_id, scroll) => {
+                if let Some(pipeline) = self.pipelines.get(&pipeline_id) {
+                    if let Err(error) =
+                        pipeline
+                            .event_loop
+                            .send(ScriptThreadMessage::ForwardKeyboardScroll(
+                                pipeline_id,
+                                scroll,
+                            ))
+                    {
+                        warn!("Could not forward {scroll:?} to {pipeline_id}: {error:?}");
+                    }
+                }
+            },
         }
     }
 

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -182,6 +182,7 @@ mod from_script {
                 Self::ReportMemory(..) => target!("ReportMemory"),
                 Self::WebDriverInputComplete(..) => target!("WebDriverInputComplete"),
                 Self::FinishJavaScriptEvaluation(..) => target!("FinishJavaScriptEvaluation"),
+                Self::ForwardKeyboardScroll(..) => target!("ForwardKeyboardScroll"),
             }
         }
     }

--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -42,7 +42,7 @@ pub struct BoxTree {
     root: BlockFormattingContext,
 
     /// Whether or not the viewport should be sensitive to scrolling input events in two axes
-    viewport_scroll_sensitivity: AxesScrollSensitivity,
+    pub(crate) viewport_overflow: AxesOverflow,
 }
 
 impl BoxTree {
@@ -65,10 +65,7 @@ impl BoxTree {
             // From https://www.w3.org/TR/css-overflow-3/#overflow-propagation:
             // > If visible is applied to the viewport, it must be interpreted as auto.
             // > If clip is applied to the viewport, it must be interpreted as hidden.
-            viewport_scroll_sensitivity: AxesScrollSensitivity {
-                x: viewport_overflow.x.to_scrollable().into(),
-                y: viewport_overflow.y.to_scrollable().into(),
-            },
+            viewport_overflow: viewport_overflow.to_scrollable(),
         }
     }
 
@@ -266,11 +263,16 @@ impl BoxTree {
             &mut root_fragments,
         );
 
+        let viewport_scroll_sensitivity = AxesScrollSensitivity {
+            x: self.viewport_overflow.x.into(),
+            y: self.viewport_overflow.y.into(),
+        };
+
         FragmentTree::new(
             layout_context,
             root_fragments,
             physical_containing_block,
-            self.viewport_scroll_sensitivity,
+            viewport_scroll_sensitivity,
         )
     }
 }

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -333,11 +333,17 @@ impl Layout for LayoutThread {
     #[servo_tracing::instrument(skip_all)]
     fn query_scroll_container(
         &self,
-        node: TrustedNodeAddress,
+        node: Option<TrustedNodeAddress>,
         flags: ScrollContainerQueryFlags,
     ) -> Option<ScrollContainerResponse> {
-        let node = unsafe { ServoLayoutNode::new(&node) };
-        process_scroll_container_query(node, flags)
+        let node = unsafe { node.as_ref().map(|node| ServoLayoutNode::new(node)) };
+        let viewport_overflow = self
+            .box_tree
+            .borrow()
+            .as_ref()
+            .expect("Should have a BoxTree for all scroll container queries.")
+            .viewport_overflow;
+        process_scroll_container_query(node, flags, viewport_overflow)
     }
 
     #[servo_tracing::instrument(skip_all)]

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -12,7 +12,7 @@ use euclid::{SideOffsets2D, Size2D};
 use itertools::Itertools;
 use layout_api::wrapper_traits::{LayoutNode, ThreadSafeLayoutElement, ThreadSafeLayoutNode};
 use layout_api::{
-    BoxAreaType, LayoutElementType, LayoutNodeType, OffsetParentResponse,
+    AxesOverflow, BoxAreaType, LayoutElementType, LayoutNodeType, OffsetParentResponse,
     ScrollContainerQueryFlags, ScrollContainerResponse,
 };
 use script::layout_dom::{ServoLayoutNode, ServoThreadSafeLayoutNode};
@@ -676,9 +676,14 @@ pub fn process_offset_parent_query(
 ///
 #[inline]
 pub(crate) fn process_scroll_container_query(
-    node: ServoLayoutNode<'_>,
+    node: Option<ServoLayoutNode<'_>>,
     query_flags: ScrollContainerQueryFlags,
+    viewport_overflow: AxesOverflow,
 ) -> Option<ScrollContainerResponse> {
+    let Some(node) = node else {
+        return Some(ScrollContainerResponse::Viewport(viewport_overflow));
+    };
+
     let layout_data = node.to_threadsafe().inner_layout_data()?;
 
     // 1. If any of the following holds true, return null and terminate this algorithm:
@@ -776,7 +781,7 @@ pub(crate) fn process_scroll_container_query(
 
     match current_position_value {
         Position::Fixed => None,
-        _ => Some(ScrollContainerResponse::Viewport),
+        _ => Some(ScrollContainerResponse::Viewport(viewport_overflow)),
     }
 }
 

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -933,6 +933,7 @@ malloc_size_of_is_stylo_malloc_size_of!(style::values::computed::FontWeight);
 malloc_size_of_is_stylo_malloc_size_of!(style::values::computed::font::SingleFontFamily);
 malloc_size_of_is_stylo_malloc_size_of!(style::values::computed::JustifyContent);
 malloc_size_of_is_stylo_malloc_size_of!(style::values::specified::align::AlignFlags);
+malloc_size_of_is_stylo_malloc_size_of!(style::values::specified::box_::Overflow);
 malloc_size_of_is_stylo_malloc_size_of!(style::values::specified::TextDecorationLine);
 malloc_size_of_is_stylo_malloc_size_of!(stylo_dom::ElementState);
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -33,7 +33,10 @@ use euclid::default::{Rect, Size2D};
 use html5ever::{LocalName, Namespace, QualName, local_name, ns};
 use hyper_serde::Serde;
 use js::rust::{HandleObject, HandleValue, MutableHandleValue};
-use layout_api::{PendingRestyle, ReflowGoal, ReflowPhasesRun, RestyleReason, TrustedNodeAddress};
+use layout_api::{
+    PendingRestyle, ReflowGoal, ReflowPhasesRun, RestyleReason, ScrollContainerQueryFlags,
+    TrustedNodeAddress,
+};
 use metrics::{InteractiveFlag, InteractiveWindow, ProgressiveWebMetrics};
 use net_traits::CookieSource::NonHTTP;
 use net_traits::CoreResourceMsg::{GetCookiesForUrl, SetCookiesForUrl};
@@ -173,7 +176,7 @@ use crate::dom::processinginstruction::ProcessingInstruction;
 use crate::dom::promise::Promise;
 use crate::dom::range::Range;
 use crate::dom::resizeobserver::{ResizeObservationDepth, ResizeObserver};
-use crate::dom::scrolling_box::{ScrollingBox, ScrollingBoxSource};
+use crate::dom::scrolling_box::ScrollingBox;
 use crate::dom::selection::Selection;
 use crate::dom::servoparser::ServoParser;
 use crate::dom::shadowroot::ShadowRoot;
@@ -4447,8 +4450,10 @@ impl Document {
         self.active_sandboxing_flag_set.set(flags)
     }
 
-    pub(crate) fn viewport_scrolling_box(&self) -> ScrollingBox {
-        ScrollingBox::new(ScrollingBoxSource::Viewport(DomRoot::from_ref(self)))
+    pub(crate) fn viewport_scrolling_box(&self, flags: ScrollContainerQueryFlags) -> ScrollingBox {
+        self.window()
+            .scrolling_box_query(None, flags)
+            .expect("We should always have a ScrollingBox for the Viewport")
     }
 }
 

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -450,9 +450,12 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     #[allow(unsafe_code)]
     fn GetScrollParent(&self) -> Option<DomRoot<Element>> {
         self.owner_window()
-            .scroll_container_query(self.upcast(), ScrollContainerQueryFlags::ForScrollParent)
+            .scroll_container_query(
+                Some(self.upcast()),
+                ScrollContainerQueryFlags::ForScrollParent,
+            )
             .and_then(|response| match response {
-                ScrollContainerResponse::Viewport => self.owner_document().GetScrollingElement(),
+                ScrollContainerResponse::Viewport(_) => self.owner_document().GetScrollingElement(),
                 ScrollContainerResponse::Element(parent_node_address, _) => {
                     let node = unsafe { from_untrusted_node_address(parent_node_address) };
                     DomRoot::downcast(node)

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -157,6 +157,7 @@ use crate::dom::promise::Promise;
 use crate::dom::reportingendpoint::{ReportingEndpoint, SendReportsToEndpoints};
 use crate::dom::reportingobserver::ReportingObserver;
 use crate::dom::screen::Screen;
+use crate::dom::scrolling_box::{ScrollingBox, ScrollingBoxSource};
 use crate::dom::selection::Selection;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::storage::Storage;
@@ -2628,13 +2629,37 @@ impl Window {
 
     pub(crate) fn scroll_container_query(
         &self,
-        node: &Node,
+        node: Option<&Node>,
         flags: ScrollContainerQueryFlags,
     ) -> Option<ScrollContainerResponse> {
         self.layout_reflow(QueryMsg::ScrollParentQuery);
         self.layout
             .borrow()
-            .query_scroll_container(node.to_trusted_node_address(), flags)
+            .query_scroll_container(node.map(Node::to_trusted_node_address), flags)
+    }
+
+    #[allow(unsafe_code)]
+    pub(crate) fn scrolling_box_query(
+        &self,
+        node: Option<&Node>,
+        flags: ScrollContainerQueryFlags,
+    ) -> Option<ScrollingBox> {
+        self.scroll_container_query(node, flags)
+            .and_then(|response| {
+                Some(match response {
+                    ScrollContainerResponse::Viewport(overflow) => {
+                        (ScrollingBoxSource::Viewport(self.Document()), overflow)
+                    },
+                    ScrollContainerResponse::Element(parent_node_address, overflow) => {
+                        let node = unsafe { from_untrusted_node_address(parent_node_address) };
+                        (
+                            ScrollingBoxSource::Element(DomRoot::downcast(node)?),
+                            overflow,
+                        )
+                    },
+                })
+            })
+            .map(|(source, overflow)| ScrollingBox::new(source, overflow))
     }
 
     pub(crate) fn text_index_query(

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -107,7 +107,9 @@ pub(crate) struct WindowProxy {
     /// <https://html.spec.whatwg.org/multipage/#is-closing>
     is_closing: Cell<bool>,
 
-    /// The containing iframe element, if this is a same-origin iframe
+    /// If the containing `<iframe>` of this [`WindowProxy`] is from a same-origin page,
+    /// this will be the [`Element`] of the `<iframe>` element in the realm of the
+    /// parent page. Otherwise, it is `None`.
     frame_element: Option<Dom<Element>>,
 
     /// The parent browsing context's window proxy, if this is a nested browsing context
@@ -630,6 +632,9 @@ impl WindowProxy {
         self.webview_id
     }
 
+    /// If the containing `<iframe>` of this [`WindowProxy`] is from a same-origin page,
+    /// this will return an [`Element`] of the `<iframe>` element in the realm of the parent
+    /// page.
     pub(crate) fn frame_element(&self) -> Option<&Element> {
         self.frame_element.as_deref()
     }

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -101,6 +101,7 @@ impl MixedMessage {
                 ScriptThreadMessage::SendImageKeysBatch(..) => None,
                 ScriptThreadMessage::PreferencesUpdated(..) => None,
                 ScriptThreadMessage::NoLongerWaitingOnAsychronousImageUpdates(_) => None,
+                ScriptThreadMessage::ForwardKeyboardScroll(id, _) => Some(*id),
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1911,6 +1911,11 @@ impl ScriptThread {
                 }
                 prefs::set(current_preferences);
             },
+            ScriptThreadMessage::ForwardKeyboardScroll(pipeline_id, scroll) => {
+                if let Some(document) = self.documents.borrow().find_document(pipeline_id) {
+                    document.event_handler().do_keyboard_scroll(scroll);
+                }
+            },
         }
     }
 

--- a/components/shared/constellation/Cargo.toml
+++ b/components/shared/constellation/Cargo.toml
@@ -26,6 +26,7 @@ fonts_traits = { workspace = true }
 http = { workspace = true }
 hyper_serde = { workspace = true }
 ipc-channel = { workspace = true }
+keyboard-types = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -480,6 +480,27 @@ pub struct IFrameSizeMsg {
     pub type_: WindowSizeType,
 }
 
+/// An enum that describe a type of keyboard scroll.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum KeyboardScroll {
+    /// Scroll the container one line up.
+    Up,
+    /// Scroll the container one line down.
+    Down,
+    /// Scroll the container one "line" left.
+    Left,
+    /// Scroll the container one "line" right.
+    Right,
+    /// Scroll the container one page up.
+    PageUp,
+    /// Scroll the container one page down.
+    PageDown,
+    /// Scroll the container to the vertical start.
+    Home,
+    /// Scroll the container to the vertical end.
+    End,
+}
+
 /// Messages from the script to the constellation.
 #[derive(Deserialize, IntoStaticStr, Serialize)]
 pub enum ScriptToConstellationMessage {
@@ -665,6 +686,8 @@ pub enum ScriptToConstellationMessage {
     ),
     /// Notify the completion of a webdriver command.
     WebDriverInputComplete(WebDriverMessageId),
+    /// Forward a keyboard scroll operation from an `<iframe>` to a parent pipeline.
+    ForwardKeyboardScroll(PipelineId, KeyboardScroll),
 }
 
 impl fmt::Debug for ScriptToConstellationMessage {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -306,9 +306,11 @@ pub trait Layout {
     fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32>;
     fn query_element_inner_outer_text(&self, node: TrustedNodeAddress) -> String;
     fn query_offset_parent(&self, node: TrustedNodeAddress) -> OffsetParentResponse;
+    /// Query the scroll container for the given node. If node is `None`, the scroll container for
+    /// the viewport is returned.
     fn query_scroll_container(
         &self,
-        node: TrustedNodeAddress,
+        node: Option<TrustedNodeAddress>,
         flags: ScrollContainerQueryFlags,
     ) -> Option<ScrollContainerResponse>;
     fn query_resolved_style(
@@ -377,7 +379,7 @@ bitflags! {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, MallocSizeOf)]
 pub struct AxesOverflow {
     pub x: Overflow,
     pub y: Overflow,
@@ -401,9 +403,18 @@ impl From<&ComputedValues> for AxesOverflow {
     }
 }
 
+impl AxesOverflow {
+    pub fn to_scrollable(&self) -> Self {
+        Self {
+            x: self.x.to_scrollable(),
+            y: self.y.to_scrollable(),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub enum ScrollContainerResponse {
-    Viewport,
+    Viewport(AxesOverflow),
     Element(UntrustedNodeAddress, AxesOverflow),
 }
 

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -21,8 +21,8 @@ use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
 use compositing_traits::CrossProcessCompositorApi;
 use constellation_traits::{
-    LoadData, NavigationHistoryBehavior, ScriptToConstellationChan, StructuredSerializedData,
-    WindowSizeType,
+    KeyboardScroll, LoadData, NavigationHistoryBehavior, ScriptToConstellationChan,
+    StructuredSerializedData, WindowSizeType,
 };
 use crossbeam_channel::{RecvTimeoutError, Sender};
 use devtools_traits::ScriptToDevtoolsControlMsg;
@@ -265,6 +265,8 @@ pub enum ScriptThreadMessage {
     /// asynchronous image uploads for the given `Pipeline`. These are mainly used
     /// by canvas to perform uploads while the display list is being built.
     NoLongerWaitingOnAsychronousImageUpdates(PipelineId),
+    /// Forward a keyboard scroll operation from an `<iframe>` to a parent pipeline.
+    ForwardKeyboardScroll(PipelineId, KeyboardScroll),
 }
 
 impl fmt::Debug for ScriptThreadMessage {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12757,15 +12757,6 @@
       {}
      ]
     ],
-    "keyboard-scrolling.html": [
-     "2d9a0c40272d8af49f26de8dc49283df68b2d7b0",
-     [
-      null,
-      {
-       "testdriver": true
-      }
-     ]
-    ],
     "matchMedia.html": [
      "45a7ea268b1ebdba69e947b79d675cc9221428d4",
      [
@@ -13809,6 +13800,24 @@
      [
       null,
       {}
+     ]
+    ],
+    "keyboard-scrolling-iframe.sub.html": [
+     "e002eb6f2a35ed4f73a079acb05b3d99eb04813b",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
+    "keyboard-scrolling.html": [
+     "45916c5d11f351f0ca10cde5e52d5ee60c11bd9d",
+     [
+      null,
+      {
+       "testdriver": true
+      }
      ]
     ],
     "keyframe-infinite-percentage.html": [

--- a/tests/wpt/mozilla/tests/mozilla/keyboard-scrolling-iframe.sub.html
+++ b/tests/wpt/mozilla/tests/mozilla/keyboard-scrolling-iframe.sub.html
@@ -1,0 +1,165 @@
+
+<!doctype html>
+<meta charset="utf-8">
+<title>A test to verify that keyboard scrolling works properly in Servo in IFRAMEs.</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+    iframe {
+        position: fixed;
+        width: 200px;
+        height: 200px;
+        outline: solid;
+    }
+</style>
+
+<!-- This is an IFRAME that should be scrollable via keyboard. -->
+<iframe id="iframe" style="left: 100px; top: 100px;" srcdoc='
+    <!DOCTYPE html>
+    <body style="margin: 0;">
+    <div style="width: 600px; height: 600px; background: blue;">Lorem ipsum dolor sit amet,</div>
+'></iframe>
+
+<!-- This IFRAME does not scroll, so keyboard events should chain to the main frame. -->
+<iframe id="iframeWithSmallContent" style="left: 300px; top: 100px;" src='iframe_child1.html'></iframe>
+
+<!-- This IFRAME does not scroll and is also cross origin, so keyboard events should chain to the main frame. -->
+<iframe id="iframeCrossOriginWithSmallContent" style="left: 100px; top: 300px;" src='//{{hosts[alt][]}}:{{ports[http][0]}}/_mozilla/mozilla/iframe_child1.html'></iframe>
+
+<!-- This IFRAME does not scroll because the body has overflow: hidden, so keyboard events should chain to the main frame. -->
+<iframe id="iframeWithOverflowHiddenBody" style="left: 300px; top: 300px;" srcdoc='
+    <!DOCTYPE html>
+    <body style="overflow:hidden;">
+    <div style="width: 600px; height: 600px; background: blue;">Lorem ipsum dolor sit amet,</div>
+'></iframe>
+
+
+<div style="width: 300vw; height: 300vh; background: green;">
+    Lorem ipsum dolor sit amet,
+</div>
+
+<script>
+const end = "\uE010";
+const home = "\uE011";
+const arrowDown = "\uE015";
+const arrowUp = "\uE013";
+const arrowRight = "\uE014";
+const arrowLeft = "\uE012";
+const pageDown = "\uE00F";
+const pageUp = "\uE00E";
+const lineSize = 76;
+const pageSize = scrollportHeight => scrollportHeight - 2 * lineSize;
+
+const pressKeyAndAssert = async (key, element, [expectedX, expectedY], description) => {
+    await test_driver.send_keys(document.body, key);
+    const actualX =
+        element == null ? scrollX
+        : element.nodeName == "IFRAME" ? element.contentWindow.scrollX
+        : element.scrollLeft;
+    const actualY =
+        element == null ? scrollY
+        : element.nodeName == "IFRAME" ? element.contentWindow.scrollY
+        : element.scrollTop;
+    assert_array_equals([actualX, actualY], [expectedX, expectedY], description);
+};
+
+promise_test(async () => {
+    await test_driver.click(iframe);
+
+    let bottom = iframe.contentDocument.documentElement.scrollHeight - iframe.contentWindow.innerHeight;
+    await pressKeyAndAssert(end, iframe, [0, bottom], "End key scrolls #iframe to bottom");
+    await pressKeyAndAssert(home, iframe, [0, 0], "Home key scrolls #iframe to top");
+    await pressKeyAndAssert(arrowDown, iframe, [0, lineSize], "ArrowDown key scrolls #iframe down by a line");
+    await pressKeyAndAssert(arrowDown, iframe, [0, lineSize * 2], "ArrowDown key scrolls #iframe down by a line");
+    await pressKeyAndAssert(arrowUp, iframe, [0, lineSize], "ArrowUp key scrolls #iframe up by a line");
+    await pressKeyAndAssert(arrowUp, iframe, [0, 0], "ArrowUp key scrolls #iframe up by a line");
+    await pressKeyAndAssert(arrowRight, iframe, [lineSize, 0], "ArrowRight key scrolls #iframe right by a line");
+    await pressKeyAndAssert(arrowRight, iframe, [lineSize * 2, 0], "ArrowRight key scrolls #iframe right by a line");
+    await pressKeyAndAssert(arrowLeft, iframe, [lineSize, 0], "ArrowLeft key scrolls #iframe left by a line");
+    await pressKeyAndAssert(arrowLeft, iframe, [0, 0], "ArrowLeft key scrolls #iframe left by a line");
+    await pressKeyAndAssert(pageDown, iframe, [0, pageSize(iframe.contentWindow.innerHeight)], "PageDown key scrolls #iframe down by almost a screenful");
+    await pressKeyAndAssert(pageDown, iframe, [0, pageSize(iframe.contentWindow.innerHeight) * 2], "PageDown key scrolls #iframe down by almost a screenful");
+    await pressKeyAndAssert(pageUp, iframe, [0, pageSize(iframe.contentWindow.innerHeight)], "PageUp key scrolls #iframe up by almost a screenful");
+    await pressKeyAndAssert(pageUp, iframe, [0, 0], "PageUp key scrolls #iframe up by almost a screenful");
+
+    // At the bottom of the IFRAME, we should not chain up to scrolling the document.
+    await pressKeyAndAssert(end, iframe, [0, bottom], "End key scrolls #iframe to bottom");
+    await pressKeyAndAssert(arrowDown, iframe, [0, bottom], "ArrowDown should not move the iframe past the max Y position");
+    await pressKeyAndAssert(arrowDown, iframe, [0, bottom], "ArrowDown should not move the iframe past the max Y position");
+    await pressKeyAndAssert(arrowDown, iframe, [0, bottom], "ArrowDown should not move the iframe past the max Y position");
+    assert_array_equals([scrollX, scrollY], [0, 0], "Keyboard scroll on a div should not chain to body");
+    await pressKeyAndAssert(home, iframe, [0, 0], "Home key scrolls #iframe to top");
+}, "Keyboard scrolling works in #iframe");
+
+promise_test(async () => {
+    await test_driver.click(iframeWithOverflowHiddenBody);
+
+    await pressKeyAndAssert(arrowDown, iframeWithOverflowHiddenBody, [0, 0], "Arrow down key should not scroll #iframeWithOverflowHiddenBody");
+    assert_array_equals([scrollX, scrollY], [0, lineSize], "The body should scroll instead of #iframeWithOverflowHiddenBody");
+    await pressKeyAndAssert(arrowDown, iframeWithOverflowHiddenBody, [0, 0], "Arrow down key should not scroll #iframeWithOverflowHiddenBody");
+    assert_array_equals([scrollX, scrollY], [0, lineSize * 2], "The body should scroll instead of #iframeWithOverflowHiddenBody");
+
+    await pressKeyAndAssert(arrowUp, iframeWithOverflowHiddenBody, [0, 0], "Arrow up key should not scroll #iframeWithOverflowHiddenBody");
+    assert_array_equals([scrollX, scrollY], [0, lineSize], "The body should scroll instead of #iframeWithOverflowHiddenBody");
+    await pressKeyAndAssert(arrowUp, iframeWithOverflowHiddenBody, [0, 0], "Arrow up key should not scroll #iframeWithOverflowHiddenBody");
+    assert_array_equals([scrollX, scrollY], [0, 0], "The body should scroll instead of #iframeWithOverflowHiddenBody");
+}, "Keyboard scrolling on iframe with a body that has `overflow:hidden` chains to main document");
+
+promise_test(async () => {
+    await test_driver.click(iframeCrossOriginWithSmallContent);
+
+    function waitForScrollEvent() {
+      return new Promise((resolve) => {
+          addEventListener("scroll", () => {
+            resolve();
+          }, { "once": true })
+        }
+      )
+    }
+
+
+    // We must create the promise before actually triggering the event, as the event might
+    // be fired while we are awaiting the keyboard action.
+    let promise = waitForScrollEvent();
+    await test_driver.send_keys(document.body, arrowDown);
+    await promise;
+    assert_array_equals([scrollX, scrollY], [0, lineSize], "The body should scroll instead of #iframeCrossOriginWithSmallContent");
+
+    promise = waitForScrollEvent();
+    await test_driver.send_keys(document.body, arrowDown);
+    await promise;
+    assert_array_equals([scrollX, scrollY], [0, lineSize * 2], "The body should scroll instead of #iframeCrossOriginWithSmallContent");
+
+    promise = waitForScrollEvent();
+    await test_driver.send_keys(document.body, arrowUp);
+    await promise;
+    assert_array_equals([scrollX, scrollY], [0, lineSize], "The body should scroll instead of #iframeCrossOriginWithSmallContent");
+
+    promise = waitForScrollEvent();
+    await test_driver.send_keys(document.body, arrowUp);
+    await promise;
+    assert_array_equals([scrollX, scrollY], [0, 0], "The body should scroll instead of #iframeCrossOriginWithSmallContent");
+}, "Keyboard scrolling on cross-origin iframe with small content chains to main document");
+
+promise_test(async () => {
+    await test_driver.click(iframeWithSmallContent);
+
+    await pressKeyAndAssert(arrowDown, iframeWithSmallContent, [0, 0], "Arrow down key should not scroll #iframeWithSmallContent");
+    assert_array_equals([scrollX, scrollY], [0, lineSize], "The body should scroll instead of #iframeWithSmallContent");
+    await pressKeyAndAssert(arrowDown, iframeWithSmallContent, [0, 0], "Arrow down key should not scroll #iframeWithSmallContent");
+    assert_array_equals([scrollX, scrollY], [0, lineSize * 2], "The body should scroll instead of #iframeWithSmallContent");
+
+    await pressKeyAndAssert(arrowUp, iframeWithSmallContent, [0, 0], "Arrow up key should not scroll #iframeWithSmallContent");
+    assert_array_equals([scrollX, scrollY], [0, lineSize], "The body should scroll instead of #iframeWithSmallContent");
+    await pressKeyAndAssert(arrowUp, iframeWithSmallContent, [0, 0], "Arrow up key should not scroll #iframeWithSmallContent");
+    assert_array_equals([scrollX, scrollY], [0, 0], "The body should scroll instead of #iframeWithSmallContent");
+}, "Keyboard scrolling on iframe with small content chains to main document");
+
+
+</script>

--- a/tests/wpt/mozilla/tests/mozilla/keyboard-scrolling.html
+++ b/tests/wpt/mozilla/tests/mozilla/keyboard-scrolling.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>CSS test: Calc expressions with numbers should still serialize as calc()</title>
+<title>A test to verify that keyboard scrolling works properly in Servo.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
@@ -36,15 +36,8 @@
     <div style="width: 100px; height: 100px; background: blue;">Lorem ipsum dolor sit amet,</div>
 </div>
 
-<!-- This is an IFRAME that should be scrollable via keyboard. -->
-<iframe id="iframe" style="left: 300px; top: 300px;" srcdoc='
-    <!doctype html><meta charset="utf-8">
-    <body style="margin: 0;">
-    <div style="width: 600px; height: 600px; background: blue;">Lorem ipsum dolor sit amet,</div>
-'></iframe>
-
 <!-- This is a DIV with `overflow: hidden` that should not be keyboard scrollable as its content is smaller than the DIV. -->
-<div id="boxWithOverflowHidden" class="scroller" style="overflow: hidden; left: 500px; top: 300px;">
+<div id="boxWithOverflowHidden" class="scroller" style="overflow: hidden; left: 300px; top: 300px;">
     <div style="width: 600px; height: 600px; background: blue;">Lorem ipsum dolor sit amet,</div>
 </div>
 
@@ -66,13 +59,9 @@ const pageSize = scrollportHeight => scrollportHeight - 2 * lineSize;
 const pressKeyAndAssert = async (key, element, [expectedX, expectedY], description) => {
     await test_driver.send_keys(document.body, key);
     const actualX =
-        element == null ? scrollX
-        : element.nodeName == "IFRAME" ? element.contentWindow.scrollX
-        : element.scrollLeft;
+        element == null ? scrollX : element.scrollLeft;
     const actualY =
-        element == null ? scrollY
-        : element.nodeName == "IFRAME" ? element.contentWindow.scrollY
-        : element.scrollTop;
+        element == null ? scrollY : element.scrollTop;
     assert_array_equals([actualX, actualY], [expectedX, expectedY], description);
 };
 
@@ -155,27 +144,6 @@ promise_test(async () => {
 
     await pressKeyAndAssert(home, null, [0, 0], "Home key scrolls viewport to top");
 }, "Keyboard scrolling chains past inactive overflow:scroll DIVs");
-
-promise_test(async () => {
-    await test_driver.click(iframe);
-
-    await pressKeyAndAssert(end, iframe, [0, iframe.contentDocument.documentElement.scrollHeight - iframe.contentWindow.innerHeight], "End key scrolls #iframe to bottom");
-    await pressKeyAndAssert(home, iframe, [0, 0], "Home key scrolls #iframe to top");
-    await pressKeyAndAssert(arrowDown, iframe, [0, lineSize], "ArrowDown key scrolls #iframe down by a line");
-    await pressKeyAndAssert(arrowDown, iframe, [0, lineSize * 2], "ArrowDown key scrolls #iframe down by a line");
-    await pressKeyAndAssert(arrowUp, iframe, [0, lineSize], "ArrowUp key scrolls #iframe up by a line");
-    await pressKeyAndAssert(arrowUp, iframe, [0, 0], "ArrowUp key scrolls #iframe up by a line");
-    await pressKeyAndAssert(arrowRight, iframe, [lineSize, 0], "ArrowRight key scrolls #iframe right by a line");
-    await pressKeyAndAssert(arrowRight, iframe, [lineSize * 2, 0], "ArrowRight key scrolls #iframe right by a line");
-    await pressKeyAndAssert(arrowLeft, iframe, [lineSize, 0], "ArrowLeft key scrolls #iframe left by a line");
-    await pressKeyAndAssert(arrowLeft, iframe, [0, 0], "ArrowLeft key scrolls #iframe left by a line");
-    await pressKeyAndAssert(pageDown, iframe, [0, pageSize(iframe.contentWindow.innerHeight)], "PageDown key scrolls #iframe down by almost a screenful");
-    await pressKeyAndAssert(pageDown, iframe, [0, pageSize(iframe.contentWindow.innerHeight) * 2], "PageDown key scrolls #iframe down by almost a screenful");
-    await pressKeyAndAssert(pageUp, iframe, [0, pageSize(iframe.contentWindow.innerHeight)], "PageUp key scrolls #iframe up by almost a screenful");
-    await pressKeyAndAssert(pageUp, iframe, [0, 0], "PageUp key scrolls #iframe up by almost a screenful");
-
-    // TODO: test that scrolls chain up from iframe when they fail.
-}, "Keyboard scrolling works in #iframe");
 
 promise_test(async () => {
     await test_driver.click(boxWithOverflowHidden);


### PR DESCRIPTION
When an `<iframe>` cannot scroll because the size of the frame is greater than or
equal to the size of page contents, chain up the keyboard scroll
operation to the parent frame.

Testing: A new Servo-only WPT tests is added, though needs to be manually
run with `--product servodriver`.
