### PR TITLE
layout: Avoid fixed table layout when `inline-size` is `max-content`

### DIFF
--- a/components/layout/table/layout.rs
+++ b/components/layout/table/layout.rs
@@ -245,11 +245,14 @@ impl Zero for CellOrTrackMeasure {
 
 impl<'a> TableLayout<'a> {
     fn new(table: &'a Table) -> TableLayout<'a> {
-        // The CSSWG resolved that only `inline-size: auto` can prevent fixed table mode.
-        // <https://github.com/w3c/csswg-drafts/issues/10937#issuecomment-2669150397>
+        // The CSSWG resolved that `auto` and `max-content` inline sizes prevent fixed table mode.
+        // <https://github.com/w3c/csswg-drafts/issues/10937>
         let style = &table.style;
         let is_in_fixed_mode = style.get_table().table_layout == TableLayoutMode::Fixed &&
-            !style.box_size(style.writing_mode).inline.is_initial();
+            !matches!(
+                style.box_size(style.writing_mode).inline,
+                Size::Initial | Size::MaxContent
+            );
         Self {
             table,
             pbm: PaddingBorderMargin::zero(),

--- a/tests/wpt/tests/css/css-tables/fixed-layout-2.html
+++ b/tests/wpt/tests/css/css-tables/fixed-layout-2.html
@@ -3,7 +3,7 @@
 <link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
 <link rel="help" href="https://drafts.csswg.org/css-tables-3/#in-fixed-mode">
 <link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10937">
-<meta name="assert" content="Fixed table layout is triggered except when inline-size is auto.">
+<meta name="assert" content="Fixed table layout is triggered except when inline-size is auto or max-content.">
 <link rel="stylesheet" href="./support/base.css">
 
 <style>
@@ -103,7 +103,7 @@ function checkSize(size, allowsFixed) {
 
 for (let size of sizes) {
   if (CSS.supports("width", size)) {
-    let allowsFixed = size !== "auto";
+    let allowsFixed = size !== "auto" && size !== "max-content";
     checkSize(size, allowsFixed);
 
     // calc-size() should trigger fixed table layout.


### PR DESCRIPTION
This undoes #35882 according to the last CSSWG resolution, since this is required by web compat.

Testing: Modifying the relevant test
