### PR TITLE
script: Refactor imported stylesheets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7522,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.32.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf3d6e326b229602c93014618"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#1e99bdab75f60ad1a4ae00387c178c83cdc69009"
 dependencies = [
  "bitflags 2.9.4",
  "cssparser",
@@ -7855,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.2"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf3d6e326b229602c93014618"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#1e99bdab75f60ad1a4ae00387c178c83cdc69009"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8368,7 +8368,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf3d6e326b229602c93014618"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#1e99bdab75f60ad1a4ae00387c178c83cdc69009"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8425,7 +8425,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf3d6e326b229602c93014618"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#1e99bdab75f60ad1a4ae00387c178c83cdc69009"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8434,12 +8434,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf3d6e326b229602c93014618"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#1e99bdab75f60ad1a4ae00387c178c83cdc69009"
 
 [[package]]
 name = "stylo_derive"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf3d6e326b229602c93014618"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#1e99bdab75f60ad1a4ae00387c178c83cdc69009"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8451,7 +8451,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf3d6e326b229602c93014618"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#1e99bdab75f60ad1a4ae00387c178c83cdc69009"
 dependencies = [
  "bitflags 2.9.4",
  "stylo_malloc_size_of",
@@ -8460,7 +8460,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf3d6e326b229602c93014618"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#1e99bdab75f60ad1a4ae00387c178c83cdc69009"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8477,12 +8477,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf3d6e326b229602c93014618"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#1e99bdab75f60ad1a4ae00387c178c83cdc69009"
 
 [[package]]
 name = "stylo_traits"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf3d6e326b229602c93014618"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#1e99bdab75f60ad1a4ae00387c178c83cdc69009"
 dependencies = [
  "app_units",
  "bitflags 2.9.4",
@@ -8897,7 +8897,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf3d6e326b229602c93014618"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#1e99bdab75f60ad1a4ae00387c178c83cdc69009"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8910,7 +8910,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#4ba7bdb4040a909bf3d6e326b229602c93014618"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#1e99bdab75f60ad1a4ae00387c178c83cdc69009"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -218,7 +218,7 @@ impl Layout for LayoutThread {
         self.stylist.device()
     }
 
-    fn load_web_fonts_from_stylesheet(&self, stylesheet: ServoArc<Stylesheet>) {
+    fn load_web_fonts_from_stylesheet(&self, stylesheet: &ServoArc<Stylesheet>) {
         let guard = stylesheet.shared_lock.read();
         self.load_all_web_fonts_from_stylesheet_with_guard(
             &DocumentStyleSheet(stylesheet.clone()),

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4231,7 +4231,7 @@ impl Document {
     }
 
     /// Given a stylesheet, load all web fonts from it in Layout.
-    pub(crate) fn load_web_fonts_from_stylesheet(&self, stylesheet: Arc<Stylesheet>) {
+    pub(crate) fn load_web_fonts_from_stylesheet(&self, stylesheet: &Arc<Stylesheet>) {
         self.window
             .layout()
             .load_web_fonts_from_stylesheet(stylesheet);

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -243,7 +243,7 @@ pub trait Layout {
 
     /// Load all fonts from the given stylesheet, returning the number of fonts that
     /// need to be loaded.
-    fn load_web_fonts_from_stylesheet(&self, stylesheet: ServoArc<Stylesheet>);
+    fn load_web_fonts_from_stylesheet(&self, stylesheet: &ServoArc<Stylesheet>);
 
     /// Add a stylesheet to this Layout. This will add it to the Layout's `Stylist` as well as
     /// loading all web fonts defined in the stylesheet. The second stylesheet is the insertion


### PR DESCRIPTION
We were previously using the unsound `StylesheetContents::from_data()` to create a dummy stylesheet, which we were later replacing with the actual imported stylesheet once it loaded.

This patch changes that to use `ImportSheet::Pending` instead. But then:
 - We need to store the `MediaList` in `StylesheetContextSource`. Previosuly we stored it in the dummy stylesheet.
 - We also need to store an Arc pointer to the `ImportRule`, in order to update its stylesheet to `ImportSheet::Sheet(stylesheet)` later on.

Testing: Unnecessary, there should be no behavior change
Fixes: #39710

Stylo PR: https://github.com/servo/stylo/pull/250
