### PR TITLE
mach: Tighten tidy lint to check if binding implementation has a spec link

### DIFF
--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -252,7 +252,7 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
             .map_err(|_| Error::JSFailed)
     }
 
-    // https://webaudio.github.io/web-audio-api/#dom-audiobuffer-copyfromchannel
+    /// <https://webaudio.github.io/web-audio-api/#dom-audiobuffer-copyfromchannel>
     fn CopyFromChannel(
         &self,
         mut destination: CustomAutoRooterGuard<Float32Array>,

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -71,7 +71,7 @@ impl BluetoothRemoteGATTServerMethods<crate::DomTypeHolder> for BluetoothRemoteG
         self.connected.get()
     }
 
-    // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-connect
+    /// <https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-connect>
     fn Connect(&self, comp: InRealm, can_gc: CanGc) -> Rc<Promise> {
         // Step 1.
         let p = Promise::new_in_current_realm(comp, can_gc);

--- a/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/canvasrenderingcontext2d.rs
@@ -549,7 +549,7 @@ impl CanvasRenderingContext2DMethods<crate::DomTypeHolder> for CanvasRenderingCo
             .put_image_data(self.canvas.size(), imagedata, dx, dy)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
+    /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata>
     fn PutImageData_(
         &self,
         imagedata: &ImageData,

--- a/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
@@ -415,7 +415,7 @@ impl OffscreenCanvasRenderingContext2DMethods<crate::DomTypeHolder>
         self.context.PutImageData(imagedata, dx, dy)
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata
+    /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-putimagedata>
     fn PutImageData_(
         &self,
         imagedata: &ImageData,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2882,9 +2882,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         DOMString::from(&*name)
     }
 
-    // https://dom.spec.whatwg.org/#dom-element-id
-    // This always returns a string; if you'd rather see None
-    // on a null id, call get_id
+    /// <https://dom.spec.whatwg.org/#dom-element-id>
+    /// This always returns a string; if you'd rather see None
+    /// on a null id, call get_id
     fn Id(&self) -> DOMString {
         self.get_string_attribute(&local_name!("id"))
     }
@@ -3286,8 +3286,8 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         point.y.abs() as f64
     }
 
-    // https://drafts.csswg.org/cssom-view/#dom-element-scrolltop
     // TODO(stevennovaryo): Need to update the scroll API to follow the spec since it is quite outdated.
+    /// <https://drafts.csswg.org/cssom-view/#dom-element-scrolltop>
     fn SetScrollTop(&self, y_: f64) {
         let behavior = ScrollBehavior::Auto;
 
@@ -3510,7 +3510,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         self.client_rect().size.height
     }
 
-    // https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom
+    /// <https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom>
     fn CurrentCSSZoom(&self) -> Finite<f64> {
         let window = self.owner_window();
         Finite::wrap(window.current_css_zoom_query(self.upcast::<Node>()) as f64)

--- a/components/script/dom/filereader.rs
+++ b/components/script/dom/filereader.rs
@@ -247,7 +247,7 @@ impl FileReader {
         fr.dispatch_progress_event(atom!("progress"), 0, None, can_gc);
     }
 
-    // https://w3c.github.io/FileAPI/#dfn-readAsText
+    /// <https://w3c.github.io/FileAPI/#dfn-readAsText>
     pub(crate) fn process_read(filereader: TrustedFileReader, gen_id: GenerationId, can_gc: CanGc) {
         let fr = filereader.root();
 
@@ -263,7 +263,7 @@ impl FileReader {
         fr.dispatch_progress_event(atom!("loadstart"), 0, None, can_gc);
     }
 
-    // https://w3c.github.io/FileAPI/#dfn-readAsText
+    /// <https://w3c.github.io/FileAPI/#dfn-readAsText>
     pub(crate) fn process_read_eof(
         filereader: TrustedFileReader,
         gen_id: GenerationId,
@@ -373,35 +373,35 @@ impl FileReaderMethods<crate::DomTypeHolder> for FileReader {
         Ok(FileReader::new(global, proto, can_gc))
     }
 
-    // https://w3c.github.io/FileAPI/#dfn-onloadstart
+    // <https://w3c.github.io/FileAPI/#dfn-onloadstart>
     event_handler!(loadstart, GetOnloadstart, SetOnloadstart);
 
-    // https://w3c.github.io/FileAPI/#dfn-onprogress
+    // <https://w3c.github.io/FileAPI/#dfn-onprogress>
     event_handler!(progress, GetOnprogress, SetOnprogress);
 
-    // https://w3c.github.io/FileAPI/#dfn-onload
+    // <https://w3c.github.io/FileAPI/#dfn-onload>
     event_handler!(load, GetOnload, SetOnload);
 
-    // https://w3c.github.io/FileAPI/#dfn-onabort
+    // <https://w3c.github.io/FileAPI/#dfn-onabort>
     event_handler!(abort, GetOnabort, SetOnabort);
 
-    // https://w3c.github.io/FileAPI/#dfn-onerror
+    // <https://w3c.github.io/FileAPI/#dfn-onerror>
     event_handler!(error, GetOnerror, SetOnerror);
 
-    // https://w3c.github.io/FileAPI/#dfn-onloadend
+    // <https://w3c.github.io/FileAPI/#dfn-onloadend>
     event_handler!(loadend, GetOnloadend, SetOnloadend);
 
-    // https://w3c.github.io/FileAPI/#dfn-readAsArrayBuffer
+    /// <https://w3c.github.io/FileAPI/#dfn-readAsArrayBuffer>
     fn ReadAsArrayBuffer(&self, blob: &Blob, can_gc: CanGc) -> ErrorResult {
         self.read(FileReaderFunction::ArrayBuffer, blob, None, can_gc)
     }
 
-    // https://w3c.github.io/FileAPI/#dfn-readAsDataURL
+    /// <https://w3c.github.io/FileAPI/#dfn-readAsDataURL>
     fn ReadAsDataURL(&self, blob: &Blob, can_gc: CanGc) -> ErrorResult {
         self.read(FileReaderFunction::DataUrl, blob, None, can_gc)
     }
 
-    // https://w3c.github.io/FileAPI/#dfn-readAsText
+    /// <https://w3c.github.io/FileAPI/#dfn-readAsText>
     fn ReadAsText(&self, blob: &Blob, label: Option<DOMString>, can_gc: CanGc) -> ErrorResult {
         self.read(FileReaderFunction::Text, blob, label, can_gc)
     }

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -2617,7 +2617,7 @@ impl HTMLInputElement {
         TextControlSelection::new(self, &self.textinput)
     }
 
-    // https://html.spec.whatwg.org/multipage/#implicit-submission
+    /// <https://html.spec.whatwg.org/multipage/#implicit-submission>
     fn implicit_submission(&self, can_gc: CanGc) {
         let doc = self.owner_document();
         let node = doc.upcast::<Node>();

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -304,7 +304,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
         navigatorinfo::AppVersion()
     }
 
-    // https://webbluetoothcg.github.io/web-bluetooth/#dom-navigator-bluetooth
+    /// <https://webbluetoothcg.github.io/web-bluetooth/#dom-navigator-bluetooth>
     #[cfg(feature = "bluetooth")]
     fn Bluetooth(&self) -> DomRoot<Bluetooth> {
         self.bluetooth
@@ -327,7 +327,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
         navigatorinfo::Language()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-navigator-languages
+    /// <https://html.spec.whatwg.org/multipage/#dom-navigator-languages>
     fn Languages(&self, cx: JSContext, can_gc: CanGc, retval: MutableHandleValue) {
         to_frozen_array(&[self.Language()], cx, retval, can_gc)
     }
@@ -413,7 +413,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
         })
     }
 
-    // https://gpuweb.github.io/gpuweb/#dom-navigator-gpu
+    /// <https://gpuweb.github.io/gpuweb/#dom-navigator-gpu>
     #[cfg(feature = "webgpu")]
     fn Gpu(&self) -> DomRoot<GPU> {
         self.gpu.or_init(|| GPU::new(&self.global(), CanGc::note()))

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -2739,7 +2739,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
         self.buffer_data_(target, size, usage, bound_buffer)
     }
 
-    // https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5
+    /// <https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.5>
     fn BufferSubData(&self, target: u32, offset: i64, data: ArrayBufferViewOrArrayBuffer) {
         let bound_buffer = handle_potential_webgl_error!(self, self.bound_buffer(target), return);
         self.buffer_sub_data(target, offset, data, bound_buffer)

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -157,7 +157,7 @@ impl Worker {
 }
 
 impl WorkerMethods<crate::DomTypeHolder> for Worker {
-    // https://html.spec.whatwg.org/multipage/#dom-worker
+    /// <https://html.spec.whatwg.org/multipage/#dom-worker>
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/workers/workernavigator.rs
+++ b/components/script/dom/workers/workernavigator.rs
@@ -99,7 +99,7 @@ impl WorkerNavigatorMethods<crate::DomTypeHolder> for WorkerNavigator {
         navigatorinfo::Language()
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-navigator-languages
+    /// <https://html.spec.whatwg.org/multipage/#dom-navigator-languages>
     fn Languages(&self, cx: JSContext, can_gc: CanGc, retval: MutableHandleValue) {
         to_frozen_array(&[self.Language()], cx, retval, can_gc)
     }

--- a/python/tidy/tests/speclink.rs
+++ b/python/tidy/tests/speclink.rs
@@ -14,10 +14,6 @@ impl SpecLinkMethods<crate::DomTypeHolder> for SpecLink {
         0
     }
 
-    // A spec link.
-    // https://example.com/
-    fn Foo() {}
-
     /// A spec link.
     /// <https://example.com/>
     fn Foo() {}

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -700,7 +700,8 @@ def check_spec(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:
     macro_patt = re.compile(r"^\s*\S+!(.*)$")
 
     # Pattern representing a line with comment containing a spec link
-    link_patt = re.compile(r"^\s*/// (<https://.+>.*|https://.+)$")
+    fn_link_patt = re.compile(r"^\s*/// (<https://.+>.*|https://.+)$")
+    macro_link_patt = re.compile(r"^\s*// (<https://.+>.*|https://.+)$")
 
     # Pattern representing a line with comment or attribute
     comment_patt = re.compile(r"^\s*(///?.+|#\[.+\])$")
@@ -718,7 +719,9 @@ def check_spec(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:
             if ("fn " in line or macro_patt.match(line)) and brace_count == 1:
                 for up_idx in range(1, idx + 1):
                     up_line = lines[idx - up_idx].decode("utf-8")
-                    if link_patt.match(up_line):
+                    if ("fn " in line and fn_link_patt.match(up_line)) or (
+                        macro_patt.match(line) and macro_link_patt.match(up_line)
+                    ):
                         # Comment with spec link exists
                         break
                     if not comment_patt.match(up_line):

--- a/python/tidy/tidy.py
+++ b/python/tidy/tidy.py
@@ -700,7 +700,7 @@ def check_spec(file_name: str, lines: list[bytes]) -> Iterator[tuple[int, str]]:
     macro_patt = re.compile(r"^\s*\S+!(.*)$")
 
     # Pattern representing a line with comment containing a spec link
-    link_patt = re.compile(r"^\s*///? (<https://.+>.*|https://.+)$")
+    link_patt = re.compile(r"^\s*/// (<https://.+>.*|https://.+)$")
 
     # Pattern representing a line with comment or attribute
     comment_patt = re.compile(r"^\s*(///?.+|#\[.+\])$")


### PR DESCRIPTION
Ensures that spec links are of the format "/// <http(s)://" via a tidy lint.