### PR TITLE
html: Add shadow tree for input type="file"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7524,7 +7524,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.31.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#bb62b4e71c44fbb00f4657a1431282193e34d306"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F245%2Fhead#a28aa713a99254b07f99ec9ff104c1546965ec94"
 dependencies = [
  "bitflags 2.9.4",
  "cssparser",
@@ -7857,7 +7857,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#bb62b4e71c44fbb00f4657a1431282193e34d306"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F245%2Fhead#a28aa713a99254b07f99ec9ff104c1546965ec94"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8372,7 +8372,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#bb62b4e71c44fbb00f4657a1431282193e34d306"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F245%2Fhead#a28aa713a99254b07f99ec9ff104c1546965ec94"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8429,7 +8429,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#bb62b4e71c44fbb00f4657a1431282193e34d306"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F245%2Fhead#a28aa713a99254b07f99ec9ff104c1546965ec94"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8438,12 +8438,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#bb62b4e71c44fbb00f4657a1431282193e34d306"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F245%2Fhead#a28aa713a99254b07f99ec9ff104c1546965ec94"
 
 [[package]]
 name = "stylo_derive"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#bb62b4e71c44fbb00f4657a1431282193e34d306"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F245%2Fhead#a28aa713a99254b07f99ec9ff104c1546965ec94"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8455,7 +8455,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#bb62b4e71c44fbb00f4657a1431282193e34d306"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F245%2Fhead#a28aa713a99254b07f99ec9ff104c1546965ec94"
 dependencies = [
  "bitflags 2.9.4",
  "stylo_malloc_size_of",
@@ -8464,7 +8464,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#bb62b4e71c44fbb00f4657a1431282193e34d306"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F245%2Fhead#a28aa713a99254b07f99ec9ff104c1546965ec94"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8481,12 +8481,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#bb62b4e71c44fbb00f4657a1431282193e34d306"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F245%2Fhead#a28aa713a99254b07f99ec9ff104c1546965ec94"
 
 [[package]]
 name = "stylo_traits"
 version = "0.7.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#bb62b4e71c44fbb00f4657a1431282193e34d306"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F245%2Fhead#a28aa713a99254b07f99ec9ff104c1546965ec94"
 dependencies = [
  "app_units",
  "bitflags 2.9.4",
@@ -8901,7 +8901,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#bb62b4e71c44fbb00f4657a1431282193e34d306"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F245%2Fhead#a28aa713a99254b07f99ec9ff104c1546965ec94"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8914,7 +8914,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-09-02#bb62b4e71c44fbb00f4657a1431282193e34d306"
+source = "git+https://github.com/servo/stylo?rev=refs%2Fpull%2F245%2Fhead#a28aa713a99254b07f99ec9ff104c1546965ec94"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ rustls = { version = "0.23", default-features = false, features = ["logging", "s
 rustls-pemfile = "2.0"
 rustls-pki-types = "1.12"
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2025-09-02" }
+selectors = { git = "https://github.com/servo/stylo", rev = "refs/pull/245/head" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -137,19 +137,19 @@ servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-09-02" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "refs/pull/245/head" }
 skrifa = "0.35.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
 string_cache = "0.8"
 strum = "0.26"
 strum_macros = "0.26"
-stylo = { git = "https://github.com/servo/stylo", branch = "2025-09-02" }
-stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-09-02" }
-stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-09-02" }
-stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-09-02" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-09-02" }
-stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-09-02" }
+stylo = { git = "https://github.com/servo/stylo", rev = "refs/pull/245/head" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "refs/pull/245/head" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "refs/pull/245/head" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "refs/pull/245/head" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "refs/pull/245/head" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "refs/pull/245/head" }
 surfman = { version = "0.10.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -60,6 +60,15 @@ input::color-swatch {
   width: 100%;
 }
 
+input::file-selector-button {
+  box-sizing: border-box;
+  display: inline-block;
+  border: 1px solid gray;
+  border-radius: 2px;
+  background: lightgrey;
+  color: black;
+}
+
 input::selection,
 textarea::selection {
   background: rgba(176, 214, 255, 1.0);
@@ -112,15 +121,6 @@ input[type="radio"]::before {
 }
 
 input[type="radio"]:checked::before { content: "●"; line-height: 1em; }
-
-input[type="file"]::before {
-  content: "Choose File";
-  background: lightgrey;
-  border-top: solid 1px #EEEEEE;
-  border-left: solid 1px #CCCCCC;
-  border-right: solid 1px #999999;
-  border-bottom: solid 1px #999999;
-}
 
 input[type="file"] {
   text-align: center;
@@ -343,6 +343,7 @@ button {
 input[type="reset" i],
 input[type="button" i],
 input[type="submit" i],
+input[type="file"]::file-selector-button,
 button {
   text-align: center;
 }

--- a/components/script/dom/filelist.rs
+++ b/components/script/dom/filelist.rs
@@ -6,7 +6,6 @@ use std::slice::Iter;
 
 use dom_struct::dom_struct;
 
-use super::bindings::root::{LayoutDom, ToLayout};
 use crate::dom::bindings::codegen::Bindings::FileListBinding::FileListMethods;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
 use crate::dom::bindings::root::{Dom, DomRoot};
@@ -68,25 +67,5 @@ impl FileListMethods<crate::DomTypeHolder> for FileList {
     // check-tidy: no specs after this line
     fn IndexedGetter(&self, index: u32) -> Option<DomRoot<File>> {
         self.Item(index)
-    }
-}
-
-pub(crate) trait LayoutFileListHelpers<'dom> {
-    fn file_for_layout(&self, index: u32) -> Option<&File>;
-    fn len(&self) -> usize;
-}
-
-#[allow(unsafe_code)]
-impl<'dom> LayoutFileListHelpers<'dom> for LayoutDom<'dom, FileList> {
-    fn len(&self) -> usize {
-        self.unsafe_get().list.len()
-    }
-    fn file_for_layout(&self, index: u32) -> Option<&File> {
-        let list = &self.unsafe_get().list;
-        if (index as usize) < list.len() {
-            Some(unsafe { list[index as usize].to_layout().unsafe_get() })
-        } else {
-            None
-        }
     }
 }

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1869,7 +1869,9 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
         {
             let input = self.unsafe_get().downcast::<HTMLInputElement>().unwrap();
 
-            !input.is_textual_widget() && input.input_type() != InputType::Color
+            !input.is_textual_widget() &&
+                input.input_type() != InputType::Color &&
+                input.input_type() != InputType::File
         } else {
             type_id ==
                 NodeTypeId::Element(ElementTypeId::HTMLElement(

--- a/tests/wpt/meta/css/css-pseudo/file-selector-button-001.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/file-selector-button-001.html.ini
@@ -1,2 +1,0 @@
-[file-selector-button-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/file-selector-button-after-part.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/file-selector-button-after-part.html.ini
@@ -1,2 +1,0 @@
-[file-selector-button-after-part.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/parsing/tree-abiding-pseudo-elements.html.ini
@@ -8,9 +8,6 @@
   ["foo.bar[baz\]::placeholder" should be a valid selector]
     expected: FAIL
 
-  ["::file-selector-button" should be a valid selector]
-    expected: FAIL
-
   ["::file-selector-button:hover" should be a valid selector]
     expected: FAIL
 


### PR DESCRIPTION
Update file inputs to have their buttons styled with file-selector-button. Before these changes, the button was emulated using `::before`, which was not really correct in the first place, but a good temporary solution. 

This only wires up basic support (button is a styled div), since if the "Browse..." element is an actual button, clicking it does not seem to activate the input element. That's why the tests for `:hover`, `:active` and `:focus` still fail.

The CSS UA definitions for type=color were adapted for the new pseudo-element, and now the text used matches Firefox behaviour.

Testing: The big change is that now `::file-selector-button` is supported in Servo, fixing some issues with Tailwind (see linked issue). However, these changes also help pass a few more WPT tests.
Fixes: #39565 

New look (no file selected, one file selected, two files selected):
<img width="434" height="289" alt="image" src="https://github.com/user-attachments/assets/71c87d36-59b4-4359-8741-487faba7b90a" />

linux-wpt run at https://github.com/AlexVasiluta/servo/actions/runs/18114075055