### PR TITLE
unit test: Remove unused import in fonts

### DIFF
--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -14,7 +14,6 @@ mod font_context {
     use std::thread;
 
     use app_units::Au;
-    use base::generic_channel;
     use compositing_traits::CrossProcessCompositorApi;
     use fonts::platform::font::PlatformFont;
     use fonts::{


### PR DESCRIPTION
Remove unused import (`use base::generic_channel;`)

Testing: Clippy ran successfully, no tests added
Fixes: #39609 
