### PR TITLE
script: Make stylesheets loaded via `<link>` elements block the rendering

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2347,6 +2347,10 @@ impl Window {
             return;
         }
 
+        if document.render_blocking_element_count() > 0 {
+            return;
+        }
+
         // Checks if the html element has reftest-wait attribute present.
         // See http://testthewebforward.org/docs/reftests.html
         // and https://web-platform-tests.org/writing-tests/crashtest.html

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -277,6 +277,15 @@ impl FetchResponseListener for StylesheetContext {
             document.decrement_script_blocking_stylesheet_count();
         }
 
+        // From <https://html.spec.whatwg.org/multipage/#link-type-stylesheet>:
+        // > A link element of this type is implicitly potentially render-blocking if the element
+        // > was created by its node document's parser.
+        if matches!(self.source, StylesheetContextSource::LinkElement { .. }) &&
+            owner.parser_inserted()
+        {
+            document.decrement_render_blocking_element_count();
+        }
+
         document.finish_load(LoadType::Stylesheet(self.url.clone()), CanGc::note());
 
         if let Some(any_failed) = owner.load_finished(successful) {
@@ -374,6 +383,15 @@ impl StylesheetLoader<'_> {
         owner.increment_pending_loads_count();
         if owner.parser_inserted() {
             document.increment_script_blocking_stylesheet_count();
+        }
+
+        // From <https://html.spec.whatwg.org/multipage/#link-type-stylesheet>:
+        // > A link element of this type is implicitly potentially render-blocking if the element
+        // > was created by its node document's parser.
+        if matches!(context.source, StylesheetContextSource::LinkElement { .. }) &&
+            owner.parser_inserted()
+        {
+            document.increment_render_blocking_element_count();
         }
 
         // https://html.spec.whatwg.org/multipage/#default-fetch-and-process-the-linked-resource

--- a/tests/wpt/meta/html/dom/render-blocking/parser-inserted-stylesheet-link.html.ini
+++ b/tests/wpt/meta/html/dom/render-blocking/parser-inserted-stylesheet-link.html.ini
@@ -1,3 +1,0 @@
-[parser-inserted-stylesheet-link.html]
-  [Rendering is blocked before render-blocking resources are loaded]
-    expected: FAIL

--- a/tests/wpt/meta/html/dom/render-blocking/remove-attr-stylesheet-link-keeps-blocking.html.ini
+++ b/tests/wpt/meta/html/dom/render-blocking/remove-attr-stylesheet-link-keeps-blocking.html.ini
@@ -1,3 +1,0 @@
-[remove-attr-stylesheet-link-keeps-blocking.html]
-  [Rendering is blocked before render-blocking resources are loaded]
-    expected: FAIL


### PR DESCRIPTION
Stylesheets loaded via the `<link>` element should block the rendering
of the page according to the HTML specification [1]. This change makes
it so that they do this and, in addition, we do not take reftest
screenshots until all no element is blocking the rendering.

This change does not add support for the `blocking` attribute of
`<link>`, but that can be added in a follow change. In addition to
fixing a few tests, this change likely makes other tests no longer
intermittent. We will need to watch CI runs after this lands in order to
verify that though.

Testing: This change fixes at least two WPT tests.
Fixes: #26424.
