### PR TITLE
constellation: add source browsing context info in forwarded post message

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4275,7 +4275,7 @@ where
         // and to prevent panic as part of that round-trip
         // in the case that the source would already have been closed.
         let mut next_iteration_pipeline = source_pipeline;
-        let mut source_ancestry: Vec<BrowsingContextId> = vec![];
+        let mut source_with_ancestry: Vec<BrowsingContextId> = vec![];
         loop {
             match self
                 .pipelines
@@ -4284,12 +4284,12 @@ where
                 .map(|ctx| (ctx.id, ctx.parent_pipeline_id))
             {
                 Some((bc, Some(parent))) => {
-                    source_ancestry.push(bc);
+                    source_with_ancestry.push(bc);
                     next_iteration_pipeline = parent;
                     continue;
                 },
                 Some((bc, None)) => {
-                    source_ancestry.push(bc);
+                    source_with_ancestry.push(bc);
                     break;
                 },
                 None => {
@@ -4303,7 +4303,7 @@ where
         let msg = ScriptThreadMessage::PostMessage {
             target: pipeline_id,
             source_webview,
-            source_ancestry,
+            source_with_ancestry,
             target_origin: origin,
             source_origin,
             data: Box::new(data),

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4245,6 +4245,7 @@ where
         }
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#window-post-message-steps>
     #[servo_tracing::instrument(skip_all)]
     fn handle_post_message_msg(
         &mut self,
@@ -4263,13 +4264,39 @@ where
             },
             Some(browsing_context) => browsing_context.pipeline_id,
         };
-        let source_browsing_context = match self.pipelines.get(&source_pipeline) {
+        let source_webview = match self.pipelines.get(&source_pipeline) {
             Some(pipeline) => pipeline.webview_id,
             None => return warn!("{}: PostMessage from closed pipeline", source_pipeline),
         };
+
+        // Step 8.3: Let source be the WindowProxy object corresponding to
+        // incumbentSettings's global object (a Window object).
+        // Note: done here to prevent a round-trip to the constellation later,
+        // and to prevent panic as part of that round-trip
+        // in the case that the source would already have been closed.
+        let mut next_iteration_pipeline = source_pipeline;
+        let source_browsing_context = loop {
+            match self
+                .pipelines
+                .get(&next_iteration_pipeline)
+                .and_then(|pipeline| self.browsing_contexts.get(&pipeline.browsing_context_id))
+                .map(|ctx| (ctx.id, ctx.parent_pipeline_id))
+            {
+                Some((_, Some(parent))) => {
+                    next_iteration_pipeline = parent;
+                    continue;
+                },
+                Some((bc, None)) => {
+                    break bc;
+                },
+                None => {
+                    return warn!("{}: PostMessage from closed pipeline", source_pipeline);
+                },
+            }
+        };
         let msg = ScriptThreadMessage::PostMessage {
             target: pipeline_id,
-            source: source_pipeline,
+            source_webview,
             source_browsing_context,
             target_origin: origin,
             source_origin,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2732,7 +2732,7 @@ impl ScriptThread {
         match window {
             None => warn!("postMessage after target pipeline {} closed.", pipeline_id),
             Some(window) => {
-                let mut last: Option<DomRoot<WindowProxy>> = None;
+                let mut last = None;
                 for browsing_context_id in source_with_ancestry.into_iter().rev() {
                     if let Some(window_proxy) = self.window_proxies.get(browsing_context_id) {
                         last = Some(window_proxy);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2718,6 +2718,7 @@ impl ScriptThread {
         }
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#window-post-message-steps>
     fn handle_post_message_msg(
         &self,
         pipeline_id: PipelineId,
@@ -2749,6 +2750,9 @@ impl ScriptThread {
                         .insert(browsing_context_id, window_proxy.clone());
                     last = Some(window_proxy);
                 }
+
+                // Step 8.3: Let source be the WindowProxy object corresponding to
+                // incumbentSettings's global object (a Window object).
                 let source = last.expect("Source with ancestry should contain at least one bc.");
 
                 // FIXME(#22512): enqueues a task; unnecessary delay.

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2749,7 +2749,7 @@ impl ScriptThread {
                         .insert(browsing_context_id, window_proxy.clone());
                     last = Some(window_proxy);
                 }
-                let source = last.expect("Ancestry should contain at least one bc.");
+                let source = last.expect("Source with ancestry should contain at least one bc.");
 
                 // FIXME(#22512): enqueues a task; unnecessary delay.
                 window.post_message(origin, source_origin, &source, data)

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -179,7 +179,7 @@ pub enum ScriptThreadMessage {
         source_webview: WebViewId,
         /// The ancestry of browsing context associated with the source,
         /// starting with the source itself.
-        source_ancestry: Vec<BrowsingContextId>,
+        source_with_ancestry: Vec<BrowsingContextId>,
         /// The expected origin of the target.
         target_origin: Option<ImmutableOrigin>,
         /// The source origin of the message.

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -175,10 +175,10 @@ pub enum ScriptThreadMessage {
     PostMessage {
         /// The target of the message.
         target: PipelineId,
-        /// The source of the message.
-        source: PipelineId,
-        /// The top level browsing context associated with the source pipeline.
-        source_browsing_context: WebViewId,
+        /// The webview associated with the source pipeline.
+        source_webview: WebViewId,
+        /// The browsing context associated with the source.
+        source_browsing_context: BrowsingContextId,
         /// The expected origin of the target.
         target_origin: Option<ImmutableOrigin>,
         /// The source origin of the message.

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -177,8 +177,9 @@ pub enum ScriptThreadMessage {
         target: PipelineId,
         /// The webview associated with the source pipeline.
         source_webview: WebViewId,
-        /// The browsing context associated with the source.
-        source_browsing_context: BrowsingContextId,
+        /// The ancestry of browsing context associated with the source,
+        /// starting with the source itself.
+        source_ancestry: Vec<BrowsingContextId>,
         /// The expected origin of the target.
         target_origin: Option<ImmutableOrigin>,
         /// The source origin of the message.

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-3.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_escaping-3.html.ini
@@ -1,4 +1,3 @@
 [iframe_sandbox_popups_escaping-3.html]
-  expected: TIMEOUT
   [Check that popups from a sandboxed iframe escape the sandbox if\n       allow-popups-to-escape-sandbox is used]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-3.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_popups_nonescaping-3.html.ini
@@ -1,4 +1,3 @@
 [iframe_sandbox_popups_nonescaping-3.html]
-  expected: CRASH
   [Check that popups from a sandboxed iframe do not escape the sandbox]
     expected: FAIL


### PR DESCRIPTION
For cross-document messaging, when the constellation forwards the message, it can add the source browsing context and ancestry info to the message. This saves a round-trip back to the constellation from script later, and also allows for messages to be delivered when the source pipeline is closed by the time of delivery(but not by the time of forwarding by the constellation).

Testing: Updated  various tests in `/html/semantics/embedded-content/the-iframe-element/` WPT: from TIMEOUT(because message was not delivered) or intermittent CRASH(because the source pipeline would be closed by the time of attempted delivery.) to FAIL.
Fixes: https://github.com/servo/servo/issues/39748
