### PR TITLE
Add policy container to all requests

### DIFF
--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -806,6 +806,8 @@ impl RemoteWebFontDownloader {
         // FIXME: This shouldn't use NoReferrer, but the current documents url
         let request =
             RequestBuilder::new(state.webview_id, url.clone().into(), Referrer::NoReferrer)
+                // TODO: Set policy_container from globalscope that contains the fontcontext
+                .policy_container(Default::default())
                 .destination(Destination::Font);
 
         let core_resource_thread_clone = state.core_resource_thread.clone();

--- a/components/net/tests/data_loader.rs
+++ b/components/net/tests/data_loader.rs
@@ -28,6 +28,7 @@ fn assert_parse(
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
         .pipeline_id(None)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -69,6 +69,7 @@ fn test_fetch_response_is_not_network_error() {
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     let _ = server.close();
@@ -83,6 +84,7 @@ fn test_fetch_on_bad_port_is_network_error() {
     let url = ServoUrl::parse("http://www.example.org:6667").unwrap();
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     assert!(fetch_response.is_network_error());
@@ -105,6 +107,7 @@ fn test_fetch_response_body_matches_const_message() {
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     let _ = server.close();
@@ -125,6 +128,7 @@ fn test_fetch_aboutblank() {
     let url = ServoUrl::parse("about:blank").unwrap();
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
 
     let fetch_response = fetch(request, None);
@@ -191,6 +195,7 @@ fn test_fetch_blob() {
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(origin.origin())
+        .policy_container(Default::default())
         .build();
 
     let (sender, receiver) = unbounded();
@@ -233,6 +238,7 @@ fn test_file() {
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
 
     let pool = ThreadPool::new(1, "CoreResourceTestPool".to_string());
@@ -276,6 +282,7 @@ fn test_fetch_ftp() {
     let url = ServoUrl::parse("ftp://not-supported").unwrap();
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     assert!(fetch_response.is_network_error());
@@ -286,6 +293,7 @@ fn test_fetch_bogus_scheme() {
     let url = ServoUrl::parse("bogus://whatever").unwrap();
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     assert!(fetch_response.is_network_error());
@@ -338,12 +346,15 @@ fn test_cors_preflight_fetch() {
         };
     let (server, url) = make_server(handler);
 
+    let origin = url.origin();
     let target_url = url.clone().join("a.html").unwrap();
     let mut request = RequestBuilder::new(
         Some(TEST_WEBVIEW_ID),
         url,
         Referrer::ReferrerUrl(target_url),
     )
+    .origin(origin)
+    .policy_container(Default::default())
     .build();
     request.referrer_policy = ReferrerPolicy::Origin;
     request.use_cors_preflight = true;
@@ -401,7 +412,9 @@ fn test_cors_preflight_cache_fetch() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer).build();
+    let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
+        .policy_container(Default::default())
+        .build();
     request.use_cors_preflight = true;
     request.mode = RequestMode::CorsMode;
     let wrapped_request0 = request.clone();
@@ -470,7 +483,9 @@ fn test_cors_preflight_fetch_network_error() {
         };
     let (server, url) = make_server(handler);
 
-    let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer).build();
+    let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
+        .policy_container(Default::default())
+        .build();
     request.method = Method::from_bytes(b"CHICKEN").unwrap();
     request.use_cors_preflight = true;
     request.mode = RequestMode::CorsMode;
@@ -501,6 +516,7 @@ fn test_fetch_response_is_basic_filtered() {
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     let _ = server.close();
@@ -566,7 +582,9 @@ fn test_fetch_response_is_cors_filtered() {
     let (server, url) = make_server(handler);
 
     // an origin mis-match will stop it from defaulting to a basic filtered response
-    let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer).build();
+    let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
+        .policy_container(Default::default())
+        .build();
     request.mode = RequestMode::CorsMode;
     let fetch_response = fetch(request, None);
     let _ = server.close();
@@ -602,7 +620,9 @@ fn test_fetch_response_is_opaque_filtered() {
     let (server, url) = make_server(handler);
 
     // an origin mis-match will fall through to an Opaque filtered response
-    let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer).build();
+    let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
+        .policy_container(Default::default())
+        .build();
     let fetch_response = fetch(request, None);
     let _ = server.close();
 
@@ -652,6 +672,7 @@ fn test_fetch_response_is_opaque_redirect_filtered() {
 
     let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     request.redirect_mode = RedirectMode::Manual;
     let fetch_response = fetch(request, None);
@@ -689,6 +710,7 @@ fn test_fetch_with_local_urls_only() {
         let mut request =
             RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
                 .origin(url.origin())
+                .policy_container(Default::default())
                 .build();
 
         // Set the flag.
@@ -757,6 +779,7 @@ fn test_fetch_with_hsts() {
     }
     let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     // Set the flag.
     request.local_urls_only = false;
@@ -815,6 +838,7 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
         .destination(Destination::Document)
         .origin(url.clone().origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -875,6 +899,7 @@ fn test_fetch_self_signed() {
         .destination(Destination::Document)
         .origin(url.clone().origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -896,6 +921,7 @@ fn test_fetch_self_signed() {
         .destination(Destination::Document)
         .origin(url.clone().origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -917,6 +943,7 @@ fn test_fetch_with_sri_network_error() {
 
     let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     // To calulate hash use :
     // echo -n "alert('Hello, Network Error');" | openssl dgst -sha384 -binary | openssl base64 -A
@@ -943,6 +970,7 @@ fn test_fetch_with_sri_sucess() {
 
     let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     // To calulate hash use :
     // echo -n "alert('Hello, Network Error');" | openssl dgst -sha384 -binary | openssl base64 -A
@@ -986,6 +1014,7 @@ fn test_fetch_blocked_nosniff() {
         let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
             .origin(url.origin())
             .destination(destination)
+            .policy_container(Default::default())
             .build();
         let fetch_response = fetch(request, None);
         let _ = server.close();
@@ -1032,6 +1061,7 @@ fn setup_server_and_fetch(message: &'static [u8], redirect_cap: u32) -> Response
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
     let _ = server.close();
@@ -1123,6 +1153,7 @@ fn test_fetch_redirect_updates_method_runner(
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
         .method(method)
+        .policy_container(Default::default())
         .build();
 
     let _ = fetch(request, None);
@@ -1207,6 +1238,7 @@ fn test_fetch_async_returns_complete_response() {
 
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let fetch_response = fetch(request, None);
 
@@ -1225,7 +1257,9 @@ fn test_opaque_filtered_fetch_async_returns_complete_response() {
     let (server, url) = make_server(handler);
 
     // an origin mis-match will fall through to an Opaque filtered response
-    let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer).build();
+    let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
+        .policy_container(Default::default())
+        .build();
     let fetch_response = fetch(request, None);
 
     let _ = server.close();
@@ -1262,6 +1296,7 @@ fn test_opaque_redirect_filtered_fetch_async_returns_complete_response() {
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
         .redirect_mode(RedirectMode::Manual)
+        .policy_container(Default::default())
         .build();
 
     let fetch_response = fetch(request, None);
@@ -1288,6 +1323,7 @@ fn test_fetch_with_devtools() {
         .origin(url.origin())
         .redirect_mode(RedirectMode::Manual)
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let (devtools_chan, devtools_port) = unbounded();
@@ -1429,6 +1465,7 @@ fn test_fetch_request_intercepted() {
     let url = ServoUrl::parse("http://www.example.org").unwrap();
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url.clone(), Referrer::NoReferrer)
         .origin(url.origin())
+        .policy_container(Default::default())
         .build();
     let response = fetch_with_context(request, &mut context);
 

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -236,6 +236,7 @@ fn test_check_default_headers_loaded_in_every_request() {
         .destination(Destination::Document)
         .origin(url.clone().origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = dbg!(fetch(request, None));
@@ -264,6 +265,7 @@ fn test_check_default_headers_loaded_in_every_request() {
         .destination(Destination::Document)
         .origin(url.clone().origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -297,6 +299,7 @@ fn test_load_when_request_is_not_get_or_head_and_there_is_no_body_content_length
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -333,6 +336,7 @@ fn test_request_and_response_data_with_network_messages() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let (devtools_chan, devtools_port) = unbounded();
@@ -449,6 +453,7 @@ fn test_request_and_response_message_from_devtool_without_pipeline_id() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(None)
+        .policy_container(Default::default())
         .build();
 
     let (devtools_chan, devtools_port) = unbounded();
@@ -488,6 +493,7 @@ fn test_redirected_request_to_devtools() {
         .method(Method::POST)
         .destination(Destination::Document)
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let (devtools_chan, devtools_port) = unbounded();
@@ -549,6 +555,7 @@ fn test_load_when_redirecting_from_a_post_should_rewrite_next_request_as_get() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -582,6 +589,7 @@ fn test_load_should_decode_the_response_as_deflate_when_response_headers_have_co
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -617,6 +625,7 @@ fn test_load_should_decode_the_response_as_gzip_when_response_headers_have_conte
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -664,6 +673,7 @@ fn test_load_doesnt_send_request_body_on_any_redirect() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -694,6 +704,7 @@ fn test_load_doesnt_add_host_to_hsts_list_when_url_is_http_even_if_hsts_headers_
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let mut context = new_fetch_context(None, None, None);
@@ -744,6 +755,7 @@ fn test_load_sets_cookies_in_the_resource_manager_when_it_get_set_cookie_header_
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -799,6 +811,7 @@ fn test_load_sets_requests_cookies_header_for_url_by_getting_cookies_from_the_re
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -848,6 +861,7 @@ fn test_load_sends_cookie_if_nonhttp() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -889,6 +903,7 @@ fn test_cookie_set_with_httponly_should_not_be_available_using_getcookiesforurl(
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -942,6 +957,7 @@ fn test_when_cookie_received_marked_secure_is_ignored_for_http() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -977,6 +993,7 @@ fn test_load_sets_content_length_to_length_of_request_body() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1019,6 +1036,7 @@ fn test_load_uses_explicit_accept_from_headers_in_load_data() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1058,6 +1076,7 @@ fn test_load_sets_default_accept_to_html_xhtml_xml_and_then_anything_else() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1100,6 +1119,7 @@ fn test_load_uses_explicit_accept_encoding_from_load_data_headers() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1139,6 +1159,7 @@ fn test_load_sets_default_accept_encoding_to_gzip_and_deflate() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1197,6 +1218,7 @@ fn test_load_errors_when_there_a_redirect_loop() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1257,6 +1279,7 @@ fn test_load_succeeds_with_a_redirect_loop() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1300,6 +1323,7 @@ fn test_load_follows_a_redirect() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1386,6 +1410,7 @@ fn test_redirect_from_x_to_y_provides_y_cookies_from_y() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch_with_context(request, &mut context);
@@ -1437,6 +1462,7 @@ fn test_redirect_from_x_to_x_provides_x_with_cookie_from_first_response() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1472,6 +1498,7 @@ fn test_if_auth_creds_not_in_url_but_in_cache_it_sets_it() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let mut context = new_fetch_context(None, None, None);
@@ -1520,6 +1547,7 @@ fn test_auth_ui_needs_www_auth() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let response = fetch(request, None);
@@ -1586,6 +1614,7 @@ fn test_fetch_compressed_response_update_count() {
         .destination(Destination::Document)
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
+        .policy_container(Default::default())
         .build();
 
     struct FetchResponseCollector {
@@ -1675,6 +1704,7 @@ fn test_user_credentials_prompt_when_proxy_authentication_is_required() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
@@ -1732,6 +1762,7 @@ fn test_prompt_credentials_when_client_receives_unauthorized_response() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
@@ -1778,6 +1809,7 @@ fn test_dont_prompt_credentials_when_unauthorized_response_contains_no_www_authe
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
@@ -1839,6 +1871,7 @@ fn test_prompt_credentials_user_cancels_dialog_input() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
@@ -1885,6 +1918,7 @@ fn test_prompt_credentials_user_input_incorrect_credentials() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();
@@ -1937,6 +1971,7 @@ fn test_prompt_credentials_user_input_incorrect_mode() {
         .origin(mock_origin())
         .pipeline_id(Some(TEST_PIPELINE_ID))
         .credentials_mode(CredentialsMode::Include)
+        .policy_container(Default::default())
         .build();
 
     let (embedder_proxy, embedder_receiver) = create_embedder_proxy_and_receiver();


### PR DESCRIPTION
In preparation of adding a client to a request, we first need to add a policy container to all requests. Some where missing and relying on fallbacks (that need to be removed).

For worklets this adds the appropriate policy container from the containing global, but since that's still behind a pref, no tests are affected.

For font contexts I tried to pass through the relevant information, but it is a tad too much. Once fontcontext knows more information about its containing global (as the TODO also points to referrer), we should clean this up.

Part of #35035