### PR TITLE
script: Combine `WebDriverJSError` with `JavaScriptEvaluationError` and add the stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,6 +2388,7 @@ dependencies = [
  "servo_geometry",
  "servo_malloc_size_of",
  "servo_url",
+ "strum",
  "strum_macros",
  "stylo",
  "stylo_traits",

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -86,7 +86,9 @@ use crate::dom::bindings::codegen::Bindings::VoidFunctionBinding::VoidFunction;
 use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::codegen::Bindings::WorkerGlobalScopeBinding::WorkerGlobalScopeMethods;
 use crate::dom::bindings::conversions::{root_from_object, root_from_object_static};
-use crate::dom::bindings::error::{Error, ErrorInfo, report_pending_exception};
+use crate::dom::bindings::error::{
+    Error, ErrorInfo, report_pending_exception, take_and_report_pending_exception_for_api,
+};
 use crate::dom::bindings::frozenarray::CachedFrozenArray;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
@@ -2919,8 +2921,9 @@ impl GlobalScope {
 
             if !result {
                 debug!("error evaluating Dom string");
-                report_pending_exception(cx, true, InRealm::Entered(&ar), can_gc);
-                return Err(JavaScriptEvaluationError::EvaluationFailure);
+                let error_info =
+                    take_and_report_pending_exception_for_api(cx, InRealm::Entered(&ar), can_gc);
+                return Err(JavaScriptEvaluationError::EvaluationFailure(error_info));
             }
 
             maybe_resume_unwind();

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3857,9 +3857,7 @@ impl ScriptThread {
             return_value.handle(),
             (&realm).into(),
             can_gc,
-        )
-        .map_err(|_| JavaScriptEvaluationError::SerializationError);
-
+        );
         let _ = self.senders.pipeline_to_constellation_sender.send((
             pipeline_id,
             ScriptToConstellationMessage::FinishJavaScriptEvaluation(evaluation_id, result),

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -660,7 +660,7 @@ DOMInterfaces = {
 
 'Window': {
     'canGc': ['CreateImageBitmap', 'CreateImageBitmap_', 'CookieStore', 'Fetch', 'FetchLater', 'Open', 'SetInterval', 'SetTimeout', 'Stop', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException'],
-    'inRealms': ['Fetch', 'GetOpener', 'WebdriverCallback', 'WebdriverException'],
+    'inRealms': ['Fetch', 'GetOpener', 'WebdriverCallback'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
 },
 

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -104,7 +104,10 @@ fn test_evaluate_javascript_basic(servo_test: &ServoTest) -> Result<(), anyhow::
     ensure!(result == Err(JavaScriptEvaluationError::CompilationFailure));
 
     let result = evaluate_javascript(servo_test, webview.clone(), "throw new Error()");
-    ensure!(result == Err(JavaScriptEvaluationError::EvaluationFailure));
+    ensure!(matches!(
+        result,
+        Err(JavaScriptEvaluationError::EvaluationFailure(_))
+    ));
 
     Ok(())
 }

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -37,6 +37,7 @@ serde = { workspace = true }
 servo_geometry = { path = "../../geometry" }
 servo_url = { path = "../../url" }
 strum_macros = { workspace = true }
+strum = { workspace = true }
 stylo = { workspace = true }
 stylo_traits = { workspace = true }
 url = { workspace = true }

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -24,7 +24,10 @@ use style_traits::CSSPixel;
 use webdriver::error::ErrorStatus;
 use webrender_api::units::DevicePixel;
 
-use crate::{JSValue, MouseButton, MouseButtonAction, ScreenshotCaptureError, TraversalId};
+use crate::{
+    JSValue, JavaScriptEvaluationError, MouseButton, MouseButtonAction, ScreenshotCaptureError,
+    TraversalId,
+};
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct WebDriverInputEventId(pub usize);
@@ -253,19 +256,7 @@ pub enum WebDriverScriptCommand {
     RemoveLoadStatusSender(WebViewId),
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-pub enum WebDriverJSError {
-    /// Occurs when handler received an event message for a layout channel that is not
-    /// associated with the current script thread
-    BrowsingContextNotFound,
-    DetachedShadowRoot,
-    JSException(JSValue),
-    JSError,
-    StaleElementReference,
-    UnknownType,
-}
-
-pub type WebDriverJSResult = Result<JSValue, WebDriverJSError>;
+pub type WebDriverJSResult = Result<JSValue, JavaScriptEvaluationError>;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebDriverFrameId {


### PR DESCRIPTION
This change merges the WebDriver only `WebDriverJSError` with the API
`JavaScriptEvaluationError` and also allows passing `ErrorInfo`
information through to the API layer when possible. In addition, the
stack is added to `ErrorInfo` (but only in situations when evaluating
JavaScript code for WebDriver or via the API for performance reasons).

These changes allow much more useful error output when script execution
fails via WebDriver. Now the error message and source file line numbers
are printed by the test executor.

Testing: These changes should be reflected in the testing output.
