### PR TITLE
Update to Stylo with cheaper border paint damage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7511,7 +7511,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.32.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?rev=e04e74a3ed9bdf8ff8df5c712fa682f9875a4113#e04e74a3ed9bdf8ff8df5c712fa682f9875a4113"
 dependencies = [
  "bitflags 2.9.4",
  "cssparser",
@@ -7844,7 +7844,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.2"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?rev=e04e74a3ed9bdf8ff8df5c712fa682f9875a4113#e04e74a3ed9bdf8ff8df5c712fa682f9875a4113"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8357,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?rev=e04e74a3ed9bdf8ff8df5c712fa682f9875a4113#e04e74a3ed9bdf8ff8df5c712fa682f9875a4113"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8414,7 +8414,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?rev=e04e74a3ed9bdf8ff8df5c712fa682f9875a4113#e04e74a3ed9bdf8ff8df5c712fa682f9875a4113"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8423,12 +8423,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?rev=e04e74a3ed9bdf8ff8df5c712fa682f9875a4113#e04e74a3ed9bdf8ff8df5c712fa682f9875a4113"
 
 [[package]]
 name = "stylo_derive"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?rev=e04e74a3ed9bdf8ff8df5c712fa682f9875a4113#e04e74a3ed9bdf8ff8df5c712fa682f9875a4113"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8440,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?rev=e04e74a3ed9bdf8ff8df5c712fa682f9875a4113#e04e74a3ed9bdf8ff8df5c712fa682f9875a4113"
 dependencies = [
  "bitflags 2.9.4",
  "stylo_malloc_size_of",
@@ -8449,7 +8449,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?rev=e04e74a3ed9bdf8ff8df5c712fa682f9875a4113#e04e74a3ed9bdf8ff8df5c712fa682f9875a4113"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8466,12 +8466,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?rev=e04e74a3ed9bdf8ff8df5c712fa682f9875a4113#e04e74a3ed9bdf8ff8df5c712fa682f9875a4113"
 
 [[package]]
 name = "stylo_traits"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?rev=e04e74a3ed9bdf8ff8df5c712fa682f9875a4113#e04e74a3ed9bdf8ff8df5c712fa682f9875a4113"
 dependencies = [
  "app_units",
  "bitflags 2.9.4",
@@ -8886,7 +8886,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?rev=e04e74a3ed9bdf8ff8df5c712fa682f9875a4113#e04e74a3ed9bdf8ff8df5c712fa682f9875a4113"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8899,7 +8899,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#954a537a13b1702b4b7d1ccf23ae2ef8d7a0007b"
+source = "git+https://github.com/servo/stylo?rev=e04e74a3ed9bdf8ff8df5c712fa682f9875a4113#e04e74a3ed9bdf8ff8df5c712fa682f9875a4113"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ rustls = { version = "0.23", default-features = false, features = ["logging", "s
 rustls-pemfile = "2.0"
 rustls-pki-types = "1.12"
 script_traits = { path = "components/shared/script" }
-selectors = { git = "https://github.com/servo/stylo", branch = "2025-10-01" }
+selectors = { git = "https://github.com/servo/stylo", rev = "e04e74a3ed9bdf8ff8df5c712fa682f9875a4113" }
 serde = "1.0.228"
 serde_bytes = "0.11"
 serde_core = "1.0.226"
@@ -137,19 +137,19 @@ servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
-servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-10-01" }
+servo_arc = { git = "https://github.com/servo/stylo", rev = "e04e74a3ed9bdf8ff8df5c712fa682f9875a4113" }
 skrifa = "0.35.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
 string_cache = "0.8"
 strum = "0.26"
 strum_macros = "0.26"
-stylo = { git = "https://github.com/servo/stylo", branch = "2025-10-01" }
-stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-10-01" }
-stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-10-01" }
-stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-10-01" }
-stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-10-01" }
-stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-10-01" }
+stylo = { git = "https://github.com/servo/stylo", rev = "e04e74a3ed9bdf8ff8df5c712fa682f9875a4113" }
+stylo_atoms = { git = "https://github.com/servo/stylo", rev = "e04e74a3ed9bdf8ff8df5c712fa682f9875a4113" }
+stylo_config = { git = "https://github.com/servo/stylo", rev = "e04e74a3ed9bdf8ff8df5c712fa682f9875a4113" }
+stylo_dom = { git = "https://github.com/servo/stylo", rev = "e04e74a3ed9bdf8ff8df5c712fa682f9875a4113" }
+stylo_malloc_size_of = { git = "https://github.com/servo/stylo", rev = "e04e74a3ed9bdf8ff8df5c712fa682f9875a4113" }
+stylo_traits = { git = "https://github.com/servo/stylo", rev = "e04e74a3ed9bdf8ff8df5c712fa682f9875a4113" }
 surfman = { version = "0.10.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"


### PR DESCRIPTION
Use `repaint` damage for `border-radius` and `border-color`. Actual changes in Stylo.

Stylo PR: https://github.com/servo/stylo/pull/253
