### PR TITLE
Implement document preloaded resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5562,6 +5562,7 @@ dependencies = [
  "http 1.3.1",
  "hyper-util",
  "hyper_serde",
+ "indexmap",
  "ipc-channel",
  "log",
  "malloc_size_of_derive",

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -24,7 +24,7 @@ use parking_lot::{Mutex, RwLock};
 use rustc_hash::FxHashSet;
 use servo_arc::Arc as ServoArc;
 use servo_config::pref;
-use servo_url::ServoUrl;
+use servo_url::{ImmutableOrigin, ServoUrl};
 use style::Atom;
 use style::computed_values::font_variant_caps::T as FontVariantCaps;
 use style::font_face::{
@@ -820,6 +820,8 @@ impl RemoteWebFontDownloader {
             RequestBuilder::new(state.webview_id, url.clone().into(), Referrer::NoReferrer)
                 // TODO: Set policy_container from globalscope that contains the fontcontext
                 .policy_container(Default::default())
+                // TODO: Set origin from document that contains the fontcontext
+                .origin(ImmutableOrigin::new(url.origin()))
                 .destination(Destination::Font);
 
         let core_resource_thread_clone = state.core_resource_thread.clone();

--- a/components/net/fetch/fetch_params.rs
+++ b/components/net/fetch/fetch_params.rs
@@ -3,16 +3,30 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use net_traits::request::Request;
+use net_traits::response::Response;
+
+/// <https://fetch.spec.whatwg.org/#fetch-params-preloaded-response-candidate>
+#[derive(Clone)]
+pub(crate) enum PreloadResponseCandidate {
+    None,
+    Pending,
+    Response(Box<Response>),
+}
 
 /// <https://fetch.spec.whatwg.org/#fetch-params>
 #[derive(Clone)]
 pub struct FetchParams {
-    /// <https://fetch.spec.whatwg.org/#concept-request>
+    /// <https://fetch.spec.whatwg.org/#fetch-params-request>
     pub request: Request,
+    /// <https://fetch.spec.whatwg.org/#fetch-params-preloaded-response-candidate>
+    pub(crate) preload_response_candidate: PreloadResponseCandidate,
 }
 
 impl FetchParams {
     pub fn new(request: Request) -> FetchParams {
-        FetchParams { request }
+        FetchParams {
+            request,
+            preload_response_candidate: PreloadResponseCandidate::None,
+        }
     }
 }

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -46,14 +46,14 @@ use net_traits::{
     ResourceTimingType,
 };
 use servo_arc::Arc as ServoArc;
-use servo_url::ServoUrl;
+use servo_url::{ImmutableOrigin, ServoUrl};
 use uuid::Uuid;
 
 use crate::http_loader::{devtools_response_with_body, expect_devtools_http_request};
 use crate::{
     DEFAULT_USER_AGENT, create_embedder_proxy, create_embedder_proxy_and_receiver,
     create_http_state, fetch, fetch_with_context, fetch_with_cors_cache, make_body, make_server,
-    make_ssl_server, new_fetch_context,
+    make_ssl_server, mock_origin, new_fetch_context,
 };
 
 // TODO write a struct that impls Handler for storing test values
@@ -415,6 +415,7 @@ fn test_cors_preflight_cache_fetch() {
 
     let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
         .policy_container(Default::default())
+        .origin(mock_origin())
         .build();
     request.use_cors_preflight = true;
     request.mode = RequestMode::CorsMode;
@@ -486,6 +487,7 @@ fn test_cors_preflight_fetch_network_error() {
 
     let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
         .policy_container(Default::default())
+        .origin(mock_origin())
         .build();
     request.method = Method::from_bytes(b"CHICKEN").unwrap();
     request.use_cors_preflight = true;
@@ -585,6 +587,7 @@ fn test_fetch_response_is_cors_filtered() {
     // an origin mis-match will stop it from defaulting to a basic filtered response
     let mut request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
         .policy_container(Default::default())
+        .origin(mock_origin())
         .build();
     request.mode = RequestMode::CorsMode;
     let fetch_response = fetch(request, None);
@@ -623,6 +626,7 @@ fn test_fetch_response_is_opaque_filtered() {
     // an origin mis-match will fall through to an Opaque filtered response
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
         .policy_container(Default::default())
+        .origin(ImmutableOrigin::new_opaque())
         .build();
     let fetch_response = fetch(request, None);
     let _ = server.close();
@@ -1269,6 +1273,7 @@ fn test_opaque_filtered_fetch_async_returns_complete_response() {
     // an origin mis-match will fall through to an Opaque filtered response
     let request = RequestBuilder::new(Some(TEST_WEBVIEW_ID), url, Referrer::NoReferrer)
         .policy_container(Default::default())
+        .origin(ImmutableOrigin::new_opaque())
         .build();
     let fetch_response = fetch(request, None);
 

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -16,7 +16,6 @@ mod http_cache;
 mod http_loader;
 mod resource_thread;
 mod subresource_integrity;
-
 use core::convert::Infallible;
 use std::collections::HashMap;
 use std::fs::File;
@@ -54,7 +53,7 @@ use rustc_hash::FxHashMap;
 use rustls_pemfile::{certs, pkcs8_private_keys};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 use servo_arc::Arc as ServoArc;
-use servo_url::ServoUrl;
+use servo_url::{ImmutableOrigin, ServoUrl};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::{self, TlsAcceptor};
 
@@ -420,4 +419,8 @@ pub fn make_body(bytes: Vec<u8>) -> BoxBody<Bytes, hyper::Error> {
     Full::new(Bytes::from(bytes))
         .map_err(|_| unreachable!())
         .boxed()
+}
+
+pub(crate) fn mock_origin() -> ImmutableOrigin {
+    ServoUrl::parse("http://servo.org").unwrap().origin()
 }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -536,9 +536,11 @@ impl HTMLLinkElement {
         let fetch_context = LinkFetchContext {
             url,
             link: Some(Trusted::new(self)),
+            document: Trusted::new(&document),
             global: Trusted::new(&document.global()),
             resource_timing: ResourceFetchTiming::new(ResourceTimingType::Resource),
             type_: LinkFetchContextType::Prefetch,
+            response_body: vec![],
         };
 
         document.fetch_background(request, fetch_context);
@@ -800,19 +802,12 @@ impl HTMLLinkElement {
             }
         }
         // Step 6. Preload options, with the following steps given a response response:
-        let Some(request) = options.preload(self.owner_window().webview_id()) else {
-            return;
-        };
-        let url = request.url.clone();
         let document = self.upcast::<Node>().owner_doc();
-        let fetch_context = LinkFetchContext {
-            url,
-            link: Some(Trusted::new(self)),
-            global: Trusted::new(&document.global()),
-            resource_timing: ResourceFetchTiming::new(ResourceTimingType::Resource),
-            type_: LinkFetchContextType::Preload,
-        };
-        document.fetch_background(request, fetch_context);
+        options.preload(
+            self.owner_window().webview_id(),
+            Some(Trusted::new(self)),
+            &document,
+        );
     }
 
     /// <https://html.spec.whatwg.org/multipage/#link-type-preload:fetch-and-process-the-linked-resource-2>

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -17,7 +17,7 @@ use net_traits::request::{
     CacheMode as NetTraitsRequestCache, CredentialsMode as NetTraitsRequestCredentials,
     Destination as NetTraitsRequestDestination, Origin, RedirectMode as NetTraitsRequestRedirect,
     Referrer as NetTraitsRequestReferrer, Request as NetTraitsRequest, RequestBuilder,
-    RequestMode as NetTraitsRequestMode, Window,
+    RequestMode as NetTraitsRequestMode, TraversableForUserPrompts,
 };
 use servo_url::ServoUrl;
 
@@ -150,7 +150,7 @@ impl Request {
         let origin = base_url.origin();
 
         // Step 8. Let traversableForUserPrompts be "client".
-        let mut window = Window::Client;
+        let mut traversable_for_user_prompts = TraversableForUserPrompts::Client;
 
         // Step 9. If request’s traversable for user prompts is an environment settings object
         // and its origin is same origin with origin, then set traversableForUserPrompts
@@ -164,7 +164,7 @@ impl Request {
 
         // Step 11. If init["window"] exists, then set traversableForUserPrompts to "no-traversable".
         if !init.window.handle().is_undefined() {
-            window = Window::NoWindow;
+            traversable_for_user_prompts = TraversableForUserPrompts::NoTraversable;
         }
 
         // Step 12. Set request to a new request with the following properties:
@@ -173,7 +173,7 @@ impl Request {
         request.method = temporary_request.method;
         request.headers = temporary_request.headers.clone();
         request.unsafe_request = true;
-        request.window = window;
+        request.traversable_for_user_prompts = traversable_for_user_prompts;
         // TODO: `entry settings object` is not implemented in Servo yet.
         request.origin = Origin::Client;
         request.referrer = temporary_request.referrer;
@@ -567,6 +567,7 @@ fn net_request_from_global(global: &GlobalScope, url: ServoUrl) -> NetTraitsRequ
         .https_state(global.get_https_state())
         .insecure_requests_policy(global.insecure_requests_policy())
         .has_trustworthy_ancestor_origin(global.has_trustworthy_ancestor_or_current_origin())
+        .policy_container(global.policy_container())
         .build()
 }
 

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -405,6 +405,7 @@ impl ElementStylesheetLoader<'_> {
         .origin(document.origin().immutable().clone())
         .pipeline_id(Some(self.element.global().pipeline_id()))
         .referrer_policy(referrer_policy)
+        .client(global.request_client())
         .integrity_metadata(integrity_metadata);
 
         document.fetch(LoadType::Stylesheet(url), request, context);

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -25,6 +25,7 @@ headers = { workspace = true }
 http = { workspace = true }
 hyper-util = { workspace = true }
 hyper_serde = { workspace = true }
+indexmap = { workspace = true }
 ipc-channel = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -1095,7 +1095,10 @@ pub fn http_percent_encode(bytes: &[u8]) -> String {
     percent_encoding::percent_encode(bytes, HTTP_VALUE).to_string()
 }
 
+/// Step 12 of <https://fetch.spec.whatwg.org/#concept-fetch>
 pub fn set_default_accept_language(headers: &mut HeaderMap) {
+    // If request’s header list does not contain `Accept-Language`,
+    // then user agents should append (`Accept-Language, an appropriate header value) to request’s header list.
     if headers.contains_key(header::ACCEPT_LANGUAGE) {
         return;
     }


### PR DESCRIPTION
This aligns the request object more with the specification,
since the spec now has a `traversable_for_user_prompts` and
a separate field for the client. Before, they were present
in the same enum.

In doing so, new structs are added that are all required in
the new spec. With this we can add support for preloaded
resources in this client, which are only populated when
we have an applicable Global.

Since the spec moved things around a bit, it now has a
dedicated method to populate the client from the request.

Unfortunately none of the WPT preload tests pass, since
the requests are received out-of-order. The specification
requires us to wait for that to settle, but I haven't figured
out yet how to do that. Given that this PR is already quite
large, opted to do that in a follow-up.

Part of #35035