### PR TITLE
script: Return cached object from `CryptoKey.usages` getter

### DIFF
--- a/tests/wpt/meta/WebCryptoAPI/crypto_key_cached_slots.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/crypto_key_cached_slots.https.any.js.ini
@@ -1,8 +1,0 @@
-[crypto_key_cached_slots.https.any.worker.html]
-  [CryptoKey.usages getter returns cached object]
-    expected: FAIL
-
-
-[crypto_key_cached_slots.https.any.html]
-  [CryptoKey.usages getter returns cached object]
-    expected: FAIL


### PR DESCRIPTION
Create and store a cached object in `CryptoKey` for the `[[usages]]` internal slot when the key is created or when its `[[usages]]` internal slot is updated. The getter can then return the cached object as specified in https://w3c.github.io/webcrypto/#dom-cryptokey-usages, instead of creating a new object on each call.

Testing: Pass WPT tests that were expected to fail.
