### PR TITLE
webdriver: Safely converting to OpenGL coordinates when taking (element) screenshot

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1263,7 +1263,9 @@ impl IOCompositor {
             let x = rect.origin.x as i32;
             // We need to convert to the bottom-left origin coordinate
             // system used by OpenGL
-            let y = (size.height as f32 - rect.origin.y - rect.size.height) as i32;
+            // If dpi > 1, y can be computed to be -1 due to rounding issue, resulting in panic.
+            // https://github.com/servo/servo/issues/39306#issuecomment-3342204869
+            let y = 0.max((size.height as f32 - rect.origin.y - rect.size.height) as i32);
             let w = rect.size.width as i32;
             let h = rect.size.height as i32;
 


### PR DESCRIPTION
When taking element screenshot, we need to convert y-coordinates to comply with OpenGL. With dpi > 1, sometimes y can be -1 due to rounding, resulting in panic when https://github.com/servo/servo/blob/660f90f6879c4bf3cb16ec405c64070d5fdefa68/components/shared/compositing/rendering_context.rs#L655

This PR safely converts.

Testing: When running in headed mode with dpi > 1, `/webdriver/tests/classic/take_element_screenshot/scroll_into_view.py` always passes locally now without panic.
Fixes the panic: https://github.com/servo/servo/issues/39306#issuecomment-3342204869
