### PR TITLE
servoshell(egl): Adjust `WebViewRenderer` size when resizing surface size

### DIFF
--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -569,6 +569,9 @@ impl RunningAppState {
             coordinates.viewport.width() as u32,
             coordinates.viewport.height() as u32,
         ));
+        let size = coordinates.viewport.size;
+        self.active_webview()
+            .move_resize(DeviceRect::from_size(size.to_f32()));
         *self.callbacks.coordinates.borrow_mut() = coordinates;
         self.perform_updates();
     }

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -565,13 +565,10 @@ impl RunningAppState {
     /// Let Servo know that the window has been resized.
     pub fn resize(&self, coordinates: Coordinates) {
         info!("resize to {:?}", coordinates,);
-        self.active_webview().resize(PhysicalSize::new(
-            coordinates.viewport.width() as u32,
-            coordinates.viewport.height() as u32,
-        ));
         let size = coordinates.viewport.size;
+        self.active_webview().move_resize(size.to_f32().into());
         self.active_webview()
-            .move_resize(DeviceRect::from_size(size.to_f32()));
+            .resize(PhysicalSize::new(size.width as u32, size.height as u32));
         *self.callbacks.coordinates.borrow_mut() = coordinates;
         self.perform_updates();
     }


### PR DESCRIPTION
For egl, previously, the resize function only set rendering_context size.  It needs to change webview_renderer size at the same time.

Testing: Testing the Mossel [homepage](https://www.huaweimossel.com/) on mobile devices shows no issues when resizing.