### PR TITLE
Implement backend for geolocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,8 @@ dependencies = [
  "euclid",
  "fonts",
  "gaol",
+ "geolocation",
+ "geolocation_traits",
  "ipc-channel",
  "keyboard-types",
  "layout_api",
@@ -3062,6 +3064,22 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "geolocation"
+version = "0.0.1"
+dependencies = [
+ "geolocation_traits",
+ "ipc-channel",
+]
+
+[[package]]
+name = "geolocation_traits"
+version = "0.0.1"
+dependencies = [
+ "ipc-channel",
+ "serde",
 ]
 
 [[package]]
@@ -4999,6 +5017,8 @@ dependencies = [
  "euclid",
  "fonts",
  "gaol",
+ "geolocation",
+ "geolocation_traits",
  "gleam",
  "gstreamer",
  "http 1.3.1",
@@ -7311,6 +7331,7 @@ dependencies = [
  "euclid",
  "fonts",
  "fonts_traits",
+ "geolocation_traits",
  "glow",
  "headers 0.4.1",
  "html5ever",
@@ -7453,6 +7474,7 @@ dependencies = [
  "devtools_traits",
  "embedder_traits",
  "euclid",
+ "geolocation_traits",
  "ipc-channel",
  "keyboard-types",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ env_logger = "0.11"
 euclid = "0.22"
 fonts_traits = { path = "components/shared/fonts" }
 freetype-sys = "0.20"
+geolocation_traits = { path = "components/shared/geolocation" }
 gleam = "0.15"
 glow = "0.16.0"
 gstreamer = { version = "0.23", features = ["v1_18"] }

--- a/components/constellation/Cargo.toml
+++ b/components/constellation/Cargo.toml
@@ -38,6 +38,8 @@ devtools_traits = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }
 fonts = { path = "../fonts" }
+geolocation = { path = "../geolocation" }
+geolocation_traits = { workspace = true }
 ipc-channel = { workspace = true }
 keyboard-types = { workspace = true }
 layout_api = { workspace = true }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -141,6 +141,7 @@ use embedder_traits::{
 use euclid::Size2D;
 use euclid::default::Size2D as UntypedSize2D;
 use fonts::SystemFontServiceProxy;
+use geolocation_traits::GeolocationRequest;
 use ipc_channel::Error as IpcError;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
@@ -373,6 +374,9 @@ pub struct Constellation<STF, SWF> {
     #[cfg(feature = "bluetooth")]
     bluetooth_ipc_sender: IpcSender<BluetoothRequest>,
 
+    /// An IPC channel for the constellation to send messages to the geolocation thread.
+    geolocation_ipc_sender: IpcSender<GeolocationRequest>,
+
     /// A map of origin to sender to a Service worker manager.
     sw_managers: HashMap<ImmutableOrigin, GenericSender<ServiceWorkerMsg>>,
 
@@ -528,6 +532,9 @@ pub struct InitialConstellationState {
     /// A channel to the bluetooth thread.
     #[cfg(feature = "bluetooth")]
     pub bluetooth_thread: IpcSender<BluetoothRequest>,
+
+    /// A channel to the geolocation thread.
+    pub geolocation_thread: IpcSender<GeolocationRequest>,
 
     /// A proxy to the `SystemFontService` which manages the list of system fonts.
     pub system_font_service: Arc<SystemFontServiceProxy>,
@@ -707,6 +714,7 @@ where
                     devtools_sender: state.devtools_sender,
                     #[cfg(feature = "bluetooth")]
                     bluetooth_ipc_sender: state.bluetooth_thread,
+                    geolocation_ipc_sender: state.geolocation_thread,
                     public_resource_threads: state.public_resource_threads,
                     private_resource_threads: state.private_resource_threads,
                     public_storage_threads: state.public_storage_threads,
@@ -1026,6 +1034,7 @@ where
             devtools_sender: self.devtools_sender.clone(),
             #[cfg(feature = "bluetooth")]
             bluetooth_thread: self.bluetooth_ipc_sender.clone(),
+            geolocation_thread: self.geolocation_ipc_sender.clone(),
             swmanager_thread: self.swmanager_ipc_sender.clone(),
             system_font_service: self.system_font_service.clone(),
             resource_threads,

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -30,6 +30,7 @@ use embedder_traits::{
     AnimationState, FocusSequenceNumber, ScriptToEmbedderChan, Theme, ViewportDetails,
 };
 use fonts::{SystemFontServiceProxy, SystemFontServiceProxySender};
+use geolocation_traits::GeolocationRequest;
 use ipc_channel::Error;
 use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
@@ -154,6 +155,9 @@ pub struct InitialPipelineState {
     /// A channel to the bluetooth thread.
     #[cfg(feature = "bluetooth")]
     pub bluetooth_thread: IpcSender<BluetoothRequest>,
+
+    /// A channel to the geolocation thread.
+    pub geolocation_thread: IpcSender<GeolocationRequest>,
 
     /// A channel to the service worker manager thread
     pub swmanager_thread: GenericSender<SWManagerMsg>,
@@ -293,6 +297,7 @@ impl Pipeline {
                     devtools_ipc_sender: script_to_devtools_ipc_sender,
                     #[cfg(feature = "bluetooth")]
                     bluetooth_thread: state.bluetooth_thread,
+                    geolocation_thread: state.geolocation_thread,
                     swmanager_thread: state.swmanager_thread,
                     system_font_service: state.system_font_service.to_sender(),
                     resource_threads: state.resource_threads,
@@ -491,6 +496,7 @@ pub struct UnprivilegedPipelineContent {
     devtools_ipc_sender: Option<IpcSender<ScriptToDevtoolsControlMsg>>,
     #[cfg(feature = "bluetooth")]
     bluetooth_thread: IpcSender<BluetoothRequest>,
+    geolocation_thread: IpcSender<GeolocationRequest>,
     swmanager_thread: GenericSender<SWManagerMsg>,
     system_font_service: SystemFontServiceProxySender,
     resource_threads: ResourceThreads,
@@ -550,6 +556,7 @@ impl UnprivilegedPipelineContent {
                 background_hang_monitor_register: background_hang_monitor_register.clone(),
                 #[cfg(feature = "bluetooth")]
                 bluetooth_sender: self.bluetooth_thread,
+                geolocation_sender: self.geolocation_thread,
                 resource_threads: self.resource_threads,
                 storage_threads: self.storage_threads,
                 image_cache,

--- a/components/geolocation/Cargo.toml
+++ b/components/geolocation/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "geolocation"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[lib]
+path = "lib.rs"
+doctest = false
+test = false
+
+[dependencies]
+geolocation_traits = { workspace = true }
+ipc-channel = "0.20"

--- a/components/geolocation/lib.rs
+++ b/components/geolocation/lib.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+use std::thread;
+
+use geolocation_traits::{GeolocationError, GeolocationProvider, GeolocationRequest};
+use ipc_channel::ipc;
+use ipc_channel::ipc::{IpcReceiver, IpcSender};
+
+pub struct GeolocationManager {
+    provider: Arc<Option<Box<dyn GeolocationProvider + Send + Sync>>>,
+    receiver: IpcReceiver<GeolocationRequest>,
+}
+
+impl GeolocationManager {
+    pub fn new(
+        provider: Arc<Option<Box<dyn GeolocationProvider + Send + Sync>>>,
+        receiver: IpcReceiver<GeolocationRequest>,
+    ) -> Self {
+        Self { provider, receiver }
+    }
+
+    pub fn start(&self) {
+        while let Ok(req) = self.receiver.recv() {
+            if let Some(provider) = &*self.provider {
+                match req {
+                    GeolocationRequest::GetPosition(_, sender) => {
+                        let result = provider.get_location();
+                        let _ = sender.send(result);
+                    },
+                    GeolocationRequest::WatchPosition(_, sender) => {
+                        let result = provider.get_location();
+                        let _ = sender.send(result);
+                    },
+                }
+            } else {
+                match req {
+                    GeolocationRequest::GetPosition(_, sender) => {
+                        let _ = sender.send(Err(GeolocationError::PositionUnavailable));
+                    },
+                    GeolocationRequest::WatchPosition(_, sender) => {
+                        let _ = sender.send(Err(GeolocationError::PositionUnavailable));
+                    },
+                }
+            }
+        }
+    }
+}
+
+pub trait GeolocationThreadFactory {
+    fn new(provider: Arc<Option<Box<dyn GeolocationProvider + Send + Sync>>>) -> Self;
+}
+
+impl GeolocationThreadFactory for IpcSender<GeolocationRequest> {
+    fn new(
+        provider: Arc<Option<Box<dyn GeolocationProvider + Send + Sync>>>,
+    ) -> IpcSender<GeolocationRequest> {
+        let (sender, receiver) = ipc::channel().unwrap();
+        thread::Builder::new()
+            .name("Geolocation".to_owned())
+            .spawn(move || {
+                GeolocationManager::new(provider, receiver).start();
+            })
+            .expect("Thread spawning failed");
+        sender
+    }
+}

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -67,6 +67,7 @@ encoding_rs = { workspace = true }
 euclid = { workspace = true }
 fonts = { path = "../fonts" }
 fonts_traits = { workspace = true }
+geolocation_traits = { workspace = true }
 glow = { workspace = true }
 headers = { workspace = true }
 html5ever = { workspace = true }

--- a/components/script/dom/geolocation/geolocation.rs
+++ b/components/script/dom/geolocation/geolocation.rs
@@ -3,20 +3,31 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::time::UNIX_EPOCH;
 
 use dom_struct::dom_struct;
+use geolocation_traits::GeolocationRequest;
+use ipc_channel::ipc::IpcSender;
+use ipc_channel::router::ROUTER;
 use rustc_hash::FxHashSet;
 use script_bindings::codegen::GenericBindings::GeolocationBinding::Geolocation_Binding::GeolocationMethods;
 use script_bindings::codegen::GenericBindings::GeolocationBinding::{
     PositionCallback, PositionOptions,
 };
+use script_bindings::codegen::GenericBindings::PermissionStatusBinding::{
+    PermissionDescriptor, PermissionName,
+};
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
+use script_bindings::num::Finite;
 use script_bindings::reflector::Reflector;
 use script_bindings::root::DomRoot;
 use script_bindings::script_runtime::CanGc;
 
 use crate::dom::bindings::codegen::DomTypeHolder::DomTypeHolder;
+use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
+use crate::dom::geolocationcoordinates::GeolocationCoordinates;
+use crate::dom::geolocationposition::GeolocationPosition;
 use crate::dom::globalscope::GlobalScope;
 
 #[dom_struct]
@@ -39,30 +50,110 @@ impl Geolocation {
     pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<Self> {
         reflect_dom_object(Box::new(Self::new_inherited()), global, can_gc)
     }
+
+    fn geolocation_sender(&self) -> IpcSender<GeolocationRequest> {
+        self.global().as_window().geolocation_thread()
+    }
+
+    /// https://www.w3.org/TR/geolocation/#request-a-position
+    fn request_a_position(
+        &self,
+        success_callback: Rc<PositionCallback<DomTypeHolder>>,
+        options: &PositionOptions,
+        watch_id: Option<u32>,
+    ) {
+        // Step 1: Let watchIDs be geolocation's [[watchIDs]].
+
+        // Step 2: Let document be the geolocation's relevant global object's associated Document.
+        let document = self.global().as_window().Document();
+        // Step 3: If document is not allowed to use the "geolocation" feature:
+        if !document.allowed_to_use_feature(PermissionName::Geolocation) {
+            // Step 3.1: If watchId was passed, remove watchId from watchIDs.
+            if let Some(watch_id) = watch_id {
+                self.watch_ids.borrow_mut().remove(&watch_id);
+            }
+            // Step 3.2: Call back with error passing errorCallback and PERMISSION_DENIED.
+            // TODO: Error callback not implemented yet.
+            // Step 3.3: Terminate this algorithm.
+            return;
+        }
+        // TODO: Step 4: If geolocation's environment settings object is a non-secure context:
+        // Step 4.1: If watchId was passed, remove watchId from watchIDs.
+        // Step 4.2: Call back with error passing errorCallback and PERMISSION_DENIED.
+        // Step 4.3: Terminate this algorithm.
+        // TODO: Step 5: If document's visibility state is "hidden", wait for the following page visibility change steps to run:
+        // Step 5.1: Assert: document's visibility state is "visible".
+        // Step 5.2: Continue to the next steps below.
+        // TODO: Step 6: Let descriptor be a new PermissionDescriptor whose name is "geolocation".
+        // Step 7: In parallel:
+        let task_source = self.global().task_manager().geolocation_task_source();
+        let sendable_task_source = task_source.to_sendable();
+        task_source.queue(task!(request_position: move || {
+            let options = geolocation_traits::Options {
+                accuracy: if options.enableHighAccuracy {
+                    geolocation_traits::Accuracy::High
+                } else {
+                    geolocation_traits::Accuracy::Low
+                },
+                maximum_age: options.maximumAge,
+                timeout: options.timeout
+            };
+            let this = Trusted::new(self);
+            let (sen, rec) = ipc_channel::ipc::channel().unwrap();
+            self.geolocation_sender().send(GeolocationRequest::GetPosition(options, sen)).unwrap();
+            ROUTER.add_typed_route(rec, Box::new(move |message| {
+                let message = message.unwrap();
+                sendable_task_source.queue(task!(return_position: move || {
+                    let this = this.root();
+                    let global = this.global();
+                    match message {
+                        Ok(position) => {
+                            let coordinates = GeolocationCoordinates::new(&global,
+                                Finite::new(position.coords.accuracy).unwrap(),
+                                Finite::new(position.coords.latitude).unwrap(),
+                                Finite::new(position.coords.longitude).unwrap(),
+                                position.coords.altitude.map(Finite::new).flatten(),
+                                position.coords.altitude_accuracy.map(Finite::new).flatten(),
+                                position.coords.heading.map(Finite::new).flatten(),
+                                position.coords.speed.map(Finite::new).flatten(),
+                                CanGc::note(),
+                            );
+                            let position = GeolocationPosition::new(&global, &coordinates, position.timestamp.duration_since(UNIX_EPOCH).unwrap().as_secs(), CanGc::note());
+                            success_callback.call(&position);
+                        }
+                        Err(_e) => {
+                            // TODO: report error
+                        }
+                    }
+                }));
+            }));
+        }));
+    }
 }
 
 impl GeolocationMethods<DomTypeHolder> for Geolocation {
     /// <https://www.w3.org/TR/geolocation/#dom-geolocation-getcurrentposition>
     fn GetCurrentPosition(
         &self,
-        _success_callback: Rc<PositionCallback<DomTypeHolder>>,
-        _options: &PositionOptions,
+        success_callback: Rc<PositionCallback<DomTypeHolder>>,
+        options: &PositionOptions,
     ) {
         // Step 1. If this's relevant global object's associated Document is not fully active:
-        // if !self.global().as_window().Document().is_active() {
-        // Step 1.1 Call back with error errorCallback and POSITION_UNAVAILABLE.
-        // Step 1.2 Terminate this algorithm.
-        // return;
-        // }
+        if !self.global().as_window().Document().is_active() {
+            // Step 1.1 Call back with error errorCallback and POSITION_UNAVAILABLE.
+            // TODO: Error callback not implemented yet.
+            // Step 1.2 Terminate this algorithm.
+            return;
+        }
         // Step 2. Request a position passing this, successCallback, errorCallback, and options.
-        // FIXME(arihant2math)
+        self.request_a_position(success_callback, options, None);
     }
 
     /// <https://www.w3.org/TR/geolocation/#watchposition-method>
     fn WatchPosition(
         &self,
-        _success_callback: Rc<PositionCallback<DomTypeHolder>>,
-        _options: &PositionOptions,
+        success_callback: Rc<PositionCallback<DomTypeHolder>>,
+        options: &PositionOptions,
     ) -> i32 {
         // Step 1. If this's relevant global object's associated Document is not fully active:
         if !self.global().as_window().Document().is_active() {
@@ -76,7 +167,7 @@ impl GeolocationMethods<DomTypeHolder> for Geolocation {
         // Step 3. Append watchId to this's [[watchIDs]].
         self.watch_ids.borrow_mut().insert(watch_id);
         // Step 4. Request a position passing this, successCallback, errorCallback, options, and watchId.
-        // FIXME(arihant2math)
+        self.request_a_position(success_callback, options, Some(watch_id));
         // Step 5. Return watchId.
         watch_id as i32
     }

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -16,6 +16,7 @@ use constellation_traits::ScriptToConstellationMessage;
 use crossbeam_channel::{Receiver, SendError, Sender, select};
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg};
 use embedder_traits::ScriptToEmbedderChan;
+use geolocation_traits::GeolocationRequest;
 use ipc_channel::ipc::IpcSender;
 use net_traits::FetchResponseMsg;
 use net_traits::image_cache::ImageCacheResponseMessage;
@@ -336,6 +337,10 @@ pub(crate) struct ScriptThreadSenders {
     #[no_trace]
     #[cfg(feature = "bluetooth")]
     pub(crate) bluetooth_sender: IpcSender<BluetoothRequest>,
+
+    /// A handle to the geolocation thread.
+    #[no_trace]
+    pub(crate) geolocation_sender: IpcSender<GeolocationRequest>,
 
     /// A [`Sender`] that sends messages to the `Constellation`.
     #[no_trace]

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -234,6 +234,9 @@ pub struct ScriptThread {
     incomplete_loads: DomRefCell<Vec<InProgressLoad>>,
     /// A vector containing parser contexts which have not yet been fully processed
     incomplete_parser_contexts: IncompleteParserContexts,
+    // The platform services
+    // #[no_trace]
+    // platform_services: Arc<()>,
     /// Image cache for this script thread.
     #[no_trace]
     image_cache: Arc<dyn ImageCache>,
@@ -914,6 +917,7 @@ impl ScriptThread {
             self_sender,
             #[cfg(feature = "bluetooth")]
             bluetooth_sender: state.bluetooth_sender,
+            geolocation_sender: state.geolocation_sender,
             constellation_sender: state.constellation_sender,
             pipeline_to_constellation_sender: state.pipeline_to_constellation_sender.sender.clone(),
             pipeline_to_embedder_sender: state.pipeline_to_embedder_sender.clone(),
@@ -3188,6 +3192,7 @@ impl ScriptThread {
             self.storage_threads.clone(),
             #[cfg(feature = "bluetooth")]
             self.senders.bluetooth_sender.clone(),
+            self.senders.geolocation_sender.clone(),
             self.senders.memory_profiler_sender.clone(),
             self.senders.time_profiler_sender.clone(),
             self.senders.devtools_server_sender.clone(),

--- a/components/script/task_manager.rs
+++ b/components/script/task_manager.rs
@@ -142,8 +142,7 @@ impl TaskManager {
     task_source_functions!(self, file_reading_task_source, FileReading);
     task_source_functions!(self, font_loading_task_source, FontLoading);
     task_source_functions!(self, gamepad_task_source, Gamepad);
-    // FIXME(arihant2math): uncomment when geolocation is implemented.
-    // task_source_functions!(self, geolocation_task_source, Geolocation);
+    task_source_functions!(self, geolocation_task_source, Geolocation);
     task_source_functions!(self, media_element_task_source, MediaElement);
     task_source_functions!(self, networking_task_source, Networking);
     task_source_functions!(self, performance_timeline_task_source, PerformanceTimeline);

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -83,6 +83,8 @@ embedder_traits = { workspace = true }
 env_logger = { workspace = true }
 euclid = { workspace = true }
 fonts = { path = "../fonts" }
+geolocation = { path = "../geolocation" }
+geolocation_traits = { workspace = true }
 gleam = { workspace = true }
 gstreamer = { workspace = true, optional = true }
 image = { workspace = true }

--- a/components/shared/geolocation/Cargo.toml
+++ b/components/shared/geolocation/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "geolocation_traits"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+publish.workspace = true
+rust-version.workspace = true
+
+[lib]
+name = "geolocation_traits"
+path = "lib.rs"
+
+[dependencies]
+ipc-channel = "0.20"
+serde = { workspace = true }

--- a/components/shared/geolocation/lib.rs
+++ b/components/shared/geolocation/lib.rs
@@ -1,0 +1,82 @@
+use std::time::SystemTime;
+
+use ipc_channel::ipc::IpcSender;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct Options {
+    pub accuracy: Accuracy,
+    pub maximum_age: u32,
+    pub timeout: u32,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct Coordinates {
+    pub latitude: f64,
+    pub longitude: f64,
+    pub accuracy: f64,
+    pub altitude: Option<f64>,
+    pub altitude_accuracy: Option<f64>,
+    pub heading: Option<f64>,
+    pub speed: Option<f64>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct Position {
+    pub coords: Coordinates,
+    pub timestamp: SystemTime,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub enum Accuracy {
+    High,
+    Low,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum GeolocationError {
+    /// The user denied permission to access their location.
+    PermissionDenied,
+    PositionUnavailable,
+    Timeout,
+    /// An unknown error occurred.
+    Other(String),
+}
+
+pub trait GeolocationProvider {
+    /// Sets the watcher callback that should be called when the location changes or an error occurs.
+    /// The watcher can be set to None to stop receiving updates.
+    /// The watcher can be set at any time, even after start() has been called.
+    /// The watcher can also be set multiple times, and the previous watcher will be replaced,
+    /// it is up to the provider to use interior mutability to ensure this works.
+    fn set_watcher(&self, callback: Option<Box<dyn Fn(Result<Position, GeolocationError>) + Send>>);
+    /// Starts the geolocation provider.
+    /// The provider should stream location updates to the watcher callback if set.
+    /// This method should not block, and should return immediately.
+    fn start(&self);
+    /// Stops the geolocation provider.
+    /// The provider should stop streaming location updates to the watcher callback.
+    /// The watcher callback should not be called after this method is called.
+    /// This method should not block, and should return immediately.
+    fn stop(&self);
+
+    /// Returns the current location if available.
+    /// If an error occurs while trying to get the location, returns a GeolocationError.
+    /// This can block, as the script thread won't be blocked while waiting for a location update.
+    fn get_location(&self) -> Result<Position, GeolocationError>;
+
+    /// Sets the desired accuracy for location updates.
+    /// This method can be called at any time to change the accuracy.
+    /// However, the provider may choose to ignore this request, either for privacy reasons,
+    /// or because the provider cannot honor the request due to technical limitations.
+    fn set_accuracy(&self, accuracy: Accuracy);
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub enum GeolocationRequest {
+    /// One-shot request to get the current position.
+    GetPosition(Options, IpcSender<Result<Position, GeolocationError>>),
+    /// Continuous request to watch the position.
+    /// Dropping the sender can be used to stop watching the position.
+    WatchPosition(Options, IpcSender<Result<Position, GeolocationError>>),
+}

--- a/components/shared/script/Cargo.toml
+++ b/components/shared/script/Cargo.toml
@@ -26,6 +26,7 @@ crossbeam-channel = { workspace = true }
 devtools_traits = { workspace = true }
 embedder_traits = { workspace = true }
 euclid = { workspace = true }
+geolocation_traits = { workspace = true }
 ipc-channel = { workspace = true }
 keyboard-types = { workspace = true }
 log = { workspace = true }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -32,6 +32,7 @@ use embedder_traits::{
     MediaSessionActionType, ScriptToEmbedderChan, Theme, ViewportDetails, WebDriverScriptCommand,
 };
 use euclid::{Rect, Scale, Size2D, UnknownUnit};
+use geolocation_traits::GeolocationRequest;
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use keyboard_types::Modifiers;
 use malloc_size_of_derive::MallocSizeOf;
@@ -340,6 +341,8 @@ pub struct InitialScriptState {
     /// A channel to the bluetooth thread.
     #[cfg(feature = "bluetooth")]
     pub bluetooth_sender: IpcSender<BluetoothRequest>,
+    /// A channel to the geolocation thread.
+    pub geolocation_sender: IpcSender<GeolocationRequest>,
     /// The image cache for this script thread.
     pub image_cache: Arc<dyn ImageCache>,
     /// A channel to the time profiler thread.


### PR DESCRIPTION
Creates a framework for services that are guaranteed to vary by the OS. This framework should be extended for #38472 and #38788, and also any other web APIs that servo chooses to implement that are OS specific. This architecture creates a `PlatformServices` structure to manage all these. This also exists so we can handle cleanup in one place (i.e. we might want to call a shutdown function to stop a background thread for the geolocation API).

This PR isn't complete, I still need to implement the script thread side of this.