### PR TITLE
layout: Ensure that the `Epoch` stored in layout is accurate

### DIFF
--- a/components/shared/base/lib.rs
+++ b/components/shared/base/lib.rs
@@ -77,8 +77,8 @@ where
 pub struct Epoch(pub u32);
 
 impl Epoch {
-    pub fn next(&mut self) {
-        self.0 += 1;
+    pub fn next(&self) -> Self {
+        Self(self.0 + 1)
     }
 }
 

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -103,7 +103,7 @@ pub enum CompositorMsg {
     /// The load of a page has completed
     LoadComplete(WebViewId),
     /// Inform WebRender of the existence of this pipeline.
-    SendInitialTransaction(WebRenderPipelineId),
+    SendInitialTransaction(WebViewId, WebRenderPipelineId),
     /// Perform a scroll operation.
     SendScrollNode(
         WebViewId,
@@ -204,8 +204,11 @@ impl CrossProcessCompositorApi {
     }
 
     /// Inform WebRender of the existence of this pipeline.
-    pub fn send_initial_transaction(&self, pipeline: WebRenderPipelineId) {
-        if let Err(e) = self.0.send(CompositorMsg::SendInitialTransaction(pipeline)) {
+    pub fn send_initial_transaction(&self, webview_id: WebViewId, pipeline: WebRenderPipelineId) {
+        if let Err(e) = self
+            .0
+            .send(CompositorMsg::SendInitialTransaction(webview_id, pipeline))
+        {
             warn!("Error sending initial transaction: {}", e);
         }
     }


### PR DESCRIPTION
The first epoch is 0 as that is the one used in the initial transaction,
but the code was setting the first `Epoch` to `Epoch(1)`. This means that
when layout advanced the epoch, the `Epoch` of the first produced
display list was `Epoch(2)`.

This change makes the value reflected in `current_epoch` actually match
the index of the display list produced. In addition, we always store
this epoch in `PipelineDetails` in the renderer. This will be important
when adding the `WebView::take_screenshot` API.

Testing: This should not change behavior, so is covered by existing tests which
rely on proper `Epoch` advancement.
