### PR TITLE
constellation: Unload documents when traversing session history.

### DIFF
--- a/tests/wpt/meta/html/browsers/history/the-history-interface/joint_session_history/001.html.ini
+++ b/tests/wpt/meta/html/browsers/history/the-history-interface/joint_session_history/001.html.ini
@@ -1,4 +1,0 @@
-[001.html]
-  expected: TIMEOUT
-  [Traversing history forward]
-    expected: NOTRUN


### PR DESCRIPTION
We're not yet at the point where it makes sense to label HTML specification steps in our implementation of navigation/session history because we're so far from the specified model. However, this change reflects a very small part of the specification, where we:
* https://html.spec.whatwg.org/#apply-the-history-step
* https://html.spec.whatwg.org/#deactivate-a-document-for-a-cross-document-navigation
* https://html.spec.whatwg.org/#updating-the-traversable:unload-a-document-and-its-descendants
* https://html.spec.whatwg.org/#unloading-documents:unload-a-document-and-its-descendants
* https://html.spec.whatwg.org/#unload-a-document

We unload documents as expected when navigating, but not when traversing the session history.

Testing: Newly passing test.
Fixes: #39798
