### PR TITLE
Script: len,is_empty and match for DOMString

### DIFF
--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -12,6 +12,7 @@ use euclid::default::Size2D;
 use js::rust::{HandleObject, HandleValue};
 use pixels::{EncodedImageType, Snapshot};
 use rustc_hash::FxHashMap;
+use script_bindings::match_domstring_ascii;
 use script_bindings::weakref::WeakRef;
 
 use crate::canvas_context::{CanvasContext, OffscreenRenderingContext};
@@ -297,23 +298,22 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
             return Err(Error::InvalidState(None));
         }
 
-        match &*id.str() {
-            "2d" => Ok(self
-                .get_or_init_2d_context(can_gc)
-                .map(RootedOffscreenRenderingContext::OffscreenCanvasRenderingContext2D)),
-            "bitmaprenderer" => Ok(self
-                .get_or_init_bitmaprenderer_context(can_gc)
-                .map(RootedOffscreenRenderingContext::ImageBitmapRenderingContext)),
-            /*"webgl" | "experimental-webgl" => self
-                .get_or_init_webgl_context(cx, options)
-                .map(OffscreenRenderingContext::WebGLRenderingContext),
-            "webgl2" | "experimental-webgl2" => self
-                .get_or_init_webgl2_context(cx, options)
-                .map(OffscreenRenderingContext::WebGL2RenderingContext),*/
-            _ => Err(Error::Type(String::from(
-                "Unrecognized OffscreenCanvas context type",
-            ))),
-        }
+        match_domstring_ascii!(id, Err(Error::Type(String::from(
+            "Unrecognized OffscreenCanvas context type",
+        ))),
+        "2d" => Ok(self
+            .get_or_init_2d_context(can_gc)
+            .map(RootedOffscreenRenderingContext::OffscreenCanvasRenderingContext2D)),
+        "bitmaprenderer" => Ok(self
+            .get_or_init_bitmaprenderer_context(can_gc)
+            .map(RootedOffscreenRenderingContext::ImageBitmapRenderingContext)),
+        /*"webgl" | "experimental-webgl" => self
+            .get_or_init_webgl_context(cx, options)
+            .map(OffscreenRenderingContext::WebGLRenderingContext),
+        "webgl2" | "experimental-webgl2" => self
+            .get_or_init_webgl2_context(cx, options)
+            .map(OffscreenRenderingContext::WebGL2RenderingContext),*/
+        )
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-offscreencanvas-width>

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -298,9 +298,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
             return Err(Error::InvalidState(None));
         }
 
-        match_domstring_ascii!(id, Err(Error::Type(String::from(
-            "Unrecognized OffscreenCanvas context type",
-        ))),
+        match_domstring_ascii!(id,
         "2d" => Ok(self
             .get_or_init_2d_context(can_gc)
             .map(RootedOffscreenRenderingContext::OffscreenCanvasRenderingContext2D)),
@@ -313,6 +311,9 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         "webgl2" | "experimental-webgl2" => self
             .get_or_init_webgl2_context(cx, options)
             .map(OffscreenRenderingContext::WebGL2RenderingContext),*/
+            _ => Err(Error::Type(String::from(
+                "Unrecognized OffscreenCanvas context type",
+            ))),
         )
     }
 

--- a/components/script/dom/datatransfer.rs
+++ b/components/script/dom/datatransfer.rs
@@ -188,14 +188,15 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
         // Step 4 Let convert-to-URL be false.
         let mut convert_to_url = false;
 
-        let type_ = match_domstring_ascii!(format, format.clone(),
+        let type_ = match_domstring_ascii!(format,
             // Step 5 If format equals "text", change it to "text/plain".
             "text" => DOMString::from("text/plain"),
             // Step 6 If format equals "url", change it to "text/uri-list" and set convert-to-URL to true.
             "url" => {
                 convert_to_url = true;
                 DOMString::from("text/uri-list")
-            },);
+            },
+            _ => format.clone(),);
 
         let data = data_store.find_matching_text(&type_);
 

--- a/components/script/dom/datatransfer.rs
+++ b/components/script/dom/datatransfer.rs
@@ -8,6 +8,7 @@ use std::rc::Rc;
 use dom_struct::dom_struct;
 use js::rust::{HandleObject, MutableHandleValue};
 use net_traits::image_cache::Image;
+use script_bindings::match_domstring_ascii;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::DataTransferBinding::DataTransferMethods;
@@ -187,16 +188,14 @@ impl DataTransferMethods<crate::DomTypeHolder> for DataTransfer {
         // Step 4 Let convert-to-URL be false.
         let mut convert_to_url = false;
 
-        let type_ = match &*format.str() {
+        let type_ = match_domstring_ascii!(format, format.clone(),
             // Step 5 If format equals "text", change it to "text/plain".
             "text" => DOMString::from("text/plain"),
             // Step 6 If format equals "url", change it to "text/uri-list" and set convert-to-URL to true.
             "url" => {
                 convert_to_url = true;
                 DOMString::from("text/uri-list")
-            },
-            _ => format.clone(),
-        };
+            },);
 
         let data = data_store.find_matching_text(&type_);
 

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -31,6 +31,7 @@ use script_bindings::codegen::GenericBindings::PerformanceBinding::PerformanceMe
 use script_bindings::codegen::GenericBindings::TouchBinding::TouchMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::{ScrollBehavior, WindowMethods};
 use script_bindings::inheritance::Castable;
+use script_bindings::match_domstring_ascii;
 use script_bindings::num::Finite;
 use script_bindings::reflector::DomObject;
 use script_bindings::root::{Dom, DomRoot, DomSlice};
@@ -1342,7 +1343,9 @@ impl DocumentEventHandler {
 
         // Step 4 If the event was canceled, then
         if event.DefaultPrevented() {
-            match &*event.Type().str() {
+            let event_type = event.Type();
+            match_domstring_ascii!(event_type, (),
+
                 "copy" => {
                     // Step 4.1 Call the write content to the clipboard algorithm,
                     // passing on the DataTransferItemList items, a clear-was-called flag and a types-to-clear list.
@@ -1368,8 +1371,7 @@ impl DocumentEventHandler {
                 // Note: This function deviates from the specification a bit by returning
                 // the `InputEventResult` below.
                 "paste" => (),
-                _ => (),
-            }
+            )
         }
 
         // Step 5: Return true from the action.

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -1344,7 +1344,7 @@ impl DocumentEventHandler {
         // Step 4 If the event was canceled, then
         if event.DefaultPrevented() {
             let event_type = event.Type();
-            match_domstring_ascii!(event_type, (),
+            match_domstring_ascii!(event_type,
 
                 "copy" => {
                     // Step 4.1 Call the write content to the clipboard algorithm,
@@ -1371,6 +1371,7 @@ impl DocumentEventHandler {
                 // Note: This function deviates from the specification a bit by returning
                 // the `InputEventResult` below.
                 "paste" => (),
+                _ => (),
             )
         }
 

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -7,6 +7,7 @@ use constellation_traits::DomException;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use rustc_hash::FxHashMap;
+use script_bindings::match_domstring_ascii;
 
 use crate::dom::bindings::codegen::Bindings::DOMExceptionBinding::{
     DOMExceptionConstants, DOMExceptionMethods,
@@ -61,7 +62,7 @@ pub(crate) enum DOMErrorName {
 
 impl DOMErrorName {
     pub(crate) fn from(s: &DOMString) -> Option<DOMErrorName> {
-        match &*s.str() {
+        match_domstring_ascii!(s, None,
             "IndexSizeError" => Some(DOMErrorName::IndexSizeError),
             "HierarchyRequestError" => Some(DOMErrorName::HierarchyRequestError),
             "WrongDocumentError" => Some(DOMErrorName::WrongDocumentError),
@@ -93,8 +94,7 @@ impl DOMErrorName {
             "OperationError" => Some(DOMErrorName::OperationError),
             "NotAllowedError" => Some(DOMErrorName::NotAllowedError),
             "ConstraintError" => Some(DOMErrorName::ConstraintError),
-            _ => None,
-        }
+        )
     }
 }
 

--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -62,7 +62,7 @@ pub(crate) enum DOMErrorName {
 
 impl DOMErrorName {
     pub(crate) fn from(s: &DOMString) -> Option<DOMErrorName> {
-        match_domstring_ascii!(s, None,
+        match_domstring_ascii!(s,
             "IndexSizeError" => Some(DOMErrorName::IndexSizeError),
             "HierarchyRequestError" => Some(DOMErrorName::HierarchyRequestError),
             "WrongDocumentError" => Some(DOMErrorName::WrongDocumentError),
@@ -94,6 +94,7 @@ impl DOMErrorName {
             "OperationError" => Some(DOMErrorName::OperationError),
             "NotAllowedError" => Some(DOMErrorName::NotAllowedError),
             "ConstraintError" => Some(DOMErrorName::ConstraintError),
+            _ => None,
         )
     }
 }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -19,7 +19,6 @@ use net_traits::request::Referrer;
 use rand::random;
 use rustc_hash::FxBuildHasher;
 use script_bindings::match_domstring_ascii;
-use servo_rand::random;
 use style::attr::AttrValue;
 use style::str::split_html_space_chars;
 use stylo_atoms::Atom;
@@ -162,9 +161,9 @@ impl HTMLFormElement {
                 RadioListMode::ControlsExceptImageInputs => {
                     if child
                         .downcast::<HTMLElement>()
-                        .is_some_and(|c| c.is_listed_element())
-                        && (child.get_id().is_some_and(|i| i == *name)
-                            || child.get_name().is_some_and(|n| n == *name))
+                        .is_some_and(|c| c.is_listed_element()) &&
+                        (child.get_id().is_some_and(|i| i == *name) ||
+                            child.get_name().is_some_and(|n| n == *name))
                     {
                         if let Some(inp) = child.downcast::<HTMLInputElement>() {
                             // input, only return it if it's not image-button state
@@ -177,9 +176,9 @@ impl HTMLFormElement {
                     return false;
                 },
                 RadioListMode::Images => {
-                    return child.is::<HTMLImageElement>()
-                        && (child.get_id().is_some_and(|i| i == *name)
-                            || child.get_name().is_some_and(|n| n == *name));
+                    return child.is::<HTMLImageElement>() &&
+                        (child.get_id().is_some_and(|i| i == *name) ||
+                            child.get_name().is_some_and(|n| n == *name));
                 },
             }
         }
@@ -615,8 +614,8 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         sourced_names_vec.sort_by(|a, b| {
             if a.element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>())
-                == 0
+                .CompareDocumentPosition(b.element.upcast::<Node>()) ==
+                0
             {
                 if a.source.is_past() && b.source.is_past() {
                     b.source.cmp(&a.source)
@@ -626,9 +625,9 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
             } else if a
                 .element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>())
-                & NodeConstants::DOCUMENT_POSITION_FOLLOWING
-                == NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                .CompareDocumentPosition(b.element.upcast::<Node>()) &
+                NodeConstants::DOCUMENT_POSITION_FOLLOWING ==
+                NodeConstants::DOCUMENT_POSITION_FOLLOWING
             {
                 std::cmp::Ordering::Less
             } else {
@@ -911,11 +910,11 @@ impl HTMLFormElement {
                 );
             },
             // https://html.spec.whatwg.org/multipage/#submit-get-action
-            ("file", _)
-            | ("about", _)
-            | ("data", FormMethod::Post)
-            | ("ftp", _)
-            | ("javascript", _) => {
+            ("file", _) |
+            ("about", _) |
+            ("data", FormMethod::Post) |
+            ("ftp", _) |
+            ("javascript", _) => {
                 self.plan_to_navigate(load_data, target_window);
             },
             ("mailto", FormMethod::Post) => {
@@ -1615,9 +1614,9 @@ pub(crate) trait FormControl: DomObject {
             .next();
 
         // Step 1
-        if old_owner.is_some()
-            && !(self.is_listed() && has_form_id)
-            && nearest_form_ancestor == old_owner
+        if old_owner.is_some() &&
+            !(self.is_listed() && has_form_id) &&
+            nearest_form_ancestor == old_owner
         {
             return;
         }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1498,9 +1498,10 @@ impl FormSubmitterElement<'_> {
         };
         // https://html.spec.whatwg.org/multipage/#attr-fs-enctype
         // urlencoded is the default
-        match_domstring_ascii!(attr, FormEncType::UrlEncoded,
+        match_domstring_ascii!(attr,
             "multipart/form-data" => FormEncType::MultipartFormData,
             "text/plain" => FormEncType::TextPlain,
+            _ => FormEncType::UrlEncoded,
         )
     }
 
@@ -1518,9 +1519,10 @@ impl FormSubmitterElement<'_> {
                 |f| f.Method(),
             ),
         };
-        match_domstring_ascii!(attr, FormMethod::Get,
+        match_domstring_ascii!(attr,
             "dialog" => FormMethod::Dialog,
             "post" => FormMethod::Post,
+            _ => FormMethod::Get,
         )
     }
 

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -18,6 +18,8 @@ use net_traits::http_percent_encode;
 use net_traits::request::Referrer;
 use rand::random;
 use rustc_hash::FxBuildHasher;
+use script_bindings::match_domstring_ascii;
+use servo_rand::random;
 use style::attr::AttrValue;
 use style::str::split_html_space_chars;
 use stylo_atoms::Atom;
@@ -160,9 +162,9 @@ impl HTMLFormElement {
                 RadioListMode::ControlsExceptImageInputs => {
                     if child
                         .downcast::<HTMLElement>()
-                        .is_some_and(|c| c.is_listed_element()) &&
-                        (child.get_id().is_some_and(|i| i == *name) ||
-                            child.get_name().is_some_and(|n| n == *name))
+                        .is_some_and(|c| c.is_listed_element())
+                        && (child.get_id().is_some_and(|i| i == *name)
+                            || child.get_name().is_some_and(|n| n == *name))
                     {
                         if let Some(inp) = child.downcast::<HTMLInputElement>() {
                             // input, only return it if it's not image-button state
@@ -175,9 +177,9 @@ impl HTMLFormElement {
                     return false;
                 },
                 RadioListMode::Images => {
-                    return child.is::<HTMLImageElement>() &&
-                        (child.get_id().is_some_and(|i| i == *name) ||
-                            child.get_name().is_some_and(|n| n == *name));
+                    return child.is::<HTMLImageElement>()
+                        && (child.get_id().is_some_and(|i| i == *name)
+                            || child.get_name().is_some_and(|n| n == *name));
                 },
             }
         }
@@ -613,8 +615,8 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
         sourced_names_vec.sort_by(|a, b| {
             if a.element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) ==
-                0
+                .CompareDocumentPosition(b.element.upcast::<Node>())
+                == 0
             {
                 if a.source.is_past() && b.source.is_past() {
                     b.source.cmp(&a.source)
@@ -624,9 +626,9 @@ impl HTMLFormElementMethods<crate::DomTypeHolder> for HTMLFormElement {
             } else if a
                 .element
                 .upcast::<Node>()
-                .CompareDocumentPosition(b.element.upcast::<Node>()) &
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING ==
-                NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                .CompareDocumentPosition(b.element.upcast::<Node>())
+                & NodeConstants::DOCUMENT_POSITION_FOLLOWING
+                == NodeConstants::DOCUMENT_POSITION_FOLLOWING
             {
                 std::cmp::Ordering::Less
             } else {
@@ -909,11 +911,11 @@ impl HTMLFormElement {
                 );
             },
             // https://html.spec.whatwg.org/multipage/#submit-get-action
-            ("file", _) |
-            ("about", _) |
-            ("data", FormMethod::Post) |
-            ("ftp", _) |
-            ("javascript", _) => {
+            ("file", _)
+            | ("about", _)
+            | ("data", FormMethod::Post)
+            | ("ftp", _)
+            | ("javascript", _) => {
                 self.plan_to_navigate(load_data, target_window);
             },
             ("mailto", FormMethod::Post) => {
@@ -1495,13 +1497,12 @@ impl FormSubmitterElement<'_> {
                 |f| f.Enctype(),
             ),
         };
-        match &*attr.str() {
+        // https://html.spec.whatwg.org/multipage/#attr-fs-enctype
+        // urlencoded is the default
+        match_domstring_ascii!(attr, FormEncType::UrlEncoded,
             "multipart/form-data" => FormEncType::MultipartFormData,
             "text/plain" => FormEncType::TextPlain,
-            // https://html.spec.whatwg.org/multipage/#attr-fs-enctype
-            // urlencoded is the default
-            _ => FormEncType::UrlEncoded,
-        }
+        )
     }
 
     fn method(&self) -> FormMethod {
@@ -1518,11 +1519,10 @@ impl FormSubmitterElement<'_> {
                 |f| f.Method(),
             ),
         };
-        match &*attr.str() {
+        match_domstring_ascii!(attr, FormMethod::Get,
             "dialog" => FormMethod::Dialog,
             "post" => FormMethod::Post,
-            _ => FormMethod::Get,
-        }
+        )
     }
 
     fn target(&self) -> DOMString {
@@ -1615,9 +1615,9 @@ pub(crate) trait FormControl: DomObject {
             .next();
 
         // Step 1
-        if old_owner.is_some() &&
-            !(self.is_listed() && has_form_id) &&
-            nearest_form_ancestor == old_owner
+        if old_owner.is_some()
+            && !(self.is_listed() && has_form_id)
+            && nearest_form_ancestor == old_owner
         {
             return;
         }

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -10,6 +10,7 @@ use euclid::Point2D;
 use js::rust::HandleObject;
 use keyboard_types::Modifiers;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
+use script_bindings::match_domstring_ascii;
 use script_traits::ConstellationInputEvent;
 use servo_config::pref;
 use style_traits::CSSPixel;
@@ -557,7 +558,9 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
 
     /// <https://w3c.github.io/uievents/#dom-mouseevent-getmodifierstate>
     fn GetModifierState(&self, key_arg: DOMString) -> bool {
-        self.modifiers.get().contains(match &*key_arg.str() {
+        self.modifiers
+            .get()
+            .contains(match_domstring_ascii!(key_arg, { return false; },
             "Alt" => Modifiers::ALT,
             "AltGraph" => Modifiers::ALT_GRAPH,
             "CapsLock" => Modifiers::CAPS_LOCK,
@@ -570,7 +573,6 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
             "Shift" => Modifiers::SHIFT,
             "Symbol" => Modifiers::SYMBOL,
             "SymbolLock" => Modifiers::SYMBOL_LOCK,
-            _ => return false,
-        })
+            ))
     }
 }

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -560,19 +560,20 @@ impl MouseEventMethods<crate::DomTypeHolder> for MouseEvent {
     fn GetModifierState(&self, key_arg: DOMString) -> bool {
         self.modifiers
             .get()
-            .contains(match_domstring_ascii!(key_arg, { return false; },
-            "Alt" => Modifiers::ALT,
-            "AltGraph" => Modifiers::ALT_GRAPH,
-            "CapsLock" => Modifiers::CAPS_LOCK,
-            "Control" => Modifiers::CONTROL,
-            "Fn" => Modifiers::FN,
-            "FnLock" => Modifiers::FN_LOCK,
-            "Meta" => Modifiers::META,
-            "NumLock" => Modifiers::NUM_LOCK,
-            "ScrollLock" => Modifiers::SCROLL_LOCK,
-            "Shift" => Modifiers::SHIFT,
-            "Symbol" => Modifiers::SYMBOL,
-            "SymbolLock" => Modifiers::SYMBOL_LOCK,
+            .contains(match_domstring_ascii!(key_arg,
+                "Alt" => Modifiers::ALT,
+                "AltGraph" => Modifiers::ALT_GRAPH,
+                "CapsLock" => Modifiers::CAPS_LOCK,
+                "Control" => Modifiers::CONTROL,
+                "Fn" => Modifiers::FN,
+                "FnLock" => Modifiers::FN_LOCK,
+                "Meta" => Modifiers::META,
+                "NumLock" => Modifiers::NUM_LOCK,
+                "ScrollLock" => Modifiers::SCROLL_LOCK,
+                "Shift" => Modifiers::SHIFT,
+                "Symbol" => Modifiers::SYMBOL,
+                "SymbolLock" => Modifiers::SYMBOL_LOCK,
+                    _ => { return false; },
             ))
     }
 }

--- a/components/script/dom/reportingobserver.rs
+++ b/components/script/dom/reportingobserver.rs
@@ -8,6 +8,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
+use script_bindings::match_domstring_ascii;
 use script_bindings::str::DOMString;
 use servo_url::ServoUrl;
 
@@ -67,11 +68,10 @@ impl ReportingObserver {
     }
 
     fn report_is_visible_to_reporting_observers(report: &Report) -> bool {
-        match &*report.type_.str() {
-            // https://w3c.github.io/webappsec-csp/#reporting
-            "csp-violation" => true,
-            _ => false,
-        }
+        match_domstring_ascii!(report.type_, false,
+                // https://w3c.github.io/webappsec-csp/#reporting
+                "csp-violation" => true,
+        )
     }
 
     /// <https://w3c.github.io/reporting/#add-report>

--- a/components/script/dom/reportingobserver.rs
+++ b/components/script/dom/reportingobserver.rs
@@ -68,9 +68,10 @@ impl ReportingObserver {
     }
 
     fn report_is_visible_to_reporting_observers(report: &Report) -> bool {
-        match_domstring_ascii!(report.type_, false,
+        match_domstring_ascii!(report.type_,
                 // https://w3c.github.io/webappsec-csp/#reporting
                 "csp-violation" => true,
+                _ =>  false,
         )
     }
 

--- a/components/script/dom/webrtc/rtcdatachannel.rs
+++ b/components/script/dom/webrtc/rtcdatachannel.rs
@@ -207,7 +207,7 @@ impl RTCDataChannel {
             },
             DataChannelMessage::Binary(data) => {
                 let binary_type = self.binary_type.borrow();
-                match_domstring_ascii!(binary_type, unreachable!(),
+                match_domstring_ascii!(binary_type,
                     "blob" => {
                         let blob = Blob::new(
                             &global,
@@ -229,7 +229,8 @@ impl RTCDataChannel {
                             )
                         };
                         (*array_buffer).safe_to_jsval(cx, message.handle_mut());
-                },)
+                },
+            _ => unreachable!(),)
             },
         }
 

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -128,9 +128,10 @@ impl AddAssign for UTF16CodeUnits {
 
 impl From<DOMString> for SelectionDirection {
     fn from(direction: DOMString) -> SelectionDirection {
-        match_domstring_ascii!(direction, SelectionDirection::None,
+        match_domstring_ascii!(direction,
             "forward" => SelectionDirection::Forward,
             "backward" => SelectionDirection::Backward,
+            _ => SelectionDirection::None,
         )
     }
 }
@@ -1250,7 +1251,7 @@ impl<T: ClipboardProvider> TextInput<T> {
         }
 
         let event_type = event.Type();
-        match_domstring_ascii!(event_type, ClipboardEventReaction::empty(),
+        match_domstring_ascii!(event_type,
             "copy" => {
                 // These steps are from <https://www.w3.org/TR/clipboard-apis/#copy-action>:
                 let selection = self.get_selection_text();
@@ -1321,6 +1322,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                 // Step 3.1.2: Queue tasks to fire any events that should fire due to the
                 // modification, see § 5.3 Integration with other scripts and events for details.
                 ClipboardEventReaction::QueueInputEvent
-            },)
+            },
+        _ => ClipboardEventReaction::empty(),)
     }
 }

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -11,6 +11,7 @@ use std::ops::{Add, AddAssign, Range};
 
 use bitflags::bitflags;
 use keyboard_types::{Key, KeyState, Modifiers, NamedKey, ShortcutMatcher};
+use script_bindings::match_domstring_ascii;
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::clipboard_provider::ClipboardProvider;
@@ -127,11 +128,10 @@ impl AddAssign for UTF16CodeUnits {
 
 impl From<DOMString> for SelectionDirection {
     fn from(direction: DOMString) -> SelectionDirection {
-        match &*direction.str() {
+        match_domstring_ascii!(direction, SelectionDirection::None,
             "forward" => SelectionDirection::Forward,
             "backward" => SelectionDirection::Backward,
-            _ => SelectionDirection::None,
-        }
+        )
     }
 }
 
@@ -1249,7 +1249,8 @@ impl<T: ClipboardProvider> TextInput<T> {
             return ClipboardEventReaction::empty();
         }
 
-        match &*event.Type().str() {
+        let event_type = event.Type();
+        match_domstring_ascii!(event_type, ClipboardEventReaction::empty(),
             "copy" => {
                 // These steps are from <https://www.w3.org/TR/clipboard-apis/#copy-action>:
                 let selection = self.get_selection_text();
@@ -1280,8 +1281,8 @@ impl<T: ClipboardProvider> TextInput<T> {
 
                 // Step 3.1.3 Fire a clipboard event named clipboardchange
                 // Step 3.1.4 Queue tasks to fire any events that should fire due to the modification.
-                ClipboardEventReaction::FireClipboardChangedEvent |
-                    ClipboardEventReaction::QueueInputEvent
+                ClipboardEventReaction::FireClipboardChangedEvent
+                    | ClipboardEventReaction::QueueInputEvent
             },
             "paste" => {
                 // These steps are from <https://www.w3.org/TR/clipboard-apis/#paste-action>:
@@ -1320,8 +1321,6 @@ impl<T: ClipboardProvider> TextInput<T> {
                 // Step 3.1.2: Queue tasks to fire any events that should fire due to the
                 // modification, see § 5.3 Integration with other scripts and events for details.
                 ClipboardEventReaction::QueueInputEvent
-            },
-            _ => ClipboardEventReaction::empty(),
-        }
+            },)
     }
 }

--- a/components/script_bindings/domstring.rs
+++ b/components/script_bindings/domstring.rs
@@ -371,7 +371,7 @@ impl DOMString {
         self.view().is_empty()
     }
 
-    /// This length (as rust spec) is in bytes not chars.
+    /// This length (as rust spec) is in bytes if the string would be utf8 not chars.
     pub fn len(&self) -> usize {
         self.view().len()
     }
@@ -792,6 +792,61 @@ mod tests {
     }
 
     #[test]
+    fn test_length() {
+        let s1 = from_latin1(vec![
+            0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD,
+            0xAE, 0xAF,
+        ]);
+        let s2 = from_latin1(vec![
+            0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBB, 0xBC, 0xBD,
+            0xBE, 0xBF,
+        ]);
+        let s3 = from_latin1(vec![
+            0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD,
+            0xCE, 0xCF,
+        ]);
+        let s4 = from_latin1(vec![
+            0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD,
+            0xDE, 0xDF,
+        ]);
+        let s5 = from_latin1(vec![
+            0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB, 0xEC, 0xED,
+            0xEE, 0xEF,
+        ]);
+        let s6 = from_latin1(vec![
+            0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD,
+            0xFE, 0xFF,
+        ]);
+
+        let s1_utf8 = String::from("\u{00A0}¡¢£¤¥¦§¨©ª«¬\u{00AD}®¯");
+        let s2_utf8 = String::from("°±²³´µ¶·¸¹º»¼½¾¿");
+        let s3_utf8 = String::from("ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏ");
+        let s4_utf8 = String::from("ÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß");
+        let s5_utf8 = String::from("àáâãäåæçèéêëìíîï");
+        let s6_utf8 = String::from("ðñòóôõö÷øùúûüýþÿ");
+
+        assert_eq!(s1.len(), s1_utf8.len());
+        assert_eq!(s2.len(), s2_utf8.len());
+        assert_eq!(s3.len(), s3_utf8.len());
+        assert_eq!(s4.len(), s4_utf8.len());
+        assert_eq!(s5.len(), s5_utf8.len());
+        assert_eq!(s6.len(), s6_utf8.len());
+
+        s1.make_rust();
+        s2.make_rust();
+        s3.make_rust();
+        s4.make_rust();
+        s5.make_rust();
+        s6.make_rust();
+        assert_eq!(s1.len(), s1_utf8.len());
+        assert_eq!(s2.len(), s2_utf8.len());
+        assert_eq!(s3.len(), s3_utf8.len());
+        assert_eq!(s4.len(), s4_utf8.len());
+        assert_eq!(s5.len(), s5_utf8.len());
+        assert_eq!(s6.len(), s6_utf8.len());
+    }
+
+    #[test]
     fn test_convert() {
         let s = from_latin1(vec![b'a', b'b', b'c', b'%', b'$']);
         s.make_rust();
@@ -883,8 +938,8 @@ mod tests {
 
         {
             let s = DOMString::from_string(String::from("abcde"));
-            match_domstring_ascii!( s, (),
-                "abc" => assert!(true),
+            match_domstring_ascii!( s, assert!(true),
+                "abc" => assert!(false),
                 "bcd" => assert!(false),
             );
         }


### PR DESCRIPTION
This replaces the implementation of is_empty and len with more efficient representation without conversion
and allocation based on the underlying bytes.
For this we use a new view, EncodedBytesView.
Additionally, we implement a new macro `match_domstring_ascii!` which allows simple match clauses
matching ascii strings with DOMStrings without conversion/allocation.
The macro will panic in debug builds if the strings are non-ascii but will not match all DOMStrings correctly.
We replaced the usage of `DOMString::str()` in many places with this macro.


Testing: len and is_empty were already covered by tests. match_domstring_ascii! has more unit tests added with this PR.
