### PR TITLE
script: implement url matches about:blank

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -837,9 +837,9 @@ impl Document {
                     return base_url;
                 }
             }
-            // Step 2: If document's URL is about:blank, and document's browsing
+            // Step 2: If document's URL matches about:blank, and document's browsing
             // context's creator base URL is non-null, then return that creator base URL.
-            if document_url.as_str() == "about:blank" && browsing_context.has_creator_base_url() {
+            if document_url.matches_about_blank() && browsing_context.has_creator_base_url() {
                 return browsing_context.creator_base_url().unwrap();
             }
         }

--- a/components/url/Cargo.toml
+++ b/components/url/Cargo.toml
@@ -10,6 +10,8 @@ rust-version.workspace = true
 [lib]
 name = "servo_url"
 path = "lib.rs"
+test = false
+doctest = false
 
 [dependencies]
 encoding_rs = { workspace = true }

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -246,6 +246,26 @@ impl ServoUrl {
         // Step 3
         self.origin().is_potentially_trustworthy()
     }
+
+    /// <https://html.spec.whatwg.org/multipage/#matches-about:blank>
+    pub fn matches_about_blank(&self) -> bool {
+        // A URL matches about:blank if
+
+        // its scheme is "about",
+        let scheme_is_about = self.scheme() == "about";
+
+        // its path contains a single string "blank",
+        let path_contains_blank = self.0.path().contains("blank");
+
+        // its username and password are the empty string,
+        let empty_username_and_password =
+            self.0.username().is_empty() && self.0.password().is_none();
+
+        // and its host is null.
+        let null_host = self.0.host().is_none();
+
+        scheme_is_about && path_contains_blank && empty_username_and_password && null_host
+    }
 }
 
 impl fmt::Display for ServoUrl {

--- a/components/url/lib.rs
+++ b/components/url/lib.rs
@@ -255,7 +255,7 @@ impl ServoUrl {
         let scheme_is_about = self.scheme() == "about";
 
         // its path contains a single string "blank",
-        let path_contains_blank = self.0.path().contains("blank");
+        let path_is_blank = self.0.path() == "blank";
 
         // its username and password are the empty string,
         let empty_username_and_password =
@@ -264,7 +264,7 @@ impl ServoUrl {
         // and its host is null.
         let null_host = self.0.host().is_none();
 
-        scheme_is_about && path_contains_blank && empty_username_and_password && null_host
+        scheme_is_about && path_is_blank && empty_username_and_password && null_host
     }
 }
 

--- a/components/url/tests/main.rs
+++ b/components/url/tests/main.rs
@@ -10,8 +10,6 @@ use url::Url;
 #[test]
 fn test_matches_about_blank_matches_simple_about_blank() {
     let mut url = ServoUrl::from_str("about:blank").unwrap();
-    assert!(url.path().contains("blank"));
-    assert!(url.scheme() == "about");
     assert!(url.matches_about_blank());
 
     // Cannot set password.
@@ -24,6 +22,12 @@ fn test_matches_about_blank_matches_simple_about_blank() {
 
     // Note: cannot set host, `set_host` not available on `ServoUrl`.
     assert!(url.host().is_none());
+}
+
+#[test]
+fn test_matches_about_blank_doest_matches_fake_about_blank() {
+    let url = ServoUrl::from_str("about:blank2").unwrap();
+    assert!(!url.matches_about_blank());
 }
 
 #[test]

--- a/components/url/tests/main.rs
+++ b/components/url/tests/main.rs
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::str::FromStr;
+
+use servo_url::ServoUrl;
+use url::Url;
+
+#[test]
+fn test_matches_about_blank_matches_simple_about_blank() {
+    let mut url = ServoUrl::from_str("about:blank").unwrap();
+    assert!(url.path().contains("blank"));
+    assert!(url.scheme() == "about");
+    assert!(url.matches_about_blank());
+
+    // Cannot set password.
+    assert!(url.set_password(Some("Test")).is_err());
+    assert!(url.matches_about_blank());
+
+    // Cannot set username.
+    assert!(url.set_username("user1").is_err());
+    assert!(url.matches_about_blank());
+
+    // Note: cannot set host, `set_host` not available on `ServoUrl`.
+    assert!(url.host().is_none());
+}
+
+#[test]
+fn test_matches_about_blank_does_not_match() {
+    let mut url = ServoUrl::from_str("ftp://user1:secret1@example.com").unwrap();
+    assert!(!url.matches_about_blank());
+
+    url.set_password(Some("Test")).unwrap();
+    assert!(!url.matches_about_blank());
+
+    url.set_username("user1").unwrap();
+    assert!(!url.matches_about_blank());
+}
+
+#[test]
+fn test_matches_about_blank_does_not_match_from_other_url() {
+    let mut url = Url::parse("https://example.com").unwrap();
+
+    // Cannot construct something passing off like about:blank from url.
+    assert!(url.set_scheme("about").is_err());
+    assert!(url.set_host(None).is_err());
+    assert!(url.set_password(Some("Test")).is_ok());
+    url.set_path("blank");
+
+    let servo_url = ServoUrl::from_url(url);
+    assert!(!servo_url.matches_about_blank());
+}
+
+#[test]
+fn test_matches_about_blank_does_not_match_invariants_maintained_from_url() {
+    // Invariants of about:blank maintained at the url level as well.
+    let mut url = Url::parse("about:blank").unwrap();
+
+    // Cannot set password.
+    assert!(url.set_password(Some("Test")).is_err());
+
+    // Cannot set username.
+    assert!(url.set_username("user1").is_err());
+
+    // Cannot set host.
+    assert!(url.set_host(Some("rust-lang.org")).is_err());
+
+    let servo_url = ServoUrl::from_url(url.clone());
+    assert!(servo_url.matches_about_blank());
+
+    // Can set path, but match will fail.
+    url.set_path("test");
+    let servo_url = ServoUrl::from_url(url);
+    assert!(!servo_url.matches_about_blank());
+}

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -221,6 +221,7 @@ class MachCommands(CommandBase):
             "selectors",
             "servo_config",
             "servoshell",
+            "servo_url",
         ]
         if not packages:
             packages = set(os.listdir(path.join(self.context.topdir, "tests", "unit"))) - set([".DS_Store"])


### PR DESCRIPTION
Implement [matches-about:blank](https://html.spec.whatwg.org/multipage/#matches-about:blank), and uses it to compute the fallback url of a document.

This will also be useful as part of [fixing iframe loading](https://github.com/servo/servo/issues/31973).

There is one unrelated change to origin.rs, which is the result of an fmt.

Testing: added unit-tests and the fallback url should be covered by wpt tests.
