### PR TITLE
servoshell/desktop: condition gamepad support on pref

### DIFF
--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -114,6 +114,11 @@ impl RunningAppState {
         webdriver_receiver: Option<Receiver<WebDriverCommandMsg>>,
     ) -> RunningAppState {
         servo.set_delegate(Rc::new(ServoShellServoDelegate));
+        let gamepad_support = if pref!(dom_gamepad_enabled) {
+            GamepadSupport::maybe_new()
+        } else {
+            None
+        };
         RunningAppState {
             servo,
             servoshell_preferences,
@@ -125,7 +130,7 @@ impl RunningAppState {
                 focused_webview_id: None,
                 dialogs: Default::default(),
                 window,
-                gamepad_support: GamepadSupport::maybe_new(),
+                gamepad_support,
                 need_update: false,
                 need_repaint: false,
                 dialog_amount_changed: false,


### PR DESCRIPTION
In desktop servoshell, only initialize gamepad support if pref is on, in particular because gilrs spawns background threads which we don't need unless the pref is on(and which cannot be shutdown cleanly because they are outside of our reach). Note that gamepad is enabled by default, so avoiding the threads requires `dom_gamepad_enabled=false`.

Testing: Manual; gilrs threads abstent when running servo with `--pref dom_gamepad_enabled=false`
Fixes: https://github.com/servo/servo/issues/30849
