### PR TITLE
Add style as potential preload destination

### DIFF
--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -408,12 +408,13 @@ impl VirtualMethods for HTMLLinkElement {
 }
 
 impl HTMLLinkElement {
-    fn compute_destination_for_attribute(&self) -> Destination {
+    fn compute_destination_for_attribute(&self) -> Option<Destination> {
+        // Let destination be the result of translating the keyword
+        // representing the state of el's as attribute.
         let element = self.upcast::<Element>();
         element
             .get_attribute(&ns!(), &local_name!("as"))
-            .map(|attr| translate_a_preload_destination(&attr.value()))
-            .unwrap_or(Destination::None)
+            .and_then(|attr| LinkProcessingOptions::translate_a_preload_destination(&attr.value()))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#create-link-options-from-element>
@@ -424,11 +425,9 @@ impl HTMLLinkElement {
         let document = self.upcast::<Node>().owner_doc();
 
         // Step 2. Let options be a new link processing options
-        let destination = self.compute_destination_for_attribute();
-
         let mut options = LinkProcessingOptions {
             href: String::new(),
-            destination: Some(destination),
+            destination: Destination::None,
             integrity: String::new(),
             link_type: String::new(),
             cryptographic_nonce_metadata: self.upcast::<Element>().nonce_value(),
@@ -519,7 +518,7 @@ impl HTMLLinkElement {
         let mut options = self.processing_options();
 
         // Step 3. Set options's destination to the empty string.
-        options.destination = Some(Destination::None);
+        options.destination = Destination::None;
 
         // Step 4. Let request be the result of creating a link request given options.
         let Some(request) = options.create_link_request(self.owner_window().webview_id()) else {
@@ -781,7 +780,15 @@ impl HTMLLinkElement {
         // Step 1. Update the source set for el.
         // TODO
         // Step 2. Let options be the result of creating link options from el.
-        let options = self.processing_options();
+        let mut options = self.processing_options();
+        // Step 3. Let destination be the result of translating the keyword
+        // representing the state of el's as attribute.
+        let Some(destination) = self.compute_destination_for_attribute() else {
+            // Step 4. If destination is null, then return.
+            return;
+        };
+        // Step 5. Set options's destination to destination.
+        options.destination = destination;
         // Steps for https://html.spec.whatwg.org/multipage/#preload
         {
             // Step 1. If options's type doesn't match options's destination, then return.
@@ -791,7 +798,7 @@ impl HTMLLinkElement {
                 return;
             }
         }
-        // Step 3. Preload options, with the following steps given a response response:
+        // Step 6. Preload options, with the following steps given a response response:
         let Some(request) = options.preload(self.owner_window().webview_id()) else {
             return;
         };
@@ -992,18 +999,6 @@ impl HTMLLinkElementMethods<crate::DomTypeHolder> for HTMLLinkElement {
     // https://drafts.csswg.org/cssom/#dom-linkstyle-sheet
     fn GetSheet(&self, can_gc: CanGc) -> Option<DomRoot<DOMStyleSheet>> {
         self.get_cssom_stylesheet(can_gc).map(DomRoot::upcast)
-    }
-}
-
-/// <https://html.spec.whatwg.org/multipage/#translate-a-preload-destination>
-fn translate_a_preload_destination(potential_destination: &str) -> Destination {
-    match potential_destination {
-        "fetch" => Destination::None,
-        "font" => Destination::Font,
-        "image" => Destination::Image,
-        "script" => Destination::Script,
-        "track" => Destination::Track,
-        _ => Destination::None,
     }
 }
 

--- a/tests/wpt/meta/fetch/metadata/preload.https.sub.html.ini
+++ b/tests/wpt/meta/fetch/metadata/preload.https.sub.html.ini
@@ -1,9 +1,0 @@
-[preload.https.sub.html]
-  [preload style www.not-web-platform.test:8443: sec-fetch-dest]
-    expected: FAIL
-
-  [preload style www.web-platform.test:8443: sec-fetch-dest]
-    expected: FAIL
-
-  [preload style web-platform.test:8443: sec-fetch-dest]
-    expected: FAIL

--- a/tests/wpt/meta/preload/download-resources.html.ini
+++ b/tests/wpt/meta/preload/download-resources.html.ini
@@ -1,3 +1,0 @@
-[download-resources.html]
-  [Makes sure that preloaded resources are downloaded]
-    expected: FAIL

--- a/tests/wpt/meta/preload/preload-csp.sub.html.ini
+++ b/tests/wpt/meta/preload/preload-csp.sub.html.ini
@@ -1,3 +1,0 @@
-[preload-csp.sub.html]
-  [Preload requests are blocked by CSP.]
-    expected: FAIL

--- a/tests/wpt/meta/preload/preload-default-csp.sub.html.ini
+++ b/tests/wpt/meta/preload/preload-default-csp.sub.html.ini
@@ -1,3 +1,0 @@
-[preload-default-csp.sub.html]
-  [Preload requests are blocked by CSP ("default-src 'none').]
-    expected: FAIL

--- a/tests/wpt/meta/preload/preload-nonce.sub.html.ini
+++ b/tests/wpt/meta/preload/preload-nonce.sub.html.ini
@@ -1,3 +1,0 @@
-[preload-nonce.sub.html]
-  [Preload requests without a nonce are blocked by CSP.]
-    expected: FAIL

--- a/tests/wpt/meta/preload/preload-type-match.html.ini
+++ b/tests/wpt/meta/preload/preload-type-match.html.ini
@@ -2,17 +2,14 @@
   [Preload with {as=image; type=image/unknown} should timeout when retrieved resource is a png]
     expected: FAIL
 
-  [Preload with {as=style; type=application/css} should timeout when retrieved resource is a css]
-    expected: FAIL
-
-  [Preload with {as=style; type=text/plain} should timeout when retrieved resource is a css]
-    expected: FAIL
-
-  [Preload with {as=json; type=text/plain} should timeout when retrieved resource is a json]
-    expected: FAIL
-
-  [Preload with {as=json; type=application/javascript} should timeout when retrieved resource is a json]
-    expected: FAIL
-
   [Preload with {as=font; type=font/not-a-font} should timeout when retrieved resource is a ttf]
+    expected: FAIL
+
+  [Preload with {as=json; type=application/json} should load when retrieved resource is a json]
+    expected: FAIL
+
+  [Preload with {as=json; type=text/json} should load when retrieved resource is a json]
+    expected: FAIL
+
+  [Preload with {as=json; type=application/geo+json} should load when retrieved resource is a json]
     expected: FAIL

--- a/tests/wpt/tests/preload/download-resources.html
+++ b/tests/wpt/tests/preload/download-resources.html
@@ -23,8 +23,8 @@
         if (numberOfResourceTimingEntries("resources/dummy.js") == 1 &&
             numberOfResourceTimingEntries("resources/dummy.css") == 1 &&
             numberOfResourceTimingEntries("/fonts/CanvasTest.ttf") == 1 &&
-            numberOfResourceTimingEntries("resources/white.mp4") == 1 &&
-            numberOfResourceTimingEntries("resources/sound_5.oga") == 1 &&
+            numberOfResourceTimingEntries("resources/white.mp4") == 0 &&
+            numberOfResourceTimingEntries("resources/sound_5.oga") == 0 &&
             numberOfResourceTimingEntries("resources/foo.vtt") == 1 &&
             numberOfResourceTimingEntries("resources/dummy.xml?foo=bar") == 0 &&
             numberOfResourceTimingEntries("resources/dummy.xml?novalue") == 0 &&
@@ -37,8 +37,8 @@
             verifyNumberOfResourceTimingEntries("resources/dummy.js", 1);
             verifyNumberOfResourceTimingEntries("resources/dummy.css", 1);
             verifyNumberOfResourceTimingEntries("/fonts/CanvasTest.ttf", 1);
-            verifyNumberOfResourceTimingEntries("resources/white.mp4", 1);
-            verifyNumberOfResourceTimingEntries("resources/sound_5.oga", 1);
+            verifyNumberOfResourceTimingEntries("resources/white.mp4", 0);
+            verifyNumberOfResourceTimingEntries("resources/sound_5.oga", 0);
             verifyNumberOfResourceTimingEntries("resources/foo.vtt", 1);
             verifyNumberOfResourceTimingEntries("resources/dummy.xml?foo=bar", 0);
             verifyNumberOfResourceTimingEntries("resources/dummy.xml?novalue", 0);


### PR DESCRIPTION
This was missed during the previous implementation and was the reason that the CSP tests weren't working.

It also updates a test to ensure that audio and video are not preloaded. No browsers do that and with this fix, the test now passes in Chrome. In Firefox it still fails as it doesn't implement `.vtt` support.

Part of #35035