### PR TITLE
webdriver: Improve argument extraction of (async) script execution 

### DIFF
--- a/components/webdriver_server/elements.rs
+++ b/components/webdriver_server/elements.rs
@@ -100,29 +100,25 @@ impl Handler {
                 format!("[{}]", elems.join(", "))
             },
             Value::Object(map) => {
-                let key = map.keys().next().map(String::as_str);
-                match (key, map.values().next()) {
-                    (Some(ELEMENT_IDENTIFIER), Some(id)) => {
-                        return self.deserialize_web_element(id);
-                    },
-                    (Some(FRAME_IDENTIFIER), Some(id)) => {
-                        let frame_ref = match id {
-                            Value::String(s) => s.clone(),
-                            _ => id.to_string(),
-                        };
-                        return Ok(format!("window.webdriverFrame(\"{}\")", frame_ref));
-                    },
-                    (Some(WINDOW_IDENTIFIER), Some(id)) => {
-                        let window_ref = match id {
-                            Value::String(s) => s.clone(),
-                            _ => id.to_string(),
-                        };
-                        return Ok(format!("window.webdriverWindow(\"{}\")", window_ref));
-                    },
-                    (Some(SHADOW_ROOT_IDENTIFIER), Some(id)) => {
-                        return self.deserialize_shadow_root(id);
-                    },
-                    _ => {},
+                if let Some(id) = map.get(ELEMENT_IDENTIFIER) {
+                    return self.deserialize_web_element(id);
+                }
+                if let Some(id) = map.get(SHADOW_ROOT_IDENTIFIER) {
+                    return self.deserialize_shadow_root(id);
+                }
+                if let Some(id) = map.get(FRAME_IDENTIFIER) {
+                    let frame_ref = match id {
+                        Value::String(s) => s.clone(),
+                        _ => id.to_string(),
+                    };
+                    return Ok(format!("window.webdriverFrame(\"{}\")", frame_ref));
+                }
+                if let Some(id) = map.get(WINDOW_IDENTIFIER) {
+                    let window_ref = match id {
+                        Value::String(s) => s.clone(),
+                        _ => id.to_string(),
+                    };
+                    return Ok(format!("window.webdriverWindow(\"{}\")", window_ref));
                 }
                 let elems = map
                     .iter()

--- a/components/webdriver_server/elements.rs
+++ b/components/webdriver_server/elements.rs
@@ -111,14 +111,14 @@ impl Handler {
                         Value::String(s) => s.clone(),
                         _ => id.to_string(),
                     };
-                    return Ok(format!("window.webdriverFrame(\"{}\")", frame_ref));
+                    return Ok(format!("window.webdriverFrame(\"{frame_ref}\")"));
                 }
                 if let Some(id) = map.get(WINDOW_IDENTIFIER) {
                     let window_ref = match id {
                         Value::String(s) => s.clone(),
                         _ => id.to_string(),
                     };
-                    return Ok(format!("window.webdriverWindow(\"{}\")", window_ref));
+                    return Ok(format!("window.webdriverWindow(\"{window_ref}\")"));
                 }
                 let elems = map
                     .iter()

--- a/tests/wpt/tests/webdriver/tests/classic/execute_async_script/arguments.py
+++ b/tests/wpt/tests/webdriver/tests/classic/execute_async_script/arguments.py
@@ -205,3 +205,32 @@ def test_element_reference(session, get_test_page, expression, expected_type):
         resolve(arguments[0] == {expression})
         """, [reference])
     assert_success(result, True)
+
+
+@pytest.mark.parametrize("expression, expected_type", [
+    ("window.frames[0]", WebFrame),
+    ("document.querySelector('div')", WebElement),
+    ("document.querySelector('custom-element').shadowRoot", ShadowRoot),
+    ("window", WebWindow)
+], ids=["frame", "node", "shadow-root", "window"])
+def test_object_with_identifier_not_first_key(session, get_test_page, expression, expected_type):
+    session.url = get_test_page(as_frame=False)
+
+    result = execute_async_script(session, f"arguments[0]({expression})")
+    reference = assert_success(result)
+    value = {
+        "foo": "bar",
+        expected_type.identifier: reference.id,
+        "baz": 1314
+    }
+
+    result = execute_async_script(
+        session,
+        """
+        let resolve = arguments[1];
+        resolve(arguments[0]);
+        """,
+        args=[value]
+    )
+    reference = assert_success(result)
+    assert isinstance(reference, expected_type)

--- a/tests/wpt/tests/webdriver/tests/classic/execute_script/arguments.py
+++ b/tests/wpt/tests/webdriver/tests/classic/execute_script/arguments.py
@@ -190,3 +190,24 @@ def test_element_reference(session, get_test_page, expression, expected_type):
 
     result = execute_script(session, f"return arguments[0] == {expression}", [reference])
     assert_success(result, True)
+
+@pytest.mark.parametrize("expression, expected_type", [
+    ("window.frames[0]", WebFrame),
+    ("document.querySelector('div')", WebElement),
+    ("document.querySelector('custom-element').shadowRoot", ShadowRoot),
+    ("window", WebWindow)
+], ids=["frame", "node", "shadow-root", "window"])
+def test_object_with_identifier_not_first_key(session, get_test_page, expression, expected_type):
+    session.url = get_test_page(as_frame=False)
+    
+    result = execute_script(session, f"return {expression}")
+    reference = assert_success(result)
+    value = {
+        "foo": "bar",
+         expected_type.identifier: reference.id,
+        "baz": 1314
+    }
+
+    result = execute_script(session, "return arguments[0]", args=[value])
+    reference = assert_success(result)
+    assert isinstance(reference, expected_type)

--- a/tests/wpt/tests/webdriver/tests/classic/execute_script/arguments.py
+++ b/tests/wpt/tests/webdriver/tests/classic/execute_script/arguments.py
@@ -199,7 +199,7 @@ def test_element_reference(session, get_test_page, expression, expected_type):
 ], ids=["frame", "node", "shadow-root", "window"])
 def test_object_with_identifier_not_first_key(session, get_test_page, expression, expected_type):
     session.url = get_test_page(as_frame=False)
-    
+
     result = execute_script(session, f"return {expression}")
     reference = assert_success(result)
     value = {


### PR DESCRIPTION
According to [spec](https://w3c.github.io/webdriver/#dfn-json-deserialize), we should regard an object as webelement/shadowroot/webframe//webwindow, as long as one of the key is the corresponding identifier. Moreover, the order matters. This PR addresses this.

Testing: Added 8 subtests to wdspec.
Fixes: Part of #38083.