### PR TITLE
script: avoid marking iframes as not blocking loads when they weren't 

### DIFF
--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -387,10 +387,11 @@ impl WindowProxy {
 
     /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     pub(crate) fn stop_delaying_load_events_mode(&self) {
-        self.delaying_load_events_mode.set(false);
-        if let Some(document) = self.document() {
-            if !document.loader().events_inhibited() {
-                ScriptThread::mark_document_with_no_blocked_loads(&document);
+        if self.delaying_load_events_mode.replace(false) {
+            if let Some(document) = self.document() {
+                if !document.loader().events_inhibited() {
+                    ScriptThread::mark_document_with_no_blocked_loads(&document);
+                }
             }
         }
     }


### PR DESCRIPTION
As part of investigating https://github.com/servo/servo/issues/31973, I noticed that iframes would be re-added to the `docs_with_no_blocking_loads` by the window proxy, in in the case that `delaying_load_events_mode` was already false when `stop_delaying_load_events_mode` is called into(unnecessarily it seems). So this makes running the steps of that method conditional on the flag transitioning from true to false. Note that this flag only applies to iframes.

Testing: WPT
