### PR TITLE
Add basic `IDL` implementation for `LargestContentfulPaint`

### DIFF
--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -208,7 +208,22 @@ impl ProgressiveWebMetrics {
         self.main_thread_available.get()
     }
 
-    pub fn set_first_paint(&self, paint_time: CrossProcessInstant, first_reflow: bool) {
+    pub fn set_performance_paint_metric(
+        &self,
+        paint_time: CrossProcessInstant,
+        first_reflow: bool,
+        metric_type: ProgressiveWebMetricType,
+    ) {
+        match metric_type {
+            ProgressiveWebMetricType::FirstPaint => self.set_first_paint(paint_time, first_reflow),
+            ProgressiveWebMetricType::FirstContentfulPaint => {
+                self.set_first_contentful_paint(paint_time, first_reflow)
+            },
+            _ => {},
+        }
+    }
+
+    fn set_first_paint(&self, paint_time: CrossProcessInstant, first_reflow: bool) {
         set_metric(
             self,
             Some(self.make_metadata(first_reflow)),
@@ -220,7 +235,7 @@ impl ProgressiveWebMetrics {
         );
     }
 
-    pub fn set_first_contentful_paint(&self, paint_time: CrossProcessInstant, first_reflow: bool) {
+    fn set_first_contentful_paint(&self, paint_time: CrossProcessInstant, first_reflow: bool) {
         set_metric(
             self,
             Some(self.make_metadata(first_reflow)),

--- a/components/script/dom/performance/largestcontentfulpaint.rs
+++ b/components/script/dom/performance/largestcontentfulpaint.rs
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use base::cross_process_instant::CrossProcessInstant;
+use dom_struct::dom_struct;
+use script_traits::ProgressiveWebMetricType;
+use time::Duration;
+
+use super::performanceentry::PerformanceEntry;
+use crate::dom::bindings::codegen::Bindings::LargestContentfulPaintBinding::LargestContentfulPaintMethods;
+use crate::dom::bindings::codegen::Bindings::PerformanceBinding::DOMHighResTimeStamp;
+use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::element::Element;
+use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+pub(crate) struct LargestContentfulPaint {
+    entry: PerformanceEntry,
+    #[no_trace]
+    load_time: CrossProcessInstant,
+    #[no_trace]
+    render_time: CrossProcessInstant,
+    size: usize,
+    element: Option<DomRoot<Element>>,
+}
+
+impl LargestContentfulPaint {
+    pub(crate) fn new_inherited(
+        metric_type: ProgressiveWebMetricType,
+        render_time: CrossProcessInstant,
+    ) -> LargestContentfulPaint {
+        LargestContentfulPaint {
+            entry: PerformanceEntry::new_inherited(
+                DOMString::from(""),
+                DOMString::from("largest-contentful-paint"),
+                Some(render_time),
+                Duration::ZERO,
+            ),
+            load_time: CrossProcessInstant::epoch(),
+            render_time,
+            size: metric_type.area(),
+            element: None,
+        }
+    }
+
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
+    pub(crate) fn new(
+        global: &GlobalScope,
+        metric_type: ProgressiveWebMetricType,
+        render_time: CrossProcessInstant,
+        can_gc: CanGc,
+    ) -> DomRoot<LargestContentfulPaint> {
+        let entry = LargestContentfulPaint::new_inherited(metric_type, render_time);
+        reflect_dom_object(Box::new(entry), global, can_gc)
+    }
+}
+
+impl LargestContentfulPaintMethods<crate::DomTypeHolder> for LargestContentfulPaint {
+    /// <https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-loadtime>
+    fn LoadTime(&self) -> DOMHighResTimeStamp {
+        self.global()
+            .performance()
+            .to_dom_high_res_time_stamp(self.load_time)
+    }
+
+    /// <https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-rendertime>
+    fn RenderTime(&self) -> DOMHighResTimeStamp {
+        self.global()
+            .performance()
+            .to_dom_high_res_time_stamp(self.render_time)
+    }
+
+    /// <https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-size>
+    fn Size(&self) -> u32 {
+        self.size as u32
+    }
+
+    /// <https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-element>
+    fn GetElement(&self) -> Option<DomRoot<Element>> {
+        self.element.clone()
+    }
+}

--- a/components/script/dom/performance/mod.rs
+++ b/components/script/dom/performance/mod.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+pub(crate) mod largestcontentfulpaint;
 #[allow(clippy::module_inception, reason = "The interface name is Performance")]
 pub(crate) mod performance;
 #[allow(dead_code)]

--- a/components/script/dom/performance/performanceobserver.rs
+++ b/components/script/dom/performance/performanceobserver.rs
@@ -28,12 +28,13 @@ use crate::script_runtime::{CanGc, JSContext};
 /// List of allowed performance entry types, in alphabetical order.
 pub(crate) const VALID_ENTRY_TYPES: &[&str] = &[
     // "frame", // TODO Frame Timing API
-    "mark",       // User Timing API
-    "measure",    // User Timing API
-    "navigation", // Navigation Timing API
-    "paint",      // Paint Timing API
-    "resource",   // Resource Timing API
-                  // "server", XXX Server Timing API
+    "largest-contentful-paint", // Largest Contentful Paint API
+    "mark",                     // User Timing API
+    "measure",                  // User Timing API
+    "navigation",               // Navigation Timing API
+    "paint",                    // Paint Timing API
+    "resource",                 // Resource Timing API
+                                // "server", XXX Server Timing API
 ];
 
 #[derive(Clone, Copy, JSTraceable, MallocSizeOf, PartialEq)]

--- a/components/script/dom/performance/performancepainttiming.rs
+++ b/components/script/dom/performance/performancepainttiming.rs
@@ -29,9 +29,6 @@ impl PerformancePaintTiming {
             ProgressiveWebMetricType::FirstContentfulPaint => {
                 DOMString::from("first-contentful-paint")
             },
-            ProgressiveWebMetricType::LargestContentfulPaint { .. } => {
-                DOMString::from("largest-contentful-paint")
-            },
             _ => DOMString::from(""),
         };
         PerformancePaintTiming {

--- a/components/script_bindings/webidls/LargestContentfulPaint.webidl
+++ b/components/script_bindings/webidls/LargestContentfulPaint.webidl
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * The origin of this IDL file is
+ * https://w3c.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface
+ */
+
+[Exposed=Window]
+interface LargestContentfulPaint : PerformanceEntry {
+    readonly attribute DOMHighResTimeStamp loadTime;
+    readonly attribute DOMHighResTimeStamp renderTime;
+    readonly attribute unsigned long size;
+    readonly attribute Element? element;
+};

--- a/components/script_bindings/webidls/PerformancePaintTiming.webidl
+++ b/components/script_bindings/webidls/PerformancePaintTiming.webidl
@@ -3,7 +3,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/.
  *
  * The origin of this IDL file is
- * https://wicg.github.io/paint-timing/#sec-PerformancePaintTiming
+ * https://w3c.github.io/paint-timing/#sec-PerformancePaintTiming
  */
 
 [Exposed=(Window,Worker)]

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -122,6 +122,16 @@ pub enum ProgressiveWebMetricType {
     TimeToInteractive,
 }
 
+impl ProgressiveWebMetricType {
+    /// Returns the area if the metric type is LargestContentfulPaint
+    pub fn area(&self) -> usize {
+        match self {
+            ProgressiveWebMetricType::LargestContentfulPaint { area, .. } => *area,
+            _ => 0,
+        }
+    }
+}
+
 /// The reason why the pipeline id of an iframe is being updated.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub enum UpdatePipelineIdReason {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13798,7 +13798,7 @@
      ]
     ],
     "interfaces.https.html": [
-     "db30ab94fda4ccedf0ab26d98a2ec014ad9730f2",
+     "62690889fd4fc8eef443959a6e40bf03b1769e4e",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
+++ b/tests/wpt/mozilla/tests/mozilla/interfaces.https.html
@@ -237,6 +237,7 @@ test_interfaces([
   "IntersectionObserver",
   "IntersectionObserverEntry",
   "KeyboardEvent",
+  "LargestContentfulPaint",
   "Location",
   "MediaElementAudioSourceNode",
   "MediaError",


### PR DESCRIPTION
Add basic `IDL` implementation for `LargestContentfulPaint`

Testing: Tested locally
Fixes: N/A

<img width="800" height="210" alt="Screenshot from 2025-11-06 12-56-37" src="https://github.com/user-attachments/assets/af453b8d-7605-4300-8c87-c2574feff81f" />

