### PR TITLE
Fully implement request constructor body handling

### DIFF
--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -617,7 +617,7 @@ pub(crate) fn consume_body<T: BodyMixin + DomObject>(
     let promise = Promise::new_in_current_realm(comp, can_gc);
 
     // If object is unusable, then return a promise rejected with a TypeError.
-    if object.is_disturbed() || object.is_locked() {
+    if object.is_unusable() {
         promise.reject_error(
             Error::Type("The body's stream is disturbed or locked".to_string()),
             can_gc,
@@ -874,12 +874,12 @@ pub(crate) fn decode_to_utf16_with_bom_removal(
 
 /// <https://fetch.spec.whatwg.org/#body>
 pub(crate) trait BodyMixin {
-    /// <https://fetch.spec.whatwg.org/#concept-body-disturbed>
-    fn is_disturbed(&self) -> bool;
+    /// <https://fetch.spec.whatwg.org/#dom-body-bodyused>
+    fn is_body_used(&self) -> bool;
+    /// <https://fetch.spec.whatwg.org/#body-unusable>
+    fn is_unusable(&self) -> bool;
     /// <https://fetch.spec.whatwg.org/#dom-body-body>
     fn body(&self) -> Option<DomRoot<ReadableStream>>;
-    /// <https://fetch.spec.whatwg.org/#concept-body-locked>
-    fn is_locked(&self) -> bool;
     /// <https://fetch.spec.whatwg.org/#concept-body-mime-type>
     fn get_mime_type(&self, can_gc: CanGc) -> Vec<u8>;
 }

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -59,7 +59,6 @@ use script_bindings::script_runtime::{mark_runtime_dead, runtime_is_alive};
 use servo_config::{opts, pref};
 use style::thread_state::{self, ThreadState};
 
-use crate::body::BodyMixin;
 use crate::dom::bindings::codegen::Bindings::PromiseBinding::PromiseJobCallback;
 use crate::dom::bindings::codegen::Bindings::ResponseBinding::Response_Binding::ResponseMethods;
 use crate::dom::bindings::codegen::Bindings::ResponseBinding::ResponseType as DOMResponseType;

--- a/tests/wpt/meta/fetch/api/abort/general.any.js.ini
+++ b/tests/wpt/meta/fetch/api/abort/general.any.js.ini
@@ -5,9 +5,6 @@
   expected: ERROR
 
 [general.any.html]
-  [Request is still 'used' if signal is aborted before fetching]
-    expected: FAIL
-
   [response.arrayBuffer() rejects if already aborted]
     expected: FAIL
 
@@ -31,9 +28,6 @@
 
 
 [general.any.worker.html]
-  [Request is still 'used' if signal is aborted before fetching]
-    expected: FAIL
-
   [response.arrayBuffer() rejects if already aborted]
     expected: FAIL
 

--- a/tests/wpt/meta/fetch/api/abort/request.any.js.ini
+++ b/tests/wpt/meta/fetch/api/abort/request.any.js.ini
@@ -1,20 +1,8 @@
 [request.any.html]
-  [Calling arrayBuffer() on an aborted consumed nonempty request]
-    expected: FAIL
-
-  [Calling blob() on an aborted consumed nonempty request]
-    expected: FAIL
-
   [Calling formData() on an aborted request]
     expected: FAIL
 
   [Aborting a request after calling formData()]
-    expected: FAIL
-
-  [Calling json() on an aborted consumed nonempty request]
-    expected: FAIL
-
-  [Calling text() on an aborted consumed nonempty request]
     expected: FAIL
 
 
@@ -25,20 +13,8 @@
   expected: ERROR
 
 [request.any.worker.html]
-  [Calling arrayBuffer() on an aborted consumed nonempty request]
-    expected: FAIL
-
-  [Calling blob() on an aborted consumed nonempty request]
-    expected: FAIL
-
   [Calling formData() on an aborted request]
     expected: FAIL
 
   [Aborting a request after calling formData()]
-    expected: FAIL
-
-  [Calling json() on an aborted consumed nonempty request]
-    expected: FAIL
-
-  [Calling text() on an aborted consumed nonempty request]
     expected: FAIL


### PR DESCRIPTION
This aligns the implementation with the spec, where both input body and init body are now set. In doing so, it fixes a fetch abort test, since the stream was missing for the input body.

It also introduces the `unusable` method, as that's the one the spec uses. The other two getters no longer exist in the spec.

Fixes #39448