### PR TITLE
script: Convert less between string types in range-related methods of HTMLInputElement

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -225,8 +225,8 @@ impl Attr {
     pub(crate) fn summarize(&self) -> AttrInfo {
         AttrInfo {
             namespace: (**self.namespace()).to_owned(),
-            name: String::from(self.Name()),
-            value: String::from(self.Value()),
+            name: (**self.name()).to_owned(),
+            value: (**self.value()).to_owned(),
         }
     }
 


### PR DESCRIPTION
The current code has snippets like `self.convert_string_to_number(&DOMString::from(attr.summarize().value))` in various places. 

The snippet wants to take the value of an attribute and parse it as a number. In theory this is an easy problem, the attribute internally stores a `AttrValue` (which can be treated as `str`) and the conversion code wants a `str` - no conversions or copies necessary!

But the reality of what happens is less ideal:
`attr.summarize` allocates a `AttrInfo` containing owned copies of the attributes namespace, name and value. The name and value are also converted from the `AttrValue` to a `DOMString` and then back to a `String` in the process. And then we take the value field from `AttrInfo` and create a new DOMString from it, passing that to `self.self.convert_string_to_number` - which ends up internally calling `str()` on it.

All in all this is not a big issue, because this code doesn't run often. But it's also not hard to fix, and we end up with cleaner code in the process.

