### PR TITLE
webdriver: Send events to the embedder as `InputEvent` with a response channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9859,6 +9859,7 @@ dependencies = [
  "time",
  "uuid",
  "webdriver",
+ "webrender_api",
 ]
 
 [[package]]

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4573,11 +4573,7 @@ where
             WebDriverCommandMsg::MaximizeWebView(..) |
             WebDriverCommandMsg::LoadUrl(..) |
             WebDriverCommandMsg::Refresh(..) |
-            WebDriverCommandMsg::DispatchComposition(..) |
-            WebDriverCommandMsg::KeyboardAction(..) |
-            WebDriverCommandMsg::MouseButtonAction(..) |
-            WebDriverCommandMsg::MouseMoveAction(..) |
-            WebDriverCommandMsg::WheelScrollAction(..) |
+            WebDriverCommandMsg::InputEvent(..) |
             WebDriverCommandMsg::TakeScreenshot(..) => {
                 unreachable!("This command should be send directly to the embedder.");
             },

--- a/components/webdriver_server/Cargo.toml
+++ b/components/webdriver_server/Cargo.toml
@@ -33,4 +33,5 @@ servo_url = { path = "../url" }
 stylo_traits = { workspace = true }
 time = { workspace = true }
 uuid = { workspace = true }
+webrender_api = { workspace = true }
 webdriver = { workspace = true }

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -7,10 +7,14 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use base::id::BrowsingContextId;
-use embedder_traits::{MouseButtonAction, WebDriverCommandMsg, WebDriverScriptCommand};
+use crossbeam_channel::Select;
+use embedder_traits::{
+    InputEvent, KeyboardEvent, MouseButtonAction, MouseButtonEvent, MouseMoveEvent,
+    WebDriverCommandMsg, WebDriverScriptCommand, WheelDelta, WheelEvent, WheelMode,
+};
 use ipc_channel::ipc;
 use keyboard_types::webdriver::KeyInputState;
-use log::{error, info};
+use log::info;
 use rustc_hash::FxHashSet;
 use webdriver::actions::{
     ActionSequence, ActionsType, GeneralAction, KeyAction, KeyActionItem, KeyDownAction,
@@ -20,6 +24,7 @@ use webdriver::actions::{
 };
 use webdriver::command::ActionsParameters;
 use webdriver::error::{ErrorStatus, WebDriverError};
+use webrender_api::units::DevicePoint;
 
 use crate::{Handler, VerifyBrowsingContextIsOpen, WebElement, wait_for_ipc_response};
 
@@ -139,18 +144,10 @@ impl Handler {
         browsing_context: BrowsingContextId,
     ) -> Result<(), ErrorStatus> {
         // Step 1. Wait for an action queue token with input state.
-        let new_token = self.id_generator.next();
-        assert!(self.current_action_id.get().is_none());
-        self.current_action_id.set(Some(new_token));
-
         // Step 2. Let actions result be the result of dispatch actions inner.
-        let res = self.dispatch_actions_inner(actions_by_tick, browsing_context);
-
         // Step 3. Dequeue input state's actions queue.
-        self.current_action_id.set(None);
-
         // Step 4. Return actions result.
-        res
+        self.dispatch_actions_inner(actions_by_tick, browsing_context)
     }
 
     /// <https://w3c.github.io/webdriver/#dfn-dispatch-actions-inner>
@@ -198,29 +195,20 @@ impl Handler {
     }
 
     fn wait_for_user_agent_handling_complete(&self) -> Result<(), ErrorStatus> {
-        // To ensure we wait for all events to be processed, only the last event
-        // in each tick action step holds the message id.
-        // Whenever a new event is generated, the message id is passed to it.
-        //
-        // Wait for num_pending_actions number of responses
-        for _ in 0..self.num_pending_actions.get() {
-            match self.webdriver_response_receiver.recv() {
-                Ok(response) => {
-                    let current_waiting_id = self
-                        .current_action_id
-                        .get()
-                        .expect("Current id should be set before dispatch_actions_inner is called");
+        let mut pending_event_receivers =
+            std::mem::take(&mut *self.pending_input_event_receivers.borrow_mut());
 
-                    if current_waiting_id != response.id {
-                        error!("Dispatch actions completed with wrong id in response");
-                        return Err(ErrorStatus::UnknownError);
-                    }
-                },
-                Err(error) => {
-                    error!("Dispatch actions completed with IPC error: {error}");
-                    return Err(ErrorStatus::UnknownError);
-                },
-            };
+        while !pending_event_receivers.is_empty() {
+            let mut select = Select::new();
+            for receiver in &pending_event_receivers {
+                select.recv(receiver);
+            }
+
+            let operation = select.select();
+            let index = operation.index();
+            let _ = operation.recv(&pending_event_receivers[index]);
+
+            pending_event_receivers.remove(index);
         }
 
         self.num_pending_actions.set(0);
@@ -318,12 +306,15 @@ impl Handler {
 
         let keyboard_event = key_input_state.dispatch_keydown(raw_key);
 
-        // Step 12
-        self.increment_num_pending_actions();
-        let msg_id = self.current_action_id.get();
-        let cmd_msg =
-            WebDriverCommandMsg::KeyboardAction(self.verified_webview_id(), keyboard_event, msg_id);
-        let _ = self.send_message_to_embedder(cmd_msg);
+        // Step 12: Perform implementation-specific action dispatch steps on browsing
+        // context equivalent to pressing a key on the keyboard in accordance with the
+        // requirements of [UI-EVENTS], and producing the following events, as
+        // appropriate, with the specified properties. This will always produce events
+        // including at least a keyDown event.
+        self.send_input_event_to_embedder(
+            InputEvent::Keyboard(KeyboardEvent::new(keyboard_event)),
+            true, /* blocking */
+        );
     }
 
     /// <https://w3c.github.io/webdriver/#dfn-dispatch-a-keyup-action>
@@ -350,17 +341,16 @@ impl Handler {
             _ => unreachable!(),
         };
 
-        if let Some(keyboard_event) = key_input_state.dispatch_keyup(raw_key) {
-            // Step 12
-            self.increment_num_pending_actions();
-            let msg_id = self.current_action_id.get();
-            let cmd_msg = WebDriverCommandMsg::KeyboardAction(
-                self.verified_webview_id(),
-                keyboard_event,
-                msg_id,
-            );
-            let _ = self.send_message_to_embedder(cmd_msg);
-        }
+        // Step 12: Perform implementation-specific action dispatch steps on browsing
+        // context equivalent to releasing a key on the keyboard in accordance with the
+        // requirements of [UI-EVENTS], ...
+        let Some(keyboard_event) = key_input_state.dispatch_keyup(raw_key) else {
+            return;
+        };
+        self.send_input_event_to_embedder(
+            InputEvent::Keyboard(KeyboardEvent::new(keyboard_event)),
+            true, /* blocking */
+        );
     }
 
     /// <https://w3c.github.io/webdriver/#dfn-dispatch-a-pointerdown-action>
@@ -379,19 +369,17 @@ impl Handler {
         // Step 6. Add button to the set corresponding to source's pressed property
         pointer_input_state.pressed.insert(action.button);
         // Step 7 - 15: Variable namings already done.
+
         // Step 16. Perform implementation-specific action dispatch steps
         // TODO: We have not considered pen/touch pointer type
-        self.increment_num_pending_actions();
-        let msg_id = self.current_action_id.get();
-        let cmd_msg = WebDriverCommandMsg::MouseButtonAction(
-            self.verified_webview_id(),
-            MouseButtonAction::Down,
-            action.button.into(),
-            x as f32,
-            y as f32,
-            msg_id,
+        self.send_input_event_to_embedder(
+            InputEvent::MouseButton(MouseButtonEvent::new(
+                MouseButtonAction::Down,
+                action.button.into(),
+                DevicePoint::new(x as f32, y as f32),
+            )),
+            true, /* blocking */
         );
-        let _ = self.send_message_to_embedder(cmd_msg);
 
         // Step 17. Return success with data null.
     }
@@ -423,17 +411,14 @@ impl Handler {
         }
 
         // Step 7. Perform implementation-specific action dispatch steps
-        self.increment_num_pending_actions();
-        let msg_id = self.current_action_id.get();
-        let cmd_msg = WebDriverCommandMsg::MouseButtonAction(
-            self.verified_webview_id(),
-            MouseButtonAction::Up,
-            action.button.into(),
-            x as f32,
-            y as f32,
-            msg_id,
+        self.send_input_event_to_embedder(
+            InputEvent::MouseButton(MouseButtonEvent::new(
+                MouseButtonAction::Up,
+                action.button.into(),
+                DevicePoint::new(x as f32, y as f32),
+            )),
+            true, /* blocking */
         );
-        let _ = self.send_message_to_embedder(cmd_msg);
 
         // Step 8. Return success with data null.
     }
@@ -546,23 +531,16 @@ impl Handler {
 
             // Step 7. If x != current x or y != current y, run the following steps:
             // FIXME: Actually "last" should not be checked here based on spec.
-            // However, we need to send the webdriver id at the final perform.
             if x != current_x || y != current_y || last {
                 // Step 7.1. Let buttons be equal to input state's buttons property.
                 // Step 7.2. Perform implementation-specific action dispatch steps
-                let msg_id = if last {
-                    self.increment_num_pending_actions();
-                    self.current_action_id.get()
-                } else {
-                    None
-                };
-                let cmd_msg = WebDriverCommandMsg::MouseMoveAction(
-                    self.verified_webview_id(),
-                    x as f32,
-                    y as f32,
-                    msg_id,
+                self.send_input_event_to_embedder(
+                    InputEvent::MouseMove(MouseMoveEvent::new(DevicePoint::new(
+                        x as f32, y as f32,
+                    ))),
+                    last,
                 );
-                let _ = self.send_message_to_embedder(cmd_msg);
+
                 // Step 7.3. Let input state's x property equal x and y property equal y.
                 let pointer_input_state = self.get_pointer_input_state_mut(source_id);
                 pointer_input_state.x = x;
@@ -716,21 +694,17 @@ impl Handler {
             // However, we need to send the webdriver id at the final perform.
             if delta_x != 0.0 || delta_y != 0.0 || last {
                 // Step 5.1. Perform implementation-specific action dispatch steps
-                let msg_id = if last {
-                    self.increment_num_pending_actions();
-                    self.current_action_id.get()
-                } else {
-                    None
+                let delta = WheelDelta {
+                    x: -delta_x,
+                    y: -delta_y,
+                    z: 0.0,
+                    mode: WheelMode::DeltaPixel,
                 };
-                let cmd_msg = WebDriverCommandMsg::WheelScrollAction(
-                    self.verified_webview_id(),
-                    x,
-                    y,
-                    delta_x,
-                    delta_y,
-                    msg_id,
+                let point = DevicePoint::new(x as f32, y as f32);
+                self.send_input_event_to_embedder(
+                    InputEvent::Wheel(WheelEvent::new(delta, point)),
+                    last,
                 );
-                let _ = self.send_message_to_embedder(cmd_msg);
 
                 // Step 5.2. Let current delta x property equal delta x + current delta x
                 // and current delta y property equal delta y + current delta y.

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -423,21 +423,19 @@ impl Handler {
             .ok_or_else(|| WebDriverError::new(ErrorStatus::UnknownError, "No webview available"))
     }
 
-    fn send_input_event_to_embedder(&self, input_event: InputEvent, blocking: bool) {
-        let webview_id = self.verified_webview_id();
-        if !blocking {
-            let _ = self.send_message_to_embedder(WebDriverCommandMsg::InputEvent(
-                webview_id,
-                input_event,
-                None,
-            ));
-            return;
-        }
+    fn send_input_event_to_embedder(&self, input_event: InputEvent) {
+        let _ = self.send_message_to_embedder(WebDriverCommandMsg::InputEvent(
+            self.verified_webview_id(),
+            input_event,
+            None,
+        ));
+    }
 
+    fn send_blocking_input_event_to_embedder(&self, input_event: InputEvent) {
         let (result_sender, result_receiver) = unbounded();
         if self
             .send_message_to_embedder(WebDriverCommandMsg::InputEvent(
-                webview_id,
+                self.verified_webview_id(),
                 input_event,
                 Some(result_sender),
             ))
@@ -2219,10 +2217,9 @@ impl Handler {
                     }
                 },
                 DispatchStringEvent::Composition(event) => {
-                    self.send_input_event_to_embedder(
-                        InputEvent::Ime(ImeEvent::Composition(event)),
-                        false, /* blocking */
-                    );
+                    self.send_input_event_to_embedder(InputEvent::Ime(ImeEvent::Composition(
+                        event,
+                    )));
                 },
             }
         }

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -14,7 +14,7 @@ mod timeout;
 mod user_prompt;
 
 use std::borrow::ToOwned;
-use std::cell::{Cell, LazyCell};
+use std::cell::{Cell, LazyCell, RefCell};
 use std::collections::{BTreeMap, HashMap};
 use std::io::Cursor;
 use std::net::{SocketAddr, SocketAddrV4};
@@ -27,12 +27,11 @@ use base::id::{BrowsingContextId, WebViewId};
 use base64::Engine;
 use capabilities::ServoCapabilities;
 use cookie::{CookieBuilder, Expiration, SameSite};
-use crossbeam_channel::{Sender, after, select};
+use crossbeam_channel::{Receiver, Sender, after, select, unbounded};
 use embedder_traits::{
-    EventLoopWaker, JSValue, JavaScriptEvaluationError,
+    EventLoopWaker, ImeEvent, InputEvent, JSValue, JavaScriptEvaluationError,
     JavaScriptEvaluationResultSerializationError, MouseButton, WebDriverCommandMsg,
-    WebDriverCommandResponse, WebDriverFrameId, WebDriverInputEventId, WebDriverJSResult,
-    WebDriverLoadStatus, WebDriverScriptCommand,
+    WebDriverFrameId, WebDriverJSResult, WebDriverLoadStatus, WebDriverScriptCommand,
 };
 use euclid::{Point2D, Rect, Size2D};
 use http::method::Method;
@@ -78,26 +77,6 @@ use crate::actions::{InputSourceState, PointerInputState};
 use crate::session::{PageLoadStrategy, WebDriverSession};
 use crate::timeout::DEFAULT_PAGE_LOAD_TIMEOUT;
 
-#[derive(Default)]
-pub struct WebDriverMessageIdGenerator {
-    counter: Cell<usize>,
-}
-
-impl WebDriverMessageIdGenerator {
-    pub fn new() -> Self {
-        Self {
-            counter: Cell::new(0),
-        }
-    }
-
-    /// Returns a unique ID.
-    pub fn next(&self) -> WebDriverInputEventId {
-        let id = self.counter.get();
-        self.counter.set(id + 1);
-        WebDriverInputEventId(id)
-    }
-}
-
 fn extension_routes() -> Vec<(Method, &'static str, ServoExtensionRoute)> {
     vec![
         (
@@ -138,13 +117,8 @@ pub fn start_server(
     port: u16,
     embedder_sender: Sender<WebDriverCommandMsg>,
     event_loop_waker: Box<dyn EventLoopWaker>,
-    webdriver_response_receiver: IpcReceiver<WebDriverCommandResponse>,
 ) {
-    let handler = Handler::new(
-        embedder_sender,
-        event_loop_waker,
-        webdriver_response_receiver,
-    );
+    let handler = Handler::new(embedder_sender, event_loop_waker);
 
     thread::Builder::new()
         .name("WebDriverHttpServer".to_owned())
@@ -184,12 +158,11 @@ struct Handler {
     /// An [`EventLoopWaker`] which is used to wake up the embedder event loop.
     event_loop_waker: Box<dyn EventLoopWaker>,
 
-    /// Receiver notification from the constellation when a command is completed
-    webdriver_response_receiver: IpcReceiver<WebDriverCommandResponse>,
-
-    id_generator: WebDriverMessageIdGenerator,
-
-    current_action_id: Cell<Option<WebDriverInputEventId>>,
+    /// A list of [`Receiver`]s that are used to track when input events are handled in the DOM.
+    /// Once these receivers receive a response, we know that the event has been handled.
+    ///
+    /// TODO: Once we upgrade crossbeam-channel this can be replaced with a `WaitGroup`.
+    pending_input_event_receivers: RefCell<Vec<Receiver<()>>>,
 
     /// Number of pending actions of which WebDriver is waiting for responses.
     num_pending_actions: Cell<u32>,
@@ -416,7 +389,6 @@ impl Handler {
     pub fn new(
         embedder_sender: Sender<WebDriverCommandMsg>,
         event_loop_waker: Box<dyn EventLoopWaker>,
-        webdriver_response_receiver: IpcReceiver<WebDriverCommandResponse>,
     ) -> Handler {
         // Create a pair of both an IPC and a threaded channel,
         // keep the IPC sender to clone and pass to the constellation for each load,
@@ -432,9 +404,7 @@ impl Handler {
             session: None,
             embedder_sender,
             event_loop_waker,
-            webdriver_response_receiver,
-            id_generator: WebDriverMessageIdGenerator::new(),
-            current_action_id: Cell::new(None),
+            pending_input_event_receivers: Default::default(),
             num_pending_actions: Cell::new(0),
         }
     }
@@ -453,10 +423,30 @@ impl Handler {
             .ok_or_else(|| WebDriverError::new(ErrorStatus::UnknownError, "No webview available"))
     }
 
-    fn increment_num_pending_actions(&self) {
-        // Increase the num_pending_actions by one every time we dispatch non null actions.
-        self.num_pending_actions
-            .set(self.num_pending_actions.get() + 1);
+    fn send_input_event_to_embedder(&self, input_event: InputEvent, blocking: bool) {
+        let webview_id = self.verified_webview_id();
+        if !blocking {
+            let _ = self.send_message_to_embedder(WebDriverCommandMsg::InputEvent(
+                webview_id,
+                input_event,
+                None,
+            ));
+            return;
+        }
+
+        let (result_sender, result_receiver) = unbounded();
+        if self
+            .send_message_to_embedder(WebDriverCommandMsg::InputEvent(
+                webview_id,
+                input_event,
+                Some(result_sender),
+            ))
+            .is_ok()
+        {
+            self.pending_input_event_receivers
+                .borrow_mut()
+                .push(result_receiver);
+        }
     }
 
     fn send_message_to_embedder(&self, msg: WebDriverCommandMsg) -> WebDriverResult<()> {
@@ -2229,9 +2219,10 @@ impl Handler {
                     }
                 },
                 DispatchStringEvent::Composition(event) => {
-                    let cmd_msg =
-                        WebDriverCommandMsg::DispatchComposition(self.webview_id()?, event);
-                    self.send_message_to_embedder(cmd_msg)?;
+                    self.send_input_event_to_embedder(
+                        InputEvent::Ime(ImeEvent::Composition(event)),
+                        false, /* blocking */
+                    );
                 },
             }
         }

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -23,9 +23,9 @@ use servo::{
     LoadStatus, MediaSessionActionType, MediaSessionEvent, MouseButton, MouseButtonAction,
     MouseButtonEvent, MouseMoveEvent, NavigationRequest, PermissionRequest, RenderingContext,
     ScreenGeometry, Servo, ServoDelegate, ServoError, SimpleDialog, TouchEvent, TouchEventType,
-    TouchId, TraversalId, WebDriverCommandMsg, WebDriverCommandResponse, WebDriverJSResult,
-    WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView, WebViewBuilder,
-    WebViewDelegate, WindowRenderingContext,
+    TouchId, TraversalId, WebDriverCommandMsg, WebDriverJSResult, WebDriverLoadStatus,
+    WebDriverScriptCommand, WebDriverSenders, WebView, WebViewBuilder, WebViewDelegate,
+    WindowRenderingContext,
 };
 use url::Url;
 
@@ -80,8 +80,6 @@ pub struct RunningAppState {
     /// A [`Receiver`] for receiving commands from a running WebDriver server, if WebDriver
     /// was enabled.
     webdriver_receiver: Option<Receiver<WebDriverCommandMsg>>,
-    /// An [`IpcSender`] to inform WebDriver that an input event has been handled by Servo.
-    webdriver_event_handled_sender: Option<IpcSender<WebDriverCommandResponse>>,
     webdriver_senders: RefCell<WebDriverSenders>,
 }
 
@@ -344,7 +342,6 @@ impl RunningAppState {
         callbacks: Rc<ServoWindowCallbacks>,
         servoshell_preferences: ServoShellPreferences,
         webdriver_receiver: Option<Receiver<WebDriverCommandMsg>>,
-        webdriver_event_handled_sender: Option<IpcSender<WebDriverCommandResponse>>,
     ) -> Rc<Self> {
         let initial_url = initial_url.and_then(|string| Url::parse(&string).ok());
         let initial_url = initial_url
@@ -363,7 +360,6 @@ impl RunningAppState {
             callbacks,
             servoshell_preferences,
             webdriver_receiver,
-            webdriver_event_handled_sender,
             webdriver_senders: RefCell::default(),
             inner: RefCell::new(RunningAppStateInner {
                 need_present: false,


### PR DESCRIPTION
This change simplifies the WebDriver <-> Embedder API by exposing a
single message for dispatching input event actions. This message now
includes a `Sender` which is used to inform the WebDriver server that
the embedder has finished processing the message in the DOM. This
replaces the system of ids and the side channel that was used for this
purpose before.

Testing: This is just a simplification of the WebDriver API and shouldn't
really change behavior in a perceivable way, so it covered by existing tests.
