### PR TITLE
layout: Fix optimization of skipping fragments for empty inline boxes

### DIFF
--- a/components/layout/flow/inline/line.rs
+++ b/components/layout/flow/inline/line.rs
@@ -400,8 +400,19 @@ impl LineItemLayout<'_, '_> {
         //
         // Note: This is an optimization, but also has side effects. Any fragments on a line will
         // force the baseline to advance in the parent IFC.
+        //
+        // Note: We don't need to check the inline-start padding, border and margin because they
+        // must have been set to zero in the code above. But checking whether `pbm_sums.inline_end`
+        // is zero doesn't suffice, because it could be nullified by a negative margin.
+        //
+        // TODO: Once we implement `box-decoration-break: clone`, it may happen that `had_start` is
+        // true even if this isn't the first fragment.
         let pbm_sums = padding + border + margin;
-        if inner_state.fragments.is_empty() && !had_start && pbm_sums.inline_sum().is_zero() {
+        if inner_state.fragments.is_empty() &&
+            !had_start &&
+            pbm_sums.inline_end.is_zero() &&
+            margin.inline_end.is_zero()
+        {
             return;
         }
 

--- a/tests/wpt/tests/css/CSS2/margin-padding-clear/margin-right-114.html
+++ b/tests/wpt/tests/css/CSS2/margin-padding-clear/margin-right-114.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>CSS Test: Negative margin-right on an inline split by a block descendant</title>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="http://www.w3.org/TR/CSS21/box.html#propdef-margin-right">
+<link rel="help" href="http://www.w3.org/TR/CSS21/box.html#margin-properties">
+<link rel="match" href="../../reference/ref-filled-green-200px-square.html">
+<meta name="assert" content="The negative 'margin-right' doesn't hide the 'border-right'.">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="width: 200px; background: red">
+  <span style="font: 200px/1 Ahem; border-right: 200px solid green; margin-right: -200px">
+    <div><!-- This is a block that splits the inline --></div>
+  </span>
+</div>


### PR DESCRIPTION
This optimization was only happening when the sum of padding, border and margin was zero. However, since margins can be negative, a sum of zero doesn't guarantee that the components are individually zero.

Testing: Adding new test
