### PR TITLE
libservo: Make `FormControl` responses completely asynchronous

### DIFF
--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -82,6 +82,7 @@ mod from_compositor {
                     target!("NoLongerWaitingOnCanvas")
                 },
                 Self::RequestScreenshotReadiness(..) => target!("RequestScreenshotReadiness"),
+                Self::EmbedderControlResponse(..) => target!("EmbedderControlResponse"),
             }
         }
     }

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -8,7 +8,6 @@ use std::mem;
 use std::sync::Arc;
 
 use app_units::Au;
-use base::Epoch;
 use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
 use compositing_traits::display_list::{
@@ -141,7 +140,7 @@ impl StackingContextTree {
             scrollable_overflow,
             pipeline_id,
             // This epoch is set when the WebRender display list is built. For now use a dummy value.
-            Epoch(0),
+            Default::default(),
             fragment_tree.viewport_scroll_sensitivity,
             first_reflow,
         );

--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::Cell;
+
+use base::Epoch;
+use embedder_traits::{EmbedderControlId, EmbedderMsg, FormControlRequest, FormControlResponse};
+use rustc_hash::FxHashMap;
+use script_bindings::root::{Dom, DomRoot};
+use script_bindings::script_runtime::CanGc;
+use webrender_api::units::DeviceIntRect;
+
+use crate::dom::bindings::cell::DomRefCell;
+use crate::dom::bindings::trace::NoTrace;
+use crate::dom::types::{HTMLInputElement, HTMLSelectElement, Window};
+
+#[derive(JSTraceable, MallocSizeOf)]
+pub(crate) enum ControlElement {
+    Select(DomRoot<HTMLSelectElement>),
+    ColorInput(DomRoot<HTMLInputElement>),
+}
+
+#[derive(JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, allow(crown::unrooted_must_root))]
+pub(crate) struct DocumentEmbedderControls {
+    /// The [`Window`] element for this [`DocumentUserInterfaceElements`].
+    window: Dom<Window>,
+    /// The id of the next user interface element that the `Document` requests that the
+    /// embedder show. This is used to track user interface elements in the API.
+    #[no_trace]
+    user_interface_element_index: Cell<Epoch>,
+    /// A map of visible user interface elements.
+    visible_elements: DomRefCell<FxHashMap<NoTrace<Epoch>, ControlElement>>,
+}
+
+impl DocumentEmbedderControls {
+    pub fn new(window: &Window) -> Self {
+        Self {
+            window: Dom::from_ref(window),
+            user_interface_element_index: Default::default(),
+            visible_elements: Default::default(),
+        }
+    }
+
+    pub(crate) fn show_form_control(
+        &self,
+        element: ControlElement,
+        rect: DeviceIntRect,
+        form_control: FormControlRequest,
+    ) -> EmbedderControlId {
+        let index = self.user_interface_element_index.get();
+        self.user_interface_element_index.set(index.next());
+
+        let id = EmbedderControlId {
+            webview_id: self.window.webview_id(),
+            pipeline_id: self.window.pipeline_id(),
+            index,
+        };
+
+        self.visible_elements
+            .borrow_mut()
+            .insert(id.index.into(), element);
+        self.window
+            .send_to_embedder(EmbedderMsg::ShowEmbedderControl(id, rect, form_control));
+
+        id
+    }
+
+    pub(crate) fn handle_embedder_control_response(
+        &self,
+        id: EmbedderControlId,
+        response: FormControlResponse,
+        can_gc: CanGc,
+    ) {
+        assert_eq!(self.window.pipeline_id(), id.pipeline_id);
+        assert_eq!(self.window.webview_id(), id.webview_id);
+
+        let Some(element) = self.visible_elements.borrow_mut().remove(&id.index.into()) else {
+            return;
+        };
+
+        match (element, response) {
+            (
+                ControlElement::Select(select_element),
+                FormControlResponse::SelectElement(response),
+            ) => {
+                select_element.handle_menu_response(response, can_gc);
+            },
+            (
+                ControlElement::ColorInput(input_element),
+                FormControlResponse::ColorPicker(response),
+            ) => {
+                input_element.handle_color_picker_response(response, can_gc);
+            },
+            (_, _) => unreachable!(
+                "The response to a form control should always match it's originating type."
+            ),
+        }
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -286,6 +286,7 @@ pub(crate) mod dissimilaroriginlocation;
 pub(crate) mod dissimilaroriginwindow;
 #[allow(dead_code)]
 pub(crate) mod document;
+mod document_embedder_controls;
 pub(crate) mod document_event_handler;
 pub(crate) mod documentfragment;
 pub(crate) mod documentorshadowroot;

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -103,6 +103,7 @@ impl MixedMessage {
                 ScriptThreadMessage::NoLongerWaitingOnAsychronousImageUpdates(_) => None,
                 ScriptThreadMessage::ForwardKeyboardScroll(id, _) => Some(*id),
                 ScriptThreadMessage::RequestScreenshotReadiness(id) => Some(*id),
+                ScriptThreadMessage::EmbedderControlResponse(id, _) => Some(id.pipeline_id),
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -50,8 +50,8 @@ use devtools_traits::{
 };
 use embedder_traits::user_content_manager::UserContentManager;
 use embedder_traits::{
-    FocusSequenceNumber, JavaScriptEvaluationError, JavaScriptEvaluationId, MediaSessionActionType,
-    Theme, ViewportDetails, WebDriverScriptCommand,
+    EmbedderControlId, FocusSequenceNumber, FormControlResponse, JavaScriptEvaluationError,
+    JavaScriptEvaluationId, MediaSessionActionType, Theme, ViewportDetails, WebDriverScriptCommand,
 };
 use euclid::default::Rect;
 use fonts::{FontContext, SystemFontServiceProxy};
@@ -1912,6 +1912,9 @@ impl ScriptThread {
             },
             ScriptThreadMessage::RequestScreenshotReadiness(pipeline_id) => {
                 self.handle_request_screenshot_readiness(pipeline_id);
+            },
+            ScriptThreadMessage::EmbedderControlResponse(id, response) => {
+                self.handle_embedder_control_response(id, response, can_gc);
             },
         }
     }
@@ -3885,6 +3888,20 @@ impl ScriptThread {
             return;
         };
         window.request_screenshot_readiness();
+    }
+
+    fn handle_embedder_control_response(
+        &self,
+        id: EmbedderControlId,
+        response: FormControlResponse,
+        can_gc: CanGc,
+    ) {
+        let Some(document) = self.documents.borrow().find_document(id.pipeline_id) else {
+            return;
+        };
+        document
+            .embedder_controls()
+            .handle_embedder_control_response(id, response, can_gc);
     }
 }
 

--- a/components/shared/base/lib.rs
+++ b/components/shared/base/lib.rs
@@ -72,7 +72,18 @@ where
 
 /// A struct for denoting the age of messages; prevents race conditions.
 #[derive(
-    Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, MallocSizeOf,
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Deserialize,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    MallocSizeOf,
 )]
 pub struct Epoch(pub u32);
 

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -18,8 +18,9 @@ use std::time::Duration;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{MessagePortId, PipelineId, WebViewId};
 use embedder_traits::{
-    CompositorHitTestResult, InputEvent, JavaScriptEvaluationId, MediaSessionActionType, Theme,
-    TraversalId, ViewportDetails, WebDriverCommandMsg, WebDriverCommandResponse,
+    CompositorHitTestResult, EmbedderControlId, FormControlResponse, InputEvent,
+    JavaScriptEvaluationId, MediaSessionActionType, Theme, TraversalId, ViewportDetails,
+    WebDriverCommandMsg, WebDriverCommandResponse,
 };
 pub use from_script_message::*;
 use ipc_channel::ipc::IpcSender;
@@ -109,6 +110,8 @@ pub enum EmbedderToConstellationMessage {
     /// Request preparation for a screenshot of the given WebView. The Constellation will
     /// send a message to the Embedder when the screenshot is ready to be taken.
     RequestScreenshotReadiness(WebViewId),
+    /// A response to a request to show an embedder user interface control.
+    EmbedderControlResponse(EmbedderControlId, FormControlResponse),
 }
 
 /// A description of a paint metric that is sent from the Servo renderer to the

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -21,6 +21,7 @@ use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use base::Epoch;
 use base::generic_channel::{GenericCallback, GenericSender, SendResult};
 use base::id::{PipelineId, WebViewId};
 use crossbeam_channel::Sender;
@@ -516,7 +517,7 @@ pub enum EmbedderMsg {
     /// Request to display a notification.
     ShowNotification(Option<WebViewId>, Notification),
     /// Request to display a form control to the embedder.
-    ShowFormControl(WebViewId, DeviceIntRect, FormControl),
+    ShowEmbedderControl(EmbedderControlId, DeviceIntRect, FormControlRequest),
     /// Inform the embedding layer that a JavaScript evaluation has
     /// finished with the given result.
     FinishJavaScriptEvaluation(
@@ -532,16 +533,25 @@ impl Debug for EmbedderMsg {
     }
 }
 
-#[derive(Deserialize, Serialize)]
-pub enum FormControl {
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct EmbedderControlId {
+    pub webview_id: WebViewId,
+    pub pipeline_id: PipelineId,
+    pub index: Epoch,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum FormControlRequest {
     /// Indicates that the user has activated a `<select>` element.
-    SelectElement(
-        Vec<SelectElementOptionOrOptgroup>,
-        Option<usize>,
-        GenericSender<Option<usize>>,
-    ),
+    SelectElement(Vec<SelectElementOptionOrOptgroup>, Option<usize>),
     /// Indicates that the user has activated a `<input type=color>` element.
-    ColorPicker(RgbColor, GenericSender<Option<RgbColor>>),
+    ColorPicker(RgbColor),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum FormControlResponse {
+    SelectElement(Option<usize>),
+    ColorPicker(Option<RgbColor>),
 }
 
 /// Filter for file selection;

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -28,8 +28,9 @@ use crossbeam_channel::{RecvTimeoutError, Sender};
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use embedder_traits::user_content_manager::UserContentManager;
 use embedder_traits::{
-    CompositorHitTestResult, FocusSequenceNumber, InputEvent, JavaScriptEvaluationId,
-    MediaSessionActionType, ScriptToEmbedderChan, Theme, ViewportDetails, WebDriverScriptCommand,
+    CompositorHitTestResult, EmbedderControlId, FocusSequenceNumber, FormControlResponse,
+    InputEvent, JavaScriptEvaluationId, MediaSessionActionType, ScriptToEmbedderChan, Theme,
+    ViewportDetails, WebDriverScriptCommand,
 };
 use euclid::{Rect, Scale, Size2D, UnknownUnit};
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
@@ -272,6 +273,8 @@ pub enum ScriptThreadMessage {
     /// respond when it is ready to take the screenshot or will not be able to take it
     /// in the future.
     RequestScreenshotReadiness(PipelineId),
+    /// A response to a request to show an embedder user interface control.
+    EmbedderControlResponse(EmbedderControlId, FormControlResponse),
 }
 
 impl fmt::Debug for ScriptThreadMessage {

--- a/components/webgpu/canvas_context.rs
+++ b/components/webgpu/canvas_context.rs
@@ -487,7 +487,7 @@ impl ContextData {
             self.presentation
                 .as_ref()
                 .map(|p| p.epoch)
-                .unwrap_or(Epoch(0))
+                .unwrap_or_default()
         {
             self.presentation.replace(presentation)
         } else {

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -129,11 +129,10 @@ impl Dialog {
         prompt: ColorPicker,
         toolbar_offset: Length<f32, DeviceIndependentPixel>,
     ) -> Self {
-        let current_color = egui::Color32::from_rgb(
-            prompt.current_color().red,
-            prompt.current_color().green,
-            prompt.current_color().blue,
-        );
+        let current_color = prompt
+            .current_color()
+            .map(|color| egui::Color32::from_rgb(color.red, color.green, color.blue))
+            .unwrap_or_default();
         Dialog::ColorPicker {
             current_color,
             maybe_prompt: Some(prompt),


### PR DESCRIPTION
Before responses to `FormControl` requests were handled synchronous in
script (ie they would block the page). This change makes it so that they
are handled asynchronously, with their responses filtering back through
the Constellation. This should fix many WPT tests when run with
WebDriver.

Testing: There are some WebDriver-based test for this, but they do
not quite pass yet. More investigation is required, but this is
necessary to get them to pass.
Fixes: #39652
Fixes: #37013