### PR TITLE
indexeddb: Support deletion of key ranges

### DIFF
--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -394,12 +394,12 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
         // Step 7. Let operation be an algorithm to run delete records from an object store with store and range.
         // Step 8. Return the result (an IDBRequest) of running asynchronously execute a request with this and operation.
         let (sender, receiver) = indexed_db::create_channel(self.global());
-        serialized_query.and_then(|q| {
+        serialized_query.and_then(|key_range| {
             IDBRequest::execute_async(
                 self,
                 AsyncOperation::ReadWrite(AsyncReadWriteOperation::RemoveItem {
                     sender,
-                    key_range: q,
+                    key_range,
                 }),
                 receiver,
                 None,

--- a/components/shared/storage/indexeddb_thread.rs
+++ b/components/shared/storage/indexeddb_thread.rs
@@ -294,7 +294,7 @@ pub enum AsyncReadWriteOperation {
     /// Removes the key/value pair for the given key in the associated idb data
     RemoveItem {
         sender: IpcSender<BackendResult<()>>,
-        key: IndexedDBKeyType,
+        key_range: IndexedDBKeyRange,
     },
     /// Clears all key/value pairs in the associated idb data
     Clear(IpcSender<BackendResult<()>>),

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_delete.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_delete.any.js.ini
@@ -1,7 +1,4 @@
 [idbobjectstore_delete.any.worker.html]
-  [delete() removes all of the records in the range]
-    expected: FAIL
-
   [delete() key doesn't match any records]
     expected: FAIL
 
@@ -10,9 +7,6 @@
   expected: ERROR
 
 [idbobjectstore_delete.any.html]
-  [delete() removes all of the records in the range]
-    expected: FAIL
-
   [delete() key doesn't match any records]
     expected: FAIL
 


### PR DESCRIPTION
Allows for key ranges to be deleted, as per spec.

Testing: WPT