### PR TITLE
Establish baselines for testdriver.js infrastructure tests

### DIFF
--- a/tests/wpt/meta/infrastructure/testdriver/actions/eventOrder.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/eventOrder.html.ini
@@ -1,0 +1,3 @@
+[eventOrder.html]
+  [indivisible actions on the same track dispatch events in series]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/mouseClickCount.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/mouseClickCount.html.ini
@@ -1,0 +1,3 @@
+[mouseClickCount.html]
+  [TestDriver actions: test the mouse click counts at different cases]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/multiTouchPoints.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/multiTouchPoints.html.ini
@@ -1,0 +1,3 @@
+[multiTouchPoints.html]
+  [TestDriver actions: two touch points with one moving one pause]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/multiTouchPointsReleaseFirstPoint.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/multiTouchPointsReleaseFirstPoint.html.ini
@@ -1,0 +1,3 @@
+[multiTouchPointsReleaseFirstPoint.html]
+  [TestDriver actions: two touch points with one moving one pause]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/multiTouchPointsReleaseSecondPoint.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/multiTouchPointsReleaseSecondPoint.html.ini
@@ -1,0 +1,3 @@
+[multiTouchPointsReleaseSecondPoint.html]
+  [TestDriver actions: two touch points with one moving one pause]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/multiTouchPointsSimultaneousMove.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/multiTouchPointsSimultaneousMove.html.ini
@@ -1,0 +1,3 @@
+[multiTouchPointsSimultaneousMove.html]
+  [TestDriver actions: two touch points with both moving]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/multiTouchPointsTwoTouchStarts.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/multiTouchPointsTwoTouchStarts.html.ini
@@ -1,0 +1,3 @@
+[multiTouchPointsTwoTouchStarts.html]
+  [TestDriver actions: two touch points with one moving one pause]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/multiTouchPointsWithPause.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/multiTouchPointsWithPause.html.ini
@@ -1,0 +1,3 @@
+[multiTouchPointsWithPause.html]
+  [TestDriver actions: two touch points with one moving one pause]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/penPointerEventProperties.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/penPointerEventProperties.html.ini
@@ -1,0 +1,3 @@
+[penPointerEventProperties.html]
+  [TestDriver actions: pointerevent properties of pen type]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/penPointerEvents.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/penPointerEvents.html.ini
@@ -1,0 +1,3 @@
+[penPointerEvents.html]
+  [TestDriver actions: pointerevent properties of pen type]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/actions/touchPointerEventProperties.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/actions/touchPointerEventProperties.html.ini
@@ -1,0 +1,3 @@
+[touchPointerEventProperties.html]
+  [TestDriver actions: pointerevent properties of touch type]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/handle_request_device_prompt.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/handle_request_device_prompt.https.html.ini
@@ -1,0 +1,2 @@
+[handle_request_device_prompt.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_adapter.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_adapter.https.html.ini
@@ -1,0 +1,2 @@
+[simulate_adapter.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_characteristic.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_characteristic.https.html.ini
@@ -1,0 +1,2 @@
+[simulate_characteristic.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_characteristic_response.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_characteristic_response.https.html.ini
@@ -1,0 +1,2 @@
+[simulate_characteristic_response.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_descriptor.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_descriptor.https.html.ini
@@ -1,0 +1,2 @@
+[simulate_descriptor.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_descriptor_response.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_descriptor_response.https.html.ini
@@ -1,0 +1,2 @@
+[simulate_descriptor_response.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_gatt_connection_response.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_gatt_connection_response.https.html.ini
@@ -1,0 +1,2 @@
+[simulate_gatt_connection_response.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_gatt_disconnection.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_gatt_disconnection.https.html.ini
@@ -1,0 +1,2 @@
+[simulate_gatt_disconnection.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_preconnected_peripheral.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_preconnected_peripheral.https.html.ini
@@ -1,0 +1,2 @@
+[simulate_preconnected_peripheral.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_service.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/bluetooth/simulate_service.https.html.ini
@@ -1,0 +1,2 @@
+[simulate_service.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/emulation/set_geolocation_override.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/emulation/set_geolocation_override.https.html.ini
@@ -1,0 +1,2 @@
+[set_geolocation_override.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/emulation/set_locale_override.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/emulation/set_locale_override.https.html.ini
@@ -1,0 +1,2 @@
+[set_locale_override.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/emulation/set_screen_orientation_override.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/emulation/set_screen_orientation_override.https.html.ini
@@ -1,0 +1,3 @@
+[set_screen_orientation_override.https.html]
+  [emulate screen orientation and clear override]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/bidi/permissions/set_permission.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/bidi/permissions/set_permission.https.html.ini
@@ -1,0 +1,2 @@
+[set_permission.https.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/click_iframe.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/click_iframe.html.ini
@@ -1,0 +1,3 @@
+[click_iframe.html]
+  [TestDriver click on a document in an iframe]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/click_nested.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/click_nested.html.ini
@@ -1,0 +1,3 @@
+[click_nested.html]
+  [TestDriver click method with multiple windows and nested iframe]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/click_window.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/click_window.html.ini
@@ -1,0 +1,3 @@
+[click_window.html]
+  [TestDriver click method in window]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/generate_test_report.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/generate_test_report.html.ini
@@ -1,0 +1,2 @@
+[generate_test_report.html]
+  expected: ERROR

--- a/tests/wpt/meta/infrastructure/testdriver/get_all_cookies.sub.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/get_all_cookies.sub.html.ini
@@ -1,0 +1,3 @@
+[get_all_cookies.sub.html]
+  [Get all HTTP cookies]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/get_all_cookies.sub.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/get_all_cookies.sub.https.html.ini
@@ -1,0 +1,3 @@
+[get_all_cookies.sub.https.html]
+  [Get all HTTPS cookies]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/get_named_cookie.sub.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/get_named_cookie.sub.html.ini
@@ -1,0 +1,3 @@
+[get_named_cookie.sub.html]
+  [Get Named HTTP cookie]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/get_named_cookie.sub.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/get_named_cookie.sub.https.html.ini
@@ -1,0 +1,3 @@
+[get_named_cookie.sub.https.html]
+  [Get Named HTTPS cookie]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/minimize_restore_popup.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/minimize_restore_popup.html.ini
@@ -1,0 +1,4 @@
+[minimize_restore_popup.html]
+  expected: TIMEOUT
+  [minimize and restore on popup]
+    expected: TIMEOUT

--- a/tests/wpt/meta/infrastructure/testdriver/set_permission.https.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/set_permission.https.html.ini
@@ -1,0 +1,6 @@
+[set_permission.https.html]
+  [Grant Permission]
+    expected: FAIL
+
+  [Deny Permission]
+    expected: FAIL

--- a/tests/wpt/meta/infrastructure/testdriver/virtual_authenticator.html.ini
+++ b/tests/wpt/meta/infrastructure/testdriver/virtual_authenticator.html.ini
@@ -1,0 +1,21 @@
+[virtual_authenticator.html]
+  [Can create an authenticator]
+    expected: FAIL
+
+  [Can add a credential]
+    expected: FAIL
+
+  [Can get the credentials]
+    expected: FAIL
+
+  [Can remove a credential]
+    expected: FAIL
+
+  [Can remove all credentials]
+    expected: FAIL
+
+  [Can set user verified]
+    expected: FAIL
+
+  [Can remove a virtual authenticator]
+    expected: FAIL


### PR DESCRIPTION
Update testdriver infrastructure test expectation.
For now, most failures of testdriver tests are caused by missing implementation or issue in Servo. 