### PR TITLE
layout: Clone static position rectangles when caching in `IndependentFormattingContext`

### DIFF
--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -2153,7 +2153,7 @@ impl<'container> PlacementState<'container> {
             Fragment::AbsoluteOrFixedPositioned(fragment) => {
                 // The alignment of absolutes in block flow layout is always "start", so the size of
                 // the static position rectangle does not matter.
-                fragment.borrow_mut().static_position_rect = LogicalRect {
+                fragment.borrow_mut().original_static_position_rect = LogicalRect {
                     start_corner: LogicalVec2 {
                         block: (self.current_margin.solve() +
                             self.current_block_direction_position),

--- a/components/layout/fragment_tree/hoisted_shared_fragment.rs
+++ b/components/layout/fragment_tree/hoisted_shared_fragment.rs
@@ -4,54 +4,31 @@
 
 use app_units::Au;
 use malloc_size_of_derive::MallocSizeOf;
-use style::logical_geometry::WritingMode;
-use style::values::specified::align::AlignFlags;
 
 use super::Fragment;
-use crate::geom::{LogicalVec2, PhysicalRect, PhysicalVec};
+use crate::geom::PhysicalRect;
 
 /// A reference to a Fragment which is shared between `HoistedAbsolutelyPositionedBox`
 /// and its placeholder `AbsoluteOrFixedPositionedFragment` in the original tree position.
 /// This will be used later in order to paint this hoisted box in tree order.
-#[derive(MallocSizeOf)]
+#[derive(Default, MallocSizeOf)]
 pub(crate) struct HoistedSharedFragment {
     pub fragment: Option<Fragment>,
-    /// The "static-position rect" of this absolutely positioned box. This is defined by the
-    /// layout mode from which the box originates.
+    /// The original "static-position rect" of this absolutely positioned box. This is
+    /// defined by the layout mode from which the box originates. As this fragment is
+    /// hoisted up the tree this rectangle will be adjusted by the offsets of all
+    /// ancestors between the tree position of the absolute and the containing block for
+    /// absolutes that it is laid out in.
     ///
     /// See <https://drafts.csswg.org/css-position-3/#staticpos-rect>
-    pub static_position_rect: PhysicalRect<Au>,
-    /// The resolved alignment values used for aligning this absolutely positioned element
-    /// if the "static-position rect" ends up being the "inset-modified containing block".
-    /// These values are dependent on the layout mode (currently only interesting for
-    /// flexbox).
-    pub resolved_alignment: LogicalVec2<AlignFlags>,
-    /// This is the [`WritingMode`] of the original parent of the element that created this
-    /// hoisted absolutely-positioned fragment. This helps to interpret the offset for
-    /// static positioning. If the writing mode is right-to-left or bottom-to-top, the static
-    /// offset needs to be adjusted by the absolutely positioned element's inline size.
-    pub original_parent_writing_mode: WritingMode,
+    pub original_static_position_rect: PhysicalRect<Au>,
 }
 
 impl HoistedSharedFragment {
-    pub(crate) fn new(
-        static_position_rect: PhysicalRect<Au>,
-        resolved_alignment: LogicalVec2<AlignFlags>,
-        original_parent_writing_mode: WritingMode,
-    ) -> Self {
-        HoistedSharedFragment {
-            fragment: None,
-            static_position_rect,
-            resolved_alignment,
-            original_parent_writing_mode,
+    pub(crate) fn new(original_static_position_rect: PhysicalRect<Au>) -> Self {
+        Self {
+            fragment: Default::default(),
+            original_static_position_rect,
         }
-    }
-}
-
-impl HoistedSharedFragment {
-    /// `inset: auto`-positioned elements do not know their precise position until after
-    /// they're hoisted. This lets us adjust auto values after the fact.
-    pub(crate) fn adjust_offsets(&mut self, offset: &PhysicalVec<Au>) {
-        self.static_position_rect = self.static_position_rect.translate(*offset);
     }
 }


### PR DESCRIPTION
Hoisted absolutes that are cached in IndependentFormattingContexts may
have their HoistedSharedFragment reused between layouts. This means
that the original value of the adjusted static positioning rectangles
need to be preserved in cache. This change makes it so that these values
are cloned when being retrieved from the cache. Further adjustments up
the tree will now no longer affected the version in teh cache.

Testing: This should cause `/_mozilla/css/stacked_layers.html` to no longer
be flaky.
Fixes: #39548.
Fixes: #39439.
