### PR TITLE
script: Allow zero length in deriveBits operation of HKDF and PBKDF2

### DIFF
--- a/components/script/dom/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/subtlecrypto/pbkdf2_operation.rs
@@ -24,12 +24,11 @@ pub(crate) fn derive_bits(
     key: &CryptoKey,
     length: Option<u32>,
 ) -> Result<Vec<u8>, Error> {
-    // Step 1. If length is null or zero, or is not a multiple of 8, then throw an OperationError.
-    // FIXME: The spec is updated.
+    // Step 1. If length is null or is not a multiple of 8, then throw an OperationError.
     let Some(length) = length else {
         return Err(Error::Operation);
     };
-    if length == 0 || length % 8 != 0 {
+    if length % 8 != 0 {
         return Err(Error::Operation);
     };
 
@@ -38,7 +37,7 @@ pub(crate) fn derive_bits(
         return Err(Error::Operation);
     };
 
-    // TODO: Step 3. If length is zero, return an empty byte sequence.
+    // Step 3. If length is zero, return an empty byte sequence.
     if length == 0 {
         return Ok(Vec::new());
     }

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/derived_bits_length.https.any.js.ini
@@ -44,12 +44,6 @@
   [X25519 derivation with 230 as 'length' parameter]
     expected: FAIL
 
-  [HKDF derivation with 0 as 'length' parameter]
-    expected: FAIL
-
-  [PBKDF2 derivation with 0 as 'length' parameter]
-    expected: FAIL
-
 
 [derived_bits_length.https.any.worker.html]
   [ECDH derivation with 256 as 'length' parameter]
@@ -95,10 +89,4 @@
     expected: FAIL
 
   [X25519 derivation with 230 as 'length' parameter]
-    expected: FAIL
-
-  [HKDF derivation with 0 as 'length' parameter]
-    expected: FAIL
-
-  [PBKDF2 derivation with 0 as 'length' parameter]
     expected: FAIL

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/hkdf.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/hkdf.https.any.js.ini
@@ -773,30 +773,6 @@
   [empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [empty derivedKey, empty salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
 
 [hkdf.https.any.worker.html?1-1000]
   [short derivedKey, normal salt, SHA-384, with normal info]
@@ -2116,48 +2092,6 @@
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
 
 [hkdf.https.any.html?3001-last]
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
@@ -2932,30 +2866,6 @@
     expected: FAIL
 
   [empty derivedKey, empty salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, empty salt, SHA-256, with empty info with 0 length]
     expected: FAIL
 
 
@@ -4170,45 +4080,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with normal info with 0 length]
     expected: FAIL
 
 
@@ -5530,48 +5401,6 @@
   [Derived key of type name: AES-GCM length: 128  using short derivedKey, empty salt, SHA-1, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [short derivedKey, normal salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, normal salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
 
 [hkdf.https.any.html?1001-2000]
   [Derived key of type name: AES-GCM length: 192  using short derivedKey, empty salt, SHA-1, with empty info]
@@ -6784,45 +6613,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-CTR length: 256  using long derivedKey, empty salt, SHA-512, with normal info with wrong (ECDH) key]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
-  [short derivedKey, empty salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, normal salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with normal info with 0 length]
     expected: FAIL
 
 
@@ -8096,45 +7886,6 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
     expected: FAIL
 
-  [long derivedKey, empty salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
 
 [hkdf.https.any.html?2001-3000]
   [Derived key of type name: AES-GCM length: 128  using long derivedKey, empty salt, SHA-512, with normal info]
@@ -9404,43 +9155,4 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using empty derivedKey, normal salt, SHA-256, with empty info with wrong (ECDH) key]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
-  [long derivedKey, empty salt, SHA-256, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-384, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-512, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-1, with empty info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with normal info with 0 length]
-    expected: FAIL
-
-  [empty derivedKey, normal salt, SHA-256, with empty info with 0 length]
     expected: FAIL

--- a/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.js.ini
@@ -560,45 +560,6 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [long password, short salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
   [Derived key of type name: AES-GCM length: 128  using long password, short salt, SHA-512, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
@@ -1271,42 +1232,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [long password, long salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-384, with 100000 iterations with 0 length]
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using long password, long salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -2007,42 +1932,6 @@
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [empty password, short salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
 
 [pbkdf2.https.any.worker.html?2001-3000]
   [Derived key of type name: AES-CBC length: 256  using short password, empty salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -2690,42 +2579,6 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [short password, empty salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
 
 [pbkdf2.https.any.worker.html?8001-last]
   [Derived key of type name: AES-GCM length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -3113,27 +2966,6 @@
     expected: FAIL
 
   [empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-256, with 100000 iterations with 0 length]
     expected: FAIL
 
 
@@ -3783,42 +3615,6 @@
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [long password, long salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
 
 [pbkdf2.https.any.worker.html?6001-7000]
   [Derived key of type name: AES-CTR length: 192  using empty password, short salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -4461,42 +4257,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty password, short salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-512, with 1 iterations with 0 length]
     expected: FAIL
 
 
@@ -5143,45 +4903,6 @@
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [short password, long salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
 
 [pbkdf2.https.any.html?1001-2000]
   [Derived key of type name: AES-KW length: 192  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
@@ -5826,45 +5547,6 @@
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [short password, long salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
 
 [pbkdf2.https.any.worker.html?5001-6000]
   [long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
@@ -6495,45 +6177,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [long password, empty salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-512, with 1 iterations with 0 length]
     expected: FAIL
 
 
@@ -7180,45 +6823,6 @@
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [short password, short salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
 
 [pbkdf2.https.any.html?7001-8000]
   [Derived key of type name: HMAC hash: SHA-384 length: 256  using empty password, long salt, SHA-512, with 1 iterations with wrong (ECDH) key]
@@ -7861,45 +7465,6 @@
     expected: FAIL
 
   [Derived key of type name: AES-GCM length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty password, long salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-512, with 1000 iterations with 0 length]
     expected: FAIL
 
 
@@ -8546,45 +8111,6 @@
   [Derived key of type name: AES-GCM length: 128  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [empty password, long salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, long salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
 
 [pbkdf2.https.any.worker.html?3001-4000]
   [Derived key of type name: HMAC hash: SHA-256 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
@@ -9227,45 +8753,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [long password, short salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, long salt, SHA-384, with 100000 iterations with 0 length]
     expected: FAIL
 
 
@@ -9915,42 +9402,6 @@
   [Derived key of type name: HMAC hash: SHA-1 length: 256  using long password, short salt, SHA-384, with 1000 iterations with wrong (ECDH) key]
     expected: FAIL
 
-  [short password, empty salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, empty salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, short salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
 
 [pbkdf2.https.any.html?8001-last]
   [Derived key of type name: AES-GCM length: 192  using empty password, empty salt, SHA-512, with 1000 iterations with wrong (ECDH) key]
@@ -10338,27 +9789,6 @@
     expected: FAIL
 
   [empty password, empty salt, SHA-256, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, empty salt, SHA-256, with 100000 iterations with 0 length]
     expected: FAIL
 
 
@@ -10991,45 +10421,6 @@
     expected: FAIL
 
   [Derived key of type name: HMAC hash: SHA-512 length: 256  using long password, empty salt, SHA-384, with 100000 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [long password, empty salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [long password, empty salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [empty password, short salt, SHA-512, with 1 iterations with 0 length]
     expected: FAIL
 
 
@@ -11674,43 +11065,4 @@
     expected: FAIL
 
   [Derived key of type name: AES-KW length: 128  using short password, long salt, SHA-384, with 1 iterations with wrong (ECDH) key]
-    expected: FAIL
-
-  [short password, short salt, SHA-384, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-384, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-384, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-512, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-512, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-512, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-1, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-1, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-1, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-256, with 1 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-256, with 1000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, short salt, SHA-256, with 100000 iterations with 0 length]
-    expected: FAIL
-
-  [short password, long salt, SHA-384, with 1 iterations with 0 length]
     expected: FAIL


### PR DESCRIPTION
The WebCrypto API specification was updated (https://github.com/w3c/webcrypto/pull/380) to allow zero length in deriveBits operation of HKDF and PBKDF2. This patch updates our implementation accordingly.

Testing: Pass some WPT tests that were expected to fail.