### PR TITLE
fonts: Add `is_variable()` to `PlatformFontMethods`

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -124,6 +124,9 @@ pub trait PlatformFontMethods: Sized {
     /// Return all the variation values that the font was instantiated with.
     fn variations(&self) -> &[FontVariation];
 
+    /// Returns `true` if font variation is supported, otherwise `false`
+    fn is_variable(&self) -> bool;
+
     fn descriptor_from_os2_table(os2: &Os2) -> FontTemplateDescriptor {
         let mut style = FontStyle::NORMAL;
         if os2.fs_selection().contains(SelectionFlags::ITALIC) {

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -424,12 +424,12 @@ impl FreeTypeFaceTableProviderData {
             .font_ref()
             .and_then(|font_ref| font_ref.os2())
             .is_ok_and(|table| table.us_weight_class() >= SEMI_BOLD_U16);
-        let is_variable_font = self.has_variation();
+        let is_variable_font = self.has_variations();
         !face_is_bold && !is_variable_font && synthetic_bold
     }
 
     /// Returns `true` if `Self` has non-empty variation axes, `false` otherwise
-    fn has_variation(&self) -> bool {
+    fn has_variations(&self) -> bool {
         self.font_ref()
             .and_then(|font_ref| font_ref.fvar())
             .is_ok_and(|table| table.axis_count() > 0)

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -392,6 +392,10 @@ impl PlatformFontMethods for PlatformFont {
     fn variations(&self) -> &[FontVariation] {
         &self.variations
     }
+
+    fn is_variable(&self) -> bool {
+        self.table_provider_data.has_variations()
+    }
 }
 
 impl PlatformFont {

--- a/components/fonts/platform/freetype/font.rs
+++ b/components/fonts/platform/freetype/font.rs
@@ -424,11 +424,15 @@ impl FreeTypeFaceTableProviderData {
             .font_ref()
             .and_then(|font_ref| font_ref.os2())
             .is_ok_and(|table| table.us_weight_class() >= SEMI_BOLD_U16);
-        let is_variable_font = self
-            .font_ref()
-            .and_then(|font_ref| font_ref.fvar())
-            .is_ok_and(|table| table.axis_count() > 0);
+        let is_variable_font = self.has_variation();
         !face_is_bold && !is_variable_font && synthetic_bold
+    }
+
+    /// Returns `true` if `Self` has non-empty variation axes, `false` otherwise
+    fn has_variation(&self) -> bool {
+        self.font_ref()
+            .and_then(|font_ref| font_ref.fvar())
+            .is_ok_and(|table| table.axis_count() > 0)
     }
 }
 

--- a/components/fonts/platform/macos/font.rs
+++ b/components/fonts/platform/macos/font.rs
@@ -83,7 +83,7 @@ impl PlatformFont {
         synthetic_bold: bool,
     ) -> PlatformFont {
         let ctfont_is_bold = ctfont.all_traits().weight() >= FontWeight::BOLD_THRESHOLD;
-        let is_variable_font = ctfont_has_variation(&ctfont);
+        let is_variable_font = ctfont_has_variations(&ctfont);
 
         let synthetic_bold = !ctfont_is_bold && !is_variable_font && synthetic_bold;
 
@@ -447,7 +447,7 @@ impl PlatformFontMethods for PlatformFont {
     }
 
     fn is_variable(&self) -> bool {
-        ctfont_has_variation(&self.ctfont)
+        ctfont_has_variations(&self.ctfont)
     }
 }
 
@@ -499,7 +499,7 @@ impl CoreTextFontTraitsMapping for CTFontTraits {
 }
 
 /// Returns `true` if `ctfont` has non-empty variation axes, `false` otherwise
-fn ctfont_has_variation(ctfont: &CTFont) -> bool {
+fn ctfont_has_variations(ctfont: &CTFont) -> bool {
     ctfont
         .get_variation_axes()
         .is_some_and(|arr| !arr.is_empty())

--- a/components/fonts/platform/macos/font.rs
+++ b/components/fonts/platform/macos/font.rs
@@ -83,9 +83,7 @@ impl PlatformFont {
         synthetic_bold: bool,
     ) -> PlatformFont {
         let ctfont_is_bold = ctfont.all_traits().weight() >= FontWeight::BOLD_THRESHOLD;
-        let is_variable_font = ctfont
-            .get_variation_axes()
-            .is_some_and(|arr| !arr.is_empty());
+        let is_variable_font = ctfont_has_variation(&ctfont);
 
         let synthetic_bold = !ctfont_is_bold && !is_variable_font && synthetic_bold;
 
@@ -447,6 +445,10 @@ impl PlatformFontMethods for PlatformFont {
     fn variations(&self) -> &[FontVariation] {
         &self.variations
     }
+
+    fn is_variable(&self) -> bool {
+        ctfont_has_variation(&self.ctfont)
+    }
 }
 
 pub(super) trait CoreTextFontTraitsMapping {
@@ -494,4 +496,11 @@ impl CoreTextFontTraitsMapping for CTFontTraits {
         // > values represent condensed glyph spacing.
         FontStretch::from_percentage(self.normalized_width() as f32 + 1.0)
     }
+}
+
+/// Returns `true` if `ctfont` has non-empty variation axes, `false` otherwise
+fn ctfont_has_variation(ctfont: &CTFont) -> bool {
+    ctfont
+        .get_variation_axes()
+        .is_some_and(|arr| !arr.is_empty())
 }

--- a/components/fonts/platform/windows/font.rs
+++ b/components/fonts/platform/windows/font.rs
@@ -354,6 +354,10 @@ impl PlatformFontMethods for PlatformFont {
     fn variations(&self) -> &[FontVariation] {
         &self.variations
     }
+
+    fn is_variable(&self) -> bool {
+        self.face.has_variation()
+    }
 }
 
 /// A wrapper struct around [`PlatformFont`] which is responsible for

--- a/components/fonts/platform/windows/font.rs
+++ b/components/fonts/platform/windows/font.rs
@@ -356,7 +356,7 @@ impl PlatformFontMethods for PlatformFont {
     }
 
     fn is_variable(&self) -> bool {
-        self.face.has_variation()
+        self.face.has_variations()
     }
 }
 


### PR DESCRIPTION
Per discussion in https://github.com/servo/servo/pull/39122, some way to tell whether a `PlatformFont` is a variable font is needed. This PR adds this method to the `PlatformFontMethods` trait and provide the implementation for FreeType, Windows, and macos platforms.

Testing: There is no test directly targeting whether a `PlatformFont` supports font variations, but this will eventually get tested once the remaining of supporting font variations is completed and enabled. There, technically, are some WPT testcases (`/css/css-fonts/font-face-weight-default-variable.html` and `/css/css-fonts/font-face-weight-auto-variable.html`) that would fail if the underlying function (ie. `has_variations` on Windows and FreeType, and `ctfont_has_variations` on macos) that checks if a `PlatformFont` supports font variations
Related: This is part of https://github.com/servo/servo/issues/38800
