### PR TITLE
compositor: Remove the `CompositorMsg::TouchEventProcessed` message

### DIFF
--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -33,7 +33,6 @@ mod from_constellation {
                 Self::ChangeRunningAnimationsState(..) => target!("ChangeRunningAnimationsState"),
                 Self::CreateOrUpdateWebView(..) => target!("CreateOrUpdateWebView"),
                 Self::RemoveWebView(..) => target!("RemoveWebView"),
-                Self::TouchEventProcessed(..) => target!("TouchEventProcessed"),
                 Self::SetThrottled(..) => target!("SetThrottled"),
                 Self::NewWebRenderFrameReady(..) => target!("NewWebRenderFrameReady"),
                 Self::PipelineExited(..) => target!("PipelineExited"),

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1884,16 +1884,6 @@ where
                 };
                 self.handle_log_entry(Some(webview_id), thread_name, entry);
             },
-            ScriptToConstellationMessage::TouchEventProcessed(result) => {
-                let Some(webview_id) = get_webview_id() else {
-                    return warn!(
-                        "{}: TouchEventProcessed from closed pipeline",
-                        source_pipeline_id
-                    );
-                };
-                self.compositor_proxy
-                    .send(CompositorMsg::TouchEventProcessed(webview_id, result))
-            },
             ScriptToConstellationMessage::GetBrowsingContextInfo(pipeline_id, response_sender) => {
                 let result = self
                     .pipelines

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -164,7 +164,6 @@ mod from_script {
                 Self::ActivateDocument => target!("ActivateDocument"),
                 Self::SetDocumentState(..) => target!("SetDocumentState"),
                 Self::SetFinalUrl(..) => target!("SetFinalUrl"),
-                Self::TouchEventProcessed(..) => target!("TouchEventProcessed"),
                 Self::LogEntry(..) => target!("LogEntry"),
                 Self::DiscardDocument => target!("DiscardDocument"),
                 Self::DiscardTopLevelBrowsingContext => target!("DiscardTopLevelBrowsingContext"),

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -212,11 +212,6 @@ use crate::task::NonSendTaskBox;
 use crate::task_source::TaskSourceName;
 use crate::timers::OneshotTimerCallback;
 
-pub(crate) enum TouchEventResult {
-    Processed(bool),
-    Forwarded,
-}
-
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) enum FireMouseEventType {
     Move,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -764,6 +764,12 @@ impl Servo {
                     .finish_evaluation(evaluation_id, result);
             },
             EmbedderMsg::InputEventHandled(webview_id, input_event_id, result) => {
+                self.compositor.borrow_mut().notify_input_event_handled(
+                    webview_id,
+                    input_event_id,
+                    result,
+                );
+
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     webview
                         .delegate()

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -9,7 +9,7 @@ use std::fmt::{Debug, Error, Formatter};
 use base::Epoch;
 use base::id::{PipelineId, RenderingGroupId, WebViewId};
 use crossbeam_channel::Sender;
-use embedder_traits::{AnimationState, EventLoopWaker, TouchEventResult};
+use embedder_traits::{AnimationState, EventLoopWaker};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
 use rustc_hash::FxHashMap;
@@ -85,8 +85,6 @@ pub enum CompositorMsg {
     CreateOrUpdateWebView(SendableFrameTree),
     /// Remove a webview.
     RemoveWebView(WebViewId),
-    /// Script has handled a touch event, and either prevented or allowed default actions.
-    TouchEventProcessed(WebViewId, TouchEventResult),
     /// Set whether to use less resources by stopping animations.
     SetThrottled(WebViewId, PipelineId, bool),
     /// WebRender has produced a new frame. This message informs the compositor that

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -18,8 +18,7 @@ use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId};
 use embedder_traits::{
     AnimationState, FocusSequenceNumber, JSValue, JavaScriptEvaluationError,
-    JavaScriptEvaluationId, MediaSessionEvent, ScriptToEmbedderChan, Theme, TouchEventResult,
-    ViewportDetails,
+    JavaScriptEvaluationId, MediaSessionEvent, ScriptToEmbedderChan, Theme, ViewportDetails,
 };
 use euclid::default::Size2D as UntypedSize2D;
 use fonts_traits::SystemFontServiceProxySender;
@@ -651,8 +650,6 @@ pub enum ScriptToConstellationMessage {
     SetDocumentState(DocumentState),
     /// Update the pipeline Url, which can change after redirections.
     SetFinalUrl(ServoUrl),
-    /// Script has handled a touch event, and either prevented or allowed default actions.
-    TouchEventProcessed(TouchEventResult),
     /// A log entry, with the top-level browsing context id and thread name
     LogEntry(Option<String>, LogEntry),
     /// Discard the document.

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -950,15 +950,6 @@ pub struct CompositorHitTestResult {
     pub external_scroll_id: ExternalScrollId,
 }
 
-/// Whether the default action for a touch event was prevented by web content
-#[derive(Debug, Deserialize, Serialize)]
-pub enum TouchEventResult {
-    /// Allowed by web content
-    DefaultAllowed(TouchSequenceId, TouchEventType),
-    /// Prevented by web content
-    DefaultPrevented(TouchSequenceId, TouchEventType),
-}
-
 /// For a given pipeline, whether any animations are currently running
 /// and any animation callbacks are queued
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]


### PR DESCRIPTION
The renderer needs needs to know when touch events processing has
finished in the DOM in order to properly handle them. This was
previously done using the `CompositorMsg::TouchEventProcessed` message.
This message is now redudant with the general-purpose
`EmbedderMsg::InputEventHandled` message.

This change removes the former message and instead, has the
`TouchHandler` keep a `HashMap` of pending touch events which is uses to
finish their processing when they come back from script. The goal here
is reduce the number of messages sent and to keep the complexity of
touch handling more centered in the `TouchHandler`.

Testing: This should not change observable behavior, so is covered by existing tests.
