### PR TITLE
Script: Lazily transform the DOMString into Rust String instead of immediately.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,12 +431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
-
-[[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7382,7 +7376,6 @@ dependencies = [
 name = "script_bindings"
 version = "0.0.1"
 dependencies = [
- "ascii",
  "bitflags 2.9.4",
  "crossbeam-channel",
  "cssparser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "ash"
 version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7376,6 +7382,7 @@ dependencies = [
 name = "script_bindings"
 version = "0.0.1"
 dependencies = [
+ "ascii",
  "bitflags 2.9.4",
  "crossbeam-channel",
  "cssparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ aes-kw = { version = "0.2.1", features = ["alloc"] }
 app_units = "0.7"
 arboard = "3"
 arrayvec = "0.7"
+ascii = "1.1.0"
 async-tungstenite = { version = "0.29", features = ["tokio-rustls-webpki-roots"] }
 atomic_refcell = "0.1.13"
 aws-lc-rs = { version = "1.14", default-features = false, features = ["aws-lc-sys"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ aes-kw = { version = "0.2.1", features = ["alloc"] }
 app_units = "0.7"
 arboard = "3"
 arrayvec = "0.7"
-ascii = "1.1.0"
 async-tungstenite = { version = "0.29", features = ["tokio-rustls-webpki-roots"] }
 atomic_refcell = "0.1.13"
 aws-lc-rs = { version = "1.14", default-features = false, features = ["aws-lc-sys"] }

--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -255,7 +255,7 @@ pub(crate) fn handle_get_stylesheet_style(
             .filter_map(move |i| {
                 let rule = list.Item(i, can_gc)?;
                 let style = rule.downcast::<CSSStyleRule>()?;
-                if *selector != style.SelectorText() {
+                if selector != style.SelectorText() {
                     return None;
                 };
                 Some(style.Style(can_gc))

--- a/components/script/dom/bindings/domname.rs
+++ b/components/script/dom/bindings/domname.rs
@@ -95,6 +95,7 @@ pub(crate) fn is_valid_doctype_name(name: &DOMString) -> bool {
     // A string is a valid doctype name if it does not contain
     // ASCII whitespace, U+0000 NULL, or U+003E (>).
     !name
+        .str()
         .chars()
         .any(|c| c.is_ascii_whitespace() || matches!(c, '\u{0000}' | '\u{003E}'))
 }
@@ -124,18 +125,20 @@ pub(crate) fn validate_and_extract(
     qualified_name: &DOMString,
     context: Context,
 ) -> Fallible<(Namespace, Option<Prefix>, LocalName)> {
+    let qualified_name = String::from(&*qualified_name.str());
+
     // Step 1. If namespace is the empty string, then set it to null.
     let namespace = namespace_from_domstring(namespace);
 
     // Step 2. Let prefix be null.
     let mut prefix = None;
     // Step 3. Let localName be qualifiedName.
-    let mut local_name = qualified_name.str();
+    let mut local_name = qualified_name.as_str();
     // Step 4. If qualifiedName contains a U+003A (:):
     if let Some(idx) = qualified_name.find(':') {
         //     Step 4.1. Let splitResult be the result of running
         //          strictly split given qualifiedName and U+003A (:).
-        let p = &qualified_name.str()[..idx];
+        let p = &qualified_name[..idx];
 
         // Step 5. If prefix is not a valid namespace prefix,
         // then throw an "InvalidCharacterError" DOMException.
@@ -148,7 +151,7 @@ pub(crate) fn validate_and_extract(
         prefix = Some(p);
 
         //     Step 4.3. Set localName to splitResult[1].
-        let remaining = &qualified_name.str()[(idx + 1).min(qualified_name.len())..];
+        let remaining = &qualified_name.as_str()[(idx + 1).min(qualified_name.len())..];
         match remaining.find(':') {
             Some(end) => local_name = &remaining[..end],
             None => local_name = remaining,

--- a/components/script/dom/bindings/str.rs
+++ b/components/script/dom/bindings/str.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::ops::Deref;
 use std::sync::LazyLock;
 
 use num_traits::Zero;
@@ -284,7 +285,7 @@ pub(crate) trait FromInputValueString {
     fn is_valid_email_address_string(&self) -> bool;
 }
 
-impl FromInputValueString for &str {
+impl<T: Deref<Target = str>> FromInputValueString for T {
     fn parse_date_string(&self) -> Option<OffsetDateTime> {
         // Step 1, 2, 3
         let (year_int, month_int, day_int) = parse_date_component(self)?;

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -138,7 +138,7 @@ pub(crate) fn blob_parts_to_bytes(
     for blobpart in &mut blobparts {
         match blobpart {
             ArrayBufferOrArrayBufferViewOrBlobOrString::String(s) => {
-                ret.extend(s.as_bytes());
+                ret.extend_from_slice(&s.as_bytes());
             },
             ArrayBufferOrArrayBufferViewOrBlobOrString::Blob(b) => {
                 let bytes = b.get_bytes().unwrap_or(vec![]);
@@ -176,7 +176,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
             },
         };
 
-        let type_string = normalize_type_string(blobPropertyBag.type_.str());
+        let type_string = normalize_type_string(&blobPropertyBag.type_.str());
         let blob_impl = BlobImpl::new_from_bytes(bytes, type_string);
 
         Ok(Blob::new_with_proto(global, proto, blob_impl, can_gc))
@@ -206,7 +206,7 @@ impl BlobMethods<crate::DomTypeHolder> for Blob {
         can_gc: CanGc,
     ) -> DomRoot<Blob> {
         let global = self.global();
-        let type_string = normalize_type_string(content_type.unwrap_or_default().str());
+        let type_string = normalize_type_string(&content_type.unwrap_or_default().str());
 
         // If our parent is already a sliced blob then we reference the data from the grandparent instead,
         // to keep the blob ancestry chain short.

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -42,7 +42,6 @@ use js::jsval::{ObjectValue, UndefinedValue};
 use profile_traits::ipc as ProfiledIpc;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 const KEY_CONVERSION_ERROR: &str =
@@ -432,7 +431,7 @@ fn canonicalize_filter(filter: &BluetoothLEScanFilterInit) -> Fallible<Bluetooth
             let mut map = HashMap::new();
             for (key, bdfi) in manufacturer_data_map.iter() {
                 // Step 7.1 - 7.2.
-                let manufacturer_id = match u16::from_str(key.str()) {
+                let manufacturer_id = match key.str().parse::<u16>() {
                     Ok(id) => id,
                     Err(err) => {
                         return Err(Type(format!("{} {} {}", KEY_CONVERSION_ERROR, key, err)));
@@ -461,7 +460,7 @@ fn canonicalize_filter(filter: &BluetoothLEScanFilterInit) -> Fallible<Bluetooth
             }
             let mut map = HashMap::new();
             for (key, bdfi) in service_data_map.iter() {
-                let service_name = match u32::from_str(key.str()) {
+                let service_name = match key.str().parse::<u32>() {
                     // Step 9.1.
                     Ok(number) => StringOrUnsignedLong::UnsignedLong(number),
                     // Step 9.2.

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -153,7 +153,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         let p = Promise::new_in_current_realm(comp, can_gc);
 
         // Step 1.
-        if uuid_is_blocklisted(self.uuid.str(), Blocklist::Reads) {
+        if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
             p.reject_error(Security, can_gc);
             return p;
         }
@@ -191,7 +191,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         let p = Promise::new_in_current_realm(comp, can_gc);
 
         // Step 1.
-        if uuid_is_blocklisted(self.uuid.str(), Blocklist::Writes) {
+        if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Writes) {
             p.reject_error(Security, can_gc);
             return p;
         }
@@ -242,7 +242,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         let p = Promise::new_in_current_realm(comp, can_gc);
 
         // Step 1.
-        if uuid_is_blocklisted(self.uuid.str(), Blocklist::Reads) {
+        if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
             p.reject_error(Security, can_gc);
             return p;
         }

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -101,7 +101,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
         let p = Promise::new_in_current_realm(comp, can_gc);
 
         // Step 1.
-        if uuid_is_blocklisted(self.uuid.str(), Blocklist::Reads) {
+        if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
             p.reject_error(Security, can_gc);
             return p;
         }
@@ -138,7 +138,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
         let p = Promise::new_in_current_realm(comp, can_gc);
 
         // Step 1.
-        if uuid_is_blocklisted(self.uuid.str(), Blocklist::Writes) {
+        if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Writes) {
             p.reject_error(Security, can_gc);
             return p;
         }

--- a/components/script/dom/bluetooth/bluetoothuuid.rs
+++ b/components/script/dom/bluetooth/bluetoothuuid.rs
@@ -638,7 +638,7 @@ fn resolve_uuid_name(
         StringOrUnsignedLong::String(dstring) => {
             // Step 2.
             let regex = Regex::new(VALID_UUID_REGEX).unwrap();
-            if regex.is_match(dstring.str()) {
+            if regex.is_match(&dstring.str()) {
                 Ok(dstring)
             } else {
                 // Step 3.

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -1307,7 +1307,7 @@ impl CanvasState {
             repetition.push_str("repeat");
         }
 
-        if let Ok(rep) = RepetitionStyle::from_str(repetition.str()) {
+        if let Ok(rep) = RepetitionStyle::from_str(&repetition.str()) {
             let size = snapshot.size();
             Ok(Some(CanvasPattern::new(
                 global,
@@ -1366,7 +1366,7 @@ impl CanvasState {
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-globalcompositeoperation
     pub(super) fn set_global_composite_operation(&self, op_str: DOMString) {
-        if let Ok(op) = CompositionOrBlending::from_str(op_str.str()) {
+        if let Ok(op) = CompositionOrBlending::from_str(&op_str.str()) {
             self.state.borrow_mut().global_composition = op;
         }
     }
@@ -1408,7 +1408,7 @@ impl CanvasState {
 
         let Some((bounds, text_run)) = self.text_with_size(
             global_scope,
-            text.str(),
+            &text.str(),
             Point2D::new(x, y),
             size,
             max_width,
@@ -1452,7 +1452,7 @@ impl CanvasState {
 
         let Some((bounds, text_run)) = self.text_with_size(
             global_scope,
-            text.str(),
+            &text.str(),
             Point2D::new(x, y),
             size,
             max_width,
@@ -1484,7 +1484,7 @@ impl CanvasState {
         // Max width is not provided for `measureText()`.
 
         // > Step 2: Replace all ASCII whitespace in text with U+0020 SPACE characters.
-        let text = replace_ascii_whitespace(text.str());
+        let text = replace_ascii_whitespace(&text.str());
 
         // > Step 3: Let font be the current font of target, as given by that object's font
         // > attribute.
@@ -2517,7 +2517,8 @@ pub(super) fn parse_color(
     canvas: Option<&HTMLCanvasElement>,
     string: &DOMString,
 ) -> Result<AbsoluteColor, ()> {
-    let mut input = ParserInput::new(string.str());
+    let string = string.str();
+    let mut input = ParserInput::new(&string);
     let mut parser = Parser::new(&mut input);
     let url = Url::parse("about:blank").unwrap().into();
     let context = ParserContext::new(

--- a/components/script/dom/canvas/2d/path2d.rs
+++ b/components/script/dom/canvas/2d/path2d.rs
@@ -217,7 +217,7 @@ impl Path2DMethods<crate::DomTypeHolder> for Path2D {
         path_string: DOMString,
     ) -> DomRoot<Path2D> {
         reflect_dom_object_with_proto(
-            Box::new(Self::new_with_str(path_string.str())),
+            Box::new(Self::new_with_str(&path_string.str())),
             global,
             proto,
             can_gc,

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -297,7 +297,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
             return Err(Error::InvalidState(None));
         }
 
-        match id.str() {
+        match &*id.str() {
             "2d" => Ok(self
                 .get_or_init_2d_context(can_gc)
                 .map(RootedOffscreenRenderingContext::OffscreenCanvasRenderingContext2D)),

--- a/components/script/dom/clipboarditem.rs
+++ b/components/script/dom/clipboarditem.rs
@@ -160,8 +160,9 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
 
             // Step 6.3 If key starts with `"web "` prefix, then
             // Step 6.3.1 Remove `"web "` prefix and assign the remaining string to key.
-            let (key, is_custom) = match key.str().strip_prefix(CUSTOM_FORMAT_PREFIX) {
-                None => (key.str(), false),
+            let key = key.str();
+            let (key, is_custom) = match key.strip_prefix(CUSTOM_FORMAT_PREFIX) {
+                None => (&*key, false),
                 // Step 6.3.2 Set isCustom true
                 Some(stripped) => (stripped, true),
             };
@@ -252,8 +253,9 @@ impl ClipboardItemMethods<crate::DomTypeHolder> for ClipboardItem {
 
         // Step 3 If type starts with `"web "` prefix, then:
         // Step 3.1 Remove `"web "` prefix and assign the remaining string to type.
+        let type_ = type_.str();
         let (type_, is_custom) = match type_.strip_prefix(CUSTOM_FORMAT_PREFIX) {
-            None => (type_.str(), false),
+            None => (&*type_, false),
             // Step 3.2 Set isCustom to true.
             Some(stripped) => (stripped, true),
         };

--- a/components/script/dom/css.rs
+++ b/components/script/dom/css.rs
@@ -31,16 +31,16 @@ impl CSSMethods<crate::DomTypeHolder> for CSS {
     /// <https://drafts.csswg.org/cssom/#the-css.escape()-method>
     fn Escape(_: &Window, ident: DOMString) -> Fallible<DOMString> {
         let mut escaped = String::new();
-        serialize_identifier(ident.str(), &mut escaped).unwrap();
+        serialize_identifier(&ident.str(), &mut escaped).unwrap();
         Ok(DOMString::from(escaped))
     }
 
     /// <https://drafts.csswg.org/css-conditional/#dom-css-supports>
     fn Supports(win: &Window, property: DOMString, value: DOMString) -> bool {
         let mut decl = String::new();
-        serialize_identifier(property.str(), &mut decl).unwrap();
+        serialize_identifier(&property.str(), &mut decl).unwrap();
         decl.push_str(": ");
-        decl.push_str(value.str());
+        decl.push_str(&value.str());
         let decl = Declaration(decl);
         let url_data = UrlExtraData(win.Document().url().get_arc());
         let context = ParserContext::new(
@@ -58,7 +58,8 @@ impl CSSMethods<crate::DomTypeHolder> for CSS {
 
     /// <https://drafts.csswg.org/css-conditional/#dom-css-supports>
     fn Supports_(win: &Window, condition: DOMString) -> bool {
-        let mut input = ParserInput::new(condition.str());
+        let condition = condition.str();
+        let mut input = ParserInput::new(&condition);
         let mut input = Parser::new(&mut input);
         let cond = match parse_condition_or_declaration(&mut input) {
             Ok(c) => c,

--- a/components/script/dom/csskeyframesrule.rs
+++ b/components/script/dom/csskeyframesrule.rs
@@ -77,7 +77,8 @@ impl CSSKeyframesRule {
 
     /// Given a keyframe selector, finds the index of the first corresponding rule if any
     fn find_rule(&self, selector: &DOMString) -> Option<usize> {
-        let mut input = ParserInput::new(selector.str());
+        let selector = selector.str();
+        let mut input = ParserInput::new(&selector);
         let mut input = Parser::new(&mut input);
         if let Ok(sel) = KeyframeSelector::parse(&mut input) {
             let guard = self.cssrule.shared_lock().read();
@@ -116,8 +117,9 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
     // https://drafts.csswg.org/css-animations/#dom-csskeyframesrule-appendrule
     fn AppendRule(&self, rule: DOMString, can_gc: CanGc) {
         let style_stylesheet = self.cssrule.parent_stylesheet().style_stylesheet();
+        let rule = rule.str();
         let rule = Keyframe::parse(
-            rule.str(),
+            &rule,
             &style_stylesheet.contents,
             &style_stylesheet.shared_lock,
         );
@@ -161,7 +163,7 @@ impl CSSKeyframesRuleMethods<crate::DomTypeHolder> for CSSKeyframesRule {
         // Setting this property to a CSS-wide keyword or `none` does not throw,
         // it stores a value that serializes as a quoted string.
         self.cssrule.parent_stylesheet().will_modify();
-        let name = KeyframesName::from_ident(value.str());
+        let name = KeyframesName::from_ident(&value.str());
         let mut guard = self.cssrule.shared_lock().write();
         self.keyframesrule.borrow().write_with(&mut guard).name = name;
         self.cssrule.parent_stylesheet().notify_invalidations();

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -139,7 +139,7 @@ impl CSSRuleList {
         let new_rule = css_rules
             .insert_rule(
                 &parent_stylesheet.shared_lock,
-                rule.str(),
+                &rule.str(),
                 &parent_stylesheet.contents,
                 index,
                 containing_rule_types,

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -356,7 +356,7 @@ impl CSSStyleDeclaration {
                 id
             },
             PotentiallyParsedPropertyId::NotParsed(unparsed) => {
-                match PropertyId::parse_enabled_for_all_content(unparsed.str()) {
+                match PropertyId::parse_enabled_for_all_content(&unparsed.str()) {
                     Ok(id) => id,
                     Err(..) => return Ok(()),
                 }
@@ -374,7 +374,7 @@ impl CSSStyleDeclaration {
 
                 // Step 4. If priority is not the empty string and is not an ASCII case-insensitive
                 // match for the string "important", then return.
-                let importance = match priority.str() {
+                let importance = match &*priority.str() {
                     "" => Importance::Normal,
                     p if p.eq_ignore_ascii_case("important") => Importance::Important,
                     _ => {
@@ -390,7 +390,7 @@ impl CSSStyleDeclaration {
                 let result = parse_one_declaration_into(
                     &mut declarations,
                     id,
-                    value.str(),
+                    &value.str(),
                     Origin::Author,
                     &UrlExtraData(self.owner.base_url().get_arc()),
                     window.css_error_reporter(),
@@ -481,7 +481,7 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
 
     // https://dev.w3.org/csswg/cssom/#dom-cssstyledeclaration-getpropertyvalue
     fn GetPropertyValue(&self, property: DOMString) -> DOMString {
-        let id = match PropertyId::parse_enabled_for_all_content(property.str()) {
+        let id = match PropertyId::parse_enabled_for_all_content(&property.str()) {
             Ok(id) => id,
             Err(..) => return DOMString::new(),
         };
@@ -494,7 +494,7 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
             // Readonly style declarations are used for getComputedStyle.
             return DOMString::new();
         }
-        let id = match PropertyId::parse_enabled_for_all_content(property.str()) {
+        let id = match PropertyId::parse_enabled_for_all_content(&property.str()) {
             Ok(id) => id,
             Err(..) => return DOMString::new(),
         };
@@ -532,7 +532,7 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
             return Err(Error::NoModificationAllowed);
         }
 
-        let id = match PropertyId::parse_enabled_for_all_content(property.str()) {
+        let id = match PropertyId::parse_enabled_for_all_content(&property.str()) {
             Ok(id) => id,
             Err(..) => return Ok(DOMString::new()),
         };
@@ -609,7 +609,7 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
             |pdb, _changed| {
                 // Step 3
                 *pdb = parse_style_attribute(
-                    value.str(),
+                    &value.str(),
                     &UrlExtraData(self.owner.base_url().get_arc()),
                     window.css_error_reporter(),
                     quirks_mode,

--- a/components/script/dom/cssstylerule.rs
+++ b/components/script/dom/cssstylerule.rs
@@ -151,7 +151,8 @@ impl CSSStyleRuleMethods<crate::DomTypeHolder> for CSSStyleRule {
             url_data: &url_data,
             for_supports_rule: false,
         };
-        let mut css_parser = CssParserInput::new(value.str());
+        let value = value.str();
+        let mut css_parser = CssParserInput::new(&value);
         let mut css_parser = CssParser::new(&mut css_parser);
         // TODO: Maybe allow setting relative selectors from the OM, if we're in a nested style
         // rule?

--- a/components/script/dom/cssstylesheet.rs
+++ b/components/script/dom/cssstylesheet.rs
@@ -294,7 +294,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
         let media = Arc::new(shared_lock.wrap(match &options.media {
             Some(media) => match media {
                 MediaListOrString::MediaList(media_list) => media_list.clone_media_list(),
-                MediaListOrString::String(str) => MediaList::parse_media_list(str.str(), window),
+                MediaListOrString::String(str) => MediaList::parse_media_list(&str.str(), window),
             },
             None => StyleMediaList::empty(),
         }));
@@ -392,7 +392,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
             rule.push_str(" { }");
         } else {
             rule.push_str(" { ");
-            rule.push_str(block.str());
+            rule.push_str(&block.str());
             rule.push_str(" }");
         };
 

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -392,19 +392,19 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
             // TODO Step 7.1 If this's is scoped is true, then throw a "NotSupportedError" DOMException.
 
             // Step 7.2 If extends is a valid custom element name, then throw a "NotSupportedError" DOMException.
-            if is_valid_custom_element_name(extended_name.str()) {
+            if is_valid_custom_element_name(&extended_name.str()) {
                 return Err(Error::NotSupported);
             }
 
             // Step 7.3 If the element interface for extends and the HTML namespace is HTMLUnknownElement
             // (e.g., if extends does not indicate an element definition in this specification)
             // then throw a "NotSupportedError" DOMException.
-            if !is_extendable_element_interface(extended_name.str()) {
+            if !is_extendable_element_interface(&extended_name.str()) {
                 return Err(Error::NotSupported);
             }
 
             // Step 7.4 Set localName to extends.
-            LocalName::from(extended_name.str())
+            LocalName::from(extended_name)
         } else {
             // Step 5. Let localName be name.
             name.clone()

--- a/components/script/dom/customstateset.rs
+++ b/components/script/dom/customstateset.rs
@@ -46,7 +46,7 @@ impl CustomStateSet {
     {
         // FIXME: This creates new atoms whenever it is called, which is not optimal.
         for state in self.internal.borrow().iter() {
-            callback(&AtomIdent::from(state.str()));
+            callback(&AtomIdent::from(&*state.str()));
         }
     }
 

--- a/components/script/dom/datatransfer.rs
+++ b/components/script/dom/datatransfer.rs
@@ -112,7 +112,7 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-datatransfer-dropeffect>
     fn SetDropEffect(&self, value: DOMString) {
-        if VALID_DROP_EFFECTS.contains(&value.str()) {
+        if VALID_DROP_EFFECTS.contains(&&*value.str()) {
             *self.drop_effect.borrow_mut() = value;
         }
     }
@@ -129,7 +129,7 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
             .borrow()
             .as_ref()
             .is_some_and(|data_store| data_store.mode() == Mode::ReadWrite) &&
-            VALID_EFFECTS_ALLOWED.contains(&value.str())
+            VALID_EFFECTS_ALLOWED.contains(&&*value.str())
         {
             *self.drop_effect.borrow_mut() = value;
         }
@@ -187,7 +187,7 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
         // Step 4 Let convert-to-URL be false.
         let mut convert_to_url = false;
 
-        let type_ = match format.str() {
+        let type_ = match &*format.str() {
             // Step 5 If format equals "text", change it to "text/plain".
             "text" => DOMString::from("text/plain"),
             // Step 6 If format equals "url", change it to "text/uri-list" and set convert-to-URL to true.
@@ -195,7 +195,7 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
                 convert_to_url = true;
                 DOMString::from("text/uri-list")
             },
-            _ => format,
+            _ => format.clone(),
         };
 
         let data = data_store.find_matching_text(&type_);

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -216,7 +216,7 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
             // (currently impossible to do robustly due to <https://bugzilla.mozilla.org/show_bug.cgi?id=1982001>)
             let url_original = args.url.str();
             // FIXME: use page/worker url as base here
-            let url_original = ServoUrl::parse(url_original).ok();
+            let url_original = ServoUrl::parse(&url_original).ok();
 
             // If the source has a `urlOverride` (aka `displayURL` aka `//# sourceURL`), it should be a valid url,
             // possibly relative to the page/worker url, and we should treat the source as coming from that url for
@@ -227,7 +227,7 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                 .as_ref()
                 .map(|url| url.str())
                 // FIXME: use page/worker url as base here, not `url_original`
-                .and_then(|url| ServoUrl::parse_with_base(url_original.as_ref(), url).ok());
+                .and_then(|url| ServoUrl::parse_with_base(url_original.as_ref(), &url).ok());
 
             // If the `introductionType` is “eval or eval-like”, the `url` won’t be meaningful, so ignore these
             // sources unless we have a `urlOverride` (aka `displayURL` aka `//# sourceURL`).
@@ -241,7 +241,7 @@ impl DebuggerGlobalScopeMethods<crate::DomTypeHolder> for DebuggerGlobalScope {
                 IntroductionType::EVENT_HANDLER_STR,
                 IntroductionType::DOM_TIMER_STR,
             ]
-            .contains(&introduction_type.str()) &&
+            .contains(&&*introduction_type.str()) &&
                 url_override.is_none()
             {
                 debug!(

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -1341,7 +1341,7 @@ impl DocumentEventHandler {
 
         // Step 4 If the event was canceled, then
         if e.DefaultPrevented() {
-            match e.Type().str() {
+            match &*e.Type().str() {
                 "copy" => {
                     // Step 4.1 Call the write content to the clipboard algorithm,
                     // passing on the DataTransferItemList items, a clear-was-called flag and a types-to-clear list.

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -61,7 +61,7 @@ pub(crate) enum DOMErrorName {
 
 impl DOMErrorName {
     pub(crate) fn from(s: &DOMString) -> Option<DOMErrorName> {
-        match s.str() {
+        match &*s.str() {
             "IndexSizeError" => Some(DOMErrorName::IndexSizeError),
             "HierarchyRequestError" => Some(DOMErrorName::HierarchyRequestError),
             "WrongDocumentError" => Some(DOMErrorName::WrongDocumentError),

--- a/components/script/dom/domtokenlist.rs
+++ b/components/script/dom/domtokenlist.rs
@@ -64,7 +64,7 @@ impl DOMTokenList {
 
     fn check_token_exceptions(&self, token: &DOMString) -> Fallible<Atom> {
         let token = token.str();
-        match token {
+        match &*token {
             "" => Err(Error::Syntax(None)),
             slice if slice.find(HTML_SPACE_CHARACTERS).is_some() => Err(Error::InvalidCharacter),
             slice => Ok(Atom::from(slice)),
@@ -235,7 +235,7 @@ impl DOMTokenListMethods<crate::DomTypeHolder> for DOMTokenList {
 
     /// <https://dom.spec.whatwg.org/#dom-domtokenlist-supports>
     fn Supports(&self, token: DOMString) -> Fallible<bool> {
-        self.validation_steps(token.str())
+        self.validation_steps(&token.str())
     }
 
     // check-tidy: no specs after this line

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -747,7 +747,7 @@ impl Element {
         let name = &local_name!("translate");
         if self.has_attribute(name) {
             let attribute = self.get_string_attribute(name);
-            match_ignore_ascii_case! { attribute.str(),
+            match_ignore_ascii_case! { &*attribute.str(),
                 "yes" | "" => return true,
                 "no" => return false,
                 _ => {},
@@ -1557,7 +1557,7 @@ impl Element {
 
     /// Element branch of <https://dom.spec.whatwg.org/#locate-a-namespace>
     pub(crate) fn locate_namespace(&self, prefix: Option<DOMString>) -> Namespace {
-        let namespace_prefix = prefix.clone().map(|s| Prefix::from(s.str()));
+        let namespace_prefix = prefix.clone().map(|s| Prefix::from(&*s.str()));
 
         // Step 1. If prefix is "xml", then return the XML namespace.
         if namespace_prefix == Some(namespace_prefix!("xml")) {
@@ -1569,7 +1569,7 @@ impl Element {
             return ns!(xmlns);
         }
 
-        let prefix = prefix.map(|s| LocalName::from(s.str()));
+        let prefix = prefix.map(LocalName::from);
 
         let inclusive_ancestor_elements = self
             .upcast::<Node>()
@@ -2005,7 +2005,7 @@ impl Element {
         can_gc: CanGc,
     ) -> ErrorResult {
         // Step 1.
-        if !matches_name_production(name.str()) {
+        if !matches_name_production(&name.str()) {
             return Err(Error::InvalidCharacter);
         }
 
@@ -2953,7 +2953,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     ) -> Fallible<bool> {
         // Step 1. If qualifiedName is not a valid attribute local name,
         //      then throw an "InvalidCharacterError" DOMException.
-        if !is_valid_attribute_local_name(name.str()) {
+        if !is_valid_attribute_local_name(&name.str()) {
             return Err(Error::InvalidCharacter);
         }
 
@@ -3002,7 +3002,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     ) -> ErrorResult {
         // Step 1. If qualifiedName does not match the Name production in XML,
         // then throw an "InvalidCharacterError" DOMException.
-        if !is_valid_attribute_local_name(name.str()) {
+        if !is_valid_attribute_local_name(&name.str()) {
             return Err(Error::InvalidCharacter);
         }
 
@@ -3126,7 +3126,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         HTMLCollection::by_qualified_name(
             &window,
             self.upcast(),
-            LocalName::from(localname.str()),
+            LocalName::from(localname),
             can_gc,
         )
     }
@@ -3748,7 +3748,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let doc = self.owner_document();
         let url = doc.url();
         let selectors = match SelectorParser::parse_author_origin_no_namespace(
-            selectors.str(),
+            &selectors.str(),
             &UrlExtraData(url.get_arc()),
         ) {
             Err(_) => return Err(Error::Syntax(None)),
@@ -3775,7 +3775,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         let doc = self.owner_document();
         let url = doc.url();
         let selectors = match SelectorParser::parse_author_origin_no_namespace(
-            selectors.str(),
+            &selectors.str(),
             &UrlExtraData(url.get_arc()),
         ) {
             Err(_) => return Err(Error::Syntax(None)),

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -567,7 +567,7 @@ impl EventSourceMethods<crate::DomTypeHolder> for EventSource {
         // Step 3 Let urlRecord be the result of encoding-parsing a URL given url,
         // relative to settings.
         let base_url = global.api_base_url();
-        let url_record = match base_url.join(url.str()) {
+        let url_record = match base_url.join(&url.str()) {
             Ok(u) => u,
             // Step 4 If urlRecord is failure, then throw a "SyntaxError" DOMException.
             Err(_) => return Err(Error::Syntax(None)),

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -723,7 +723,7 @@ impl EventTarget {
         }
 
         // Step 3.3
-        let body: Vec<u16> = handler.source.encode_utf16().collect();
+        let body: Vec<u16> = handler.source.str().encode_utf16().collect();
 
         // Step 3.4 is handler.line
 

--- a/components/script/dom/file.rs
+++ b/components/script/dom/file.rs
@@ -136,7 +136,7 @@ impl FileMethods<crate::DomTypeHolder> for File {
             .map(|modified| OffsetDateTime::UNIX_EPOCH + Duration::milliseconds(modified))
             .map(Into::into);
 
-        let type_string = normalize_type_string(blobPropertyBag.type_.str());
+        let type_string = normalize_type_string(&blobPropertyBag.type_.str());
         Ok(File::new_with_proto(
             global,
             proto,

--- a/components/script/dom/formdata.rs
+++ b/components/script/dom/formdata.rs
@@ -39,7 +39,7 @@ impl FormData {
         let data = match form_datums {
             Some(data) => data
                 .iter()
-                .map(|datum| (NoTrace(LocalName::from(datum.name.str())), datum.clone()))
+                .map(|datum| (NoTrace(LocalName::from(&datum.name)), datum.clone()))
                 .collect::<Vec<(NoTrace<LocalName>, FormDatum)>>(),
             None => Vec::new(),
         };

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2864,7 +2864,7 @@ impl GlobalScope {
                     compiled_script.set(Compile1(
                         *cx,
                         options.ptr,
-                        &mut transform_str_to_source_text(text_code.str()),
+                        &mut transform_str_to_source_text(&text_code.str()),
                     ));
 
                     if compiled_script.is_null() {

--- a/components/script/dom/html/htmlareaelement.rs
+++ b/components/script/dom/html/htmlareaelement.rs
@@ -304,7 +304,7 @@ impl HTMLAreaElement {
     pub(crate) fn get_shape_from_coords(&self) -> Option<Area> {
         let elem = self.upcast::<Element>();
         let shape = elem.get_string_attribute(&"shape".into());
-        let shp: Shape = match_ignore_ascii_case! { shape.str(),
+        let shp: Shape = match_ignore_ascii_case! { &*shape.str(),
            "circle" => Shape::Circle,
            "circ" => Shape::Circle,
            "rectangle" => Shape::Rectangle,
@@ -315,7 +315,7 @@ impl HTMLAreaElement {
         };
         if elem.has_attribute(&"coords".into()) {
             let attribute = elem.get_string_attribute(&"coords".into());
-            Area::parse(attribute.str(), shp)
+            Area::parse(&attribute.str(), shp)
         } else {
             None
         }

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -469,7 +469,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
             return Err(Error::InvalidState(None));
         }
 
-        Ok(match id.str() {
+        Ok(match &*id.str() {
             "2d" => self
                 .get_or_init_2d_context(can_gc)
                 .map(RootedRenderingContext::CanvasRenderingContext2D),

--- a/components/script/dom/html/htmlcollection.rs
+++ b/components/script/dom/html/htmlcollection.rs
@@ -270,7 +270,7 @@ impl HTMLCollection {
         classes: DOMString,
         can_gc: CanGc,
     ) -> DomRoot<HTMLCollection> {
-        let class_atoms = split_html_space_chars(classes.str())
+        let class_atoms = split_html_space_chars(&classes.str())
             .map(Atom::from)
             .collect();
         HTMLCollection::by_atomic_class_name(window, root, class_atoms, can_gc)

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -720,7 +720,7 @@ static DATA_HYPHEN_SEPARATOR: char = '\x2d';
 fn to_snake_case(name: DOMString) -> DOMString {
     let mut attr_name = String::with_capacity(name.len() + DATA_PREFIX.len());
     attr_name.push_str(DATA_PREFIX);
-    for ch in name.chars() {
+    for ch in name.str().chars() {
         if ch.is_ascii_uppercase() {
             attr_name.push(DATA_HYPHEN_SEPARATOR);
             attr_name.push(ch.to_ascii_lowercase());
@@ -775,6 +775,7 @@ impl HTMLElement {
         can_gc: CanGc,
     ) -> ErrorResult {
         if name
+            .str()
             .chars()
             .skip_while(|&ch| ch != '\u{2d}')
             .nth(1)
@@ -1044,6 +1045,7 @@ impl HTMLElement {
 
         // Step 2: Let position be a position variable for input, initially pointing at the start
         // of input.
+        let input = input.str();
         let mut position = input.chars().peekable();
 
         // Step 3: Let text be the empty string.

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -377,6 +377,8 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
             return None;
         }
 
+        #[allow(clippy::mutable_key_type)]
+        // See `impl Hash for DOMString`.
         let mut item_attr_values = HashSet::new();
         for attr_value in &atoms {
             item_attr_values.insert(DOMString::from(String::from(attr_value.trim())));
@@ -395,6 +397,8 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
             return None;
         }
 
+        #[allow(clippy::mutable_key_type)]
+        // See `impl Hash for DOMString`.
         let mut item_attr_values = HashSet::new();
         for attr_value in &atoms {
             item_attr_values.insert(DOMString::from(String::from(attr_value.trim())));

--- a/components/script/dom/html/htmlfontelement.rs
+++ b/components/script/dom/html/htmlfontelement.rs
@@ -182,7 +182,8 @@ fn parse_size(input: &DOMString) -> AttrValue {
     // Steps 1 & 2 are not relevant
 
     // Step 3
-    let input = input.str().trim_matches(HTML_SPACE_CHARACTERS);
+    let input = input.str();
+    let input = input.trim_matches(HTML_SPACE_CHARACTERS);
 
     enum ParseMode {
         RelativePlus,

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -312,7 +312,7 @@ impl HTMLIFrameElement {
         // Note: despite not being explicitly stated in the spec steps, this falls back to
         // document's referrer policy here because it satisfies the expectations that when unset,
         // the iframe should inherit the referrer policy of its parent
-        let referrer_policy = match ReferrerPolicy::from(referrer_policy_token.str()) {
+        let referrer_policy = match ReferrerPolicy::from(&*referrer_policy_token.str()) {
             ReferrerPolicy::EmptyString => document.get_referrer_policy(),
             policy => policy,
         };

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1045,7 +1045,7 @@ impl HTMLMediaElement {
                         SrcObject::Blob(blob) => {
                             let blob_url = URL::CreateObjectURL(&self.global(), blob);
                             *self.blob_url.borrow_mut() =
-                                Some(ServoUrl::parse(blob_url.str()).expect("infallible"));
+                                Some(ServoUrl::parse(&blob_url.str()).expect("infallible"));
                             self.fetch_request(None, None);
                         },
                         SrcObject::MediaStream(stream) => {
@@ -2350,7 +2350,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
     // https://html.spec.whatwg.org/multipage/#dom-navigator-canplaytype
     fn CanPlayType(&self, type_: DOMString) -> CanPlayTypeResult {
-        match ServoMedia::get().can_play_type(type_.str()) {
+        match ServoMedia::get().can_play_type(&type_.str()) {
             SupportsMediaType::No => CanPlayTypeResult::_empty,
             SupportsMediaType::Maybe => CanPlayTypeResult::Maybe,
             SupportsMediaType::Probably => CanPlayTypeResult::Probably,

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -170,7 +170,7 @@ impl HTMLMetaElement {
         if !content.is_empty() {
             // 3
             self.owner_document()
-                .shared_declarative_refresh_steps(content.as_bytes());
+                .shared_declarative_refresh_steps(&content.as_bytes());
         }
     }
 }

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -215,13 +215,13 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
 
             if node.is::<Text>() {
                 let characterdata = node.downcast::<CharacterData>().unwrap();
-                content.push_str(characterdata.Data().str());
+                content.push_str(&characterdata.Data().str());
             }
 
             iterator.next();
         }
 
-        DOMString::from(str_join(split_html_space_chars(content.str()), " "))
+        DOMString::from(str_join(split_html_space_chars(&content.str()), " "))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-option-text>

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -121,7 +121,7 @@ impl HTMLStyleElement {
                 global,
                 self.upcast(),
                 InlineCheckType::Style,
-                node.child_text_content().str(),
+                &node.child_text_content().str(),
             )
         {
             return;
@@ -132,14 +132,14 @@ impl HTMLStyleElement {
             .GetTextContent()
             .expect("Element.textContent must be a string");
         let shared_lock = node.owner_doc().style_shared_lock().clone();
-        let mq = Arc::new(shared_lock.wrap(self.create_media_list(self.Media().str())));
+        let mq = Arc::new(shared_lock.wrap(self.create_media_list(&self.Media().str())));
         let loader = ElementStylesheetLoader::new(self.upcast());
 
         let stylesheetcontents_create_callback = || {
             #[cfg(feature = "tracing")]
             let _span = tracing::trace_span!("ParseStylesheet", servo_profiling = true).entered();
             StylesheetContents::from_str(
-                data.str(),
+                &data.str(),
                 UrlExtraData(window.get_url().get_arc()),
                 Origin::Author,
                 &shared_lock,
@@ -156,7 +156,7 @@ impl HTMLStyleElement {
         // stylo's `CascadeDataCache` can now be significantly improved. When shared `StylesheetContents`
         // is modified, copy-on-write will occur, see `CSSStyleSheet::will_modify`.
         let (cache_key, contents) = StylesheetContentsCache::get_or_insert_with(
-            data.str(),
+            &data.str(),
             &shared_lock,
             UrlExtraData(window.get_url().get_arc()),
             doc.quirks_mode(),

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -52,7 +52,7 @@ pub(crate) struct HTMLTextAreaElement {
     htmlelement: HTMLElement,
     #[no_trace]
     textinput: DomRefCell<TextInput<EmbedderClipboardProvider>>,
-    placeholder: DomRefCell<DOMString>,
+    placeholder: DomRefCell<String>,
     // https://html.spec.whatwg.org/multipage/#concept-textarea-dirty
     value_dirty: Cell<bool>,
     form_owner: MutNullableDom<HTMLFormElement>,
@@ -88,7 +88,7 @@ impl<'dom> LayoutDom<'dom, HTMLTextAreaElement> {
     }
 
     fn placeholder(self) -> &'dom str {
-        unsafe { self.unsafe_get().placeholder.borrow_for_layout().str() }
+        unsafe { self.unsafe_get().placeholder.borrow_for_layout() }
     }
 }
 
@@ -153,7 +153,7 @@ impl HTMLTextAreaElement {
                 prefix,
                 document,
             ),
-            placeholder: DomRefCell::new(DOMString::new()),
+            placeholder: DomRefCell::new(String::new()),
             textinput: DomRefCell::new(TextInput::new(
                 Lines::Multiple,
                 DOMString::new(),

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -816,7 +816,7 @@ fn parse_a_margin(value: Option<&DOMString>) -> Result<IntersectionObserverMargi
     // <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserverinit-scrollmargin>
     // > ... defaulting to "0px".
     let value = match value {
-        Some(str) => str.str(),
+        Some(str) => &str.str(),
         _ => "0px",
     };
 

--- a/components/script/dom/keyboardevent.rs
+++ b/components/script/dom/keyboardevent.rs
@@ -265,7 +265,7 @@ impl KeyboardEventMethods<crate::DomTypeHolder> for KeyboardEvent {
 
     /// <https://w3c.github.io/uievents/#dom-keyboardevent-getmodifierstate>
     fn GetModifierState(&self, key_arg: DOMString) -> bool {
-        self.modifiers.get().contains(match key_arg.str() {
+        self.modifiers.get().contains(match &*key_arg.str() {
             "Alt" => Modifiers::ALT,
             "AltGraph" => Modifiers::ALT_GRAPH,
             "CapsLock" => Modifiers::CAPS_LOCK,

--- a/components/script/dom/medialist.rs
+++ b/components/script/dom/medialist.rs
@@ -164,7 +164,7 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
         let mut guard = self.shared_lock().write();
         let media_queries_borrowed = self.media_queries.borrow();
         let media_queries = media_queries_borrowed.write_with(&mut guard);
-        *media_queries = Self::parse_media_list(value.str(), global.as_window());
+        *media_queries = Self::parse_media_list(&value.str(), global.as_window());
         self.parent_stylesheet.notify_invalidations();
     }
 
@@ -198,7 +198,8 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
     fn AppendMedium(&self, medium: DOMString) {
         // Step 1
         let global = self.global();
-        let m = Self::parse_media_query(medium.str(), global.as_window());
+        let medium = medium.str();
+        let m = Self::parse_media_query(&medium, global.as_window());
         // Step 2
         if m.is_err() {
             return;
@@ -233,7 +234,8 @@ impl MediaListMethods<crate::DomTypeHolder> for MediaList {
     fn DeleteMedium(&self, medium: DOMString) {
         // Step 1
         let global = self.global();
-        let m = Self::parse_media_query(medium.str(), global.as_window());
+        let medium = medium.str();
+        let m = Self::parse_media_query(&medium, global.as_window());
         // Step 2
         if m.is_err() {
             return;

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -557,7 +557,7 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
 
     /// <https://w3c.github.io/uievents/#dom-mouseevent-getmodifierstate>
     fn GetModifierState(&self, key_arg: DOMString) -> bool {
-        self.modifiers.get().contains(match key_arg.str() {
+        self.modifiers.get().contains(match &*key_arg.str() {
             "Alt" => Modifiers::ALT,
             "AltGraph" => Modifiers::ALT_GRAPH,
             "CapsLock" => Modifiers::CAPS_LOCK,

--- a/components/script/dom/mutationobserver.rs
+++ b/components/script/dom/mutationobserver.rs
@@ -41,7 +41,7 @@ pub(crate) enum Mutation<'a> {
         old_value: Option<DOMString>,
     },
     CharacterData {
-        old_value: DOMString,
+        old_value: String,
     },
     ChildList {
         added: Option<&'a [&'a Node]>,
@@ -172,7 +172,8 @@ impl MutationObserver {
                         let mo = registered.observer.clone();
                         if registered.options.character_data_old_value {
                             // 3.2.3 ... type is "characterData" and options["characterDataOldValue"] is true
-                            interested_observers.insert(mo, Some(old_value.clone()));
+                            interested_observers
+                                .insert(mo, Some(DOMString::from(old_value.clone())));
                         } else {
                             // 3.2.2 If interestedObservers[mo] does not exist, then set interestedObservers[mo] to null.
                             interested_observers.entry(mo).or_insert(None);

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -4,6 +4,7 @@
 
 use std::cell::Cell;
 use std::convert::TryInto;
+use std::ops::Deref;
 use std::sync::{Arc, LazyLock, Mutex};
 
 use dom_struct::dom_struct;
@@ -393,7 +394,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
                 cors_mode = RequestMode::CorsMode;
                 // If contentType value is a CORS-safelisted request-header value for the Content-Type header,
                 // set corsMode to "no-cors".
-                if is_cors_safelisted_request_content_type(content_type.as_bytes()) {
+                if is_cors_safelisted_request_content_type(content_type.as_bytes().deref()) {
                     cors_mode = RequestMode::NoCors;
                 }
                 // Append a Content-Type header with value contentType to headerList.
@@ -402,7 +403,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
                 // since it lowercases `charset=UTF-8`: https://github.com/hyperium/mime/issues/116
                 headers.insert(
                     header::CONTENT_TYPE,
-                    HeaderValue::from_str(content_type.str()).unwrap(),
+                    HeaderValue::from_str(&content_type.str()).unwrap(),
                 );
             }
             request_body = Some(extracted_body.into_net_request_body().0);

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1128,7 +1128,7 @@ impl Node {
         // Step 1.
         let doc = self.owner_doc();
         match SelectorParser::parse_author_origin_no_namespace(
-            selectors.str(),
+            &selectors.str(),
             &UrlExtraData(doc.url().get_arc()),
         ) {
             // Step 2.
@@ -1165,7 +1165,7 @@ impl Node {
         // Step 1.
         let url = self.owner_doc().url();
         match SelectorParser::parse_author_origin_no_namespace(
-            selectors.str(),
+            &selectors.str(),
             &UrlExtraData(url.get_arc()),
         ) {
             // Step 2.
@@ -3077,7 +3077,7 @@ impl Node {
         let mut content = String::new();
         for node in iterator {
             if let Some(text) = node.downcast::<Text>() {
-                content.push_str(text.upcast::<CharacterData>().data().str());
+                content.push_str(&text.upcast::<CharacterData>().data());
             }
         }
         DOMString::from(content)
@@ -3664,7 +3664,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                         .move_to_text_child_at(self, index as u32, &node, length);
                     let sibling_cdata = sibling.downcast::<CharacterData>().unwrap();
                     length += sibling_cdata.Length();
-                    cdata.append_data(sibling_cdata.data().str());
+                    cdata.append_data(&sibling_cdata.data());
                     Node::remove(&sibling, self, SuppressObserver::Unsuppressed, can_gc);
                 }
             } else {

--- a/components/script/dom/performance.rs
+++ b/components/script/dom/performance.rs
@@ -489,7 +489,7 @@ impl PerformanceMethods<crate::DomTypeHolder> for Performance {
     fn Mark(&self, mark_name: DOMString, can_gc: CanGc) -> Fallible<()> {
         let global = self.global();
         // Step 1.
-        if global.is::<Window>() && INVALID_ENTRY_NAMES.contains(&mark_name.str()) {
+        if global.is::<Window>() && INVALID_ENTRY_NAMES.contains(&&*mark_name.str()) {
             return Err(Error::Syntax(None));
         }
 

--- a/components/script/dom/performanceobserver.rs
+++ b/components/script/dom/performanceobserver.rs
@@ -197,7 +197,7 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
             // Steps 6.1 - 6.2
             let entry_types = entry_types
                 .iter()
-                .filter(|e| VALID_ENTRY_TYPES.contains(&e.str()))
+                .filter(|e| VALID_ENTRY_TYPES.contains(&&*e.str()))
                 .cloned()
                 .collect::<Vec<DOMString>>();
 
@@ -219,7 +219,7 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
             Ok(())
         } else if let Some(entry_type) = &options.type_ {
             // Step 7.2
-            if !VALID_ENTRY_TYPES.contains(&entry_type.str()) {
+            if !VALID_ENTRY_TYPES.contains(&&*entry_type.str()) {
                 Console::internal_warn(
                     &self.global(),
                     DOMString::from("No valid entry type provided to observe()."),

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1077,7 +1077,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
             // Step 3.
             s.push_str(
-                char_data
+                &char_data
                     .SubstringData(
                         self.start_offset(),
                         char_data.Length() - self.start_offset(),
@@ -1095,14 +1095,14 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
         for child in iter {
             if self.contains(child.upcast()) {
-                s.push_str(child.upcast::<CharacterData>().Data().str());
+                s.push_str(&child.upcast::<CharacterData>().Data().str());
             }
         }
 
         // Step 5.
         if let Some(text_node) = end_node.downcast::<Text>() {
             let char_data = text_node.upcast::<CharacterData>();
-            s.push_str(char_data.SubstringData(0, self.end_offset()).unwrap().str());
+            s.push_str(&char_data.SubstringData(0, self.end_offset()).unwrap().str());
         }
 
         // Step 6.

--- a/components/script/dom/reportingendpoint.rs
+++ b/components/script/dom/reportingendpoint.rs
@@ -129,6 +129,8 @@ impl SendReportsToEndpoints for GlobalScope {
         endpoints: Vec<ReportingEndpoint>,
     ) {
         // Step 1. Let endpoint map be an empty map of endpoint objects to lists of report objects.
+        #[allow(clippy::mutable_key_type)]
+        // See `impl Hash for DOMString`.
         let mut endpoint_map: HashMap<&ReportingEndpoint, Vec<Report>> = HashMap::new();
         // Step 2. For each report in reports:
         reports.retain(|report| {

--- a/components/script/dom/reportingendpoint.rs
+++ b/components/script/dom/reportingendpoint.rs
@@ -154,7 +154,7 @@ impl SendReportsToEndpoints for GlobalScope {
             let mut origin_map: HashMap<ImmutableOrigin, Vec<&Report>> = HashMap::new();
             // Step 3.2. For each report in report list:
             for report in report_list {
-                let Ok(url) = ServoUrl::parse(report.url.str()) else {
+                let Ok(url) = ServoUrl::parse(&report.url.str()) else {
                     continue;
                 };
                 // Step 3.2.1. Let origin be the origin of report’s url.

--- a/components/script/dom/reportingobserver.rs
+++ b/components/script/dom/reportingobserver.rs
@@ -67,7 +67,7 @@ impl ReportingObserver {
     }
 
     fn report_is_visible_to_reporting_observers(report: &Report) -> bool {
-        match report.type_.str() {
+        match &*report.type_.str() {
             // https://w3c.github.io/webappsec-csp/#reporting
             "csp-violation" => true,
             _ => false,

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -473,7 +473,7 @@ impl Request {
                     // In Servo r.Headers's header list isn't a pointer to
                     // the same actual list as r.request's, and so we need to
                     // append to both lists to keep them in sync.
-                    if let Ok(v) = HeaderValue::from_bytes(ct_header_val) {
+                    if let Ok(v) = HeaderValue::from_bytes(&ct_header_val) {
                         r.request
                             .borrow_mut()
                             .headers

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -303,23 +303,23 @@ pub(crate) fn serialize_html_fragment<S: Serializer>(
             SerializationCommand::SerializeNonelement(n) => match n.type_id() {
                 NodeTypeId::DocumentType => {
                     let doctype = n.downcast::<DocumentType>().unwrap();
-                    serializer.write_doctype(doctype.name().str())?;
+                    serializer.write_doctype(&doctype.name().str())?;
                 },
 
                 NodeTypeId::CharacterData(CharacterDataTypeId::Text(_)) => {
                     let cdata = n.downcast::<CharacterData>().unwrap();
-                    serializer.write_text(cdata.data().str())?;
+                    serializer.write_text(&cdata.data())?;
                 },
 
                 NodeTypeId::CharacterData(CharacterDataTypeId::Comment) => {
                     let cdata = n.downcast::<CharacterData>().unwrap();
-                    serializer.write_comment(cdata.data().str())?;
+                    serializer.write_comment(&cdata.data())?;
                 },
 
                 NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) => {
                     let pi = n.downcast::<ProcessingInstruction>().unwrap();
                     let data = pi.upcast::<CharacterData>().data();
-                    serializer.write_processing_instruction(pi.target().str(), data.str())?;
+                    serializer.write_processing_instruction(&pi.target().str(), &data)?;
                 },
 
                 NodeTypeId::DocumentFragment(_) | NodeTypeId::Attr => {},

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1743,7 +1743,7 @@ fn create_element_for_token(
     let is = attrs
         .iter()
         .find(|attr| attr.name.local.eq_str_ignore_ascii_case("is"))
-        .map(|attr| LocalName::from(attr.value.str()));
+        .map(|attr| LocalName::from(&attr.value));
 
     // Step 4.
     let definition = document.lookup_custom_element_definition(&name.ns, &name.local, is.as_ref());

--- a/components/script/dom/stylepropertymapreadonly.rs
+++ b/components/script/dom/stylepropertymapreadonly.rs
@@ -90,13 +90,13 @@ impl StylePropertyMapReadOnlyMethods<crate::DomTypeHolder> for StylePropertyMapR
         // https://drafts.css-houdini.org/css-typed-om-1/#dom-stylepropertymap-getproperties
         // requires this sort order
         result.sort_by(|key1, key2| {
-            if let Ok(key1) = custom_properties::parse_name(key1.str()) {
-                if let Ok(key2) = custom_properties::parse_name(key2.str()) {
+            if let Ok(key1) = custom_properties::parse_name(&key1.str()) {
+                if let Ok(key2) = custom_properties::parse_name(&key2.str()) {
                     key1.cmp(key2)
                 } else {
                     Ordering::Greater
                 }
-            } else if custom_properties::parse_name(key2.str()).is_ok() {
+            } else if custom_properties::parse_name(&key2.str()).is_ok() {
                 Ordering::Less
             } else {
                 key1.cmp(key2)

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -2636,7 +2636,7 @@ impl SubtleCrypto {
 
                 // Step 2.4. Let data be the byte sequence obtained by decoding the k field of jwk.
                 data = base64::engine::general_purpose::STANDARD_NO_PAD
-                    .decode(jwk.k.as_ref().ok_or(Error::Data)?.as_bytes())
+                    .decode(&*jwk.k.as_ref().ok_or(Error::Data)?.as_bytes())
                     .map_err(|_| Error::Data)?;
 
                 // NOTE: This function is shared by AES-CBC, AES-CTR, AES-GCM and AES-KW.
@@ -2979,7 +2979,7 @@ impl SubtleCrypto {
 
                 // Step 2.4. Let data be the byte sequence obtained by decoding the k field of jwk.
                 data = base64::engine::general_purpose::STANDARD_NO_PAD
-                    .decode(jwk.k.as_ref().ok_or(Error::Data)?.as_bytes())
+                    .decode(&*jwk.k.as_ref().ok_or(Error::Data)?.as_bytes())
                     .map_err(|_| Error::Data)?;
 
                 // Step 2.5. Set the hash to equal the hash member of normalizedAlgorithm.
@@ -3685,7 +3685,7 @@ impl JsonWebKeyExt for JsonWebKey {
     fn get_usages_from_key_ops(&self) -> Result<Vec<KeyUsage>, Error> {
         let mut usages = vec![];
         for op in self.key_ops.as_ref().ok_or(Error::Data)? {
-            usages.push(KeyUsage::from_str(op.str()).map_err(|_| Error::Data)?);
+            usages.push(KeyUsage::from_str(&op.str()).map_err(|_| Error::Data)?);
         }
         Ok(usages)
     }
@@ -3786,7 +3786,7 @@ fn normalize_algorithm(
             //     Otherwise:
             //         Return a new NotSupportedError and terminate this algorithm.
             let Some(&alg_name) = SUPPORTED_ALGORITHMS.iter().find(|supported_algorithm| {
-                supported_algorithm.eq_ignore_ascii_case(initial_alg.name.str())
+                supported_algorithm.eq_ignore_ascii_case(&initial_alg.name.str())
             }) else {
                 return Err(Error::NotSupported);
             };

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -23,7 +23,7 @@ pub(crate) fn sign(key: &CryptoKey, message: &[u8], can_gc: CanGc) -> Result<Vec
     let cx = GlobalScope::get_cx();
     rooted!(in(*cx) let mut algorithm_slot = ObjectValue(key.Algorithm(cx).as_ptr()));
     let params = value_from_js_object::<HmacKeyAlgorithm>(cx, algorithm_slot.handle(), can_gc)?;
-    let hash_algorithm = match params.hash.name.str() {
+    let hash_algorithm = match &*params.hash.name.str() {
         ALG_SHA1 => hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
         ALG_SHA256 => hmac::HMAC_SHA256,
         ALG_SHA384 => hmac::HMAC_SHA384,
@@ -50,7 +50,7 @@ pub(crate) fn verify(
     let cx = GlobalScope::get_cx();
     rooted!(in(*cx) let mut algorithm_slot = ObjectValue(key.Algorithm(cx).as_ptr()));
     let params = value_from_js_object::<HmacKeyAlgorithm>(cx, algorithm_slot.handle(), can_gc)?;
-    let hash_algorithm = match params.hash.name.str() {
+    let hash_algorithm = match &*params.hash.name.str() {
         ALG_SHA1 => hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY,
         ALG_SHA256 => hmac::HMAC_SHA256,
         ALG_SHA384 => hmac::HMAC_SHA384,

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -882,14 +882,14 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     fn PassVariadicObject(&self, _: SafeJSContext, _: Vec<*mut JSObject>) {}
     fn BooleanMozPreference(&self, pref_name: DOMString) -> bool {
         prefs::get()
-            .get_value(pref_name.str())
+            .get_value(&pref_name.str())
             .try_into()
             .unwrap_or(false)
     }
     fn StringMozPreference(&self, pref_name: DOMString) -> DOMString {
         DOMString::from_string(
             prefs::get()
-                .get_value(pref_name.str())
+                .get_value(&pref_name.str())
                 .try_into()
                 .unwrap_or_default(),
         )

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -117,7 +117,7 @@ impl TextMethods<crate::DomTypeHolder> for Text {
         let mut text = String::new();
         for ref node in nodes {
             let cdata = node.downcast::<CharacterData>().unwrap();
-            text.push_str(cdata.data().str());
+            text.push_str(&cdata.data());
         }
         DOMString::from(text)
     }

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -79,7 +79,7 @@ impl TextDecoderMethods<crate::DomTypeHolder> for TextDecoder {
         label: DOMString,
         options: &TextDecoderBinding::TextDecoderOptions,
     ) -> Fallible<DomRoot<TextDecoder>> {
-        let encoding = match Encoding::for_label_no_replacement(label.as_bytes()) {
+        let encoding = match Encoding::for_label_no_replacement(&label.as_bytes()) {
             None => return TextDecoder::make_range_error(),
             Some(enc) => enc,
         };

--- a/components/script/dom/textdecoderstream.rs
+++ b/components/script/dom/textdecoderstream.rs
@@ -157,7 +157,7 @@ impl TextDecoderStreamMethods<crate::DomTypeHolder> for TextDecoderStream {
         label: DOMString,
         options: &TextDecoderBinding::TextDecoderOptions,
     ) -> Fallible<DomRoot<TextDecoderStream>> {
-        let encoding = match Encoding::for_label_no_replacement(label.as_bytes()) {
+        let encoding = match Encoding::for_label_no_replacement(&label.as_bytes()) {
             Some(enc) => enc,
             None => {
                 return Err(Error::Range(

--- a/components/script/dom/trustedhtml.rs
+++ b/components/script/dom/trustedhtml.rs
@@ -70,7 +70,7 @@ impl TrustedHTML {
 impl fmt::Display for TrustedHTML {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.data.str())
+        f.write_str(&self.data.str())
     }
 }
 

--- a/components/script/dom/trustedscript.rs
+++ b/components/script/dom/trustedscript.rs
@@ -150,14 +150,14 @@ impl TrustedScript {
         };
         global
             .get_csp_list()
-            .is_js_evaluation_allowed(global, source_string.str())
+            .is_js_evaluation_allowed(global, &source_string.str())
     }
 }
 
 impl fmt::Display for TrustedScript {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.data.str())
+        f.write_str(&self.data.str())
     }
 }
 

--- a/components/script/dom/trustedscripturl.rs
+++ b/components/script/dom/trustedscripturl.rs
@@ -70,7 +70,7 @@ impl TrustedScriptURL {
 impl fmt::Display for TrustedScriptURL {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.data.str())
+        f.write_str(&self.data.str())
     }
 }
 

--- a/components/script/dom/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypepolicyfactory.rs
@@ -320,7 +320,7 @@ impl TrustedTypePolicyFactory {
                         global,
                         sink,
                         sink_group,
-                        input.str(),
+                        &input.str(),
                     );
                 // Step 6.2: If disposition is “Allowed”, return stringified input and abort further steps.
                 if !is_blocked {

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -199,7 +199,7 @@ impl URLMethods<crate::DomTypeHolder> for URL {
         // this method call does nothing. User agents may display a message on the error console.
         let origin = get_blob_origin(&global.get_url());
 
-        if let Ok(url) = ServoUrl::parse(url.str()) {
+        if let Ok(url) = ServoUrl::parse(&url.str()) {
             if url.fragment().is_none() && origin == get_blob_origin(&url) {
                 if let Ok((id, _)) = parse_blob_url(&url) {
                     let resource_threads = global.resource_threads();

--- a/components/script/dom/webgl/webglprogram.rs
+++ b/components/script/dom/webgl/webglprogram.rs
@@ -439,7 +439,7 @@ impl WebGLProgram {
             let uniforms = self.active_uniforms.borrow();
             match uniforms
                 .iter()
-                .find(|attrib| &*attrib.base_name == base_name)
+                .find(|attrib| *attrib.base_name == base_name)
             {
                 Some(uniform) if array_index.is_none() || array_index < uniform.size => (
                     uniform
@@ -683,7 +683,7 @@ fn validate_glsl_name(name: &DOMString) -> WebGLResult<bool> {
     if name.len() > MAX_UNIFORM_AND_ATTRIBUTE_LEN {
         return Err(WebGLError::InvalidValue);
     }
-    for c in name.chars() {
+    for c in name.str().chars() {
         validate_glsl_char(c)?;
     }
     if name.starts_with_str("webgl_") || name.starts_with_str("_webgl_") {
@@ -732,16 +732,16 @@ fn validate_glsl_char(c: char) -> WebGLResult<()> {
     }
 }
 
-fn parse_uniform_name(name: &DOMString) -> Option<(&str, Option<i32>)> {
+fn parse_uniform_name(name: &DOMString) -> Option<(String, Option<i32>)> {
     let name = name.str();
     if !name.ends_with(']') {
-        return Some((name, None));
+        return Some((String::from(name), None));
     }
     let bracket_pos = name[..name.len() - 1].rfind('[')?;
     let index = name[(bracket_pos + 1)..(name.len() - 1)]
         .parse::<i32>()
         .ok()?;
-    Some((&name[..bracket_pos], Some(index)))
+    Some((String::from(&name[..bracket_pos]), Some(index)))
 }
 
 pub(crate) const MAX_UNIFORM_AND_ATTRIBUTE_LEN: usize = 256;

--- a/components/script/dom/webgl/webglshader.rs
+++ b/components/script/dom/webgl/webglshader.rs
@@ -206,7 +206,7 @@ impl WebGLShader {
             options.set_clampIndirectArrayBounds(1);
         }
 
-        match validator.compile(&[source.str()], options) {
+        match validator.compile(&[&source.str()], options) {
             Ok(()) => {
                 let translated_source = validator.object_code();
                 debug!("Shader translated: {}", translated_source);

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -139,7 +139,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
         let mut required_limits = wgpu_types::Limits::default();
         if let Some(limits) = &descriptor.requiredLimits {
             for (limit, value) in (*limits).iter() {
-                if !set_limit(&mut required_limits, limit.str(), *value) {
+                if !set_limit(&mut required_limits, &limit.str(), *value) {
                     warn!("Unknown GPUDevice limit: {limit}");
                     promise.reject_error(Error::Operation, can_gc);
                     return promise;

--- a/components/script/dom/webrtc/rtcdatachannel.rs
+++ b/components/script/dom/webrtc/rtcdatachannel.rs
@@ -204,7 +204,7 @@ impl RTCDataChannel {
             DataChannelMessage::Text(text) => {
                 text.safe_to_jsval(cx, message.handle_mut());
             },
-            DataChannelMessage::Binary(data) => match self.binary_type.borrow().str() {
+            DataChannelMessage::Binary(data) => match &*self.binary_type.borrow().str() {
                 "blob" => {
                     let blob = Blob::new(
                         &global,

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -190,7 +190,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
         // Step 1. Let baseURL be this's relevant settings object's API base URL.
         // Step 2. Let urlRecord be the result of applying the URL parser to url with baseURL.
         // Step 3. If urlRecord is failure, then throw a "SyntaxError" DOMException.
-        let mut url_record = ServoUrl::parse(url.str()).or(Err(Error::Syntax(None)))?;
+        let mut url_record = ServoUrl::parse(&url.str()).or(Err(Error::Syntax(None)))?;
 
         // Step 4. If urlRecord’s scheme is "http", then set urlRecord’s scheme to "ws".
         // Step 5. Otherwise, if urlRecord’s scheme is "https", set urlRecord’s scheme to "wss".

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -847,14 +847,18 @@ pub(crate) fn base64_btoa(input: DOMString) -> Fallible<DOMString> {
     // "The btoa() method must throw an InvalidCharacterError exception if
     //  the method's first argument contains any character whose code point
     //  is greater than U+00FF."
-    if input.chars().any(|c: char| c > '\u{FF}') {
+    if input.str().chars().any(|c: char| c > '\u{FF}') {
         Err(Error::InvalidCharacter)
     } else {
         // "Otherwise, the user agent must convert that argument to a
         //  sequence of octets whose nth octet is the eight-bit
         //  representation of the code point of the nth character of
         //  the argument,"
-        let octets = input.chars().map(|c: char| c as u8).collect::<Vec<u8>>();
+        let octets = input
+            .str()
+            .chars()
+            .map(|c: char| c as u8)
+            .collect::<Vec<u8>>();
 
         // "and then must apply the base64 algorithm to that sequence of
         //  octets, and return the result. [RFC4648]"
@@ -872,6 +876,7 @@ pub(crate) fn base64_atob(input: DOMString) -> Fallible<DOMString> {
         HTML_SPACE_CHARACTERS.contains(&c)
     }
     let without_spaces = input
+        .str()
         .chars()
         .filter(|&c| !is_html_space(c))
         .collect::<String>();
@@ -1645,7 +1650,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             return None;
         }
 
-        if self.webview_id().to_string() == webview_id.str() {
+        if self.webview_id().to_string() == webview_id {
             Some(DomRoot::from_ref(&window_proxy))
         } else {
             None
@@ -1917,7 +1922,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
     // https://drafts.csswg.org/cssom-view/#dom-window-matchmedia
     fn MatchMedia(&self, query: DOMString) -> DomRoot<MediaQueryList> {
-        let media_query_list = MediaList::parse_media_list(query.str(), self);
+        let media_query_list = MediaList::parse_media_list(&query.str(), self);
         let document = self.Document();
         let mql = MediaQueryList::new(&document, media_query_list, CanGc::note());
         self.media_query_lists.track(&*mql);

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -495,9 +495,10 @@ impl WindowProxy {
         can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<WindowProxy>>> {
         // Step 5. If target is the empty string, then set target to "_blank".
-        let non_empty_target = match target.str() {
-            "" => DOMString::from("_blank"),
-            _ => target,
+        let non_empty_target = if target.is_empty() {
+            DOMString::from("_blank")
+        } else {
+            target
         };
         // Step 6. Let tokenizedFeatures be the result of tokenizing features.
         let tokenized_features = tokenize_open_features(features);
@@ -836,6 +837,7 @@ fn tokenize_open_features(features: DOMString) -> IndexMap<String, String> {
     // Step 1
     let mut tokenized_features = IndexMap::new();
     // Step 2
+    let features = features.str();
     let mut iter = features.chars();
     let mut cur = iter.next();
 

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -177,7 +177,7 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
             can_gc,
         )?;
         // Step 2-4.
-        let worker_url = match global.api_base_url().join(compliant_script_url.str()) {
+        let worker_url = match global.api_base_url().join(&compliant_script_url.str()) {
             Ok(url) => url,
             Err(_) => return Err(Error::Syntax(None)),
         };

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -394,7 +394,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
                 "importScripts",
                 can_gc,
             )?;
-            let url = self.worker_url.borrow().join(url.str());
+            let url = self.worker_url.borrow().join(&url.str());
             match url {
                 Ok(url) => urls.push(url),
                 Err(_) => return Err(Error::Syntax(None)),
@@ -663,7 +663,7 @@ impl WorkerGlobalScope {
         options.set_introduction_type(IntroductionType::WORKER);
         match self.runtime.borrow().as_ref().unwrap().evaluate_script(
             self.reflector().get_jsobject(),
-            source.str(),
+            &source.str(),
             rval.handle_mut(),
             options,
         ) {

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -552,7 +552,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         // Step 4 (first half)
         let mut extracted_or_serialized = match data {
             Some(DocumentOrXMLHttpRequestBodyInit::Document(ref doc)) => {
-                let bytes = Vec::from(serialize_document(doc)?.str());
+                let bytes = Vec::from(&*serialize_document(doc)?.as_bytes());
                 let content_type = if doc.is_html_document() {
                     "text/html;charset=UTF-8"
                 } else {
@@ -720,7 +720,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
             if !request.headers.contains_key(header::CONTENT_TYPE) {
                 request.headers.insert(
                     header::CONTENT_TYPE,
-                    HeaderValue::from_str(content_type.str()).unwrap(),
+                    HeaderValue::from_str(&content_type.str()).unwrap(),
                 );
                 content_type_set = true;
             }

--- a/components/script/dom/xpathevaluator.rs
+++ b/components/script/dom/xpathevaluator.rs
@@ -70,7 +70,7 @@ impl XPathEvaluatorMethods<crate::DomTypeHolder> for XPathEvaluator {
         // NB: this function is *not* Fallible according to the spec, so we swallow any parsing errors and
         // just pass a None as the expression... it's not great.
         let parsed_expression =
-            xpath::parse::<()>(expression.str()).map_err(|_e| Error::Syntax(None))?;
+            xpath::parse::<()>(&expression.str()).map_err(|_e| Error::Syntax(None))?;
         Ok(XPathExpression::new(
             window,
             None,
@@ -98,7 +98,7 @@ impl XPathEvaluatorMethods<crate::DomTypeHolder> for XPathEvaluator {
         let global = self.global();
         let window = global.as_window();
         let parsed_expression =
-            xpath::parse::<()>(expression_str.str()).map_err(|_| Error::Syntax(None))?;
+            xpath::parse::<()>(&expression_str.str()).map_err(|_| Error::Syntax(None))?;
         let expression = XPathExpression::new(window, None, can_gc, parsed_expression);
         expression.evaluate_internal(context_node, result_type, result, resolver, can_gc)
     }

--- a/components/script/drag_data_store.rs
+++ b/components/script/drag_data_store.rs
@@ -279,7 +279,7 @@ fn normalize_mime(mut format: DOMString) -> DOMString {
     // Convert format to ASCII lowercase.
     format.make_ascii_lowercase();
 
-    match format.str() {
+    match &*format.str() {
         // If format equals "text", change it to "text/plain".
         "text" => DOMString::from("text/plain"),
         // If format equals "url", change it to "text/uri-list".

--- a/components/script/indexed_db.rs
+++ b/components/script/indexed_db.rs
@@ -106,10 +106,11 @@ pub(crate) fn is_valid_key_path(key_path: &StrOrStringSequence) -> Result<bool, 
 
         // An identifier, which is a string matching the IdentifierName production from the
         // ECMAScript Language Specification [ECMA-262].
-        let is_identifier = is_identifier_name(path.str())?;
+        let is_identifier = is_identifier_name(&path.str())?;
 
         // A string consisting of two or more identifiers separated by periods (U+002E FULL STOP).
         let is_identifier_list = path
+            .str()
             .split('.')
             .map(is_identifier_name)
             .try_collect::<bool, Vec<bool>, Error>()?
@@ -367,7 +368,7 @@ pub(crate) fn evaluate_key_path_on_value(
             // Step 3. Let identifiers be the result of strictly splitting keyPath on U+002E
             // FULL STOP characters (.).
             // Step 4. For each identifier of identifiers, jump to the appropriate step below:
-            for identifier in key_path.split('.') {
+            for identifier in key_path.str().split('.') {
                 // If Type(value) is String, and identifier is "length"
                 if identifier == "length" && current_value.is_string() {
                     // Let value be a Number equal to the number of elements in value.

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -415,7 +415,7 @@ pub(crate) fn follow_hyperlink(
         if let Some(suffix) = hyperlink_suffix {
             href.push_str(&suffix);
         }
-        let Ok(url) = document.base_url().join(href.str()) else {
+        let Ok(url) = document.base_url().join(&href.str()) else {
             return;
         };
 

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -465,7 +465,7 @@ impl JsTimers {
                 // If this throws an exception, catch it, report it for global, and abort these steps.
                 if global
                     .get_csp_list()
-                    .is_js_evaluation_allowed(global, code_str.str())
+                    .is_js_evaluation_allowed(global, &code_str.str())
                 {
                     // Step 9.6.2. Assert: handler is a string.
                     InternalTimerCallback::StringTimerCallback(code_str)
@@ -611,7 +611,7 @@ impl JsTimerTask {
                 //
                 // FIXME(cybai): Use base url properly by saving private reference for timers (#27260)
                 _ = global.evaluate_js_on_global_with_result(
-                    code_str.str(),
+                    &code_str.str(),
                     rval.handle_mut(),
                     ScriptFetchOptions::default_classic_script(&global),
                     // Step 9.6. Let base URL be settings object's API base URL.

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -16,6 +16,7 @@ name = "script_bindings"
 path = "lib.rs"
 
 [dependencies]
+ascii = { workspace = true }
 bitflags = { workspace = true }
 crossbeam-channel = { workspace = true }
 cssparser = { workspace = true }

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -16,7 +16,6 @@ name = "script_bindings"
 path = "lib.rs"
 
 [dependencies]
-ascii = { workspace = true }
 bitflags = { workspace = true }
 crossbeam-channel = { workspace = true }
 cssparser = { workspace = true }

--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -2963,7 +2963,7 @@ def DomTypes(descriptors: list[Descriptor],
     elements += [CGGeneric("}\n")]
     imports = [
         CGGeneric("use crate::root::DomRoot;\n"),
-        CGGeneric("use crate::str::DOMString;\n"),
+        CGGeneric("use crate::domstring::DOMString;\n"),
     ]
     return CGList(imports + elements)
 

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -72,13 +72,6 @@ pub enum StringificationBehavior {
     Empty,
 }
 
-// https://heycam.github.io/webidl/#es-DOMString
-impl ToJSValConvertible for DOMString {
-    unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
-        self.str().to_jsval(cx, rval);
-    }
-}
-
 /// A safe wrapper for `FromJSValConvertible`.
 pub trait SafeFromJSValConvertible: Sized {
     type Config;

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -1,0 +1,628 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::borrow::{Cow, ToOwned};
+use std::default::Default;
+use std::ops::Deref;
+use std::str::{CharIndices, EncodeUtf16, FromStr};
+use std::sync::LazyLock;
+use std::{fmt, str};
+
+use ascii::ToAsciiChar;
+use html5ever::{LocalName, Namespace};
+use js::conversions::ToJSValConvertible;
+use js::gc::MutableHandleValue;
+use js::jsapi::JSContext;
+use num_traits::Zero;
+use regex::Regex;
+use style::Atom;
+use style::str::HTML_SPACE_CHARACTERS;
+
+use crate::domstring::domstring_inner::DOMStringInner;
+
+#[allow(unused)]
+fn char_to_latin1_u8(c: char) -> u8 {
+    c.to_ascii_char().unwrap().into()
+}
+
+#[allow(unused)]
+fn latin1_u8_to_char(c: u8) -> char {
+    c.to_ascii_char().unwrap().into()
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum EncodedBytes<'a> {
+    Latin1Bytes(&'a [u8]),
+    Utf8Bytes(&'a str),
+}
+
+impl<'a> PartialEq<str> for EncodedBytes<'a> {
+    fn eq(&self, other: &str) -> bool {
+        match self {
+            EncodedBytes::Utf8Bytes(s) => *s == other,
+            EncodedBytes::Latin1Bytes(s) => {
+                let v = s.iter().map(|c| *c as char as u8).collect::<Vec<u8>>();
+                v == *s
+            },
+        }
+    }
+}
+
+impl<'a> PartialEq<&str> for EncodedBytes<'a> {
+    fn eq(&self, other: &&str) -> bool {
+        match self {
+            EncodedBytes::Utf8Bytes(s) => s == other,
+            EncodedBytes::Latin1Bytes(s) => {
+                let v = s.iter().map(|c| *c as char as u8).collect::<Vec<u8>>();
+                &String::from_utf8(v).unwrap() == other
+            },
+        }
+    }
+}
+
+impl<'a> PartialEq<&str> for Box<EncodedBytes<'a>> {
+    fn eq(&self, other: &&str) -> bool {
+        match self.deref() {
+            EncodedBytes::Utf8Bytes(s) => s == other,
+            EncodedBytes::Latin1Bytes(s) => {
+                let v = s.iter().map(|c| *c as char as u8).collect::<Vec<u8>>();
+                &String::from_utf8(v).unwrap() == other
+            },
+        }
+    }
+}
+
+/// We encapsulate the `dangerous methods` in the inner mod. You should use
+/// bytes set_rust_string or get_rust_string.
+mod domstring_inner {
+    use std::cell::OnceCell;
+    use std::ptr::NonNull;
+    use std::{fmt, ptr, slice};
+
+    use js::conversions::jsstr_to_string;
+    use js::jsapi::{Heap, JS_GetLatin1StringCharsAndLength, JSContext, JSString};
+    use js::rust::Trace;
+    use malloc_size_of::MallocSizeOfOps;
+
+    use super::EncodedBytes;
+    use crate::trace::RootedTraceableBox;
+
+    pub(super) struct DOMStringInner {
+        rust_string: OnceCell<String>,
+        js_context: Option<*mut JSContext>,
+        js_string: Option<RootedTraceableBox<Heap<*mut JSString>>>,
+    }
+
+    /// Safety comment: ??
+    ///
+    /// This method will _not_ trace the pointer if the rust string exists.
+    /// The js string could be garbage collected and, hence, violating this
+    /// could lead to undefined behavior
+    unsafe impl Trace for DOMStringInner {
+        unsafe fn trace(&self, tracer: *mut js::jsapi::JSTracer) {
+            if self.rust_string.get().is_none() {
+                if let Some(ref s) = self.js_string {
+                    unsafe {
+                        s.trace(tracer);
+                    }
+                }
+            }
+        }
+    }
+
+    impl malloc_size_of::MallocSizeOf for DOMStringInner {
+        fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+            if let Some(s) = self.rust_string.get() {
+                s.size_of(ops)
+            } else {
+                // Managed by JS Engine
+                0
+            }
+        }
+    }
+
+    impl std::fmt::Debug for DOMStringInner {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("LazyDOMString")
+                .field("rust_string", &self.rust_string)
+                .finish()
+        }
+    }
+
+    impl Clone for DOMStringInner {
+        fn clone(&self) -> Self {
+            self.make_me_string();
+            Self {
+                rust_string: self.rust_string.clone(),
+                js_context: None,
+                js_string: None,
+            }
+        }
+    }
+
+    impl DOMStringInner {
+        pub(super) fn new() -> DOMStringInner {
+            DOMStringInner {
+                rust_string: OnceCell::from(String::new()),
+                js_context: None,
+                js_string: None,
+            }
+        }
+
+        /// This method will do some work if necessary but not an allocation.
+        /// It returns the bytes either in Utf8 or Latin1 encoded, depending on the
+        /// raw mozjs string.
+        #[allow(unused)]
+        pub(super) fn bytes<'a>(&'a self) -> EncodedBytes<'a> {
+            self.debug_js();
+            match self.rust_string.get() {
+                Some(s) => EncodedBytes::Utf8Bytes(s.as_str()),
+                None => {
+                    let mut length = 0;
+                    unsafe {
+                        let chars = JS_GetLatin1StringCharsAndLength(
+                            self.js_context.unwrap(),
+                            ptr::null(),
+                            self.js_string.as_ref().unwrap().get(),
+                            &mut length,
+                        );
+                        assert!(!chars.is_null());
+
+                        EncodedBytes::Latin1Bytes(slice::from_raw_parts(chars, length))
+                    }
+                },
+            }
+        }
+
+        /// Panics if it is already set.
+        pub(super) fn set_rust_string(&mut self, s: String) {
+            let _ = self.rust_string.set(s);
+        }
+
+        /// Converts into a rust string and takes it.
+        pub(super) fn take_rust_string(mut self) -> String {
+            self.make_me_string();
+            self.rust_string.take().unwrap()
+        }
+
+        /// Convert the mozjs string to a rust string if necessary and safe the result.
+        /// Returns the &str
+        pub(super) fn make_me_string(&self) -> &str {
+            self.rust_string.get_or_init(|| unsafe {
+                jsstr_to_string(
+                    self.js_context.unwrap(),
+                    NonNull::new(self.js_string.as_ref().unwrap().get()).unwrap(),
+                )
+            })
+        }
+
+        /// Converts to rust string and returns `&mut String` of it.`
+        pub(super) fn make_me_string_mut(&mut self) -> &mut String {
+            self.make_me_string();
+            self.rust_string.get_mut().unwrap()
+        }
+
+        /// Take the jsstring. If it only has Latin1 characters, we store the ptr in a Heap::boxed
+        /// Otherwise we convert the string to a rust string.
+        pub(super) unsafe fn from_js_string(
+            cx: *mut JSContext,
+            value: js::gc::HandleValue,
+        ) -> DOMStringInner {
+            let string_ptr = unsafe { js::rust::ToString(cx, value) };
+            if !string_ptr.is_null() {
+                let latin1 = unsafe { js::jsapi::JS_DeprecatedStringHasLatin1Chars(string_ptr) };
+                if latin1 {
+                    let h = RootedTraceableBox::from_box(Heap::boxed(string_ptr));
+                    DOMStringInner {
+                        rust_string: OnceCell::new(),
+                        js_context: Some(cx),
+                        js_string: Some(h),
+                    }
+                } else {
+                    // We need to convert the string anyway as it is not just latin1
+                    DOMStringInner::from_string(unsafe {
+                        jsstr_to_string(cx, ptr::NonNull::new(string_ptr).unwrap())
+                    })
+                }
+            } else {
+                DOMStringInner::from_string(String::new())
+            }
+        }
+
+        /// Creates a new `DOMString` from a `String`.
+        pub fn from_string(s: String) -> DOMStringInner {
+            DOMStringInner {
+                rust_string: OnceCell::from(s),
+                js_context: None,
+                js_string: None,
+            }
+        }
+
+        /// Debug the current  state of the string
+        #[allow(unused)]
+        fn debug_js(&self) {
+            if self.js_string.is_some() && self.rust_string.get().is_none() {
+                unsafe {
+                    println!(
+                        "jsstring {:?}",
+                        jsstr_to_string(
+                            self.js_context.unwrap(),
+                            ptr::NonNull::new(self.js_string.as_ref().unwrap().get()).unwrap()
+                        )
+                    );
+                }
+            } else {
+                println!("only rust string {:?}", self.rust_string.get().unwrap());
+            }
+        }
+
+        /// Clears the string.
+        pub(super) fn clear(&mut self) {
+            if let Some(val) = self.rust_string.get_mut() {
+                val.clear();
+            } else {
+                self.rust_string
+                    .set(String::new())
+                    .expect("Error in clearing");
+            }
+        }
+    }
+}
+
+////// A DOMString.
+///
+/// This type corresponds to the [`DOMString`] type in WebIDL.
+///
+/// [`DOMString`]: https://webidl.spec.whatwg.org/#idl-DOMString
+///
+/// Conceptually, a DOMString has the same value space as a JavaScript String,
+/// i.e., an array of 16-bit *code units* representing UTF-16, potentially with
+/// unpaired surrogates present (also sometimes called WTF-16).
+///
+/// However, Rust `String`s are guaranteed to be valid UTF-8, and as such have
+/// a *smaller value space* than WTF-16 (i.e., some JavaScript String values
+/// can not be represented as a Rust `String`). This introduces the question of
+/// what to do with values being passed from JavaScript to Rust that contain
+/// unpaired surrogates.
+///
+/// The hypothesis is that it does not matter much how exactly those values are
+/// transformed, because  passing unpaired surrogates into the DOM is very rare.
+/// Instead Servo withh replace the unpaired surrogate by a U+FFFD replacement
+/// character.
+///
+/// Currently, the lack of crash reports about this issue provides some
+/// evidence to support the hypothesis. This evidence will hopefully be used to
+/// convince other browser vendors that it would be safe to replace unpaired
+/// surrogates at the boundary between JavaScript and native code. (This would
+/// unify the `DOMString` and `USVString` types, both in the WebIDL standard
+/// and in Servo.)
+///
+/// This string class will keep either the Reference to the mozjs object alive
+/// or will have an internal rust string.
+/// We currently default to doing most of the string operation on the rust side.
+/// As this conversion was anyway needed, it does not much extra cost.
+/// You should assume that all the functions incur the conversion cost.
+///
+#[repr(transparent)]
+#[derive(Clone, Debug, MallocSizeOf, JSTraceable)]
+pub struct DOMString(DOMStringInner);
+
+impl DOMString {
+    /// Creates a new `DOMString`.
+    pub fn new() -> DOMString {
+        DOMString(DOMStringInner::new())
+    }
+
+    /// # Safety
+    ///  Requires the context be a non-null ptr and the HandleValue be a proper value.
+    pub unsafe fn from_js_string(cx: *mut JSContext, value: js::gc::HandleValue) -> DOMString {
+        unsafe { DOMString(DOMStringInner::from_js_string(cx, value)) }
+    }
+
+    pub fn from_string(s: String) -> DOMString {
+        DOMString(DOMStringInner::from_string(s))
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.make_me_string().as_bytes()
+    }
+
+    pub fn chars(&self) -> impl Iterator<Item = char> {
+        self.0.make_me_string().chars()
+    }
+
+    pub fn char_indices(&self) -> CharIndices<'_> {
+        self.0.make_me_string().char_indices()
+    }
+
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    pub fn encode_utf16(&self) -> EncodeUtf16<'_> {
+        self.0.make_me_string().encode_utf16()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.make_me_string().is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.make_me_string().len()
+    }
+
+    pub fn make_ascii_lowercase(&mut self) {
+        self.0.make_me_string_mut().make_ascii_lowercase();
+    }
+
+    /// This method is here for compatibilities sake.
+    pub fn str(&self) -> &str {
+        self.0.make_me_string()
+    }
+
+    pub fn push_str(&mut self, s: &str) {
+        self.0.make_me_string_mut().push_str(s);
+    }
+
+    pub fn strip_leading_and_trailing_ascii_whitespace(&mut self) {
+        if self.is_empty() {
+            return;
+        }
+
+        let s = self.0.make_me_string_mut();
+
+        let trailing_whitespace_len = s
+            .trim_end_matches(|ref c| char::is_ascii_whitespace(c))
+            .len();
+        s.truncate(trailing_whitespace_len);
+        if s.is_empty() {
+            return;
+        }
+
+        let first_non_whitespace = s.find(|ref c| !char::is_ascii_whitespace(c)).unwrap();
+        s.replace_range(0..first_non_whitespace, "");
+    }
+
+    /// This is a dom spec
+    pub fn is_valid_floating_point_number_string(&self) -> bool {
+        static RE: LazyLock<Regex> = LazyLock::new(|| {
+            Regex::new(r"^-?(?:\d+\.\d+|\d+|\.\d+)(?:(e|E)(\+|\-)?\d+)?$").unwrap()
+        });
+
+        RE.is_match(self.0.make_me_string()) && self.parse_floating_point_number().is_some()
+    }
+
+    pub fn parse<T: FromStr>(&self) -> Result<T, <T as FromStr>::Err> {
+        self.0.make_me_string().parse::<T>()
+    }
+
+    /// This is a domspec
+    /// <https://html.spec.whatwg.org/multipage/#rules-for-parsing-floating-point-number-values>
+    pub fn parse_floating_point_number(&self) -> Option<f64> {
+        // Steps 15-16 are telling us things about IEEE rounding modes
+        // for floating-point significands; this code assumes the Rust
+        // compiler already matches them in any cases where
+        // that actually matters. They are not
+        // related to f64::round(), which is for rounding to integers.
+        let input = self.0.make_me_string();
+        if let Ok(val) = input.trim().parse::<f64>() {
+            if !(
+                // A valid number is the same as what rust considers to be valid,
+                // except for +1., NaN, and Infinity.
+                val.is_infinite() || val.is_nan() || input.ends_with('.') || input.starts_with('+')
+            ) {
+                return Some(val);
+            }
+        }
+        None
+    }
+
+    /// This is a dom spec
+    pub fn set_best_representation_of_the_floating_point_number(&mut self) {
+        if let Some(val) = self.parse_floating_point_number() {
+            // [tc39] Step 2: If x is either +0 or -0, return "0".
+            let parsed_value = if val.is_zero() { 0.0_f64 } else { val };
+
+            self.0.set_rust_string(parsed_value.to_string());
+        }
+    }
+
+    pub fn to_lowercase(&self) -> String {
+        self.0.make_me_string().to_lowercase()
+    }
+
+    pub fn to_uppercase(&self) -> String {
+        self.0.make_me_string().to_uppercase()
+    }
+
+    pub fn strip_newlines(&mut self) {
+        self.0
+            .make_me_string_mut()
+            .retain(|c| c != '\r' && c != '\n');
+    }
+
+    pub fn replace(self, needle: &str, replace_char: &str) -> DOMString {
+        let new_string = self.0.make_me_string().to_owned();
+        DOMString(DOMStringInner::from_string(
+            new_string.replace(needle, replace_char),
+        ))
+    }
+
+    pub fn split(&self, c: char) -> impl Iterator<Item = &str> {
+        self.0.make_me_string().split(c)
+    }
+
+    pub fn find(&self, c: char) -> Option<usize> {
+        self.0.make_me_string().find(c)
+    }
+
+    /// Pattern is not yet stable in rust, hence, we need different methods for str and char
+    pub fn starts_with(&self, c: char) -> bool {
+        self.0.make_me_string().starts_with(c)
+    }
+
+    pub fn starts_with_str(&self, needle: &str) -> bool {
+        self.0.make_me_string().starts_with(needle)
+    }
+
+    pub fn contains(&self, needle: &str) -> bool {
+        self.0.make_me_string().contains(needle)
+    }
+
+    pub fn to_ascii_lowercase(&self) -> String {
+        self.0.make_me_string().to_ascii_lowercase()
+    }
+
+    pub fn contains_html_space_characters(&self) -> bool {
+        self.0.make_me_string().contains(HTML_SPACE_CHARACTERS)
+    }
+
+    pub fn split_html_space_characters(&self) -> impl Iterator<Item = &str> {
+        self.0
+            .make_me_string()
+            .split(HTML_SPACE_CHARACTERS)
+            .filter(|s| !s.is_empty())
+    }
+
+    pub fn strip_prefix(&self, needle: &str) -> Option<&str> {
+        self.0.make_me_string().strip_prefix(needle)
+    }
+}
+
+impl Ord for DOMString {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.make_me_string().cmp(other.0.make_me_string())
+    }
+}
+
+#[allow(clippy::non_canonical_partial_ord_impl)]
+impl PartialOrd for DOMString {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0
+            .make_me_string()
+            .partial_cmp(other.0.make_me_string())
+    }
+}
+
+impl Extend<char> for DOMString {
+    fn extend<T: IntoIterator<Item = char>>(&mut self, iter: T) {
+        self.0.make_me_string_mut().extend(iter)
+    }
+}
+
+impl ToJSValConvertible for DOMString {
+    unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
+        unsafe {
+            self.0.make_me_string().to_jsval(cx, rval);
+        }
+    }
+}
+
+// We need to be extra careful here as two strings that have different
+// representation need to have the same hash.
+// Additionally, the interior mutability is only used for the conversion
+// which is forced by Hash. Hence, it is safe to have this interior mutability.
+impl std::hash::Hash for DOMString {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.make_me_string().hash(state);
+    }
+}
+
+impl From<&str> for DOMString {
+    fn from(contents: &str) -> DOMString {
+        DOMString(DOMStringInner::from_string(String::from(contents)))
+    }
+}
+
+impl From<DOMString> for String {
+    fn from(val: DOMString) -> Self {
+        val.0.make_me_string().to_owned()
+    }
+}
+
+impl From<DOMString> for Vec<u8> {
+    fn from(mut value: DOMString) -> Self {
+        value.0.make_me_string_mut().as_bytes().to_vec()
+    }
+}
+
+impl From<Cow<'_, str>> for DOMString {
+    fn from(value: Cow<'_, str>) -> Self {
+        DOMString(DOMStringInner::from_string(value.into_owned()))
+    }
+}
+
+impl std::fmt::Display for DOMString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self.0.make_me_string(), f)
+    }
+}
+
+impl Default for DOMString {
+    fn default() -> Self {
+        DOMString::new()
+    }
+}
+
+impl std::cmp::PartialEq<&str> for DOMString {
+    fn eq(&self, other: &&str) -> bool {
+        self.0.make_me_string() == *other
+    }
+}
+
+impl std::cmp::PartialEq<str> for DOMString {
+    fn eq(&self, other: &str) -> bool {
+        self.0.make_me_string() == other
+    }
+}
+
+impl std::cmp::PartialEq<DOMString> for str {
+    fn eq(&self, other: &DOMString) -> bool {
+        other.0.make_me_string() == self
+    }
+}
+
+impl std::cmp::PartialEq<String> for DOMString {
+    fn eq(&self, other: &String) -> bool {
+        self.0.make_me_string() == other
+    }
+}
+
+impl std::cmp::PartialEq<DOMString> for String {
+    fn eq(&self, other: &DOMString) -> bool {
+        other.0.make_me_string() == self
+    }
+}
+
+impl std::cmp::PartialEq for DOMString {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.make_me_string() == other.0.make_me_string()
+    }
+}
+
+impl std::cmp::Eq for DOMString {}
+
+impl From<std::string::String> for DOMString {
+    fn from(value: String) -> Self {
+        DOMString(DOMStringInner::from_string(value))
+    }
+}
+
+impl From<DOMString> for LocalName {
+    fn from(contents: DOMString) -> LocalName {
+        LocalName::from(contents.0.take_rust_string())
+    }
+}
+
+impl From<DOMString> for Namespace {
+    fn from(contents: DOMString) -> Namespace {
+        Namespace::from(contents.0.take_rust_string())
+    }
+}
+
+impl From<DOMString> for Atom {
+    fn from(contents: DOMString) -> Atom {
+        Atom::from(contents.0.take_rust_string())
+    }
+}

--- a/components/script_bindings/lib.rs
+++ b/components/script_bindings/lib.rs
@@ -19,6 +19,7 @@ pub mod callback;
 mod constant;
 mod constructor;
 pub mod conversions;
+pub mod domstring;
 pub mod error;
 mod finalize;
 mod guard;

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -376,7 +376,7 @@ pub(crate) unsafe fn cross_origin_has_own(
     *bp = jsid_to_string(*cx, Handle::from_raw(id)).is_some_and(|key| {
         cross_origin_properties.keys().any(|defined_key| {
             let defined_key = CStr::from_ptr(defined_key);
-            defined_key.to_bytes() == key.as_bytes()
+            defined_key.to_bytes() == key.str().as_bytes()
         })
     });
 
@@ -520,6 +520,7 @@ pub(crate) fn report_cross_origin_denial<D: DomTypes>(
         id_to_source(cx, id)
             .as_ref()
             .map(|source| source.str())
+            .as_deref()
             .unwrap_or("< error >"),
     );
     let in_realm_proof = AlreadyInRealm::assert_for_cx(cx);

--- a/components/script_bindings/str.rs
+++ b/components/script_bindings/str.rs
@@ -144,8 +144,8 @@ pub fn is_token(s: &[u8]) -> bool {
         // http://tools.ietf.org/html/rfc2616#section-2.2
         match x {
             0..=31 | 127 => false, // CTLs
-            40 | 41 | 60 | 62 | 64 | 44 | 59 | 58 | 92 | 34 | 47 | 91 | 93 | 63 | 61 | 123
-            | 125 | 32 => false, // separators
+            40 | 41 | 60 | 62 | 64 | 44 | 59 | 58 | 92 | 34 | 47 | 91 | 93 | 63 | 61 | 123 |
+            125 | 32 => false, // separators
             x if x > 127 => false, // non-CHARs
             _ => true,
         }

--- a/components/script_bindings/trace.rs
+++ b/components/script_bindings/trace.rs
@@ -35,7 +35,7 @@ use xml5ever::tree_builder::{Tracer as XmlTracer, XmlTreeBuilder};
 use crate::JSTraceable;
 use crate::error::Error;
 use crate::reflector::Reflector;
-use crate::str::{DOMString, USVString};
+use crate::str::USVString;
 
 /// Trace the `JSObject` held by `reflector`.
 ///
@@ -82,7 +82,6 @@ macro_rules! unsafe_no_jsmanaged_fields(
     );
 );
 
-unsafe_no_jsmanaged_fields!(DOMString);
 unsafe_no_jsmanaged_fields!(USVString);
 unsafe_no_jsmanaged_fields!(Error);
 

--- a/components/script_bindings/utils.rs
+++ b/components/script_bindings/utils.rs
@@ -226,7 +226,7 @@ pub(crate) unsafe fn find_enum_value<'a, T>(
             Ok((
                 pairs
                     .iter()
-                    .find(|&&(key, _)| search == *key)
+                    .find(|&&(key, _)| search == key)
                     .map(|(_, ev)| ev),
                 search,
             ))

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -218,6 +218,7 @@ class MachCommands(CommandBase):
             "net_traits",
             "pixels",
             "script_traits",
+            "script_bindings",
             "selectors",
             "servo_config",
             "servoshell",

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -35,5 +35,5 @@ sizeof_checker!(size_element, Element, 344);
 sizeof_checker!(size_htmlelement, HTMLElement, 360);
 sizeof_checker!(size_div, HTMLDivElement, 360);
 sizeof_checker!(size_span, HTMLSpanElement, 360);
-sizeof_checker!(size_text, Text, 200);
-sizeof_checker!(size_characterdata, CharacterData, 200);
+sizeof_checker!(size_text, Text, 232);
+sizeof_checker!(size_characterdata, CharacterData, 232);

--- a/tests/unit/script/size_of.rs
+++ b/tests/unit/script/size_of.rs
@@ -35,5 +35,5 @@ sizeof_checker!(size_element, Element, 344);
 sizeof_checker!(size_htmlelement, HTMLElement, 360);
 sizeof_checker!(size_div, HTMLDivElement, 360);
 sizeof_checker!(size_span, HTMLSpanElement, 360);
-sizeof_checker!(size_text, Text, 232);
-sizeof_checker!(size_characterdata, CharacterData, 232);
+sizeof_checker!(size_text, Text, 200);
+sizeof_checker!(size_characterdata, CharacterData, 200);


### PR DESCRIPTION
This implements LazyDOMString (from now on DOMString) as outlined in https://github.com/servo/servo/issues/39479.
Constructing from a *mut JSString we keep the in a RootedTraceableBox<Heap<*mut JSString>> and transform
the string into a rust string if necessary via the `make_rust_string` method.
Methods used in script are implemented on this string. Currently we transform the string at all times.
But in the future more efficient implementations are possible.

We implement the safety critical sections in a separate module DOMStringInner which allows simple constructors, `make_rust_string` and the `bytes` method.
This method returns the new type `EncodedBytes` which contains the reference to the underlying string in either format.

Testing: WPT tests still seem to work, so this should test this functionality. 
