### PR TITLE
webdriver: Apply script timeout to related IPC messaging as well

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -36,7 +36,7 @@ use embedder_traits::{
 use euclid::{Point2D, Rect, Size2D};
 use http::method::Method;
 use image::{DynamicImage, ImageFormat};
-use ipc_channel::ipc::{self, IpcReceiver};
+use ipc_channel::ipc::{self, IpcReceiver, TryRecvError};
 use keyboard_types::webdriver::{Event as DispatchStringEvent, KeyInputState, send_keys};
 use keyboard_types::{Code, Key, KeyState, KeyboardEvent, Location, NamedKey};
 use log::{debug, error, info};
@@ -75,6 +75,7 @@ use webdriver::server::{self, Session, SessionTeardownKind, WebDriverHandler};
 
 use crate::actions::{InputSourceState, PointerInputState};
 use crate::session::{PageLoadStrategy, WebDriverSession};
+use crate::timeout::DEFAULT_PAGE_LOAD_TIMEOUT;
 
 #[derive(Default)]
 pub struct WebDriverMessageIdGenerator {
@@ -587,7 +588,7 @@ impl Handler {
                 self.session_mut()?.set_webview_id(webview_id);
                 self.session_mut()?
                     .set_browsing_context_id(BrowsingContextId::from(webview_id));
-                let _ = self.wait_document_ready(3000);
+                let _ = self.wait_document_ready(Some(3000));
             },
         };
 
@@ -692,7 +693,12 @@ impl Handler {
         Ok(WebDriverResponse::Void)
     }
 
-    fn wait_document_ready(&self, timeout: u64) -> WebDriverResult<WebDriverResponse> {
+    fn wait_document_ready(&self, timeout: Option<u64>) -> WebDriverResult<WebDriverResponse> {
+        let timeout_channel = match timeout {
+            Some(timeout) => after(Duration::from_millis(timeout)),
+            None => crossbeam_channel::never(),
+        };
+
         select! {
             recv(self.load_status_receiver) -> res => {
                 match res {
@@ -716,7 +722,7 @@ impl Handler {
                     )),
                 }
             },
-            recv(after(Duration::from_millis(timeout))) -> _ => Err(
+            recv(timeout_channel) -> _ => Err(
                 WebDriverError::new(ErrorStatus::Timeout, "Load timed out")
             ),
         }
@@ -1917,10 +1923,13 @@ impl Handler {
     fn handle_get_timeouts(&mut self) -> WebDriverResult<WebDriverResponse> {
         let timeouts = self.session()?.session_timeouts();
 
+        // FIXME: The specification says that all of these values can be `null`, but the `webdriver` crate
+        // only supports setting `script` as null. When set to null, report these values as being the
+        // default ones for now.
         let timeouts = TimeoutsResponse {
             script: timeouts.script,
-            page_load: timeouts.page_load,
-            implicit: timeouts.implicit_wait,
+            page_load: timeouts.page_load.unwrap_or(DEFAULT_PAGE_LOAD_TIMEOUT),
+            implicit: timeouts.implicit_wait.unwrap_or(0),
         };
 
         Ok(WebDriverResponse::Timeouts(timeouts))
@@ -1937,10 +1946,10 @@ impl Handler {
             session.session_timeouts_mut().script = timeout;
         }
         if let Some(timeout) = parameters.page_load {
-            session.session_timeouts_mut().page_load = timeout;
+            session.session_timeouts_mut().page_load = Some(timeout);
         }
         if let Some(timeout) = parameters.implicit {
-            session.session_timeouts_mut().implicit_wait = timeout
+            session.session_timeouts_mut().implicit_wait = Some(timeout);
         }
 
         Ok(WebDriverResponse::Void)
@@ -2055,7 +2064,14 @@ impl Handler {
         let (sender, receiver) = ipc::channel().unwrap();
         let cmd = WebDriverScriptCommand::ExecuteScript(script, sender);
         self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
-        let result = wait_for_ipc_response(receiver)?;
+
+        let timeout_duration = self
+            .session()?
+            .session_timeouts()
+            .script
+            .map(Duration::from_millis);
+        let result = wait_for_script_ipc_response_with_timeout(receiver, timeout_duration)?;
+
         self.postprocess_js_result(result)
     }
 
@@ -2065,30 +2081,27 @@ impl Handler {
     ) -> WebDriverResult<WebDriverResponse> {
         // Step 1. Let body and arguments be the result of trying to extract the script arguments
         // from a request with argument parameters.
-        let (func_body, mut args_string) = self.extract_script_arguments(parameters)?;
+        let (function_body, mut args_string) = self.extract_script_arguments(parameters)?;
         args_string.push("resolve".to_string());
 
-        let timeout_script = if let Some(script_timeout) = self.session()?.session_timeouts().script
-        {
-            format!("setTimeout(webdriverTimeout, {});", script_timeout)
-        } else {
-            "".into()
-        };
+        let timeout = self.session()?.session_timeouts().script;
+        let timeout_script = timeout
+            .map(|script_timeout| format!("setTimeout(webdriverTimeout, {script_timeout});"))
+            .unwrap_or_default();
+
+        let joined_args = args_string.join(", ");
         let script = format!(
             r#"(function() {{
               let webdriverPromise = new Promise(function(resolve, reject) {{
-                  {}
+                  {timeout_script}
                   (async function() {{
-                    {}
-                  }})({})
+                    {function_body}
+                  }})({joined_args})
                     .then((v) => {{}}, (err) => reject(err))
               }})
               .then((v) => window.webdriverCallback(v), (r) => window.webdriverException(r))
               .catch((r) => window.webdriverException(r));
             }})();"#,
-            timeout_script,
-            func_body,
-            args_string.join(", "),
         );
         debug!("{}", script);
 
@@ -2100,9 +2113,14 @@ impl Handler {
         self.handle_any_user_prompts(self.webview_id()?)?;
 
         let (sender, receiver) = ipc::channel().unwrap();
-        let cmd = WebDriverScriptCommand::ExecuteAsyncScript(script, sender);
-        self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
-        let result = wait_for_ipc_response(receiver)?;
+        self.browsing_context_script_command(
+            WebDriverScriptCommand::ExecuteAsyncScript(script, sender),
+            VerifyBrowsingContextIsOpen::No,
+        )?;
+
+        let timeout_duration = timeout.map(Duration::from_millis);
+        let result = wait_for_script_ipc_response_with_timeout(receiver, timeout_duration)?;
+
         self.postprocess_js_result(result)
     }
 
@@ -2678,16 +2696,32 @@ where
 /// This function is like `wait_for_ipc_response`, but works on a channel that
 /// returns a `Result<T, ErrorStatus>`, mapping all errors into `WebDriverError`.
 fn wait_for_ipc_response_flatten<T>(
-    receiver: IpcReceiver<Result<T, ErrorStatus>>,
-) -> Result<T, WebDriverError>
+    receiver: IpcReceiver<Result<T, ErrorStatus>>,) -> Result<T, WebDriverError>
 where
-    T: for<'de> Deserialize<'de> + Serialize,
-{
-    match receiver.recv() {
+    T: for<'de> Deserialize<'de> + Serialize,{
+        match receiver.recv() {
         Ok(Ok(value)) => Ok(value),
         Ok(Err(error_status)) => Err(WebDriverError::new(error_status, "")),
         Err(_) => Err(WebDriverError::new(ErrorStatus::NoSuchWindow, "")),
     }
+    }
+fn wait_for_script_ipc_response_with_timeout<T>(
+    receiver: IpcReceiver<T>,
+    timeout: Option<Duration>,
+) -> Result<T, WebDriverError>
+where
+    T: for<'de> Deserialize<'de> + Serialize,
+{
+    
+    let Some(timeout) = timeout else {
+        return wait_for_ipc_response(receiver);
+    };
+    receiver
+        .try_recv_timeout(timeout)
+        .map_err(|error| match error {
+            TryRecvError::IpcError(_) => WebDriverError::new(ErrorStatus::NoSuchWindow, ""),
+            TryRecvError::Empty => WebDriverError::new(ErrorStatus::ScriptTimeout, ""),
+        })
 }
 
 fn unwrap_first_element_response(res: WebDriverResponse) -> WebDriverResult<WebDriverResponse> {

--- a/components/webdriver_server/timeout.rs
+++ b/components/webdriver_server/timeout.rs
@@ -19,9 +19,9 @@ pub(crate) const DEFAULT_IMPLICIT_WAIT: u64 = 0;
 
 pub(crate) struct TimeoutsConfiguration {
     pub script: Option<u64>,
-    pub sleep_interval: u64,
     pub page_load: Option<u64>,
     pub implicit_wait: Option<u64>,
+    pub sleep_interval: u64,
 }
 
 impl Default for TimeoutsConfiguration {

--- a/components/webdriver_server/timeout.rs
+++ b/components/webdriver_server/timeout.rs
@@ -5,19 +5,31 @@
 use serde_json::Value;
 use webdriver::error::{ErrorStatus, WebDriverError, WebDriverResult};
 
+/// Initial script timeout from
+/// <https://w3c.github.io/webdriver/#dfn-timeouts-configuration>.
+pub(crate) const DEFAULT_SCRIPT_TIMEOUT: u64 = 30_000;
+
+/// Initial page load timeout from
+/// <https://w3c.github.io/webdriver/#dfn-timeouts-configuration>.
+pub(crate) const DEFAULT_PAGE_LOAD_TIMEOUT: u64 = 300_000;
+
+/// Initial initial wait timeout from
+/// <https://w3c.github.io/webdriver/#dfn-timeouts-configuration>.
+pub(crate) const DEFAULT_IMPLICIT_WAIT: u64 = 0;
+
 pub(crate) struct TimeoutsConfiguration {
     pub script: Option<u64>,
-    pub page_load: u64,
-    pub implicit_wait: u64,
     pub sleep_interval: u64,
+    pub page_load: Option<u64>,
+    pub implicit_wait: Option<u64>,
 }
 
 impl Default for TimeoutsConfiguration {
     fn default() -> Self {
         TimeoutsConfiguration {
-            script: Some(30_000),
-            page_load: 300_000,
-            implicit_wait: 0,
+            script: Some(DEFAULT_SCRIPT_TIMEOUT),
+            page_load: Some(DEFAULT_PAGE_LOAD_TIMEOUT),
+            implicit_wait: Some(DEFAULT_IMPLICIT_WAIT),
             sleep_interval: 10,
         }
     }
@@ -29,43 +41,32 @@ pub(crate) fn deserialize_as_timeouts_configuration(
 ) -> WebDriverResult<TimeoutsConfiguration> {
     if let Value::Object(map) = timeouts {
         let mut config = TimeoutsConfiguration::default();
+
+        // Step 3: For each key → value in timeouts:
         for (key, value) in map {
-            match key.as_str() {
-                "implicit" => {
-                    config.implicit_wait = value.as_f64().ok_or_else(|| {
-                        WebDriverError::new(
-                            ErrorStatus::InvalidArgument,
-                            "Invalid implicit timeout",
-                        )
-                    })? as u64;
-                },
-                "pageLoad" => {
-                    config.page_load = value.as_f64().ok_or_else(|| {
-                        WebDriverError::new(
-                            ErrorStatus::InvalidArgument,
-                            "Invalid page load timeout",
-                        )
-                    })? as u64;
-                },
-                "script" => {
-                    config.script = match value {
-                        Value::Null => None,
-                        _ => Some(value.as_f64().ok_or_else(|| {
-                            WebDriverError::new(
-                                ErrorStatus::InvalidArgument,
-                                "Invalid script timeout",
-                            )
-                        })? as u64),
-                    };
-                },
-                _ => {
-                    return Err(WebDriverError::new(
-                        ErrorStatus::UnknownCommand,
-                        "Unknown timeout key",
-                    ));
-                },
-            }
+            // Step 3.1: If «"script", "pageLoad", "implicit"» does not contain key, then continue.
+            let target = match key.as_str() {
+                "implicit" => &mut config.implicit_wait,
+                "pageLoad" => &mut config.page_load,
+                "script" => &mut config.script,
+                _ => continue,
+            };
+
+            // Step 3.2: If value is neither null nor a number greater than or equal to 0
+            // and less than or equal to the maximum safe integer return error with error
+            // code invalid argument.
+            // Step 3.3: Run the substeps matching key:
+            //  - "script": Set configuration's script timeout to value.
+            //  - "pageLoad": Set configuration's page load timeout to value.
+            //  - "implicit": Set configuration's implicit wait timeout to value.
+            *target = match value {
+                Value::Null => None,
+                _ => Some(value.as_f64().ok_or_else(|| {
+                    WebDriverError::new(ErrorStatus::InvalidArgument, "Invalid value for {key}")
+                })? as u64),
+            };
         }
+
         Ok(config)
     } else {
         Err(WebDriverError::new(


### PR DESCRIPTION
In some cases scripts never call their `setTimeout` guard. In that case also
timeout if we never hear a reply from the script thread. In general, the
script timeout is applied to all synchronous IPC waiting for script
replies.

In addition, rework timeout setting a bit to be more similar to the
specifciation.

Testing: This causes some tests run with the WebDriver test runner to fail with
TIMEOUT rather than CRASH, accurately reflecting their reason for failing.
