### PR TITLE
fonts: Use OS/2 table to determine if font face is already bold when synthesizing bold face for FreeType platform

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -278,10 +278,9 @@ impl Font {
     ) -> Result<Font, &'static str> {
         let synthetic_bold = {
             let is_bold = descriptor.weight >= FontWeight::BOLD_THRESHOLD;
-            let template_is_bold = template.descriptor().weight.0 >= FontWeight::BOLD_THRESHOLD;
             let allows_synthetic_bold = matches!(descriptor.synthesis_weight, FontSynthesis::Auto);
 
-            is_bold && !template_is_bold && allows_synthetic_bold
+            is_bold && allows_synthetic_bold
         };
 
         let handle = PlatformFont::new_from_template(

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -138,7 +138,7 @@ impl PlatformFontMethods for PlatformFont {
         );
         let face_is_bold = table_provider_data
             .font_ref()
-            .and_then(|font_ref| font_ref.os2())
+            .and_then(FontRef::os2)
             .is_ok_and(|table| table.us_weight_class() >= SEMI_BOLD_U16);
 
         // Variable fonts do not count as font synthesis and their use is not affected by

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -147,11 +147,7 @@ impl PlatformFontMethods for PlatformFont {
         // <https://www.w3.org/TR/css-fonts-4/#font-synthesis-intro>
         let is_variable_font = FT_HAS_MULTIPLE_MASTERS(face.as_ptr());
 
-        let synthetic_bold = if face_is_bold || is_variable_font {
-            false
-        } else {
-            synthetic_bold
-        };
+        let synthetic_bold = !face_is_bold && !is_variable_font && synthetic_bold;
 
         Ok(PlatformFont {
             face: ReentrantMutex::new(face),

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -138,7 +138,7 @@ impl PlatformFontMethods for PlatformFont {
         );
         let face_is_bold = table_provider_data
             .font_ref()
-            .and_then(FontRef::os2)
+            .and_then(|font_ref| font_ref.os2())
             .is_ok_and(|table| table.us_weight_class() >= SEMI_BOLD_U16);
 
         // Variable fonts do not count as font synthesis and their use is not affected by

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -9,7 +9,9 @@ use app_units::Au;
 use euclid::default::{Point2D, Rect, Size2D};
 use fonts_traits::{FontIdentifier, FontTemplateDescriptor, LocalFontIdentifier};
 use freetype_sys::{
-    ft_sfnt_os2, FT_F26Dot6, FT_Get_Char_Index, FT_Get_Kerning, FT_Get_Sfnt_Table, FT_GlyphSlot, FT_Load_Glyph, FT_SizeRec, FT_Size_Metrics, FT_UInt, FT_ULong, FT_Vector, FT_HAS_MULTIPLE_MASTERS, FT_KERNING_DEFAULT, FT_LOAD_DEFAULT, FT_LOAD_NO_HINTING, TT_OS2
+    FT_F26Dot6, FT_Get_Char_Index, FT_Get_Kerning, FT_Get_Sfnt_Table, FT_GlyphSlot,
+    FT_HAS_MULTIPLE_MASTERS, FT_KERNING_DEFAULT, FT_LOAD_DEFAULT, FT_LOAD_NO_HINTING,
+    FT_Load_Glyph, FT_Size_Metrics, FT_SizeRec, FT_UInt, FT_ULong, FT_Vector, TT_OS2, ft_sfnt_os2,
 };
 use log::debug;
 use memmap2::Mmap;
@@ -135,7 +137,7 @@ impl PlatformFontMethods for PlatformFont {
             if os2_table.is_null() {
                 false
             } else {
-                (*os2_table).usWeightClass >= BOLD_THRESHOLD 
+                (*os2_table).usWeightClass >= BOLD_THRESHOLD
             }
         };
 
@@ -145,7 +147,7 @@ impl PlatformFontMethods for PlatformFont {
         // <https://www.w3.org/TR/css-fonts-4/#font-synthesis-intro>
         let is_variable_font = FT_HAS_MULTIPLE_MASTERS(face.as_ptr());
 
-        let synthetic_bold = if face_is_bold || is_variable_font  {
+        let synthetic_bold = if face_is_bold || is_variable_font {
             false
         } else {
             synthetic_bold

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -16,9 +16,8 @@ use freetype_sys::{
 use log::debug;
 use memmap2::Mmap;
 use parking_lot::ReentrantMutex;
-use read_fonts::tables::os2::Os2;
 use read_fonts::types::Tag;
-use read_fonts::{FontRead, FontRef, ReadError, TableProvider};
+use read_fonts::{FontRef, ReadError, TableProvider};
 use servo_arc::Arc;
 use skrifa::attribute::Weight;
 use style::Zero;
@@ -139,10 +138,8 @@ impl PlatformFontMethods for PlatformFont {
         );
         let face_is_bold = table_provider_data
             .font_ref()
-            .ok()
-            .and_then(|font_ref| font_ref.table_data(Tag::new(b"OS/2")))
-            .and_then(|data| Os2::read(data).ok())
-            .is_some_and(|table| table.us_weight_class() >= SEMI_BOLD_U16);
+            .and_then(|font_ref| font_ref.os2())
+            .is_ok_and(|table| table.us_weight_class() >= SEMI_BOLD_U16);
 
         // Variable fonts do not count as font synthesis and their use is not affected by
         // the font-synthesis property.


### PR DESCRIPTION
The previous implementation in #39519 mistakenly used the `FontTemplateDescriptor` to determine whether the font face itself is already bold. This PR fixes that by using the `usWeightClass` in the `OS/2` table of the font face to determine if the font face is bold already.

Testing: A new testcase `/tests/wpt/mozilla/tests/css/font_synthesis_weight_static_bold.html` is getting added in #39633. This test checks whether a bold font face gets "double emboldened"
Depends on: #39633
