### PR TITLE
Consistently rename storage to webstorage to prevent confusion

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -167,7 +167,7 @@ use servo_config::{opts, pref};
 use servo_rand::{Rng, ServoRng, SliceRandom, random};
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
-use storage_traits::storage_thread::{StorageThreadMsg, StorageType};
+use storage_traits::webstorage_thread::{StorageType, WebStorageThreadMsg};
 use style::global_style_data::StyleThreadPool;
 #[cfg(feature = "webgpu")]
 use webgpu::canvas_context::WGPUImageMap;
@@ -2703,7 +2703,7 @@ where
         debug!("Exiting storage resource threads.");
         if let Err(e) = generic_channel::GenericSend::send(
             &self.public_storage_threads,
-            StorageThreadMsg::Exit(storage_ipc_sender),
+            WebStorageThreadMsg::Exit(storage_ipc_sender),
         ) {
             warn!("Exit storage thread failed ({})", e);
         }

--- a/components/script/dom/storage.rs
+++ b/components/script/dom/storage.rs
@@ -7,7 +7,7 @@ use constellation_traits::ScriptToConstellationMessage;
 use dom_struct::dom_struct;
 use profile_traits::generic_channel;
 use servo_url::ServoUrl;
-use storage_traits::storage_thread::{StorageThreadMsg, StorageType};
+use storage_traits::webstorage_thread::{StorageType, WebStorageThreadMsg};
 
 use crate::dom::bindings::codegen::Bindings::StorageBinding::StorageMethods;
 use crate::dom::bindings::error::{Error, ErrorResult};
@@ -56,7 +56,7 @@ impl Storage {
         self.global().get_url()
     }
 
-    fn send_storage_msg(&self, msg: StorageThreadMsg) -> SendResult {
+    fn send_storage_msg(&self, msg: WebStorageThreadMsg) -> SendResult {
         GenericSend::send(self.global().storage_threads(), msg)
     }
 }
@@ -67,7 +67,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
         let (sender, receiver) =
             generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
 
-        self.send_storage_msg(StorageThreadMsg::Length(
+        self.send_storage_msg(WebStorageThreadMsg::Length(
             sender,
             self.storage_type,
             self.webview_id(),
@@ -82,7 +82,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
         let (sender, receiver) =
             generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
 
-        self.send_storage_msg(StorageThreadMsg::Key(
+        self.send_storage_msg(WebStorageThreadMsg::Key(
             sender,
             self.storage_type,
             self.webview_id(),
@@ -99,7 +99,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
             generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
         let name = String::from(name);
 
-        let msg = StorageThreadMsg::GetItem(
+        let msg = WebStorageThreadMsg::GetItem(
             sender,
             self.storage_type,
             self.webview_id(),
@@ -117,7 +117,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
         let name = String::from(name);
         let value = String::from(value);
 
-        let msg = StorageThreadMsg::SetItem(
+        let msg = WebStorageThreadMsg::SetItem(
             sender,
             self.storage_type,
             self.webview_id(),
@@ -146,7 +146,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
             generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
         let name = String::from(name);
 
-        let msg = StorageThreadMsg::RemoveItem(
+        let msg = WebStorageThreadMsg::RemoveItem(
             sender,
             self.storage_type,
             self.webview_id(),
@@ -164,7 +164,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
         let (sender, receiver) =
             generic_channel::channel(self.global().time_profiler_chan().clone()).unwrap();
 
-        self.send_storage_msg(StorageThreadMsg::Clear(
+        self.send_storage_msg(WebStorageThreadMsg::Clear(
             sender,
             self.storage_type,
             self.webview_id(),
@@ -181,7 +181,7 @@ impl StorageMethods<crate::DomTypeHolder> for Storage {
         let time_profiler = self.global().time_profiler_chan().clone();
         let (sender, receiver) = generic_channel::channel(time_profiler).unwrap();
 
-        self.send_storage_msg(StorageThreadMsg::Keys(
+        self.send_storage_msg(WebStorageThreadMsg::Keys(
             sender,
             self.storage_type,
             self.webview_id(),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -83,7 +83,7 @@ use servo_config::{opts, pref};
 use servo_geometry::{DeviceIndependentIntRect, f32_rect_to_au_rect};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
-use storage_traits::storage_thread::StorageType;
+use storage_traits::webstorage_thread::StorageType;
 use style::error_reporting::{ContextualParseError, ParseErrorReporter};
 use style::properties::PropertyId;
 use style::properties::style_structs::Font;

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -38,7 +38,7 @@ use net_traits::request::Referrer;
 use script_traits::NewLayoutInfo;
 use serde::{Deserialize, Serialize};
 use servo_url::{ImmutableOrigin, ServoUrl};
-use storage_traits::storage_thread::StorageThreadMsg;
+use storage_traits::webstorage_thread::WebStorageThreadMsg;
 use style::attr::parse_integer;
 
 use crate::dom::bindings::cell::DomRefCell;
@@ -353,7 +353,7 @@ impl WindowProxy {
 
             let (sender, receiver) = generic_channel::channel().unwrap();
 
-            let msg = StorageThreadMsg::Clone {
+            let msg = WebStorageThreadMsg::Clone {
                 sender,
                 src: window.window_proxy().webview_id(),
                 dest: response.new_webview_id,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -89,7 +89,7 @@ use script_traits::{
 use servo_config::{opts, prefs};
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
-use storage_traits::storage_thread::StorageType;
+use storage_traits::webstorage_thread::StorageType;
 use style::thread_state::{self, ThreadState};
 use stylo_atoms::Atom;
 use timers::{TimerEventRequest, TimerId, TimerScheduler};

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -34,7 +34,7 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use servo_url::{ImmutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
-use storage_traits::storage_thread::StorageType;
+use storage_traits::webstorage_thread::StorageType;
 use strum_macros::IntoStaticStr;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::{WebGPU, WebGPUAdapterResponse};

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -45,7 +45,7 @@ use serde::{Deserialize, Serialize};
 use servo_config::prefs::PrefValue;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
-use storage_traits::storage_thread::StorageType;
+use storage_traits::webstorage_thread::StorageType;
 use strum_macros::IntoStaticStr;
 use style_traits::{CSSPixel, SpeculativePainter};
 use stylo_atoms::Atom;

--- a/components/shared/storage/lib.rs
+++ b/components/shared/storage/lib.rs
@@ -9,20 +9,20 @@ use malloc_size_of::malloc_size_of_is_0;
 use serde::{Deserialize, Serialize};
 
 use crate::indexeddb_thread::IndexedDBThreadMsg;
-use crate::storage_thread::StorageThreadMsg;
+use crate::webstorage_thread::WebStorageThreadMsg;
 
 pub mod indexeddb_thread;
-pub mod storage_thread;
+pub mod webstorage_thread;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StorageThreads {
-    storage_thread: GenericSender<StorageThreadMsg>,
+    storage_thread: GenericSender<WebStorageThreadMsg>,
     idb_thread: IpcSender<IndexedDBThreadMsg>,
 }
 
 impl StorageThreads {
     pub fn new(
-        storage_thread: GenericSender<StorageThreadMsg>,
+        storage_thread: GenericSender<WebStorageThreadMsg>,
         idb_thread: IpcSender<IndexedDBThreadMsg>,
     ) -> StorageThreads {
         StorageThreads {
@@ -42,12 +42,12 @@ impl IpcSend<IndexedDBThreadMsg> for StorageThreads {
     }
 }
 
-impl GenericSend<StorageThreadMsg> for StorageThreads {
-    fn send(&self, msg: StorageThreadMsg) -> SendResult {
+impl GenericSend<WebStorageThreadMsg> for StorageThreads {
+    fn send(&self, msg: WebStorageThreadMsg) -> SendResult {
         self.storage_thread.send(msg)
     }
 
-    fn sender(&self) -> GenericSender<StorageThreadMsg> {
+    fn sender(&self) -> GenericSender<WebStorageThreadMsg> {
         self.storage_thread.clone()
     }
 }

--- a/components/shared/storage/webstorage_thread.rs
+++ b/components/shared/storage/webstorage_thread.rs
@@ -17,7 +17,7 @@ pub enum StorageType {
 
 /// Request operations on the storage data associated with a particular url
 #[derive(Debug, Deserialize, Serialize)]
-pub enum StorageThreadMsg {
+pub enum WebStorageThreadMsg {
     /// gets the number of key/value pairs present in the associated storage data
     Length(GenericSender<usize>, StorageType, WebViewId, ServoUrl),
 

--- a/components/storage/storage_thread.rs
+++ b/components/storage/storage_thread.rs
@@ -9,10 +9,10 @@ use ipc_channel::ipc::IpcSender;
 use profile_traits::mem::ProfilerChan as MemProfilerChan;
 use storage_traits::StorageThreads;
 use storage_traits::indexeddb_thread::IndexedDBThreadMsg;
-use storage_traits::storage_thread::StorageThreadMsg;
+use storage_traits::webstorage_thread::WebStorageThreadMsg;
 
 use crate::indexeddb::IndexedDBThreadFactory;
-use crate::webstorage_thread::StorageThreadFactory;
+use crate::webstorage_thread::WebStorageThreadFactory;
 
 #[allow(clippy::too_many_arguments)]
 pub fn new_storage_threads(
@@ -20,8 +20,8 @@ pub fn new_storage_threads(
     config_dir: Option<PathBuf>,
 ) -> (StorageThreads, StorageThreads) {
     let idb: IpcSender<IndexedDBThreadMsg> = IndexedDBThreadFactory::new(config_dir.clone());
-    let storage: GenericSender<StorageThreadMsg> =
-        StorageThreadFactory::new(config_dir, mem_profiler_chan);
+    let storage: GenericSender<WebStorageThreadMsg> =
+        WebStorageThreadFactory::new(config_dir, mem_profiler_chan);
     (
         StorageThreads::new(storage.clone(), idb.clone()),
         StorageThreads::new(storage, idb),


### PR DESCRIPTION
Add the prefix of "WebStorage" instead of "Storage" for all webstorage spec related things. For example, a `struct` called `StorageManager`: this could refer to either webstorage's thread manager or to the backend for [the storage manager interface](https://storage.spec.whatwg.org/#storagemanager). webstorage is the full name of the spec, so I chose to keep that in the names of files/structs to prevent confusion when storage manager is implemented.