### PR TITLE
Replace RasterImage bytes with Vec<u8> and use IpcSharedMemory for serialization only.

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -964,7 +964,7 @@ impl ImageCache for ImageCacheImpl {
                 },
                 format: PixelFormat::RGBA8,
                 frames: vec![frame],
-                bytes: IpcSharedMemory::from_bytes(&bytes),
+                bytes,
                 id: None,
                 cors_status: vector_image.cors_status,
             };

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -8,7 +8,7 @@ use std::default::Default;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
-use ipc_channel::ipc::IpcSender;
+use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
 use js::rust::HandleObject;
 use net_traits::image_cache::{
     Image, ImageCache, ImageCacheResponseMessage, ImageCacheResult, ImageLoadListener,
@@ -741,7 +741,7 @@ impl HTMLLinkElement {
             let embedder_image = embedder_traits::Image::new(
                 frame.width,
                 frame.height,
-                raster_image.bytes.clone(),
+                IpcSharedMemory::from_bytes(&raster_image.bytes),
                 raster_image.frames[0].byte_range.clone(),
                 format,
             );

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -752,7 +752,6 @@ mod test {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use ipc_channel::ipc::IpcSharedMemory;
     use pixels::{CorsStatus, ImageFrame, ImageMetadata, PixelFormat, RasterImage};
 
     use crate::ImageAnimationState;
@@ -774,7 +773,7 @@ mod test {
             },
             format: PixelFormat::BGRA8,
             id: None,
-            bytes: IpcSharedMemory::from_byte(1, 1),
+            bytes: vec![1],
             frames: image_frames,
             cors_status: CorsStatus::Unsafe,
         };


### PR DESCRIPTION
RasterImage used IPCSharedMemory as backing storage which on websites with many images or speedometer can lead to file descriptor exhaustion.
This PR moves the backing storage to Vec<u8> and introduces a new type `RasterImageSerialization` that serde automatically converts into.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Tested via google.com/images, scrolling down and checking file descriptors. Additionally tested speedometer on profiling build and log messages for the conversion functions, showing that these are indeed called.
Fixes: This should fix https://github.com/servo/servo/issues/39626
