### PR TITLE
Fix coverage job on self-hosted runners by installing nextest.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -401,7 +401,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-llvm-cov,cargo-nextest
       - name: Bootstrap dependencies
         if: ${{ runner.environment != 'self-hosted' }}
         shell: bash


### PR DESCRIPTION
`./mach test-unit` now requires nextest.
`./mach bootstrap` is skipped on self-hosted runners, which don't have nextest installed yet, so we need to install it manually. The action is also much faster than installing from source, so this also benefits the github-hosted coverage job.

Testing: Not needed, this just installs another tool in CI. 
