### PR TITLE
script: Remove `WebdriverTimeout` callback

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1619,13 +1619,6 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         }
     }
 
-    fn WebdriverTimeout(&self) {
-        let opt_chan = self.webdriver_script_chan.borrow_mut().take();
-        if let Some(chan) = opt_chan {
-            let _ = chan.send(Err(WebDriverJSError::Timeout));
-        }
-    }
-
     fn WebdriverElement(&self, id: DOMString) -> Option<DomRoot<Element>> {
         find_node_by_unique_id_in_document(&self.Document(), id.into()).and_then(Root::downcast)
     }

--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -149,7 +149,6 @@ partial interface Window {
   // Shouldn't be public, but just to make things work for now
   undefined webdriverCallback(optional any result);
   undefined webdriverException(optional any result);
-  undefined webdriverTimeout();
   Element? webdriverElement(DOMString id);
   WindowProxy? webdriverFrame(DOMString id);
   WindowProxy? webdriverWindow(DOMString id);

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -262,7 +262,6 @@ pub enum WebDriverJSError {
     JSException(JSValue),
     JSError,
     StaleElementReference,
-    Timeout,
     UnknownType,
 }
 

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2084,16 +2084,10 @@ impl Handler {
         let (function_body, mut args_string) = self.extract_script_arguments(parameters)?;
         args_string.push("resolve".to_string());
 
-        let timeout = self.session()?.session_timeouts().script;
-        let timeout_script = timeout
-            .map(|script_timeout| format!("setTimeout(webdriverTimeout, {script_timeout});"))
-            .unwrap_or_default();
-
         let joined_args = args_string.join(", ");
         let script = format!(
             r#"(function() {{
               let webdriverPromise = new Promise(function(resolve, reject) {{
-                  {timeout_script}
                   (async function() {{
                     {function_body}
                   }})({joined_args})
@@ -2118,7 +2112,11 @@ impl Handler {
             VerifyBrowsingContextIsOpen::No,
         )?;
 
-        let timeout_duration = timeout.map(Duration::from_millis);
+        let timeout_duration = self
+            .session()?
+            .session_timeouts()
+            .script
+            .map(Duration::from_millis);
         let result = wait_for_script_ipc_response_with_timeout(receiver, timeout_duration)?;
 
         self.postprocess_js_result(result)

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2150,9 +2150,6 @@ impl Handler {
                 ErrorStatus::DetachedShadowRoot,
                 "Detached shadow root",
             )),
-            Err(WebDriverJSError::Timeout) => {
-                Err(WebDriverError::new(ErrorStatus::ScriptTimeout, ""))
-            },
             Err(WebDriverJSError::UnknownType) => Err(WebDriverError::new(
                 ErrorStatus::UnsupportedOperation,
                 "Unsupported return type",


### PR DESCRIPTION
After #39682, this callback is no longer necessary. We also remove `WebDriverJSError::Timeout`.

Testing: No regression in wdspec. For servodriver, [before](https://github.com/yezhizhen/servo/actions/runs/18300017112). [after](https://github.com/yezhizhen/servo/actions/runs/18300911442) is also the same.

