### PR TITLE
webdriver: Use `take_screenshot()` API in Take (Element) Screenshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,6 +2384,7 @@ dependencies = [
  "euclid",
  "http 1.3.1",
  "hyper_serde",
+ "image",
  "ipc-channel",
  "keyboard-types",
  "log",

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -23,6 +23,7 @@ crossbeam-channel = { workspace = true }
 euclid = { workspace = true }
 http = { workspace = true }
 hyper_serde = { workspace = true }
+image = { workspace = true }
 ipc-channel = { workspace = true }
 keyboard-types = { workspace = true }
 log = { workspace = true }

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -505,7 +505,7 @@ impl RunningAppState {
             return;
         }
 
-        webview.take_screenshot(move |image| {
+        webview.take_screenshot(None, move |image| {
             achieved_stable_image.set(true);
 
             let Some(output_path) = output_path else {

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -973,7 +973,7 @@ impl RunningAppState {
             return;
         }
 
-        webview.take_screenshot(move |image| {
+        webview.take_screenshot(None, move |image| {
             achieved_stable_image.set(true);
 
             let Some(output_path) = output_path else {

--- a/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/scroll_into_view.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/take_element_screenshot/scroll_into_view.py.ini
@@ -1,3 +1,0 @@
-[scroll_into_view.py]
-  [test_scroll_into_view]
-    expected: FAIL


### PR DESCRIPTION
WPT tests require us to reliably take screenshots when test pages are fully loaded and testing is complete, and the WPT runner uses [test-wait.js](https://github.com/servo/servo/blob/a2f551eb2dda6ca35262d1c4a3b3f8d27f9ffdb5/tests/wpt/tests/tools/wptrunner/wptrunner/executors/test-wait.js) to do this in userland. when testing Servo with [--product servo](https://github.com/servo/servo/blob/a2f551eb2dda6ca35262d1c4a3b3f8d27f9ffdb5/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py), we use servoshell’s --output option, which backs that up with more reliable waiting in Servo. but when testing Servo with [--product servodriver](https://github.com/servo/servo/blob/a2f551eb2dda6ca35262d1c4a3b3f8d27f9ffdb5/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservodriver.py), we use the WebDriver Take Screenshot action, which currently takes the screenshot immediately. we think this might be a source of regressions.

this patch makes the WebDriver actions Take Screenshot and Take Element Screenshot use the same new WebView::take_screenshot() API as servoshell’s --output option, such that those actions now wait for [a variety of conditions](https://github.com/servo/servo/blob/a2f551eb2dda6ca35262d1c4a3b3f8d27f9ffdb5/components/servo/webview.rs#L596-L602) that may affect test output. it’s not clear if this is [conformant](https://w3c.github.io/webdriver/#screen-capture), so we may want to refine this to only wait when running tests at some point. other changes:

- we remove the retry loop where we try to take a screenshot every second for up to 30 seconds
- we send the result as a image::RgbaImage over crossbeam without shared memory (it’s not cross-process)
- we now handle the zero-sized element case directly in the WebDriver server

Testing: This should fix some flaky tests.
Fixes: #36715.
Fixes: (partially) #39180.
Fixes: (partially) #34683.