### PR TITLE
testing: Use nextest for unit-tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -209,6 +209,10 @@ jobs:
         run: xvfb-run ./mach smoketest --${{ inputs.profile  }}
       - name: Script tests
         run: ./mach test-scripts
+      - name: Install cargo nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
         uses: nick-fields/retry@v3

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -185,6 +185,10 @@ jobs:
           command: ./mach smoketest --${{ inputs.profile }}
       - name: Script tests
         run: ./mach test-scripts
+      - name: Install cargo nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
         uses: nick-fields/retry@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -198,6 +198,10 @@ jobs:
         run: cp D:\a\servo\servo\resources C:\a\servo\servo -Recurse
       - name: Smoketest
         run: .\mach smoketest --${{ inputs.profile }}
+      - name: Install cargo nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
         uses: nick-fields/retry@v3

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -199,9 +199,14 @@ jobs:
       - name: Smoketest
         run: .\mach smoketest --${{ inputs.profile }}
       - name: Install cargo nextest
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
+      # On self-hosted windows runners the install-action fails
+      - name: Install cargo nextest (self-hosted)
+        if: ${{ runner.environment == 'self-hosted' }}
+        run: cargo install cargo-nextest --locked
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
         uses: nick-fields/retry@v3

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -68,6 +68,7 @@ struct FetchResponseCollector {
 }
 
 fn create_embedder_proxy() -> EmbedderProxy {
+    let _init = ASYNC_RUNTIME.clone();
     let (sender, _) = unbounded();
     let event_loop_waker = || {
         struct DummyEventLoopWaker {}

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -22,18 +22,45 @@ macro_rules! run_api_tests {
         run_api_tests!(setup: |builder| builder, $($test_function),+)
     };
     (setup: $builder:expr, $($test_function:ident), +) => {
-        let mut failed = false;
 
-        // Be sure that `servo_test` is dropped before exiting early.
         {
-            let servo_test = ServoTest::new($builder);
-            $(
-                common::run_test($test_function, stringify!($test_function), &servo_test, &mut failed);
-            )+
-        }
-
-        if failed {
-            std::process::exit(1);
+            // We expect the number of tests to be low, so we just use a vec for the lookup.
+            let test_map: Vec<(&'static str, fn(&ServoTest) -> Result<(), anyhow::Error>)> = vec![
+                $((stringify!($test_function), $test_function)),+
+            ];
+            // See nextest custom test harness requirements:
+            // <https://nexte.st/docs/design/custom-test-harnesses/>
+            let args =  std::env::args().collect::<Vec<_>>();
+            if args.iter().any(|arg| arg == "--list") {
+                if args.iter().any(|arg| arg == "--ignored") {
+                    // If there are no ignored tests or if the test harness doesn't support ignored tests,
+                    // the output MUST be empty
+                    return;
+                } else {
+                        // Expected output:
+                        // ```
+                        // my-test-1: test
+                        // my-test-2: test
+                        // ```
+                        for (test_name, _test_fn) in test_map.iter() {
+                            println!("{test_name}: test")
+                        }
+                    return;
+                }
+            } else if args.len() == 4 && args[2] == "--nocapture" && args[3] == "--exact" {
+                // <test-name> --nocapture --exact
+                let exact_test_name = &args[1];
+                let servo_test = ServoTest::new($builder);
+                let Some((test_name, test_fn)) =  test_map.iter().find(|(test_name, _test_fn)| test_name == exact_test_name) else {
+                    eprintln!("Failed to find test '{exact_test_name}'");
+                    std::process::exit(127);
+                };
+                let mut failed = false;
+                common::run_test(*test_fn, test_name, &servo_test, &mut failed);
+                if failed {
+                    std::process::exit(1);
+                }
+            }
         }
     };
 }
@@ -47,11 +74,11 @@ pub(crate) fn run_test(
     failed: &mut bool,
 ) {
     match test_function(servo_test) {
-        Ok(_) => println!("    ✅ {test_name}"),
+        Ok(_) => eprintln!("    ✅ {test_name}"),
         Err(error) => {
             *failed = true;
-            println!("    ❌ {test_name}");
-            println!("{}", format!("\n{error:?}").replace("\n", "\n        "));
+            eprintln!("    ❌ {test_name}");
+            eprintln!("{}", format!("\n{error:?}").replace("\n", "\n        "));
         },
     }
 }

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -37,14 +37,14 @@ macro_rules! run_api_tests {
                     // the output MUST be empty
                     return;
                 } else {
-                        // Expected output:
-                        // ```
-                        // my-test-1: test
-                        // my-test-2: test
-                        // ```
-                        for (test_name, _test_fn) in test_map.iter() {
-                            println!("{test_name}: test")
-                        }
+                    // Expected output:
+                    // ```
+                    // my-test-1: test
+                    // my-test-2: test
+                    // ```
+                    for (test_name, _test_fn) in test_map.iter() {
+                        println!("{test_name}: test")
+                    }
                     return;
                 }
             } else if args.len() == 4 && args[2] == "--nocapture" && args[3] == "--exact" {

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -59,6 +59,7 @@ class Base:
         if not skip_platform:
             installed_something |= self._platform_bootstrap(force)
         self.install_rust_toolchain()
+        installed_something |= self.install_cargo_nextest(force)
         if not skip_lints:
             installed_something |= self.install_taplo(force)
             installed_something |= self.install_cargo_deny(force)
@@ -100,6 +101,20 @@ class Base:
         print(" * Installing cargo-deny...")
         if subprocess.call(["cargo", "install", "cargo-deny@0.18.3", "--locked"]) != 0:
             raise EnvironmentError("Installation of cargo-deny failed.")
+        return True
+
+    def install_cargo_nextest(self, force: bool) -> bool:
+        def cargo_deny_installed() -> bool:
+            if force or not shutil.which("cargo-nextest"):
+                return False
+            return True
+
+        if cargo_deny_installed():
+            return False
+
+        print(" * Installing cargo-nextest...")
+        if subprocess.call(["cargo", "install", "cargo-nextest", "--locked"]) != 0:
+            raise EnvironmentError("Installation of cargo-nextest failed.")
         return True
 
     def install_crown(self, force: bool) -> bool:

--- a/python/servo/platform/base.py
+++ b/python/servo/platform/base.py
@@ -104,14 +104,8 @@ class Base:
         return True
 
     def install_cargo_nextest(self, force: bool) -> bool:
-        def cargo_deny_installed() -> bool:
-            if force or not shutil.which("cargo-nextest"):
-                return False
-            return True
-
-        if cargo_deny_installed():
+        if not force and shutil.which("cargo-nextest") is not None:
             return False
-
         print(" * Installing cargo-nextest...")
         if subprocess.call(["cargo", "install", "cargo-nextest", "--locked"]) != 0:
             raise EnvironmentError("Installation of cargo-nextest failed.")

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -277,14 +277,15 @@ class MachCommands(CommandBase):
                 exit(1)
         elif code_coverage:
             cargo_llvm_cov_options: List[str] = llvm_cov_option or []
-            crown_cargo_command.extend(["llvm-cov", "test"])
+            crown_cargo_command.extend(["llvm-cov", "nextest"])
             crown_cargo_command.extend(cargo_llvm_cov_options)
             cargo_command = "llvm-cov"
-            args.insert(0, "test")
+            args.insert(0, "nextest")
             args.extend(cargo_llvm_cov_options)
         else:
-            crown_cargo_command.append("test")
-            cargo_command = "test"
+            crown_cargo_command.extend(["nextest", "run"])
+            cargo_command = "nextest"
+            args.insert(0, "run")
         result = call(crown_cargo_command, cwd="support/crown")
         if result != 0:
             return result

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -252,7 +252,7 @@ class MachCommands(CommandBase):
         elif build_type.is_dev():
             pass  # there is no argument for debug
         else:
-            args += ["--profile", build_type.profile]
+            args += ["--cargo-profile", build_type.profile]
 
         for crate in packages:
             args += ["-p", "%s_tests" % crate]

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -261,7 +261,8 @@ class MachCommands(CommandBase):
         args += test_patterns
 
         if nocapture:
-            args += ["--", "--nocapture"]
+            args += ["--nocapture"]
+        args += ["--no-fail-fast"]
 
         env = self.build_env()
 

--- a/shell.nix
+++ b/shell.nix
@@ -80,6 +80,7 @@ stdenv.mkDerivation (androidEnvironment // {
     rustup
     taplo
     cargo-deny
+    cargo-nextest
     llvmPackages.bintools # provides lld
 
     udev # Needed by libudev-sys for GamePad API.


### PR DESCRIPTION
Nextest is a powerful test runner, with many advantages over cargo test. Among others it will run each test in a separate process, provide a summary of the completed test execution, supports output formats like JUnit, and can handle flaky test by retrying. This PR does not use most of these advanced features yet though, that will be left to future PRs.

The change also uncovered racy tests in `net` which rely on someone initializing the `ASYNC_RUNTIME` before the test in questions is run. By explicitly accessing the lazy static in a common setup routine, we make sure it is initialized.

CLI differences of `cargo test` vs `cargo nextest`: 

- The `--profile` option in nextest is not the cargo profile, but refers to nextest configuration profiles.
- `--nocapture` is a direct argument to nextest, not to the testharness, so we can remove the preceding `--` seperator. 

Testing: Tested by running unit-tests in CI
Fixes: #39797 
