### PR TITLE
libservo: Rename `WebView::set_pinch_zoom` to `WebView::pinch_zoom`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1519,9 +1519,9 @@ impl IOCompositor {
         }
     }
 
-    pub fn set_pinch_zoom(&mut self, webview_id: WebViewId, magnification: f32) {
+    pub fn pinch_zoom(&mut self, webview_id: WebViewId, pinch_zoom_delta: f32) {
         if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-            webview_renderer.set_pinch_zoom(magnification);
+            webview_renderer.pinch_zoom(pinch_zoom_delta);
         }
     }
 

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -513,11 +513,17 @@ impl WebView {
         self.inner().compositor.borrow_mut().on_vsync(self.id());
     }
 
-    /// Set the page zoom of the [`WebView`].
+    /// Set the page zoom of the [`WebView`]. This sets the final page zoom value of the
+    /// [`WebView`]. Unlike [`WebView::pinch_zoom`] *it is not* multiplied by the current
+    /// page zoom value, but overrides it.
     ///
-    /// [`WebView`]s have two types of zoom, pinch zoom and page zoom.
-    /// This adjusts page zoom, which will adjust the `devicePixelRatio` of the page
-    /// and cause it to modify its layout.
+    /// [`WebView`]s have two types of zoom, pinch zoom and page zoom. This adjusts page
+    /// zoom, which will adjust the `devicePixelRatio` of the page and cause it to modify
+    /// its layout.
+    ///
+    /// These values will be clamped internally. The values used for clamping can be
+    /// adjusted by page content when `<meta viewport>` parsing is enabled via
+    /// `Prefs::viewport_meta_enabled`.
     pub fn set_page_zoom(&self, new_zoom: f32) {
         let new_zoom = new_zoom.clamp(MIN_PAGE_ZOOM.get(), MAX_PAGE_ZOOM.get());
         if new_zoom == self.inner().page_zoom {
@@ -536,11 +542,20 @@ impl WebView {
         self.inner().page_zoom
     }
 
-    pub fn set_pinch_zoom(&self, new_pinch_zoom: f32) {
+    /// Adjust the pinch zoom on this [`WebView`] multiplying the current pinch zoom
+    /// level with the provided `pinch_zoom_delta`.
+    ///
+    /// [`WebView`]s have two types of zoom, pinch zoom and page zoom. This adjusts pinch
+    /// zoom, which is a type of zoom which does not modify layout, and instead simply
+    /// magnifies the view in the viewport.
+    ///
+    /// The final pinch zoom values will be clamped to reasonable defaults (currently to
+    /// the inclusive range [1.0, 10.0]).
+    pub fn pinch_zoom(&self, pinch_zoom_delta: f32) {
         self.inner()
             .compositor
             .borrow_mut()
-            .set_pinch_zoom(self.id(), new_pinch_zoom);
+            .pinch_zoom(self.id(), pinch_zoom_delta);
     }
 
     pub fn device_pixels_per_css_pixel(&self) -> Scale<f32, CSSPixel, DevicePixel> {

--- a/components/shared/compositing/viewport_description.rs
+++ b/components/shared/compositing/viewport_description.rs
@@ -39,12 +39,12 @@ pub struct ViewportDescription {
     /// the zoom level when the page is first loaded
     pub initial_scale: Scale<f32, CSSPixel, DeviceIndependentPixel>,
 
+    /// The minimum page zoom that is allowed on this viewport's page.
     /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#minimum_scale>
-    /// how much zoom out is allowed on the page.
     pub minimum_scale: Scale<f32, CSSPixel, DeviceIndependentPixel>,
 
+    /// The maximum page zoom that is allowed on this viewport's page.
     /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#maximum_scale>
-    /// how much zoom in is allowed on the page
     pub maximum_scale: Scale<f32, CSSPixel, DeviceIndependentPixel>,
 
     /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#user_scalable>
@@ -141,7 +141,7 @@ impl ViewportDescription {
     }
 
     /// Constrains a zoom value within the allowed scale range
-    pub fn clamp_zoom(&self, zoom: f32) -> f32 {
+    pub fn clamp_page_zoom(&self, zoom: f32) -> f32 {
         zoom.clamp(self.minimum_scale.get(), self.maximum_scale.get())
     }
 }

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -746,7 +746,7 @@ impl WindowPortsMethods for Window {
                 )));
             },
             WindowEvent::PinchGesture { delta, .. } => {
-                webview.set_pinch_zoom(delta as f32 + 1.0);
+                webview.pinch_zoom(delta as f32 + 1.0);
             },
             WindowEvent::CloseRequested => {
                 state.servo().start_shutting_down();

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -826,21 +826,21 @@ impl RunningAppState {
     /// Start pinchzoom.
     /// x/y are pinch origin coordinates.
     pub fn pinchzoom_start(&self, factor: f32, _x: u32, _y: u32) {
-        self.active_webview().set_pinch_zoom(factor);
+        self.active_webview().pinch_zoom(factor);
         self.perform_updates();
     }
 
     /// Pinchzoom.
     /// x/y are pinch origin coordinates.
     pub fn pinchzoom(&self, factor: f32, _x: u32, _y: u32) {
-        self.active_webview().set_pinch_zoom(factor);
+        self.active_webview().pinch_zoom(factor);
         self.perform_updates();
     }
 
     /// End pinchzoom.
     /// x/y are pinch origin coordinates.
     pub fn pinchzoom_end(&self, factor: f32, _x: u32, _y: u32) {
-        self.active_webview().set_pinch_zoom(factor);
+        self.active_webview().pinch_zoom(factor);
         self.perform_updates();
     }
 


### PR DESCRIPTION
This change is meant to make it more obvious that adjusting the pinch
zoom of a `WebView` works differently than adjusting the page zoom.
New pinch zoom values are *always* zoom deltas, that is they are always
multiplied by the current pinch zoom value. This is due to the way that
system APIs and Servo's internal touch handler provide values.

In addition, stop clamping the pinch zoom by the page zoom clamp values.
They aren't meant for that. Instead set up some reasonable clamping
values for pinch zoom in the compositor.

Also add more rustdoc for public API.

Testing: The changes to API naming do not really need tests, and the changes to
behavior (the clamping) can't be easily tested now as there is no way currently
to read the current pinch zoom level of the WebView. This requires more API in
the renderer.
