### PR TITLE
script: Do not force push history handling.

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2970,7 +2970,7 @@ impl Window {
             } else if load_data.url.scheme() == "javascript" || doc.is_initial_about_blank() {
                 NavigationHistoryBehavior::Replace
             } else {
-                NavigationHistoryBehavior::Push
+                history_handling
             };
 
             if let Some(sender) = self.webdriver_load_status_sender.borrow().as_ref() {

--- a/tests/wpt/tests/html/browsers/history/the-location-interface/location_replace_session_history.html
+++ b/tests/wpt/tests/html/browsers/history/the-location-interface/location_replace_session_history.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>location.replace replaces the active session history entry</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      var t = async_test();
+      t.step(() => {
+          let i = document.createElement('iframe');
+          i.src = "resources/iframe_location_replace.html";
+          document.body.appendChild(i);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/wpt/tests/html/browsers/history/the-location-interface/resources/iframe_location_replace.html
+++ b/tests/wpt/tests/html/browsers/history/the-location-interface/resources/iframe_location_replace.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>replace.html
+<script>
+  let pageshowCount = 0;
+  onpageshow = parent.t.step_func(() => {
+      pageshowCount += 1;
+      if (pageshowCount == 2) {
+          location.replace("resources/iframe_location_replace3.html");
+      }
+  });
+  onload = parent.t.step_func(() => {
+      location.href = "resources/iframe_location_replace2.html";
+  });
+</script>

--- a/tests/wpt/tests/html/browsers/history/the-location-interface/resources/iframe_location_replace2.html
+++ b/tests/wpt/tests/html/browsers/history/the-location-interface/resources/iframe_location_replace2.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>replace2.html
+<script>
+  let pageshowCount = 0;
+  onpageshow = parent.t.step_func(() => {
+      pageshowCount += 1;
+      if (pageshowCount == 2) {
+          parent.t.done();
+      }
+  });
+  onload = parent.t.step_func(() => {
+      history.back();
+  });
+</script>

--- a/tests/wpt/tests/html/browsers/history/the-location-interface/resources/iframe_location_replace3.html
+++ b/tests/wpt/tests/html/browsers/history/the-location-interface/resources/iframe_location_replace3.html
@@ -1,0 +1,6 @@
+<!DOCTYPE HTML>replace3.html
+<script>
+  onload = parent.t.step_func(() => {
+      history.forward();
+  });
+</script>


### PR DESCRIPTION
Steps 12 and 13 of https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate contains logic to update the provided history handling mode when navigating, but there is no else clause in the specification. This change removes the logic in Servo that falls back to "push" mode if neither step is executed.

Testing: New WPT test added.
Fixes: #39818
