### PR TITLE
Add client to request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5562,6 +5562,7 @@ dependencies = [
  "http 1.3.1",
  "hyper-util",
  "hyper_serde",
+ "indexmap",
  "ipc-channel",
  "log",
  "malloc_size_of_derive",

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -806,6 +806,8 @@ impl RemoteWebFontDownloader {
         // FIXME: This shouldn't use NoReferrer, but the current documents url
         let request =
             RequestBuilder::new(state.webview_id, url.clone().into(), Referrer::NoReferrer)
+                // TODO: Set policy_container from globalscope that contains the fontcontext
+                .policy_container(Default::default())
                 .destination(Destination::Font);
 
         let core_resource_thread_clone = state.core_resource_thread.clone();

--- a/components/net/fetch/fetch_params.rs
+++ b/components/net/fetch/fetch_params.rs
@@ -4,15 +4,27 @@
 
 use net_traits::request::Request;
 
+/// <https://fetch.spec.whatwg.org/#fetch-params-preloaded-response-candidate>
+#[derive(Clone)]
+pub(crate) enum PreloadResponseCandidate {
+    None,
+    Pending,
+}
+
 /// <https://fetch.spec.whatwg.org/#fetch-params>
 #[derive(Clone)]
 pub struct FetchParams {
-    /// <https://fetch.spec.whatwg.org/#concept-request>
+    /// <https://fetch.spec.whatwg.org/#fetch-params-request>
     pub request: Request,
+    /// <https://fetch.spec.whatwg.org/#fetch-params-preloaded-response-candidate>
+    pub(crate) preload_response_candidate: PreloadResponseCandidate,
 }
 
 impl FetchParams {
     pub fn new(request: Request) -> FetchParams {
-        FetchParams { request }
+        FetchParams {
+            request,
+            preload_response_candidate: PreloadResponseCandidate::None,
+        }
     }
 }

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -25,7 +25,7 @@ use net_traits::policy_container::{PolicyContainer, RequestPolicyContainer};
 use net_traits::request::{
     BodyChunkRequest, BodyChunkResponse, CredentialsMode, Destination, Initiator,
     InsecureRequestsPolicy, Origin, ParserMetadata, RedirectMode, Referrer, Request, RequestMode,
-    ResponseTainting, Window, is_cors_safelisted_method, is_cors_safelisted_request_header,
+    ResponseTainting, is_cors_safelisted_method, is_cors_safelisted_request_header,
 };
 use net_traits::response::{Response, ResponseBody, ResponseType};
 use net_traits::{
@@ -38,8 +38,8 @@ use servo_arc::Arc as ServoArc;
 use servo_url::{Host, ImmutableOrigin, ServoUrl};
 use tokio::sync::mpsc::{UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender};
 
-use super::fetch_params::FetchParams;
 use crate::fetch::cors_cache::CorsCache;
+use crate::fetch::fetch_params::{FetchParams, PreloadResponseCandidate};
 use crate::fetch::headers::determine_nosniff;
 use crate::filemanager_thread::FileManager;
 use crate::http_loader::{
@@ -111,48 +111,60 @@ pub async fn fetch_with_cors_cache(
     target: Target<'_>,
     context: &FetchContext,
 ) {
-    // Step 8: Let fetchParams be a new fetch params whose request is request
+    // Step 8. Let fetchParams be a new fetch params whose request is request
     let mut fetch_params = FetchParams::new(request);
     let request = &mut fetch_params.request;
 
-    // Step 9: If request’s window is "client", then set request’s window to request’s client, if
-    // request’s client’s global object is a Window object; otherwise "no-window".
-    if request.window == Window::Client {
-        // TODO: Set window to request's client object if client is a Window object
-    } else {
-        request.window = Window::NoWindow;
-    }
+    // Step 4. Populate request from client given request.
+    request.populate_request_from_client();
 
-    // Step 10: If request’s origin is "client", then set request’s origin to request’s client’s
-    // origin.
-    if request.origin == Origin::Client {
-        // TODO: set request's origin to request's client's origin
-        unimplemented!()
-    }
+    // Step 5. If request’s client is non-null, then:
+    // TODO
+    // Step 5.1. Set taskDestination to request’s client’s global object.
+    // TODO
+    // Step 5.2. Set crossOriginIsolatedCapability to request’s client’s cross-origin isolated capability.
+    // TODO
 
-    // Step 11: If all of the following conditions are true:
+    // Step 10. If all of the following conditions are true:
+    if
     // - request’s URL’s scheme is an HTTP(S) scheme
-    // - request’s mode is "same-origin", "cors", or "no-cors"
-    // - request’s window is an environment settings object
-    // - request’s method is `GET`
-    // - request’s unsafe-request flag is not set or request’s header list is empty
-    // TODO: evaluate these conditions when we have an an environment settings object
-
-    // Step 12: If request’s policy container is "client", then:
-    if let RequestPolicyContainer::Client = request.policy_container {
-        // Step 12.1: If request’s client is non-null, then set request’s policy container to a clone
-        // of request’s client’s policy container.
-        // TODO: Requires request's client to support PolicyContainer
-
-        // Step 12.2: Otherwise, set request’s policy container to a new policy container.
-        request.policy_container =
-            RequestPolicyContainer::PolicyContainer(PolicyContainer::default());
+    matches!(request.current_url().scheme(), "http" | "https")
+        // - request’s mode is "same-origin", "cors", or "no-cors"
+        && matches!(request.mode, RequestMode::SameOrigin | RequestMode::CorsMode | RequestMode::NoCors)
+        // - request’s method is `GET`
+        && matches!(request.method, Method::GET)
+        // - request’s unsafe-request flag is not set or request’s header list is empty
+        && !request.unsafe_request ||
+        request.headers.is_empty()
+    {
+        // - request’s client is not null, and request’s client’s global object is a Window object
+        if let Some(client) = request.client.as_ref() {
+            // Step 10.1. Assert: request’s origin is same origin with request’s client’s origin.
+            assert!(request.origin == client.origin);
+            // Step 10.2. Let onPreloadedResponseAvailable be an algorithm that runs the
+            // following step given a response response: set fetchParams’s preloaded response candidate to response.
+            // TODO
+            // Step 10.3. Let foundPreloadedResource be the result of invoking consume a preloaded resource
+            // for request’s client, given request’s URL, request’s destination, request’s mode,
+            // request’s credentials mode, request’s integrity metadata, and onPreloadedResponseAvailable.
+            let found_preloaded_resource = client.consume_preloaded_resource();
+            // Step 10.4. If foundPreloadedResource is true and fetchParams’s preloaded response candidate is null,
+            // then set fetchParams’s preloaded response candidate to "pending".
+            if found_preloaded_resource &&
+                matches!(
+                    fetch_params.preload_response_candidate,
+                    PreloadResponseCandidate::None
+                )
+            {
+                fetch_params.preload_response_candidate = PreloadResponseCandidate::Pending;
+            }
+        }
     }
 
-    // Step 13: If request’s header list does not contain `Accept`:
+    // Step 11. If request’s header list does not contain `Accept`, then:
     set_default_accept(request);
 
-    // Step 14: If request’s header list does not contain `Accept-Language`, then user agents should
+    // Step 12. If request’s header list does not contain `Accept-Language`, then user agents should
     // append (`Accept-Language, an appropriate header value) to request’s header list.
     set_default_accept_language(&mut request.headers);
 
@@ -285,9 +297,8 @@ pub async fn main_fetch(
     }
 
     // The request should have a valid policy_container associated with it.
-    // TODO: This should not be `Client` here
     let policy_container = match &request.policy_container {
-        RequestPolicyContainer::Client => PolicyContainer::default(),
+        RequestPolicyContainer::Client => unreachable!(),
         RequestPolicyContainer::PolicyContainer(container) => container.to_owned(),
     };
     let csp_request = convert_request_to_csp_request(request);

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -43,12 +43,13 @@ use ipc_channel::router::ROUTER;
 use log::{debug, error, info, log_enabled, warn};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use net_traits::http_status::HttpStatus;
+use net_traits::policy_container::RequestPolicyContainer;
 use net_traits::pub_domains::reg_suffix;
 use net_traits::request::Origin::Origin as SpecificOrigin;
 use net_traits::request::{
     BodyChunkRequest, BodyChunkResponse, CacheMode, CredentialsMode, Destination, Initiator,
     Origin, RedirectMode, Referrer, Request, RequestBuilder, RequestMode, ResponseTainting,
-    ServiceWorkersMode, Window as RequestWindow, get_cors_unsafe_header_names,
+    ServiceWorkersMode, TraversableForUserPrompts, get_cors_unsafe_header_names,
     is_cors_non_wildcard_request_header_name, is_cors_safelisted_method,
     is_cors_safelisted_request_header,
 };
@@ -151,15 +152,19 @@ impl HttpState {
     }
 }
 
-/// Step 13 of <https://fetch.spec.whatwg.org/#concept-fetch>.
+/// Step 11 of <https://fetch.spec.whatwg.org/#concept-fetch>.
 pub(crate) fn set_default_accept(request: &mut Request) {
+    // Step 11. If request’s header list does not contain `Accept`, then:
     if request.headers.contains_key(header::ACCEPT) {
         return;
     }
 
+    // Step 11.2. If request’s initiator is "prefetch", then set value to the document `Accept` header value.
     let value = if request.initiator == Initiator::Prefetch {
         DOCUMENT_ACCEPT_HEADER_VALUE
     } else {
+        // Step 11.3. Otherwise, the user agent should set value to the first matching statement,
+        // if any, switching on request’s destination:
         match request.destination {
             Destination::Document | Destination::Frame | Destination::IFrame => {
                 DOCUMENT_ACCEPT_HEADER_VALUE
@@ -169,10 +174,12 @@ pub(crate) fn set_default_accept(request: &mut Request) {
             },
             Destination::Json => HeaderValue::from_static("application/json,*/*;q=0.5"),
             Destination::Style => HeaderValue::from_static("text/css,*/*;q=0.1"),
+            // Step 11.1. Let value be `*/*`.
             _ => HeaderValue::from_static("*/*"),
         }
     };
 
+    // Step 11.4. Append (`Accept`, value) to request’s header list.
     request.headers.insert(header::ACCEPT, value);
 }
 
@@ -1268,11 +1275,12 @@ async fn http_network_or_cache_fetch(
     let mut revalidating_flag = false;
 
     // TODO(#33616): Step 8. Run these steps, but abort when fetchParams is canceled:
-    // Step 8.1: If request’s window is "no-window" and request’s redirect mode is "error", then set
-    // httpFetchParams to fetchParams and httpRequest to request.
-    let request_has_no_window = request.window == RequestWindow::NoWindow;
-
-    let http_request = if request_has_no_window && request.redirect_mode == RedirectMode::Error {
+    // Step 8.1. If request’s traversable for user prompts is "no-traversable"
+    // and request’s redirect mode is "error", then set httpFetchParams to fetchParams and httpRequest to request.
+    let http_request = if request.traversable_for_user_prompts ==
+        TraversableForUserPrompts::NoTraversable &&
+        request.redirect_mode == RedirectMode::Error
+    {
         http_fetch_params = fetch_params;
         &mut http_fetch_params.request
     }
@@ -1785,9 +1793,9 @@ async fn http_network_or_cache_fetch(
     // Step 15. If response’s status is 407, then:
     if response.status == StatusCode::PROXY_AUTHENTICATION_REQUIRED {
         let request = &mut fetch_params.request;
-        // Step 15.1 If request’s window is "no-window", then return a network error.
+        // Step 15.1 If request’s traversable for user prompts is "no-traversable", then return a network error.
 
-        if request_has_no_window {
+        if request.traversable_for_user_prompts == TraversableForUserPrompts::NoTraversable {
             return Response::network_error(NetworkError::Internal(
                 "Can't find Window object".into(),
             ));
@@ -2239,7 +2247,16 @@ async fn cors_preflight_fetch(
     .referrer_policy(request.referrer_policy)
     .mode(RequestMode::CorsMode)
     .response_tainting(ResponseTainting::CorsTainting)
+    .policy_container(match &request.policy_container {
+        RequestPolicyContainer::Client => {
+            unreachable!("We should have a policy container for request in cors_preflight_fetch")
+        },
+        RequestPolicyContainer::PolicyContainer(policy_container) => policy_container.clone(),
+    })
     .build();
+
+    // TODO: Remove when we construct a Request instead of a RequestBuilder
+    preflight.populate_request_from_client();
 
     // Step 2. Append (`Accept`, `*/*`) to preflight’s header list.
     preflight

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -643,7 +643,7 @@ impl CoreResourceManager {
             _ => ResourceTimingType::Resource,
         };
 
-        let request = request_builder.build();
+        let mut request = request_builder.build();
         let url = request.current_url();
 
         // In the case of a valid blob URL, acquiring a token granting access to a file,
@@ -687,6 +687,12 @@ impl CoreResourceManager {
             match res_init_ {
                 Some(res_init) => {
                     let response = Response::from_init(res_init, timing_type);
+                    // TODO: Remove this once fetching is aligned with the specification.
+                    // We should only run this once in the main `fetch`. However, since
+                    // we currently call redirects separately, the request hasn't been
+                    // prepared properly. Instead, `fetch` should call `http_redirect_fetch`
+                    // and pass the request accordingly.
+                    request.populate_request_from_client();
 
                     let mut fetch_params = FetchParams::new(request);
                     http_redirect_fetch(

--- a/components/net/tests/data_loader.rs
+++ b/components/net/tests/data_loader.rs
@@ -28,6 +28,7 @@ fn assert_parse(
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
         .pipeline_id(None)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -417,6 +417,8 @@ fn test_cors_preflight_cache_fetch() {
         .build();
     request.use_cors_preflight = true;
     request.mode = RequestMode::CorsMode;
+    // To ensure that `wrapped_request3` also has a fully complete request object
+    request.populate_request_from_client();
     let wrapped_request0 = request.clone();
     let wrapped_request1 = request.clone();
     let wrapped_request2 = request.clone();

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -69,6 +69,7 @@ fn test_fetch_response_is_not_network_error() {
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     let _ = server.close();
@@ -83,6 +84,7 @@ fn test_fetch_on_bad_port_is_network_error() {
     let url = ServoUrl::parse("http://www.example.org:6667").unwrap();
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     assert!(fetch_response.is_network_error());
@@ -105,6 +107,7 @@ fn test_fetch_response_body_matches_const_message() {
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     let _ = server.close();
@@ -125,6 +128,7 @@ fn test_fetch_aboutblank() {
     let url = ServoUrl::parse("about:blank").unwrap();
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
 
     let fetch_response = fetch(request, None);
@@ -191,6 +195,7 @@ fn test_fetch_blob() {
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(origin.origin())
+        .policy_container(Default::default())
         .build();
 
     let (sender, receiver) = unbounded();
@@ -233,6 +238,7 @@ fn test_file() {
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
 
     let pool = ThreadPool::new(1, "CoreResourceTestPool".to_string());
@@ -276,6 +282,7 @@ fn test_fetch_ftp() {
     let url = ServoUrl::parse("ftp://not-supported").unwrap();
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     assert!(fetch_response.is_network_error());
@@ -286,6 +293,7 @@ fn test_fetch_bogus_scheme() {
     let url = ServoUrl::parse("bogus://whatever").unwrap();
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     assert!(fetch_response.is_network_error());
@@ -338,12 +346,15 @@ fn test_cors_preflight_fetch() {
         };
     let (server, url) = make_server(handler);
 
+    let origin = url.origin();
     let target_url = url.clone().join("a.html").unwrap();
     let mut request = RequestBuilder::new(
         Some(TEST_WEBVIEW_ID),
         url,
         Referrer::ReferrerUrl(target_url),
     )
+    .origin(origin)
+    .policy_container(Default::default())
     .build();
     request.referrer_policy = ReferrerPolicy::Origin;
     request.use_cors_preflight = true;
@@ -401,7 +412,9 @@ fn test_cors_preflight_cache_fetch() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer).build();
+    let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
+        .policy_container(Default::default())
+        .build();
     request.use_cors_preflight = true;
     request.mode = RequestMode::CorsMode;
     let wrapped_request0 = request.clone();
@@ -470,7 +483,9 @@ fn test_cors_preflight_fetch_network_error() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer).build();
+    let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
+        .policy_container(Default::default())
+        .build();
     request.method = Method::from_bytes(b"CHICKEN").unwrap();
     request.use_cors_preflight = true;
     request.mode = RequestMode::CorsMode;
@@ -501,6 +516,7 @@ fn test_fetch_response_is_basic_filtered() {
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     let _ = server.close();
@@ -566,7 +582,9 @@ fn test_fetch_response_is_cors_filtered() {
     let (server, url) = make_server(handler);
 
     // an origin mis-match will stop it from defaulting to a basic filtered response
-    let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer).build();
+    let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
+        .policy_container(Default::default())
+        .build();
     request.mode = RequestMode::CorsMode;
     let fetch_response = fetch(request, None);
     let _ = server.close();
@@ -602,7 +620,9 @@ fn test_fetch_response_is_opaque_filtered() {
     let (server, url) = make_server(handler);
 
     // an origin mis-match will fall through to an Opaque filtered response
-    let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer).build();
+    let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
+        .policy_container(Default::default())
+        .build();
     let fetch_response = fetch(request, None);
     let _ = server.close();
 
@@ -652,6 +672,7 @@ fn test_fetch_response_is_opaque_redirect_filtered() {
 
     let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     request.redirect_mode = RedirectMode::Manual;
     let fetch_response = fetch(request, None);
@@ -689,6 +710,7 @@ fn test_fetch_with_local_urls_only() {
         let mut request =
             RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
                 .origin(url.origin())
+                .policy_container(Default::default())
                 .build();
 
         // Set the flag.
@@ -757,6 +779,7 @@ fn test_fetch_with_hsts() {
     }
     let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     // Set the flag.
     request.local_urls_only = false;
@@ -815,6 +838,7 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
         .destination(Destination::Document)
         .origin(url.clone().origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -875,6 +899,7 @@ fn test_fetch_self_signed() {
         .destination(Destination::Document)
         .origin(url.clone().origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -896,6 +921,7 @@ fn test_fetch_self_signed() {
         .destination(Destination::Document)
         .origin(url.clone().origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -917,6 +943,7 @@ fn test_fetch_with_sri_network_error() {
 
     let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     // To calulate hash use :
     // echo -n "alert('Hello, Network Error');" | openssl dgst -sha384 -binary | openssl base64 -A
@@ -943,6 +970,7 @@ fn test_fetch_with_sri_sucess() {
 
     let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     // To calulate hash use :
     // echo -n "alert('Hello, Network Error');" | openssl dgst -sha384 -binary | openssl base64 -A
@@ -986,6 +1014,7 @@ fn test_fetch_blocked_nosniff() {
         let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
             .origin(url.origin())
             .destination(destination)
+            .policy_container(Default::default())
             .build();
         let fetch_response = fetch(request, None);
         let _ = server.close();
@@ -1032,6 +1061,7 @@ fn setup_server_and_fetch(message: &'static [u8], redirect_cap: u32) -> Response
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     let _ = server.close();
@@ -1123,6 +1153,7 @@ fn test_fetch_redirect_updates_method_runner(
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
         .method(method)
+        .policy_container(Default::default())
         .build();
 
     let _ = fetch(request, None);
@@ -1207,6 +1238,7 @@ fn test_fetch_async_returns_complete_response() {
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
 
@@ -1225,7 +1257,9 @@ fn test_opaque_filtered_fetch_async_returns_complete_response() {
     let (server, url) = make_server(handler);
 
     // an origin mis-match will fall through to an Opaque filtered response
-    let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer).build();
+    let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
+        .policy_container(Default::default())
+        .build();
     let fetch_response = fetch(request, None);
 
     let _ = server.close();
@@ -1262,6 +1296,7 @@ fn test_opaque_redirect_filtered_fetch_async_returns_complete_response() {
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
         .redirect_mode(RedirectMode::Manual)
+        .policy_container(Default::default())
         .build();
 
     let fetch_response = fetch(request, None);
@@ -1288,6 +1323,7 @@ fn test_fetch_with_devtools() {
         .origin(url.origin())
         .redirect_mode(RedirectMode::Manual)
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let (devtools_chan, devtools_port) = unbounded();
@@ -1429,6 +1465,7 @@ fn test_fetch_request_intercepted() {
     let url = ServoUrl::parse("http://www.example.org").unwrap();
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let response = fetch_with_context(request, &mut context);
 

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -236,6 +236,7 @@ fn test_check_default_headers_loaded_in_every_request() {
         .destination(Destination::Document)
         .origin(url.clone().origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = dbg!(fetch(request, None));
@@ -264,6 +265,7 @@ fn test_check_default_headers_loaded_in_every_request() {
         .destination(Destination::Document)
         .origin(url.clone().origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -297,6 +299,7 @@ fn test_load_when_request_is_not_get_or_head_and_there_is_no_body_content_length
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -333,6 +336,7 @@ fn test_request_and_response_data_with_network_messages() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let (devtools_chan, devtools_port) = unbounded();
@@ -449,6 +453,7 @@ fn test_request_and_response_message_from_devtool_without_pipeline_id() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(None)
+        .policy_container(Default::default())
         .build();
 
     let (devtools_chan, devtools_port) = unbounded();
@@ -488,6 +493,7 @@ fn test_redirected_request_to_devtools() {
         .method(Method::POST)
         .destination(Destination::Document)
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let (devtools_chan, devtools_port) = unbounded();
@@ -549,6 +555,7 @@ fn test_load_when_redirecting_from_a_post_should_rewrite_next_request_as_get() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -582,6 +589,7 @@ fn test_load_should_decode_the_response_as_deflate_when_response_headers_have_co
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -617,6 +625,7 @@ fn test_load_should_decode_the_response_as_gzip_when_response_headers_have_conte
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -664,6 +673,7 @@ fn test_load_doesnt_send_request_body_on_any_redirect() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -694,6 +704,7 @@ fn test_load_doesnt_add_host_to_hsts_list_when_url_is_http_even_if_hsts_headers_
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let mut context = new_fetch_context(None, None, None);
@@ -744,6 +755,7 @@ fn test_load_sets_cookies_in_the_resource_manager_when_it_get_set_cookie_header_
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -799,6 +811,7 @@ fn test_load_sets_requests_cookies_header_for_url_by_getting_cookies_from_the_re
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -848,6 +861,7 @@ fn test_load_sends_cookie_if_nonhttp() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -889,6 +903,7 @@ fn test_cookie_set_with_httponly_should_not_be_available_using_getcookiesforurl(
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -942,6 +957,7 @@ fn test_when_cookie_received_marked_secure_is_ignored_for_http() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -977,6 +993,7 @@ fn test_load_sets_content_length_to_length_of_request_body() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1019,6 +1036,7 @@ fn test_load_uses_explicit_accept_from_headers_in_load_data() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1058,6 +1076,7 @@ fn test_load_sets_default_accept_to_html_xhtml_xml_and_then_anything_else() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1100,6 +1119,7 @@ fn test_load_uses_explicit_accept_encoding_from_load_data_headers() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1139,6 +1159,7 @@ fn test_load_sets_default_accept_encoding_to_gzip_and_deflate() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1197,6 +1218,7 @@ fn test_load_errors_when_there_a_redirect_loop() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1257,6 +1279,7 @@ fn test_load_succeeds_with_a_redirect_loop() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1300,6 +1323,7 @@ fn test_load_follows_a_redirect() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1386,6 +1410,7 @@ fn test_redirect_from_x_to_y_provides_y_cookies_from_y() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -1437,6 +1462,7 @@ fn test_redirect_from_x_to_x_provides_x_with_cookie_from_first_response() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1472,6 +1498,7 @@ fn test_if_auth_creds_not_in_url_but_in_cache_it_sets_it() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let mut context = new_fetch_context(None, None, None);
@@ -1520,6 +1547,7 @@ fn test_auth_ui_needs_www_auth() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1586,6 +1614,7 @@ fn test_fetch_compressed_response_update_count() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     struct FetchResponseCollector {
@@ -1675,6 +1704,7 @@ fn test_user_credentials_prompt_when_proxy_authentication_is_required() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
@@ -1732,6 +1762,7 @@ fn test_prompt_credentials_when_client_receives_unauthorized_response() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
@@ -1778,6 +1809,7 @@ fn test_dont_prompt_credentials_when_unauthorized_response_contains_no_www_authe
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
@@ -1839,6 +1871,7 @@ fn test_prompt_credentials_user_cancels_dialog_input() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
@@ -1885,6 +1918,7 @@ fn test_prompt_credentials_user_input_incorrect_credentials() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
@@ -1937,6 +1971,7 @@ fn test_prompt_credentials_user_input_incorrect_mode() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -377,7 +377,8 @@ fn connect(
         .read()
         .unwrap()
         .apply_hsts_rules(&mut req_builder.url);
-    let request = req_builder.build();
+    let mut request = req_builder.build();
+    request.populate_request_from_client();
 
     let req_url = request.url();
     let req_origin = match request.origin {

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -17,7 +17,7 @@ use net_traits::request::{
     CacheMode as NetTraitsRequestCache, CredentialsMode as NetTraitsRequestCredentials,
     Destination as NetTraitsRequestDestination, Origin, RedirectMode as NetTraitsRequestRedirect,
     Referrer as NetTraitsRequestReferrer, Request as NetTraitsRequest, RequestBuilder,
-    RequestMode as NetTraitsRequestMode, Window,
+    RequestMode as NetTraitsRequestMode, TraversableForUserPrompts,
 };
 use servo_url::ServoUrl;
 
@@ -150,7 +150,7 @@ impl Request {
         let origin = base_url.origin();
 
         // Step 8. Let traversableForUserPrompts be "client".
-        let mut window = Window::Client;
+        let mut traversable_for_user_prompts = TraversableForUserPrompts::Client;
 
         // Step 9. If request’s traversable for user prompts is an environment settings object
         // and its origin is same origin with origin, then set traversableForUserPrompts
@@ -164,7 +164,7 @@ impl Request {
 
         // Step 11. If init["window"] exists, then set traversableForUserPrompts to "no-traversable".
         if !init.window.handle().is_undefined() {
-            window = Window::NoWindow;
+            traversable_for_user_prompts = TraversableForUserPrompts::NoTraversable;
         }
 
         // Step 12. Set request to a new request with the following properties:
@@ -173,7 +173,7 @@ impl Request {
         request.method = temporary_request.method;
         request.headers = temporary_request.headers.clone();
         request.unsafe_request = true;
-        request.window = window;
+        request.traversable_for_user_prompts = traversable_for_user_prompts;
         // TODO: `entry settings object` is not implemented in Servo yet.
         request.origin = Origin::Client;
         request.referrer = temporary_request.referrer;
@@ -567,6 +567,7 @@ fn net_request_from_global(global: &GlobalScope, url: ServoUrl) -> NetTraitsRequ
         .https_state(global.get_https_state())
         .insecure_requests_policy(global.insecure_requests_policy())
         .has_trustworthy_ancestor_origin(global.has_trustworthy_ancestor_or_current_origin())
+        .policy_container(global.policy_container())
         .build()
 }
 

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -25,6 +25,7 @@ headers = { workspace = true }
 http = { workspace = true }
 hyper-util = { workspace = true }
 hyper_serde = { workspace = true }
+indexmap = { workspace = true }
 ipc-channel = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -1080,7 +1080,10 @@ pub fn http_percent_encode(bytes: &[u8]) -> String {
     percent_encoding::percent_encode(bytes, HTTP_VALUE).to_string()
 }
 
+/// Step 12 of <https://fetch.spec.whatwg.org/#concept-fetch>
 pub fn set_default_accept_language(headers: &mut HeaderMap) {
+    // If request’s header list does not contain `Accept-Language`,
+    // then user agents should append (`Accept-Language, an appropriate header value) to request’s header list.
     if headers.contains_key(header::ACCEPT_LANGUAGE) {
         return;
     }


### PR DESCRIPTION
This aligns the request object more with the specification, since the spec now has a `traversable_for_user_prompts` and a separate field for the client. Before, they were present in the same enum.

In doing so, new structs are added that are all required in the new spec. It also adds a minimal client to start with the concept of preloaded resources.

Since the spec moved things around a bit, it now has a dedicated method to populate the client from the request.

Part of #35035