### PR TITLE
servoshell: Reimplement "onClick" action on Android

### DIFF
--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -20,8 +20,8 @@ use raw_window_handle::{
     AndroidDisplayHandle, AndroidNdkWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
 use servo::{
-    AlertResponse, EventLoopWaker, LoadStatus, MediaSessionActionType, PermissionRequest,
-    SimpleDialog, WebView,
+    AlertResponse, EventLoopWaker, LoadStatus, MediaSessionActionType, MouseButton,
+    PermissionRequest, SimpleDialog, WebView,
 };
 use simpleservo::{APP, DeviceIntRect, InitOptions, InputMethodType, MediaSessionPlaybackState};
 
@@ -339,6 +339,20 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_pinchZoomEnd<'local>(
 ) {
     debug!("pinchZoomEnd");
     call(&mut env, |s| s.pinchzoom_end(factor, x as u32, y as u32));
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_org_servo_servoview_JNIServo_click(
+    mut env: JNIEnv,
+    _: JClass,
+    x: jfloat,
+    y: jfloat,
+) {
+    debug!("click");
+    call(&mut env, |s| {
+        s.mouse_down(x, y, MouseButton::Left);
+        s.mouse_up(x, y, MouseButton::Left);
+    });
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
The Android interface needs some way to communciate click events to
Servo, so the JNI layer needs to expose a click event. Even though there
is no longer a "click" action in the API, we can implement this behavior
via a mouse button down and then mouse button up event, which should be
a more complete implementation in the DOM.

This fixes a regression from #39705.

Testing: There currently aren't tests for Android interaction via the Java layer
(which is one reason why this regression happened sadly).
Fixes #39742.
