### PR TITLE
compositor: Add Paint Metric events to Perfetto Traces

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1361,6 +1361,14 @@ impl IOCompositor {
                     // the first "real" display list.
                     PaintMetricState::Seen(epoch, first_reflow) if epoch <= current_epoch => {
                         assert!(epoch <= current_epoch);
+                        #[cfg(feature = "tracing")]
+                        tracing::info!(
+                            name: "FirstPaint",
+                            servo_profiling = true,
+                            epoch = ?epoch,
+                            paint_time = ?paint_time,
+                            pipeline_id = ?pipeline_id,
+                        );
                         if let Err(error) = self.global.borrow().constellation_sender.send(
                             EmbedderToConstellationMessage::PaintMetric(
                                 *pipeline_id,
@@ -1378,6 +1386,14 @@ impl IOCompositor {
 
                 match pipeline.first_contentful_paint_metric {
                     PaintMetricState::Seen(epoch, first_reflow) if epoch <= current_epoch => {
+                        #[cfg(feature = "tracing")]
+                        tracing::info!(
+                            name: "FirstContentfulPaint",
+                            servo_profiling = true,
+                            epoch = ?epoch,
+                            paint_time = ?paint_time,
+                            pipeline_id = ?pipeline_id,
+                        );
                         if let Err(error) = self.global.borrow().constellation_sender.send(
                             EmbedderToConstellationMessage::PaintMetric(
                                 *pipeline_id,


### PR DESCRIPTION
> Some metrics like TimeToFirstPaint and TimeToFirstContentfulPaint are only in the HTML traces. [See this](https://github.com/servo/perf-analysis-tools?tab=readme-ov-file#how-to-analyse-a-single-servo-sample)

In order to analyse the performance and refine [perf-analysis-tools](https://github.com/servo/perf-analysis-tools) we need these metrics to be added to Perfetto also.

<img width="993" height="359" alt="Screenshot from 2025-09-26 15-00-00" src="https://github.com/user-attachments/assets/9755f344-a98e-4671-b347-d76cd6311afe" />

<img width="1186" height="359" alt="Screenshot from 2025-09-26 15-00-42" src="https://github.com/user-attachments/assets/a25e3a5f-eef0-45b7-be69-5de919bfb663" />

Testing: Verified by using Perfetto traces

