### PR TITLE
webdriver: Deserialize `WebWindow` and report error correctly for script execution

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1647,19 +1647,15 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             .and_then(|iframe| iframe.GetContentWindow())
     }
 
-    fn WebdriverWindow(&self, webview_id: DOMString) -> Option<DomRoot<WindowProxy>> {
-        let window_proxy = self.window_proxy.get()?;
-
+    fn WebdriverWindow(&self, webview_id: DOMString) -> DomRoot<WindowProxy> {
+        let window_proxy = &self
+            .window_proxy
+            .get()
+            .expect("This must succeed as we checked");
         // Window must be top level browsing context.
-        if window_proxy.browsing_context_id() != window_proxy.webview_id() {
-            return None;
-        }
-
-        if self.webview_id().to_string() == webview_id {
-            Some(DomRoot::from_ref(&window_proxy))
-        } else {
-            None
-        }
+        assert!(window_proxy.browsing_context_id() == window_proxy.webview_id());
+        assert!(self.webview_id().to_string() == webview_id);
+        DomRoot::from_ref(window_proxy)
     }
 
     fn WebdriverShadowRoot(&self, id: DOMString) -> Option<DomRoot<ShadowRoot>> {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1651,7 +1651,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         let window_proxy = &self
             .window_proxy
             .get()
-            .expect("This must succeed as we checked");
+            .expect("Should always have a WindowProxy when calling WebdriverWindow");
         // Window must be top level browsing context.
         assert!(window_proxy.browsing_context_id() == window_proxy.webview_id());
         assert!(self.webview_id().to_string() == webview_id);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2319,6 +2319,14 @@ impl ScriptThread {
                     reply,
                 )
             },
+            WebDriverScriptCommand::GetKnownWindow(webview_id, reply) => {
+                webdriver_handlers::handle_get_known_window(
+                    &documents,
+                    pipeline_id,
+                    webview_id,
+                    reply,
+                )
+            },
             WebDriverScriptCommand::GetKnownShadowRoot(element_id, reply) => {
                 webdriver_handlers::handle_get_known_shadow_root(
                     &documents,

--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -151,7 +151,7 @@ partial interface Window {
   undefined webdriverException(optional any result);
   Element? webdriverElement(DOMString id);
   WindowProxy? webdriverFrame(DOMString id);
-  WindowProxy? webdriverWindow(DOMString id);
+  WindowProxy webdriverWindow(DOMString id);
   ShadowRoot? webdriverShadowRoot(DOMString id);
 };
 

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -176,6 +176,7 @@ pub enum WebDriverScriptCommand {
     ElementClick(String, IpcSender<Result<Option<String>, ErrorStatus>>),
     GetKnownElement(String, IpcSender<Result<(), ErrorStatus>>),
     GetKnownShadowRoot(String, IpcSender<Result<(), ErrorStatus>>),
+    GetKnownWindow(String, IpcSender<Result<(), ErrorStatus>>),
     GetActiveElement(IpcSender<Option<String>>),
     GetComputedRole(String, IpcSender<Result<Option<String>, ErrorStatus>>),
     GetCookie(

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -8,7 +8,7 @@
 
 mod actions;
 mod capabilities;
-mod elements;
+mod script_argument_extraction;
 mod session;
 mod timeout;
 mod user_prompt;

--- a/components/webdriver_server/script_argument_extraction.rs
+++ b/components/webdriver_server/script_argument_extraction.rs
@@ -6,7 +6,7 @@ use embedder_traits::WebDriverScriptCommand;
 use ipc_channel::ipc;
 use serde_json::Value;
 use webdriver::command::JavascriptCommandParameters;
-use webdriver::error::{WebDriverError, WebDriverResult};
+use webdriver::error::{ErrorStatus, WebDriverError, WebDriverResult};
 
 use crate::{Handler, VerifyBrowsingContextIsOpen, wait_for_ipc_response};
 
@@ -91,14 +91,14 @@ impl Handler {
     }
 
     /// <https://w3c.github.io/webdriver/#dfn-deserialize-a-web-window>
-    fn deserialize_web_window(&self, element: &Value) -> WebDriverResult<String> {
+    fn deserialize_web_window(&self, window: &Value) -> WebDriverResult<String> {
         // Step 2. Let reference be the result of getting the web window identifier property from object.
-        let window_ref = match element {
+        let window_ref = match window {
             Value::String(s) => s.clone(),
-            _ => unreachable!(),
+            _ => return Err(WebDriverError::new(ErrorStatus::InvalidArgument, "")),
         };
 
-        // Step 3. Let element be the result of trying to get a known element with session and reference.
+        // Step 3 - 5.
         let (sender, receiver) = ipc::channel().unwrap();
         self.browsing_context_script_command(
             WebDriverScriptCommand::GetKnownWindow(window_ref.clone(), sender),
@@ -106,7 +106,6 @@ impl Handler {
         )?;
 
         match wait_for_ipc_response(receiver)? {
-            // Step 4. Return success with data element.
             Ok(_) => Ok(format!("window.webdriverWindow(\"{}\")", window_ref)),
             Err(err) => Err(WebDriverError::new(err, "No such window")),
         }
@@ -137,11 +136,7 @@ impl Handler {
                     return Ok(format!("window.webdriverFrame(\"{frame_ref}\")"));
                 }
                 if let Some(id) = map.get(WINDOW_IDENTIFIER) {
-                    let window_ref = match id {
-                        Value::String(s) => s.clone(),
-                        _ => id.to_string(),
-                    };
-                    return Ok(format!("window.webdriverWindow(\"{window_ref}\")"));
+                    return self.deserialize_web_window(id);
                 }
                 let elems = map
                     .iter()

--- a/components/webdriver_server/script_argument_extraction.rs
+++ b/components/webdriver_server/script_argument_extraction.rs
@@ -47,7 +47,7 @@ impl Handler {
     fn deserialize_web_element(&self, element: &Value) -> WebDriverResult<String> {
         // Step 2. Let reference be the result of getting the web element identifier property from object.
         let element_ref = match element {
-            Value::String(s) => s.clone(),
+            Value::String(string) => string.clone(),
             _ => unreachable!(),
         };
 
@@ -69,7 +69,7 @@ impl Handler {
     fn deserialize_shadow_root(&self, shadow_root: &Value) -> WebDriverResult<String> {
         // Step 2. Let reference be the result of getting the shadow root identifier property from object.
         let shadow_root_ref = match shadow_root {
-            Value::String(s) => s.clone(),
+            Value::String(string) => string.clone(),
             _ => unreachable!(),
         };
 
@@ -94,11 +94,12 @@ impl Handler {
     fn deserialize_web_window(&self, window: &Value) -> WebDriverResult<String> {
         // Step 2. Let reference be the result of getting the web window identifier property from object.
         let window_ref = match window {
-            Value::String(s) => s.clone(),
+            Value::String(string) => string.clone(),
             _ => return Err(WebDriverError::new(ErrorStatus::InvalidArgument, "")),
         };
 
-        // Step 3 - 5.
+        // Step 3. Let browsing context be the browsing context whose window handle is reference,
+        // or null if no such browsing context exists.
         let (sender, receiver) = ipc::channel().unwrap();
         self.browsing_context_script_command(
             WebDriverScriptCommand::GetKnownWindow(window_ref.clone(), sender),
@@ -106,7 +107,10 @@ impl Handler {
         )?;
 
         match wait_for_ipc_response(receiver)? {
-            Ok(_) => Ok(format!("window.webdriverWindow(\"{}\")", window_ref)),
+            // Step 5. Return success with data browsing context's associated window.
+            Ok(_) => Ok(format!("window.webdriverWindow(\"{window_ref}\")")),
+            // Step 4. If browsing context is null or not a top-level browsing context,
+            // return error with error code no such window.
             Err(err) => Err(WebDriverError::new(err, "No such window")),
         }
     }
@@ -130,7 +134,7 @@ impl Handler {
                 }
                 if let Some(id) = map.get(FRAME_IDENTIFIER) {
                     let frame_ref = match id {
-                        Value::String(s) => s.clone(),
+                        Value::String(string) => string.clone(),
                         _ => id.to_string(),
                     };
                     return Ok(format!("window.webdriverFrame(\"{frame_ref}\")"));

--- a/tests/wpt/meta/webdriver/tests/classic/execute_async_script/arguments.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_async_script/arguments.py.ini
@@ -2,31 +2,16 @@
   [test_invalid_argument_for_window_with_invalid_type[None-frame\]]
     expected: FAIL
 
-  [test_invalid_argument_for_window_with_invalid_type[None-window\]]
-    expected: FAIL
-
   [test_invalid_argument_for_window_with_invalid_type[False-frame\]]
-    expected: FAIL
-
-  [test_invalid_argument_for_window_with_invalid_type[False-window\]]
     expected: FAIL
 
   [test_invalid_argument_for_window_with_invalid_type[42-frame\]]
     expected: FAIL
 
-  [test_invalid_argument_for_window_with_invalid_type[42-window\]]
-    expected: FAIL
-
   [test_invalid_argument_for_window_with_invalid_type[value3-frame\]]
     expected: FAIL
 
-  [test_invalid_argument_for_window_with_invalid_type[value3-window\]]
-    expected: FAIL
-
   [test_invalid_argument_for_window_with_invalid_type[value4-frame\]]
-    expected: FAIL
-
-  [test_invalid_argument_for_window_with_invalid_type[value4-window\]]
     expected: FAIL
 
   [test_no_such_window_for_window_with_invalid_value]

--- a/tests/wpt/meta/webdriver/tests/classic/execute_script/arguments.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/execute_script/arguments.py.ini
@@ -2,31 +2,16 @@
   [test_invalid_argument_for_window_with_invalid_type[None-frame\]]
     expected: FAIL
 
-  [test_invalid_argument_for_window_with_invalid_type[None-window\]]
-    expected: FAIL
-
   [test_invalid_argument_for_window_with_invalid_type[False-frame\]]
-    expected: FAIL
-
-  [test_invalid_argument_for_window_with_invalid_type[False-window\]]
     expected: FAIL
 
   [test_invalid_argument_for_window_with_invalid_type[42-frame\]]
     expected: FAIL
 
-  [test_invalid_argument_for_window_with_invalid_type[42-window\]]
-    expected: FAIL
-
   [test_invalid_argument_for_window_with_invalid_type[value3-frame\]]
     expected: FAIL
 
-  [test_invalid_argument_for_window_with_invalid_type[value3-window\]]
-    expected: FAIL
-
   [test_invalid_argument_for_window_with_invalid_type[value4-frame\]]
-    expected: FAIL
-
-  [test_invalid_argument_for_window_with_invalid_type[value4-window\]]
     expected: FAIL
 
   [test_no_such_window_for_window_with_invalid_value]


### PR DESCRIPTION
We were relying on `fn WebdriverWindow` to report `NoSuchWindow` during script execution, regardless of the fact that it is never `Fallible`. I was really hoping to refactor this to return `Fallible` to reduce one RTT of IPC, but there is no easy way to convert between DOM exception https://github.com/servo/servo/blob/56b806b129bf7111e6442d3fc2bd08d602abb951/components/script_bindings/error.rs#L15 and JavaScriptEvaluationError  https://github.com/servo/servo/blob/56b806b129bf7111e6442d3fc2bd08d602abb951/components/shared/embedder/lib.rs#L1092.

We also migrate `element.rs` to `script_argument_extraction.rs` to reflect the true purpose of the file.

Testing: 10 new subtests passing.
