### PR TITLE
libservo: Improve JavaScript evaluation error name and documentation

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -467,7 +467,7 @@ unsafe fn jsval_to_webdriver_inner(
                     CanGc::note(),
                 );
                 Err(JavaScriptEvaluationError::SerializationError(
-                    JavaScriptEvaluationResultSerializationError::Generic,
+                    JavaScriptEvaluationResultSerializationError::OtherJavaScriptError,
                 ))
             }
         } else {
@@ -499,7 +499,7 @@ unsafe fn clone_an_object(
     // Step 1. If value is in `seen`, return error with error code javascript error.
     if seen.contains(&hashable) {
         return Err(JavaScriptEvaluationError::SerializationError(
-            JavaScriptEvaluationResultSerializationError::Generic,
+            JavaScriptEvaluationResultSerializationError::OtherJavaScriptError,
         ));
     }
     // Step 2. Append value to `seen`.
@@ -524,7 +524,7 @@ unsafe fn clone_an_object(
             Err(error) => {
                 throw_dom_exception(cx, global_scope, error, CanGc::note());
                 return Err(JavaScriptEvaluationError::SerializationError(
-                    JavaScriptEvaluationResultSerializationError::Generic,
+                    JavaScriptEvaluationResultSerializationError::OtherJavaScriptError,
                 ));
             },
         };
@@ -545,7 +545,7 @@ unsafe fn clone_an_object(
                 Err(error) => {
                     throw_dom_exception(cx, global_scope, error, CanGc::note());
                     return Err(JavaScriptEvaluationError::SerializationError(
-                        JavaScriptEvaluationResultSerializationError::Generic,
+                        JavaScriptEvaluationResultSerializationError::OtherJavaScriptError,
                     ));
                 },
             }
@@ -565,7 +565,7 @@ unsafe fn clone_an_object(
         };
         if !succeeded {
             return Err(JavaScriptEvaluationError::SerializationError(
-                JavaScriptEvaluationResultSerializationError::Generic,
+                JavaScriptEvaluationResultSerializationError::OtherJavaScriptError,
             ));
         }
         for id in ids.iter() {
@@ -584,7 +584,7 @@ unsafe fn clone_an_object(
             };
             if !succeeded {
                 return Err(JavaScriptEvaluationError::SerializationError(
-                    JavaScriptEvaluationResultSerializationError::Generic,
+                    JavaScriptEvaluationResultSerializationError::OtherJavaScriptError,
                 ));
             }
 
@@ -599,7 +599,7 @@ unsafe fn clone_an_object(
             };
             if !succeeded {
                 return Err(JavaScriptEvaluationError::SerializationError(
-                    JavaScriptEvaluationResultSerializationError::Generic,
+                    JavaScriptEvaluationResultSerializationError::OtherJavaScriptError,
                 ));
             }
 
@@ -607,7 +607,7 @@ unsafe fn clone_an_object(
                 let name = unsafe { jsid_to_string(*cx, id.handle()) };
                 let Some(name) = name else {
                     return Err(JavaScriptEvaluationError::SerializationError(
-                        JavaScriptEvaluationResultSerializationError::Generic,
+                        JavaScriptEvaluationResultSerializationError::OtherJavaScriptError,
                     ));
                 };
 

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -1070,10 +1070,19 @@ pub struct JavaScriptErrorInfo {
 /// result of the evaluation.
 #[derive(Clone, Debug, Deserialize, EnumMessage, PartialEq, Serialize)]
 pub enum JavaScriptEvaluationResultSerializationError {
-    Generic,
+    /// Serialization could not complete because a JavaScript value contained a detached
+    /// shadow root according to <https://w3c.github.io/webdriver/#dfn-internal-json-clone>.
     DetachedShadowRoot,
+    /// Serialization could not complete because a JavaScript value contained a "stale"
+    /// element reference according to <https://w3c.github.io/webdriver/#dfn-get-a-known-element>.
     StaleElementReference,
+    /// Serialization could not complete because a JavaScript value of an unknown type
+    /// was encountered.
     UnknownType,
+    /// This is a catch all for other kinds of errors that can happen during JavaScript value
+    /// serialization. For instances where this can happen, see:
+    /// <https://w3c.github.io/webdriver/#dfn-clone-an-object>.
+    OtherJavaScriptError,
 }
 
 /// An error that happens when trying to evaluate JavaScript on a `WebView`.

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2149,7 +2149,7 @@ impl Handler {
                             JavaScriptEvaluationResultSerializationError::DetachedShadowRoot => {
                                 ErrorStatus::DetachedShadowRoot
                             },
-                            JavaScriptEvaluationResultSerializationError::Generic => {
+                            JavaScriptEvaluationResultSerializationError::OtherJavaScriptError => {
                                 ErrorStatus::JavascriptError
                             },
                             JavaScriptEvaluationResultSerializationError::StaleElementReference => {


### PR DESCRIPTION
Testing: this just changes a type name and adds documentation, so
doesn't need new tests.
