### PR TITLE
libservo: Prevent egui from consuming `PinchGesture` events on macOS

### DIFF
--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -144,6 +144,16 @@ impl Minibrowser {
     ) -> EventResponse {
         let mut result = self.context.on_window_event(window, event);
 
+        // For some reason, egui is eating all PinchGesture events, even when they happen
+        // on top of a WebView. Detect this situation and avoid sending those events to
+        // egui.
+        if matches!(event, WindowEvent::PinchGesture { .. }) &&
+            self.last_mouse_position
+                .is_some_and(|point| !self.is_in_egui_toolbar_rect(point))
+        {
+            return Default::default();
+        }
+
         if app_state.has_active_dialog() {
             result.consumed = true;
             return result;


### PR DESCRIPTION
For some reason, egui consumes all `PinchGesture` events trigged on
macOS, even if the cursor is over the WebView. This change is a
workaround which enables pinch zoom to work on Macbooks once again.

Testing: This is a fix for the input handling layer of servoshell, which
is currently untested.
