### PR TITLE
Mark text-decoration properties as only having paint/overflow damage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7511,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.32.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
 dependencies = [
  "bitflags 2.9.4",
  "cssparser",
@@ -7844,7 +7844,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.2"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8357,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8423,12 +8423,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
 
 [[package]]
 name = "stylo_derive"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8440,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
 dependencies = [
  "bitflags 2.9.4",
  "stylo_malloc_size_of",
@@ -8449,7 +8449,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8466,12 +8466,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
 
 [[package]]
 name = "stylo_traits"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
 dependencies = [
  "app_units",
  "bitflags 2.9.4",
@@ -8886,7 +8886,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8899,7 +8899,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
Marks some text decoration properties as only having paint/overflow damage.

Actual changes are in Stylo. This bumps to Stylo version.

Stylo PR: https://github.com/servo/stylo/pull/252

Testing: WPT tests
