### PR TITLE
servoshell: Scale WebDriver mouse button coordinates by HiDPI scale factor

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -522,7 +522,7 @@ impl App {
                             InputEvent::MouseButton(MouseButtonEvent::new(
                                 mouse_event_type,
                                 mouse_button,
-                                Point2D::new(x, y),
+                                Point2D::new(x, y) * webview.hidpi_scale_factor(),
                             ))
                             .with_webdriver_message_id(webdriver_message_id),
                         );


### PR DESCRIPTION
Mouse button events are sent in CSSPixel coordinates, but these need to
so they need to converted into device coordinates when creating an input
event for them. This isn't an issue for automated test because they
always use a scale factor of 1. This is a problem when running
interactively and not in headless mode.

Testing: This isn't really testable in an automated way, but is very obviously
causes tests to pass when run with WebDriver and without headless mode.
Fixes: Part of #38087.
