### PR TITLE
script: display top-level SVG image documents.

### DIFF
--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1000,7 +1000,8 @@ impl ParserContext {
             },
             // Return the result of loading a media document given navigationParams and type.
             MediaType::Image | MediaType::AudioVideo => {
-                self.load_media_document(parser, media_type, &mime_type)
+                self.load_media_document(parser, media_type, &mime_type);
+                return;
             },
             MediaType::Font => {
                 let page = format!(

--- a/components/shared/net/mime_classifier.rs
+++ b/components/shared/net/mime_classifier.rs
@@ -238,10 +238,13 @@ impl MimeClassifier {
     }
 
     /// <https://mimesniff.spec.whatwg.org/#xml-mime-type>
+    /// SVG is worth distinguishing from other XML MIME types:
+    /// <https://mimesniff.spec.whatwg.org/#mime-type-miscellaneous>
     fn is_xml(mt: &Mime) -> bool {
-        mt.suffix() == Some(mime::XML) ||
-            mt.essence_str() == "text/xml" ||
-            mt.essence_str() == "application/xml"
+        !Self::is_image(mt) &&
+            (mt.suffix() == Some(mime::XML) ||
+                mt.essence_str() == "text/xml" ||
+                mt.essence_str() == "application/xml")
     }
 
     /// <https://mimesniff.spec.whatwg.org/#html-mime-type>

--- a/tests/wpt/meta/custom-elements/Document-createElement-svg.svg.ini
+++ b/tests/wpt/meta/custom-elements/Document-createElement-svg.svg.ini
@@ -1,2 +1,2 @@
 [Document-createElement-svg.svg]
-  expected: ERROR
+  expected: TIMEOUT

--- a/tests/wpt/meta/custom-elements/parser/parser-uses-create-an-element-for-a-token-svg.svg.ini
+++ b/tests/wpt/meta/custom-elements/parser/parser-uses-create-an-element-for-a-token-svg.svg.ini
@@ -1,2 +1,2 @@
 [parser-uses-create-an-element-for-a-token-svg.svg]
-  expected: ERROR
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/editing/editing-0/making-entire-documents-editable-the-designmode-idl-attribute/user-interaction-editing-designMode-svg.svg.ini
+++ b/tests/wpt/meta/html/editing/editing-0/making-entire-documents-editable-the-designmode-idl-attribute/user-interaction-editing-designMode-svg.svg.ini
@@ -1,2 +1,2 @@
 [user-interaction-editing-designMode-svg.svg]
-  expected: ERROR
+  expected: TIMEOUT

--- a/tests/wpt/tests/svg/top-level-document/svg-image-document-svg-xml-mime-type-ref.html
+++ b/tests/wpt/tests/svg/top-level-document/svg-image-document-svg-xml-mime-type-ref.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<meta charset="utf-8">
+<iframe src="../shapes/circle-01.svg?pipe=header(Content-Type,image/svg)">

--- a/tests/wpt/tests/svg/top-level-document/svg-image-document-svg-xml-mime-type.tentative.html
+++ b/tests/wpt/tests/svg/top-level-document/svg-image-document-svg-xml-mime-type.tentative.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Display image/svg+xml top level documents</title>
+<link rel='match' href='svg-image-document-svg-xml-mime-type-ref.html'>
+<link rel="author" title="webbeef" href="mailto:me@webbeef.org">
+<iframe src="../shapes/circle-01.svg?pipe=header(Content-Type,image/svg+xml)">


### PR DESCRIPTION
SVG images served with the image/svg+xml mime type were recognized as XML documents instead of images, so were not displayed.

Testing: compare the results of `./mach run https://raw.githubusercontent.com/servo/servo/467821598b59bd84273d91c9d8a33651e10578b8/resources/resource_protocol/servo-color-negative-no-container.svg`
