### PR TITLE
script: Rename `StylesheetLoader` to `ElementStylesheetLoader`

### DIFF
--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -29,7 +29,7 @@ use crate::dom::cssstylesheet::CSSStyleSheet;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
-use crate::stylesheet_loader::StylesheetLoader;
+use crate::stylesheet_loader::ElementStylesheetLoader;
 
 unsafe_no_jsmanaged_fields!(RulesSource);
 
@@ -130,7 +130,7 @@ impl CSSRuleList {
             .and_then(DomRoot::downcast::<HTMLElement>);
         let loader = owner
             .as_ref()
-            .map(|element| StylesheetLoader::for_element(element));
+            .map(|element| ElementStylesheetLoader::new(element));
         let allow_import_rules = if self.parent_stylesheet.is_constructed() {
             AllowImportRules::No
         } else {

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -60,7 +60,7 @@ use crate::dom::virtualmethods::VirtualMethods;
 use crate::links::LinkRelations;
 use crate::network_listener::{PreInvoke, ResourceTimingListener, submit_timing};
 use crate::script_runtime::CanGc;
-use crate::stylesheet_loader::{StylesheetContextSource, StylesheetLoader, StylesheetOwner};
+use crate::stylesheet_loader::{ElementStylesheetLoader, StylesheetContextSource, StylesheetOwner};
 
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) struct RequestGenerationId(u32);
@@ -589,7 +589,7 @@ impl HTMLLinkElement {
         self.request_generation_id
             .set(self.request_generation_id.get().increment());
 
-        let loader = StylesheetLoader::for_element(self.upcast());
+        let loader = ElementStylesheetLoader::new(self.upcast());
         loader.load(
             StylesheetContextSource::LinkElement { media: Some(media) },
             link_url,

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -34,7 +34,7 @@ use crate::dom::stylesheet::StyleSheet as DOMStyleSheet;
 use crate::dom::stylesheetcontentscache::{StylesheetContentsCache, StylesheetContentsCacheKey};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
-use crate::stylesheet_loader::{StylesheetLoader, StylesheetOwner};
+use crate::stylesheet_loader::{ElementStylesheetLoader, StylesheetOwner};
 
 #[dom_struct]
 pub(crate) struct HTMLStyleElement {
@@ -133,7 +133,7 @@ impl HTMLStyleElement {
             .expect("Element.textContent must be a string");
         let shared_lock = node.owner_doc().style_shared_lock().clone();
         let mq = Arc::new(shared_lock.wrap(self.create_media_list(self.Media().str())));
-        let loader = StylesheetLoader::for_element(self.upcast());
+        let loader = ElementStylesheetLoader::new(self.upcast());
 
         let stylesheetcontents_create_callback = || {
             #[cfg(feature = "tracing")]


### PR DESCRIPTION
`StylesheetLoader` implements the `StylesheetLoader` trait from Stylo.
This is pretty confusing as the names are the same. This change renames
the Servo version to `ElementStyleSheet` loader so that it's clearer
from reading the code what each of these things are.

Testing: This change just makes a few renames so shouldn't change test results.
