### PR TITLE
fonts: Fix compilation warning due to added fallback mechanism

### DIFF
--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -43,6 +43,7 @@ pub(crate) enum EmojiPresentationPreference {
 pub struct FallbackFontSelectionOptions {
     pub(crate) character: char,
     pub(crate) presentation_preference: EmojiPresentationPreference,
+    #[cfg_attr(target_os = "windows", allow(dead_code))]
     pub(crate) lang: Option<String>,
 }
 


### PR DESCRIPTION
#39608 added a mechanism to read document language from layout. It was used to make sure fallback font for Hiragana/Katakana/Kanji is same for Japanese document. 

Right now, the mechanism is only used for FreeType/macOS. For Windows, it already did the job correctly even before #39608, so there is no need for the mechanism yet.

Testing: Manually tested on https://ja.wikipedia.org/wiki/Servo