### PR TITLE
libservo: Modify the `WebView::set_zoom` to take final zoom value 

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1140,24 +1140,13 @@ impl IOCompositor {
         self.set_needs_repaint(RepaintReason::Resize);
     }
 
-    pub fn on_zoom_reset_window_event(&mut self, webview_id: WebViewId) {
+    pub fn on_zoom_window_event(&mut self, webview_id: WebViewId, new_zoom: f32) {
         if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
             return;
         }
 
         if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-            webview_renderer.set_page_zoom(Scale::new(1.0));
-        }
-    }
-
-    pub fn on_zoom_window_event(&mut self, webview_id: WebViewId, magnification: f32) {
-        if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
-            return;
-        }
-
-        if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-            let current_page_zoom = webview_renderer.page_zoom();
-            webview_renderer.set_page_zoom(current_page_zoom * Scale::new(magnification));
+            webview_renderer.set_page_zoom(Scale::new(new_zoom));
         }
     }
 

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -807,10 +807,6 @@ impl WebViewRenderer {
         old_zoom != self.pinch_zoom
     }
 
-    pub(crate) fn page_zoom(&mut self) -> Scale<f32, CSSPixel, DeviceIndependentPixel> {
-        self.page_zoom
-    }
-
     pub(crate) fn set_page_zoom(
         &mut self,
         new_page_zoom: Scale<f32, CSSPixel, DeviceIndependentPixel>,

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -290,6 +290,32 @@ fn test_resize_webview_zero(servo_test: &ServoTest) -> Result<(), anyhow::Error>
     Ok(())
 }
 
+fn test_page_zoom(servo_test: &ServoTest) -> Result<(), anyhow::Error> {
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo())
+        .delegate(delegate.clone())
+        .build();
+
+    // Default zoom should be 1.0
+    ensure!(webview.page_zoom() == 1.0);
+
+    webview.set_page_zoom(1.5);
+    ensure!(webview.page_zoom() == 1.5);
+
+    webview.set_page_zoom(0.5);
+    ensure!(webview.page_zoom() == 0.5);
+
+    // Should clamp to minimum
+    webview.set_page_zoom(-1.0);
+    ensure!(webview.page_zoom() == 0.1);
+
+    // Should clamp to maximum
+    webview.set_page_zoom(100.0);
+    ensure!(webview.page_zoom() == 10.0);
+
+    Ok(())
+}
+
 fn main() {
     run_api_tests!(
         test_create_webview,
@@ -299,6 +325,7 @@ fn main() {
         test_theme_change,
         test_negative_resize_to_request,
         test_resize_webview_zero,
+        test_page_zoom,
         // This test needs to be last, as it tests creating and dropping
         // a WebView right before shutdown.
         test_create_webview_and_immediately_drop_webview_before_shutdown

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -893,16 +893,16 @@ impl WindowPortsMethods for Window {
 
         ShortcutMatcher::from_event(keyboard_event.event)
             .shortcut(CMD_OR_CONTROL, '=', || {
-                webview.set_zoom(1.1);
+                webview.set_page_zoom(webview.page_zoom() + 0.1);
             })
             .shortcut(CMD_OR_CONTROL, '+', || {
-                webview.set_zoom(1.1);
+                webview.set_page_zoom(webview.page_zoom() + 0.1);
             })
             .shortcut(CMD_OR_CONTROL, '-', || {
-                webview.set_zoom(1.0 / 1.1);
+                webview.set_page_zoom(webview.page_zoom() - 0.1);
             })
             .shortcut(CMD_OR_CONTROL, '0', || {
-                webview.reset_zoom();
+                webview.set_page_zoom(1.0);
             });
     }
 }


### PR DESCRIPTION
Previously in the `WebView::set_zoom` API, we were multiplying the zoom value with the current page zoom. This made it hard to absolute zoom value or to reset the zoom value entirely. This PR modifies the API to take a final zoom value. Now it's the embedder's responsibility to calculate relative zoom changes.

In addition, API is renamed to  `WebView::set_page_zoom()` and `WebView::page_zoom()` in order to better distinguished between page zoom and pinch zoom.

Testing:  Added unit test
