### PR TITLE
deps: Upgrade to WebRender 0.68

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,17 +2011,6 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
@@ -3033,15 +3022,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -6348,7 +6328,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 [[package]]
 name = "peek-poke"
 version = "0.3.0"
-source = "git+https://github.com/servo/webrender?branch=0.67#428d64dc5c92f157be2b0fd85dc7a6506be77132"
+source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "euclid",
  "peek-poke-derive",
@@ -6357,7 +6337,7 @@ dependencies = [
 [[package]]
 name = "peek-poke-derive"
 version = "0.3.0"
-source = "git+https://github.com/servo/webrender?branch=0.67#428d64dc5c92f157be2b0fd85dc7a6506be77132"
+source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7526,7 +7506,7 @@ source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf
 dependencies = [
  "bitflags 2.9.4",
  "cssparser",
- "derive_more 2.0.1",
+ "derive_more",
  "log",
  "new_debug_unreachable",
  "phf",
@@ -8376,7 +8356,7 @@ dependencies = [
  "bitflags 2.9.4",
  "byteorder",
  "cssparser",
- "derive_more 2.0.1",
+ "derive_more",
  "encoding_rs",
  "euclid",
  "icu_segmenter",
@@ -9952,18 +9932,17 @@ dependencies = [
 
 [[package]]
 name = "webrender"
-version = "0.66.0"
-source = "git+https://github.com/servo/webrender?branch=0.67#428d64dc5c92f157be2b0fd85dc7a6506be77132"
+version = "0.68.0"
+source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "allocator-api2",
  "bincode",
  "bitflags 2.9.4",
  "build-parallel",
  "byteorder",
- "derive_more 0.99.20",
+ "derive_more",
  "etagere",
  "euclid",
- "fxhash",
  "gleam",
  "glslopt",
  "lazy_static",
@@ -9974,6 +9953,7 @@ dependencies = [
  "plane-split",
  "rayon",
  "ron",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "svg_fmt",
@@ -9983,33 +9963,32 @@ dependencies = [
  "webrender_build",
  "wr_glyph_rasterizer",
  "wr_malloc_size_of",
+ "zeitstempel",
 ]
 
 [[package]]
 name = "webrender_api"
-version = "0.66.0"
-source = "git+https://github.com/servo/webrender?branch=0.67#428d64dc5c92f157be2b0fd85dc7a6506be77132"
+version = "0.68.0"
+source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "app_units",
  "bitflags 2.9.4",
  "byteorder",
  "crossbeam-channel",
  "euclid",
- "libc",
- "mach2",
  "malloc_size_of_derive",
  "peek-poke",
  "serde",
  "serde_bytes",
  "serde_derive",
- "windows-sys 0.59.0",
  "wr_malloc_size_of",
+ "zeitstempel",
 ]
 
 [[package]]
 name = "webrender_build"
 version = "0.0.2"
-source = "git+https://github.com/servo/webrender?branch=0.67#428d64dc5c92f157be2b0fd85dc7a6506be77132"
+source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "bitflags 2.9.4",
  "lazy_static",
@@ -10798,7 +10777,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 [[package]]
 name = "wr_glyph_rasterizer"
 version = "0.1.0"
-source = "git+https://github.com/servo/webrender?branch=0.67#428d64dc5c92f157be2b0fd85dc7a6506be77132"
+source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics",
@@ -10806,13 +10785,13 @@ dependencies = [
  "dwrote",
  "euclid",
  "freetype",
- "fxhash",
  "lazy_static",
  "libc",
  "log",
  "malloc_size_of_derive",
  "objc",
  "rayon",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "tracy-rs",
@@ -10822,8 +10801,8 @@ dependencies = [
 
 [[package]]
 name = "wr_malloc_size_of"
-version = "0.2.0"
-source = "git+https://github.com/servo/webrender?branch=0.67#428d64dc5c92f157be2b0fd85dc7a6506be77132"
+version = "0.2.2"
+source = "git+https://github.com/servo/webrender?branch=0.68#6cafc606096db4715a6119a6e16391aed9af47a5"
 dependencies = [
  "app_units",
  "euclid",
@@ -11091,6 +11070,18 @@ dependencies = [
  "static_assertions",
  "zbus_names",
  "zvariant",
+]
+
+[[package]]
+name = "zeitstempel"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94652f036694517fa67509942c3b60a51a19e1cd9cfd0f456eeb830ae8798d3d"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,8 +176,8 @@ vello_cpu = { git = "https://github.com/linebender/vello", rev = "fdf025a88dd00c
 webdriver = "0.53.0"
 webgpu_traits = { path = "components/shared/webgpu" }
 webpki-roots = "1.0"
-webrender = { git = "https://github.com/servo/webrender", branch = "0.67", features = ["capture"] }
-webrender_api = { git = "https://github.com/servo/webrender", branch = "0.67" }
+webrender = { git = "https://github.com/servo/webrender", branch = "0.68", features = ["capture"] }
+webrender_api = { git = "https://github.com/servo/webrender", branch = "0.68" }
 webxr-api = { path = "components/shared/webxr" }
 wgpu-core = "26"
 wgpu-types = "26"
@@ -185,7 +185,7 @@ winapi = "0.3"
 windows-sys = "0.61"
 winit = "0.30.12"
 wio = "0.2"
-wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.67" }
+wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.68" }
 xi-unicode = "0.3.0"
 xml5ever = "0.35"
 xpath = { path = "components/xpath" }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -49,7 +49,7 @@ use webrender_api::units::{
 use webrender_api::{
     self, BuiltDisplayList, DirtyRect, DisplayListPayload, DocumentId, Epoch as WebRenderEpoch,
     ExternalScrollId, FontInstanceFlags, FontInstanceKey, FontInstanceOptions, FontKey,
-    FontVariation, HitTestFlags, ImageKey, PipelineId as WebRenderPipelineId, PropertyBinding,
+    FontVariation, ImageKey, PipelineId as WebRenderPipelineId, PropertyBinding,
     ReferenceFrameKind, RenderReasons, SampledScrollOffset, ScrollLocation, SpaceAndClipInfo,
     SpatialId, SpatialTreeItemKey, TransformStyle,
 };
@@ -249,23 +249,11 @@ impl ServoRenderer {
     }
 
     pub(crate) fn hit_test_at_point(&self, point: DevicePoint) -> Vec<CompositorHitTestResult> {
-        self.hit_test_at_point_with_flags(point, HitTestFlags::empty())
-    }
-
-    // TODO: split this into first half (global) and second half (one for whole compositor, one for webview)
-    pub(crate) fn hit_test_at_point_with_flags(
-        &self,
-        point: DevicePoint,
-        flags: HitTestFlags,
-    ) -> Vec<CompositorHitTestResult> {
         // DevicePoint and WorldPoint are the same for us.
         let world_point = WorldPoint::from_untyped(point.to_untyped());
-        let results = self.webrender_api.hit_test(
-            self.webrender_document,
-            None, /* pipeline_id */
-            world_point,
-            flags,
-        );
+        let results = self
+            .webrender_api
+            .hit_test(self.webrender_document, world_point);
 
         results
             .items
@@ -886,7 +874,7 @@ impl IOCompositor {
 
     /// Queue a new frame in the transaction and increase the pending frames count.
     pub(crate) fn generate_frame(&self, transaction: &mut Transaction, reason: RenderReasons) {
-        transaction.generate_frame(0, true /* present */, reason);
+        transaction.generate_frame(0, true /* present */, false /* tracked */, reason);
         self.pending_frames.set(self.pending_frames.get() + 1);
     }
 

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -25,7 +25,7 @@ use rustc_hash::FxHashMap;
 use servo_geometry::DeviceIndependentPixel;
 use style_traits::{CSSPixel, PinchZoomFactor};
 use webrender_api::units::{DeviceIntPoint, DevicePixel, DevicePoint, DeviceRect, LayoutVector2D};
-use webrender_api::{ExternalScrollId, HitTestFlags, ScrollLocation};
+use webrender_api::{ExternalScrollId, ScrollLocation};
 
 use crate::compositor::{PipelineDetails, ServoRenderer};
 use crate::touch::{TouchHandler, TouchMoveAction, TouchMoveAllowed, TouchSequenceState};
@@ -748,10 +748,7 @@ impl WebViewRenderer {
             ScrollLocation::Start | ScrollLocation::End => scroll_location,
         };
 
-        let hit_test_results = self
-            .global
-            .borrow()
-            .hit_test_at_point_with_flags(cursor, HitTestFlags::FIND_ALL);
+        let hit_test_results = self.global.borrow().hit_test_at_point(cursor);
 
         // Iterate through all hit test results, processing only the first node of each pipeline.
         // This is needed to propagate the scroll events from a pipeline representing an iframe to

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -518,7 +518,12 @@ impl ExternalImageHandler for WebrenderExternalImageHandlers {
     /// image content.
     /// The WR client should not change the image content until the
     /// unlock() call.
-    fn lock(&mut self, key: ExternalImageId, _channel_index: u8) -> ExternalImage<'_> {
+    fn lock(
+        &mut self,
+        key: ExternalImageId,
+        _channel_index: u8,
+        _is_composited: bool,
+    ) -> ExternalImage<'_> {
         let external_images = self.external_images.lock().unwrap();
         let handler_type = external_images
             .get(&key)

--- a/deny.toml
+++ b/deny.toml
@@ -14,8 +14,6 @@ feature-depth = 1
 ignore = [
     # The crate `paste` is no longer maintained.
     "RUSTSEC-2024-0436",
-    # The crate `fxhash` is no longer maintained.
-    "RUSTSEC-2025-0057",
 ]
 
 # This section is considered when running `cargo deny check licenses`
@@ -158,9 +156,6 @@ skip = [
     "rand_core",
     "wasi",
     "webpki-roots",
-
-    # Stylo uses 2.0, WebRender uses 0.99
-    "derive_more",
 
     # duplicated by blurz/blurmock
     "hex",

--- a/tests/wpt/meta/css/css-borders/corner-shape/corner-shape-bevel-overflow.html.ini
+++ b/tests/wpt/meta/css/css-borders/corner-shape/corner-shape-bevel-overflow.html.ini
@@ -1,2 +1,0 @@
-[corner-shape-bevel-overflow.html]
-  expected: FAIL

--- a/tests/wpt/tests/css/css-overflow/overflow-clip-margin-border-radius.html
+++ b/tests/wpt/tests/css/css-overflow/overflow-clip-margin-border-radius.html
@@ -6,6 +6,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#shadow-shape">
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">
 <link rel="match" href="overflow-clip-margin-border-radius-ref.html">
+<meta name=fuzzy content="maxDifference=1;totalPixels=7">
 <meta name="assert" content="
   “The overflow clip edge is shaped in the corners exactly the same way
   as an outer box-shadow with a spread radius of the same cumulative offset


### PR DESCRIPTION
This is the latest release of WebRender that will be based on a recent
version of WebRender from the Gecko repository.

Testing: This should not change Servo's behavior and is thus covered
by existing tests.
Fixes: https://github.com/servo/webrender/issues/4875
