### PR TITLE
ci: Use nextest --retries in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.default]
+# Print a slow warning after period, terminate unit-test after 4x period.
+slow-timeout = { period = "5s", terminate-after = 4 }

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -212,10 +212,6 @@ jobs:
         run: xvfb-run ./mach smoketest --${{ inputs.profile  }}
       - name: Script tests
         run: ./mach test-scripts
-      - name: Install cargo nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: nextest
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
         env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -188,6 +188,9 @@ jobs:
       - name: Change Mirror Priorities
         if: ${{ runner.environment != 'self-hosted' }}
         uses: ./.github/actions/apt-mirrors
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Bootstrap dependencies
         if: ${{ runner.environment != 'self-hosted' }}
         timeout-minutes: 10
@@ -215,11 +218,9 @@ jobs:
           tool: nextest
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 2 # https://github.com/servo/servo/issues/30683
-          command: ./mach test-unit --${{ inputs.profile }}
+        env:
+          NEXTEST_RETRIES: 2 # https://github.com/servo/servo/issues/30683
+        run: ./mach test-unit --${{ inputs.profile }}
       - name: Devtools tests
         if: ${{ inputs.unit-tests }}
         run: ./mach test-devtools --${{ inputs.profile }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -168,6 +168,10 @@ jobs:
       - name: Install crown
         run: cargo install --path support/crown
 
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - if: runner.environment != 'self-hosted'
         name: Bootstrap
         run: |
@@ -191,11 +195,9 @@ jobs:
           tool: nextest
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 40 # https://github.com/servo/servo/issues/30275
-          max_attempts: 3 # https://github.com/servo/servo/issues/30683
-          command: ./mach test-unit --${{ inputs.profile }}
+        env:
+          NEXTEST_RETRIES: 3 # https://github.com/servo/servo/issues/30683
+        run: ./mach test-unit --${{ inputs.profile }}
       - name: Devtools tests
         if: ${{ inputs.unit-tests }}
         run: ./mach test-devtools --${{ inputs.profile }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -189,10 +189,6 @@ jobs:
           command: ./mach smoketest --${{ inputs.profile }}
       - name: Script tests
         run: ./mach test-scripts
-      - name: Install cargo nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: nextest
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
         env:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -180,7 +180,9 @@ jobs:
       # commit we are building uses a different rustc version.
       - name: Install crown
         run: cargo install --path support/crown --force
-
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Debug logging for incremental builds
         if: ${{ runner.environment == 'self-hosted' }}
         run: |
@@ -209,11 +211,9 @@ jobs:
         run: cargo install cargo-nextest --locked
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 30
-          max_attempts: 3 # https://github.com/servo/servo/issues/30683
-          command: .\mach test-unit --${{ inputs.profile }} -- -- --test-threads=1
+        env:
+          NEXTEST_RETRIES: 3 # https://github.com/servo/servo/issues/30683
+        run: ./mach test-unit --${{ inputs.profile }}
       - name: Devtools tests
         if: ${{ inputs.unit-tests }}
         run: .\mach test-devtools --${{ inputs.profile }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -180,9 +180,6 @@ jobs:
       # commit we are building uses a different rustc version.
       - name: Install crown
         run: cargo install --path support/crown --force
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: nextest
       - name: Debug logging for incremental builds
         if: ${{ runner.environment == 'self-hosted' }}
         run: |


### PR DESCRIPTION
Follow-up to #39812, using nextests builtin retry feature to rerun flaky unit-tests. 
This also adds a per-test timeout, replacing the global timeout set for the retry action. We could also add a global timeout for nextest tests, but per-test timeouts should be sufficient and noticably speedup CI when individual unit tests get stuck.

Testing: [mach try](https://github.com/servo/servo/actions/runs/18519094535) running the unit-tests with retries in CI. 
