### PR TITLE
webdriver: Serialize script `String` argument correctly to prevent injection attack

### DIFF
--- a/components/webdriver_server/elements.rs
+++ b/components/webdriver_server/elements.rs
@@ -6,7 +6,7 @@ use embedder_traits::WebDriverScriptCommand;
 use ipc_channel::ipc;
 use serde_json::Value;
 use webdriver::command::JavascriptCommandParameters;
-use webdriver::error::{WebDriverError, WebDriverResult};
+use webdriver::error::{ErrorStatus, WebDriverError, WebDriverResult};
 
 use crate::{Handler, VerifyBrowsingContextIsOpen, wait_for_ipc_response};
 
@@ -133,7 +133,12 @@ impl Handler {
                     .collect::<WebDriverResult<Vec<String>>>()?;
                 format!("{{{}}}", elems.join(", "))
             },
-            _ => serde_json::to_string(v).unwrap(),
+            _ => serde_json::to_string(v).map_err(|_| {
+                WebDriverError::new(
+                    ErrorStatus::InvalidArgument,
+                    "Failed to serialize script argument",
+                )
+            })?,
         };
 
         Ok(res)

--- a/components/webdriver_server/elements.rs
+++ b/components/webdriver_server/elements.rs
@@ -92,10 +92,6 @@ impl Handler {
     /// <https://w3c.github.io/webdriver/#dfn-json-deserialize>
     fn json_deserialize(&self, v: &Value) -> WebDriverResult<String> {
         let res = match v {
-            Value::Null => "null".to_string(),
-            Value::String(s) => format!("\"{}\"", s),
-            Value::Bool(b) => b.to_string(),
-            Value::Number(n) => n.to_string(),
             Value::Array(list) => {
                 let elems = list
                     .iter()
@@ -137,6 +133,7 @@ impl Handler {
                     .collect::<WebDriverResult<Vec<String>>>()?;
                 format!("{{{}}}", elems.join(", "))
             },
+            _ => serde_json::to_string(v).unwrap(),
         };
 
         Ok(res)

--- a/tests/wpt/tests/webdriver/tests/classic/execute_async_script/arguments.py
+++ b/tests/wpt/tests/webdriver/tests/classic/execute_async_script/arguments.py
@@ -21,7 +21,9 @@ def test_null(session):
     (True, "boolean"),
     (42, "number"),
     ("foo", "string"),
-], ids=["boolean", "number", "string"])
+    ("foo\"bar", 'string'),
+    ('"); alert(1); //', "string"),
+], ids=["boolean", "number", "string", "string_quote", "string_injection"])
 def test_primitives(session, value, expected_type):
     result = execute_async_script(session, """
         arguments[1]([typeof arguments[0], arguments[0]])

--- a/tests/wpt/tests/webdriver/tests/classic/execute_script/arguments.py
+++ b/tests/wpt/tests/webdriver/tests/classic/execute_script/arguments.py
@@ -19,7 +19,9 @@ def test_null(session):
     (True, "boolean"),
     (42, "number"),
     ("foo", "string"),
-], ids=["boolean", "number", "string"])
+    ("foo\"bar", 'string'),
+    ('"); alert(1); //', "string"),
+], ids=["boolean", "number", "string", "string_quote", "string_injection"])
 def test_primitives(session, value, expected_type):
     result = execute_script(session, "return [typeof arguments[0], arguments[0]]", args=[value])
     actual = assert_success(result)


### PR DESCRIPTION
The previous serialization is problematic when dealing with string argument with special characters. In addition, it was vulnerable to injection attack like below:

```rust
let s = r#""); alert(1); //"#;
let args_string = format!("\"{}\"", s);
let script = format!("(function() {{ {}\n}})({})", "/* body */", args_string); 
// script becomes: (function() { /* body */ })(""); alert(1); //")
```

Testing: Added four new tests in [wdspec](https://web-platform-tests.org/writing-tests/wdspec.html). Before this PR, we would get "javascript error" for the new tests, and trigger user prompts. Now it passes. This should also fix some testdriver tests.