### PR TITLE
script: Migrate `importKey` operation to use new normalization

### DIFF
--- a/components/script/dom/subtlecrypto/hkdf_operation.rs
+++ b/components/script/dom/subtlecrypto/hkdf_operation.rs
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::ptr;
+
+use js::jsapi::JS_NewObject;
+
+use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
+use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::{KeyAlgorithm, KeyFormat};
+use crate::dom::bindings::error::Error;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::cryptokey::{CryptoKey, Handle};
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::subtlecrypto::{ALG_HKDF, AlgorithmFromName};
+use crate::script_runtime::CanGc;
+
+/// <https://w3c.github.io/webcrypto/#hkdf-operations-import-key>
+#[allow(unsafe_code)]
+pub(crate) fn import(
+    global: &GlobalScope,
+    format: KeyFormat,
+    key_data: &[u8],
+    extractable: bool,
+    usages: Vec<KeyUsage>,
+    can_gc: CanGc,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    // Step 1. Let keyData be the key data to be imported.
+
+    // Step 2. If format is "raw":
+    if format == KeyFormat::Raw {
+        // Step 2.1. If usages contains a value that is not "deriveKey" or "deriveBits", then throw
+        // a SyntaxError.
+        if usages
+            .iter()
+            .any(|usage| !matches!(usage, KeyUsage::DeriveKey | KeyUsage::DeriveBits)) ||
+            usages.is_empty()
+        {
+            return Err(Error::Syntax(None));
+        }
+
+        // Step 2.2. If extractable is not false, then throw a SyntaxError.
+        if extractable {
+            return Err(Error::Syntax(None));
+        }
+
+        // Step 2.3. Let key be a new CryptoKey representing the key data provided in keyData.
+        // Step 2.4. Set the [[type]] internal slot of key to "secret".
+        // Step 2.5. Let algorithm be a new KeyAlgorithm object.
+        // Step 2.6. Set the name attribute of algorithm to "HKDF".
+        // Step 2.7. Set the [[algorithm]] internal slot of key to algorithm.
+        let name = DOMString::from(ALG_HKDF);
+        let cx = GlobalScope::get_cx();
+        rooted!(in(*cx) let mut algorithm_object = unsafe {JS_NewObject(*cx, ptr::null()) });
+        assert!(!algorithm_object.is_null());
+        KeyAlgorithm::from_name(name.clone(), algorithm_object.handle_mut(), cx);
+
+        let key = CryptoKey::new(
+            global,
+            KeyType::Secret,
+            extractable,
+            name,
+            algorithm_object.handle(),
+            usages,
+            Handle::Hkdf(key_data.to_vec()),
+            can_gc,
+        );
+
+        // Step 2.8. Return key.
+        Ok(key)
+    }
+    // Otherwise:
+    else {
+        // throw a NotSupportedError.
+        Err(Error::NotSupported)
+    }
+}

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -5,6 +5,7 @@
 use std::ptr;
 
 use aws_lc_rs::hmac;
+use base64::prelude::*;
 use js::jsapi::JS_NewObject;
 use js::jsval::ObjectValue;
 use servo_rand::{RngCore, ServoRng};
@@ -13,7 +14,9 @@ use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{
     CryptoKeyMethods, KeyType, KeyUsage,
 };
-use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::HmacKeyAlgorithm;
+use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::{
+    HmacKeyAlgorithm, JsonWebKey, KeyFormat,
+};
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -21,7 +24,8 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     ALG_HMAC, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, AlgorithmFromLengthAndHash,
-    SubtleHmacKeyGenParams, value_from_js_object,
+    ExportedKey, JsonWebKeyExt, SubtleHmacImportParams, SubtleHmacKeyGenParams,
+    value_from_js_object,
 };
 use crate::script_runtime::CanGc;
 
@@ -156,4 +160,188 @@ pub(crate) fn generate_key(
 
     // Step 16. Return key.
     Ok(key)
+}
+
+/// <https://w3c.github.io/webcrypto/#hmac-operations-import-key>
+#[allow(unsafe_code)]
+pub(crate) fn import_key(
+    global: &GlobalScope,
+    normalized_algorithm: &SubtleHmacImportParams,
+    format: KeyFormat,
+    key_data: &[u8],
+    extractable: bool,
+    usages: Vec<KeyUsage>,
+    can_gc: CanGc,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    // Step 1. Let keyData be the key data to be imported.
+    // Step 2. If usages contains an entry which is not "sign" or "verify", then throw a SyntaxError.
+    // Note: This is not explicitly spec'ed, but also throw a SyntaxError if usages is empty
+    if usages
+        .iter()
+        .any(|usage| !matches!(usage, KeyUsage::Sign | KeyUsage::Verify)) ||
+        usages.is_empty()
+    {
+        return Err(Error::Syntax(None));
+    }
+
+    // Step 3. Let hash be a new KeyAlgorithm.
+    let hash;
+
+    // Step 4.
+    let data;
+    match format {
+        // If format is "raw":
+        KeyFormat::Raw => {
+            // Step 4.1. Let data be keyData.
+            data = key_data.to_vec();
+
+            // Step 4.2. Set hash to equal the hash member of normalizedAlgorithm.
+            hash = &normalized_algorithm.hash;
+        },
+        // If format is "jwk":
+        KeyFormat::Jwk => {
+            // Step 2.1. If keyData is a JsonWebKey dictionary: Let jwk equal keyData.
+            // Otherwise: Throw a DataError.
+            // NOTE: Deserialize keyData to JsonWebKey dictionary by running JsonWebKey::parse
+            let jwk = JsonWebKey::parse(GlobalScope::get_cx(), key_data)?;
+
+            // Step 2.2. If the kty field of jwk is not "oct", then throw a DataError.
+            if jwk.kty.as_ref().is_none_or(|kty| kty != "oct") {
+                return Err(Error::Data);
+            }
+
+            // Step 2.3. If jwk does not meet the requirements of Section 6.4 of JSON Web
+            // Algorithms [JWA], then throw a DataError.
+            // NOTE: Done by Step 2.4 and 2.6.
+
+            // Step 2.4. Let data be the byte sequence obtained by decoding the k field of jwk.
+            data = base64::engine::general_purpose::STANDARD_NO_PAD
+                .decode(&*jwk.k.as_ref().ok_or(Error::Data)?.as_bytes())
+                .map_err(|_| Error::Data)?;
+
+            // Step 2.5. Set the hash to equal the hash member of normalizedAlgorithm.
+            hash = &normalized_algorithm.hash;
+
+            // Step 2.6.
+            match hash.name() {
+                // If the name attribute of hash is "SHA-1":
+                ALG_SHA1 => {
+                    // If the alg field of jwk is present and is not "HS1", then throw a DataError.
+                    if jwk.alg.as_ref().is_some_and(|alg| alg != "HS1") {
+                        return Err(Error::Data);
+                    }
+                },
+                // If the name attribute of hash is "SHA-256":
+                ALG_SHA256 => {
+                    // If the alg field of jwk is present and is not "HS256", then throw a DataError.
+                    if jwk.alg.as_ref().is_some_and(|alg| alg != "HS256") {
+                        return Err(Error::Data);
+                    }
+                },
+                // If the name attribute of hash is "SHA-384":
+                ALG_SHA384 => {
+                    // If the alg field of jwk is present and is not "HS384", then throw a DataError.
+                    if jwk.alg.as_ref().is_some_and(|alg| alg != "HS384") {
+                        return Err(Error::Data);
+                    }
+                },
+                // If the name attribute of hash is "SHA-512":
+                ALG_SHA512 => {
+                    // If the alg field of jwk is present and is not "HS512", then throw a DataError.
+                    if jwk.alg.as_ref().is_some_and(|alg| alg != "HS512") {
+                        return Err(Error::Data);
+                    }
+                },
+                // Otherwise,
+                _name => {
+                    // if the name attribute of hash is defined in another applicable specification:
+                    // Perform any key import steps defined by other applicable specifications,
+                    // passing format, jwk and hash and obtaining hash
+                    // NOTE: Currently not support applicable specification.
+                    return Err(Error::NotSupported);
+                },
+            }
+
+            // Step 2.7. If usages is non-empty and the use field of jwk is present and is not
+            // "sig", then throw a DataError.
+            if !usages.is_empty() && jwk.use_.as_ref().is_some_and(|use_| use_ != "sig") {
+                return Err(Error::Data);
+            }
+
+            // Step 2.8. If the key_ops field of jwk is present, and is invalid according to
+            // the requirements of JSON Web Key [JWK] or does not contain all of the specified
+            // usages values, then throw a DataError.
+            jwk.check_key_ops(&usages)?;
+
+            // Step 2.9. If the ext field of jwk is present and has the value false and
+            // extractable is true, then throw a DataError.
+            if jwk.ext.is_some_and(|ext| !ext) && extractable {
+                return Err(Error::Data);
+            }
+        },
+        // Otherwise:
+        _ => {
+            // throw a NotSupportedError.
+            return Err(Error::NotSupported);
+        },
+    }
+
+    // Step 5. Let length be the length in bits of data.
+    let mut length = data.len() as u32 * 8;
+
+    // Step 6. If length is zero then throw a DataError.
+    if length == 0 {
+        return Err(Error::Data);
+    }
+
+    // Step 7. If the length member of normalizedAlgorithm is present:
+    if let Some(given_length) = normalized_algorithm.length {
+        //  If the length member of normalizedAlgorithm is greater than length:
+        if given_length > length {
+            // throw a DataError.
+            return Err(Error::Data);
+        }
+        // Otherwise:
+        else {
+            // Set length equal to the length member of normalizedAlgorithm.
+            length = given_length;
+        }
+    }
+
+    // Step 10. Let algorithm be a new HmacKeyAlgorithm.
+    // Step 11. Set the name attribute of algorithm to "HMAC".
+    // Step 12. Set the length attribute of algorithm to length.
+    // Step 13. Set the hash attribute of algorithm to hash.
+    // Step 14. Set the [[algorithm]] internal slot of key to algorithm.
+    let truncated_data = data[..length as usize / 8].to_vec();
+    let name = DOMString::from(ALG_HMAC);
+    let cx = GlobalScope::get_cx();
+    rooted!(in(*cx) let mut algorithm_object = unsafe { JS_NewObject(*cx, ptr::null()) });
+    assert!(!algorithm_object.is_null());
+    HmacKeyAlgorithm::from_length_and_hash(length, hash, algorithm_object.handle_mut(), cx);
+    let key = CryptoKey::new(
+        global,
+        KeyType::Secret,
+        extractable,
+        name,
+        algorithm_object.handle(),
+        usages,
+        Handle::Hmac(truncated_data),
+        can_gc,
+    );
+
+    // Step 15. Return key.
+    Ok(key)
+}
+
+/// <https://w3c.github.io/webcrypto/#hmac-operations-export-key>
+pub(crate) fn export(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
+    match format {
+        KeyFormat::Raw => match key.handle() {
+            Handle::Hmac(key_data) => Ok(ExportedKey::Raw(key_data.as_slice().to_vec())),
+            _ => Err(Error::Operation),
+        },
+        // FIXME: Implement JWK export for HMAC keys
+        _ => Err(Error::NotSupported),
+    }
 }

--- a/components/script/dom/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/subtlecrypto/pbkdf2_operation.rs
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::ptr;
+
+use js::jsapi::JS_NewObject;
+
+use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
+use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::{KeyAlgorithm, KeyFormat};
+use crate::dom::bindings::error::Error;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::cryptokey::{CryptoKey, Handle};
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::subtlecrypto::{ALG_PBKDF2, AlgorithmFromName};
+use crate::script_runtime::CanGc;
+
+/// <https://w3c.github.io/webcrypto/#pbkdf2-operations-import-key>
+#[allow(unsafe_code)]
+pub(crate) fn import(
+    global: &GlobalScope,
+    format: KeyFormat,
+    key_data: &[u8],
+    extractable: bool,
+    usages: Vec<KeyUsage>,
+    can_gc: CanGc,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    // Step 1. If format is not "raw", throw a NotSupportedError
+    if format != KeyFormat::Raw {
+        return Err(Error::NotSupported);
+    }
+
+    // Step 2. If usages contains a value that is not "deriveKey" or "deriveBits", then throw a SyntaxError.
+    if usages
+        .iter()
+        .any(|usage| !matches!(usage, KeyUsage::DeriveKey | KeyUsage::DeriveBits)) ||
+        usages.is_empty()
+    {
+        return Err(Error::Syntax(None));
+    }
+
+    // Step 3. If extractable is not false, then throw a SyntaxError.
+    if extractable {
+        return Err(Error::Syntax(None));
+    }
+
+    // Step 4. Let key be a new CryptoKey representing keyData.
+    // Step 5. Set the [[type]] internal slot of key to "secret".
+    // Step 6. Let algorithm be a new KeyAlgorithm object.
+    // Step 7. Set the name attribute of algorithm to "PBKDF2".
+    // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
+    let name = DOMString::from(ALG_PBKDF2);
+    let cx = GlobalScope::get_cx();
+    rooted!(in(*cx) let mut algorithm_object = unsafe {JS_NewObject(*cx, ptr::null()) });
+    assert!(!algorithm_object.is_null());
+    KeyAlgorithm::from_name(name.clone(), algorithm_object.handle_mut(), cx);
+
+    let key = CryptoKey::new(
+        global,
+        KeyType::Secret,
+        extractable,
+        name,
+        algorithm_object.handle(),
+        usages,
+        Handle::Pbkdf2(key_data.to_vec()),
+        can_gc,
+    );
+
+    // Step 9. Return key.
+    Ok(key)
+}


### PR DESCRIPTION
Refactoring of the algorithm normalization in #39431 introduces a new algorithm normalization procedure to replace the existing one, and we continue the migration here.

In this patch:

- The `SubtleCrypto.importKey` method is migrated from using existing `normalize_algorithm_for_import_key` function to using the new `normalize_algorithm` function.
- The `import_key_aes`, `import_key_hkdf`, `import_key_hmac` and `import_key_pbkdf2` are copied to the `aes_operation`, `hkdf_operation`, `hmac_operation`, `pbkdf2_operation` submodules, according to their types of cryptographic algorithms.
- The above `import_key_xxx` methods are supposed to move the submodules, but they are copied without removal in this patch. It is because they are used by the `wrapKey` and `unwrapKey` operations which have not migrated at this moment. Once `wrapKey` and `unwrapKey` are migrated, they can be removed.
- The custom type `ImportKeyAlgorithm` and `normalize_algorithm_for_import_key` are supposed to be removed, but they are not removed at this moment since they are used by the `wrapKey` and `unwrapKey` operations which have not migrated. Once `wrapKey` and `unwrapKey` are migrated, they can be removed.

Remarks: According to the spec, the `SubtleCrypto.exportKey` method does not use the algorithm normalization. However, we move the "export" counterpart of the above `import_key_xxx` functions all together. So, some refactoring is also made to the `ExportKey` method.

Testing: Refactoring. Existing WPT tests suffice.
Fixes: Part of #39368