### PR TITLE
xpath: Let the parents of attribute nodes be their owner elements

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -97,13 +97,13 @@ impl Attr {
 }
 
 impl AttrMethods<crate::DomTypeHolder> for Attr {
-    // https://dom.spec.whatwg.org/#dom-attr-localname
+    /// <https://dom.spec.whatwg.org/#dom-attr-localname>
     fn LocalName(&self) -> DOMString {
         // FIXME(ajeffrey): convert directly from LocalName to DOMString
         DOMString::from(&**self.local_name())
     }
 
-    // https://dom.spec.whatwg.org/#dom-attr-value
+    /// <https://dom.spec.whatwg.org/#dom-attr-value>
     fn Value(&self) -> DOMString {
         // FIXME(ajeffrey): convert directly from AttrValue to DOMString
         DOMString::from(&**self.value())
@@ -146,13 +146,13 @@ impl AttrMethods<crate::DomTypeHolder> for Attr {
         Ok(())
     }
 
-    // https://dom.spec.whatwg.org/#dom-attr-name
+    /// <https://dom.spec.whatwg.org/#dom-attr-name>
     fn Name(&self) -> DOMString {
         // FIXME(ajeffrey): convert directly from LocalName to DOMString
         DOMString::from(&**self.name())
     }
 
-    // https://dom.spec.whatwg.org/#dom-attr-namespaceuri
+    /// <https://dom.spec.whatwg.org/#dom-attr-namespaceuri>
     fn GetNamespaceURI(&self) -> Option<DOMString> {
         match *self.namespace() {
             ns!() => None,
@@ -160,18 +160,18 @@ impl AttrMethods<crate::DomTypeHolder> for Attr {
         }
     }
 
-    // https://dom.spec.whatwg.org/#dom-attr-prefix
+    /// <https://dom.spec.whatwg.org/#dom-attr-prefix>
     fn GetPrefix(&self) -> Option<DOMString> {
         // FIXME(ajeffrey): convert directly from LocalName to DOMString
         self.prefix().map(|p| DOMString::from(&**p))
     }
 
-    // https://dom.spec.whatwg.org/#dom-attr-ownerelement
+    /// <https://dom.spec.whatwg.org/#dom-attr-ownerelement>
     fn GetOwnerElement(&self) -> Option<DomRoot<Element>> {
         self.owner()
     }
 
-    // https://dom.spec.whatwg.org/#dom-attr-specified
+    /// <https://dom.spec.whatwg.org/#dom-attr-specified>
     fn Specified(&self) -> bool {
         true // Always returns true
     }

--- a/tests/wpt/tests/domxpath/elements-are-parents-of-their-attributes.html
+++ b/tests/wpt/tests/domxpath/elements-are-parents-of-their-attributes.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Relationship between elements and their attributes</title>
+        <link rel="author" title="Simon Wülker" href="mailto:simon.wuelker@arcor.de">
+        <link rel="help" href="https://www.w3.org/TR/1999/REC-xpath-19991116/#attribute-nodes">
+        <script src="/resources/testharness.js"></script>
+        <script src="/resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <div id="context" foo="bar"></div>
+        <script>
+          const context = document.getElementById("context");
+
+          test(() => {
+              const result = document.evaluate(
+                "@foo/parent::*",
+                context,
+                null,
+                XPathResult.ORDERED_NODE_ITERATOR_TYPE,
+                null
+              );
+
+              assert_equals(result.iterateNext(), context);
+              assert_equals(result.iterateNext(), null);
+          }, "Elements are parents of their attributes");
+
+          test(() => {
+              const result = document.evaluate(
+                "node()",
+                context,
+                null,
+                XPathResult.ORDERED_NODE_ITERATOR_TYPE,
+                null
+              );
+
+              assert_equals(result.iterateNext(), null);
+          }, "Attributes are not children of their parents");
+      </script>
+    </body>
+</html>


### PR DESCRIPTION
This is different from the rest of the DOM, see https://www.w3.org/TR/1999/REC-xpath-19991116/#attribute-nodes. Luckily, this can cleanly be implemented for XPath because we already abstract over the concrete DOM implementation.

Testing: This change adds a test
Part of #34527 
