### PR TITLE
xpath: Remove XML QName validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10883,9 +10883,9 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 name = "xpath"
 version = "0.0.1"
 dependencies = [
- "html5ever",
  "log",
  "malloc_size_of_derive",
+ "markup5ever",
  "nom 8.0.0",
  "servo_malloc_size_of",
 ]

--- a/components/xpath/Cargo.toml
+++ b/components/xpath/Cargo.toml
@@ -12,4 +12,4 @@ log = { workspace = true }
 nom = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
-html5ever = { workspace = true }
+markup5ever = { workspace = true }

--- a/components/xpath/src/lib.rs
+++ b/components/xpath/src/lib.rs
@@ -7,7 +7,7 @@ use std::hash::Hash;
 
 use context::EvaluationCtx;
 use eval::Evaluatable;
-use html5ever::{LocalName, Namespace, Prefix};
+use markup5ever::{LocalName, Namespace, Prefix};
 use parser::{OwnedParserError, QName, parse as parse_impl};
 
 mod context;

--- a/tests/wpt/meta/domxpath/resolver-callback-interface.html.ini
+++ b/tests/wpt/meta/domxpath/resolver-callback-interface.html.ini
@@ -14,9 +14,6 @@
   [object resolver]
     expected: FAIL
 
-  [object resolver: this value and `prefix` argument]
-    expected: FAIL
-
   [object resolver: 'lookupNamespaceURI' is not cached]
     expected: FAIL
 


### PR DESCRIPTION
*Most* of the properties that were verified here were already verified by the xpath parser before. I have not found any evidence that other browsers do the remaining checks. There are web platform tests that expect contradicting behavior (which pass in other browsers). 

Additionally, this change switches `xpath` to use `markup5ever` instead of `html5ever` - this is a drop-in replacement. I thought I did this as part of https://github.com/servo/servo/pull/39546 but apparently the change got lost in the rebasing.


Testing: A new web platform test starts to pass.
Fixes https://github.com/servo/servo/issues/39442
Part of #34527

cc @minghuaw 
