### PR TITLE
Split intersection-ratio-ib-split.html test into 2 subtests

### DIFF
--- a/tests/wpt/meta/intersection-observer/intersection-ratio-ib-split.html.ini
+++ b/tests/wpt/meta/intersection-observer/intersection-ratio-ib-split.html.ini
@@ -1,3 +1,8 @@
 [intersection-ratio-ib-split.html]
-  [IntersectionObserver on an IB split gets the right intersection ratio]
+  expected: TIMEOUT
+
+  [IntersectionObserver on an IB split gets the right intersection ratio - INLINE]
     expected: FAIL
+
+  [IntersectionObserver on an IB split gets the right intersection ratio - BLOCK]
+    expected: TIMEOUT

--- a/tests/wpt/tests/intersection-observer/intersection-ratio-ib-split.html
+++ b/tests/wpt/tests/intersection-observer/intersection-ratio-ib-split.html
@@ -22,8 +22,8 @@
 // Account for rounding differences when viewport sizes can't cleanly divide.
 const epsilon = 1;
 
-promise_test(async function() {
-  for (let element of document.querySelectorAll("inline, block")) {
+for (let element of document.querySelectorAll("inline, block")) {
+  promise_test(async function() {
     let entries = await new Promise(resolve => {
       new IntersectionObserver(resolve).observe(element);
     });
@@ -40,6 +40,6 @@ promise_test(async function() {
 
     assert_rects_equal(entries[0].boundingClientRect, element.getBoundingClientRect(), element.nodeName + ": boundingClientRect should match");
     assert_rects_equal(entries[0].intersectionRect, entries[0].boundingClientRect, element.nodeName + ": intersectionRect should match entry.boundingClientRect");
-  }
-}, "IntersectionObserver on an IB split gets the right intersection ratio");
+  }, "IntersectionObserver on an IB split gets the right intersection ratio - " + element.tagName);
+}
 </script>


### PR DESCRIPTION
This test was checking 2 cases in the same subtest. Servo fails the 1st one, which was hiding the fact that the 2nd one would time out because of #39831. Therefore, it seems better to split the test into 2 subtests.

Testing: This only modifies a test
