### PR TITLE
html: Do not update the image data inside legacy <image> constructor

### DIFF
--- a/tests/wpt/tests/html/semantics/embedded-content/the-img-element/decode/image-decode.html
+++ b/tests/wpt/tests/html/semantics/embedded-content/the-img-element/decode/image-decode.html
@@ -84,6 +84,12 @@ promise_test(function(t) {
   var img = new Image();
   var promise = img.decode();
   return promise_rejects_dom(t, "EncodingError", promise);
+}, document.title + " Image (legacy) without src/srcset fails decode.");
+
+promise_test(function(t) {
+  var img = document.createElement("img");
+  var promise = img.decode();
+  return promise_rejects_dom(t, "EncodingError", promise);
 }, document.title + " Image without src/srcset fails decode.");
 
 promise_test(function() {


### PR DESCRIPTION
The legacy 'image' constructor (new Image()) doesn't have any step in specification which require to run `update the image data` algorithm.

See https://html.spec.whatwg.org/multipage/#dom-image

This non-conformant behavior was added in the PR #31269 to follow https://html.spec.whatwg.org/multipage/#when-to-obtain-images (.. whenever that element is created or has experienced relevant mutations) to handle the edge case of `decode()` with 'image' without "src" and "srcset" attributes.

See html/semantics/embedded-content/the-img-element/decode/image-decode.html#L87

Testing: No changes in test expectations