### PR TITLE
libservo: Remove `MouseButtonAction::Click` from the API

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2962,7 +2962,7 @@ where
         };
 
         match event.action {
-            MouseButtonAction::Click | MouseButtonAction::Down => {
+            MouseButtonAction::Down => {
                 self.pressed_mouse_buttons |= button_as_bitmask;
             },
             MouseButtonAction::Up => {
@@ -3026,13 +3026,6 @@ where
         // modifiers and updates the event here to reflect the current state.
         let pressed_mouse_buttons = self.pressed_mouse_buttons;
         let active_keyboard_modifiers = self.active_keyboard_modifiers;
-
-        // TODO: Click should be handled internally in the `Document`.
-        if let InputEvent::MouseButton(event) = &event {
-            if event.action == MouseButtonAction::Click {
-                self.pressed_mouse_buttons = 0;
-            }
-        }
 
         let Some(webview) = self.webviews.get_mut(webview_id) else {
             warn!("Got input event for unknown WebViewId: {webview_id:?}");

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -256,6 +256,7 @@ impl MouseEvent {
     /// Create a [MouseEvent] triggered by the embedder
     /// <https://w3c.github.io/uievents/#create-a-cancelable-mouseevent-id>
     pub(crate) fn for_platform_mouse_event(
+        event_type_string: &'static str,
         event: embedder_traits::MouseButtonEvent,
         pressed_mouse_buttons: u16,
         window: &Window,
@@ -263,12 +264,6 @@ impl MouseEvent {
         modifiers: Modifiers,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
-        let mouse_event_type_string = match event.action {
-            embedder_traits::MouseButtonAction::Click => "click",
-            embedder_traits::MouseButtonAction::Up => "mouseup",
-            embedder_traits::MouseButtonAction::Down => "mousedown",
-        };
-
         let client_point = hit_test_result.point_in_frame.to_i32();
         let page_point = hit_test_result
             .point_relative_to_initial_containing_block
@@ -277,7 +272,7 @@ impl MouseEvent {
         let click_count = 1;
         let mouse_event = MouseEvent::new(
             window,
-            mouse_event_type_string.into(),
+            event_type_string.into(),
             EventBubbles::Bubbles,
             EventCancelable::Cancelable,
             Some(window),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -50,11 +50,9 @@ use devtools_traits::{
 };
 use embedder_traits::user_content_manager::UserContentManager;
 use embedder_traits::{
-    FocusSequenceNumber, InputEvent, JavaScriptEvaluationError, JavaScriptEvaluationId,
-    MediaSessionActionType, MouseButton, MouseButtonAction, MouseButtonEvent, Theme,
-    ViewportDetails, WebDriverScriptCommand,
+    FocusSequenceNumber, JavaScriptEvaluationError, JavaScriptEvaluationId, MediaSessionActionType,
+    Theme, ViewportDetails, WebDriverScriptCommand,
 };
-use euclid::Point2D;
 use euclid::default::Rect;
 use fonts::{FontContext, SystemFontServiceProxy};
 use headers::{HeaderMapExt, LastModified, ReferrerPolicy as ReferrerPolicyHeader};
@@ -98,7 +96,7 @@ use url::Position;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::{WebGPUDevice, WebGPUMsg};
 use webrender_api::ExternalScrollId;
-use webrender_api::units::{DevicePixel, LayoutVector2D};
+use webrender_api::units::LayoutVector2D;
 
 use crate::document_collection::DocumentCollection;
 use crate::document_loader::DocumentLoader;
@@ -348,10 +346,6 @@ pub struct ScriptThread {
     /// A factory for making new layouts. This allows layout to depend on script.
     #[no_trace]
     layout_factory: Arc<dyn LayoutFactory>,
-
-    /// The screen coordinates where the primary mouse button was pressed.
-    #[no_trace]
-    relative_mouse_down_point: Cell<Point2D<f32, DevicePixel>>,
 
     /// The [`TimerId`] of a ScriptThread-scheduled "update the rendering" call, if any.
     /// The ScriptThread schedules calls to "update the rendering," but the renderer can
@@ -991,7 +985,6 @@ impl ScriptThread {
             gpu_id_hub,
             inherited_secure_context: state.inherited_secure_context,
             layout_factory,
-            relative_mouse_down_point: Cell::new(Point2D::zero()),
             scheduled_update_the_rendering: Default::default(),
             needs_rendering_update: Arc::new(AtomicBool::new(false)),
             debugger_global: debugger_global.as_traced(),
@@ -3430,61 +3423,6 @@ impl ScriptThread {
             warn!("Compositor event sent to closed pipeline {pipeline_id}.");
             return;
         };
-
-        // Also send a 'click' event with same hit-test result if this is release
-
-        // MAYBE? TODO: https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event
-        // If the button is pressed on one element and the pointer is moved outside the element
-        // before the button is released, the event is fired on the most specific ancestor element
-        // that contained both elements.
-
-        // But spec doesn't specify this https://w3c.github.io/uievents/#event-type-click
-        // "The click event type MUST be dispatched on the topmost event target indicated by
-        // the pointer, when the user presses down and releases the primary pointer button"
-
-        // Servo-specific: Trigger if within 10px of the down point
-        if let InputEvent::MouseButton(mouse_button_event) = &event.event {
-            if let MouseButton::Left = mouse_button_event.button {
-                match mouse_button_event.action {
-                    MouseButtonAction::Up => {
-                        let pixel_dist =
-                            self.relative_mouse_down_point.get() - mouse_button_event.point;
-                        let pixel_dist =
-                            (pixel_dist.x * pixel_dist.x + pixel_dist.y * pixel_dist.y).sqrt();
-                        if pixel_dist < 10.0 * document.window().device_pixel_ratio().get() {
-                            // Pass webdriver_id to the newly generated click event
-                            document.event_handler().note_pending_input_event(
-                                ConstellationInputEvent {
-                                    hit_test_result: event.hit_test_result.clone(),
-                                    pressed_mouse_buttons: event.pressed_mouse_buttons,
-                                    active_keyboard_modifiers: event.active_keyboard_modifiers,
-                                    event: event.event.clone().with_webdriver_message_id(None),
-                                },
-                            );
-                            document.event_handler().note_pending_input_event(
-                                ConstellationInputEvent {
-                                    hit_test_result: event.hit_test_result,
-                                    pressed_mouse_buttons: event.pressed_mouse_buttons,
-                                    active_keyboard_modifiers: event.active_keyboard_modifiers,
-                                    event: InputEvent::MouseButton(MouseButtonEvent::new(
-                                        MouseButtonAction::Click,
-                                        mouse_button_event.button,
-                                        mouse_button_event.point,
-                                    ))
-                                    .with_webdriver_message_id(event.event.webdriver_message_id()),
-                                },
-                            );
-                            return;
-                        }
-                    },
-                    MouseButtonAction::Down => {
-                        self.relative_mouse_down_point.set(mouse_button_event.point)
-                    },
-                    MouseButtonAction::Click => {},
-                }
-            }
-        }
-
         document.event_handler().note_pending_input_event(event);
     }
 

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -155,7 +155,7 @@ impl MouseButtonEvent {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum MouseButton {
     Left,
     Middle,
@@ -195,8 +195,6 @@ impl From<MouseButton> for i16 {
 /// The types of mouse events
 #[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub enum MouseButtonAction {
-    /// Mouse button clicked
-    Click,
     /// Mouse button down
     Down,
     /// Mouse button up

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -342,17 +342,6 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_pinchZoomEnd<'local>(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn Java_org_servo_servoview_JNIServo_click(
-    mut env: JNIEnv,
-    _: JClass,
-    x: jfloat,
-    y: jfloat,
-) {
-    debug!("click");
-    call(&mut env, |s| s.click(x, y));
-}
-
-#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_pauseCompositor(
     mut env: JNIEnv,
     _: JClass<'_>,

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -844,17 +844,6 @@ impl RunningAppState {
         self.perform_updates();
     }
 
-    /// Perform a click.
-    pub fn click(&self, x: f32, y: f32) {
-        self.active_webview()
-            .notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
-                MouseButtonAction::Click,
-                MouseButton::Left,
-                Point2D::new(x, y),
-            )));
-        self.perform_updates();
-    }
-
     pub fn key_down(&self, key: Key) {
         let key_event = KeyboardEvent::from_state_and_key(KeyState::Down, key);
         self.active_webview()


### PR DESCRIPTION
The embedder should never be responsible for triggering click events, so
this change removes that possibility from the API. In addition,
triggering of click events is simplified by moving the logic to the
`DocumentEventHandler`. This has the benefit of making behavior
consistent between in-process and out-of-process `<iframe>`s. Now click
events are never triggered when the button up and down cross frame
boundaries.

Testing: This should be covered by existing tests.
