### PR TITLE
Script: Change script/dom/{bluetooth,canvas,html} to not rely on Deref<str> for DOMString

### DIFF
--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -432,7 +432,7 @@ fn canonicalize_filter(filter: &BluetoothLEScanFilterInit) -> Fallible<Bluetooth
             let mut map = HashMap::new();
             for (key, bdfi) in manufacturer_data_map.iter() {
                 // Step 7.1 - 7.2.
-                let manufacturer_id = match u16::from_str(key.as_ref()) {
+                let manufacturer_id = match u16::from_str(key.str()) {
                     Ok(id) => id,
                     Err(err) => {
                         return Err(Type(format!("{} {} {}", KEY_CONVERSION_ERROR, key, err)));
@@ -461,7 +461,7 @@ fn canonicalize_filter(filter: &BluetoothLEScanFilterInit) -> Fallible<Bluetooth
             }
             let mut map = HashMap::new();
             for (key, bdfi) in service_data_map.iter() {
-                let service_name = match u32::from_str(key.as_ref()) {
+                let service_name = match u32::from_str(key.str()) {
                     // Step 9.1.
                     Ok(number) => StringOrUnsignedLong::UnsignedLong(number),
                     // Step 9.2.
@@ -687,7 +687,7 @@ impl PermissionAlgorithm for Bluetooth {
                     continue;
                 }
             }
-            let device_id = String::from(allowed_device.deviceId.as_ref());
+            let device_id = String::from(allowed_device.deviceId.str());
 
             // Step 6.2.
             if let Some(ref filters) = descriptor.filters {

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -153,7 +153,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         let p = Promise::new_in_current_realm(comp, can_gc);
 
         // Step 1.
-        if uuid_is_blocklisted(self.uuid.as_ref(), Blocklist::Reads) {
+        if uuid_is_blocklisted(self.uuid.str(), Blocklist::Reads) {
             p.reject_error(Security, can_gc);
             return p;
         }
@@ -191,7 +191,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         let p = Promise::new_in_current_realm(comp, can_gc);
 
         // Step 1.
-        if uuid_is_blocklisted(self.uuid.as_ref(), Blocklist::Writes) {
+        if uuid_is_blocklisted(self.uuid.str(), Blocklist::Writes) {
             p.reject_error(Security, can_gc);
             return p;
         }
@@ -242,7 +242,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         let p = Promise::new_in_current_realm(comp, can_gc);
 
         // Step 1.
-        if uuid_is_blocklisted(self.uuid.as_ref(), Blocklist::Reads) {
+        if uuid_is_blocklisted(self.uuid.str(), Blocklist::Reads) {
             p.reject_error(Security, can_gc);
             return p;
         }

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -101,7 +101,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
         let p = Promise::new_in_current_realm(comp, can_gc);
 
         // Step 1.
-        if uuid_is_blocklisted(self.uuid.as_ref(), Blocklist::Reads) {
+        if uuid_is_blocklisted(self.uuid.str(), Blocklist::Reads) {
             p.reject_error(Security, can_gc);
             return p;
         }
@@ -138,7 +138,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
         let p = Promise::new_in_current_realm(comp, can_gc);
 
         // Step 1.
-        if uuid_is_blocklisted(self.uuid.as_ref(), Blocklist::Writes) {
+        if uuid_is_blocklisted(self.uuid.str(), Blocklist::Writes) {
             p.reject_error(Security, can_gc);
             return p;
         }

--- a/components/script/dom/bluetooth/bluetoothuuid.rs
+++ b/components/script/dom/bluetooth/bluetoothuuid.rs
@@ -638,7 +638,7 @@ fn resolve_uuid_name(
         StringOrUnsignedLong::String(dstring) => {
             // Step 2.
             let regex = Regex::new(VALID_UUID_REGEX).unwrap();
-            if regex.is_match(&dstring) {
+            if regex.is_match(dstring.str()) {
                 Ok(dstring)
             } else {
                 // Step 3.

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -1298,7 +1298,7 @@ impl CanvasState {
             repetition.push_str("repeat");
         }
 
-        if let Ok(rep) = RepetitionStyle::from_str(&repetition) {
+        if let Ok(rep) = RepetitionStyle::from_str(repetition.str()) {
             let size = snapshot.size();
             Ok(Some(CanvasPattern::new(
                 global,
@@ -1357,7 +1357,7 @@ impl CanvasState {
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalcompositeoperation
     pub(super) fn set_global_composite_operation(&self, op_str: DOMString) {
-        if let Ok(op) = CompositionOrBlending::from_str(&op_str) {
+        if let Ok(op) = CompositionOrBlending::from_str(op_str.str()) {
             self.state.borrow_mut().global_composition = op;
         }
     }
@@ -2506,9 +2506,9 @@ impl UnshapedTextRun<'_> {
 
 pub(super) fn parse_color(
     canvas: Option<&HTMLCanvasElement>,
-    string: &str,
+    string: &DOMString,
 ) -> Result<AbsoluteColor, ()> {
-    let mut input = ParserInput::new(string);
+    let mut input = ParserInput::new(string.str());
     let mut parser = Parser::new(&mut input);
     let url = Url::parse("about:blank").unwrap().into();
     let context = ParserContext::new(

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -297,7 +297,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
             return Err(Error::InvalidState);
         }
 
-        match &*id {
+        match id.str() {
             "2d" => Ok(self
                 .get_or_init_2d_context(can_gc)
                 .map(RootedOffscreenRenderingContext::OffscreenCanvasRenderingContext2D)),

--- a/components/script/dom/html/htmlareaelement.rs
+++ b/components/script/dom/html/htmlareaelement.rs
@@ -304,7 +304,7 @@ impl HTMLAreaElement {
     pub(crate) fn get_shape_from_coords(&self) -> Option<Area> {
         let elem = self.upcast::<Element>();
         let shape = elem.get_string_attribute(&"shape".into());
-        let shp: Shape = match_ignore_ascii_case! { &shape,
+        let shp: Shape = match_ignore_ascii_case! { shape.str(),
            "circle" => Shape::Circle,
            "circ" => Shape::Circle,
            "rectangle" => Shape::Rectangle,
@@ -315,7 +315,7 @@ impl HTMLAreaElement {
         };
         if elem.has_attribute(&"coords".into()) {
             let attribute = elem.get_string_attribute(&"coords".into());
-            Area::parse(&attribute, shp)
+            Area::parse(attribute.str(), shp)
         } else {
             None
         }

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -449,7 +449,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
             return Err(Error::InvalidState);
         }
 
-        Ok(match &*id {
+        Ok(match id.str() {
             "2d" => self
                 .get_or_init_2d_context(can_gc)
                 .map(RootedRenderingContext::CanvasRenderingContext2D),

--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -270,7 +270,9 @@ impl HTMLCollection {
         classes: DOMString,
         can_gc: CanGc,
     ) -> DomRoot<HTMLCollection> {
-        let class_atoms = split_html_space_chars(&classes).map(Atom::from).collect();
+        let class_atoms = split_html_space_chars(classes.str())
+            .map(Atom::from)
+            .collect();
         HTMLCollection::by_atomic_class_name(window, root, class_atoms, can_gc)
     }
 

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -932,7 +932,7 @@ impl HTMLElement {
     // returns Some if can infer direction by itself or from child nodes
     // returns None if requires to go up to parent
     pub(crate) fn directionality(&self) -> Option<String> {
-        let element_direction: &str = &self.Dir();
+        let element_direction = &self.Dir();
 
         if element_direction == "ltr" {
             return Some("ltr".to_owned());

--- a/components/script/dom/html/htmlfontelement.rs
+++ b/components/script/dom/html/htmlfontelement.rs
@@ -177,12 +177,12 @@ impl HTMLFontElementLayoutHelpers for LayoutDom<'_, HTMLFontElement> {
 }
 
 /// <https://html.spec.whatwg.org/multipage/#rules-for-parsing-a-legacy-font-size>
-fn parse_size(mut input: &str) -> AttrValue {
+fn parse_size(input: &DOMString) -> AttrValue {
     let original_input = input;
     // Steps 1 & 2 are not relevant
 
     // Step 3
-    input = input.trim_matches(HTML_SPACE_CHARACTERS);
+    let input = input.str().trim_matches(HTML_SPACE_CHARACTERS);
 
     enum ParseMode {
         RelativePlus,
@@ -192,7 +192,7 @@ fn parse_size(mut input: &str) -> AttrValue {
     let mut input_chars = input.chars().peekable();
     let parse_mode = match input_chars.peek() {
         // Step 4
-        None => return AttrValue::String(original_input.into()),
+        None => return AttrValue::String(original_input.str().into()),
 
         // Step 5
         Some(&'+') => {
@@ -209,7 +209,7 @@ fn parse_size(mut input: &str) -> AttrValue {
     // Steps 6, 7, 8
     let mut value = match read_numbers(input_chars) {
         (Some(v), _) if v >= 0 => v,
-        _ => return AttrValue::String(original_input.into()),
+        _ => return AttrValue::String(original_input.str().into()),
     };
 
     // Step 9
@@ -220,5 +220,5 @@ fn parse_size(mut input: &str) -> AttrValue {
     }
 
     // Steps 10, 11, 12
-    AttrValue::UInt(original_input.into(), value as u32)
+    AttrValue::UInt(original_input.str().into(), value as u32)
 }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -685,8 +685,8 @@ impl HTMLFormElement {
                 .get_string_attribute(&local_name!("accept-charset"));
 
             // Substep 2, 3, 4
-            let mut candidate_encodings =
-                split_html_space_chars(&input).filter_map(|c| Encoding::for_label(c.as_bytes()));
+            let mut candidate_encodings = split_html_space_chars(input.str())
+                .filter_map(|c| Encoding::for_label(c.as_bytes()));
 
             // Substep 5, 6
             return candidate_encodings.next().unwrap_or(UTF_8);
@@ -829,7 +829,7 @@ impl HTMLFormElement {
             action = DOMString::from(base.as_str());
         }
         // Step 12-13
-        let action_components = match base.join(&action) {
+        let action_components = match base.join(action.str()) {
             Ok(url) => url,
             Err(_) => return,
         };
@@ -940,7 +940,7 @@ impl HTMLFormElement {
             &mut load_data.url,
             form_data
                 .iter()
-                .map(|field| (&*field.name, field.replace_value(charset))),
+                .map(|field| (field.name.str(), field.replace_value(charset))),
         );
 
         self.plan_to_navigate(load_data, target);
@@ -969,7 +969,7 @@ impl HTMLFormElement {
                     &mut url,
                     form_data
                         .iter()
-                        .map(|field| (&*field.name, field.replace_value(charset))),
+                        .map(|field| (field.name.str(), field.replace_value(charset))),
                 );
 
                 url.query().unwrap_or("").to_string().into_bytes()
@@ -1491,7 +1491,7 @@ impl FormSubmitterElement<'_> {
                 |f| f.Enctype(),
             ),
         };
-        match &*attr {
+        match attr.str() {
             "multipart/form-data" => FormEncType::MultipartFormData,
             "text/plain" => FormEncType::TextPlain,
             // https://html.spec.whatwg.org/multipage/#attr-fs-enctype
@@ -1514,7 +1514,7 @@ impl FormSubmitterElement<'_> {
                 |f| f.Method(),
             ),
         };
-        match &*attr {
+        match attr.str() {
             "dialog" => FormMethod::Dialog,
             "post" => FormMethod::Post,
             _ => FormMethod::Get,
@@ -1896,7 +1896,7 @@ pub(crate) fn encode_multipart_form_data(
     let mut result = vec![];
 
     // Newline replacement routine as described in Step 1
-    fn clean_crlf(s: &str) -> DOMString {
+    fn clean_crlf(s: &DOMString) -> DOMString {
         let mut buf = "".to_owned();
         let mut prev = ' ';
         for ch in s.chars() {

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -620,7 +620,7 @@ impl HTMLIFrameElementMethods<crate::DomTypeHolder> for HTMLIFrameElement {
         // Step 2: Set an attribute value given this, srcdoc's local name, and compliantString.
         element.set_attribute(
             &local_name!("srcdoc"),
-            AttrValue::String(value.as_ref().to_owned()),
+            AttrValue::String(value.str().to_owned()),
             can_gc,
         );
         Ok(())

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1609,7 +1609,7 @@ fn get_correct_referrerpolicy_from_raw_token(token: &DOMString) -> DOMString {
         // so it should remain unchanged.
         DOMString::new()
     } else {
-        let policy = determine_policy_for_token(token);
+        let policy = determine_policy_for_token(token.str());
 
         if policy == ReferrerPolicy::EmptyString {
             return DOMString::new();

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1045,7 +1045,7 @@ impl HTMLMediaElement {
                         SrcObject::Blob(blob) => {
                             let blob_url = URL::CreateObjectURL(&self.global(), blob);
                             *self.blob_url.borrow_mut() =
-                                Some(ServoUrl::parse(&blob_url).expect("infallible"));
+                                Some(ServoUrl::parse(blob_url.str()).expect("infallible"));
                             self.fetch_request(None, None);
                         },
                         SrcObject::MediaStream(stream) => {
@@ -1723,7 +1723,7 @@ impl HTMLMediaElement {
                 if let Some(servo_url) = self.resource_url.borrow().as_ref() {
                     let fragment = MediaFragmentParser::from(servo_url);
                     if let Some(id) = fragment.id() {
-                        if audio_track.id() == DOMString::from(id) {
+                        if audio_track.id() == id {
                             self.AudioTracks()
                                 .set_enabled(self.AudioTracks().len() - 1, true);
                         }
@@ -1784,7 +1784,7 @@ impl HTMLMediaElement {
                     if let Some(servo_url) = self.resource_url.borrow().as_ref() {
                         let fragment = MediaFragmentParser::from(servo_url);
                         if let Some(id) = fragment.id() {
-                            if track.id() == DOMString::from(id) {
+                            if track.id() == id {
                                 self.VideoTracks().set_selected(0, true);
                             }
                         } else if fragment.tracks().contains(&track.kind().into()) {
@@ -2350,7 +2350,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-canplaytype
     fn CanPlayType(&self, type_: DOMString) -> CanPlayTypeResult {
-        match ServoMedia::get().can_play_type(&type_) {
+        match ServoMedia::get().can_play_type(type_.str()) {
             SupportsMediaType::No => CanPlayTypeResult::_empty,
             SupportsMediaType::Maybe => CanPlayTypeResult::Maybe,
             SupportsMediaType::Probably => CanPlayTypeResult::Probably,

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -215,13 +215,13 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
 
             if node.is::<Text>() {
                 let characterdata = node.downcast::<CharacterData>().unwrap();
-                content.push_str(&characterdata.Data());
+                content.push_str(characterdata.Data().str());
             }
 
             iterator.next();
         }
 
-        DOMString::from(str_join(split_html_space_chars(&content), " "))
+        DOMString::from(str_join(split_html_space_chars(content.str()), " "))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-option-text>

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -707,7 +707,7 @@ impl HTMLScriptElement {
                     global,
                     element,
                     InlineCheckType::Script,
-                    &text,
+                    text.str(),
                 )
         {
             warn!("Blocking inline script due to CSP");
@@ -751,14 +751,13 @@ impl HTMLScriptElement {
         let module_credentials_mode = match script_type {
             ScriptType::Classic => CredentialsMode::CredentialsSameOrigin,
             ScriptType::Module | ScriptType::ImportMap => reflect_cross_origin_attribute(element)
-                .map_or(
-                    CredentialsMode::CredentialsSameOrigin,
-                    |attr| match &*attr {
+                .map_or(CredentialsMode::CredentialsSameOrigin, |attr| {
+                    match attr.str() {
                         "use-credentials" => CredentialsMode::Include,
                         "anonymous" => CredentialsMode::CredentialsSameOrigin,
                         _ => CredentialsMode::CredentialsSameOrigin,
-                    },
-                ),
+                    }
+                }),
         };
 
         // Step 24. Let cryptographic nonce be el's [[CryptographicNonce]] internal slot's value.
@@ -1385,7 +1384,7 @@ impl HTMLScriptElementMethods<crate::DomTypeHolder> for HTMLScriptElement {
         )?;
         element.set_attribute(
             local_name,
-            AttrValue::String(value.as_ref().to_owned()),
+            AttrValue::String(value.str().to_owned()),
             can_gc,
         );
         Ok(())

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -342,7 +342,7 @@ impl HTMLSelectElement {
             .unwrap_or_default();
 
         // Replace newlines with whitespace, then collapse and trim whitespace
-        let displayed_text = itertools::join(selected_option_text.split_whitespace(), " ");
+        let displayed_text = itertools::join(selected_option_text.str().split_whitespace(), " ");
 
         shadow_tree
             .selected_option

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -121,7 +121,7 @@ impl HTMLStyleElement {
                 global,
                 self.upcast(),
                 InlineCheckType::Style,
-                &node.child_text_content(),
+                node.child_text_content().str(),
             )
         {
             return;
@@ -132,14 +132,14 @@ impl HTMLStyleElement {
             .GetTextContent()
             .expect("Element.textContent must be a string");
         let shared_lock = node.owner_doc().style_shared_lock().clone();
-        let mq = Arc::new(shared_lock.wrap(self.create_media_list(&self.Media())));
+        let mq = Arc::new(shared_lock.wrap(self.create_media_list(self.Media().str())));
         let loader = StylesheetLoader::for_element(self.upcast());
 
         let stylesheetcontents_create_callback = || {
             #[cfg(feature = "tracing")]
             let _span = tracing::trace_span!("ParseStylesheet", servo_profiling = true).entered();
             StylesheetContents::from_str(
-                &data,
+                data.str(),
                 UrlExtraData(window.get_url().get_arc()),
                 Origin::Author,
                 &shared_lock,
@@ -156,7 +156,7 @@ impl HTMLStyleElement {
         // stylo's `CascadeDataCache` can now be significantly improved. When shared `StylesheetContents`
         // is modified, copy-on-write will occur, see `CSSStyleSheet::will_modify`.
         let (cache_key, contents) = StylesheetContentsCache::get_or_insert_with(
-            &data,
+            data.str(),
             &shared_lock,
             UrlExtraData(window.get_url().get_arc()),
             doc.quirks_mode(),

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -88,7 +88,7 @@ impl<'dom> LayoutDom<'dom, HTMLTextAreaElement> {
     }
 
     fn placeholder(self) -> &'dom str {
-        unsafe { self.unsafe_get().placeholder.borrow_for_layout() }
+        unsafe { self.unsafe_get().placeholder.borrow_for_layout().str() }
     }
 }
 
@@ -530,7 +530,7 @@ impl VirtualMethods for HTMLTextAreaElement {
                     let mut placeholder = self.placeholder.borrow_mut();
                     placeholder.clear();
                     if let AttributeMutation::Set(_) = mutation {
-                        placeholder.push_str(&attr.value());
+                        placeholder.push_str(attr.value().as_ref());
                     }
                 }
                 self.update_placeholder_shown_state();

--- a/components/script/dom/idbdatabase.rs
+++ b/components/script/dom/idbdatabase.rs
@@ -217,12 +217,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
         }
 
         // Step 6
-        if self
-            .object_store_names
-            .borrow()
-            .iter()
-            .any(|store_name| store_name.to_string() == name.to_string())
-        {
+        if self.object_store_names.borrow().contains(&name) {
             return Err(Error::Constraint);
         }
 
@@ -303,19 +298,14 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
         }
 
         // Step 4
-        if !self
-            .object_store_names
-            .borrow()
-            .iter()
-            .any(|store_name| store_name.to_string() == name.to_string())
-        {
+        if !self.object_store_names.borrow().contains(&name) {
             return Err(Error::NotFound(None));
         }
 
         // Step 5
         self.object_store_names
             .borrow_mut()
-            .retain(|store_name| store_name.to_string() != name.to_string());
+            .retain(|store_name| *store_name != name);
 
         // Step 6
         // FIXME:(arihant2math) Remove from index set ...

--- a/components/script_bindings/str.rs
+++ b/components/script_bindings/str.rs
@@ -212,6 +212,10 @@ impl DOMString {
         &self.0
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Appends a given string slice onto the end of this String.
     pub fn push_str(&mut self, string: &str) {
         self.0.push_str(string)
@@ -309,10 +313,6 @@ impl DOMString {
 
     pub fn len(&self) -> usize {
         self.0.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
     }
 
     pub fn chars(&self) -> Chars<'_> {
@@ -433,7 +433,6 @@ impl Default for DOMString {
 
 impl Deref for DOMString {
     type Target = str;
-
     #[inline]
     fn deref(&self) -> &str {
         &self.0
@@ -456,13 +455,13 @@ impl AsRef<str> for DOMString {
 impl fmt::Display for DOMString {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&**self, f)
+        fmt::Display::fmt(self.str(), f)
     }
 }
 
 impl PartialEq<str> for DOMString {
     fn eq(&self, other: &str) -> bool {
-        &**self == other
+        self.str() == other
     }
 }
 
@@ -474,7 +473,19 @@ impl PartialEq<DOMString> for str {
 
 impl<'a> PartialEq<&'a str> for DOMString {
     fn eq(&self, other: &&'a str) -> bool {
-        &**self == *other
+        self.str() == *other
+    }
+}
+
+impl PartialEq<DOMString> for String {
+    fn eq(&self, other: &DOMString) -> bool {
+        *other.0 == *self
+    }
+}
+
+impl PartialEq<String> for DOMString {
+    fn eq(&self, other: &String) -> bool {
+        self.0 == *other
     }
 }
 


### PR DESCRIPTION
This is part of the future work of implementing LazyDOMString as outlined in https://github.com/servo/servo/issues/39479.

We use str() method or direct implementations on DOMString for these methods. We also change some types.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>


Testing: This is essentially just renaming a method and a type and should not change functionality.
