### PR TITLE
script: Migrate `digest` operation to use new normalization

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -518,12 +518,12 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
 
         // Step 3. Let normalizedAlgorithm be the result of normalizing an algorithm,
         // with alg set to algorithm and op set to "digest".
+        // Step 4. If an error occurred, return a Promise rejected with normalizedAlgorithm.
         let promise = Promise::new_in_current_realm(comp, can_gc);
         let normalized_algorithm =
             match normalize_algorithm(cx, &Operation::Digest, &algorithm, can_gc) {
                 Ok(normalized_algorithm) => normalized_algorithm,
                 Err(error) => {
-                    // Step 4. If an error occurred, return a Promise rejected with normalizedAlgorithm.
                     promise.reject_error(error, can_gc);
                     return promise;
                 },


### PR DESCRIPTION
Refactoring of the algorithm normalization in #39431 introduces a new algorithm normalization procedure to replace the existing one.

This patch migrates the `digest` operation from using existing `normalize_algorithm_for_digest` function to using the new `normalize_algorithm` function.

Note that the custom type `DigestAlgorithm` has not yet completely removed since other operations like `get key length`  (not migrated yet) depend on it. It will be removed when those operations are also migrated.

A minor bug (missing a step) in `normalize_algorithm` is also fixed.

Testing: Refactoring. Existing WPT tests are enough.
Fixes: Part of #39368
