### PR TITLE
Define conditional_malloc_size_of for all Rc

### DIFF
--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -74,10 +74,13 @@ pub(crate) enum BaseAudioContextOptions {
     OfflineAudioContext(OfflineAudioContextOptions),
 }
 
-#[derive(JSTraceable)]
+#[derive(JSTraceable, MallocSizeOf)]
 struct DecodeResolver {
+    #[conditional_malloc_size_of]
     pub(crate) promise: Rc<Promise>,
+    #[conditional_malloc_size_of]
     pub(crate) success_callback: Option<Rc<DecodeSuccessCallback>>,
+    #[conditional_malloc_size_of]
     pub(crate) error_callback: Option<Rc<DecodeErrorCallback>>,
 }
 
@@ -93,12 +96,11 @@ pub(crate) struct BaseAudioContext {
     destination: MutNullableDom<AudioDestinationNode>,
     listener: MutNullableDom<AudioListener>,
     /// Resume promises which are soon to be fulfilled by a queued task.
-    #[ignore_malloc_size_of = "promises are hard"]
+    #[conditional_malloc_size_of]
     in_flight_resume_promises_queue: DomRefCell<VecDeque<(BoxedSliceOfPromises, ErrorResult)>>,
     /// <https://webaudio.github.io/web-audio-api/#pendingresumepromises>
-    #[ignore_malloc_size_of = "promises are hard"]
+    #[conditional_malloc_size_of]
     pending_resume_promises: DomRefCell<Vec<Rc<Promise>>>,
-    #[ignore_malloc_size_of = "promises are hard"]
     decode_resolvers: DomRefCell<HashMap<String, DecodeResolver>>,
     /// <https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-samplerate>
     sample_rate: f32,

--- a/components/script/dom/audio/offlineaudiocontext.rs
+++ b/components/script/dom/audio/offlineaudiocontext.rs
@@ -39,7 +39,7 @@ pub(crate) struct OfflineAudioContext {
     channel_count: u32,
     length: u32,
     rendering_started: Cell<bool>,
-    #[ignore_malloc_size_of = "promises are hard"]
+    #[conditional_malloc_size_of]
     pending_rendering_promise: DomRefCell<Option<Rc<Promise>>>,
 }
 

--- a/components/script/dom/bindings/trace.rs
+++ b/components/script/dom/bindings/trace.rs
@@ -39,7 +39,7 @@ pub(crate) use js::gc::Traceable as JSTraceable;
 use js::glue::{CallScriptTracer, CallStringTracer, CallValueTracer};
 use js::jsapi::{GCTraceKindToAscii, Heap, JSScript, JSString, JSTracer, TraceKind};
 use js::jsval::JSVal;
-use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
+use malloc_size_of::{MallocConditionalSizeOf, MallocSizeOf, MallocSizeOfOps};
 use rustc_hash::FxBuildHasher;
 pub(crate) use script_bindings::trace::*;
 
@@ -197,6 +197,17 @@ where
 {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         self.0.size_of(ops)
+    }
+}
+
+impl<K, V, S> MallocConditionalSizeOf for HashMapTracedValues<K, V, S>
+where
+    K: Eq + Hash + MallocSizeOf,
+    V: MallocConditionalSizeOf,
+    S: BuildHasher,
+{
+    fn conditional_size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        self.0.conditional_size_of(ops)
     }
 }
 

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -204,7 +204,7 @@ pub(super) struct CanvasState {
     size: Cell<Size2D<u64>>,
     state: DomRefCell<CanvasContextState>,
     origin_clean: Cell<bool>,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "ImageCache"]
     #[no_trace]
     image_cache: Arc<dyn ImageCache>,
     /// The base URL for resolving CSS image URL values.

--- a/components/script/dom/clipboard.rs
+++ b/components/script/dom/clipboard.rs
@@ -34,7 +34,7 @@ use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>.
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 struct RepresentationDataPromiseFulfillmentHandler {
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[conditional_malloc_size_of]
     promise: Rc<Promise>,
 }
 
@@ -59,7 +59,7 @@ impl Callback for RepresentationDataPromiseFulfillmentHandler {
 /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>.
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 struct RepresentationDataPromiseRejectionHandler {
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[conditional_malloc_size_of]
     promise: Rc<Promise>,
 }
 

--- a/components/script/dom/clipboarditem.rs
+++ b/components/script/dom/clipboarditem.rs
@@ -35,7 +35,7 @@ use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 /// <https://w3c.github.io/clipboard-apis/#dom-clipboarditem-gettype>.
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 struct RepresentationDataPromiseFulfillmentHandler {
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[conditional_malloc_size_of]
     promise: Rc<Promise>,
     type_: String,
 }
@@ -76,7 +76,7 @@ impl Callback for RepresentationDataPromiseFulfillmentHandler {
 /// <https://w3c.github.io/clipboard-apis/#dom-clipboarditem-gettype>.
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 struct RepresentationDataPromiseRejectionHandler {
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[conditional_malloc_size_of]
     promise: Rc<Promise>,
 }
 
@@ -98,7 +98,7 @@ pub(super) struct Representation {
     #[ignore_malloc_size_of = "Extern type"]
     pub mime_type: Mime,
     pub is_custom: bool,
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     pub data: Rc<Promise>,
 }
 

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -43,7 +43,7 @@ use crate::task_source::SendableTaskSource;
 #[dom_struct]
 pub(crate) struct CookieStore {
     eventtarget: EventTarget,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     in_flight: DomRefCell<VecDeque<Rc<Promise>>>,
     // Store an id so that we can send it with requests and the resource thread knows who to respond to
     #[no_trace]

--- a/components/script/dom/cssconditionrule.rs
+++ b/components/script/dom/cssconditionrule.rs
@@ -20,7 +20,7 @@ use crate::dom::csssupportsrule::CSSSupportsRule;
 #[dom_struct]
 pub(crate) struct CSSConditionRule {
     cssgroupingrule: CSSGroupingRule,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     rules: RefCell<Arc<Locked<StyleCssRules>>>,
 }

--- a/components/script/dom/cssfontfacerule.rs
+++ b/components/script/dom/cssfontfacerule.rs
@@ -20,7 +20,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct CSSFontFaceRule {
     cssrule: CSSRule,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     fontfacerule: RefCell<Arc<Locked<FontFaceRule>>>,
 }

--- a/components/script/dom/cssimportrule.rs
+++ b/components/script/dom/cssimportrule.rs
@@ -23,7 +23,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct CSSImportRule {
     cssrule: CSSRule,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     import_rule: RefCell<Arc<Locked<ImportRule>>>,
 }

--- a/components/script/dom/csskeyframerule.rs
+++ b/components/script/dom/csskeyframerule.rs
@@ -24,7 +24,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct CSSKeyframeRule {
     cssrule: CSSRule,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     keyframerule: RefCell<Arc<Locked<Keyframe>>>,
     style_decl: MutNullableDom<CSSStyleDeclaration>,

--- a/components/script/dom/csskeyframesrule.rs
+++ b/components/script/dom/csskeyframesrule.rs
@@ -28,7 +28,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct CSSKeyframesRule {
     cssrule: CSSRule,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     keyframesrule: RefCell<Arc<Locked<KeyframesRule>>>,
     rulelist: MutNullableDom<CSSRuleList>,

--- a/components/script/dom/csslayerblockrule.rs
+++ b/components/script/dom/csslayerblockrule.rs
@@ -23,7 +23,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct CSSLayerBlockRule {
     cssgroupingrule: CSSGroupingRule,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     layerblockrule: RefCell<Arc<LayerBlockRule>>,
 }

--- a/components/script/dom/csslayerstatementrule.rs
+++ b/components/script/dom/csslayerstatementrule.rs
@@ -24,7 +24,7 @@ use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 #[dom_struct]
 pub(crate) struct CSSLayerStatementRule {
     cssrule: CSSRule,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     layerstatementrule: RefCell<Arc<LayerStatementRule>>,
 }

--- a/components/script/dom/cssmediarule.rs
+++ b/components/script/dom/cssmediarule.rs
@@ -24,7 +24,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct CSSMediaRule {
     cssconditionrule: CSSConditionRule,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     mediarule: RefCell<Arc<MediaRule>>,
     medialist: MutNullableDom<MediaList>,

--- a/components/script/dom/cssnamespacerule.rs
+++ b/components/script/dom/cssnamespacerule.rs
@@ -21,7 +21,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct CSSNamespaceRule {
     cssrule: CSSRule,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     namespacerule: RefCell<Arc<NamespaceRule>>,
 }

--- a/components/script/dom/cssnesteddeclarations.rs
+++ b/components/script/dom/cssnesteddeclarations.rs
@@ -23,7 +23,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct CSSNestedDeclarations {
     cssrule: CSSRule,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     nesteddeclarationsrule: RefCell<Arc<Locked<NestedDeclarationsRule>>>,
     style_decl: MutNullableDom<CSSStyleDeclaration>,

--- a/components/script/dom/cssrulelist.rs
+++ b/components/script/dom/cssrulelist.rs
@@ -48,7 +48,7 @@ impl Convert<Error> for RulesMutateError {
 pub(crate) struct CSSRuleList {
     reflector_: Reflector,
     parent_stylesheet: Dom<CSSStyleSheet>,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     rules: RefCell<RulesSource>,
     dom_rules: DomRefCell<Vec<MutNullableDom<CSSRule>>>,
 }

--- a/components/script/dom/cssstyledeclaration.rs
+++ b/components/script/dom/cssstyledeclaration.rs
@@ -52,7 +52,7 @@ pub(crate) enum CSSStyleOwner {
     Element(Dom<Element>),
     CSSRule(
         Dom<CSSRule>,
-        #[ignore_malloc_size_of = "Arc"]
+        #[ignore_malloc_size_of = "Stylo"]
         #[no_trace]
         RefCell<Arc<Locked<PropertyDeclarationBlock>>>,
     ),

--- a/components/script/dom/cssstylerule.rs
+++ b/components/script/dom/cssstylerule.rs
@@ -28,7 +28,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct CSSStyleRule {
     cssgroupingrule: CSSGroupingRule,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     stylerule: RefCell<Arc<Locked<StyleRule>>>,
     style_decl: MutNullableDom<CSSStyleDeclaration>,

--- a/components/script/dom/cssstylesheet.rs
+++ b/components/script/dom/cssstylesheet.rs
@@ -55,7 +55,7 @@ pub(crate) struct CSSStyleSheet {
     rulelist: MutNullableDom<CSSRuleList>,
 
     /// The inner Stylo's [Stylesheet].
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     style_stylesheet: DomRefCell<Arc<StyleStyleSheet>>,
 

--- a/components/script/dom/csssupportsrule.rs
+++ b/components/script/dom/csssupportsrule.rs
@@ -22,7 +22,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct CSSSupportsRule {
     cssconditionrule: CSSConditionRule,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     supportsrule: RefCell<Arc<SupportsRule>>,
 }

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -68,14 +68,14 @@ pub(crate) struct CustomElementRegistry {
 
     window: Dom<Window>,
 
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     /// It is safe to use FxBuildHasher here as `LocalName` is an `Atom` in the string_cache.
     /// These get a u32 hashed instead of a string.
     when_defined: DomRefCell<HashMapTracedValues<LocalName, Rc<Promise>, FxBuildHasher>>,
 
     element_definition_is_running: Cell<bool>,
 
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     definitions:
         DomRefCell<HashMapTracedValues<LocalName, Rc<CustomElementDefinition>, FxBuildHasher>>,
 }

--- a/components/script/dom/datatransfer.rs
+++ b/components/script/dom/datatransfer.rs
@@ -42,7 +42,7 @@ pub(crate) struct DataTransfer {
     drop_effect: DomRefCell<DOMString>,
     effect_allowed: DomRefCell<DOMString>,
     items: Dom<DataTransferItemList>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     #[no_trace]
     data_store: Rc<RefCell<Option<DragDataStore>>>,
 }

--- a/components/script/dom/datatransferitem.rs
+++ b/components/script/dom/datatransferitem.rs
@@ -24,7 +24,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct DataTransferItem {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     #[no_trace]
     data_store: Rc<RefCell<Option<DragDataStore>>>,
     id: u16,
@@ -35,7 +35,7 @@ pub(crate) struct DataTransferItem {
 #[derive(JSTraceable, MallocSizeOf)]
 struct PendingStringCallback {
     id: usize,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     callback: Rc<FunctionStringCallback>,
 }
 

--- a/components/script/dom/datatransferitemlist.rs
+++ b/components/script/dom/datatransferitemlist.rs
@@ -23,7 +23,7 @@ use crate::script_runtime::{CanGc, JSContext};
 #[dom_struct]
 pub(crate) struct DataTransferItemList {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     #[no_trace]
     data_store: Rc<RefCell<Option<DragDataStore>>>,
     #[ignore_malloc_size_of = "mozjs"]

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -209,7 +209,7 @@ pub(crate) struct DedicatedWorkerGlobalScope {
     #[ignore_malloc_size_of = "Can't measure trait objects"]
     /// Sender to the parent thread.
     parent_event_loop_sender: ScriptEventLoopSender,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "ImageCache"]
     #[no_trace]
     image_cache: Arc<dyn ImageCache>,
     #[no_trace]

--- a/components/script/dom/defaultteereadrequest.rs
+++ b/components/script/dom/defaultteereadrequest.rs
@@ -50,17 +50,17 @@ pub(crate) struct DefaultTeeReadRequest {
     stream: Dom<ReadableStream>,
     branch_1: Dom<ReadableStream>,
     branch_2: Dom<ReadableStream>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     reading: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     read_again: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_1: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     clone_for_branch_2: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     cancel_promise: Rc<Promise>,
     tee_underlying_source: Dom<DefaultTeeUnderlyingSource>,
 }

--- a/components/script/dom/defaultteeunderlyingsource.rs
+++ b/components/script/dom/defaultteeunderlyingsource.rs
@@ -35,23 +35,23 @@ pub(crate) struct DefaultTeeUnderlyingSource {
     stream: Dom<ReadableStream>,
     branch_1: MutNullableDom<ReadableStream>,
     branch_2: MutNullableDom<ReadableStream>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     reading: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     read_again: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_1: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     clone_for_branch_2: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[ignore_malloc_size_of = "mozjs"]
     #[allow(clippy::redundant_allocation)]
     reason_1: Rc<Box<Heap<Value>>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[ignore_malloc_size_of = "mozjs"]
     #[allow(clippy::redundant_allocation)]
     reason_2: Rc<Box<Heap<Value>>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     cancel_promise: Rc<Promise>,
     tee_cancel_algorithm: TeeCancelAlgorithm,
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -6067,7 +6067,7 @@ pub(crate) enum AnimationFrameCallback {
         actor_name: String,
     },
     FrameRequestCallback {
-        #[ignore_malloc_size_of = "Rc is hard"]
+        #[conditional_malloc_size_of]
         callback: Rc<FrameRequestCallback>,
     },
 }

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -71,7 +71,7 @@ impl StylesheetSource {
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct ServoStylesheetInDocument {
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     pub(crate) sheet: Arc<Stylesheet>,
     /// The object that owns this stylesheet. For constructed stylesheet, it would be the

--- a/components/script/dom/dynamicmoduleowner.rs
+++ b/components/script/dom/dynamicmoduleowner.rs
@@ -22,7 +22,7 @@ pub(crate) struct DynamicModuleId(#[no_trace] pub(crate) Uuid);
 pub(crate) struct DynamicModuleOwner {
     reflector_: Reflector,
 
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     promise: Rc<Promise>,
 
     /// Unique id for each dynamic module

--- a/components/script/dom/fontface.rs
+++ b/components/script/dom/fontface.rs
@@ -62,7 +62,7 @@ pub struct FontFace {
     urls: DomRefCell<Option<SourceList>>,
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontface-fontstatuspromise-slot>
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     font_status_promise: Rc<Promise>,
 }
 

--- a/components/script/dom/fontfaceset.rs
+++ b/components/script/dom/fontfaceset.rs
@@ -28,7 +28,7 @@ pub(crate) struct FontFaceSet {
     target: EventTarget,
 
     /// <https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-readypromise-slot>
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     promise: Rc<Promise>,
 }
 

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -61,7 +61,7 @@ pub(crate) struct GamepadHapticActuator {
     /// <https://www.w3.org/TR/gamepad/#dfn-effects>
     effects: Vec<GamepadHapticEffectType>,
     /// <https://www.w3.org/TR/gamepad/#dfn-playingeffectpromise>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     playing_effect_promise: DomRefCell<Option<Rc<Promise>>>,
     /// The current sequence ID for playing effects,
     /// incremented on every call to playEffect() or reset().

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -146,17 +146,20 @@ use crate::timers::{
 };
 use crate::unminify::unminified_path;
 
-#[derive(JSTraceable)]
+#[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct AutoCloseWorker {
     /// <https://html.spec.whatwg.org/multipage/#dom-workerglobalscope-closing>
+    #[conditional_malloc_size_of]
     closing: Arc<AtomicBool>,
     /// A handle to join on the worker thread.
+    #[ignore_malloc_size_of = "JoinHandle"]
     join_handle: Option<JoinHandle<()>>,
     /// A sender of control messages,
     /// currently only used to signal shutdown.
     #[no_trace]
     control_sender: Sender<DedicatedWorkerControlMsg>,
     /// The context to request an interrupt on the worker thread.
+    #[ignore_malloc_size_of = "mozjs"]
     #[no_trace]
     context: ThreadSafeJSContext,
 }
@@ -304,11 +307,10 @@ pub(crate) struct GlobalScope {
     /// same microtask queue.
     ///
     /// <https://html.spec.whatwg.org/multipage/#microtask-queue>
-    #[ignore_malloc_size_of = "Rc<T> is hard"]
+    #[conditional_malloc_size_of]
     microtask_queue: Rc<MicrotaskQueue>,
 
     /// Vector storing closing references of all workers
-    #[ignore_malloc_size_of = "Arc"]
     list_auto_close_worker: DomRefCell<Vec<AutoCloseWorker>>,
 
     /// Vector storing references of all eventsources.
@@ -379,17 +381,17 @@ pub(crate) struct GlobalScope {
     /// `size` getter of `ByteLengthQueuingStrategy` is called.
     ///
     /// <https://streams.spec.whatwg.org/#byte-length-queuing-strategy-size-function>
-    #[ignore_malloc_size_of = "Rc<T> is hard"]
+    #[ignore_malloc_size_of = "callbacks are hard"]
     byte_length_queuing_strategy_size_function: OnceCell<Rc<Function>>,
 
     /// The count queuing strategy size function that will be initialized once
     /// `size` getter of `CountQueuingStrategy` is called.
     ///
     /// <https://streams.spec.whatwg.org/#count-queuing-strategy-size-function>
-    #[ignore_malloc_size_of = "Rc<T> is hard"]
+    #[ignore_malloc_size_of = "callbacks are hard"]
     count_queuing_strategy_size_function: OnceCell<Rc<Function>>,
 
-    #[ignore_malloc_size_of = "Rc<T> is hard"]
+    #[ignore_malloc_size_of = "callbacks are hard"]
     notification_permission_request_callback_map:
         DomRefCell<HashMap<String, Rc<NotificationPermissionCallback>>>,
 

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -76,7 +76,7 @@ pub(crate) struct HTMLCanvasElement {
 
     // This id and hashmap are used to keep track of ongoing toBlob() calls.
     callback_id: Cell<u32>,
-    #[ignore_malloc_size_of = "not implemented for webidl callbacks"]
+    #[conditional_malloc_size_of]
     blob_callbacks: RefCell<FxHashMap<u32, Rc<BlobCallback>>>,
 }
 

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -185,7 +185,7 @@ pub(crate) struct HTMLImageElement {
     /// Always non-null after construction.
     dimension_attribute_source: MutNullableDom<Element>,
     last_selected_source: DomRefCell<Option<USVString>>,
-    #[ignore_malloc_size_of = "promises are hard"]
+    #[conditional_malloc_size_of]
     image_decode_promises: DomRefCell<Vec<Rc<Promise>>>,
     /// Line number this element was created on
     line_number: u64,
@@ -1488,7 +1488,7 @@ pub(crate) enum ImageElementMicrotask {
     },
     Decode {
         elem: DomRoot<HTMLImageElement>,
-        #[ignore_malloc_size_of = "promises are hard"]
+        #[conditional_malloc_size_of]
         promise: Rc<Promise>,
     },
 }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -385,11 +385,11 @@ pub(crate) struct HTMLMediaElement {
     /// <https://html.spec.whatwg.org/multipage/#delaying-the-load-event-flag>
     delaying_the_load_event_flag: DomRefCell<Option<LoadBlocker>>,
     /// <https://html.spec.whatwg.org/multipage/#list-of-pending-play-promises>
-    #[ignore_malloc_size_of = "promises are hard"]
+    #[conditional_malloc_size_of]
     pending_play_promises: DomRefCell<Vec<Rc<Promise>>>,
     /// Play promises which are soon to be fulfilled by a queued task.
     #[allow(clippy::type_complexity)]
-    #[ignore_malloc_size_of = "promises are hard"]
+    #[conditional_malloc_size_of]
     in_flight_play_promises_queue: DomRefCell<VecDeque<(Box<[Rc<Promise>]>, ErrorResult)>>,
     #[ignore_malloc_size_of = "servo_media"]
     #[no_trace]
@@ -397,7 +397,7 @@ pub(crate) struct HTMLMediaElement {
     #[conditional_malloc_size_of]
     #[no_trace]
     video_renderer: Arc<Mutex<MediaFrameRenderer>>,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "servo_media"]
     #[no_trace]
     audio_renderer: DomRefCell<Option<Arc<Mutex<dyn AudioRenderer>>>>,
     /// <https://html.spec.whatwg.org/multipage/#show-poster-flag>

--- a/components/script/dom/html/htmlobjectelement.rs
+++ b/components/script/dom/html/htmlobjectelement.rs
@@ -29,7 +29,7 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct HTMLObjectElement {
     htmlelement: HTMLElement,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "RasterImage"]
     #[no_trace]
     image: DomRefCell<Option<Arc<RasterImage>>>,
     form_owner: MutNullableDom<HTMLFormElement>,

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -72,7 +72,7 @@ pub(crate) struct IntersectionObserver {
     /// > with the intersection root, as per the processing model.
     ///
     /// <https://w3c.github.io/IntersectionObserver/#intersection-observer-callback>
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[conditional_malloc_size_of]
     callback: Rc<IntersectionObserverCallback>,
 
     /// <https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-queuedentries-slot>

--- a/components/script/dom/medialist.rs
+++ b/components/script/dom/medialist.rs
@@ -27,7 +27,7 @@ use crate::script_runtime::CanGc;
 pub(crate) struct MediaList {
     reflector_: Reflector,
     parent_stylesheet: Dom<CSSStyleSheet>,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "Stylo"]
     #[no_trace]
     media_queries: RefCell<Arc<Locked<StyleMediaList>>>,
 }

--- a/components/script/dom/mediasession.rs
+++ b/components/script/dom/mediasession.rs
@@ -44,7 +44,7 @@ pub(crate) struct MediaSession {
     /// <https://w3c.github.io/mediasession/#dom-mediasession-playbackstate>
     playback_state: DomRefCell<MediaSessionPlaybackState>,
     /// <https://w3c.github.io/mediasession/#supported-media-session-actions>
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     action_handlers: DomRefCell<
         HashMapTracedValues<MediaSessionActionType, Rc<MediaSessionActionHandler>, FxBuildHasher>,
     >,

--- a/components/script/dom/nodeiterator.rs
+++ b/components/script/dom/nodeiterator.rs
@@ -26,7 +26,6 @@ pub(crate) struct NodeIterator {
     reference_node: MutDom<Node>,
     pointer_before_reference_node: Cell<bool>,
     what_to_show: u32,
-    #[ignore_malloc_size_of = "Rc<NodeFilter> has shared ownership, so its size cannot be measured accurately"]
     filter: Filter,
     active: Cell<bool>,
 }
@@ -227,8 +226,8 @@ impl NodeIterator {
     }
 }
 
-#[derive(JSTraceable)]
+#[derive(JSTraceable, MallocSizeOf)]
 pub(crate) enum Filter {
     None,
-    Callback(Rc<NodeFilter>),
+    Callback(#[ignore_malloc_size_of = "callbacks are hard"] Rc<NodeFilter>),
 }

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -111,15 +111,15 @@ pub(crate) struct Notification {
     #[no_trace] // RequestId is not traceable
     pending_request_ids: DomRefCell<HashSet<RequestId>>,
     /// <https://notifications.spec.whatwg.org/#image-resource>
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "RasterImage"]
     #[no_trace]
     image_resource: DomRefCell<Option<Arc<RasterImage>>>,
     /// <https://notifications.spec.whatwg.org/#icon-resource>
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "RasterImage"]
     #[no_trace]
     icon_resource: DomRefCell<Option<Arc<RasterImage>>>,
     /// <https://notifications.spec.whatwg.org/#badge-resource>
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "RasterImage"]
     #[no_trace]
     badge_resource: DomRefCell<Option<Arc<RasterImage>>>,
 }
@@ -557,7 +557,7 @@ struct Action {
     /// <https://notifications.spec.whatwg.org/#action-icon-url>
     icon_url: Option<USVString>,
     /// <https://notifications.spec.whatwg.org/#action-icon-resource>
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "RasterImage"]
     #[no_trace]
     icon_resource: DomRefCell<Option<Arc<RasterImage>>>,
 }

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -57,7 +57,7 @@ pub(crate) struct PaintWorkletGlobalScope {
     /// The worklet global for this object
     worklet_global: WorkletGlobalScope,
     /// The image cache
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "ImageCache"]
     #[no_trace]
     image_cache: Arc<dyn ImageCache>,
     /// <https://drafts.css-houdini.org/css-paint-api/#paint-definitions>

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -419,12 +419,12 @@ type WaitForAllFailureSteps = Rc<dyn Fn(HandleValue)>;
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct WaitForAllFulfillmentHandler {
     /// The steps to call when all promises are resolved.
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[ignore_malloc_size_of = "callbacks are hard"]
     #[no_trace]
     success_steps: WaitForAllSuccessSteps,
 
     /// The results of the promises.
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[ignore_malloc_size_of = "mozjs"]
     #[allow(clippy::vec_box)]
     result: Rc<RefCell<Vec<Box<Heap<JSVal>>>>>,
 
@@ -432,7 +432,7 @@ struct WaitForAllFulfillmentHandler {
     promise_index: usize,
 
     /// A count of fulfilled promises.
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     fulfilled_count: Rc<RefCell<usize>>,
 }
 
@@ -468,7 +468,7 @@ impl Callback for WaitForAllFulfillmentHandler {
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 struct WaitForAllRejectionHandler {
     /// The steps to call if any promise rejects.
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[ignore_malloc_size_of = "callbacks are hard"]
     #[no_trace]
     failure_steps: WaitForAllFailureSteps,
 

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -69,7 +69,7 @@ use super::bindings::codegen::Bindings::ReadableStreamBYOBReaderBinding::Readabl
 use super::readablestreambyobreader::ReadIntoRequest;
 
 /// State Machine for `PipeTo`.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, MallocSizeOf, PartialEq)]
 enum PipeToState {
     /// The starting state
     #[default]
@@ -91,7 +91,7 @@ enum PipeToState {
 }
 
 /// <https://streams.spec.whatwg.org/#rs-pipeTo-shutdown-with-action>
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, MallocSizeOf, PartialEq)]
 enum ShutdownAction {
     /// <https://streams.spec.whatwg.org/#writable-stream-abort>
     WritableStreamAbort,
@@ -124,11 +124,11 @@ pub(crate) struct PipeTo {
 
     /// Pending writes are needed when shutting down(with an action),
     /// because we can only finalize when all writes are finished.
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[ignore_malloc_size_of = "nested Rc"]
     pending_writes: Rc<RefCell<VecDeque<Rc<Promise>>>>,
 
     /// The state machine.
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[conditional_malloc_size_of]
     #[no_trace]
     state: Rc<RefCell<PipeToState>>,
 
@@ -143,7 +143,7 @@ pub(crate) struct PipeTo {
 
     /// The `shuttingDown` variable of
     /// <https://streams.spec.whatwg.org/#readable-stream-pipe-to>
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[conditional_malloc_size_of]
     shutting_down: Rc<Cell<bool>>,
 
     /// The abort reason of the abort signal,
@@ -158,12 +158,12 @@ pub(crate) struct PipeTo {
 
     /// The promise returned by a shutdown action.
     /// We keep it to only continue when it is not pending anymore.
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[ignore_malloc_size_of = "nested Rc"]
     shutdown_action_promise: Rc<RefCell<Option<Rc<Promise>>>>,
 
     /// The promise resolved or rejected at
     /// <https://streams.spec.whatwg.org/#rs-pipeTo-finalize>
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[conditional_malloc_size_of]
     result_promise: Rc<Promise>,
 }
 
@@ -808,7 +808,7 @@ impl PipeTo {
 /// <https://streams.spec.whatwg.org/#readable-stream-cancel>.
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 struct SourceCancelPromiseFulfillmentHandler {
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[conditional_malloc_size_of]
     result: Rc<Promise>,
 }
 
@@ -825,7 +825,7 @@ impl Callback for SourceCancelPromiseFulfillmentHandler {
 /// <https://streams.spec.whatwg.org/#readable-stream-cancel>.
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 struct SourceCancelPromiseRejectionHandler {
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[conditional_malloc_size_of]
     result: Rc<Promise>,
 }
 

--- a/components/script/dom/readablestreambyobreader.rs
+++ b/components/script/dom/readablestreambyobreader.rs
@@ -34,7 +34,7 @@ use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 pub enum ReadIntoRequest {
     /// <https://streams.spec.whatwg.org/#byob-reader-read>
-    Read(#[ignore_malloc_size_of = "Rc is hard"] Rc<Promise>),
+    Read(#[conditional_malloc_size_of] Rc<Promise>),
 }
 
 impl ReadIntoRequest {
@@ -104,7 +104,7 @@ pub(crate) struct ReadableStreamBYOBReader {
     read_into_requests: DomRefCell<VecDeque<ReadIntoRequest>>,
 
     /// <https://streams.spec.whatwg.org/#readablestreamgenericreader-closedpromise>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     closed_promise: DomRefCell<Rc<Promise>>,
 }
 

--- a/components/script/dom/readablestreamdefaultreader.rs
+++ b/components/script/dom/readablestreamdefaultreader.rs
@@ -43,17 +43,17 @@ impl js::gc::Rootable for ReadLoopFulFillmentHandler {}
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct ReadLoopFulFillmentHandler {
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[ignore_malloc_size_of = "callbacks are hard"]
     #[no_trace]
     success_steps: Rc<ReadAllBytesSuccessSteps>,
 
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[ignore_malloc_size_of = "callbacks are hard"]
     #[no_trace]
     failure_steps: Rc<ReadAllBytesFailureSteps>,
 
     reader: Dom<ReadableStreamDefaultReader>,
 
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     bytes: Rc<DomRefCell<Vec<u8>>>,
 }
 
@@ -118,7 +118,7 @@ impl Callback for ReadLoopFulFillmentHandler {
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 /// <https://streams.spec.whatwg.org/#readablestreamdefaultreader-read-all-bytes>
 struct ReadLoopRejectionHandler {
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[ignore_malloc_size_of = "callbacks are hard"]
     #[no_trace]
     failure_steps: Rc<ReadAllBytesFailureSteps>,
 }
@@ -164,7 +164,7 @@ fn read_loop(
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 pub(crate) enum ReadRequest {
     /// <https://streams.spec.whatwg.org/#default-reader-read>
-    Read(#[ignore_malloc_size_of = "Rc is hard"] Rc<Promise>),
+    Read(#[conditional_malloc_size_of] Rc<Promise>),
     /// <https://streams.spec.whatwg.org/#ref-for-read-request%E2%91%A2>
     DefaultTee {
         tee_read_request: Dom<DefaultTeeReadRequest>,
@@ -236,11 +236,11 @@ impl ReadRequest {
 struct ClosedPromiseRejectionHandler {
     branch_1_controller: Dom<ReadableStreamDefaultController>,
     branch_2_controller: Dom<ReadableStreamDefaultController>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_1: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     canceled_2: Rc<Cell<bool>>,
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     cancel_promise: Rc<Promise>,
 }
 
@@ -274,7 +274,7 @@ pub(crate) struct ReadableStreamDefaultReader {
     read_requests: DomRefCell<VecDeque<ReadRequest>>,
 
     /// <https://streams.spec.whatwg.org/#readablestreamgenericreader-closedpromise>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     closed_promise: DomRefCell<Rc<Promise>>,
 }
 

--- a/components/script/dom/reportingobserver.rs
+++ b/components/script/dom/reportingobserver.rs
@@ -29,7 +29,7 @@ use crate::script_runtime::CanGc;
 pub(crate) struct ReportingObserver {
     reflector_: Reflector,
 
-    #[ignore_malloc_size_of = "Rc has unclear ownership"]
+    #[conditional_malloc_size_of]
     callback: Rc<ReportingObserverCallback>,
     buffered: RefCell<bool>,
     types: DomRefCell<Vec<DOMString>>,

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -43,7 +43,7 @@ pub(crate) struct ResizeObserver {
     reflector_: Reflector,
 
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserver-callback-slot>
-    #[ignore_malloc_size_of = "Rc are hard"]
+    #[conditional_malloc_size_of]
     callback: Rc<ResizeObserverCallback>,
 
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserver-observationtargets-slot>

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -1027,7 +1027,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
 
         #[derive(JSTraceable, MallocSizeOf)]
         struct SimpleHandler {
-            #[ignore_malloc_size_of = "Rc has unclear ownership semantics"]
+            #[conditional_malloc_size_of]
             handler: Rc<SimpleCallback>,
         }
         impl SimpleHandler {

--- a/components/script/dom/textdecoderstream.rs
+++ b/components/script/dom/textdecoderstream.rs
@@ -103,7 +103,7 @@ pub(crate) struct TextDecoderStream {
     reflector_: Reflector,
 
     /// <https://encoding.spec.whatwg.org/#textdecodercommon>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     decoder: Rc<TextDecoderCommon>,
 
     /// <https://streams.spec.whatwg.org/#generictransformstream>

--- a/components/script/dom/transformstream.rs
+++ b/components/script/dom/transformstream.rs
@@ -52,7 +52,7 @@ impl js::gc::Rootable for TransformBackPressureChangePromiseFulfillment {}
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct TransformBackPressureChangePromiseFulfillment {
     /// The result of reacting to backpressureChangePromise.
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     result_promise: Rc<Promise>,
 
     #[ignore_malloc_size_of = "mozjs"]
@@ -117,7 +117,7 @@ impl Callback for TransformBackPressureChangePromiseFulfillment {
 /// Reacting to fulfillment of performTransform as part of
 /// <https://streams.spec.whatwg.org/#transform-stream-default-sink-write-algorithm>
 struct PerformTransformFulfillment {
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     result_promise: Rc<Promise>,
 }
 
@@ -133,7 +133,7 @@ impl Callback for PerformTransformFulfillment {
 /// Reacting to rejection of performTransform as part of
 /// <https://streams.spec.whatwg.org/#transform-stream-default-sink-write-algorithm>
 struct PerformTransformRejection {
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     result_promise: Rc<Promise>,
 }
 
@@ -149,7 +149,7 @@ impl Callback for PerformTransformRejection {
 /// Reacting to rejection of backpressureChangePromise as part of
 /// <https://streams.spec.whatwg.org/#transform-stream-default-sink-write-algorithm>
 struct BackpressureChangeRejection {
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     result_promise: Rc<Promise>,
 }
 
@@ -393,7 +393,7 @@ pub struct TransformStream {
     backpressure: Cell<bool>,
 
     /// <https://streams.spec.whatwg.org/#transformstream-backpressurechangepromise>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     backpressure_change_promise: DomRefCell<Option<Rc<Promise>>>,
 
     /// <https://streams.spec.whatwg.org/#transformstream-controller>

--- a/components/script/dom/transformstreamdefaultcontroller.rs
+++ b/components/script/dom/transformstreamdefaultcontroller.rs
@@ -107,7 +107,7 @@ pub struct TransformStreamDefaultController {
     stream: MutNullableDom<TransformStream>,
 
     /// <https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-finishpromise>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     finish_promise: DomRefCell<Option<Rc<Promise>>>,
 }
 

--- a/components/script/dom/trustedtypepolicy.rs
+++ b/components/script/dom/trustedtypepolicy.rs
@@ -31,11 +31,11 @@ pub struct TrustedTypePolicy {
 
     name: String,
 
-    #[ignore_malloc_size_of = "Rc has unclear ownership"]
+    #[conditional_malloc_size_of]
     create_html: Option<Rc<CreateHTMLCallback>>,
-    #[ignore_malloc_size_of = "Rc has unclear ownership"]
+    #[conditional_malloc_size_of]
     create_script: Option<Rc<CreateScriptCallback>>,
-    #[ignore_malloc_size_of = "Rc has unclear ownership"]
+    #[conditional_malloc_size_of]
     create_script_url: Option<Rc<CreateScriptURLCallback>>,
 }
 

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -78,7 +78,7 @@ pub(crate) struct GPUBuffer {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-usage>
     usage: GPUFlagsConstant,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-pending_map-slot>
-    #[ignore_malloc_size_of = "promises are hard"]
+    #[conditional_malloc_size_of]
     pending_map: DomRefCell<Option<Rc<Promise>>>,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapping-slot>
     mapping: DomRefCell<Option<ActiveBufferMapping>>,

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -83,7 +83,7 @@ pub(crate) struct GPUDevice {
     device: WebGPUDevice,
     default_queue: Dom<GPUQueue>,
     /// <https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost>
-    #[ignore_malloc_size_of = "promises are hard"]
+    #[conditional_malloc_size_of]
     lost_promise: DomRefCell<Rc<Promise>>,
     valid: Cell<bool>,
 }

--- a/components/script/dom/webrtc/rtcpeerconnection.rs
+++ b/components/script/dom/webrtc/rtcpeerconnection.rs
@@ -63,9 +63,9 @@ pub(crate) struct RTCPeerConnection {
     // Helps track state changes between the time createOffer/createAnswer
     // is called and resolved
     offer_answer_generation: Cell<u32>,
-    #[ignore_malloc_size_of = "promises are hard"]
+    #[conditional_malloc_size_of]
     offer_promises: DomRefCell<Vec<Rc<Promise>>>,
-    #[ignore_malloc_size_of = "promises are hard"]
+    #[conditional_malloc_size_of]
     answer_promises: DomRefCell<Vec<Rc<Promise>>>,
     local_description: MutNullableDom<RTCSessionDescription>,
     remote_description: MutNullableDom<RTCSessionDescription>,

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -96,7 +96,7 @@ pub(crate) struct XRSession {
     current_raf_callback_list: DomRefCell<Vec<(i32, Option<Rc<XRFrameRequestCallback>>)>>,
     input_sources: Dom<XRInputSourceArray>,
     // Any promises from calling end()
-    #[ignore_malloc_size_of = "promises are hard"]
+    #[conditional_malloc_size_of]
     end_promises: DomRefCell<Vec<Rc<Promise>>>,
     /// <https://immersive-web.github.io/webxr/#ended>
     ended: Cell<bool>,
@@ -113,7 +113,7 @@ pub(crate) struct XRSession {
     #[no_trace]
     input_frames: DomRefCell<HashMap<InputId, InputFrame>>,
     framerate: Cell<f32>,
-    #[ignore_malloc_size_of = "promises are hard"]
+    #[conditional_malloc_size_of]
     update_framerate_promise: DomRefCell<Option<Rc<Promise>>>,
     reference_spaces: DomRefCell<Vec<Dom<XRReferenceSpace>>>,
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -268,7 +268,7 @@ pub(crate) struct Window {
     #[ignore_malloc_size_of = "TODO: Add MallocSizeOf support to layout"]
     layout: RefCell<Box<dyn Layout>>,
     navigator: MutNullableDom<Navigator>,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "ImageCache"]
     #[no_trace]
     image_cache: Arc<dyn ImageCache>,
     #[no_trace]
@@ -3483,7 +3483,7 @@ impl Window {
 /// performed.
 #[derive(MallocSizeOf)]
 pub(crate) struct LayoutValue<T: MallocSizeOf> {
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     is_valid: Rc<Cell<bool>>,
     value: T,
 }

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -133,7 +133,7 @@ pub(crate) struct WindowProxy {
     creator_origin: Option<ImmutableOrigin>,
 
     /// The window proxies the script thread knows.
-    #[ignore_malloc_size_of = "Rc"]
+    #[conditional_malloc_size_of]
     script_window_proxies: Rc<ScriptWindowProxies>,
 }
 

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -51,10 +51,10 @@ pub(crate) struct Worker {
     /// Sender to the Receiver associated with the DedicatedWorkerGlobalScope
     /// this Worker created.
     sender: Sender<DedicatedWorkerScriptMsg>,
-    #[ignore_malloc_size_of = "Arc"]
+    #[conditional_malloc_size_of]
     closing: Arc<AtomicBool>,
     terminated: Cell<bool>,
-    #[ignore_malloc_size_of = "Arc"]
+    #[ignore_malloc_size_of = "mozjs"]
     #[no_trace]
     context_for_interrupt: DomRefCell<Option<ThreadSafeJSContext>>,
 }

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -113,7 +113,7 @@ pub(crate) struct WorkerGlobalScope {
     worker_id: WorkerId,
     #[no_trace]
     worker_url: DomRefCell<ServoUrl>,
-    #[ignore_malloc_size_of = "Arc"]
+    #[conditional_malloc_size_of]
     closing: Arc<AtomicBool>,
     #[ignore_malloc_size_of = "Defined in js"]
     runtime: DomRefCell<Option<Runtime>>,

--- a/components/script/dom/writablestream.rs
+++ b/components/script/dom/writablestream.rs
@@ -54,7 +54,7 @@ impl js::gc::Rootable for AbortAlgorithmFulfillmentHandler {}
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct AbortAlgorithmFulfillmentHandler {
     stream: Dom<WritableStream>,
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     abort_request_promise: Rc<Promise>,
 }
 
@@ -78,7 +78,7 @@ impl js::gc::Rootable for AbortAlgorithmRejectionHandler {}
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct AbortAlgorithmRejectionHandler {
     stream: Dom<WritableStream>,
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     abort_request_promise: Rc<Promise>,
 }
 
@@ -101,7 +101,7 @@ impl js::gc::Rootable for PendingAbortRequest {}
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct PendingAbortRequest {
     /// <https://streams.spec.whatwg.org/#pending-abort-request-promise>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     promise: Rc<Promise>,
 
     /// <https://streams.spec.whatwg.org/#pending-abort-request-reason>
@@ -131,7 +131,7 @@ pub struct WritableStream {
     backpressure: Cell<bool>,
 
     /// <https://streams.spec.whatwg.org/#writablestream-closerequest>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     close_request: DomRefCell<Option<Rc<Promise>>>,
 
     /// <https://streams.spec.whatwg.org/#writablestream-controller>
@@ -141,11 +141,11 @@ pub struct WritableStream {
     detached: Cell<bool>,
 
     /// <https://streams.spec.whatwg.org/#writablestream-inflightwriterequest>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     in_flight_write_request: DomRefCell<Option<Rc<Promise>>>,
 
     /// <https://streams.spec.whatwg.org/#writablestream-inflightcloserequest>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     in_flight_close_request: DomRefCell<Option<Rc<Promise>>>,
 
     /// <https://streams.spec.whatwg.org/#writablestream-pendingabortrequest>
@@ -162,7 +162,7 @@ pub struct WritableStream {
     writer: MutNullableDom<WritableStreamDefaultWriter>,
 
     /// <https://streams.spec.whatwg.org/#writablestream-writerequests>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     write_requests: DomRefCell<VecDeque<Rc<Promise>>>,
 }
 
@@ -1149,7 +1149,7 @@ pub(crate) struct CrossRealmTransformWritable {
     controller: Dom<WritableStreamDefaultController>,
 
     /// The `backpressurePromise` used in the algorithm.
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[ignore_malloc_size_of = "nested Rc"]
     backpressure_promise: Rc<RefCell<Option<Rc<Promise>>>>,
 }
 

--- a/components/script/dom/writablestreamdefaultcontroller.rs
+++ b/components/script/dom/writablestreamdefaultcontroller.rs
@@ -146,11 +146,11 @@ impl js::gc::Rootable for TransferBackPressurePromiseReaction {}
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 struct TransferBackPressurePromiseReaction {
     /// The result of reacting to backpressurePromise.
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     result_promise: Rc<Promise>,
 
     /// The backpressurePromise.
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[ignore_malloc_size_of = "nested Rc"]
     backpressure_promise: Rc<RefCell<Option<Rc<Promise>>>>,
 
     /// The chunk received by the `writeAlgorithm`.
@@ -335,7 +335,7 @@ pub struct WritableStreamDefaultController {
     strategy_hwm: f64,
 
     /// <https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-strategysizealgorithm>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[ignore_malloc_size_of = "QueuingStrategySize"]
     strategy_size: RefCell<Option<Rc<QueuingStrategySize>>>,
 
     /// <https://streams.spec.whatwg.org/#writablestreamdefaultcontroller-stream>

--- a/components/script/dom/writablestreamdefaultwriter.rs
+++ b/components/script/dom/writablestreamdefaultwriter.rs
@@ -24,11 +24,11 @@ use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 pub struct WritableStreamDefaultWriter {
     reflector_: Reflector,
 
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     ready_promise: RefCell<Rc<Promise>>,
 
     /// <https://streams.spec.whatwg.org/#writablestreamdefaultwriter-closedpromise>
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     closed_promise: RefCell<Rc<Promise>>,
 
     /// <https://streams.spec.whatwg.org/#writablestreamdefaultwriter-stream>

--- a/components/script/drag_data_store.rs
+++ b/components/script/drag_data_store.rs
@@ -16,6 +16,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::script_runtime::CanGc;
 
 /// <https://html.spec.whatwg.org/multipage/#the-drag-data-item-kind>
+#[derive(MallocSizeOf)]
 pub(crate) enum Kind {
     Text {
         data: DOMString,
@@ -68,15 +69,16 @@ impl Kind {
 }
 
 /// <https://html.spec.whatwg.org/multipage/#drag-data-store-bitmap>
-#[allow(dead_code)] // TODO this used by DragEvent.
+#[derive(MallocSizeOf)]
 struct Bitmap {
+    #[ignore_malloc_size_of = "RasterImage"]
     image: Option<Arc<RasterImage>>,
     x: i32,
     y: i32,
 }
 
 /// Control the behaviour of the drag data store
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Eq, MallocSizeOf, PartialEq)]
 pub(crate) enum Mode {
     /// <https://html.spec.whatwg.org/multipage/#concept-dnd-rw>
     ReadWrite,
@@ -86,7 +88,7 @@ pub(crate) enum Mode {
     Protected,
 }
 
-#[allow(dead_code)] // TODO some fields are used by DragEvent.
+#[derive(MallocSizeOf)]
 pub(crate) struct DragDataStore {
     /// <https://html.spec.whatwg.org/multipage/#drag-data-store-item-list>
     item_list: IndexMap<u16, Kind>,

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1724,7 +1724,7 @@ impl DynamicModuleList {
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 #[derive(JSTraceable, MallocSizeOf)]
 struct DynamicModule {
-    #[ignore_malloc_size_of = "Rc is hard"]
+    #[conditional_malloc_size_of]
     promise: Rc<Promise>,
     #[ignore_malloc_size_of = "GC types are hard"]
     specifier: Heap<*mut JSObject>,

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -408,7 +408,7 @@ enum InternalTimerCallback {
     StringTimerCallback(DOMString),
     FunctionTimerCallback(
         #[conditional_malloc_size_of] Rc<Function>,
-        #[ignore_malloc_size_of = "Rc"] Rc<Box<[Heap<JSVal>]>>,
+        #[ignore_malloc_size_of = "mozjs"] Rc<Box<[Heap<JSVal>]>>,
     ),
 }
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -655,7 +655,7 @@ pub fn node_id_from_scroll_id(id: usize) -> Option<usize> {
 
 #[derive(Clone, Debug, MallocSizeOf)]
 pub struct ImageAnimationState {
-    #[ignore_malloc_size_of = "Arc is hard"]
+    #[ignore_malloc_size_of = "RasterImage"]
     pub image: Arc<RasterImage>,
     pub active_frame: usize,
     frame_start_time: f64,


### PR DESCRIPTION
This updates all Rc that were ignored for malloc_size_of to use conditional_malloc_size_of, unless the type in the Rc itself doesn't support malloc_size.

Regular expressions used to search for all occurrences:

```
ignore_malloc_size_of = "Rc.*"
ignore_malloc_size_of = "Arc.*"
```

There are a couple left since they have nested Rc, which I don't know how to fix.

To be able to define these, several new implementations were added to `malloc_size_of/lib.rs` as well as
`HashMapTracedValues`.

Testing: if it compiles, it's safe