### PR TITLE
nix: Update Android NDK version in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -44,7 +44,7 @@ let
       systemImageTypes = [ "google_apis" ];
       abiVersions = [ "x86" "armeabi-v7a" ];
       includeNDK = true;
-      ndkVersion = "26.2.11394342";
+      ndkVersion = "28.2.13676358";
       useGoogleAPIs = false;
       useGoogleTVAddOns = false;
       includeExtras = [


### PR DESCRIPTION
Servo now requires r28 of the NDK. This needs to land after #39625 as
the newer NDK is not available in the current pinned version of nixpkgs.

Signed-off-by: Mukilan Thiyagarajan <mukilan@igalia.com>
