### PR TITLE
wpt: Rebaseline some more `testdriver.js` tests

### DIFF
--- a/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-arrow-key-scroll.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-arrow-key-scroll.html.ini
@@ -1,0 +1,2 @@
+[scroll-state-scrolled-arrow-key-scroll.html]
+  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-home-end-scroll.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-home-end-scroll.html.ini
@@ -1,0 +1,2 @@
+[scroll-state-scrolled-home-end-scroll.html]
+  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-keyboard-scroll-on-body.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-keyboard-scroll-on-body.html.ini
@@ -1,0 +1,2 @@
+[scroll-state-scrolled-keyboard-scroll-on-body.html]
+  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-keyboard-scroll-on-root.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-keyboard-scroll-on-root.html.ini
@@ -1,0 +1,2 @@
+[scroll-state-scrolled-keyboard-scroll-on-root.html]
+  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-mouse-drag-scroll.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-mouse-drag-scroll.html.ini
@@ -1,0 +1,2 @@
+[scroll-state-scrolled-mouse-drag-scroll.html]
+  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-multiple-scrollers.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-multiple-scrollers.html.ini
@@ -1,0 +1,2 @@
+[scroll-state-scrolled-multiple-scrollers.html]
+  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-pu-pd-scroll.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-pu-pd-scroll.html.ini
@@ -1,0 +1,2 @@
+[scroll-state-scrolled-pu-pd-scroll.html]
+  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-scrollbar-button-clicks.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-scrollbar-button-clicks.html.ini
@@ -1,0 +1,2 @@
+[scroll-state-scrolled-scrollbar-button-clicks.html]
+  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-scrollbar-track-clicks.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-scrollbar-track-clicks.html.ini
@@ -1,0 +1,2 @@
+[scroll-state-scrolled-scrollbar-track-clicks.html]
+  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-spacebar-scroll.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-spacebar-scroll.html.ini
@@ -1,0 +1,2 @@
+[scroll-state-scrolled-spacebar-scroll.html]
+  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-user-touch-scroll.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-user-touch-scroll.html.ini
@@ -1,0 +1,2 @@
+[scroll-state-scrolled-user-touch-scroll.html]
+  expected: ERROR

--- a/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-wheel-scroll.html.ini
+++ b/tests/wpt/meta/css/css-conditional/container-queries/scroll-state/scroll-state-scrolled-wheel-scroll.html.ini
@@ -1,0 +1,2 @@
+[scroll-state-scrolled-wheel-scroll.html]
+  expected: ERROR

--- a/tests/wpt/meta/css/css-overflow/column-scroll-marker-002.html.ini
+++ b/tests/wpt/meta/css/css-overflow/column-scroll-marker-002.html.ini
@@ -1,0 +1,2 @@
+[column-scroll-marker-002.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-overflow/scroll-button-focus-active-element.html.ini
+++ b/tests/wpt/meta/css/css-overflow/scroll-button-focus-active-element.html.ini
@@ -1,0 +1,3 @@
+[scroll-button-focus-active-element.html]
+  [CSS Test: document.activeElement for ::scroll-button is scroller]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-pseudo/marker-hit-testing.html.ini
+++ b/tests/wpt/meta/css/css-pseudo/marker-hit-testing.html.ini
@@ -1,7 +1,4 @@
 [marker-hit-testing.html]
-  [outside image ::marker's content]
-    expected: FAIL
-
   [outside image ::marker]
     expected: FAIL
 

--- a/tests/wpt/meta/css/css-shadow-parts/interaction-with-nested-pseudo-class.html.ini
+++ b/tests/wpt/meta/css/css-shadow-parts/interaction-with-nested-pseudo-class.html.ini
@@ -1,2 +1,2 @@
 [interaction-with-nested-pseudo-class.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/css/css-text-decor/invalidation/text-decoration-thickness.html.ini
+++ b/tests/wpt/meta/css/css-text-decor/invalidation/text-decoration-thickness.html.ini
@@ -1,2 +1,0 @@
-[text-decoration-thickness.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/selectors/remove-hovered-element.html.ini
+++ b/tests/wpt/meta/css/selectors/remove-hovered-element.html.ini
@@ -1,2 +1,2 @@
 [remove-hovered-element.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/dom/events/Event-dispatch-on-disabled-elements.html.ini
+++ b/tests/wpt/meta/dom/events/Event-dispatch-on-disabled-elements.html.ini
@@ -1,2 +1,2 @@
 [Event-dispatch-on-disabled-elements.html]
-  expected: CRASH
+  expected: ERROR

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-document.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-document.tentative.html.ini
@@ -1,3 +1,4 @@
 [overscroll-event-fired-to-document.tentative.html]
+  expected: TIMEOUT
   [Tests that the document gets overscroll event when no element scrolls after touch scrolling.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-element-with-overscroll-behavior.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-element-with-overscroll-behavior.tentative.html.ini
@@ -1,3 +1,4 @@
 [overscroll-event-fired-to-element-with-overscroll-behavior.tentative.html]
+  expected: TIMEOUT
   [Tests that the last element in the cut scroll chain gets overscroll event when no element scrolls by touch.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-scrolled-element.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-scrolled-element.tentative.html.ini
@@ -1,3 +1,4 @@
 [overscroll-event-fired-to-scrolled-element.tentative.html]
+  expected: TIMEOUT
   [Tests that the scrolled element gets overscroll event after fully scrolling by touch.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-window.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-window.tentative.html.ini
@@ -1,3 +1,4 @@
 [overscroll-event-fired-to-window.tentative.html]
+  expected: TIMEOUT
   [Tests that the window gets overscroll event when no element scrollsafter touch scrolling.]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/scrollend-event-fired-after-snap.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/scrollend-event-fired-after-snap.html.ini
@@ -1,7 +1,7 @@
 [scrollend-event-fired-after-snap.html]
   expected: TIMEOUT
   [Tests that scrollend is fired after scroll snap animation completion.]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Tests that scrollend is fired after fling snap animation completion.]
-    expected: TIMEOUT
+    expected: NOTRUN

--- a/tests/wpt/meta/dom/events/scrolling/scrollend-event-handler-content-attributes.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/scrollend-event-handler-content-attributes.html.ini
@@ -1,10 +1,13 @@
 [scrollend-event-handler-content-attributes.html]
   expected: TIMEOUT
   [Tests scrollend event is handled by event handler content attribute.]
-    expected: FAIL
-
-  [Tests scrollend event is fired to document event handler property]
     expected: TIMEOUT
 
+  [Tests scrollend event is fired to document event handler property]
+    expected: NOTRUN
+
   [Tests scrollend event is fired to element event handler property]
+    expected: NOTRUN
+
+  [Tests scrollend event is not fired to document body event handler content attribute.]
     expected: NOTRUN

--- a/tests/wpt/meta/dom/events/scrolling/scrollend-event-not-fired-after-removing-scroller.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/scrollend-event-not-fired-after-removing-scroller.tentative.html.ini
@@ -1,3 +1,4 @@
 [scrollend-event-not-fired-after-removing-scroller.tentative.html]
+  expected: TIMEOUT
   [scrollend is received after removing descendant div]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/focus/focus-event-after-switching-iframes.sub.html.ini
+++ b/tests/wpt/meta/focus/focus-event-after-switching-iframes.sub.html.ini
@@ -1,2 +1,2 @@
 [focus-event-after-switching-iframes.sub.html]
-  expected: CRASH
+  expected: ERROR

--- a/tests/wpt/meta/fullscreen/rendering/backdrop-iframe.html.ini
+++ b/tests/wpt/meta/fullscreen/rendering/backdrop-iframe.html.ini
@@ -1,2 +1,2 @@
 [backdrop-iframe.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/fullscreen/rendering/backdrop-inherit.html.ini
+++ b/tests/wpt/meta/fullscreen/rendering/backdrop-inherit.html.ini
@@ -1,2 +1,2 @@
 [backdrop-inherit.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden.html.ini
+++ b/tests/wpt/meta/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden.html.ini
@@ -1,0 +1,2 @@
+[exit-fullscreen-scroll-to-unscrollable-area-overflow-hidden.html]
+  expected: FAIL

--- a/tests/wpt/meta/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden.html.ini
+++ b/tests/wpt/meta/fullscreen/rendering/exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden.html.ini
@@ -1,0 +1,2 @@
+[exit-fullscreen-scroll-to-unscrollable-area-overflow-x-hidden.html]
+  expected: FAIL

--- a/tests/wpt/meta/fullscreen/rendering/fullscreen-root-fills-page.html.ini
+++ b/tests/wpt/meta/fullscreen/rendering/fullscreen-root-fills-page.html.ini
@@ -1,2 +1,2 @@
 [fullscreen-root-fills-page.html]
-  expected: TIMEOUT
+  expected: CRASH

--- a/tests/wpt/meta/html/editing/dnd/images/015.html.ini
+++ b/tests/wpt/meta/html/editing/dnd/images/015.html.ini
@@ -1,2 +1,0 @@
-[015.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/editing/dnd/images/016.html.ini
+++ b/tests/wpt/meta/html/editing/dnd/images/016.html.ini
@@ -1,2 +1,0 @@
-[016.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/editing/dnd/images/017.html.ini
+++ b/tests/wpt/meta/html/editing/dnd/images/017.html.ini
@@ -1,2 +1,0 @@
-[017.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/editing/dnd/images/018.html.ini
+++ b/tests/wpt/meta/html/editing/dnd/images/018.html.ini
@@ -1,2 +1,0 @@
-[018.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/editing/dnd/images/021.html.ini
+++ b/tests/wpt/meta/html/editing/dnd/images/021.html.ini
@@ -1,2 +1,0 @@
-[021.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/editing/dnd/images/022.xhtml.ini
+++ b/tests/wpt/meta/html/editing/dnd/images/022.xhtml.ini
@@ -1,2 +1,0 @@
-[022.xhtml]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/interaction/focus/focusgroup/tentative/behavior-first-requirement.html.ini
+++ b/tests/wpt/meta/html/interaction/focus/focusgroup/tentative/behavior-first-requirement.html.ini
@@ -1,0 +1,9 @@
+[behavior-first-requirement.html]
+  [Valid behavior-first token 'toolbar' enables focusgroup navigation]
+    expected: FAIL
+
+  [Valid behavior-first token 'tablist' with modifier enables focusgroup navigation]
+    expected: FAIL
+
+  [Valid behavior-first token 'radiogroup' with modifier enables focusgroup navigation]
+    expected: FAIL

--- a/tests/wpt/meta/html/interaction/focus/focusgroup/tentative/behavior-tokens-comprehensive.html.ini
+++ b/tests/wpt/meta/html/interaction/focus/focusgroup/tentative/behavior-tokens-comprehensive.html.ini
@@ -1,0 +1,27 @@
+[behavior-tokens-comprehensive.html]
+  [Behavior token 'toolbar' enables focusgroup navigation]
+    expected: FAIL
+
+  [Behavior token 'tablist' enables focusgroup navigation]
+    expected: FAIL
+
+  [Behavior token 'radiogroup' enables focusgroup navigation]
+    expected: FAIL
+
+  [Behavior token 'listbox' enables focusgroup navigation]
+    expected: FAIL
+
+  [Behavior token 'menu' enables focusgroup navigation]
+    expected: FAIL
+
+  [Behavior token 'menubar' enables focusgroup navigation]
+    expected: FAIL
+
+  [Behavior token 'grid' enables focusgroup navigation]
+    expected: FAIL
+
+  [Behavior token 'toolbar' with modifiers 'inline wrap' works correctly]
+    expected: FAIL
+
+  [Behavior token 'grid' with modifiers 'row-wrap col-flow' works correctly]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-input-element/click-user-gesture.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-input-element/click-user-gesture.html.ini
@@ -1,2 +1,2 @@
 [click-user-gesture.html]
-  expected: CRASH
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select-multiple-popup/select-multiple-popup-appearance.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select-multiple-popup/select-multiple-popup-appearance.tentative.html.ini
@@ -1,0 +1,2 @@
+[select-multiple-popup-appearance.tentative.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted.html.ini
@@ -1,0 +1,2 @@
+[picker-and-slotted.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-active.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-active.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-active.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-option.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-option.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-button-after-option.html]
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-span.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-span.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-button-after-span.html]
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-text.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-text.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-button-after-text.html]
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-custom-button.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-custom-button.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-custom-button.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-dark-mode.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-dark-mode.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-dark-mode.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-default-button.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-default-button.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-default-button.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-option.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-disabled-option.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-disabled-option.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-scroller.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-scroller.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-fallback-bottom-left-scroller.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-fallback-bottom-left.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right-scroller.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right-scroller.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-fallback-bottom-right-scroller.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-right.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-fallback-bottom-right.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left-scroller.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left-scroller.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-fallback-top-left-scroller.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-fallback-top-left.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-scroller.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-scroller.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-fallback-top-right-scroller.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-fallback-top-right.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-font-inheriting.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-font-inheriting.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-font-inheriting.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-hover.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-hover.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-hover.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-and-label.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-and-label.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-optgroup-legend-and-label.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-optgroup-legend.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-optgroup-rendering.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-option-with-label.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-option-with-label.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-option-with-label.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-picker-select-border.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-picker-select-border.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-picker-select-border.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-switching-invalidation.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-lr.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-lr.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-writing-mode-vertical-lr.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-rl.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-writing-mode-vertical-rl.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-writing-mode-vertical-rl.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-wrong-picker-argument.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-appearance-wrong-picker-argument.html.ini
@@ -1,0 +1,2 @@
+[select-appearance-wrong-picker-argument.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-events-2.optional.html.ini
@@ -1,2 +1,2 @@
 [select-events-2.optional.html]
-  expected: CRASH
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-focus-visible-with-mouse.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-focus-visible-with-mouse.html.ini
@@ -1,2 +1,2 @@
 [select-focus-visible-with-mouse.html]
-  expected: CRASH
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior.html.ini
@@ -1,2 +1,2 @@
 [select-mouse-behavior.html]
-  expected: CRASH
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-only-button-opt-in.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-only-button-opt-in.html.ini
@@ -1,0 +1,2 @@
+[select-only-button-opt-in.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in.html.ini
@@ -1,0 +1,2 @@
+[select-only-picker-opt-in.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-open-invalidation.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-open-invalidation.html.ini
@@ -1,0 +1,2 @@
+[select-open-invalidation.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-option-images.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-option-images.html.ini
@@ -1,0 +1,2 @@
+[select-option-images.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-picker-interactive-element-focus.optional.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-picker-interactive-element-focus.optional.html.ini
@@ -1,2 +1,2 @@
 [select-picker-interactive-element-focus.optional.html]
-  expected: CRASH
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-popover-exit-animation.html.ini
@@ -1,0 +1,2 @@
+[select-popover-exit-animation.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-second-child-button.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/select-second-child-button.html.ini
@@ -1,0 +1,2 @@
+[select-second-child-button.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/uses-label-dynamic.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/customizable-select/uses-label-dynamic.html.ini
@@ -1,0 +1,2 @@
+[uses-label-dynamic.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/list-box-important-colors.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/list-box-important-colors.html.ini
@@ -1,0 +1,2 @@
+[list-box-important-colors.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/select-many-options.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/select-many-options.tentative.html.ini
@@ -1,2 +1,2 @@
 [select-many-options.tentative.html]
-  expected: CRASH
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/select-popover-position-with-zoom.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/select-popover-position-with-zoom.tentative.html.ini
@@ -1,2 +1,2 @@
 [select-popover-position-with-zoom.tentative.html]
-  expected: CRASH
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/interestfor/interestfor-keyboard-invalidation.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/interestfor/interestfor-keyboard-invalidation.tentative.html.ini
@@ -1,0 +1,2 @@
+[interestfor-keyboard-invalidation.tentative.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/semantics/interestfor/interestfor-plain-inline-element.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/interestfor/interestfor-plain-inline-element.tentative.html.ini
@@ -1,0 +1,2 @@
+[interestfor-plain-inline-element.tentative.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/user-activation/navigate-to-sameorigin.html.ini
+++ b/tests/wpt/meta/html/user-activation/navigate-to-sameorigin.html.ini
@@ -1,0 +1,4 @@
+[navigate-to-sameorigin.html]
+  expected: TIMEOUT
+  [User activation propagation across a same-origin navigation]
+    expected: TIMEOUT

--- a/tests/wpt/meta/webxr/xrSession_visibilityState_inline.https.html.ini
+++ b/tests/wpt/meta/webxr/xrSession_visibilityState_inline.https.html.ini
@@ -1,0 +1,7 @@
+[xrSession_visibilityState_inline.https.html]
+  expected: ERROR
+  [Ensures that the XRSession's visibilityState is correctly reported and that the associated visibilitychange event fires for non-immersive sessions. - webgl]
+    expected: TIMEOUT
+
+  [Ensures that the XRSession's visibilityState is correctly reported and that the associated visibilitychange event fires for non-immersive sessions. - webgl2]
+    expected: NOTRUN


### PR DESCRIPTION
These tests were missed in the first batch of `testdriver.js` baselines,
likely because the script which identified them didn't handle reference
tests. With this change, the number of tests with differing results is
down to 111[^1].

[^1]: https://github.com/servo/servo/actions/runs/18339818090

Testing: These changes are rebaselines of test results, so are tests themselves.
