### PR TITLE
servoshell: Clean up minibrowser mutability

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -717,10 +717,7 @@ impl ApplicationHandler<AppEvent> for App {
                         scale_factor, effective_egui_zoom_factor
                     );
 
-                    minibrowser
-                        .context
-                        .egui_ctx
-                        .set_zoom_factor(effective_egui_zoom_factor);
+                    minibrowser.set_zoom_factor(effective_egui_zoom_factor);
 
                     state.hidpi_scale_factor_changed();
 

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -282,7 +282,7 @@ impl App {
 
     /// Takes any events generated during `egui` updates and performs their actions.
     fn handle_servoshell_ui_events(&mut self) {
-        let Some(minibrowser) = self.minibrowser.as_ref() else {
+        let Some(minibrowser) = self.minibrowser.as_mut() else {
             return;
         };
         // We should always be in the running state.

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -38,7 +38,7 @@ use crate::prefs::{EXPERIMENTAL_PREFS, ServoShellPreferences};
 
 pub struct Minibrowser {
     rendering_context: Rc<OffscreenRenderingContext>,
-    pub context: EguiGlow,
+    context: EguiGlow,
     event_queue: Vec<MinibrowserEvent>,
     toolbar_height: Length<f32, DeviceIndependentPixel>,
 
@@ -572,6 +572,11 @@ impl Minibrowser {
                 false
             },
         }
+    }
+
+    pub(crate) fn set_zoom_factor(&self, factor: f32) {
+        self.context.egui_ctx.set_zoom_factor(factor);
+
     }
 }
 

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -45,7 +45,7 @@ pub struct Minibrowser {
 
     last_update: Instant,
     last_mouse_position: Option<Point2D<f32, DeviceIndependentPixel>>,
-    location: RefCell<String>,
+    location: String,
 
     /// Whether the location has been edited by the user without clicking Go.
     location_dirty: Cell<bool>,
@@ -121,7 +121,7 @@ impl Minibrowser {
             toolbar_height: Default::default(),
             last_update: Instant::now(),
             last_mouse_position: None,
-            location: RefCell::new(initial_url.to_string()),
+            location: initial_url.to_string(),
             location_dirty: false.into(),
             load_status: LoadStatus::Complete,
             status_text: None,
@@ -361,7 +361,7 @@ impl Minibrowser {
                                     let location_id = egui::Id::new("location_input");
                                     let location_field = ui.add_sized(
                                         ui.available_size(),
-                                        egui::TextEdit::singleline(&mut *location.borrow_mut())
+                                        egui::TextEdit::singleline(location)
                                             .id(location_id),
                                     );
 
@@ -388,7 +388,7 @@ impl Minibrowser {
                                             // Select the whole input.
                                             state.cursor.set_char_range(Some(CCursorRange::two(
                                                 CCursor::new(0),
-                                                CCursor::new(location.borrow().len()),
+                                                CCursor::new(location.len()),
                                             )));
                                             state.store(ui.ctx(), location_id);
                                         }
@@ -399,7 +399,7 @@ impl Minibrowser {
                                     {
                                         event_queue
                                             .borrow_mut()
-                                            .push(MinibrowserEvent::Go(location.borrow().clone()));
+                                            .push(MinibrowserEvent::Go(location.clone()));
                                     }
                                 },
                             );
@@ -516,8 +516,8 @@ impl Minibrowser {
             .focused_webview()
             .and_then(|webview| Some(webview.url()?.to_string()));
         match current_url_string {
-            Some(location) if location != *self.location.get_mut() => {
-                self.location = RefCell::new(location.to_owned());
+            Some(location) if location != self.location => {
+                self.location = location.to_owned();
                 true
             },
             _ => false,

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -164,8 +164,7 @@ impl Minibrowser {
                 button: MouseButton::Forward,
                 ..
             } => {
-                self.event_queue
-                    .push(MinibrowserEvent::Forward);
+                self.event_queue.push(MinibrowserEvent::Forward);
                 true
             },
             WindowEvent::MouseInput {
@@ -359,8 +358,7 @@ impl Minibrowser {
                                     let location_id = egui::Id::new("location_input");
                                     let location_field = ui.add_sized(
                                         ui.available_size(),
-                                        egui::TextEdit::singleline(location)
-                                            .id(location_id),
+                                        egui::TextEdit::singleline(location).id(location_id),
                                     );
 
                                     if location_field.changed() {
@@ -395,8 +393,7 @@ impl Minibrowser {
                                     if location_field.lost_focus() &&
                                         ui.input(|i| i.clone().key_pressed(Key::Enter))
                                     {
-                                        event_queue
-                                            .push(MinibrowserEvent::Go(location.clone()));
+                                        event_queue.push(MinibrowserEvent::Go(location.clone()));
                                     }
                                 },
                             );
@@ -576,7 +573,6 @@ impl Minibrowser {
 
     pub(crate) fn set_zoom_factor(&self, factor: f32) {
         self.context.egui_ctx.set_zoom_factor(factor);
-
     }
 }
 

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -48,7 +48,7 @@ pub struct Minibrowser {
     location: String,
 
     /// Whether the location has been edited by the user without clicking Go.
-    location_dirty: Cell<bool>,
+    location_dirty: bool,
 
     load_status: LoadStatus,
 
@@ -122,7 +122,7 @@ impl Minibrowser {
             last_update: Instant::now(),
             last_mouse_position: None,
             location: initial_url.to_string(),
-            location_dirty: false.into(),
+            location_dirty: false,
             load_status: LoadStatus::Complete,
             status_text: None,
             favicon_textures: Default::default(),
@@ -366,7 +366,7 @@ impl Minibrowser {
                                     );
 
                                     if location_field.changed() {
-                                        location_dirty.set(true);
+                                        *location_dirty = true;
                                     }
                                     // Handle adddress bar shortcut.
                                     if ui.input(|i| {
@@ -508,7 +508,7 @@ impl Minibrowser {
     /// editing it without clicking Go, returning true iff it has changed (needing an egui update).
     pub fn update_location_in_toolbar(&mut self, state: &RunningAppState) -> bool {
         // User edited without clicking Go?
-        if self.location_dirty.get() {
+        if self.location_dirty {
             return false;
         }
 
@@ -524,8 +524,8 @@ impl Minibrowser {
         }
     }
 
-    pub fn update_location_dirty(&self, dirty: bool) {
-        self.location_dirty.set(dirty);
+    pub fn update_location_dirty(&mut self, dirty: bool) {
+        self.location_dirty = dirty;
     }
 
     pub fn update_load_status(&mut self, state: &RunningAppState) -> bool {


### PR DESCRIPTION
Remove unnecessary interior mutability from the minibrowser implementation, and make all remaining members private.

Testing: Existing tests suffice; this is a refactoring that leans into the supported Rust safety model.