### PR TITLE
libservo: Allow Servo to hide embedder controls

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -1012,6 +1012,11 @@ impl Servo {
                     webview.delegate().show_form_control(webview, form_control);
                 }
             },
+            EmbedderMsg::HideEmbedderControl(control_id) => {
+                if let Some(webview) = self.get_webview_handle(control_id.webview_id) {
+                    webview.delegate().hide_form_control(webview, control_id);
+                }
+            },
             EmbedderMsg::GetWindowRect(webview_id, response_sender) => {
                 let window_rect = || {
                     let Some(webview) = self.get_webview_handle(webview_id) else {

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -325,6 +325,11 @@ pub struct SelectElement {
 }
 
 impl SelectElement {
+    /// Return the [`EmbedderComtrolId`] associated with this element.
+    pub fn id(&self) -> EmbedderControlId {
+        self.id
+    }
+
     /// Return the area occupied by the `<select>` element that triggered the prompt.
     ///
     /// The embedder should use this value to position the prompt that is shown to the user.
@@ -383,6 +388,11 @@ pub struct ColorPicker {
 }
 
 impl ColorPicker {
+    /// Return the [`EmbedderComtrolId`] associated with this element.
+    pub fn id(&self) -> EmbedderControlId {
+        self.id
+    }
+
     /// Get the area occupied by the `<input>` element that triggered the prompt.
     ///
     /// The embedder should use this value to position the prompt that is shown to the user.
@@ -589,6 +599,12 @@ pub trait WebViewDelegate {
     /// Request that the embedder show UI elements for form controls that are not integrated
     /// into page content, such as dropdowns for `<select>` elements.
     fn show_form_control(&self, _webview: WebView, _form_control: FormControl) {}
+
+    /// Request that the embedder hide and ignore a previous [`FormControl`] request, if it hasn’t
+    /// already responded to it.
+    ///
+    /// After this point, any further responses to that request will be ignored.
+    fn hide_form_control(&self, _webview: WebView, _control_id: EmbedderControlId) {}
 
     /// Request to play a haptic effect on a connected gamepad.
     fn play_gamepad_haptic_effect(

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -516,6 +516,8 @@ pub enum EmbedderMsg {
     ShowNotification(Option<WebViewId>, Notification),
     /// Request to display a form control to the embedder.
     ShowEmbedderControl(EmbedderControlId, DeviceIntRect, FormControlRequest),
+    /// Request to display a form control to the embedder.
+    HideEmbedderControl(EmbedderControlId),
     /// Inform the embedding layer that a JavaScript evaluation has
     /// finished with the given result.
     FinishJavaScriptEvaluation(
@@ -534,7 +536,7 @@ impl Debug for EmbedderMsg {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct EmbedderControlId {
     pub webview_id: WebViewId,
     pub pipeline_id: PipelineId,

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -12,8 +12,8 @@ use log::warn;
 use servo::base::generic_channel::GenericSender;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::{
-    AlertResponse, AuthenticationRequest, ColorPicker, ConfirmResponse, FilterPattern,
-    PermissionRequest, PromptResponse, RgbColor, SelectElement, SelectElementOption,
+    AlertResponse, AuthenticationRequest, ColorPicker, ConfirmResponse, EmbedderControlId,
+    FilterPattern, PermissionRequest, PromptResponse, RgbColor, SelectElement, SelectElementOption,
     SelectElementOptionOrOptgroup, SimpleDialog, WebDriverUserPrompt,
 };
 
@@ -616,6 +616,18 @@ impl Dialog {
             Dialog::SimpleDialog(SimpleDialog::Confirm { .. }) => WebDriverUserPrompt::Confirm,
             Dialog::SimpleDialog(SimpleDialog::Prompt { .. }) => WebDriverUserPrompt::Prompt,
             _ => WebDriverUserPrompt::Default,
+        }
+    }
+
+    pub(crate) fn embedder_control_id(&self) -> Option<EmbedderControlId> {
+        match self {
+            Dialog::SelectElement { maybe_prompt, .. } => {
+                maybe_prompt.as_ref().map(|element| element.id())
+            },
+            Dialog::ColorPicker { maybe_prompt, .. } => {
+                maybe_prompt.as_ref().map(|element| element.id())
+            },
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
In some situations, web content may need to hide embedder controls. For
example, when focus shifts when a `<select>` box is open or when the
element showing the control is removed from the DOM. This change adds a
new API to hide embedder controls when that happens.

Testing: This change adds a new API test.