### PR TITLE
script: Allow loading of `<iframe srcdoc>` with a `sandbox` attribute

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2529,7 +2529,6 @@ impl ScriptThread {
         } = new_layout_info;
 
         // Kick off the fetch for the new resource.
-        let url = load_data.url.clone();
         let new_load = InProgressLoad::new(
             new_pipeline_id,
             browsing_context_id,
@@ -2541,13 +2540,7 @@ impl ScriptThread {
             origin,
             load_data,
         );
-        if url.as_str() == "about:blank" {
-            self.start_page_load_about_blank(new_load);
-        } else if url.as_str() == "about:srcdoc" {
-            self.page_load_about_srcdoc(new_load);
-        } else {
-            self.pre_page_load(new_load);
-        }
+        self.pre_page_load(new_load);
     }
 
     fn collect_reports(&self, reports_chan: ReportsChan) {
@@ -3552,6 +3545,16 @@ impl ScriptThread {
     /// Instructs the constellation to fetch the document that will be loaded. Stores the InProgressLoad
     /// argument until a notification is received that the fetch is complete.
     fn pre_page_load(&self, mut incomplete: InProgressLoad) {
+        let url_str = incomplete.load_data.url.as_str();
+        if url_str == "about:blank" {
+            self.start_page_load_about_blank(incomplete);
+            return;
+        }
+        if url_str == "about:srcdoc" {
+            self.page_load_about_srcdoc(incomplete);
+            return;
+        }
+
         let context = ParserContext::new(
             incomplete.pipeline_id,
             incomplete.load_data.url.clone(),

--- a/tests/wpt/meta/IndexedDB/idbfactory-databases-opaque-origin.html.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory-databases-opaque-origin.html.ini
@@ -1,13 +1,12 @@
 [idbfactory-databases-opaque-origin.html]
-  expected: TIMEOUT
   [IDBFactory.databases() in non-sandboxed iframe should not reject]
     expected: FAIL
 
   [IDBFactory.databases() in sandboxed iframe should reject]
-    expected: TIMEOUT
+    expected: FAIL
 
   [IDBFactory.databases() in data URL dedicated worker should throw SecurityError]
-    expected: NOTRUN
+    expected: FAIL
 
   [IDBFactory.databases() in data URL shared worker should throw SecurityError]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbfactory-deleteDatabase-opaque-origin.html.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory-deleteDatabase-opaque-origin.html.ini
@@ -1,10 +1,3 @@
 [idbfactory-deleteDatabase-opaque-origin.html]
-  expected: TIMEOUT
-  [IDBFactory.deleteDatabase() in sandboxed iframe should throw SecurityError]
-    expected: TIMEOUT
-
-  [IDBFactory.deleteDatabase() in data URL dedicated worker should throw SecurityError]
-    expected: NOTRUN
-
   [IDBFactory.deleteDatabase() in data URL shared worker should throw SecurityError]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbfactory-open-opaque-origin.html.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory-open-opaque-origin.html.ini
@@ -1,10 +1,3 @@
 [idbfactory-open-opaque-origin.html]
-  expected: TIMEOUT
-  [IDBFactory.open() in sandboxed iframe should throw SecurityError]
-    expected: TIMEOUT
-
-  [IDBFactory.open() in data URL dedicated workers should throw SecurityError]
-    expected: NOTRUN
-
   [IDBFactory.open() in data URL shared workers should throw SecurityError]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/base-uri/base-uri_iframe_sandbox.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/base-uri/base-uri_iframe_sandbox.sub.html.ini
@@ -1,7 +1,3 @@
 [base-uri_iframe_sandbox.sub.html]
-  expected: TIMEOUT
-  [base-uri 'self' works with same-origin sandboxed iframes.]
-    expected: TIMEOUT
-
   [base-uri 'self' blocks foreign-origin sandboxed iframes.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/meta/sandbox-iframe.html.ini
+++ b/tests/wpt/meta/content-security-policy/meta/sandbox-iframe.html.ini
@@ -1,4 +1,3 @@
 [sandbox-iframe.html]
-  expected: TIMEOUT
   [img-src 'self' works when specified in a meta tag.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/cookies/cookie-enabled-noncookie-frame.html.ini
+++ b/tests/wpt/meta/cookies/cookie-enabled-noncookie-frame.html.ini
@@ -1,4 +1,0 @@
-[cookie-enabled-noncookie-frame.html]
-  expected: TIMEOUT
-  [navigator.cookieEnabled behavior on frames without cookie access]
-    expected: TIMEOUT

--- a/tests/wpt/meta/cookiestore/cookieStore_opaque_origin.https.html.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_opaque_origin.https.html.ini
@@ -1,4 +1,0 @@
-[cookieStore_opaque_origin.https.html]
-  expected: TIMEOUT
-  [cookieStore in sandboxed iframe should throw SecurityError]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/sandboxing/sandbox-disallow-popups.html.ini
+++ b/tests/wpt/meta/html/browsers/sandboxing/sandbox-disallow-popups.html.ini
@@ -1,5 +1,3 @@
 [sandbox-disallow-popups.html]
-  expected: TIMEOUT
   [window.open in sandbox iframe]
-    expected: NOTRUN
-
+    expected: FAIL

--- a/tests/wpt/meta/html/infrastructure/urls/terminology-0/document-base-url-about-srcdoc.https.window.js.ini
+++ b/tests/wpt/meta/html/infrastructure/urls/terminology-0/document-base-url-about-srcdoc.https.window.js.ini
@@ -1,4 +1,3 @@
 [document-base-url-about-srcdoc.https.window.html]
-  expected: TIMEOUT
   [disallow-same-origin]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/html/infrastructure/urls/terminology-0/document-base-url-changes-about-srcdoc.https.window.js.ini
+++ b/tests/wpt/meta/html/infrastructure/urls/terminology-0/document-base-url-changes-about-srcdoc.https.window.js.ini
@@ -1,7 +1,0 @@
-[document-base-url-changes-about-srcdoc.https.window.html]
-  expected: TIMEOUT
-  [non-sandboxed srcdoc - parent changes baseURI]
-    expected: FAIL
-
-  [sandboxed srcdoc - parent changes baseURI]
-    expected: TIMEOUT

--- a/tests/wpt/meta/secure-contexts/basic-popup-and-iframe-tests.html.ini
+++ b/tests/wpt/meta/secure-contexts/basic-popup-and-iframe-tests.html.ini
@@ -1,4 +1,12 @@
 [basic-popup-and-iframe-tests.html]
-  expected: TIMEOUT
-  [Test Window.isSecureContext in a sandboxed iframe loading a srcdoc]
-    expected: TIMEOUT
+  [Test Window.isSecureContext in a popup loading a blob: URI]
+    expected: FAIL
+
+  [Test Window.isSecureContext in a popup loading a javascript: URI]
+    expected: FAIL
+
+  [Test Window.isSecureContext in a popup loading about:blank]
+    expected: FAIL
+
+  [Test Window.isSecureContext in a popup loading initial about:blank]
+    expected: FAIL

--- a/tests/wpt/meta/secure-contexts/basic-popup-and-iframe-tests.https.html.ini
+++ b/tests/wpt/meta/secure-contexts/basic-popup-and-iframe-tests.https.html.ini
@@ -1,4 +1,0 @@
-[basic-popup-and-iframe-tests.https.html]
-  expected: TIMEOUT
-  [Test Window.isSecureContext in a sandboxed iframe loading a srcdoc]
-    expected: TIMEOUT


### PR DESCRIPTION
Before, `about: srcdoc` was only handled when loading `<iframe>`
contents in the same `ScriptThread` as the parent. This is not always
the case though with sandboxed `<iframe>`s. This change makes it so that
both code paths properly handle `about: srcdoc`.

Testing: This causes around 12 new WPT passes.
Fixes: #36529.
Fixes: #27791.