### PR TITLE
compositor: Fix a performance regression from #39583

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1357,10 +1357,14 @@ impl IOCompositor {
         // this type of received. In addition, if any of these frames need a repaint, that reflected
         // when calling `handle_new_webrender_frame_ready`.
         let mut repaint_needed = false;
+        let mut saw_webrender_frame_ready = false;
+
         messages.retain(|message| match message {
             CompositorMsg::NewWebRenderFrameReady(_, need_repaint) => {
                 self.pending_frames.set(self.pending_frames.get() - 1);
                 repaint_needed |= need_repaint;
+                saw_webrender_frame_ready = true;
+
                 false
             },
             _ => true,
@@ -1373,7 +1377,9 @@ impl IOCompositor {
             }
         }
 
-        self.handle_new_webrender_frame_ready(repaint_needed);
+        if saw_webrender_frame_ready {
+            self.handle_new_webrender_frame_ready(repaint_needed);
+        }
     }
 
     #[servo_tracing::instrument(skip_all)]


### PR DESCRIPTION
When processing new WebRender frames after handling messages in the
compositor, only do that when we actually receive
`NewWebRenderFrameReady` messages. This isn't an issue unless there are
active animations. When there are, every spin of the event loop was
triggering a repaint.

Testing: This should fix the performance regression on the Speedometer Bencher
benchmarks.
Fixes: #39641
