### PR TITLE
compositing: Use the same hit test during an entire touch sequence

### DIFF
--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -587,8 +587,11 @@ impl TouchHandler {
     }
 
     pub(crate) fn get_hit_test_result_cache_value(&self) -> Option<CompositorHitTestResult> {
-        self.touch_sequence_map
-            .get(&self.current_sequence_id)?
+        let sequence = self.touch_sequence_map.get(&self.current_sequence_id)?;
+        if sequence.state == Finished {
+            return None;
+        }
+        sequence
             .hit_test_result_cache
             .as_ref()
             .map(|cache| Some(cache.value.clone()))?

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -40,7 +40,9 @@ pub enum TouchMoveAllowed {
     Pending,
 }
 
-/// Cache for the last touch hit test result.
+/// A cached [`CompositorHitTestResult`] to use during a touch sequence. This
+/// is kept so that the renderer doesn't have to constantly keep making hit tests
+/// while during panning and flinging actions.
 struct HitTestResultCache {
     value: CompositorHitTestResult,
     device_pixels_per_page: Scale<f32, CSSPixel, DevicePixel>,

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -753,15 +753,11 @@ impl WebViewRenderer {
             ScrollLocation::Start | ScrollLocation::End => scroll_location,
         };
 
-        let mut hit_test_results: Vec<_> = self
+        let hit_test_results: Vec<_> = self
             .touch_handler
             .get_hit_test_result_cache_value()
-            .into_iter()
-            .collect();
-
-        if hit_test_results.is_empty() {
-            hit_test_results = self.global.borrow().hit_test_at_point(cursor);
-        }
+            .map(|result| vec![result])
+            .unwrap_or_else(|| self.global.borrow().hit_test_at_point(cursor));
 
         // Iterate through all hit test results, processing only the first node of each pipeline.
         // This is needed to propagate the scroll events from a pipeline representing an iframe to

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -280,21 +280,24 @@ impl WebViewRenderer {
         }
     }
 
-    pub(crate) fn dispatch_input_event_with_hit_testing(&self, mut event: InputEventAndId) -> bool {
+    pub(crate) fn dispatch_input_event_with_hit_testing(
+        &mut self,
+        mut event: InputEventAndId,
+    ) -> bool {
         let event_point = event.event.point();
         let hit_test_result = match event_point {
             Some(point) => {
-                let hit_test_result = self
-                    .global
-                    .borrow()
-                    .hit_test_at_point(point)
-                    .into_iter()
-                    .nth(0);
-                if hit_test_result.is_none() {
-                    warn!("Empty hit test result for input event, ignoring.");
-                    return false;
-                }
-                hit_test_result
+                let cached_hit_test_result = match event.event {
+                    InputEvent::Touch(_) => self.touch_handler.get_hit_test_result_cache_value(),
+                    _ => None,
+                };
+                cached_hit_test_result.or_else(|| {
+                    self.global
+                        .borrow()
+                        .hit_test_at_point(point)
+                        .into_iter()
+                        .nth(0)
+                })
             },
             None => None,
         };
@@ -750,7 +753,15 @@ impl WebViewRenderer {
             ScrollLocation::Start | ScrollLocation::End => scroll_location,
         };
 
-        let hit_test_results = self.global.borrow().hit_test_at_point(cursor);
+        let mut hit_test_results: Vec<_> = self
+            .touch_handler
+            .get_hit_test_result_cache_value()
+            .into_iter()
+            .collect();
+
+        if hit_test_results.is_empty() {
+            hit_test_results = self.global.borrow().hit_test_at_point(cursor);
+        }
 
         // Iterate through all hit test results, processing only the first node of each pipeline.
         // This is needed to propagate the scroll events from a pipeline representing an iframe to
@@ -767,6 +778,10 @@ impl WebViewRenderer {
                     ScrollType::InputEvents,
                 );
                 if let Some((external_scroll_id, offset)) = scroll_result {
+                    self.touch_handler.set_hit_test_result_cache_value(
+                        hit_test_result.clone(),
+                        self.device_pixels_per_page_pixel(),
+                    );
                     return Some(ScrollResult {
                         hit_test_result: hit_test_result.clone(),
                         external_scroll_id,

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -778,6 +778,11 @@ impl WebViewRenderer {
                     ScrollType::InputEvents,
                 );
                 if let Some((external_scroll_id, offset)) = scroll_result {
+                    // We would like to cache the hit test for the node that that actually scrolls
+                    // while panning, which we don't know until right now (as some nodes
+                    // might be at the end of their scroll area). In particular, directionality of
+                    // scroll matters. That's why this is done here and not as soon as the touch
+                    // starts.
                     self.touch_handler.set_hit_test_result_cache_value(
                         hit_test_result.clone(),
                         self.device_pixels_per_page_pixel(),


### PR DESCRIPTION
Add hit test cache when swiping with a single finger. The compositor's request for WebRender's hit testing requires synchronous waiting. This modification reduces the number of hit tests by adding a hit test cache, thereby improving the frame rate during scrolling.

Testing: Manual testing was done the [Huawei Mossel page](https://www.huaweimossel.com/) on mobile devices. This  showed no issues.
