### PR TITLE
mach: New powershell script `mach.ps1` mimicking globbing of Unix

### DIFF
--- a/mach.ps1
+++ b/mach.ps1
@@ -1,0 +1,26 @@
+$workdir = $PSScriptRoot
+$arguments = $args
+$expanded = $false
+if ($arguments.Count -gt 0) {
+    $expandedArgs = @()
+    foreach ($arg in $arguments) {
+        if ($arg -match '[\*\?\[\]]') {
+            $expandedItems = Get-Item -Path $arg -ErrorAction SilentlyContinue
+            if ($expandedItems) {
+                $expandedArgs += $expandedItems | Select-Object -ExpandProperty FullName
+                $expanded = $true
+            } else {
+                # Expansion fails. Use original arg.
+                $expandedArgs += $arg
+            }
+        } else {
+            $expandedArgs += $arg
+        }
+    }
+    $arguments = $expandedArgs
+    if ($expanded){
+        Write-Host "Expanded arguments: $arguments"
+    }
+}
+
+uv run --no-project python (Join-Path $workdir "mach") @arguments


### PR DESCRIPTION
Unix terminal natively supports globbing, but Windows don't. That's why command like `.\mach update-wpt D:\selenium_servo\linux\*.log` works differently on Windows.

This PR creates a new script `mach.ps1`. 

1. If user uses cmd, `./mach` still runs `./mach.bat`.
2. If user uses powershell, `./mach` runs `./mach.ps1`, supporting the feature mentioned.

Testing: Manually tested. 
Fixes: #39724