### PR TITLE
Adding message argument in WrongDocument Error

### DIFF
--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -113,12 +113,7 @@ pub(crate) fn create_dom_exception(
         Error::NotFound(None) => DOMErrorName::NotFoundError,
         Error::HierarchyRequest => DOMErrorName::HierarchyRequestError,
         Error::WrongDocument(Some(doc_err_custom_message)) => {
-            return Ok(DOMException::new_with_custom_message(
-                global,
-                DOMErrorName::WrongDocumentError,
-                doc_err_custom_message,
-                can_gc,
-            ));
+            return new_custom_exception(DOMErrorName::WrongDocumentError, custom_message);
         },
         Error::WrongDocument(None) => DOMErrorName::WrongDocumentError,
         Error::InvalidCharacter => DOMErrorName::InvalidCharacterError,

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -113,7 +113,7 @@ pub(crate) fn create_dom_exception(
         Error::NotFound(None) => DOMErrorName::NotFoundError,
         Error::HierarchyRequest => DOMErrorName::HierarchyRequestError,
         Error::WrongDocument(Some(doc_err_custom_message)) => {
-            return new_custom_exception(DOMErrorName::WrongDocumentError, custom_message);
+            return new_custom_exception(DOMErrorName::WrongDocumentError, doc_err_custom_message);
         },
         Error::WrongDocument(None) => DOMErrorName::WrongDocumentError,
         Error::InvalidCharacter => DOMErrorName::InvalidCharacterError,

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -112,7 +112,15 @@ pub(crate) fn create_dom_exception(
         },
         Error::NotFound(None) => DOMErrorName::NotFoundError,
         Error::HierarchyRequest => DOMErrorName::HierarchyRequestError,
-        Error::WrongDocument => DOMErrorName::WrongDocumentError,
+        Error::WrongDocument(Some(doc_err_custom_message)) => {
+            return Ok(DOMException::new_with_custom_message(
+                global,
+                DOMErrorName::WrongDocumentError,
+                doc_err_custom_message,
+                can_gc,
+            ));
+        },
+        Error::WrongDocument(None) => DOMErrorName::WrongDocumentError,
         Error::InvalidCharacter => DOMErrorName::InvalidCharacterError,
         Error::NotSupported => DOMErrorName::NotSupportedError,
         Error::InUseAttribute => DOMErrorName::InUseAttributeError,

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -252,7 +252,7 @@ impl Range {
             .unwrap();
         if start_node_root != node_root {
             // Step 1.
-            return Err(Error::WrongDocument);
+            return Err(Error::WrongDocument(None));
         }
         if node.is_doctype() {
             // Step 2.
@@ -505,7 +505,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             .unwrap();
         if this_root != other_root {
             // Step 2.
-            return Err(Error::WrongDocument);
+            return Err(Error::WrongDocument(None));
         }
         // Step 3.
         let (this_point, other_point) = match how {
@@ -543,7 +543,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             Ok(Ordering::Less) => Ok(false),
             Ok(Ordering::Equal) => Ok(true),
             Ok(Ordering::Greater) => Ok(false),
-            Err(Error::WrongDocument) => {
+            Err(Error::WrongDocument(None)) => {
                 // Step 2.
                 Ok(false)
             },

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
     /// HierarchyRequestError DOMException
     HierarchyRequest,
     /// WrongDocumentError DOMException
-    WrongDocument,
+    WrongDocument(Option<String>),
     /// InvalidCharacterError DOMException
     InvalidCharacter,
     /// NotSupportedError DOMException


### PR DESCRIPTION
*This pull request address one of the action item of [*Provide messages in JS errors*](https://github.com/servo/servo/issues/39053) i.e. it adds message argument in WrongDocument Error *

Testing: *This PR is tested using CLI ./mach test-unit -p libservo --jobs=3*
Fixes: [*Provide messages in JS errors*](https://github.com/servo/servo/issues/39053)
