### PR TITLE
script: Remove wrongly registered operations for AES-KW

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -3704,16 +3704,6 @@ fn normalize_algorithm(
                 },
 
                 // <https://w3c.github.io/webcrypto/#aes-kw-registration>
-                (ALG_AES_KW, Operation::Encrypt) => {
-                    let mut params = value_from_js_object::<Algorithm>(cx, value.handle(), can_gc)?;
-                    params.name = DOMString::from(alg_name);
-                    NormalizedAlgorithm::Algorithm(params.into())
-                },
-                (ALG_AES_KW, Operation::Decrypt) => {
-                    let mut params = value_from_js_object::<Algorithm>(cx, value.handle(), can_gc)?;
-                    params.name = DOMString::from(alg_name);
-                    NormalizedAlgorithm::Algorithm(params.into())
-                },
                 (ALG_AES_KW, Operation::GenerateKey) => {
                     let mut params =
                         value_from_js_object::<AesKeyGenParams>(cx, value.handle(), can_gc)?;


### PR DESCRIPTION
AES-KW algorithm does not support encryption and decryption (https://w3c.github.io/webcrypto/#aes-kw-registration), but it was wrongly registered with these two operations in our implementation.

Luckily, our implementation can catch this mistake and throw NotSupportedError in later steps, by `NormalizedAlgorithm::encrypt` and `NormalizedAlgorithm::decrypt`. However, we should remove the wrong registration.

Testing: No behavioral change. Existing WPT tests suffice.
