### PR TITLE
storage: Port webstorage to sqlite3

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -255,6 +255,8 @@ pub struct Preferences {
     pub threadpools_image_cache_workers_max: i64,
     /// Maximum number of workers for the IndexedDB thread pool
     pub threadpools_indexeddb_workers_max: i64,
+    /// Maximum number of workers for the Web Storage thread pool
+    pub threadpools_webstorage_workers_max: i64,
     /// Maximum number of workers for the Networking async runtime thread pool
     pub threadpools_async_runtime_workers_max: i64,
     /// Maximum number of workers for the Core Resource Manager
@@ -428,6 +430,7 @@ impl Preferences {
             threadpools_fallback_worker_num: 3,
             threadpools_image_cache_workers_max: 4,
             threadpools_indexeddb_workers_max: 4,
+            threadpools_webstorage_workers_max: 4,
             threadpools_resource_workers_max: 4,
             threadpools_webrender_workers_max: 4,
             webgl_testing_context_creation_error: false,

--- a/components/storage/indexeddb/engines/mod.rs
+++ b/components/storage/indexeddb/engines/mod.rs
@@ -38,6 +38,7 @@ pub trait KvsEngine {
 
     fn delete_store(&self, store_name: &str) -> Result<(), Self::Error>;
 
+    #[expect(dead_code)]
     fn close_store(&self, store_name: &str) -> Result<(), Self::Error>;
 
     fn delete_database(self) -> Result<(), Self::Error>;

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -20,23 +20,13 @@ use tokio::sync::oneshot;
 
 use crate::indexeddb::engines::{KvsEngine, KvsTransaction};
 use crate::indexeddb::idb_thread::IndexedDBDescription;
+use crate::shared::{DB_INIT_PRAGMAS, DB_PRAGMAS};
 
 mod create;
 mod database_model;
 mod object_data_model;
 mod object_store_index_model;
 mod object_store_model;
-
-// These pragmas need to be set once
-const DB_INIT_PRAGMAS: [&str; 2] = ["PRAGMA journal_mode = WAL;", "PRAGMA encoding = 'UTF-16';"];
-
-// These pragmas need to be run once per connection.
-const DB_PRAGMAS: [&str; 4] = [
-    "PRAGMA synchronous = NORMAL;",
-    "PRAGMA journal_size_limit = 67108864 -- 64 megabytes;",
-    "PRAGMA mmap_size = 67108864 -- 64 megabytes;",
-    "PRAGMA cache_size = 2000;",
-];
 
 fn range_to_query(range: IndexedDBKeyRange) -> Condition {
     // Special case for optimization

--- a/components/storage/lib.rs
+++ b/components/storage/lib.rs
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-pub mod indexeddb;
+mod indexeddb;
+pub(crate) mod shared;
 mod storage_thread;
-mod webstorage_thread;
+mod webstorage;
 
+pub(crate) use indexeddb::IndexedDBThreadFactory;
 pub use storage_thread::new_storage_threads;
+pub(crate) use webstorage::WebStorageThreadFactory;

--- a/components/storage/shared/mod.rs
+++ b/components/storage/shared/mod.rs
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// These pragmas need to be set once
+pub const DB_INIT_PRAGMAS: [&str; 2] =
+    ["PRAGMA journal_mode = WAL;", "PRAGMA encoding = 'UTF-16';"];
+
+// These pragmas need to be run once per connection.
+pub const DB_PRAGMAS: [&str; 4] = [
+    "PRAGMA synchronous = NORMAL;",
+    "PRAGMA journal_size_limit = 67108864 -- 64 megabytes;",
+    "PRAGMA mmap_size = 67108864 -- 64 megabytes;",
+    "PRAGMA cache_size = 2000;",
+];

--- a/components/storage/storage_thread.rs
+++ b/components/storage/storage_thread.rs
@@ -11,8 +11,7 @@ use storage_traits::StorageThreads;
 use storage_traits::indexeddb_thread::IndexedDBThreadMsg;
 use storage_traits::webstorage_thread::WebStorageThreadMsg;
 
-use crate::indexeddb::IndexedDBThreadFactory;
-use crate::webstorage_thread::WebStorageThreadFactory;
+use crate::{IndexedDBThreadFactory, WebStorageThreadFactory};
 
 #[allow(clippy::too_many_arguments)]
 pub fn new_storage_threads(

--- a/components/storage/webstorage/engines/mod.rs
+++ b/components/storage/webstorage/engines/mod.rs
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::webstorage::webstorage_thread::OriginEntry;
+
+pub mod sqlite;
+
+pub trait WebStorageEngine {
+    type Error;
+    fn load(&self) -> Result<OriginEntry, Self::Error>;
+    fn clear(&mut self) -> Result<(), Self::Error>;
+    fn delete(&mut self, key: &str) -> Result<(), Self::Error>;
+    fn set(&mut self, key: &str, value: &str) -> Result<(), Self::Error>;
+    fn save(&mut self, data: &OriginEntry);
+}

--- a/components/storage/webstorage/engines/sqlite.rs
+++ b/components/storage/webstorage/engines/sqlite.rs
@@ -20,9 +20,12 @@ pub struct SqliteEngine {
 }
 
 impl SqliteEngine {
-    pub fn new(db_path: &Option<PathBuf>, pool: Arc<ThreadPool>) -> rusqlite::Result<Self> {
-        let connection = match db_path {
-            Some(path) => Self::init_db(path)?,
+    pub fn new(db_dir: &Option<PathBuf>, pool: Arc<ThreadPool>) -> rusqlite::Result<Self> {
+        let connection = match db_dir {
+            Some(path) => {
+                let path = path.join("webstorage.sqlite");
+                Self::init_db(&path)?
+            },
             None => Connection::open_in_memory()?,
         };
         // Initialize the database with necessary pragmas

--- a/components/storage/webstorage/engines/sqlite.rs
+++ b/components/storage/webstorage/engines/sqlite.rs
@@ -15,12 +15,10 @@ use crate::webstorage::webstorage_thread::OriginEntry;
 
 pub struct SqliteEngine {
     connection: Connection,
-    #[expect(dead_code)]
-    pool: Arc<ThreadPool>,
 }
 
 impl SqliteEngine {
-    pub fn new(db_dir: &Option<PathBuf>, pool: Arc<ThreadPool>) -> rusqlite::Result<Self> {
+    pub fn new(db_dir: &Option<PathBuf>, _pool: Arc<ThreadPool>) -> rusqlite::Result<Self> {
         let connection = match db_dir {
             Some(path) => {
                 let path = path.join("webstorage.sqlite");
@@ -32,7 +30,7 @@ impl SqliteEngine {
         for pragma in DB_PRAGMAS.iter() {
             let _ = connection.execute(pragma, []);
         }
-        Ok(SqliteEngine { connection, pool })
+        Ok(SqliteEngine { connection })
     }
 
     pub fn init_db(path: &PathBuf) -> rusqlite::Result<Connection> {

--- a/components/storage/webstorage/engines/sqlite.rs
+++ b/components/storage/webstorage/engines/sqlite.rs
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use base::threadpool::ThreadPool;
+use log::error;
+use rusqlite::Connection;
+
+use crate::shared::{DB_INIT_PRAGMAS, DB_PRAGMAS};
+use crate::webstorage::engines::WebStorageEngine;
+use crate::webstorage::webstorage_thread::OriginEntry;
+
+pub struct SqliteEngine {
+    connection: Connection,
+    #[expect(dead_code)]
+    pool: Arc<ThreadPool>,
+}
+
+impl SqliteEngine {
+    pub fn new(db_path: &Option<PathBuf>, pool: Arc<ThreadPool>) -> rusqlite::Result<Self> {
+        let connection = match db_path {
+            Some(path) => Self::init_db(path)?,
+            None => Connection::open_in_memory()?,
+        };
+        // Initialize the database with necessary pragmas
+        for pragma in DB_PRAGMAS.iter() {
+            let _ = connection.execute(pragma, []);
+        }
+        Ok(SqliteEngine { connection, pool })
+    }
+
+    pub fn init_db(path: &PathBuf) -> rusqlite::Result<Connection> {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let connection = Connection::open(path)?;
+        for pragma in DB_INIT_PRAGMAS.iter() {
+            let _ = connection.execute(pragma, []);
+        }
+        connection.execute("CREATE TABLE IF NOT EXISTS data (id INTEGER PRIMARY KEY AUTOINCREMENT, key TEXT, value TEXT);", [])?;
+        Ok(connection)
+    }
+}
+
+impl WebStorageEngine for SqliteEngine {
+    type Error = rusqlite::Error;
+
+    fn load(&self) -> Result<OriginEntry, Self::Error> {
+        let mut stmt = self.connection.prepare("SELECT key, value FROM data;")?;
+        let rows = stmt.query_map([], |row| {
+            let key: String = row.get(0)?;
+            let value: String = row.get(1)?;
+            Ok((key, value))
+        })?;
+
+        let mut map = OriginEntry::default();
+        for row in rows {
+            let (key, value) = row?;
+            map.insert(key, value);
+        }
+        Ok(map)
+    }
+
+    fn clear(&mut self) -> Result<(), Self::Error> {
+        self.connection.execute("DELETE FROM data;", [])?;
+        Ok(())
+    }
+
+    fn delete(&mut self, key: &str) -> Result<(), Self::Error> {
+        self.connection
+            .execute("DELETE FROM data WHERE key = ?;", [key])?;
+        Ok(())
+    }
+
+    fn set(&mut self, key: &str, value: &str) -> Result<(), Self::Error> {
+        // update or insert
+        self.connection.execute(
+            "INSERT INTO data (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value;",
+            [key, value],
+        )?;
+        Ok(())
+    }
+
+    fn save(&mut self, data: &OriginEntry) {
+        fn save_inner(conn: &mut Connection, data: &OriginEntry) -> rusqlite::Result<()> {
+            let tx = conn.transaction()?;
+            tx.execute("DELETE FROM data;", [])?;
+            let mut stmt = tx.prepare("INSERT INTO data (key, value) VALUES (?, ?);")?;
+            for (key, value) in data.inner() {
+                stmt.execute(rusqlite::params![key, value])?;
+            }
+            drop(stmt);
+            tx.commit()?;
+            Ok(())
+        }
+        if let Err(e) = save_inner(&mut self.connection, data) {
+            error!("localstorage save error: {:?}", e);
+        }
+    }
+}

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-pub use self::idb_thread::IndexedDBThreadFactory;
+mod engines;
+pub mod webstorage_thread;
 
-pub(super) mod engines;
-
-pub mod idb_thread;
+pub use webstorage_thread::WebStorageThreadFactory;

--- a/tests/wpt/meta/webstorage/storage_local_setitem_quotaexceedederr.window.js.ini
+++ b/tests/wpt/meta/webstorage/storage_local_setitem_quotaexceedederr.window.js.ini
@@ -1,2 +1,0 @@
-[storage_local_setitem_quotaexceedederr.window.html]
-    expected: TIMEOUT


### PR DESCRIPTION
Currently we use a single json file to hold all webstorage data. This is bad; this json file would become slow to read or write to as the number of origins and key/value pairs increase. This PR splits this into one database per an origin, and uses sqlite3 instead of json.  IndexedDB already uses sqlite3, so no additionally dependencies are added.

Fixes: #36034
Testing: WPT