### PR TITLE
[39497] Makes action dispatch methods mutable

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -357,22 +357,18 @@ impl Handler {
         source_id: &str,
         action: &PointerDownAction,
     ) {
-        let x: f32;
-        let y: f32;
-        {
-            let pointer_input_state = self.get_pointer_input_state(source_id);
+        let pointer_input_state = self.get_pointer_input_state(source_id);
 
-            // Step 3. If the source's pressed property contains button return success with data null.
-            if pointer_input_state.pressed.contains(&action.button) {
-                return;
-            }
-
-            // Step 6. Add button to the set corresponding to source's pressed property
-            pointer_input_state.pressed.insert(action.button);
-
-            x = pointer_input_state.x as f32;
-            y = pointer_input_state.y as f32;
+        // Step 3. If the source's pressed property contains button return success with data null.
+        if pointer_input_state.pressed.contains(&action.button) {
+            return;
         }
+
+        // Step 6. Add button to the set corresponding to source's pressed property
+        pointer_input_state.pressed.insert(action.button);
+
+        let x = pointer_input_state.x as f32;
+        let y = pointer_input_state.y as f32;
 
         // Step 7 - 15: Variable namings already done.
         // Step 16. Perform implementation-specific action dispatch steps
@@ -394,21 +390,17 @@ impl Handler {
 
     /// <https://w3c.github.io/webdriver/#dfn-dispatch-a-pointerup-action>
     pub(crate) fn dispatch_pointerup_action(&mut self, source_id: &str, action: &PointerUpAction) {
-        let x: f32;
-        let y: f32;
-        {
-            let pointer_input_state = self.get_pointer_input_state(source_id);
+        let pointer_input_state = self.get_pointer_input_state(source_id);
 
-            // Step 3. If the source's pressed property does not contain button, return success with data null.
-            if !pointer_input_state.pressed.contains(&action.button) {
-                return;
-            }
-
-            // Step 6. Remove button from the set corresponding to source's pressed property,
-            pointer_input_state.pressed.remove(&action.button);
-            x = pointer_input_state.x as f32;
-            y = pointer_input_state.y as f32;
+        // Step 3. If the source's pressed property does not contain button, return success with data null.
+        if !pointer_input_state.pressed.contains(&action.button) {
+            return;
         }
+
+        // Step 6. Remove button from the set corresponding to source's pressed property,
+        pointer_input_state.pressed.remove(&action.button);
+        let x = pointer_input_state.x as f32;
+        let y = pointer_input_state.y as f32;
 
         // Remove matching pointerUp(must be unique) from `[input_cancel_list]` due to bugs in spec
         // See https://github.com/w3c/webdriver/issues/1905 &&
@@ -521,13 +513,9 @@ impl Handler {
         target_y: f64,
         tick_start: Instant,
     ) {
-        let p_x: f64;
-        let p_y: f64;
-        {
-            let pointer_input_state = self.get_pointer_input_state(source_id);
-            p_x = pointer_input_state.x;
-            p_y = pointer_input_state.y;
-        }
+        let pointer_input_state = self.get_pointer_input_state(source_id);
+        let p_x = pointer_input_state.x;
+        let p_y = pointer_input_state.y;
 
         loop {
             // Step 1. Let time delta be the time since the beginning of the
@@ -609,8 +597,13 @@ impl Handler {
     }
 
     fn get_pointer_input_state(&mut self, source_id: &str) -> &mut PointerInputState {
-        let input_state_table = self.session_mut().unwrap().input_state_table_mut();
-        match input_state_table.get_mut(source_id).unwrap() {
+        match self
+            .session_mut()
+            .unwrap()
+            .input_state_table_mut()
+            .get_mut(source_id)
+            .unwrap()
+        {
             InputSourceState::Pointer(pointer_input_state) => pointer_input_state,
             _ => unreachable!(),
         }

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -351,7 +352,11 @@ impl Handler {
     }
 
     /// <https://w3c.github.io/webdriver/#dfn-dispatch-a-pointerdown-action>
-    pub(crate) fn dispatch_pointerdown_action(&mut self, source_id: &str, action: &PointerDownAction) {
+    pub(crate) fn dispatch_pointerdown_action(
+        &mut self,
+        source_id: &str,
+        action: &PointerDownAction,
+    ) {
         let x: f32;
         let y: f32;
         {
@@ -603,10 +608,7 @@ impl Handler {
         }
     }
 
-    fn get_pointer_input_state(
-        &mut self,
-        source_id: &str,
-    ) -> &mut PointerInputState {
+    fn get_pointer_input_state(&mut self, source_id: &str) -> &mut PointerInputState {
         let input_state_table = self.session_mut().unwrap().input_state_table_mut();
         match input_state_table.get_mut(source_id).unwrap() {
             InputSourceState::Pointer(pointer_input_state) => pointer_input_state,
@@ -871,7 +873,10 @@ impl Handler {
     }
 
     /// <https://w3c.github.io/webdriver/#dfn-extract-an-action-sequence>
-    pub(crate) fn extract_an_action_sequence(&mut self, params: ActionsParameters) -> ActionsByTick {
+    pub(crate) fn extract_an_action_sequence(
+        &mut self,
+        params: ActionsParameters,
+    ) -> ActionsByTick {
         // Step 1. Let actions be the result of getting a property named "actions" from parameters.
         // Step 2. (ignored because params is already validated earlier). If actions is not a list,
         // return an error with status InvalidArgument.

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1977,7 +1977,8 @@ impl Handler {
 
         // Step 6. Let undo actions be input cancel list in reverse order.
 
-        let undo_actions = self.session_mut()?
+        let undo_actions = self
+            .session_mut()?
             .input_cancel_list_mut()
             .drain(..)
             .rev()

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1959,7 +1959,6 @@ impl Handler {
 
     /// <https://w3c.github.io/webdriver/#dfn-release-actions>
     fn handle_release_actions(&mut self) -> WebDriverResult<WebDriverResponse> {
-        let session = self.session()?;
         let browsing_context_id = self.browsing_context_id()?;
 
         // Step 1. If session's current browsing context is no longer open,
@@ -1978,7 +1977,7 @@ impl Handler {
 
         // Step 6. Let undo actions be input cancel list in reverse order.
 
-        let undo_actions = session
+        let undo_actions = self.session_mut()?
             .input_cancel_list_mut()
             .drain(..)
             .rev()
@@ -1990,7 +1989,7 @@ impl Handler {
         }
 
         // Step 8. Reset the input state of session's current top-level browsing context.
-        session.input_state_table_mut().clear();
+        self.session_mut()?.input_state_table_mut().clear();
 
         Ok(WebDriverResponse::Void)
     }

--- a/components/webdriver_server/session.rs
+++ b/components/webdriver_server/session.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 
 use base::id::{BrowsingContextId, WebViewId};
@@ -64,10 +63,10 @@ pub struct WebDriverSession {
     user_prompt_handler: UserPromptHandler,
 
     /// <https://w3c.github.io/webdriver/#dfn-input-state-map>
-    input_state_table: RefCell<HashMap<String, InputSourceState>>,
+    input_state_table: HashMap<String, InputSourceState>,
 
     /// <https://w3c.github.io/webdriver/#dfn-input-cancel-list>
-    input_cancel_list: RefCell<Vec<(String, ActionItem)>>,
+    input_cancel_list: Vec<(String, ActionItem)>,
 }
 
 impl WebDriverSession {
@@ -80,8 +79,8 @@ impl WebDriverSession {
             page_loading_strategy: PageLoadStrategy::Normal,
             strict_file_interactability: false,
             user_prompt_handler: UserPromptHandler::new(),
-            input_state_table: RefCell::new(HashMap::new()),
-            input_cancel_list: RefCell::new(Vec::new()),
+            input_state_table: HashMap::new(),
+            input_cancel_list: Vec::new(),
         }
     }
 
@@ -121,16 +120,16 @@ impl WebDriverSession {
         &self.user_prompt_handler
     }
 
-    pub fn input_state_table(&self) -> Ref<'_, HashMap<String, InputSourceState>> {
-        self.input_state_table.borrow()
+    pub fn input_state_table(&self) -> &HashMap<String, InputSourceState> {
+        &self.input_state_table
     }
 
-    pub fn input_state_table_mut(&self) -> RefMut<'_, HashMap<String, InputSourceState>> {
-        self.input_state_table.borrow_mut()
+    pub fn input_state_table_mut(&mut self) -> &mut HashMap<String, InputSourceState> {
+        &mut self.input_state_table
     }
 
-    pub fn input_cancel_list_mut(&self) -> RefMut<'_, Vec<(String, ActionItem)>> {
-        self.input_cancel_list.borrow_mut()
+    pub fn input_cancel_list_mut(&mut self) -> &mut Vec<(String, ActionItem)> {
+        &mut self.input_cancel_list
     }
 }
 


### PR DESCRIPTION
Refactors action dispatch methods to take a mutable reference to the handler, allowing modification of the session state during action execution.

This change avoids unnecessary borrowing and cloning of data, and it aligns better with the intended behavior of modifying the session's input state during action dispatching.


Testing: This task is only for refactoring, it doesn't require new tests
Fixes: #39497 
