### PR TITLE
Upload junit report of unit-tests in CI 

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,9 @@
 [profile.default]
 # Print a slow warning after period, terminate unit-test after 4x period.
 slow-timeout = { period = "5s", terminate-after = 4 }
+
+[profile.ci]
+fail-fast = false
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,3 @@
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    carryforward: false

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -191,7 +191,16 @@ jobs:
         if: ${{ inputs.unit-tests }}
         env:
           NEXTEST_RETRIES: 2 # https://github.com/servo/servo/issues/30683
-        run: ./mach test-unit --profile ${{ inputs.profile }}
+        run: ./mach test-unit --profile ${{ inputs.profile }} --nextest-profile ci
+      # We upload the test-results to Codecov to help us identify flaky unit-tests.
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: target/nextest/ci/junit.xml
+          disable_search: true
+          flags: unittests-linux
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Devtools tests
         if: ${{ false && inputs.unit-tests }}  # FIXME #39273
         run: ./mach test-devtools --profile ${{ inputs.profile }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -199,7 +199,7 @@ jobs:
         with:
           files: target/nextest/ci/junit.xml
           disable_search: true
-          flags: unittests-linux
+          flags: unittests,unittests-linux,unittests-linux-${{ inputs.profile }}
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Devtools tests
         if: ${{ false && inputs.unit-tests }}  # FIXME #39273

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -148,7 +148,16 @@ jobs:
         if: ${{ inputs.unit-tests }}
         env:
           NEXTEST_RETRIES: 3 # https://github.com/servo/servo/issues/30683
-        run: ./mach test-unit --profile ${{ inputs.profile }}
+        run: ./mach test-unit --profile ${{ inputs.profile }} --nextest-profile ci
+      # We upload the test-results to Codecov to help us identify flaky unit-tests.
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: target/nextest/ci/junit.xml
+          disable_search: true
+          flags: unittests,unittests-mac-arm64,unittests-mac-arm64-${{ inputs.profile }}
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Devtools tests
         if: ${{ false && inputs.unit-tests }} # FIXME #39273
         run: ./mach test-devtools --profile ${{ inputs.profile }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           files: target/nextest/ci/junit.xml
           disable_search: true
-          flags: unittests-mac
+          flags: unittests,unittests-mac,unittests-mac-${{ inputs.profile }}
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Devtools tests
         if: ${{ false && inputs.unit-tests }}  # FIXME #39273

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -167,7 +167,16 @@ jobs:
         if: ${{ inputs.unit-tests }}
         env:
           NEXTEST_RETRIES: 3 # https://github.com/servo/servo/issues/30683
-        run: ./mach test-unit --profile ${{ inputs.profile }}
+        run: ./mach test-unit --profile ${{ inputs.profile }} --nextest-profile ci
+      # We upload the test-results to Codecov to help us identify flaky unit-tests.
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: target/nextest/ci/junit.xml
+          disable_search: true
+          flags: unittests-mac
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Devtools tests
         if: ${{ false && inputs.unit-tests }}  # FIXME #39273
         run: ./mach test-devtools --profile ${{ inputs.profile }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -188,7 +188,7 @@ jobs:
         with:
           files: target/nextest/ci/junit.xml
           disable_search: true
-          flags: unittests-windows
+          flags: unittests,unittests-windows,unittests-windows-${{ inputs.profile }}
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Devtools tests
         if: ${{ false && inputs.unit-tests }}  # FIXME #39273

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -180,7 +180,16 @@ jobs:
         if: ${{ inputs.unit-tests }}
         env:
           NEXTEST_RETRIES: 3 # https://github.com/servo/servo/issues/30683
-        run: ./mach test-unit --profile ${{ inputs.profile }}
+        run: ./mach test-unit --profile ${{ inputs.profile }} --nextest-profile ci
+      # We upload the test-results to Codecov to help us identify flaky unit-tests.
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          files: target/nextest/ci/junit.xml
+          disable_search: true
+          flags: unittests-windows
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Devtools tests
         if: ${{ false && inputs.unit-tests }}  # FIXME #39273
         run: .\mach test-devtools --profile ${{ inputs.profile }}

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -165,16 +165,20 @@ class MachCommands(CommandBase):
     )
     @CommandArgument("--code-coverage", default=False, action="store_true", help="Run in code coverage mode")
     @CommandArgument("--llvm-cov-option", default=None, action="append", help="Additional options for llvm-cov")
+    @CommandArgument("--nextest-profile", default=None, help="Specify the Nextest profile to use")
+    @CommandArgument("params", nargs="...", help="Command-line arguments to be passed through to Cargo nextest")
     @CommandBase.common_command_arguments(build_configuration=True, build_type=True)
     def test_unit(
         self,
         build_type: BuildType,
         test_name: list[str] | None = None,
+        params: list[str] | None = None,
         package: str | None = None,
         bench: bool = False,
         code_coverage: bool = False,
         llvm_cov_option: Optional[List[str]] = None,
         nocapture: bool = False,
+        nextest_profile: str | None = None,
         **kwargs: Any,
     ) -> int:
         if test_name is None:
@@ -247,7 +251,7 @@ class MachCommands(CommandBase):
         if len(packages) == 0 and len(in_crate_packages) == 0:
             return 0
 
-        args: list[str] = []
+        args: list[str] = params or []
 
         if build_type.is_release():
             args += ["--release"]
@@ -255,6 +259,9 @@ class MachCommands(CommandBase):
             pass  # there is no argument for debug
         else:
             args += ["--cargo-profile", build_type.profile]
+
+        if nextest_profile is not None:
+            args += ["--profile", nextest_profile]
 
         for crate in packages:
             args += ["-p", "%s_tests" % crate]


### PR DESCRIPTION
This should help identify flaky unit tests, since codecov will gather statistics of tests (of the last 60 days) and allow us to easily identify flaky unit-tests. [Test page on codecov](https://app.codecov.io/github/servo/servo/tests) based on an uploaded report from a try run.
Additionally add a catch-all parameter for `test-unit` which is passed through to the `cargo nextest` invocation, useful for e.g. stressing a test via `--stress-count`. 

Testing: Manually tested with [try run](https://github.com/servo/servo/actions/runs/18529823800)
