### PR TITLE
libservo: Merge file selection dialog into EmbedderControls

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -132,8 +132,8 @@ use devtools_traits::{
 use embedder_traits::resources::{self, Resource};
 use embedder_traits::user_content_manager::UserContentManager;
 use embedder_traits::{
-    AnimationState, CompositorHitTestResult, EmbedderControlId, EmbedderMsg, EmbedderProxy,
-    FocusSequenceNumber, FormControlResponse, InputEvent, InputEventAndId, JSValue,
+    AnimationState, CompositorHitTestResult, EmbedderControlId, EmbedderControlResponse,
+    EmbedderMsg, EmbedderProxy, FocusSequenceNumber, InputEvent, InputEventAndId, JSValue,
     JavaScriptEvaluationError, JavaScriptEvaluationId, KeyboardEvent, MediaSessionActionType,
     MediaSessionEvent, MediaSessionPlaybackState, MouseButton, MouseButtonAction, MouseButtonEvent,
     ScriptToEmbedderChan, Theme, ViewportDetails, WebDriverCommandMsg, WebDriverLoadStatus,
@@ -5700,7 +5700,7 @@ where
     fn handle_embedder_control_response(
         &self,
         id: EmbedderControlId,
-        response: FormControlResponse,
+        response: EmbedderControlResponse,
     ) {
         let pipeline_id = id.pipeline_id;
         let Some(pipeline) = self.pipelines.get(&pipeline_id) else {

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -10,7 +10,6 @@ use std::sync::atomic::{self, AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock, Weak};
 
 use base::generic_channel;
-use base::id::WebViewId;
 use base::threadpool::ThreadPool;
 use embedder_traits::{EmbedderControlId, EmbedderMsg, EmbedderProxy, FilterPattern};
 use headers::{ContentLength, ContentRange, ContentType, HeaderMap, HeaderMapExt, Range};

--- a/components/net/filemanager_thread.rs
+++ b/components/net/filemanager_thread.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex, RwLock, Weak};
 use base::generic_channel;
 use base::id::WebViewId;
 use base::threadpool::ThreadPool;
-use embedder_traits::{EmbedderMsg, EmbedderProxy, FilterPattern};
+use embedder_traits::{EmbedderControlId, EmbedderMsg, EmbedderProxy, FilterPattern};
 use headers::{ContentLength, ContentRange, ContentType, HeaderMap, HeaderMapExt, Range};
 use http::header::{self, HeaderValue};
 use ipc_channel::ipc::IpcSender;
@@ -152,14 +152,14 @@ impl FileManager {
     /// Message handler
     pub fn handle(&self, msg: FileManagerThreadMsg) {
         match msg {
-            FileManagerThreadMsg::SelectFile(webview_id, filter, sender, origin, opt_test_path) => {
+            FileManagerThreadMsg::SelectFile(control_id, filter, sender, origin, opt_test_path) => {
                 let store = self.store.clone();
                 let embedder = self.embedder_proxy.clone();
                 self.thread_pool
                     .upgrade()
                     .map(|pool| {
                         pool.spawn(move || {
-                            store.select_file(webview_id, filter, sender, origin, opt_test_path, embedder);
+                            store.select_file(control_id, filter, sender, origin, opt_test_path, embedder);
                         });
                     })
                     .unwrap_or_else(|| {
@@ -169,7 +169,7 @@ impl FileManager {
                     });
             },
             FileManagerThreadMsg::SelectFiles(
-                webview_id,
+                control_id,
                 filter,
                 sender,
                 origin,
@@ -181,7 +181,7 @@ impl FileManager {
                     .upgrade()
                     .map(|pool| {
                         pool.spawn(move || {
-                            store.select_files(webview_id, filter, sender, origin, opt_test_paths, embedder);
+                            store.select_files(control_id, filter, sender, origin, opt_test_paths, embedder);
                         });
                     })
                     .unwrap_or_else(|| {
@@ -576,7 +576,7 @@ impl FileManagerStore {
 
     fn query_files_from_embedder(
         &self,
-        webview_id: WebViewId,
+        control_id: EmbedderControlId,
         patterns: Vec<FilterPattern>,
         multiple_files: bool,
         embedder_proxy: EmbedderProxy,
@@ -584,7 +584,7 @@ impl FileManagerStore {
         let (ipc_sender, ipc_receiver) =
             generic_channel::channel().expect("Failed to create IPC channel!");
         embedder_proxy.send(EmbedderMsg::SelectFiles(
-            webview_id,
+            control_id,
             patterns,
             multiple_files,
             ipc_sender,
@@ -600,7 +600,7 @@ impl FileManagerStore {
 
     fn select_file(
         &self,
-        webview_id: WebViewId,
+        control_id: EmbedderControlId,
         patterns: Vec<FilterPattern>,
         sender: IpcSender<FileManagerResult<SelectedFile>>,
         origin: FileOrigin,
@@ -613,7 +613,7 @@ impl FileManagerStore {
         let opt_s = if pref!(dom_testing_html_input_element_select_files_enabled) {
             opt_test_path
         } else {
-            self.query_files_from_embedder(webview_id, patterns, false, embedder_proxy)
+            self.query_files_from_embedder(control_id, patterns, false, embedder_proxy)
                 .and_then(|mut x| x.pop())
         };
 
@@ -631,7 +631,7 @@ impl FileManagerStore {
 
     fn select_files(
         &self,
-        webview_id: WebViewId,
+        control_id: EmbedderControlId,
         patterns: Vec<FilterPattern>,
         sender: IpcSender<FileManagerResult<Vec<SelectedFile>>>,
         origin: FileOrigin,
@@ -644,7 +644,7 @@ impl FileManagerStore {
         let opt_v = if pref!(dom_testing_html_input_element_select_files_enabled) {
             opt_test_paths
         } else {
-            self.query_files_from_embedder(webview_id, patterns, true, embedder_proxy)
+            self.query_files_from_embedder(control_id, patterns, true, embedder_proxy)
         };
 
         match opt_v {

--- a/components/net/tests/filemanager_thread.rs
+++ b/components/net/tests/filemanager_thread.rs
@@ -7,9 +7,10 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use base::id::TEST_WEBVIEW_ID;
+use base::Epoch;
+use base::id::{TEST_PIPELINE_ID, TEST_WEBVIEW_ID};
 use base::threadpool::ThreadPool;
-use embedder_traits::FilterPattern;
+use embedder_traits::{EmbedderControlId, FilterPattern};
 use ipc_channel::ipc;
 use net::filemanager_thread::FileManager;
 use net_traits::blob_url_store::BlobURLStoreError;
@@ -44,8 +45,13 @@ fn test_filemanager() {
     {
         // Try to select a dummy file "components/net/tests/test.jpeg"
         let (tx, rx) = ipc::channel().unwrap();
+        let control_id = EmbedderControlId {
+            webview_id: TEST_WEBVIEW_ID,
+            pipeline_id: TEST_PIPELINE_ID,
+            index: Epoch(0),
+        };
         filemanager.handle(FileManagerThreadMsg::SelectFile(
-            TEST_WEBVIEW_ID,
+            control_id,
             patterns.clone(),
             tx,
             origin.clone(),

--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -55,21 +55,25 @@ impl DocumentEmbedderControls {
         }
     }
 
+    /// Generate the next unused [`EmbedderControlId`]. This method is only needed for some older
+    /// types of controls that are still being migrated, and it will eventually be removed.
+    pub(crate) fn next_control_id(&self) -> EmbedderControlId {
+        let index = self.user_interface_element_index.get();
+        self.user_interface_element_index.set(index.next());
+        EmbedderControlId {
+            webview_id: self.window.webview_id(),
+            pipeline_id: self.window.pipeline_id(),
+            index,
+        }
+    }
+
     pub(crate) fn show_embedder_control(
         &self,
         element: ControlElement,
         rect: DeviceIntRect,
         embedder_control: EmbedderControlRequest,
     ) -> EmbedderControlId {
-        let index = self.user_interface_element_index.get();
-        self.user_interface_element_index.set(index.next());
-
-        let id = EmbedderControlId {
-            webview_id: self.window.webview_id(),
-            pipeline_id: self.window.pipeline_id(),
-            index,
-        };
-
+        let id = self.next_control_id();
         self.visible_elements
             .borrow_mut()
             .insert(id.index.into(), element);

--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -5,7 +5,9 @@
 use std::cell::Cell;
 
 use base::Epoch;
-use embedder_traits::{EmbedderControlId, EmbedderMsg, FormControlRequest, FormControlResponse};
+use embedder_traits::{
+    EmbedderControlId, EmbedderControlRequest, EmbedderControlResponse, EmbedderMsg,
+};
 use rustc_hash::FxHashMap;
 use script_bindings::root::{Dom, DomRoot};
 use script_bindings::script_runtime::CanGc;
@@ -53,11 +55,11 @@ impl DocumentEmbedderControls {
         }
     }
 
-    pub(crate) fn show_form_control(
+    pub(crate) fn show_embedder_control(
         &self,
         element: ControlElement,
         rect: DeviceIntRect,
-        form_control: FormControlRequest,
+        embedder_control: EmbedderControlRequest,
     ) -> EmbedderControlId {
         let index = self.user_interface_element_index.get();
         self.user_interface_element_index.set(index.next());
@@ -72,12 +74,12 @@ impl DocumentEmbedderControls {
             .borrow_mut()
             .insert(id.index.into(), element);
         self.window
-            .send_to_embedder(EmbedderMsg::ShowEmbedderControl(id, rect, form_control));
+            .send_to_embedder(EmbedderMsg::ShowEmbedderControl(id, rect, embedder_control));
 
         id
     }
 
-    pub(crate) fn hide_form_control(&self, element: &Element) {
+    pub(crate) fn hide_embedder_control(&self, element: &Element) {
         self.visible_elements
             .borrow_mut()
             .retain(|index, control_element| {
@@ -98,7 +100,7 @@ impl DocumentEmbedderControls {
     pub(crate) fn handle_embedder_control_response(
         &self,
         id: EmbedderControlId,
-        response: FormControlResponse,
+        response: EmbedderControlResponse,
         can_gc: CanGc,
     ) {
         assert_eq!(self.window.pipeline_id(), id.pipeline_id);
@@ -111,13 +113,13 @@ impl DocumentEmbedderControls {
         match (element, response) {
             (
                 ControlElement::Select(select_element),
-                FormControlResponse::SelectElement(response),
+                EmbedderControlResponse::SelectElement(response),
             ) => {
                 select_element.handle_menu_response(response, can_gc);
             },
             (
                 ControlElement::ColorInput(input_element),
-                FormControlResponse::ColorPicker(response),
+                EmbedderControlResponse::ColorPicker(response),
             ) => {
                 input_element.handle_color_picker_response(response, can_gc);
             },

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -2358,7 +2358,6 @@ impl HTMLInputElement {
 
         let mut files: Vec<DomRoot<File>> = vec![];
 
-        let webview_id = window.webview_id();
         let filter = filter_from_accept(&self.Accept());
         let target = self.upcast::<EventTarget>();
 

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -2388,8 +2388,9 @@ impl HTMLInputElement {
             let (chan, recv) =
                 profile_traits::ipc::channel(self.global().time_profiler_chan().clone())
                     .expect("Error initializing channel");
+            let control_id = self.owner_document().embedder_controls().next_control_id();
             let msg =
-                FileManagerThreadMsg::SelectFiles(webview_id, filter, chan, origin, opt_test_paths);
+                FileManagerThreadMsg::SelectFiles(control_id, filter, chan, origin, opt_test_paths);
             resource_threads
                 .send(CoreResourceMsg::ToFileManager(msg))
                 .unwrap();
@@ -2420,8 +2421,9 @@ impl HTMLInputElement {
             let (chan, recv) =
                 profile_traits::ipc::channel(self.global().time_profiler_chan().clone())
                     .expect("Error initializing channel");
+            let control_id = self.owner_document().embedder_controls().next_control_id();
             let msg =
-                FileManagerThreadMsg::SelectFile(webview_id, filter, chan, origin, opt_test_path);
+                FileManagerThreadMsg::SelectFile(control_id, filter, chan, origin, opt_test_path);
             resource_threads
                 .send(CoreResourceMsg::ToFileManager(msg))
                 .unwrap();

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -14,7 +14,7 @@ use std::{f64, ptr};
 use base::IpcSend;
 use dom_struct::dom_struct;
 use embedder_traits::{
-    FilterPattern, FormControlRequest as EmbedderFormControl, InputMethodType, RgbColor,
+    EmbedderControlRequest as EmbedderFormControl, FilterPattern, InputMethodType, RgbColor,
 };
 use encoding_rs::Encoding;
 use euclid::{Point2D, Rect, Size2D};
@@ -2831,7 +2831,7 @@ impl HTMLInputElement {
                 green: u8::from_str_radix(&current_value.str()[3..5], 16).unwrap(),
                 blue: u8::from_str_radix(&current_value.str()[5..7], 16).unwrap(),
             };
-            document.embedder_controls().show_form_control(
+            document.embedder_controls().show_embedder_control(
                 ControlElement::ColorInput(DomRoot::from_ref(self)),
                 DeviceIntRect::from_untyped(&rect.to_box2d()),
                 EmbedderFormControl::ColorPicker(current_color),
@@ -3069,7 +3069,7 @@ impl VirtualMethods for HTMLInputElement {
         if could_have_had_embedder_control && !self.may_have_embedder_control() {
             self.owner_document()
                 .embedder_controls()
-                .hide_form_control(self.upcast());
+                .hide_embedder_control(self.upcast());
         }
     }
 
@@ -3140,7 +3140,7 @@ impl VirtualMethods for HTMLInputElement {
         if self.input_type() == InputType::Color {
             self.owner_document()
                 .embedder_controls()
-                .hide_form_control(self.upcast());
+                .hide_embedder_control(self.upcast());
         }
     }
 
@@ -3279,7 +3279,7 @@ impl VirtualMethods for HTMLInputElement {
             if *event.upcast::<Event>().type_() != *"blur" {
                 self.owner_document()
                     .embedder_controls()
-                    .hide_form_control(self.upcast());
+                    .hide_embedder_control(self.upcast());
             }
         }
 

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -6,7 +6,7 @@ use std::default::Default;
 use std::iter;
 
 use dom_struct::dom_struct;
-use embedder_traits::{FormControlRequest as EmbedderFormControl};
+use embedder_traits::{EmbedderControlRequest as EmbedderFormControl};
 use embedder_traits::{SelectElementOption, SelectElementOptionOrOptgroup};
 use euclid::{Point2D, Rect, Size2D};
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
@@ -401,11 +401,13 @@ impl HTMLSelectElement {
 
         let selected_index = self.list_of_options().position(|option| option.Selected());
 
-        self.owner_document().embedder_controls().show_form_control(
-            ControlElement::Select(DomRoot::from_ref(self)),
-            DeviceIntRect::from_untyped(&rect.to_box2d()),
-            EmbedderFormControl::SelectElement(options, selected_index),
-        );
+        self.owner_document()
+            .embedder_controls()
+            .show_embedder_control(
+                ControlElement::Select(DomRoot::from_ref(self)),
+                DeviceIntRect::from_untyped(&rect.to_box2d()),
+                EmbedderFormControl::SelectElement(options, selected_index),
+            );
     }
 
     pub(crate) fn handle_menu_response(&self, response: Option<usize>, can_gc: CanGc) {
@@ -702,7 +704,7 @@ impl VirtualMethods for HTMLSelectElement {
         if could_have_had_embedder_control && !self.may_have_embedder_control() {
             self.owner_document()
                 .embedder_controls()
-                .hide_form_control(self.upcast());
+                .hide_embedder_control(self.upcast());
         }
     }
 
@@ -731,7 +733,7 @@ impl VirtualMethods for HTMLSelectElement {
 
         self.owner_document()
             .embedder_controls()
-            .hide_form_control(self.upcast());
+            .hide_embedder_control(self.upcast());
     }
 
     fn children_changed(&self, mutation: &ChildrenMutation) {
@@ -758,7 +760,7 @@ impl VirtualMethods for HTMLSelectElement {
             if *event.upcast::<Event>().type_() != *"blur" {
                 self.owner_document()
                     .embedder_controls()
-                    .hide_form_control(self.upcast());
+                    .hide_embedder_control(self.upcast());
             }
         }
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -50,7 +50,7 @@ use devtools_traits::{
 };
 use embedder_traits::user_content_manager::UserContentManager;
 use embedder_traits::{
-    EmbedderControlId, EmbedderMsg, FocusSequenceNumber, FormControlResponse,
+    EmbedderControlId, EmbedderControlResponse, EmbedderMsg, FocusSequenceNumber,
     JavaScriptEvaluationError, JavaScriptEvaluationId, MediaSessionActionType, Theme,
     ViewportDetails, WebDriverScriptCommand,
 };
@@ -3907,7 +3907,7 @@ impl ScriptThread {
     fn handle_embedder_control_response(
         &self,
         id: EmbedderControlId,
-        response: FormControlResponse,
+        response: EmbedderControlResponse,
         can_gc: CanGc,
     ) {
         let Some(document) = self.documents.borrow().find_document(id.pipeline_id) else {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -138,8 +138,8 @@ use crate::webrender_api::FrameReadyParams;
 use crate::webview::MINIMUM_WEBVIEW_SIZE;
 pub use crate::webview::{WebView, WebViewBuilder};
 pub use crate::webview_delegate::{
-    AllowOrDenyRequest, AuthenticationRequest, ColorPicker, EmbedderControl, NavigationRequest,
-    PermissionRequest, SelectElement, WebResourceLoad, WebViewDelegate,
+    AllowOrDenyRequest, AuthenticationRequest, ColorPicker, EmbedderControl, FilePicker,
+    NavigationRequest, PermissionRequest, SelectElement, WebResourceLoad, WebViewDelegate,
 };
 
 #[cfg(feature = "media-gstreamer")]
@@ -1007,6 +1007,18 @@ impl Servo {
                                 response_sent: false,
                             })
                         },
+                        EmbedderControlRequest::FilePicker {
+                            current_paths,
+                            filter_patterns,
+                            allow_select_multiple,
+                        } => EmbedderControl::FilePicker(FilePicker {
+                            id: control_id,
+                            current_paths,
+                            filter_patterns,
+                            allow_select_multiple,
+                            constellation_proxy,
+                            response_sent: false,
+                        }),
                     };
 
                     webview

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -66,7 +66,6 @@ use constellation::{
 pub use constellation_traits::EmbedderToConstellationMessage;
 use constellation_traits::ScriptToConstellationChan;
 use crossbeam_channel::{Receiver, Sender, unbounded};
-use embedder_traits::EmbedderControlRequest;
 use embedder_traits::user_content_manager::UserContentManager;
 pub use embedder_traits::{WebDriverSenders, *};
 use env_logger::Builder as EnvLoggerBuilder;

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -870,17 +870,23 @@ impl Servo {
                 }
             },
             EmbedderMsg::SelectFiles(
-                webview_id,
+                control_id,
                 filter_patterns,
                 allow_select_multiple,
                 response_sender,
             ) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview.delegate().show_file_selection_dialog(
+                if let Some(webview) = self.get_webview_handle(control_id.webview_id) {
+                    webview.delegate().show_embedder_control(
                         webview,
-                        filter_patterns,
-                        allow_select_multiple,
-                        response_sender,
+                        EmbedderControl::FilePicker(FilePicker {
+                            id: control_id,
+                            // TODO: fill this field when we merge the message into script
+                            current_paths: None,
+                            filter_patterns,
+                            allow_select_multiple,
+                            response_sender,
+                            response_sent: false,
+                        }),
                     );
                 }
             },
@@ -1008,17 +1014,10 @@ impl Servo {
                             })
                         },
                         EmbedderControlRequest::FilePicker {
-                            current_paths,
-                            filter_patterns,
-                            allow_select_multiple,
-                        } => EmbedderControl::FilePicker(FilePicker {
-                            id: control_id,
-                            current_paths,
-                            filter_patterns,
-                            allow_select_multiple,
-                            constellation_proxy,
-                            response_sent: false,
-                        }),
+                            current_paths: _,
+                            filter_patterns: _,
+                            allow_select_multiple: _,
+                        } => todo!("Implement this when EmbedderMsg::SelectFiles is removed"),
                     };
 
                     webview

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -13,7 +13,7 @@ use compositing_traits::rendering_context::{RenderingContext, SoftwareRenderingC
 use dpi::PhysicalSize;
 use embedder_traits::EventLoopWaker;
 use servo::{
-    FormControl, JSValue, JavaScriptEvaluationError, LoadStatus, Servo, ServoBuilder, WebView,
+    EmbedderControl, JSValue, JavaScriptEvaluationError, LoadStatus, Servo, ServoBuilder, WebView,
     WebViewDelegate,
 };
 
@@ -145,7 +145,7 @@ pub(crate) struct WebViewDelegateImpl {
     pub(crate) cursor_changed: Cell<bool>,
     pub(crate) new_frame_ready: Cell<bool>,
     pub(crate) load_status_changed: Cell<bool>,
-    pub(crate) controls_shown: RefCell<Vec<FormControl>>,
+    pub(crate) controls_shown: RefCell<Vec<EmbedderControl>>,
     pub(crate) number_of_controls_shown: Cell<usize>,
     pub(crate) number_of_controls_hidden: Cell<usize>,
 }
@@ -181,7 +181,7 @@ impl WebViewDelegate for WebViewDelegateImpl {
         }
     }
 
-    fn show_form_control(&self, _: WebView, form_control: FormControl) {
+    fn show_form_control(&self, _: WebView, form_control: EmbedderControl) {
         // Even if not used, controls must be stored so that they do not automatically reply
         // when dropped.
         self.controls_shown.borrow_mut().push(form_control);

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -181,16 +181,16 @@ impl WebViewDelegate for WebViewDelegateImpl {
         }
     }
 
-    fn show_form_control(&self, _: WebView, form_control: EmbedderControl) {
+    fn show_embedder_control(&self, _: WebView, embedder_control: EmbedderControl) {
         // Even if not used, controls must be stored so that they do not automatically reply
         // when dropped.
-        self.controls_shown.borrow_mut().push(form_control);
+        self.controls_shown.borrow_mut().push(embedder_control);
 
         self.number_of_controls_shown
             .set(self.number_of_controls_shown.get() + 1);
     }
 
-    fn hide_form_control(&self, _webview: WebView, _control_id: servo::EmbedderControlId) {
+    fn hide_embedder_control(&self, _webview: WebView, _control_id: servo::EmbedderControlId) {
         self.number_of_controls_hidden
             .set(self.number_of_controls_hidden.get() + 1);
     }

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -443,7 +443,6 @@ pub struct FilePicker {
     pub(crate) current_paths: Option<Vec<PathBuf>>,
     pub(crate) filter_patterns: Vec<FilterPattern>,
     pub(crate) allow_select_multiple: bool,
-    // TODO: reroute this via the constellation and script, not directly to the file manager thread
     pub(crate) response_sender: GenericSender<Option<Vec<PathBuf>>>,
     pub(crate) response_sent: bool,
 }

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -9,10 +9,10 @@ use base::id::PipelineId;
 use constellation_traits::EmbedderToConstellationMessage;
 use embedder_traits::{
     AllowOrDeny, AuthenticationResponse, ContextMenuResult, Cursor, EmbedderControlId,
-    FilterPattern, FormControlResponse, GamepadHapticEffectType, InputEventId, InputEventResult,
-    InputMethodType, LoadStatus, MediaSessionEvent, Notification, PermissionFeature, RgbColor,
-    ScreenGeometry, SelectElementOptionOrOptgroup, SimpleDialog, TraversalId, WebResourceRequest,
-    WebResourceResponse, WebResourceResponseMsg,
+    EmbedderControlResponse, FilterPattern, GamepadHapticEffectType, InputEventId,
+    InputEventResult, InputMethodType, LoadStatus, MediaSessionEvent, Notification,
+    PermissionFeature, RgbColor, ScreenGeometry, SelectElementOptionOrOptgroup, SimpleDialog,
+    TraversalId, WebResourceRequest, WebResourceResponse, WebResourceResponseMsg,
 };
 use ipc_channel::ipc::IpcSender;
 use serde::Serialize;
@@ -298,18 +298,18 @@ impl Drop for InterceptedWebResourceLoad {
 }
 
 /// The controls of an interactive form element.
-pub enum FormControl {
+pub enum EmbedderControl {
     /// The picker of a `<select>` element.
     SelectElement(SelectElement),
     /// The picker of a `<input type=color>` element.
     ColorPicker(ColorPicker),
 }
 
-impl FormControl {
+impl EmbedderControl {
     pub fn id(&self) -> EmbedderControlId {
         match self {
-            FormControl::SelectElement(select_element) => select_element.id,
-            FormControl::ColorPicker(color_picker) => color_picker.id,
+            EmbedderControl::SelectElement(select_element) => select_element.id,
+            EmbedderControl::ColorPicker(color_picker) => color_picker.id,
         }
     }
 }
@@ -361,7 +361,7 @@ impl SelectElement {
         self.constellation_proxy
             .send(EmbedderToConstellationMessage::EmbedderControlResponse(
                 self.id,
-                FormControlResponse::SelectElement(self.selected_option()),
+                EmbedderControlResponse::SelectElement(self.selected_option()),
             ));
     }
 }
@@ -372,7 +372,7 @@ impl Drop for SelectElement {
             self.constellation_proxy
                 .send(EmbedderToConstellationMessage::EmbedderControlResponse(
                     self.id,
-                    FormControlResponse::SelectElement(self.selected_option()),
+                    EmbedderControlResponse::SelectElement(self.selected_option()),
                 ));
         }
     }
@@ -416,7 +416,7 @@ impl ColorPicker {
         self.constellation_proxy
             .send(EmbedderToConstellationMessage::EmbedderControlResponse(
                 self.id,
-                FormControlResponse::ColorPicker(self.current_color),
+                EmbedderControlResponse::ColorPicker(self.current_color),
             ));
     }
 }
@@ -427,7 +427,7 @@ impl Drop for ColorPicker {
             self.constellation_proxy
                 .send(EmbedderToConstellationMessage::EmbedderControlResponse(
                     self.id,
-                    FormControlResponse::ColorPicker(self.current_color),
+                    EmbedderControlResponse::ColorPicker(self.current_color),
                 ));
         }
     }
@@ -598,13 +598,13 @@ pub trait WebViewDelegate {
 
     /// Request that the embedder show UI elements for form controls that are not integrated
     /// into page content, such as dropdowns for `<select>` elements.
-    fn show_form_control(&self, _webview: WebView, _form_control: FormControl) {}
+    fn show_embedder_control(&self, _webview: WebView, _embedder_control: EmbedderControl) {}
 
-    /// Request that the embedder hide and ignore a previous [`FormControl`] request, if it hasn’t
+    /// Request that the embedder hide and ignore a previous [`EmbedderControl`] request, if it hasn’t
     /// already responded to it.
     ///
     /// After this point, any further responses to that request will be ignored.
-    fn hide_form_control(&self, _webview: WebView, _control_id: EmbedderControlId) {}
+    fn hide_embedder_control(&self, _webview: WebView, _control_id: EmbedderControlId) {}
 
     /// Request to play a haptic effect on a connected gamepad.
     fn play_gamepad_haptic_effect(

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{MessagePortId, PipelineId, WebViewId};
 use embedder_traits::{
-    CompositorHitTestResult, EmbedderControlId, FormControlResponse, InputEventAndId,
+    CompositorHitTestResult, EmbedderControlId, EmbedderControlResponse, InputEventAndId,
     JavaScriptEvaluationId, MediaSessionActionType, Theme, TraversalId, ViewportDetails,
     WebDriverCommandMsg,
 };
@@ -109,7 +109,7 @@ pub enum EmbedderToConstellationMessage {
     /// send a message to the Embedder when the screenshot is ready to be taken.
     RequestScreenshotReadiness(WebViewId),
     /// A response to a request to show an embedder user interface control.
-    EmbedderControlResponse(EmbedderControlId, FormControlResponse),
+    EmbedderControlResponse(EmbedderControlId, EmbedderControlResponse),
 }
 
 /// A description of a paint metric that is sent from the Servo renderer to the

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -549,12 +549,19 @@ pub enum EmbedderControlRequest {
     SelectElement(Vec<SelectElementOptionOrOptgroup>, Option<usize>),
     /// Indicates that the user has activated a `<input type=color>` element.
     ColorPicker(RgbColor),
+    /// Indicates that the user has activated a `<input type=file>` element.
+    FilePicker {
+        current_paths: Option<Vec<PathBuf>>,
+        filter_patterns: Vec<FilterPattern>,
+        allow_select_multiple: bool,
+    },
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum EmbedderControlResponse {
     SelectElement(Option<usize>),
     ColorPicker(Option<RgbColor>),
+    FilePicker(Option<Vec<PathBuf>>),
 }
 
 /// Filter for file selection;

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -475,7 +475,7 @@ pub enum EmbedderMsg {
     GetSelectedBluetoothDevice(WebViewId, Vec<String>, GenericSender<Option<String>>),
     /// Open file dialog to select files. Set boolean flag to true allows to select multiple files.
     SelectFiles(
-        WebViewId,
+        EmbedderControlId,
         Vec<FilterPattern>,
         bool,
         GenericSender<Option<Vec<PathBuf>>>,

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -515,7 +515,7 @@ pub enum EmbedderMsg {
     /// Request to display a notification.
     ShowNotification(Option<WebViewId>, Notification),
     /// Request to display a form control to the embedder.
-    ShowEmbedderControl(EmbedderControlId, DeviceIntRect, FormControlRequest),
+    ShowEmbedderControl(EmbedderControlId, DeviceIntRect, EmbedderControlRequest),
     /// Request to display a form control to the embedder.
     HideEmbedderControl(EmbedderControlId),
     /// Inform the embedding layer that a JavaScript evaluation has
@@ -544,7 +544,7 @@ pub struct EmbedderControlId {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub enum FormControlRequest {
+pub enum EmbedderControlRequest {
     /// Indicates that the user has activated a `<select>` element.
     SelectElement(Vec<SelectElementOptionOrOptgroup>, Option<usize>),
     /// Indicates that the user has activated a `<input type=color>` element.
@@ -552,7 +552,7 @@ pub enum FormControlRequest {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub enum FormControlResponse {
+pub enum EmbedderControlResponse {
     SelectElement(Option<usize>),
     ColorPicker(Option<RgbColor>),
 }

--- a/components/shared/net/filemanager_thread.rs
+++ b/components/shared/net/filemanager_thread.rs
@@ -7,7 +7,6 @@ use std::ops::Range;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
-use base::id::WebViewId;
 use embedder_traits::{EmbedderControlId, FilterPattern};
 use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;

--- a/components/shared/net/filemanager_thread.rs
+++ b/components/shared/net/filemanager_thread.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 use base::id::WebViewId;
-use embedder_traits::FilterPattern;
+use embedder_traits::{EmbedderControlId, FilterPattern};
 use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
 use num_traits::ToPrimitive;
@@ -137,7 +137,7 @@ pub struct SelectedFile {
 pub enum FileManagerThreadMsg {
     /// Select a single file. Last field is pre-selected file path for testing
     SelectFile(
-        WebViewId,
+        EmbedderControlId,
         Vec<FilterPattern>,
         IpcSender<FileManagerResult<SelectedFile>>,
         FileOrigin,
@@ -146,7 +146,7 @@ pub enum FileManagerThreadMsg {
 
     /// Select multiple files. Last field is pre-selected file paths for testing
     SelectFiles(
-        WebViewId,
+        EmbedderControlId,
         Vec<FilterPattern>,
         IpcSender<FileManagerResult<Vec<SelectedFile>>>,
         FileOrigin,

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -28,7 +28,7 @@ use crossbeam_channel::{RecvTimeoutError, Sender};
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use embedder_traits::user_content_manager::UserContentManager;
 use embedder_traits::{
-    CompositorHitTestResult, EmbedderControlId, FocusSequenceNumber, FormControlResponse,
+    CompositorHitTestResult, EmbedderControlId, EmbedderControlResponse, FocusSequenceNumber,
     InputEventAndId, JavaScriptEvaluationId, MediaSessionActionType, ScriptToEmbedderChan, Theme,
     ViewportDetails, WebDriverScriptCommand,
 };
@@ -274,7 +274,7 @@ pub enum ScriptThreadMessage {
     /// in the future.
     RequestScreenshotReadiness(PipelineId),
     /// A response to a request to show an embedder user interface control.
-    EmbedderControlResponse(EmbedderControlId, FormControlResponse),
+    EmbedderControlResponse(EmbedderControlId, EmbedderControlResponse),
 }
 
 impl fmt::Debug for ScriptThreadMessage {

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -6,7 +6,6 @@ use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::mem;
-use std::path::PathBuf;
 use std::rc::Rc;
 
 use crossbeam_channel::{Receiver, Sender};
@@ -18,7 +17,7 @@ use servo::config::pref;
 use servo::ipc_channel::ipc::IpcSender;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 use servo::{
-    AllowOrDenyRequest, AuthenticationRequest, EmbedderControl, EmbedderControlId, FilterPattern,
+    AllowOrDenyRequest, AuthenticationRequest, EmbedderControl, EmbedderControlId,
     GamepadHapticEffectType, InputEvent, InputEventId, InputEventResult, JSValue, LoadStatus,
     PermissionRequest, Servo, ServoDelegate, ServoError, SimpleDialog, TraversalId,
     WebDriverCommandMsg, WebDriverJSResult, WebDriverLoadStatus, WebDriverSenders,

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -18,7 +18,7 @@ use servo::config::pref;
 use servo::ipc_channel::ipc::IpcSender;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 use servo::{
-    AllowOrDenyRequest, AuthenticationRequest, EmbedderControlId, FilterPattern, FormControl,
+    AllowOrDenyRequest, AuthenticationRequest, EmbedderControl, EmbedderControlId, FilterPattern,
     GamepadHapticEffectType, InputEvent, InputEventId, InputEventResult, JSValue, LoadStatus,
     PermissionRequest, Servo, ServoDelegate, ServoError, SimpleDialog, TraversalId,
     WebDriverCommandMsg, WebDriverJSResult, WebDriverLoadStatus, WebDriverSenders,
@@ -812,21 +812,21 @@ impl WebViewDelegate for RunningAppState {
         self.inner().window.hide_ime();
     }
 
-    fn show_form_control(&self, webview: WebView, form_control: FormControl) {
+    fn show_embedder_control(&self, webview: WebView, embedder_control: EmbedderControl) {
         if self.servoshell_preferences.headless &&
             self.servoshell_preferences.webdriver_port.is_none()
         {
             return;
         }
 
-        match form_control {
-            FormControl::SelectElement(prompt) => {
+        match embedder_control {
+            EmbedderControl::SelectElement(prompt) => {
                 // FIXME: Reading the toolbar height is needed here to properly position the select dialog.
                 // But if the toolbar height changes while the dialog is open then the position won't be updated
                 let offset = self.inner().window.toolbar_height();
                 self.add_dialog(webview, Dialog::new_select_element_dialog(prompt, offset));
             },
-            FormControl::ColorPicker(color_picker) => {
+            EmbedderControl::ColorPicker(color_picker) => {
                 // FIXME: Reading the toolbar height is needed here to properly position the select dialog.
                 // But if the toolbar height changes while the dialog is open then the position won't be updated
                 let offset = self.inner().window.toolbar_height();
@@ -838,7 +838,7 @@ impl WebViewDelegate for RunningAppState {
         }
     }
 
-    fn hide_form_control(&self, webview: WebView, control_id: servo::EmbedderControlId) {
+    fn hide_embedder_control(&self, webview: WebView, control_id: servo::EmbedderControlId) {
         self.dismiss_active_dialogs_with_control_id(webview.id(), control_id);
     }
 

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -738,18 +738,6 @@ impl WebViewDelegate for RunningAppState {
         );
     }
 
-    fn show_file_selection_dialog(
-        &self,
-        webview: servo::WebView,
-        filter_pattern: Vec<FilterPattern>,
-        allow_select_mutiple: bool,
-        response_sender: GenericSender<Option<Vec<PathBuf>>>,
-    ) {
-        let file_dialog =
-            Dialog::new_file_dialog(allow_select_mutiple, response_sender, filter_pattern);
-        self.add_dialog(webview, file_dialog);
-    }
-
     fn request_permission(&self, webview: servo::WebView, permission_request: PermissionRequest) {
         if self.servoshell_preferences.headless &&
             self.servoshell_preferences.webdriver_port.is_none()
@@ -834,6 +822,9 @@ impl WebViewDelegate for RunningAppState {
                     webview,
                     Dialog::new_color_picker_dialog(color_picker, offset),
                 );
+            },
+            EmbedderControl::FilePicker(file_picker) => {
+                self.add_dialog(webview, Dialog::new_file_dialog(file_picker));
             },
         }
     }

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use egui::Modal;
@@ -13,8 +13,8 @@ use servo::base::generic_channel::GenericSender;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::{
     AlertResponse, AuthenticationRequest, ColorPicker, ConfirmResponse, EmbedderControlId,
-    FilePicker, FilterPattern, PermissionRequest, PromptResponse, RgbColor, SelectElement,
-    SelectElementOption, SelectElementOptionOrOptgroup, SimpleDialog, WebDriverUserPrompt,
+    FilePicker, PermissionRequest, PromptResponse, RgbColor, SelectElement, SelectElementOption,
+    SelectElementOptionOrOptgroup, SimpleDialog, WebDriverUserPrompt,
 };
 
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
in #39709, we introduced a single “form control” or “embedder control” delegate that requests the embedder’s input for &lt;select> and &lt;input type="color"> elements.

this patch partially merges &lt;input type="file"> elements into that new system, and renames “form controls” to “embedder controls” for consistency.

internally we continue to use a separate code path where the embedder directly communicates with the file manager thread. subsequent work will make the messages asynchronous via the constellation and script thread, like other embedder controls.

Testing: this is currently tricky to write an automated test for; we expect to write a WebDriver test for this once we make the communication asynchronous