### PR TITLE
webdriver: Stop making fields `RefCell`

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -143,8 +143,8 @@ impl Handler {
         self.current_action_id.set(Some(new_token));
 
         // Step 2. Let actions result be the result of dispatch actions inner.
-
         let res = self.dispatch_actions_inner(actions_by_tick, browsing_context);
+
         // Step 3. Dequeue input state's actions queue.
         self.current_action_id.set(None);
 
@@ -488,7 +488,7 @@ impl Handler {
         }
 
         let (start_x, start_y) = {
-            let pointer_input_state = self.get_pointer_input_state_mut(source_id);
+            let pointer_input_state = self.get_pointer_input_state(source_id);
             (pointer_input_state.x, pointer_input_state.y)
         };
 
@@ -547,7 +547,7 @@ impl Handler {
 
             // Step 5 - 6: Let current x/y equal the x/y property of input state.
             let (current_x, current_y) = {
-                let pointer_input_state = self.get_pointer_input_state_mut(source_id);
+                let pointer_input_state = self.get_pointer_input_state(source_id);
                 (pointer_input_state.x, pointer_input_state.y)
             };
 
@@ -847,9 +847,7 @@ impl Handler {
         // Step 1. Let actions be the result of getting a property named "actions" from parameters.
         // Step 2. (ignored because params is already validated earlier). If actions is not a list,
         // return an error with status InvalidArgument.
-        let actions = params.actions;
-
-        self.actions_by_tick_from_sequence(actions)
+        self.actions_by_tick_from_sequence(params.actions)
     }
 
     pub(crate) fn actions_by_tick_from_sequence(

--- a/components/webdriver_server/session.rs
+++ b/components/webdriver_server/session.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 
 use base::id::{BrowsingContextId, WebViewId};
@@ -65,10 +64,10 @@ pub struct WebDriverSession {
     user_prompt_handler: UserPromptHandler,
 
     /// <https://w3c.github.io/webdriver/#dfn-input-state-map>
-    input_state_table: RefCell<HashMap<String, InputSourceState>>,
+    pub(crate) input_state_table: HashMap<String, InputSourceState>,
 
     /// <https://w3c.github.io/webdriver/#dfn-input-cancel-list>
-    input_cancel_list: RefCell<Vec<(String, ActionItem)>>,
+    pub(crate) input_cancel_list: Vec<(String, ActionItem)>,
 }
 
 impl WebDriverSession {
@@ -81,8 +80,8 @@ impl WebDriverSession {
             page_loading_strategy: PageLoadStrategy::Normal,
             strict_file_interactability: false,
             user_prompt_handler: UserPromptHandler::new(),
-            input_state_table: RefCell::new(HashMap::new()),
-            input_cancel_list: RefCell::new(Vec::new()),
+            input_state_table: Default::default(),
+            input_cancel_list: Default::default(),
         }
     }
 
@@ -122,26 +121,14 @@ impl WebDriverSession {
         &self.user_prompt_handler
     }
 
-    pub fn input_state_table(&self) -> Ref<'_, HashMap<String, InputSourceState>> {
-        self.input_state_table.borrow()
-    }
-
-    pub fn input_state_table_mut(&self) -> RefMut<'_, HashMap<String, InputSourceState>> {
-        self.input_state_table.borrow_mut()
-    }
-
     pub fn pointer_ids(&self) -> FxHashSet<u32> {
-        self.input_state_table()
+        self.input_state_table
             .values()
             .filter_map(|source| match source {
                 InputSourceState::Pointer(pointer_state) => Some(pointer_state.pointer_id),
                 _ => None,
             })
             .collect()
-    }
-
-    pub fn input_cancel_list_mut(&self) -> RefMut<'_, Vec<(String, ActionItem)>> {
-        self.input_cancel_list.borrow_mut()
     }
 }
 


### PR DESCRIPTION
Stop making any fields of webdriver being RefCell to completely rely on compile-time check.

Testing: No behaviour change
Fixes: #39497
Fixes: #39649
