### PR TITLE
crown: Check closure bodies for unrooted types and fix root TransmitBodyPromise*

### DIFF
--- a/support/crown/src/unrooted_must_root.rs
+++ b/support/crown/src/unrooted_must_root.rs
@@ -399,10 +399,10 @@ impl<'tcx> LateLintPass<'tcx> for UnrootedPass {
                     n.as_str() == "default" ||
                     n.as_str() == "Wrap"
             },
-            visit::FnKind::Closure => return,
+            visit::FnKind::Closure => false,
         };
 
-        if !in_derive_expn(span) {
+        if !in_derive_expn(span) && !matches!(kind, visit::FnKind::Closure) {
             let sig = cx.tcx.type_of(def_id).skip_binder().fn_sig(cx.tcx);
 
             for (arg, ty) in decl.inputs.iter().zip(sig.inputs().skip_binder().iter()) {

--- a/support/crown/tests/compile-fail/unrooted_must_root_body.rs
+++ b/support/crown/tests/compile-fail/unrooted_must_root_body.rs
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
+#[crown::unrooted_must_root_lint::must_root]
+struct Foo(i32);
+
+fn foo2() {
+    let foo = Foo(0);
+    //~^ ERROR: Expression of type Foo must be rooted
+}
+
+fn main() {}

--- a/support/crown/tests/compile-fail/unrooted_must_root_closure_body.rs
+++ b/support/crown/tests/compile-fail/unrooted_must_root_closure_body.rs
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+//@rustc-env:RUSTC_BOOTSTRAP=1
+
+#[crown::unrooted_must_root_lint::must_root]
+struct Foo(i32);
+
+fn foo2() {
+    || {
+        let foo = Foo(0);
+        //~^ ERROR: Expression of type Foo must be rooted
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
We should also check closure bodies for unrooted expressions. 

Testing: New crown tests
Fixes: #37331
Fixes (partial): #37330