### PR TITLE
OHOS CI: Abort early when speedometer crashes in test-speedometer-ohos

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -703,7 +703,15 @@ class MachCommands(CommandBase):
             except OSError:
                 return ""
 
-        subprocess.call([hdc_path, "shell", "aa", "force-stop", "org.servo.servo"])
+        subprocess.call(
+            [
+                hdc_path,
+                "shell",
+                "aa",
+                "force-stop",
+                "org.servo.servo",
+            ]
+        )
 
         subprocess.call([hdc_path, "shell", "rm", log_path])
         subprocess.call(
@@ -740,6 +748,9 @@ class MachCommands(CommandBase):
                 sleep(2)
                 whole_file = read_log_file(hdc_path)
                 break
+            if not subprocess.check_output([hdc_path, "shell", "pidof", "org.servo.servo"]):
+                print("Servo crashed, aborting speedometer test")
+                exit(1)
         else:
             print("Error failed to find console logs in log file")
             print(f"log-file contents: `{whole_file}`")


### PR DESCRIPTION
Check for the pid of servo for test-speedometer-ohos to see if it did not crash and abort early if it crashed.

Testing: Ran test-speedometer-ohos with closing servo and without closing servo on the phone.
Fixes: https://github.com/servo/servo/issues/37742
