### PR TITLE
webdriver: Update expectation for `wheel.py`

### DIFF
--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/wheel.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/wheel.py.ini
@@ -1,0 +1,2 @@
+[wheel.py]
+    expected: [OK, TIMEOUT]


### PR DESCRIPTION
This test TIMEOUT at a very low frequency: ~ once per three weeks. If not timeout, it passes all 14 sub-tests. It is better to update expectation and close the intermittent issue to avoid potential regression.

Testing: No behaviour change
Fixes: #39505
