### PR TITLE
libservo: Unify notifications to the embedder that input events are handled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,6 +2370,7 @@ name = "embedder_traits"
 version = "0.0.1"
 dependencies = [
  "base",
+ "bitflags 2.9.4",
  "cookie 0.18.1",
  "crossbeam-channel",
  "euclid",

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -26,7 +26,8 @@ use constellation_traits::{EmbedderToConstellationMessage, PaintMetricEvent};
 use crossbeam_channel::Sender;
 use dpi::PhysicalSize;
 use embedder_traits::{
-    CompositorHitTestResult, InputEvent, ScreenshotCaptureError, ShutdownState, ViewportDetails,
+    CompositorHitTestResult, InputEventAndId, ScreenshotCaptureError, ShutdownState,
+    ViewportDetails,
 };
 use euclid::{Point2D, Scale, Size2D, Transform3D};
 use image::RgbaImage;
@@ -1506,7 +1507,7 @@ impl IOCompositor {
         self.global.borrow_mut().send_transaction(transaction);
     }
 
-    pub fn notify_input_event(&mut self, webview_id: WebViewId, event: InputEvent) {
+    pub fn notify_input_event(&mut self, webview_id: WebViewId, event: InputEventAndId) {
         if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
             webview_renderer.notify_input_event(event);
         }

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -71,7 +71,7 @@ impl ConstellationWebView {
 
         // If there's no hit test, send the event to either the hovered or focused browsing context,
         // depending on the event type.
-        let browsing_context_id = if matches!(event.event, InputEvent::MouseLeftViewport(_)) {
+        let browsing_context_id = if matches!(event.event.event, InputEvent::MouseLeftViewport(_)) {
             self.hovered_browsing_context_id
                 .unwrap_or(self.focused_browsing_context_id)
         } else {
@@ -117,7 +117,7 @@ impl ConstellationWebView {
                 };
 
                 let mut synthetic_mouse_leave_event = event.clone();
-                synthetic_mouse_leave_event.event =
+                synthetic_mouse_leave_event.event.event =
                     InputEvent::MouseLeftViewport(MouseLeftViewportEvent {
                         focus_moving_to_another_iframe,
                     });
@@ -130,12 +130,12 @@ impl ConstellationWebView {
                     ));
             };
 
-        if let InputEvent::MouseLeftViewport(_) = &event.event {
+        if let InputEvent::MouseLeftViewport(_) = &event.event.event {
             update_hovered_browsing_context(None, false);
             return;
         }
 
-        if let InputEvent::MouseMove(_) = &event.event {
+        if let InputEvent::MouseMove(_) = &event.event.event {
             update_hovered_browsing_context(Some(pipeline.browsing_context_id), true);
             self.last_mouse_move_point = event
                 .hit_test_result

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -36,7 +36,7 @@ pub(crate) trait LogTarget {
 }
 
 mod from_compositor {
-    use embedder_traits::InputEvent;
+    use embedder_traits::{InputEvent, InputEventAndId};
 
     use super::LogTarget;
 
@@ -76,7 +76,6 @@ mod from_compositor {
                 Self::EvaluateJavaScript(..) => target!("EvaluateJavaScript"),
                 Self::CreateMemoryReport(..) => target!("CreateMemoryReport"),
                 Self::SendImageKeysForPipeline(..) => target!("SendImageKeysForPipeline"),
-                Self::SetWebDriverResponseSender(..) => target!("SetWebDriverResponseSender"),
                 Self::PreferencesUpdated(..) => target!("PreferencesUpdated"),
                 Self::NoLongerWaitingOnAsynchronousImageUpdates(..) => {
                     target!("NoLongerWaitingOnCanvas")
@@ -87,14 +86,14 @@ mod from_compositor {
         }
     }
 
-    impl LogTarget for InputEvent {
+    impl LogTarget for InputEventAndId {
         fn log_target(&self) -> &'static str {
             macro_rules! target_variant {
                 ($name:literal) => {
                     target!("ForwardInputEvent(" $name ")")
                 };
             }
-            match self {
+            match self.event {
                 InputEvent::EditingAction(..) => target_variant!("EditingAction"),
                 InputEvent::Gamepad(..) => target_variant!("Gamepad"),
                 InputEvent::Ime(..) => target_variant!("Ime"),
@@ -180,7 +179,6 @@ mod from_script {
                 Self::TitleChanged(..) => target!("TitleChanged"),
                 Self::IFrameSizes(..) => target!("IFrameSizes"),
                 Self::ReportMemory(..) => target!("ReportMemory"),
-                Self::WebDriverInputComplete(..) => target!("WebDriverInputComplete"),
                 Self::FinishJavaScriptEvaluation(..) => target!("FinishJavaScriptEvaluation"),
                 Self::ForwardKeyboardScroll(..) => target!("ForwardKeyboardScroll"),
                 Self::RespondToScreenshotReadinessRequest(..) => {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -764,11 +764,11 @@ impl Servo {
                     .borrow_mut()
                     .finish_evaluation(evaluation_id, result);
             },
-            EmbedderMsg::Keyboard(webview_id, keyboard_event) => {
+            EmbedderMsg::InputEventHandled(webview_id, input_event_id, result) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     webview
                         .delegate()
-                        .notify_keyboard_event(webview, keyboard_event);
+                        .notify_input_event_handled(webview, input_event_id, result);
                 }
             },
             EmbedderMsg::ClearClipboard(webview_id) => {

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -9,9 +9,9 @@ use base::id::PipelineId;
 use constellation_traits::EmbedderToConstellationMessage;
 use embedder_traits::{
     AllowOrDeny, AuthenticationResponse, ContextMenuResult, Cursor, EmbedderControlId,
-    FilterPattern, FormControlResponse, GamepadHapticEffectType, InputMethodType, KeyboardEvent,
-    LoadStatus, MediaSessionEvent, Notification, PermissionFeature, RgbColor, ScreenGeometry,
-    SelectElementOptionOrOptgroup, SimpleDialog, TraversalId, WebResourceRequest,
+    FilterPattern, FormControlResponse, GamepadHapticEffectType, InputEventId, InputEventResult,
+    InputMethodType, LoadStatus, MediaSessionEvent, Notification, PermissionFeature, RgbColor,
+    ScreenGeometry, SelectElementOptionOrOptgroup, SimpleDialog, TraversalId, WebResourceRequest,
     WebResourceResponse, WebResourceResponseMsg,
 };
 use ipc_channel::ipc::IpcSender;
@@ -469,11 +469,10 @@ pub trait WebViewDelegate {
     /// occurs.
     fn notify_closed(&self, _webview: WebView) {}
 
-    /// A keyboard event has been sent to Servo, but remains unprocessed. This allows the
-    /// embedding application to handle key events while first letting the [`WebView`]
-    /// have an opportunity to handle it first. Apart from builtin keybindings, page
-    /// content may expose custom keybindings as well.
-    fn notify_keyboard_event(&self, _webview: WebView, _: KeyboardEvent) {}
+    /// An input event passed to this [`WebView`] via [`WebView::notify_input_event`] has been handled
+    /// by Servo. This allows post-procesing of input events, such as chaining up unhandled events
+    /// to parent UI elements.
+    fn notify_input_event_handled(&self, _webview: WebView, _: InputEventId, _: InputEventResult) {}
     /// A pipeline in the webview panicked. First string is the reason, second one is the backtrace.
     fn notify_crashed(&self, _webview: WebView, _reason: String, _backtrace: Option<String>) {}
     /// Notifies the embedder about media session events

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -19,7 +19,7 @@ use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, Worke
 use embedder_traits::{
     AnimationState, FocusSequenceNumber, JSValue, JavaScriptEvaluationError,
     JavaScriptEvaluationId, MediaSessionEvent, ScriptToEmbedderChan, Theme, TouchEventResult,
-    ViewportDetails, WebDriverMessageId,
+    ViewportDetails,
 };
 use euclid::default::Size2D as UntypedSize2D;
 use fonts_traits::SystemFontServiceProxySender;
@@ -690,8 +690,6 @@ pub enum ScriptToConstellationMessage {
         JavaScriptEvaluationId,
         Result<JSValue, JavaScriptEvaluationError>,
     ),
-    /// Notify the completion of a webdriver command.
-    WebDriverInputComplete(WebDriverMessageId),
     /// Forward a keyboard scroll operation from an `<iframe>` to a parent pipeline.
     ForwardKeyboardScroll(PipelineId, KeyboardScroll),
     /// Notify the Constellation of the screenshot readiness of a given pipeline.

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -18,9 +18,9 @@ use std::time::Duration;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{MessagePortId, PipelineId, WebViewId};
 use embedder_traits::{
-    CompositorHitTestResult, EmbedderControlId, FormControlResponse, InputEvent,
+    CompositorHitTestResult, EmbedderControlId, FormControlResponse, InputEventAndId,
     JavaScriptEvaluationId, MediaSessionActionType, Theme, TraversalId, ViewportDetails,
-    WebDriverCommandMsg, WebDriverCommandResponse,
+    WebDriverCommandMsg,
 };
 pub use from_script_message::*;
 use ipc_channel::ipc::IpcSender;
@@ -78,7 +78,7 @@ pub enum EmbedderToConstellationMessage {
     /// Make none of the webviews focused.
     BlurWebView,
     /// Forward an input event to an appropriate ScriptTask.
-    ForwardInputEvent(WebViewId, InputEvent, Option<CompositorHitTestResult>),
+    ForwardInputEvent(WebViewId, InputEventAndId, Option<CompositorHitTestResult>),
     /// Request that the given pipeline refresh the cursor by doing a hit test at the most
     /// recently hovered cursor position and resetting the cursor. This happens after a
     /// display list update is rendered.
@@ -103,8 +103,6 @@ pub enum EmbedderToConstellationMessage {
     CreateMemoryReport(IpcSender<MemoryReportResult>),
     /// Sends the generated image key to the image cache associated with this pipeline.
     SendImageKeysForPipeline(PipelineId, Vec<ImageKey>),
-    /// Set WebDriver input event handled sender.
-    SetWebDriverResponseSender(IpcSender<WebDriverCommandResponse>),
     /// A set of preferences were updated with the given new values.
     PreferencesUpdated(Vec<(&'static str, PrefValue)>),
     /// Request preparation for a screenshot of the given WebView. The Constellation will

--- a/components/shared/embedder/Cargo.toml
+++ b/components/shared/embedder/Cargo.toml
@@ -18,6 +18,7 @@ baked-default-resources = []
 
 [dependencies]
 base = { workspace = true }
+bitflags = { workspace = true }
 cookie = { workspace = true }
 crossbeam-channel = { workspace = true }
 euclid = { workspace = true }

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -442,8 +442,6 @@ pub enum EmbedderMsg {
     WebViewBlurred,
     /// Wether or not to unload a document
     AllowUnload(WebViewId, GenericSender<AllowOrDeny>),
-    /// Sends an unconsumed key event back to the embedder.
-    Keyboard(WebViewId, KeyboardEvent),
     /// Inform embedder to clear the clipboard
     ClearClipboard(WebViewId),
     /// Gets system clipboard contents
@@ -524,6 +522,9 @@ pub enum EmbedderMsg {
         JavaScriptEvaluationId,
         Result<JSValue, JavaScriptEvaluationError>,
     ),
+    /// Inform the embedding layer that a particular `InputEvent` was handled by Servo
+    /// and the embedder can continue processing it, if necessary.
+    InputEventHandled(WebViewId, InputEventId, InputEventResult),
 }
 
 impl Debug for EmbedderMsg {

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -27,7 +27,7 @@ use webrender_api::units::DevicePixel;
 use crate::{JSValue, MouseButton, MouseButtonAction, ScreenshotCaptureError, TraversalId};
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
-pub struct WebDriverMessageId(pub usize);
+pub struct WebDriverInputEventId(pub usize);
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum WebDriverUserPrompt {
@@ -101,7 +101,7 @@ pub enum WebDriverCommandMsg {
         WebViewId,
         KeyboardEvent,
         // Should never be None.
-        Option<WebDriverMessageId>,
+        Option<WebDriverInputEventId>,
     ),
     /// Act as if the mouse was clicked in the browsing context with the given ID.
     MouseButtonAction(
@@ -111,7 +111,7 @@ pub enum WebDriverCommandMsg {
         f32,
         f32,
         // Should never be None.
-        Option<WebDriverMessageId>,
+        Option<WebDriverInputEventId>,
     ),
     /// Act as if the mouse was moved in the browsing context with the given ID.
     MouseMoveAction(
@@ -120,7 +120,7 @@ pub enum WebDriverCommandMsg {
         f32,
         // None if it's not the last `perform_pointer_move` since we only
         // expect one response from constellation for each tick actions.
-        Option<WebDriverMessageId>,
+        Option<WebDriverInputEventId>,
     ),
     /// Act as if the mouse wheel is scrolled in the browsing context given the given ID.
     WheelScrollAction(
@@ -131,7 +131,7 @@ pub enum WebDriverCommandMsg {
         f64,
         // None if it's not the last `perform_wheel_scroll` since we only
         // expect one response from constellation for each tick actions.
-        Option<WebDriverMessageId>,
+        Option<WebDriverInputEventId>,
     ),
     /// Set the outer window rectangle.
     SetWindowRect(
@@ -275,7 +275,7 @@ pub enum WebDriverFrameId {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct WebDriverCommandResponse {
-    pub id: WebDriverMessageId,
+    pub id: WebDriverInputEventId,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -29,7 +29,7 @@ use devtools_traits::ScriptToDevtoolsControlMsg;
 use embedder_traits::user_content_manager::UserContentManager;
 use embedder_traits::{
     CompositorHitTestResult, EmbedderControlId, FocusSequenceNumber, FormControlResponse,
-    InputEvent, JavaScriptEvaluationId, MediaSessionActionType, ScriptToEmbedderChan, Theme,
+    InputEventAndId, JavaScriptEvaluationId, MediaSessionActionType, ScriptToEmbedderChan, Theme,
     ViewportDetails, WebDriverScriptCommand,
 };
 use euclid::{Rect, Scale, Size2D, UnknownUnit};
@@ -303,8 +303,8 @@ pub struct ConstellationInputEvent {
     pub pressed_mouse_buttons: u16,
     /// The currently active keyboard modifiers.
     pub active_keyboard_modifiers: Modifiers,
-    /// The [`InputEvent`] itself.
-    pub event: InputEvent,
+    /// The [`InputEventAndId`] itself.
+    pub event: InputEventAndId,
 }
 
 /// Data needed to construct a script thread.

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -30,8 +30,8 @@ use cookie::{CookieBuilder, Expiration, SameSite};
 use crossbeam_channel::{Sender, after, select};
 use embedder_traits::{
     EventLoopWaker, JSValue, MouseButton, WebDriverCommandMsg, WebDriverCommandResponse,
-    WebDriverFrameId, WebDriverJSError, WebDriverJSResult, WebDriverLoadStatus, WebDriverMessageId,
-    WebDriverScriptCommand,
+    WebDriverFrameId, WebDriverInputEventId, WebDriverJSError, WebDriverJSResult,
+    WebDriverLoadStatus, WebDriverScriptCommand,
 };
 use euclid::{Point2D, Rect, Size2D};
 use http::method::Method;
@@ -90,10 +90,10 @@ impl WebDriverMessageIdGenerator {
     }
 
     /// Returns a unique ID.
-    pub fn next(&self) -> WebDriverMessageId {
+    pub fn next(&self) -> WebDriverInputEventId {
         let id = self.counter.get();
         self.counter.set(id + 1);
-        WebDriverMessageId(id)
+        WebDriverInputEventId(id)
     }
 }
 
@@ -188,7 +188,7 @@ struct Handler {
 
     id_generator: WebDriverMessageIdGenerator,
 
-    current_action_id: Cell<Option<WebDriverMessageId>>,
+    current_action_id: Cell<Option<WebDriverInputEventId>>,
 
     /// Number of pending actions of which WebDriver is waiting for responses.
     num_pending_actions: Cell<u32>,

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -10,7 +10,7 @@ use log::{debug, warn};
 use servo::ipc_channel::ipc::IpcSender;
 use servo::{
     GamepadEvent, GamepadHapticEffectType, GamepadIndex, GamepadInputBounds,
-    GamepadSupportedHapticEffects, GamepadUpdateType, WebView,
+    GamepadSupportedHapticEffects, GamepadUpdateType, InputEvent, WebView,
 };
 
 pub struct HapticEffect {
@@ -128,7 +128,7 @@ impl GamepadSupport {
             }
 
             if let Some(event) = gamepad_event {
-                active_webview.notify_input_event(servo::InputEvent::Gamepad(event));
+                active_webview.notify_input_event(InputEvent::Gamepad(event));
             }
         }
     }

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use euclid::{Length, Scale};
 use servo::servo_geometry::{DeviceIndependentIntRect, DeviceIndependentPixel};
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize, DevicePixel};
-use servo::{Cursor, RenderingContext, ScreenGeometry, WebView};
+use servo::{Cursor, InputEventId, InputEventResult, RenderingContext, ScreenGeometry, WebView};
 
 use super::app_state::RunningAppState;
 
@@ -66,4 +66,12 @@ pub trait WindowPortsMethods {
     }
     fn window_rect(&self) -> DeviceIndependentIntRect;
     fn maximize(&self, webview: &WebView);
+
+    fn notify_input_event_handled(
+        &self,
+        _webview: &WebView,
+        _id: InputEventId,
+        _result: InputEventResult,
+    ) {
+    }
 }

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -23,9 +23,9 @@ use servo::{
     LoadStatus, MediaSessionActionType, MediaSessionEvent, MouseButton, MouseButtonAction,
     MouseButtonEvent, MouseMoveEvent, NavigationRequest, PermissionRequest, RenderingContext,
     ScreenGeometry, Servo, ServoDelegate, ServoError, SimpleDialog, TouchEvent, TouchEventType,
-    TouchId, TraversalId, WebDriverCommandMsg, WebDriverJSResult, WebDriverLoadStatus,
-    WebDriverScriptCommand, WebDriverSenders, WebView, WebViewBuilder, WebViewDelegate,
-    WindowRenderingContext,
+    TouchId, TraversalId, WebDriverCommandMsg, WebDriverCommandResponse, WebDriverJSResult,
+    WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView, WebViewBuilder,
+    WebViewDelegate, WindowRenderingContext,
 };
 use url::Url;
 
@@ -80,6 +80,8 @@ pub struct RunningAppState {
     /// A [`Receiver`] for receiving commands from a running WebDriver server, if WebDriver
     /// was enabled.
     webdriver_receiver: Option<Receiver<WebDriverCommandMsg>>,
+    /// An [`IpcSender`] to inform WebDriver that an input event has been handled by Servo.
+    webdriver_event_handled_sender: Option<IpcSender<WebDriverCommandResponse>>,
     webdriver_senders: RefCell<WebDriverSenders>,
 }
 
@@ -342,6 +344,7 @@ impl RunningAppState {
         callbacks: Rc<ServoWindowCallbacks>,
         servoshell_preferences: ServoShellPreferences,
         webdriver_receiver: Option<Receiver<WebDriverCommandMsg>>,
+        webdriver_event_handled_sender: Option<IpcSender<WebDriverCommandResponse>>,
     ) -> Rc<Self> {
         let initial_url = initial_url.and_then(|string| Url::parse(&string).ok());
         let initial_url = initial_url
@@ -360,6 +363,7 @@ impl RunningAppState {
             callbacks,
             servoshell_preferences,
             webdriver_receiver,
+            webdriver_event_handled_sender,
             webdriver_senders: RefCell::default(),
             inner: RefCell::new(RunningAppStateInner {
                 need_present: false,


### PR DESCRIPTION
Servo currently has three ways of notifying the embedder that input
events have been processed.

1. `WebViewDelegate::notify_keyboard_event`: This is used to implement
   overridable keybindings in servoshell. It notifies the embedder when
   a keyboard event has been processed, but not "handled" by the engine.
2. WebDriver's command message senders and receivers, this is used to
   let WebDriver wait until events have been handled to continue with
   script execution.
3. Touch event processing notifications: This is used to serialize touch
   event processing.

This change unifies the first two things with a new
`WebViewDelegate::notify_input_event_handled` API. This API informs the
embedder (via a generated id) that an input event has finished
processing and what the result of the processing was.

This allows embedders to do other things with events once they have been
processed. For example, embedders might want to chain unconsumed events
up to parent widgets or to add support for overridable keybindings.

As part of this the `canceled` flag in script's `Event` data structure
is turned into a `bitflags` mirror of the new API type to describe the
result of event handling.

Testing: This shouldn't change observable behavior and is thus covered by existing tests.
The new API is consumed by servoshell, which uses it for tests.
