### PR TITLE
script: Chain up `scrollIntoView()` scrolling to parent `<iframe>`s

### DIFF
--- a/components/script/dom/scrolling_box.rs
+++ b/components/script/dom/scrolling_box.rs
@@ -4,6 +4,9 @@
 
 use std::cell::Cell;
 
+use app_units::Au;
+use euclid::Vector2D;
+use euclid::default::Rect;
 use layout_api::{AxesOverflow, ScrollContainerQueryFlags};
 use script_bindings::codegen::GenericBindings::WindowBinding::ScrollBehavior;
 use script_bindings::inheritance::Castable;
@@ -11,6 +14,7 @@ use script_bindings::root::DomRoot;
 use style::values::computed::Overflow;
 use webrender_api::units::{LayoutSize, LayoutVector2D};
 
+use crate::dom::bindings::codegen::Bindings::ElementBinding::ScrollLogicalPosition;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::types::{Document, Element};
 
@@ -139,5 +143,115 @@ impl ScrollingBox {
             ScrollingBoxAxis::X => self.content_size().width > self.size().width,
             ScrollingBoxAxis::Y => self.content_size().height > self.size().height,
         }
+    }
+
+    /// <https://drafts.csswg.org/cssom-view/#determine-the-scroll-into-view-position>
+    pub(crate) fn determine_scroll_into_view_position(
+        &self,
+        block: ScrollLogicalPosition,
+        inline: ScrollLogicalPosition,
+        target_rect: Rect<Au>,
+    ) -> LayoutVector2D {
+        let device_pixel_ratio = self.node().owner_window().device_pixel_ratio().get();
+        let to_pixel = |value: Au| value.to_nearest_pixel(device_pixel_ratio);
+
+        // Step 1 should be handled by the caller, and provided as |target_rect|.
+        // > Let target bounding border box be the box represented by the return value
+        // > of invoking Element’s getBoundingClientRect(), if target is an Element,
+        // > or Range’s getBoundingClientRect(), if target is a Range.
+        let target_top_left = target_rect.origin.map(to_pixel).to_untyped();
+        let target_bottom_right = target_rect.max().map(to_pixel);
+
+        // The rest of the steps diverge from the specification here, but essentially try
+        // to follow it using our own geometry types.
+        //
+        // TODO: This makes the code below wrong for the purposes of writing modes.
+        let (adjusted_element_top_left, adjusted_element_bottom_right) = match self.target() {
+            ScrollingBoxSource::Viewport(_) => (target_top_left, target_bottom_right),
+            ScrollingBoxSource::Element(scrolling_element) => {
+                let scrolling_padding_rect_top_left = scrolling_element
+                    .upcast::<Node>()
+                    .padding_box()
+                    .unwrap_or_default()
+                    .origin
+                    .map(to_pixel);
+                (
+                    target_top_left - scrolling_padding_rect_top_left.to_vector(),
+                    target_bottom_right - scrolling_padding_rect_top_left.to_vector(),
+                )
+            },
+        };
+
+        let size = self.size();
+        let current_scroll_position = self.scroll_position();
+        Vector2D::new(
+            Self::calculate_scroll_position_one_axis(
+                inline,
+                adjusted_element_top_left.x,
+                adjusted_element_bottom_right.x,
+                size.width,
+                current_scroll_position.x,
+            ),
+            Self::calculate_scroll_position_one_axis(
+                block,
+                adjusted_element_top_left.y,
+                adjusted_element_bottom_right.y,
+                size.height,
+                current_scroll_position.y,
+            ),
+        )
+    }
+
+    /// Step 10 from <https://drafts.csswg.org/cssom-view/#determine-the-scroll-into-view-position>:
+    fn calculate_scroll_position_one_axis(
+        alignment: ScrollLogicalPosition,
+        element_start: f32,
+        element_end: f32,
+        container_size: f32,
+        current_scroll_offset: f32,
+    ) -> f32 {
+        let element_size = element_end - element_start;
+        current_scroll_offset +
+            match alignment {
+                // Step 1 & 5: If inline is "start", then align element start edge with scrolling box start edge.
+                ScrollLogicalPosition::Start => element_start,
+                // Step 2 & 6: If inline is "end", then align element end edge with
+                // scrolling box end edge.
+                ScrollLogicalPosition::End => element_end - container_size,
+                // Step 3 & 7: If inline is "center", then align the center of target bounding
+                // border box with the center of scrolling box in scrolling box’s inline base direction.
+                ScrollLogicalPosition::Center => {
+                    element_start + (element_size - container_size) / 2.0
+                },
+                // Step 4 & 8: If inline is "nearest",
+                ScrollLogicalPosition::Nearest => {
+                    let viewport_start = current_scroll_offset;
+                    let viewport_end = current_scroll_offset + container_size;
+
+                    // Step 4.2 & 8.2: If element start edge is outside scrolling box start edge and element
+                    // size is less than scrolling box size or If element end edge is outside
+                    // scrolling box end edge and element size is greater than scrolling box size:
+                    // Align element start edge with scrolling box start edge.
+                    if (element_start < viewport_start && element_size <= container_size) ||
+                        (element_end > viewport_end && element_size >= container_size)
+                    {
+                        element_start
+                    }
+                    // Step 4.3 & 8.3: If element end edge is outside scrolling box start edge and element
+                    // size is greater than scrolling box size or If element start edge is outside
+                    // scrolling box end edge and element size is less than scrolling box size:
+                    // Align element end edge with scrolling box end edge.
+                    else if (element_end > viewport_end && element_size < container_size) ||
+                        (element_start < viewport_start && element_size > container_size)
+                    {
+                        element_end - container_size
+                    }
+                    // Step 4.1 & 8.1: If element start edge and element end edge are both outside scrolling
+                    // box start edge and scrolling box end edge or an invalid situation: Do nothing.
+                    else {
+                        current_scroll_offset
+                    }
+                },
+            }
     }
 }

--- a/tests/wpt/meta/css/cssom-view/scrollIntoView-fixed.html.ini
+++ b/tests/wpt/meta/css/cssom-view/scrollIntoView-fixed.html.ini
@@ -1,6 +1,3 @@
 [scrollIntoView-fixed.html]
-  [[Box B\] scrollIntoView from unscrollable position:fixed in iframe]
-    expected: FAIL
-
   [[Box D\] scrollIntoView from scrollable position:fixed in iframe]
     expected: FAIL

--- a/tests/wpt/tests/css/cssom-view/scrollIntoView-iframes.html
+++ b/tests/wpt/tests/css/cssom-view/scrollIntoView-iframes.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSSOM View Test: scrollIntoView in iframes</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview">
+<meta name="assert" content="Checks that scrollIntoView inside and iframe can scroll in the parent document if it has the same origin.">
+
+<style>
+.scroller {
+  overflow: hidden;
+  height: 500px;
+  border: solid;
+}
+.scroller::before {
+  content: "";
+  display: block;
+  height: 500px;
+}
+.scroller::after {
+  content: "";
+  display: block;
+  height: 300px;
+}
+iframe {
+  height: 1000px;
+  border: none;
+}
+</style>
+
+<div id="log"></div>
+
+<div class="scroller">
+  <iframe id="same-origin-iframe"></iframe>
+</div>
+<div class="scroller">
+  <iframe id="cross-origin-iframe" sandbox="allow-scripts"></iframe>
+</div>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let sameOriginIframe = document.getElementById("same-origin-iframe");
+let crossOriginIframe = document.getElementById("cross-origin-iframe");
+let sameOriginWindow = sameOriginIframe.contentWindow;
+let crossOriginWindow = crossOriginIframe.contentWindow;
+
+promise_setup(() => Promise.all([
+  new Promise(resolve => {
+    sameOriginIframe.addEventListener("load", resolve);
+    sameOriginIframe.src = "support/scrollIntoView-iframes-child.html";
+  }),
+  new Promise(resolve => {
+    crossOriginIframe.addEventListener("load", resolve);
+    crossOriginIframe.src = "support/scrollIntoView-iframes-child.html";
+  })
+]));
+
+promise_test(async () => {
+  assert_equals(sameOriginWindow.scrollY, 100, "scrollY");
+}, "scrollIntoView in same-origin iframe can scroll in inner window");
+
+promise_test(async () => {
+  assert_equals(sameOriginIframe.parentElement.scrollTop, 1200, "scrollTop");
+}, "scrollIntoView in same-origin iframe can scroll in parent window");
+
+promise_test(async () => {
+  let scrollY = await new Promise(resolve => {
+    addEventListener("message", event => {
+      if (event.source === crossOriginWindow) {
+        resolve(event.data);
+      }
+    });
+    crossOriginWindow.postMessage("scrollY", "*");
+  });
+  assert_equals(scrollY, 100, "scrollY");
+}, "scrollIntoView in cross-origin iframe can scroll in inner window");
+
+promise_test(async () => {
+  assert_equals(crossOriginIframe.parentElement.scrollTop, 0, "scrollTop");
+}, "scrollIntoView in cross-origin iframe can't scroll in parent window");
+</script>

--- a/tests/wpt/tests/css/cssom-view/support/scrollIntoView-iframes-child.html
+++ b/tests/wpt/tests/css/cssom-view/support/scrollIntoView-iframes-child.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+body {
+  margin: 0;
+  padding-top: 1000px;
+}
+#target {
+  height: 100px;
+  width: 100px;
+  background: green;
+}
+</style>
+<div id="target"></div>
+<script>
+target.scrollIntoView({block: "center"});
+
+addEventListener("message", event => {
+  if (event.data === "scrollY") {
+    event.source.postMessage(scrollY, "*");
+  }
+});
+</script>


### PR DESCRIPTION
Calling `scrollIntoView()` on an element within an `<iframe>` will now scroll scrolling boxes from the parent document(s), as long as they have the same origin.

Testing: One existing subtest passes, and adding a new test.
