### PR TITLE
fonts: Do not fall back to non-Japanese fonts for Han in Japanese language documents

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -618,6 +618,7 @@ impl FontGroup {
         codepoint: char,
         next_codepoint: Option<char>,
         first_fallback: Option<FontRef>,
+        lang: Option<String>,
     ) -> Option<FontRef> {
         // Tab characters are converted into spaces when rendering.
         // TODO: We should not render a tab character. Instead they should be converted into tab stops
@@ -627,7 +628,7 @@ impl FontGroup {
             _ => codepoint,
         };
 
-        let options = FallbackFontSelectionOptions::new(codepoint, next_codepoint);
+        let options = FallbackFontSelectionOptions::new(codepoint, next_codepoint, lang);
 
         let should_look_for_small_caps = self.descriptor.variant == font_variant_caps::T::SmallCaps &&
             options.character.is_ascii_lowercase();
@@ -673,7 +674,7 @@ impl FontGroup {
 
         if let Some(font) = self.find_fallback(
             font_context,
-            options,
+            options.clone(),
             char_in_template,
             font_has_glyph_and_presentation,
         ) {

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -39,10 +39,11 @@ pub(crate) enum EmojiPresentationPreference {
     Emoji,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct FallbackFontSelectionOptions {
     pub(crate) character: char,
     pub(crate) presentation_preference: EmojiPresentationPreference,
+    pub(crate) lang: Option<String>,
 }
 
 impl Default for FallbackFontSelectionOptions {
@@ -50,12 +51,13 @@ impl Default for FallbackFontSelectionOptions {
         Self {
             character: ' ',
             presentation_preference: EmojiPresentationPreference::None,
+            lang: None,
         }
     }
 }
 
 impl FallbackFontSelectionOptions {
-    pub(crate) fn new(character: char, next_character: Option<char>) -> Self {
+    pub(crate) fn new(character: char, next_character: Option<char>, lang: Option<String>) -> Self {
         let presentation_preference = match next_character {
             Some(next_character) if emoji::is_emoji_presentation_selector(next_character) => {
                 EmojiPresentationPreference::Emoji
@@ -83,6 +85,7 @@ impl FallbackFontSelectionOptions {
         Self {
             character,
             presentation_preference,
+            lang,
         }
     }
 }

--- a/components/fonts/platform/freetype/font_list.rs
+++ b/components/fonts/platform/freetype/font_list.rs
@@ -150,15 +150,21 @@ pub fn fallback_font_families(options: FallbackFontSelectionOptions) -> Vec<&'st
 
     add_noto_fallback_families(options.clone(), &mut families);
 
-    if matches!(
-        Script::from(options.character),
-        Script::Bopomofo | Script::Han
-    ) {
-        families.push("WenQuanYi Micro Hei");
-    }
-
     if let Some(block) = options.character.block() {
         match block {
+            // In Japanese typography, it is not common to use different fonts
+            // for Kanji(Han), Hiragana, and Katakana within the same document.
+            // We uniformly fallback to Japanese fonts when the document language is Japanese.
+            _ if options.lang == Some(String::from("ja")) => {
+                families.push("TakaoPGothic");
+            },
+            _ if matches!(
+                Script::from(options.character),
+                Script::Bopomofo | Script::Han
+            ) && options.lang != Some(String::from("ja")) =>
+            {
+                families.push("WenQuanYi Micro Hei");
+            },
             UnicodeBlock::HalfwidthandFullwidthForms |
             UnicodeBlock::EnclosedIdeographicSupplement => families.push("WenQuanYi Micro Hei"),
             UnicodeBlock::Hiragana |

--- a/components/fonts/platform/freetype/font_list.rs
+++ b/components/fonts/platform/freetype/font_list.rs
@@ -148,7 +148,7 @@ pub fn fallback_font_families(options: FallbackFontSelectionOptions) -> Vec<&'st
         families.push("Noto Color Emoji");
     }
 
-    add_noto_fallback_families(options, &mut families);
+    add_noto_fallback_families(options.clone(), &mut families);
 
     if matches!(
         Script::from(options.character),

--- a/components/fonts/platform/macos/font_list.rs
+++ b/components/fonts/platform/macos/font_list.rs
@@ -84,11 +84,20 @@ pub fn fallback_font_families(options: FallbackFontSelectionOptions) -> Vec<&'st
             {
                 families.push("Lucida Grande");
             },
+            // In Japanese typography, it is not common to use different fonts
+            // for Kanji(Han), Hiragana, and Katakana within the same document. Since Hiragino supports
+            // a comprehensive set of Japanese kanji, we uniformly fallback to Hiragino for all Japanese text.
+            _ if options.lang == Some(String::from("ja")) => {
+                families.push("Hiragino Sans");
+                families.push("Hiragino Kaku Gothic ProN");
+            },
             // CJK-related script codes are a bit troublesome because of unification;
             // we'll probably just get HAN much of the time, so the choice of which
             // language font to try for fallback is rather arbitrary. Usually, though,
             // we hope that font prefs will have handled this earlier.
-            _ if matches!(script, Script::Bopomofo | Script::Han) => {
+            _ if matches!(script, Script::Bopomofo | Script::Han) &&
+                options.lang != Some(String::from("ja")) =>
+            {
                 // TODO: Need to differentiate between traditional and simplified Han here!
                 families.push("Songti SC");
                 if options.character as u32 > 0x10000 {

--- a/components/fonts/platform/macos/font_list.rs
+++ b/components/fonts/platform/macos/font_list.rs
@@ -155,7 +155,7 @@ pub fn fallback_font_families(options: FallbackFontSelectionOptions) -> Vec<&'st
         }
     }
 
-    add_noto_fallback_families(options, &mut families);
+    add_noto_fallback_families(options.clone(), &mut families);
 
     // https://en.wikipedia.org/wiki/Plane_(Unicode)#Supplementary_Multilingual_Plane
     let unicode_plane = unicode_plane(options.character);

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -273,7 +273,7 @@ mod font_context {
 
         let font = group
             .write()
-            .find_by_codepoint(&mut context.context, 'a', None, None)
+            .find_by_codepoint(&mut context.context, 'a', None, None, None)
             .unwrap();
         assert_eq!(&font_face_name(&font.identifier()), "csstest-ascii");
         assert_eq!(
@@ -287,7 +287,7 @@ mod font_context {
 
         let font = group
             .write()
-            .find_by_codepoint(&mut context.context, 'a', None, None)
+            .find_by_codepoint(&mut context.context, 'a', None, None, None)
             .unwrap();
         assert_eq!(&font_face_name(&font.identifier()), "csstest-ascii");
         assert_eq!(
@@ -301,7 +301,7 @@ mod font_context {
 
         let font = group
             .write()
-            .find_by_codepoint(&mut context.context, 'á', None, None)
+            .find_by_codepoint(&mut context.context, 'á', None, None, None)
             .unwrap();
         assert_eq!(&font_face_name(&font.identifier()), "csstest-basic-regular");
         assert_eq!(
@@ -325,7 +325,7 @@ mod font_context {
 
         let font = group
             .write()
-            .find_by_codepoint(&mut context.context, 'a', None, None)
+            .find_by_codepoint(&mut context.context, 'a', None, None, None)
             .unwrap();
         assert_eq!(
             &font_face_name(&font.identifier()),
@@ -335,7 +335,7 @@ mod font_context {
 
         let font = group
             .write()
-            .find_by_codepoint(&mut context.context, 'á', None, None)
+            .find_by_codepoint(&mut context.context, 'á', None, None, None)
             .unwrap();
         assert_eq!(
             &font_face_name(&font.identifier()),

--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -485,11 +485,14 @@ impl TextRun {
                 }
             });
 
+            let lang = parent_style.get_font()._x_lang.clone();
+
             let Some(font) = font_group.write().find_by_codepoint(
                 font_context,
                 character,
                 next_character,
                 current_font,
+                Some(lang.0.as_ref().to_string()),
             ) else {
                 continue;
             };

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1503,7 +1503,7 @@ impl FontMetricsProvider for LayoutFontMetricsProvider {
             .or_else(|| {
                 font_group
                     .write()
-                    .find_by_codepoint(font_context, '0', None, None)?
+                    .find_by_codepoint(font_context, '0', None, None, None)?
                     .metrics
                     .zero_horizontal_advance
             })
@@ -1514,7 +1514,7 @@ impl FontMetricsProvider for LayoutFontMetricsProvider {
             .or_else(|| {
                 font_group
                     .write()
-                    .find_by_codepoint(font_context, '\u{6C34}', None, None)?
+                    .find_by_codepoint(font_context, '\u{6C34}', None, None, None)?
                     .metrics
                     .ic_horizontal_advance
             })

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -2356,7 +2356,7 @@ impl CanvasState {
             // TODO: This should ultimately handle emoji variation selectors, but raqote does not yet
             // have support for color glyphs.
             let script = Script::from(character);
-            let font = font_group.find_by_codepoint(font_context, character, None, None);
+            let font = font_group.find_by_codepoint(font_context, character, None, None, None);
 
             if !current_text_run.script_and_font_compatible(script, &font) {
                 let previous_text_run = std::mem::replace(


### PR DESCRIPTION
## Motivations

This PR improves fallback font algorithm for Japanese documents on macos and Linux.

For Japanese documents, we generally use a same font for Hiragana/Katakana/Kanji(Han).
Since their is a fallback algorithm to render serif fonts for `Script::Han`in current implementation, it gives unnatural reading experience for Japanese users.

## Changes
To achieve above, 
- added `lang` field to `FallbackFontSelectionOptions` struct
- pass `_x_lang` from text_run in layout component

## Screenshots
rendering https://ja.wikipedia.org/wiki/Servo

<table>
<thead>
<tr>
<th>before fixed</th>
<th>after fixed</th>

</tr>
</thead>
<tbody>
<tr>
<td>
<!-- before fixed -->
<img width="545" height="168" alt="CleanShot 2025-10-01 at 23 08 24" src="https://github.com/user-attachments/assets/9ad7ccb0-729a-49ad-b8ce-88b1d78a2705" />



</td>
<td>
<!-- after fixed -->

<img width="474" height="139" alt="CleanShot 2025-10-01 at 23 07 16" src="https://github.com/user-attachments/assets/010e8052-5a10-48e1-8367-ff29a5632d0f" />


</td>

</tr>
</tbody>
</table>