### PR TITLE
doc: update NDK version in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For more detailed build instructions, see the Servo book under [Setting up your 
 
 - Ensure that the following environment variables are set:
   - `ANDROID_SDK_ROOT`
-  - `ANDROID_NDK_ROOT`: `$ANDROID_SDK_ROOT/ndk/26.2.11394342/`
+  - `ANDROID_NDK_ROOT`: `$ANDROID_SDK_ROOT/ndk/28.2.13676358/`
  `ANDROID_SDK_ROOT` can be any directory (such as `~/android-sdk`).
   All of the Android build dependencies will be installed there.
 - Install the latest version of the [Android command-line
@@ -73,7 +73,7 @@ For more detailed build instructions, see the Servo book under [Setting up your 
   sudo $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install \
    "build-tools;34.0.0" \
    "emulator" \
-   "ndk;26.2.11394342" \
+   "ndk;28.2.13676358" \
    "platform-tools" \
    "platforms;android-33" \
    "system-images;android-33;google_apis;x86_64"


### PR DESCRIPTION
The build system now requires r28.

Testing: Follow the steps for an Android build.

