### PR TITLE
Compositor: Do not dispatch input event when hit-test has empty result

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -287,7 +287,7 @@ impl WebViewRenderer {
         let event_point = event.event.point();
         let hit_test_result = match event_point {
             Some(point) => {
-                let cached_hit_test_result = match event.event {
+                let hit_test_result = match event.event {
                     InputEvent::Touch(_) => self.touch_handler.get_hit_test_result_cache_value(),
                     _ => None,
                 }
@@ -298,11 +298,11 @@ impl WebViewRenderer {
                         .into_iter()
                         .nth(0)
                 });
-                if cached_hit_test_result.is_none() {
+                if hit_test_result.is_none() {
                     warn!("Empty hit test result for input event, ignoring.");
                     return false;
                 }
-                cached_hit_test_result
+                hit_test_result
             },
             None => None,
         };

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -290,14 +290,19 @@ impl WebViewRenderer {
                 let cached_hit_test_result = match event.event {
                     InputEvent::Touch(_) => self.touch_handler.get_hit_test_result_cache_value(),
                     _ => None,
-                };
-                cached_hit_test_result.or_else(|| {
+                }
+                .or_else(|| {
                     self.global
                         .borrow()
                         .hit_test_at_point(point)
                         .into_iter()
                         .nth(0)
-                })
+                });
+                if cached_hit_test_result.is_none() {
+                    warn!("Empty hit test result for input event, ignoring.");
+                    return false;
+                }
+                cached_hit_test_result
             },
             None => None,
         };


### PR DESCRIPTION
We should not dispatch input event when point is given but hit-test has empty result. This caused panic when the page is not fully loaded.
Also restructure code a bit.

Testing: Manually tested.
Fixes: #39888
