### PR TITLE
devtools: Support getting XPath selector for node actor

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2078,6 +2078,9 @@ impl ScriptThread {
             DevtoolScriptControlMsg::GetLayout(id, node_id, reply) => {
                 devtools::handle_get_layout(&documents, id, node_id, reply, can_gc)
             },
+            DevtoolScriptControlMsg::GetXPath(id, node_id, reply) => {
+                devtools::handle_get_xpath(&documents, id, node_id, reply)
+            },
             DevtoolScriptControlMsg::ModifyAttribute(id, node_id, modifications) => {
                 devtools::handle_modify_attribute(&documents, id, node_id, modifications, can_gc)
             },

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -259,6 +259,8 @@ pub enum DevtoolScriptControlMsg {
     GetComputedStyle(PipelineId, String, IpcSender<Option<Vec<NodeStyle>>>),
     /// Retrieve the computed layout properties of the given node in the given pipeline.
     GetLayout(PipelineId, String, IpcSender<Option<ComputedNodeLayout>>),
+    /// Get a unique XPath selector for the node.
+    GetXPath(PipelineId, String, IpcSender<String>),
     /// Update a given node's attributes with a list of modifications.
     ModifyAttribute(PipelineId, String, Vec<AttrModification>),
     /// Update a given node's style rules with a list of modifications.


### PR DESCRIPTION
You can copy the XPath selector from the inspector by right-clicking on a node and selecting `Copy->XPath`.

Testing: I tried adding a test but the effort didn't seem worth it. The devtools tests are currently very specifically tailored towards source-list tests.

Part of https://github.com/servo/servo/issues/39862
Part of #34527 
