### PR TITLE
Revert "Add abort signal preference to experimental web features"

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -25,7 +25,6 @@ use url::Url;
 use crate::VERSION;
 
 pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
-    "dom_abort_controller_enabled",
     "dom_async_clipboard_enabled",
     "dom_fontface_enabled",
     "dom_intersection_observer_enabled",

--- a/tests/wpt/meta/IndexedDB/back-forward-cache-open-connection.window.js.ini
+++ b/tests/wpt/meta/IndexedDB/back-forward-cache-open-connection.window.js.ini
@@ -1,4 +1,3 @@
 [back-forward-cache-open-connection.window.html]
-  expected: TIMEOUT
   [Testing BFCache support for page with open IndexedDB connection, and eviction behavior when receiving versionchange event.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/back-forward-cache-open-transaction.window.js.ini
+++ b/tests/wpt/meta/IndexedDB/back-forward-cache-open-transaction.window.js.ini
@@ -1,4 +1,3 @@
 [back-forward-cache-open-transaction.window.html]
-  expected: TIMEOUT
   [BFCache support test for page with open IndexedDB transaction]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/credential-management/credentialscontainer-get-basics.https.html.ini
+++ b/tests/wpt/meta/credential-management/credentialscontainer-get-basics.https.html.ini
@@ -1,4 +1,6 @@
 [credentialscontainer-get-basics.https.html]
+  [Calling navigator.credentials.get() without a valid matching interface.]
+    expected: FAIL
 
   [navigator.credentials.get() aborted with custom reason]
     expected: FAIL

--- a/tests/wpt/meta/dom/abort/__dir__.ini
+++ b/tests/wpt/meta/dom/abort/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "dom_abort_controller_enabled:true",
+]

--- a/tests/wpt/meta/dom/events/__dir__.ini
+++ b/tests/wpt/meta/dom/events/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "dom_abort_controller_enabled:true",
+]

--- a/tests/wpt/meta/dom/idlharness.any.js.ini
+++ b/tests/wpt/meta/dom/idlharness.any.js.ini
@@ -5,7 +5,13 @@
   expected: ERROR
 
 [idlharness.any.worker.html]
+  [AbortController interface: attribute signal]
+    expected: FAIL
+
   [AbortController interface: operation abort()]
+    expected: FAIL
+
+  [AbortController interface: new AbortController() must inherit property "signal" with the proper type]
     expected: FAIL
 
   [AbortController interface: new AbortController() must inherit property "abort()" with the proper type]
@@ -14,13 +20,97 @@
   [AbortSignal interface: operation abort()]
     expected: FAIL
 
+  [AbortSignal must be primary interface of new AbortController().signal]
+    expected: FAIL
+
+  [Stringification of new AbortController().signal]
+    expected: FAIL
+
   [AbortSignal interface: new AbortController().signal must inherit property "abort()" with the proper type]
+    expected: FAIL
+
+  [AbortSignal interface: new AbortController().signal must inherit property "aborted" with the proper type]
+    expected: FAIL
+
+  [AbortSignal interface: new AbortController().signal must inherit property "onabort" with the proper type]
+    expected: FAIL
+
+  [EventTarget interface: new AbortController().signal must inherit property "addEventListener(DOMString, EventListener?, optional (AddEventListenerOptions or boolean))" with the proper type]
+    expected: FAIL
+
+  [EventTarget interface: calling addEventListener(DOMString, EventListener?, optional (AddEventListenerOptions or boolean)) on new AbortController().signal with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [EventTarget interface: new AbortController().signal must inherit property "removeEventListener(DOMString, EventListener?, optional (EventListenerOptions or boolean))" with the proper type]
+    expected: FAIL
+
+  [EventTarget interface: calling removeEventListener(DOMString, EventListener?, optional (EventListenerOptions or boolean)) on new AbortController().signal with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [EventTarget interface: new AbortController().signal must inherit property "dispatchEvent(Event)" with the proper type]
+    expected: FAIL
+
+  [EventTarget interface: calling dispatchEvent(Event) on new AbortController().signal with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [AbortSignal interface: new AbortController().signal must inherit property "abort(optional any)" with the proper type]
+    expected: FAIL
+
+  [AbortSignal interface: calling abort(optional any) on new AbortController().signal with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [AbortSignal interface: new AbortController().signal must inherit property "reason" with the proper type]
+    expected: FAIL
+
+  [AbortSignal interface: new AbortController().signal must inherit property "throwIfAborted()" with the proper type]
     expected: FAIL
 
   [AbortSignal interface: operation timeout(unsigned long long)]
     expected: FAIL
 
+  [AbortSignal interface: new AbortController().signal must inherit property "timeout(unsigned long long)" with the proper type]
+    expected: FAIL
+
   [AbortSignal interface: calling timeout(unsigned long long) on new AbortController().signal with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [AbortSignal interface: new AbortController().signal must inherit property "any(sequence<AbortSignal>)" with the proper type]
+    expected: FAIL
+
+  [AbortSignal interface: calling any(sequence<AbortSignal>) on new AbortController().signal with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [AbortController interface: existence and properties of interface object]
+    expected: FAIL
+
+  [AbortController interface object length]
+    expected: FAIL
+
+  [AbortController interface object name]
+    expected: FAIL
+
+  [AbortController interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [AbortController interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [AbortController interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [AbortController interface: operation abort(optional any)]
+    expected: FAIL
+
+  [AbortController must be primary interface of new AbortController()]
+    expected: FAIL
+
+  [Stringification of new AbortController()]
+    expected: FAIL
+
+  [AbortController interface: new AbortController() must inherit property "abort(optional any)" with the proper type]
+    expected: FAIL
+
+  [AbortController interface: calling abort(optional any) on new AbortController() with too few arguments must throw TypeError]
     expected: FAIL
 
 

--- a/tests/wpt/meta/dom/idlharness.window.js.ini
+++ b/tests/wpt/meta/dom/idlharness.window.js.ini
@@ -1,11 +1,47 @@
 [idlharness.window.html?exclude=Node]
+  [AbortSignal must be primary interface of new AbortController().signal]
+    expected: FAIL
+
+  [EventTarget interface: calling removeEventListener(DOMString, EventListener?, optional (EventListenerOptions or boolean)) on new AbortController().signal with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [EventTarget interface: new AbortController().signal must inherit property "addEventListener(DOMString, EventListener?, optional (AddEventListenerOptions or boolean))" with the proper type]
+    expected: FAIL
+
+  [EventTarget interface: new AbortController().signal must inherit property "dispatchEvent(Event)" with the proper type]
+    expected: FAIL
+
+  [EventTarget interface: new AbortController().signal must inherit property "removeEventListener(DOMString, EventListener?, optional (EventListenerOptions or boolean))" with the proper type]
+    expected: FAIL
+
   [AbortController interface: operation abort()]
+    expected: FAIL
+
+  [AbortController interface: attribute signal]
+    expected: FAIL
+
+  [AbortController interface: new AbortController() must inherit property "signal" with the proper type]
     expected: FAIL
 
   [AbortController interface: new AbortController() must inherit property "abort()" with the proper type]
     expected: FAIL
 
+  [EventTarget interface: calling dispatchEvent(Event) on new AbortController().signal with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [AbortSignal interface: new AbortController().signal must inherit property "aborted" with the proper type]
+    expected: FAIL
+
+  [EventTarget interface: calling addEventListener(DOMString, EventListener?, optional (AddEventListenerOptions or boolean)) on new AbortController().signal with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [AbortSignal interface: new AbortController().signal must inherit property "onabort" with the proper type]
+    expected: FAIL
+
   [NodeFilter interface: existence and properties of interface object]
+    expected: FAIL
+
+  [Stringification of new AbortController().signal]
     expected: FAIL
 
   [XPathNSResolver interface: document.createNSResolver(document.body) must inherit property "lookupNamespaceURI(DOMString?)" with the proper type]
@@ -113,7 +149,22 @@
   [XSLTProcessor interface: new XSLTProcessor() must inherit property "reset()" with the proper type]
     expected: FAIL
 
+  [AbortSignal interface: new AbortController().signal must inherit property "abort(optional any)" with the proper type]
+    expected: FAIL
+
+  [AbortSignal interface: calling abort(optional any) on new AbortController().signal with too few arguments must throw TypeError]
+    expected: FAIL
+
+  [AbortSignal interface: new AbortController().signal must inherit property "reason" with the proper type]
+    expected: FAIL
+
+  [AbortSignal interface: new AbortController().signal must inherit property "throwIfAborted()" with the proper type]
+    expected: FAIL
+
   [AbortSignal interface: operation timeout(unsigned long long)]
+    expected: FAIL
+
+  [AbortSignal interface: new AbortController().signal must inherit property "timeout(unsigned long long)" with the proper type]
     expected: FAIL
 
   [AbortSignal interface: calling timeout(unsigned long long) on new AbortController().signal with too few arguments must throw TypeError]
@@ -141,6 +192,12 @@
     expected: FAIL
 
   [Element interface: element must inherit property "onfullscreenerror" with the proper type]
+    expected: FAIL
+
+  [AbortSignal interface: new AbortController().signal must inherit property "any(sequence<AbortSignal>)" with the proper type]
+    expected: FAIL
+
+  [AbortSignal interface: calling any(sequence<AbortSignal>) on new AbortController().signal with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: operation prepend((Node or TrustedScript or DOMString)...)]
@@ -195,6 +252,39 @@
     expected: FAIL
 
   [CharacterData interface: operation replaceWith((Node or TrustedScript or DOMString)...)]
+    expected: FAIL
+
+  [AbortController interface: existence and properties of interface object]
+    expected: FAIL
+
+  [AbortController interface object length]
+    expected: FAIL
+
+  [AbortController interface object name]
+    expected: FAIL
+
+  [AbortController interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [AbortController interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [AbortController interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [AbortController interface: operation abort(optional any)]
+    expected: FAIL
+
+  [AbortController must be primary interface of new AbortController()]
+    expected: FAIL
+
+  [Stringification of new AbortController()]
+    expected: FAIL
+
+  [AbortController interface: new AbortController() must inherit property "abort(optional any)" with the proper type]
+    expected: FAIL
+
+  [AbortController interface: calling abort(optional any) on new AbortController() with too few arguments must throw TypeError]
     expected: FAIL
 
   [Document interface: operation moveBefore(Node, Node?)]

--- a/tests/wpt/meta/dom/interface-objects.html.ini
+++ b/tests/wpt/meta/dom/interface-objects.html.ini
@@ -1,0 +1,6 @@
+[interface-objects.html]
+  [Should be able to delete AbortSignal.]
+    expected: FAIL
+
+  [Should be able to delete AbortController.]
+    expected: FAIL

--- a/tests/wpt/meta/fetch/api/abort/__dir__.ini
+++ b/tests/wpt/meta/fetch/api/abort/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "dom_abort_controller_enabled:true",
+]

--- a/tests/wpt/meta/fetch/fetch-later/quota/cross-origin-iframe/multiple-iframes.https.window.js.ini
+++ b/tests/wpt/meta/fetch/fetch-later/quota/cross-origin-iframe/multiple-iframes.https.window.js.ini
@@ -1,4 +1,3 @@
 [multiple-iframes.https.window.html]
-  expected: ERROR
   [fetchLater() request quota are delegated to cross-origin iframes and not shared, even if they are same origin.]
     expected: FAIL

--- a/tests/wpt/meta/fetch/fetch-later/send-on-deactivate.https.window.js.ini
+++ b/tests/wpt/meta/fetch/fetch-later/send-on-deactivate.https.window.js.ini
@@ -1,10 +1,9 @@
 [send-on-deactivate.https.window.html]
-  expected: TIMEOUT
   [fetchLater() sends on page entering BFCache if BackgroundSync is off.]
     expected: FAIL
 
   [Call fetchLater() when BFCached with activateAfter=0 sends immediately.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [fetchLater() sends on navigating away a page w/o BFCache.]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/broadcastchannel.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/broadcastchannel.window.js.ini
@@ -1,4 +1,3 @@
 [broadcastchannel.window.html]
-  expected: TIMEOUT
   [Ensure that open broadcastchannel does not block bfcache.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/dedicatedworker.tentative.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/dedicatedworker.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [dedicatedworker.tentative.window.html]
-  expected: TIMEOUT
   [BroadcastChannel messages dispatched to dedicated worker in bfcache should be queued.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/evict-on-message.tentative.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/back-forward-cache/broadcastchannel/evict-on-message.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [evict-on-message.tentative.window.html]
-  expected: TIMEOUT
   [BroadcastChannel message while in bfcache should evict the entry.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/document-state.https.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/document-state.https.html.ini
@@ -1,7 +1,6 @@
 [document-state.https.html]
-  expected: TIMEOUT
   [A navigation's initiator origin and referrer are stored in the document state and used in the document repopulation case]
-    expected: TIMEOUT
+    expected: FAIL
 
   [A navigation's initiator origin and referrer are stored in the document state and used on location.reload()]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigateToNew.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigateToNew.window.js.ini
@@ -1,0 +1,3 @@
+[navigateToNew.window.html]
+  [RemoteContextWrapper navigateToNew]
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-bfcache.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-bfcache.window.js.ini
@@ -1,4 +1,3 @@
 [navigation-bfcache.window.html]
-  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-helpers.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-helpers.window.js.ini
@@ -1,4 +1,3 @@
 [navigation-helpers.window.html]
-  expected: TIMEOUT
   [RemoteContextHelper navigation helpers]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-same-document.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/remote-context-helper-tests/navigation-same-document.window.js.ini
@@ -1,3 +1,3 @@
-[performance-navigation-timing-not-bfcached.tentative.window.html]
+[navigation-same-document.window.html]
   [RemoteContextHelper navigation using BFCache]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-cross-origin.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-cross-origin.window.js.ini
@@ -1,0 +1,3 @@
+[unload-main-frame-cross-origin.window.html]
+  [Unload runs in main frame when navigating cross-origin.]
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-same-origin.window.js.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/unloading-documents/unload/unload-main-frame-same-origin.window.js.ini
@@ -1,0 +1,3 @@
+[unload-main-frame-same-origin.window.html]
+  [Unload runs in main frame when navigating same-origin.]
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/history/the-history-interface/history-state-after-bfcache.window.js.ini
+++ b/tests/wpt/meta/html/browsers/history/the-history-interface/history-state-after-bfcache.window.js.ini
@@ -1,4 +1,3 @@
 [history-state-after-bfcache.window.html]
-  expected: TIMEOUT
   [Navigating back to a bfcached page does not reset history.state]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/windows/auxiliary-browsing-contexts/no-proactive-swap-when-other-contexts-in-group.html.ini
+++ b/tests/wpt/meta/html/browsers/windows/auxiliary-browsing-contexts/no-proactive-swap-when-other-contexts-in-group.html.ini
@@ -1,0 +1,3 @@
+[no-proactive-swap-when-other-contexts-in-group.html]
+  [no proactive browsing context group change when other contexts in group]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/links/links-created-by-a-and-area-elements/rel-opener-prevents-browsing-context-group-change.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/links/links-created-by-a-and-area-elements/rel-opener-prevents-browsing-context-group-change.tentative.html.ini
@@ -1,0 +1,6 @@
+[rel-opener-prevents-browsing-context-group-change.tentative.html]
+  [rel=opener prevents browsing context group change]
+    expected: FAIL
+
+  [opener window feature prevents browsing context group change]
+    expected: FAIL

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-attributes.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-attributes.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [performance-navigation-timing-attributes.tentative.window.html]
-  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-bfcache-reasons-stay.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-bfcache-reasons-stay.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [performance-navigation-timing-bfcache-reasons-stay.tentative.window.html]
-  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-bfcache.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-bfcache.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [performance-navigation-timing-bfcache.tentative.window.html]
-  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-cross-origin-bfcache.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-cross-origin-bfcache.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [performance-navigation-timing-cross-origin-bfcache.tentative.window.html]
-  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-fetch.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-fetch.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [performance-navigation-timing-fetch.tentative.window.html]
-  expected: TIMEOUT
   [Ensure that ongoing fetch upon entering bfcache blocks bfcache and recorded.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-navigation-failure.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-navigation-failure.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [performance-navigation-timing-navigation-failure.tentative.window.html]
-  expected: TIMEOUT
   [Ensure that navigation failure blocks bfcache and gets recorded.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-redirect-on-history.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-redirect-on-history.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [performance-navigation-timing-redirect-on-history.tentative.window.html]
-  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-reload.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-reload.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [performance-navigation-timing-reload.tentative.window.html]
-  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-same-origin-bfcache.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-same-origin-bfcache.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [performance-navigation-timing-same-origin-bfcache.tentative.window.html]
-  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/streams/__dir__.ini
+++ b/tests/wpt/meta/streams/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "dom_abort_controller_enabled:true",
+]

--- a/tests/wpt/meta/streams/piping/abort.any.js.ini
+++ b/tests/wpt/meta/streams/piping/abort.any.js.ini
@@ -1,3 +1,4 @@
+prefs: [dom_abort_controller_enabled:true]
 [abort.https.any.shadowrealm-in-serviceworker.html]
   expected: ERROR
 

--- a/tests/wpt/meta/wasm/webapi/abort.any.js.ini
+++ b/tests/wpt/meta/wasm/webapi/abort.any.js.ini
@@ -1,0 +1,38 @@
+[abort.any.html]
+  [compileStreaming() on an already-aborted request should reject with AbortError]
+    expected: FAIL
+
+  [compileStreaming() synchronously followed by abort should reject with AbortError]
+    expected: FAIL
+
+  [instantiateStreaming() on an already-aborted request should reject with AbortError]
+    expected: FAIL
+
+  [instantiateStreaming() synchronously followed by abort should reject with AbortError]
+    expected: FAIL
+
+  [compileStreaming() asynchronously racing with abort should succeed or reject with AbortError]
+    expected: FAIL
+
+  [instantiateStreaming() asynchronously racing with abort should succeed or reject with AbortError]
+    expected: FAIL
+
+
+[abort.any.worker.html]
+  [compileStreaming() on an already-aborted request should reject with AbortError]
+    expected: FAIL
+
+  [compileStreaming() synchronously followed by abort should reject with AbortError]
+    expected: FAIL
+
+  [instantiateStreaming() on an already-aborted request should reject with AbortError]
+    expected: FAIL
+
+  [instantiateStreaming() synchronously followed by abort should reject with AbortError]
+    expected: FAIL
+
+  [compileStreaming() asynchronously racing with abort should succeed or reject with AbortError]
+    expected: FAIL
+
+  [instantiateStreaming() asynchronously racing with abort should succeed or reject with AbortError]
+    expected: FAIL

--- a/tests/wpt/meta/webmessaging/message-channels/close-event/document-destroyed.tentative.window.js.ini
+++ b/tests/wpt/meta/webmessaging/message-channels/close-event/document-destroyed.tentative.window.js.ini
@@ -1,5 +1,5 @@
 [document-destroyed.tentative.window.html]
-  expected: TIMEOUT
+  expected: ERROR
   [The context is navigated to a new document and a close event is fired.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/websockets/back-forward-cache-with-closed-websocket-connection-ccns.tentative.window.js.ini
+++ b/tests/wpt/meta/websockets/back-forward-cache-with-closed-websocket-connection-ccns.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [back-forward-cache-with-closed-websocket-connection-ccns.tentative.window.html]
-  expected: TIMEOUT
   [Testing BFCache support for page with closed WebSocket connection and "Cache-Control: no-store" header.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/websockets/back-forward-cache-with-closed-websocket-connection.window.js.ini
+++ b/tests/wpt/meta/websockets/back-forward-cache-with-closed-websocket-connection.window.js.ini
@@ -1,4 +1,3 @@
 [back-forward-cache-with-closed-websocket-connection.window.html]
-  expected: TIMEOUT
   [Testing BFCache support for page with closed WebSocket connection.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/websockets/back-forward-cache-with-open-websocket-connection-ccns.tentative.window.js.ini
+++ b/tests/wpt/meta/websockets/back-forward-cache-with-open-websocket-connection-ccns.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [back-forward-cache-with-open-websocket-connection-ccns.tentative.window.html]
-  expected: TIMEOUT
   [Testing BFCache support for page with open WebSocket connection and "Cache-Control: no-store" header.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/websockets/back-forward-cache-with-open-websocket-connection.window.js.ini
+++ b/tests/wpt/meta/websockets/back-forward-cache-with-open-websocket-connection.window.js.ini
@@ -1,4 +1,3 @@
 [back-forward-cache-with-open-websocket-connection.window.html]
-  expected: TIMEOUT
   [Testing BFCache support for page with open WebSocket connection.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13775,14 +13775,14 @@
      ]
     ],
     "interfaces.https.html": [
-     "8f56cc48648cc2aeced4c5cf081296b85a5ede43",
+     "1397b723a1cb001521ac1b2032c380f1e02cf1f0",
      [
       null,
       {}
      ]
     ],
     "interfaces.worker.js": [
-     "8c0d87402f7675a6828343a18dec67c3cbe3a62a",
+     "66f95241d5518a6b82725529775dc5613cbab1c0",
      [
       "mozilla/interfaces.worker.html",
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -11,8 +11,6 @@
 
 // IMPORTANT: Do not change the list below without review from a DOM peer!
 test_interfaces([
-  "AbortController",
-  "AbortSignal",
   "AbstractRange",
   "AnalyserNode",
   "AnimationEvent",

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.worker.js
@@ -7,8 +7,6 @@ importScripts("interfaces.js");
 
 // IMPORTANT: Do not change the list below without review from a DOM peer!
 test_interfaces([
-  "AbortController",
-  "AbortSignal",
   "Blob",
   "BroadcastChannel",
   "ByteLengthQueuingStrategy",


### PR DESCRIPTION
Reverts servo/servo#39421 . There are too many new intermittent failures.

Fixes: https://github.com/servo/servo/issues/39516 
Fixes: https://github.com/servo/servo/issues/39521 
Fixes: https://github.com/servo/servo/issues/39522 
Fixes: https://github.com/servo/servo/issues/39523 
Fixes: https://github.com/servo/servo/issues/39524 
Fixes: https://github.com/servo/servo/issues/39527 
Fixes: https://github.com/servo/servo/issues/39532 
Fixes: https://github.com/servo/servo/issues/39512 
Fixes: https://github.com/servo/servo/issues/39503