### PR TITLE
storage: Use bincode for webstorage

### DIFF
--- a/components/storage/lib.rs
+++ b/components/storage/lib.rs
@@ -4,6 +4,6 @@
 
 pub mod indexeddb;
 mod storage_thread;
-mod webstorage_thread;
+pub mod webstorage;
 
 pub use storage_thread::new_storage_threads;

--- a/components/storage/storage_thread.rs
+++ b/components/storage/storage_thread.rs
@@ -12,7 +12,7 @@ use storage_traits::indexeddb_thread::IndexedDBThreadMsg;
 use storage_traits::webstorage_thread::WebStorageThreadMsg;
 
 use crate::indexeddb::IndexedDBThreadFactory;
-use crate::webstorage_thread::WebStorageThreadFactory;
+use crate::webstorage::WebStorageThreadFactory;
 
 #[allow(clippy::too_many_arguments)]
 pub fn new_storage_threads(

--- a/components/storage/webstorage/engines/bincode.rs
+++ b/components/storage/webstorage/engines/bincode.rs
@@ -1,0 +1,33 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::webstorage::engines::WebStorageEngine;
+use crate::webstorage::webstorage_thread::OriginEntry;
+
+pub struct BincodeEngine(PathBuf);
+
+impl BincodeEngine {
+    pub fn new(dir: &PathBuf) -> Self {
+        Self(dir.join("local_data.bin"))
+    }
+}
+
+impl WebStorageEngine for BincodeEngine {
+    fn load(&self) -> HashMap<String, OriginEntry> {
+        if let Ok(data) = std::fs::read(&self.0) {
+            if let Ok(map) = bincode::deserialize(&data) {
+                return map;
+            }
+        }
+        HashMap::new()
+    }
+
+    fn save(&self, data: HashMap<String, OriginEntry>) {
+        if let Ok(encoded) = bincode::serialize(&data) {
+            if let Some(parent) = self.0.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let _ = std::fs::write(&self.0, encoded);
+        }
+    }
+}

--- a/components/storage/webstorage/engines/mod.rs
+++ b/components/storage/webstorage/engines/mod.rs
@@ -1,0 +1,22 @@
+mod bincode;
+
+use std::collections::HashMap;
+
+pub use bincode::BincodeEngine;
+
+use crate::webstorage::webstorage_thread::OriginEntry;
+
+pub trait WebStorageEngine {
+    fn load(&self) -> HashMap<String, OriginEntry>;
+    fn save(&self, data: HashMap<String, OriginEntry>);
+}
+
+pub struct MemoryEngine;
+
+impl WebStorageEngine for MemoryEngine {
+    fn load(&self) -> HashMap<String, OriginEntry> {
+        HashMap::new()
+    }
+
+    fn save(&self, _data: HashMap<String, OriginEntry>) {}
+}

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -1,0 +1,4 @@
+pub use self::webstorage_thread::WebStorageThreadFactory;
+
+pub mod engines;
+pub mod webstorage_thread;


### PR DESCRIPTION
Improves performance by using bincode for localstorage. Also it abstracts it with a `WebStorageEngine` trait so that we can swap it out later if needed (similar to how indexeddb is handled). This will also be useful for private browsing, with the `MemoryEngine` struct.