### PR TITLE
script: Register "get key length" operation for AES-KW

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -2481,7 +2481,12 @@ fn normalize_algorithm(
                     params.name = DOMString::from(alg_name);
                     NormalizedAlgorithm::Algorithm(params.into())
                 },
-                // FIXME: Register "get key length" operation of AES-KW
+                (ALG_AES_KW, Operation::GetKeyLength) => {
+                    let mut params =
+                        value_from_js_object::<AesDerivedKeyParams>(cx, value.handle(), can_gc)?;
+                    params.parent.name = DOMString::from(alg_name);
+                    NormalizedAlgorithm::AesDerivedKeyParams(params.into())
+                },
 
                 // <https://w3c.github.io/webcrypto/#hmac-registration>
                 (ALG_HMAC, Operation::Sign) => {

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/hkdf.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/hkdf.https.any.js.ini
@@ -71,25 +71,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -182,25 +173,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -293,25 +275,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -404,25 +377,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -515,25 +479,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -626,25 +581,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -725,25 +671,13 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -812,25 +746,13 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -937,25 +859,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -1048,25 +961,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -1159,25 +1063,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -1270,25 +1165,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -1381,25 +1267,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -1492,25 +1369,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -1591,25 +1459,13 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -1678,25 +1534,13 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -1777,25 +1621,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -1888,25 +1723,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -1999,25 +1825,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -2110,25 +1927,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -2221,25 +2029,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -2433,25 +2232,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -2544,25 +2334,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -2655,25 +2436,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -2766,25 +2538,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -2877,25 +2640,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -2988,25 +2742,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -3087,25 +2832,13 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -3174,25 +2907,13 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -3254,25 +2975,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -3353,25 +3065,13 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -3440,25 +3140,13 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -3539,25 +3227,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -3650,25 +3329,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -3761,25 +3431,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -3872,25 +3533,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -3983,25 +3635,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -4094,25 +3737,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -4193,25 +3827,13 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -4280,25 +3902,13 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -4379,25 +3989,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -4490,25 +4091,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -4681,25 +4273,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -4792,25 +4375,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -4903,25 +4477,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -5014,25 +4579,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -5125,25 +4681,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -5236,25 +4783,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -5335,25 +4873,13 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -5422,25 +4948,13 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -5521,25 +5035,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -5632,25 +5137,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -5743,25 +5239,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -5854,25 +5341,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -5965,25 +5443,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -6120,25 +5589,16 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -6219,25 +5679,13 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -6306,25 +5754,13 @@
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -6405,25 +5841,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -6516,25 +5943,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -6627,25 +6045,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -6738,25 +6147,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -6849,25 +6249,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -6960,25 +6351,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -7059,25 +6441,13 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -7146,25 +6516,13 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -7245,25 +6603,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -7356,25 +6705,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -7508,25 +6848,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -7619,25 +6950,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -7730,25 +7052,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -7841,25 +7154,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -7940,25 +7244,13 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -8027,25 +7319,13 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -8126,25 +7406,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -8237,25 +7508,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -8348,25 +7610,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -8459,25 +7712,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -8570,25 +7814,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -8681,25 +7916,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -8780,25 +8006,13 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -8867,25 +8081,13 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -8956,25 +8158,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -9067,25 +8260,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -9178,25 +8362,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -9289,25 +8464,16 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -9388,25 +8554,13 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -9475,25 +8629,13 @@
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -9574,25 +8716,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with normal info with wrong (ECDH) key]
@@ -9685,25 +8818,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-384, with empty info with wrong (ECDH) key]
@@ -9796,25 +8920,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with normal info with wrong (ECDH) key]
@@ -9907,25 +9022,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-512, with empty info with wrong (ECDH) key]
@@ -10018,25 +9124,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with normal info with wrong (ECDH) key]
@@ -10129,25 +9226,16 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-1, with empty info with wrong (ECDH) key]
@@ -10228,25 +9316,13 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with normal info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with normal info with wrong (ECDH) key]
@@ -10315,25 +9391,13 @@
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with empty info]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js.ini
@@ -38,28 +38,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -78,15 +60,6 @@
     expected: FAIL
 
   [long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -116,28 +89,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -185,28 +140,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -245,28 +182,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -287,15 +206,6 @@
   [long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -314,28 +224,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -374,28 +266,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -434,28 +308,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -476,15 +332,6 @@
   [long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -503,28 +350,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -563,28 +392,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -623,28 +434,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -665,15 +458,6 @@
   [long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -692,28 +476,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -752,28 +518,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -937,28 +685,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -979,15 +709,6 @@
   [long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -1006,28 +727,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -1066,28 +769,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -1126,28 +811,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -1168,15 +835,6 @@
   [long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -1195,28 +853,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -1255,28 +895,10 @@
   [Derived key of type name: AES-CTR length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -1324,28 +946,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -1364,15 +968,6 @@
     expected: FAIL
 
   [long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -1402,28 +997,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -1471,28 +1048,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -1540,28 +1099,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -1580,15 +1121,6 @@
     expected: FAIL
 
   [long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -1618,28 +1150,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -1687,28 +1201,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -1756,28 +1252,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -1902,28 +1380,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -1971,28 +1431,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -2040,28 +1482,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -2080,15 +1504,6 @@
     expected: FAIL
 
   [empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -2118,28 +1533,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -2187,28 +1584,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -2256,28 +1635,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -2296,15 +1657,6 @@
     expected: FAIL
 
   [empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -2334,28 +1686,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -2403,28 +1737,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -2472,28 +1788,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -2512,15 +1810,6 @@
     expected: FAIL
 
   [empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -2550,28 +1839,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -2619,28 +1890,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -2688,28 +1941,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -2728,15 +1963,6 @@
     expected: FAIL
 
   [empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -2766,28 +1992,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -2858,28 +2066,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -2927,28 +2117,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -2967,15 +2139,6 @@
     expected: FAIL
 
   [short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -3005,28 +2168,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -3074,28 +2219,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -3143,28 +2270,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -3183,15 +2292,6 @@
     expected: FAIL
 
   [short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -3221,28 +2321,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -3290,28 +2372,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -3359,28 +2423,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -3399,15 +2445,6 @@
     expected: FAIL
 
   [short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -3437,28 +2474,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -3506,28 +2525,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -3575,28 +2576,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -3615,15 +2598,6 @@
     expected: FAIL
 
   [short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -3653,28 +2627,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -3722,28 +2678,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -3796,28 +2734,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -3865,28 +2785,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -3905,15 +2807,6 @@
     expected: FAIL
 
   [empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -3943,28 +2836,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -4012,28 +2887,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -4081,28 +2938,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -4121,15 +2960,6 @@
     expected: FAIL
 
   [empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -4159,28 +2989,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -4228,28 +3040,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -4297,28 +3091,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -4337,15 +3113,6 @@
     expected: FAIL
 
   [empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [empty password, empty salt, SHA-512, with 100000 iterations with 0 length]
@@ -4383,28 +3150,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -4423,15 +3172,6 @@
     expected: FAIL
 
   [long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -4461,28 +3201,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -4530,28 +3252,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -4599,28 +3303,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -4639,15 +3325,6 @@
     expected: FAIL
 
   [long password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -4677,28 +3354,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -4746,28 +3405,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -4815,28 +3456,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -4855,15 +3478,6 @@
     expected: FAIL
 
   [long password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -4893,28 +3507,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -4962,28 +3558,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -5031,28 +3609,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -5071,15 +3631,6 @@
     expected: FAIL
 
   [long password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -5109,28 +3660,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -5178,28 +3711,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -5247,28 +3762,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -5339,28 +3836,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -5408,28 +3887,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -5477,28 +3938,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -5517,15 +3960,6 @@
     expected: FAIL
 
   [empty password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -5555,28 +3989,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -5624,28 +4040,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -5693,28 +4091,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -5733,15 +4113,6 @@
     expected: FAIL
 
   [empty password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -5771,28 +4142,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -5840,28 +4193,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -5909,28 +4244,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -5949,15 +4266,6 @@
     expected: FAIL
 
   [empty password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -5987,28 +4295,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -6056,28 +4346,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -6125,28 +4397,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -6165,15 +4419,6 @@
     expected: FAIL
 
   [empty password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -6203,28 +4448,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -6274,19 +4501,7 @@
 
 
 [pbkdf2.https.any.worker.html?1001-2000]
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -6334,28 +4549,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -6403,28 +4600,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -6443,15 +4622,6 @@
     expected: FAIL
 
   [short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -6481,28 +4651,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -6550,28 +4702,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -6619,28 +4753,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -6659,15 +4775,6 @@
     expected: FAIL
 
   [short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -6697,28 +4804,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -6766,28 +4855,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -6835,28 +4906,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -6875,15 +4928,6 @@
     expected: FAIL
 
   [short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -6913,28 +4957,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -6982,28 +5008,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -7051,28 +5059,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -7091,15 +5081,6 @@
     expected: FAIL
 
   [short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -7129,28 +5110,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -7221,19 +5184,7 @@
 
 
 [pbkdf2.https.any.html?1001-2000]
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -7281,28 +5232,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -7350,28 +5283,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -7390,15 +5305,6 @@
     expected: FAIL
 
   [short password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -7428,28 +5334,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -7497,28 +5385,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -7566,28 +5436,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -7606,15 +5458,6 @@
     expected: FAIL
 
   [short password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -7644,28 +5487,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -7713,28 +5538,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -7782,28 +5589,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -7822,15 +5611,6 @@
     expected: FAIL
 
   [short password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -7860,28 +5640,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -7929,28 +5691,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -7998,28 +5742,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -8038,15 +5764,6 @@
     expected: FAIL
 
   [short password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -8076,28 +5793,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -8171,15 +5870,6 @@
   [long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -8207,28 +5897,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -8276,28 +5948,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -8345,28 +5999,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -8385,15 +6021,6 @@
     expected: FAIL
 
   [long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -8423,28 +6050,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -8492,28 +6101,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -8561,28 +6152,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -8601,15 +6174,6 @@
     expected: FAIL
 
   [long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -8639,28 +6203,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -8708,28 +6254,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -8777,28 +6305,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -8817,15 +6327,6 @@
     expected: FAIL
 
   [long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -8855,28 +6356,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -8924,28 +6407,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -8993,28 +6458,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -9033,15 +6480,6 @@
     expected: FAIL
 
   [empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -9127,28 +6565,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -9196,28 +6616,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -9265,28 +6667,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -9305,15 +6689,6 @@
     expected: FAIL
 
   [short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -9343,28 +6718,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -9412,28 +6769,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -9481,28 +6820,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -9521,15 +6842,6 @@
     expected: FAIL
 
   [short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -9559,28 +6871,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -9628,28 +6922,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -9697,28 +6973,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -9737,15 +6995,6 @@
     expected: FAIL
 
   [short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -9775,28 +7024,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -9844,28 +7075,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -9913,28 +7126,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -9953,15 +7148,6 @@
     expected: FAIL
 
   [short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -9989,12 +7175,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -10077,28 +7257,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -10146,28 +7308,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -10186,15 +7330,6 @@
     expected: FAIL
 
   [empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -10224,28 +7359,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -10293,28 +7410,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -10362,28 +7461,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -10402,15 +7483,6 @@
     expected: FAIL
 
   [empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -10440,28 +7512,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -10509,28 +7563,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -10578,28 +7614,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -10618,15 +7636,6 @@
     expected: FAIL
 
   [empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -10656,28 +7665,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -10725,28 +7716,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -10794,28 +7767,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -10834,15 +7789,6 @@
     expected: FAIL
 
   [empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -10872,28 +7818,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -11012,28 +7940,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -11081,28 +7991,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -11121,15 +8013,6 @@
     expected: FAIL
 
   [empty password, long salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -11159,28 +8042,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -11228,28 +8093,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -11297,28 +8144,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -11337,15 +8166,6 @@
     expected: FAIL
 
   [empty password, long salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -11375,28 +8195,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -11444,28 +8246,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -11513,28 +8297,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -11553,15 +8319,6 @@
     expected: FAIL
 
   [empty password, long salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, long salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, long salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -11591,28 +8348,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -11660,28 +8399,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -11729,28 +8450,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -11769,15 +8472,6 @@
     expected: FAIL
 
   [empty password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -11807,28 +8501,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -11950,28 +8626,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -11990,15 +8648,6 @@
     expected: FAIL
 
   [long password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -12028,28 +8677,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -12097,28 +8728,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -12166,28 +8779,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -12206,15 +8801,6 @@
     expected: FAIL
 
   [long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -12244,28 +8830,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -12313,28 +8881,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -12382,28 +8932,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -12422,15 +8954,6 @@
     expected: FAIL
 
   [long password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -12460,28 +8983,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -12529,28 +9034,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -12598,28 +9085,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -12638,15 +9107,6 @@
     expected: FAIL
 
   [long password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -12676,28 +9136,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -12745,28 +9187,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, long salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -12867,28 +9291,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -12936,28 +9342,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -12976,15 +9364,6 @@
     expected: FAIL
 
   [short password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -13014,28 +9393,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -13083,28 +9444,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -13152,28 +9495,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -13192,15 +9517,6 @@
     expected: FAIL
 
   [short password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -13230,28 +9546,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -13299,28 +9597,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -13368,28 +9648,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -13408,15 +9670,6 @@
     expected: FAIL
 
   [short password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -13446,28 +9699,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -13515,28 +9750,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -13584,28 +9801,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -13624,15 +9823,6 @@
     expected: FAIL
 
   [short password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -13662,28 +9852,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -13731,28 +9903,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -13805,28 +9959,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -13874,28 +10010,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -13914,15 +10032,6 @@
     expected: FAIL
 
   [empty password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -13952,28 +10061,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -14021,28 +10112,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -14090,28 +10163,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -14130,15 +10185,6 @@
     expected: FAIL
 
   [empty password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -14168,28 +10214,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -14237,28 +10265,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -14306,28 +10316,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -14346,15 +10338,6 @@
     expected: FAIL
 
   [empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [empty password, empty salt, SHA-512, with 100000 iterations with 0 length]
@@ -14381,15 +10364,6 @@
 
 [pbkdf2.https.any.html?5001-6000]
   [long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -14419,28 +10393,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -14488,28 +10444,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -14557,28 +10495,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -14597,15 +10517,6 @@
     expected: FAIL
 
   [long password, empty salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -14635,28 +10546,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -14704,28 +10597,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -14773,28 +10648,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -14813,15 +10670,6 @@
     expected: FAIL
 
   [long password, empty salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -14851,28 +10699,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -14920,28 +10750,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -14989,28 +10801,10 @@
   [Derived key of type name: AES-GCM length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -15029,15 +10823,6 @@
     expected: FAIL
 
   [long password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using long password, empty salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using long password, empty salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -15067,28 +10852,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -15136,28 +10903,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -15205,28 +10954,10 @@
   [Derived key of type name: AES-GCM length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -15245,15 +10976,6 @@
     expected: FAIL
 
   [empty password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using empty password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using empty password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -15339,28 +11061,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -15408,28 +11112,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -15477,28 +11163,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -15517,15 +11185,6 @@
     expected: FAIL
 
   [short password, short salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-384, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-384, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -15555,28 +11214,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -15624,28 +11265,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -15693,28 +11316,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
@@ -15733,15 +11338,6 @@
     expected: FAIL
 
   [short password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-512, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-512, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -15771,28 +11367,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1 iterations with wrong (ECDH) key]
@@ -15840,28 +11418,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 1000 iterations with wrong (ECDH) key]
@@ -15909,28 +11469,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
@@ -15949,15 +11491,6 @@
     expected: FAIL
 
   [short password, short salt, SHA-1, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-1, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-1, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -15987,28 +11520,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1 iterations with wrong (ECDH) key]
@@ -16056,28 +11571,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 1000 iterations with wrong (ECDH) key]
@@ -16125,28 +11622,10 @@
   [Derived key of type name: AES-GCM length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
-    expected: FAIL
-
   [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 100000 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 100000 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
@@ -16165,15 +11644,6 @@
     expected: FAIL
 
   [short password, short salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 192  using short password, short salt, SHA-256, with 0 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 256  using short password, short salt, SHA-256, with 0 iterations]
     expected: FAIL
 
   [Derived key of type name: AES-CBC length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -16201,12 +11671,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 256  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1 iterations]
-    expected: FAIL
-
-  [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1 iterations with missing deriveKey usage]
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]


### PR DESCRIPTION
We have already implemented the "get key length" operation for AES-KW in `components/script/dom/subtlecrypto/aes_operation.rs`. Registering it to `registeredAlgorithms` in the algorithm normalization makes it functional.

Testing: Pass some WPT tests that were expected to fail.