### PR TITLE
script: Share `Epoch` between canvas and layout and update the renderer separately

### DIFF
--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -39,6 +39,7 @@ mod from_constellation {
                 Self::PipelineExited(..) => target!("PipelineExited"),
                 Self::SendInitialTransaction(..) => target!("SendInitialTransaction"),
                 Self::SendScrollNode(..) => target!("SendScrollNode"),
+                Self::UpdateEpoch { .. } => target!("UpdateEpoch"),
                 Self::SendDisplayList { .. } => target!("SendDisplayList"),
                 Self::GenerateFrame { .. } => target!("GenerateFrame"),
                 Self::GenerateImageKey(..) => target!("GenerateImageKey"),

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -8,6 +8,7 @@ use std::mem;
 use std::sync::Arc;
 
 use app_units::Au;
+use base::Epoch;
 use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
 use compositing_traits::display_list::{
@@ -140,7 +141,7 @@ impl StackingContextTree {
             scrollable_overflow,
             pipeline_id,
             // This epoch is set when the WebRender display list is built. For now use a dummy value.
-            wr::Epoch(0),
+            Epoch(0),
             fragment_tree.viewport_scroll_sensitivity,
             first_reflow,
         );

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2317,6 +2317,7 @@ impl Window {
 
         let reflow = ReflowRequest {
             document: document.upcast::<Node>().to_trusted_node_address(),
+            epoch: document.current_rendering_epoch(),
             restyle,
             viewport_details: self.viewport_details.get(),
             origin: self.origin().immutable().clone(),
@@ -2395,13 +2396,14 @@ impl Window {
             return;
         }
 
-        if self.Document().needs_rendering_update() {
+        let document = self.Document();
+        if document.needs_rendering_update() {
             return;
         }
 
         // When all these conditions are met, notify the Constellation that we are ready to
         // have our screenshot taken, when the given layout Epoch has been rendered.
-        let epoch = self.layout.borrow().current_epoch();
+        let epoch = document.current_rendering_epoch();
         let pipeline_id = self.pipeline_id();
         debug!("Ready to take screenshot of {pipeline_id:?} at epoch={epoch:?}");
 

--- a/components/shared/compositing/display_list.rs
+++ b/components/shared/compositing/display_list.rs
@@ -7,6 +7,7 @@
 use std::cell::Cell;
 use std::collections::HashMap;
 
+use base::Epoch;
 use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
 use bitflags::bitflags;
@@ -19,7 +20,7 @@ use servo_geometry::FastLayoutTransform;
 use style::values::specified::Overflow;
 use webrender_api::units::{LayoutPixel, LayoutPoint, LayoutRect, LayoutSize, LayoutVector2D};
 use webrender_api::{
-    Epoch, ExternalScrollId, PipelineId, ReferenceFrameKind, ScrollLocation, SpatialId,
+    ExternalScrollId, PipelineId, ReferenceFrameKind, ScrollLocation, SpatialId,
     StickyOffsetBounds, TransformStyle,
 };
 

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -107,6 +107,15 @@ pub enum CompositorMsg {
         LayoutVector2D,
         ExternalScrollId,
     ),
+    /// Update the rendering epoch of the given `Pipeline`.
+    UpdateEpoch {
+        /// The [`WebViewId`] that this display list belongs to.
+        webview_id: WebViewId,
+        /// The [`PipelineId`] of the `Pipeline` to update.
+        pipeline_id: PipelineId,
+        /// The new [`Epoch`] value.
+        epoch: Epoch,
+    },
     /// Inform WebRender of a new display list for the given pipeline.
     SendDisplayList {
         /// The [`WebViewId`] that this display list belongs to.
@@ -242,6 +251,18 @@ impl CrossProcessCompositorApi {
             image_keys,
         )) {
             warn!("Error delaying frames for canvas image updates {error:?}");
+        }
+    }
+
+    /// Inform the renderer that the rendering epoch has advanced. This typically happens after
+    /// a new display list is sent and/or canvas and animated images are updated.
+    pub fn update_epoch(&self, webview_id: WebViewId, pipeline_id: PipelineId, epoch: Epoch) {
+        if let Err(error) = self.0.send(CompositorMsg::UpdateEpoch {
+            webview_id,
+            pipeline_id,
+            epoch,
+        }) {
+            warn!("Error updating epoch for pipeline: {error:?}");
         }
     }
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -241,9 +241,6 @@ pub trait Layout {
     /// resolve font metrics.
     fn device(&self) -> &Device;
 
-    /// The currently laid out Epoch that this Layout has finished.
-    fn current_epoch(&self) -> Epoch;
-
     /// Load all fonts from the given stylesheet, returning the number of fonts that
     /// need to be loaded.
     fn load_web_fonts_from_stylesheet(&self, stylesheet: ServoArc<Stylesheet>);
@@ -550,6 +547,8 @@ pub struct ReflowRequestRestyle {
 pub struct ReflowRequest {
     /// The document node.
     pub document: TrustedNodeAddress,
+    /// The current layout [`Epoch`] managed by the script thread.
+    pub epoch: Epoch,
     /// If a restyle is necessary, all of the informatio needed to do that restyle.
     pub restyle: Option<ReflowRequestRestyle>,
     /// The current [`ViewportDetails`] to use for this reflow.


### PR DESCRIPTION
Before both canvas updates and layout had their own `Epoch`. This change
makes it so the `Epoch` is shared. This means that display lists might
have non-consecutive `Epoch`s, but will also allow for the `Epoch` in
the renderer to update even when no new display list is produced. This
is important for #38991. In that PR the display list step can be skipped
for canvas-only updates, but the `Epoch` in the renderer must still
advance.

Testing: This shouldn't change the user-observable behavior and is thus covered
by existing tests. It should prevent flakiness once #38991 lands.
