### PR TITLE
libservo: Notify the embedder when an input event can't be sent to a Pipeline

### DIFF
--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -65,7 +65,7 @@ impl MixedMessage {
                 ScriptThreadMessage::UnloadDocument(id) => Some(*id),
                 ScriptThreadMessage::ExitPipeline(_webview_id, id, ..) => Some(*id),
                 ScriptThreadMessage::ExitScriptThread => None,
-                ScriptThreadMessage::SendInputEvent(id, ..) => Some(*id),
+                ScriptThreadMessage::SendInputEvent(_, id, _) => Some(*id),
                 ScriptThreadMessage::RefreshCursor(id, ..) => Some(*id),
                 ScriptThreadMessage::Viewport(id, ..) => Some(*id),
                 ScriptThreadMessage::GetTitle(id) => Some(*id),

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -148,7 +148,7 @@ pub enum ScriptThreadMessage {
     /// Notifies the script that the whole thread should be closed.
     ExitScriptThread,
     /// Sends a DOM event.
-    SendInputEvent(PipelineId, ConstellationInputEvent),
+    SendInputEvent(WebViewId, PipelineId, ConstellationInputEvent),
     /// Request that the given pipeline refresh the cursor by doing a hit test at the most
     /// recently hovered cursor position and resetting the cursor. This happens after a
     /// display list update is rendered.


### PR DESCRIPTION
The `WebViewDelegate::notify_input_event_handled` method is called for the
embedder when an input event's processing has finished within Servo.
This allows the embedder to chain the event up to parent widgets or do
some kind of post-processing such as the implementation of overridable
keybindings.

This change makes it so that this method is called even when an input
event cannot successfully be sent to a pipeline. This could happen when
an event is handled during navigation or perhaps during shutdown. In any
case, Servo should *always* tell the embedder when the event is done
processing so that they don't get eaten by the Servo widget.

Testing: This is very difficult to test as it only happens in very specific
time-sensitive sitautions.
