### PR TITLE
constellation: prevent panic when constellation receives message from closed pipeline

### DIFF
--- a/tests/wpt/meta/focus/activeelement-after-focusing-different-site-iframe-contentwindow.html.ini
+++ b/tests/wpt/meta/focus/activeelement-after-focusing-different-site-iframe-contentwindow.html.ini
@@ -1,6 +1,3 @@
 [activeelement-after-focusing-different-site-iframe-contentwindow.html]
-  [Check trailing events]
-    expected: FAIL
-
   [Check result]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-3.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-3.html.ini
@@ -1,4 +1,4 @@
 [iframe_sandbox_popups_escaping-3.html]
-  expected: CRASH
+  expected: TIMEOUT
   [Check that popups from a sandboxed iframe escape the sandbox if\n       allow-popups-to-escape-sandbox is used]
     expected: TIMEOUT


### PR DESCRIPTION
As part of https://github.com/servo/servo/issues/31973, I noticed that the intermittent crash of `/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-3.html` appears due to the closing of the of the source webview of the message, which prior to these changes would result in an early return and drop the reply sender, resulting in a panic. 

This change makes the check for whether the webview is still open specific to certain messages that need the webview and `GetBrowsingContextInfo` is not one of them. 

As to exactly what allows a webview to be closed and still send a `GetBrowsingContextInfo` message, it appears that the iframe and the pop-up opened by the iframe share the same webview, and when the pop-up calls `close`, that closes the webview but the iframe is still running and then receives a post message from a webview that was already closed(intermittently). See https://github.com/servo/servo/issues/39748

Testing: WPT
Fixes: https://github.com/servo/servo/issues/22647
