### PR TITLE
webdriver: Wait animation frame callbacks before taking (element) screenshot

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1223,7 +1223,7 @@ impl IOCompositor {
     }
 
     /// Render the WebRender scene to the active `RenderingContext`. If successful, trigger
-    /// the next round of animations.
+    /// the next round of animations. Return false if unable to render.
     pub fn render(&mut self) -> bool {
         self.global
             .borrow()

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1065,6 +1065,7 @@ impl Servo {
                     if let Err(e) = response_sender.send(Err(())) {
                         error!("Sending reply to create png failed {e:?}");
                     }
+                    return;
                 }
             }
 

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2312,6 +2312,11 @@ impl Handler {
     }
 
     fn take_screenshot(&self, rect: Option<Rect<f32, CSSPixel>>) -> WebDriverResult<String> {
+        // Spec: Take screenshot after running the animation frame callbacks.
+        let _ = self.handle_execute_async_script(JavascriptCommandParameters {
+            script: "requestAnimationFrame(() => arguments[0]());".to_string(),
+            args: None,
+        });
         let webview_id = self.webview_id()?;
         let mut img = None;
 

--- a/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/scroll_into_view.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/scroll_into_view.py.ini
@@ -1,3 +1,0 @@
-[scroll_into_view.py]
-  [test_scroll_into_view]
-    expected: FAIL


### PR DESCRIPTION
According to spec, we should wait animation frame callbacks before taking (element) screenshot. As "element screenshot" would automatically scroll into view, this solves intermittency.

Testing: Manually tested on pages, and `take_element_screenshot/scroll_into_view.py` passes stably now.
Fixes: #39306
