### PR TITLE
layout: Make inline boxes in phantom line boxes be 0px tall

### DIFF
--- a/tests/wpt/meta/css/CSS2/positioning/toogle-abspos-on-relpos-inline-child.html.ini
+++ b/tests/wpt/meta/css/CSS2/positioning/toogle-abspos-on-relpos-inline-child.html.ini
@@ -1,2 +1,0 @@
-[toogle-abspos-on-relpos-inline-child.html]
-  expected: FAIL

--- a/tests/wpt/meta/intersection-observer/intersection-ratio-ib-split.html.ini
+++ b/tests/wpt/meta/intersection-observer/intersection-ratio-ib-split.html.ini
@@ -1,8 +1,4 @@
 [intersection-ratio-ib-split.html]
   expected: TIMEOUT
-
-  [IntersectionObserver on an IB split gets the right intersection ratio - INLINE]
-    expected: FAIL
-
   [IntersectionObserver on an IB split gets the right intersection ratio - BLOCK]
     expected: TIMEOUT

--- a/tests/wpt/tests/css/cssom-view/getBoundingClientRect-empty-inline-002.html
+++ b/tests/wpt/tests/css/cssom-view/getBoundingClientRect-empty-inline-002.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/cssom-view/#dom-element-getboundingclientrect">
+<link rel="help" href="https://drafts.csswg.org/css-inline-3/#invisible-line-boxes">
+<link rel="help" href="https://github.com/servo/servo/issues/39648">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<meta name="assert" content="An inline box in a phantom line box has a size of 0.">
+
+<style>body { margin: 8px }</style>
+<span></span>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+let rect = document.querySelector("span").getBoundingClientRect();
+test(() => assert_equals(rect.x, 8), "x");
+test(() => assert_equals(rect.y, 8), "y");
+test(() => assert_equals(rect.width, 0), "width");
+test(() => assert_equals(rect.height, 0), "height");
+</script>


### PR DESCRIPTION
The height of an inline box is typically decided by font metrics, but if it's on a phantom line box, then it should be zero.

This is hard to observe, because the contents of a phantom line box are typically invisible, but it's noticeable on these cases:
 - If the inline has a box shadow or an outline (not on all browsers).
 - If the inline establishes a containing block for abspos descendants.
 - When getting the size using JS APIs.

Testing: Some existing tests pass, also adding a new one
Fixes: #39648
