### PR TITLE
webdriver: Elegantly handle "element screenshot" when bounding box has area zero

### DIFF
--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -144,7 +144,7 @@ pub enum WebDriverCommandMsg {
     TakeScreenshot(
         WebViewId,
         Option<Rect<f32, CSSPixel>>,
-        IpcSender<Option<RasterImage>>,
+        IpcSender<Result<Option<RasterImage>, ()>>,
     ),
     /// Create a new webview that loads about:blank. The embedder will use
     /// the provided channels to return the top level browsing context id


### PR DESCRIPTION
It is possible that the bounding rectangle of an element has area 0. This PR avoids panic in this case.

It is worth to mention that the panic itself won't kill the entire program for interaction, but only the webdriver thread.

Testing: Manually tested on the case of #39495