### PR TITLE
servoshell: Do not hide window in macOS when taking screenshot

### DIFF
--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -35,9 +35,8 @@ pub fn main() {
     crate::init_tracing(servoshell_preferences.tracing_filter.as_deref());
 
     let clean_shutdown = servoshell_preferences.clean_shutdown;
-    let has_output_file = servoshell_preferences.output_image_path.is_some();
-    let event_loop = EventsLoop::new(servoshell_preferences.headless, has_output_file)
-        .expect("Failed to create events loop");
+    let event_loop =
+        EventsLoop::new(servoshell_preferences.headless).expect("Failed to create events loop");
 
     {
         let mut app = App::new(opts, preferences, servoshell_preferences, &event_loop);

--- a/ports/servoshell/desktop/events_loop.rs
+++ b/ports/servoshell/desktop/events_loop.rs
@@ -11,8 +11,6 @@ use log::warn;
 use servo::EventLoopWaker;
 use winit::error::EventLoopError;
 use winit::event_loop::EventLoop as WinitEventLoop;
-#[cfg(target_os = "macos")]
-use winit::platform::macos::{ActivationPolicy, EventLoopBuilderExtMacOS};
 
 use super::app::App;
 
@@ -49,13 +47,13 @@ impl EventsLoop {
     // Ideally, we could use the winit event loop in both modes,
     // but on Linux, the event loop requires a X11 server.
     #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-    pub fn new(_headless: bool, _has_output_file: bool) -> Result<EventsLoop, EventLoopError> {
+    pub fn new(_headless: bool) -> Result<EventsLoop, EventLoopError> {
         Ok(EventsLoop(EventLoop::Winit(
             WinitEventLoop::with_user_event().build()?,
         )))
     }
     #[cfg(any(target_os = "linux", target_os = "windows"))]
-    pub fn new(headless: bool, _has_output_file: bool) -> Result<EventsLoop, EventLoopError> {
+    pub fn new(headless: bool) -> Result<EventsLoop, EventLoopError> {
         Ok(EventsLoop(if headless {
             EventLoop::Headless(Arc::new((Mutex::new(false), Condvar::new())))
         } else {
@@ -63,17 +61,11 @@ impl EventsLoop {
         }))
     }
     #[cfg(target_os = "macos")]
-    pub fn new(headless: bool, _has_output_file: bool) -> Result<EventsLoop, EventLoopError> {
+    pub fn new(headless: bool) -> Result<EventsLoop, EventLoopError> {
         Ok(EventsLoop(if headless {
             EventLoop::Headless(Arc::new((Mutex::new(false), Condvar::new())))
         } else {
-            let mut event_loop_builder = WinitEventLoop::with_user_event();
-            if _has_output_file {
-                // Prevent the window from showing in Dock.app, stealing focus,
-                // when generating an output file.
-                event_loop_builder.with_activation_policy(ActivationPolicy::Prohibited);
-            }
-            EventLoop::Winit(event_loop_builder.build()?)
+            EventLoop::Winit(WinitEventLoop::with_user_event().build()?)
         }))
     }
 }


### PR DESCRIPTION
Screenshots for tests are taken in headless mode now, in which case the
window does not show up Dock.app. In addition, servoshell now supports
taking a screenshot in headed mode, in which case one can keep using the
browser after the screenshot happens. Hiding the window makes this
impossible. Given these two things, it seems that this functionality
isn't necessary any longer.

Testing: It's difficult to test this kind of system integration with servoshell.
