### PR TITLE
script: Migrate `deriveBits`/`get key length` operation to use new normalization

### DIFF
--- a/components/script/dom/subtlecrypto/aes_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_operation.rs
@@ -29,8 +29,8 @@ use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::subtlecrypto::{
     ALG_AES_CBC, ALG_AES_CTR, ALG_AES_GCM, ALG_AES_KW, AlgorithmFromNameAndSize, ExportedKey,
-    JsonWebKeyExt, SubtleAesCbcParams, SubtleAesCtrParams, SubtleAesGcmParams,
-    SubtleAesKeyGenParams,
+    JsonWebKeyExt, SubtleAesCbcParams, SubtleAesCtrParams, SubtleAesDerivedKeyParams,
+    SubtleAesGcmParams, SubtleAesKeyGenParams,
 };
 use crate::script_runtime::CanGc;
 
@@ -157,6 +157,13 @@ pub(crate) fn import_key_aes_ctr(
 /// <https://w3c.github.io/webcrypto/#aes-ctr-operations-export-key>
 pub(crate) fn export_key_aes_ctr(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
     export_key_aes(format, key)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-ctr-operations-get-key-length>
+pub(crate) fn get_key_length_aes_ctr(
+    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+) -> Result<Option<u32>, Error> {
+    get_key_length_aes(normalized_derived_key_algorithm)
 }
 
 /// <https://w3c.github.io/webcrypto/#aes-cbc-operations-encrypt>
@@ -301,6 +308,13 @@ pub(crate) fn import_key_aes_cbc(
 /// <https://w3c.github.io/webcrypto/#aes-cbc-operations-export-key>
 pub(crate) fn export_key_aes_cbc(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
     export_key_aes(format, key)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-cbc-operations-get-key-length>
+pub(crate) fn get_key_length_aes_cbc(
+    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+) -> Result<Option<u32>, Error> {
+    get_key_length_aes(normalized_derived_key_algorithm)
 }
 
 /// <https://w3c.github.io/webcrypto/#aes-gcm-operations-encrypt>
@@ -586,6 +600,13 @@ pub(crate) fn export_key_aes_gcm(format: KeyFormat, key: &CryptoKey) -> Result<E
     export_key_aes(format, key)
 }
 
+/// <https://w3c.github.io/webcrypto/#aes-gcm-operations-get-key-length>
+pub(crate) fn get_key_length_aes_gcm(
+    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+) -> Result<Option<u32>, Error> {
+    get_key_length_aes(normalized_derived_key_algorithm)
+}
+
 /// <https://w3c.github.io/webcrypto/#aes-kw-operations-wrap-key>
 pub(crate) fn wrap_key_aes_kw(key: &CryptoKey, plaintext: &[u8]) -> Result<Vec<u8>, Error> {
     // Step 1. If plaintext is not a multiple of 64 bits in length, then throw an OperationError.
@@ -713,6 +734,13 @@ pub(crate) fn import_key_aes_kw(
 /// <https://w3c.github.io/webcrypto/#aes-kw-operations-export-key>
 pub(crate) fn export_key_aes_kw(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
     export_key_aes(format, key)
+}
+
+/// <https://w3c.github.io/webcrypto/#aes-kw-operations-get-key-length>
+pub(crate) fn get_key_length_aes_kw(
+    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+) -> Result<Option<u32>, Error> {
+    get_key_length_aes(normalized_derived_key_algorithm)
 }
 
 /// Helper function for
@@ -1069,4 +1097,22 @@ fn export_key_aes(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Err
 
     // Step 3. Return result.
     Ok(result)
+}
+
+/// Helper function for
+/// <https://w3c.github.io/webcrypto/#aes-ctr-operations-get-key-length>
+/// <https://w3c.github.io/webcrypto/#aes-cbc-operations-get-key-length>
+/// <https://w3c.github.io/webcrypto/#aes-gcm-operations-get-key-length>
+/// <https://w3c.github.io/webcrypto/#aes-kw-operations-get-key-length>
+pub(crate) fn get_key_length_aes(
+    normalized_derived_key_algorithm: &SubtleAesDerivedKeyParams,
+) -> Result<Option<u32>, Error> {
+    // Step 1. If the length member of normalizedDerivedKeyAlgorithm is not 128, 192 or 256, then
+    // throw a OperationError.
+    if !matches!(normalized_derived_key_algorithm.length, 128 | 192 | 256) {
+        return Err(Error::Operation);
+    }
+
+    // Step 2. Return the length member of normalizedDerivedKeyAlgorithm.
+    Ok(Some(normalized_derived_key_algorithm.length as u32))
 }

--- a/components/script/dom/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/subtlecrypto/pbkdf2_operation.rs
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::num::NonZero;
 use std::ptr;
 
+use aws_lc_rs::pbkdf2;
 use js::jsapi::JS_NewObject;
 
 use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
@@ -13,8 +15,70 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::cryptokey::{CryptoKey, Handle};
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::subtlecrypto::{ALG_PBKDF2, AlgorithmFromName};
+use crate::dom::subtlecrypto::{
+    ALG_PBKDF2, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, AlgorithmFromName, SubtlePbkdf2Params,
+};
 use crate::script_runtime::CanGc;
+
+/// <https://w3c.github.io/webcrypto/#pbkdf2-operations-derive-bits>
+pub(crate) fn derive_bits(
+    normalized_algorithm: &SubtlePbkdf2Params,
+    key: &CryptoKey,
+    length: Option<u32>,
+) -> Result<Vec<u8>, Error> {
+    // Step 1. If length is null or zero, or is not a multiple of 8, then throw an OperationError.
+    // FIXME: The spec is updated.
+    let Some(length) = length else {
+        return Err(Error::Operation);
+    };
+    if length == 0 || length % 8 != 0 {
+        return Err(Error::Operation);
+    };
+
+    // Step 2. If the iterations member of normalizedAlgorithm is zero, then throw an OperationError.
+    let Ok(iterations) = NonZero::<u32>::try_from(normalized_algorithm.iterations) else {
+        return Err(Error::Operation);
+    };
+
+    // TODO: Step 3. If length is zero, return an empty byte sequence.
+    if length == 0 {
+        return Ok(Vec::new());
+    }
+
+    // Step 4. Let prf be the MAC Generation function described in Section 4 of [FIPS-198-1] using
+    // the hash function described by the hash member of normalizedAlgorithm.
+    let prf = match normalized_algorithm.hash.name() {
+        ALG_SHA1 => pbkdf2::PBKDF2_HMAC_SHA1,
+        ALG_SHA256 => pbkdf2::PBKDF2_HMAC_SHA256,
+        ALG_SHA384 => pbkdf2::PBKDF2_HMAC_SHA384,
+        ALG_SHA512 => pbkdf2::PBKDF2_HMAC_SHA512,
+        _ => {
+            return Err(Error::NotSupported);
+        },
+    };
+
+    // Step 5. Let result be the result of performing the PBKDF2 operation defined in Section 5.2
+    // of [RFC8018] using prf as the pseudo-random function, PRF, the password represented by the
+    // [[handle]] internal slot of key as the password, P, the salt attribute of
+    // normalizedAlgorithm as the salt, S, the value of the iterations attribute of
+    // normalizedAlgorithm as the iteration count, c, and length divided by 8 as the intended key
+    // length, dkLen.
+    let mut result = vec![0; length as usize / 8];
+    pbkdf2::derive(
+        prf,
+        iterations,
+        &normalized_algorithm.salt,
+        key.handle().as_bytes(),
+        &mut result,
+    );
+
+    // Step 5. If the key derivation operation fails, then throw an OperationError.
+    // TODO: Investigate when key derivation can fail and how ring handles that case
+    // (pbkdf2::derive does not return a Result type)
+
+    // Step 6. Return result
+    Ok(result)
+}
 
 /// <https://w3c.github.io/webcrypto/#pbkdf2-operations-import-key>
 #[allow(unsafe_code)]
@@ -69,4 +133,10 @@ pub(crate) fn import(
 
     // Step 9. Return key.
     Ok(key)
+}
+
+/// <https://w3c.github.io/webcrypto/#pbkdf2-operations-get-key-length>
+pub(crate) fn get_key_length() -> Result<Option<u32>, Error> {
+    // Step 1. Return null.
+    Ok(None)
 }


### PR DESCRIPTION
Refactoring of the algorithm normalization in #39431 introduces a new algorithm normalization procedure to replace the existing one, and we continue the migration here. This patch is the last piece of this migration.

In this patch:

- The `SubtleCrypto.deriveKey` and `SubtleCrypto.deriveBits` method are migrated from using existing `normalize_algorithm_for_derive_bits`, `normalize_algorithm_for_import_key` and `normalize_algorithm_for_get_key_length` functions to using the new `normalize_algorithm` function.
- The custom types `DeriveBitsAlgorithm`, `ImportKeyAlgorithm` and `GetKeyLengthAlgorithm` used by `normalize_algorithm_for_derive_bits`, `normalize_algorithm_for_import_key` and `normalize_algorithm_for_get_key_length` are removed.
- The custom type `DigestAlgorithm` is also removed.
- The `SubtleHkdfParams::derive_bits` function is moved to sub-module `hkdf_operation`.
- The `Subtlepkdf2Params::derive_bits` function is moved to sub-module `pbkdf2_operation`.
- The `SubtleHmacImportParams::get_key_length` function is moved to sub-module `hmac_operation`.
- The `get_key_length_for_aes` function is moved to sub-module `aes_operation`.
- The `import_key_aes`, `import_key_hkdf`, `import_key_hmac` and `import_key_pbkdf2` are removed since they are no longer in use.

Testing: Refactoring. Existing WPT tests suffice.
Fixes: Part of #39368
