### PR TITLE
xpath: Prove that some internal errors are unreachable

### DIFF
--- a/components/xpath/src/context.rs
+++ b/components/xpath/src/context.rs
@@ -3,8 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::fmt;
-use std::iter::Enumerate;
-use std::vec::IntoIter;
 
 use crate::{Dom, NamespaceResolver, Node};
 
@@ -16,8 +14,6 @@ pub(crate) struct EvaluationCtx<D: Dom> {
     pub(crate) context_node: D::Node,
     /// Details needed for evaluating a predicate list.
     pub(crate) predicate_ctx: Option<PredicateCtx>,
-    /// The nodes we're currently matching against.
-    pub(crate) predicate_nodes: Option<Vec<D::Node>>,
     /// A list of known namespace prefixes.
     pub(crate) resolver: Option<D::NamespaceResolver>,
 }
@@ -35,7 +31,6 @@ impl<D: Dom> EvaluationCtx<D> {
             starting_node: context_node.clone(),
             context_node,
             predicate_ctx: None,
-            predicate_nodes: None,
             resolver,
         }
     }
@@ -46,31 +41,7 @@ impl<D: Dom> EvaluationCtx<D> {
             starting_node: self.starting_node.clone(),
             context_node: node,
             predicate_ctx: self.predicate_ctx,
-            predicate_nodes: self.predicate_nodes.clone(),
             resolver: self.resolver.clone(),
-        }
-    }
-
-    pub(crate) fn update_predicate_nodes(&self, nodes: Vec<D::Node>) -> Self {
-        EvaluationCtx {
-            starting_node: self.starting_node.clone(),
-            context_node: self.context_node.clone(),
-            predicate_ctx: None,
-            predicate_nodes: Some(nodes),
-            resolver: self.resolver.clone(),
-        }
-    }
-
-    pub(crate) fn subcontext_iter_for_nodes(&self) -> EvalNodesetIter<'_, D> {
-        let size = self.predicate_nodes.as_ref().map_or(0, |v| v.len());
-        EvalNodesetIter {
-            ctx: self,
-            nodes_iter: self
-                .predicate_nodes
-                .as_ref()
-                .map_or_else(|| Vec::new().into_iter(), |v| v.clone().into_iter())
-                .enumerate(),
-            size,
         }
     }
 
@@ -91,38 +62,12 @@ impl<D: Dom> EvaluationCtx<D> {
     }
 }
 
-/// When evaluating predicates, we need to keep track of the current node being evaluated and
-/// the index of that node in the nodeset we're operating on.
-pub(crate) struct EvalNodesetIter<'a, D: Dom> {
-    ctx: &'a EvaluationCtx<D>,
-    nodes_iter: Enumerate<IntoIter<D::Node>>,
-    size: usize,
-}
-
-impl<D: Dom> Iterator for EvalNodesetIter<'_, D> {
-    type Item = EvaluationCtx<D>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.nodes_iter.next().map(|(idx, node)| EvaluationCtx {
-            starting_node: self.ctx.starting_node.clone(),
-            context_node: node.clone(),
-            predicate_nodes: self.ctx.predicate_nodes.clone(),
-            predicate_ctx: Some(PredicateCtx {
-                index: idx + 1,
-                size: self.size,
-            }),
-            resolver: self.ctx.resolver.clone(),
-        })
-    }
-}
-
 impl<D: Dom> fmt::Debug for EvaluationCtx<D> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EvaluationCtx")
             .field("starting_node", &self.starting_node)
             .field("context_node", &self.context_node)
             .field("predicate_ctx", &self.predicate_ctx)
-            .field("predicate_nodes", &self.predicate_nodes)
             .field("resolver", &"<callback function>")
             .finish()
     }

--- a/components/xpath/src/eval_function.rs
+++ b/components/xpath/src/eval_function.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::context::EvaluationCtx;
-use crate::eval::{Evaluatable, try_extract_nodeset};
+use crate::eval::try_extract_nodeset;
 use crate::eval_value::str_to_num;
 use crate::parser::CoreFunction;
 use crate::{Document, Dom, Element, Error, Node, Value};
@@ -107,8 +107,11 @@ fn lang_matches(context_lang: Option<&str>, target_lang: &str) -> bool {
     false
 }
 
-impl<D: Dom> Evaluatable<D> for CoreFunction {
-    fn evaluate(&self, context: &EvaluationCtx<D>) -> Result<Value<D::Node>, Error<D::JsError>> {
+impl CoreFunction {
+    pub(crate) fn evaluate<D: Dom>(
+        &self,
+        context: &EvaluationCtx<D>,
+    ) -> Result<Value<D::Node>, Error<D::JsError>> {
         match self {
             CoreFunction::Last => {
                 let predicate_ctx = context.predicate_ctx.ok_or_else(|| Error::Internal {

--- a/components/xpath/src/lib.rs
+++ b/components/xpath/src/lib.rs
@@ -6,7 +6,6 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use context::EvaluationCtx;
-use eval::Evaluatable;
 use markup5ever::{LocalName, Namespace, Prefix};
 use parser::{OwnedParserError, QName, parse as parse_impl};
 


### PR DESCRIPTION
The `Evaluatable` trait is used for enforcing a common interface for expressions. Removing it allows us to pass additional parameters to some functions that need them, which proves that a few errors are impossible to reach.

Testing: Covered by existing tests
Part of #34527 
