### PR TITLE
ci: Tokenless self-hosted runner select

### DIFF
--- a/.github/actions/runner-select/action.yml
+++ b/.github/actions/runner-select/action.yml
@@ -130,18 +130,3 @@ runs:
         echo
         echo 'No self-hosted runners available!'
         fall_back_to_github_hosted
-
-    - id: empty-file
-      name: Create an empty file
-      shell: bash
-      run: |
-        # For the “done” artifact in the step below
-        empty_file_path=$(mktemp)
-        echo "empty_file_path=$empty_file_path" | tee -a $GITHUB_OUTPUT
-
-    - name: Publish artifact marking this job as done
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: servo-ci-runners_${{ steps.init.outputs.unique_id }}_done
-        path: ${{ steps.empty-file.outputs.empty_file_path }}

--- a/.github/actions/runner-select/action.yml
+++ b/.github/actions/runner-select/action.yml
@@ -50,17 +50,19 @@ runs:
         # <https://github.com/servo/servo/settings/variables/actions>
         if [ -n '${{ inputs.NO_SELF_HOSTED_RUNNERS }}' ]; then
           echo 'NO_SELF_HOSTED_RUNNERS is set!'
-          echo "fall_back_to_github_hosted=true" | tee -a $GITHUB_OUTPUT
+          echo "disabled=true" | tee -a $GITHUB_OUTPUT
           exit 0
         fi
 
+        # Disable self-hosted runners by calling this action with
+        # `force-github-hosted-runner` set to true.
         if [ '${{ inputs.force-github-hosted-runner }}' = true ]; then
           echo 'inputs.force-github-hosted-runner is set!'
-          echo "fall_back_to_github_hosted=true" | tee -a $GITHUB_OUTPUT
+          echo "disabled=true" | tee -a $GITHUB_OUTPUT
           exit 0
         fi
 
-        echo "fall_back_to_github_hosted=false" | tee -a $GITHUB_OUTPUT
+        echo "disabled=false" | tee -a $GITHUB_OUTPUT
 
         artifact_path=$(mktemp)
         echo "artifact_path=$artifact_path" | tee -a $GITHUB_OUTPUT
@@ -71,7 +73,7 @@ runs:
         echo "run_id=${{ github.run_id }}" | tee -a "$artifact_path"
 
     - name: Publish artifact with args
-      if: ${{ !fromJSON(steps.init.outputs.fall_back_to_github_hosted) }}
+      if: ${{ !fromJSON(steps.init.outputs.disabled) }}
       uses: actions/upload-artifact@v4
       with:
         name: servo-ci-runners_${{ steps.init.outputs.unique_id }}
@@ -83,21 +85,20 @@ runs:
       run: |
         github_hosted_runner_label='${{ inputs.github-hosted-runner-label }}'
         self_hosted_image_name='${{ inputs.self-hosted-image-name }}'
-        fall_back_to_github_hosted='${{ steps.init.outputs.fall_back_to_github_hosted }}'
+        disabled='${{ steps.init.outputs.disabled }}'
         unique_id='${{ steps.init.outputs.unique_id }}'
 
         set -euo pipefail
 
         fall_back_to_github_hosted() {
           echo 'Falling back to GitHub-hosted runner'
-          echo "fall_back_to_github_hosted=true" | tee -a $GITHUB_OUTPUT
           echo "selected_runner_label=$github_hosted_runner_label" | tee -a $GITHUB_OUTPUT
           echo "runner_type_label=$github_hosted_runner_label" | tee -a $GITHUB_OUTPUT
           echo 'is_self_hosted=false' | tee -a $GITHUB_OUTPUT
           exit 0
         }
 
-        if [ "$fall_back_to_github_hosted" = true ]; then
+        if [ "$disabled" = true ]; then
           fall_back_to_github_hosted
         fi
 

--- a/.github/actions/runner-select/action.yml
+++ b/.github/actions/runner-select/action.yml
@@ -1,6 +1,8 @@
-# NOTE: requires `GITHUB_TOKEN: ${{ github.token }}` in `env`
 name: Select Self-hosted Runner
 inputs:
+  GITHUB_TOKEN:
+    required: true
+    type: string
   github-hosted-runner-label:
     required: true
     type: string
@@ -139,6 +141,7 @@ runs:
       shell: bash
       run: |
         artifact_id='${{ steps.artifact.outputs.artifact-id }}'
-        gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' \
+        GITHUB_TOKEN='${{ inputs.GITHUB_TOKEN }}' gh api \
+          -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' \
           -X DELETE '/repos/${{ github.repository }}/actions/artifacts/'"$artifact_id" \
         || :  # Don’t fail the build if this fails

--- a/.github/actions/runner-select/action.yml
+++ b/.github/actions/runner-select/action.yml
@@ -88,10 +88,6 @@ runs:
 
         set -euo pipefail
 
-        # For the “done” artifact in the step below
-        empty_file_path=$(mktemp)
-        echo "empty_file_path=$empty_file_path" | tee -a $GITHUB_OUTPUT
-
         fall_back_to_github_hosted() {
           echo 'Falling back to GitHub-hosted runner'
           echo "fall_back_to_github_hosted=true" | tee -a $GITHUB_OUTPUT
@@ -134,8 +130,17 @@ runs:
         echo 'No self-hosted runners available!'
         fall_back_to_github_hosted
 
+    - id: empty-file
+      name: Create an empty file
+      shell: bash
+      run: |
+        # For the “done” artifact in the step below
+        empty_file_path=$(mktemp)
+        echo "empty_file_path=$empty_file_path" | tee -a $GITHUB_OUTPUT
+
     - name: Publish artifact marking this job as done
+      if: ${{ always() }}
       uses: actions/upload-artifact@v4
       with:
         name: servo-ci-runners_${{ steps.init.outputs.unique_id }}_done
-        path: ${{ steps.decision.outputs.empty_file_path }}
+        path: ${{ steps.empty-file.outputs.empty_file_path }}

--- a/.github/actions/runner-select/action.yml
+++ b/.github/actions/runner-select/action.yml
@@ -78,6 +78,7 @@ runs:
       with:
         name: servo-ci-runners_${{ steps.init.outputs.unique_id }}
         path: ${{ steps.init.outputs.artifact_path }}
+        retention-days: 1
 
     - id: decision
       name: Find a server and reserve a runner

--- a/.github/actions/runner-select/action.yml
+++ b/.github/actions/runner-select/action.yml
@@ -1,18 +1,11 @@
 name: Select Self-hosted Runner
 inputs:
-  monitor-api-token:
-    required: true
-    type: string
   github-hosted-runner-label:
     required: true
     type: string
   self-hosted-image-name:
     required: true
     type: string
-  self-hosted-runner-scope:
-    required: false
-    type: string
-    default: /orgs/${{ github.repository_owner }}/actions/runners
   force-github-hosted-runner:
     required: false
     type: boolean
@@ -23,13 +16,13 @@ inputs:
     default: ""
 outputs:
   unique-id:
-    value: ${{ steps.select.outputs.unique_id }}
+    value: ${{ steps.init.outputs.unique_id }}
   selected-runner-label:
-    value: ${{ steps.select.outputs.selected_runner_label }}
+    value: ${{ steps.decision.outputs.selected_runner_label }}
   runner-type-label:
-    value: ${{ steps.select.outputs.runner_type_label }}
+    value: ${{ steps.decision.outputs.runner_type_label }}
   is-self-hosted:
-    value: ${{ steps.select.outputs.is_self_hosted }}
+    value: ${{ steps.decision.outputs.is_self_hosted }}
 
 runs:
   using: "composite"
@@ -37,23 +30,13 @@ runs:
   # We generate a unique id for the workload, then ask our monitor API to
   # reserve a self-hosted runner for us.
   steps:
-    - name: Select and reserve best available runner
-      id: select
+    - id: init
       shell: bash
       run: |
         github_hosted_runner_label='${{ inputs.github-hosted-runner-label }}'
         self_hosted_image_name='${{ inputs.self-hosted-image-name }}'
-        self_hosted_runner_scope='${{ inputs.self-hosted-runner-scope }}'
 
         set -euo pipefail
-
-        fall_back_to_github_hosted() {
-          echo 'Falling back to GitHub-hosted runner'
-          echo "selected_runner_label=$github_hosted_runner_label" | tee -a $GITHUB_OUTPUT
-          echo "runner_type_label=$github_hosted_runner_label" | tee -a $GITHUB_OUTPUT
-          echo 'is_self_hosted=false' | tee -a $GITHUB_OUTPUT
-          exit 0
-        }
 
         # Generate a unique id that allows the workload job to find the runner
         # we are reserving for it (via runner labels), and allows the timeout
@@ -67,11 +50,55 @@ runs:
         # <https://github.com/servo/servo/settings/variables/actions>
         if [ -n '${{ inputs.NO_SELF_HOSTED_RUNNERS }}' ]; then
           echo 'NO_SELF_HOSTED_RUNNERS is set!'
-          fall_back_to_github_hosted
+          echo "fall_back_to_github_hosted=true" | tee -a $GITHUB_OUTPUT
         fi
 
         if [ '${{ inputs.force-github-hosted-runner }}' = true ]; then
           echo 'inputs.force-github-hosted-runner is set!'
+          echo "fall_back_to_github_hosted=true" | tee -a $GITHUB_OUTPUT
+        fi
+
+        artifact_path=$(mktemp)
+        echo "fall_back_to_github_hosted=false" | tee -a $GITHUB_OUTPUT
+        echo "artifact_path=$artifact_path" | tee -a $GITHUB_OUTPUT
+
+        echo "unique_id=$unique_id" | tee -a "$artifact_path"
+        echo "self_hosted_image_name=$self_hosted_image_name" | tee -a "$artifact_path"
+        echo "qualified_repo=${{ github.repository }}" | tee -a "$artifact_path"
+        echo "run_id=${{ github.run_id }}" | tee -a "$artifact_path"
+
+    - name: Publish artifact with args
+      if: ${{ !fromJSON(steps.init.outputs.fall_back_to_github_hosted) }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: servo-ci-runners_${{ steps.init.outputs.unique_id }}
+        path: ${{ steps.init.outputs.artifact_path }}
+
+    - id: decision
+      name: Find a server and reserve a runner
+      shell: bash
+      run: |
+        github_hosted_runner_label='${{ inputs.github-hosted-runner-label }}'
+        self_hosted_image_name='${{ inputs.self-hosted-image-name }}'
+        fall_back_to_github_hosted='${{ steps.init.outputs.fall_back_to_github_hosted }}'
+        unique_id='${{ steps.init.outputs.unique_id }}'
+
+        set -euo pipefail
+
+        # For the “done” artifact in the step below
+        empty_file_path=$(mktemp)
+        echo "empty_file_path=$empty_file_path" | tee -a $GITHUB_OUTPUT
+
+        fall_back_to_github_hosted() {
+          echo 'Falling back to GitHub-hosted runner'
+          echo "fall_back_to_github_hosted=true" | tee -a $GITHUB_OUTPUT
+          echo "selected_runner_label=$github_hosted_runner_label" | tee -a $GITHUB_OUTPUT
+          echo "runner_type_label=$github_hosted_runner_label" | tee -a $GITHUB_OUTPUT
+          echo 'is_self_hosted=false' | tee -a $GITHUB_OUTPUT
+          exit 0
+        }
+
+        if [ "$fall_back_to_github_hosted" = true ]; then
           fall_back_to_github_hosted
         fi
 
@@ -84,12 +111,11 @@ runs:
         | shuf); do
           # Use the monitor API to reserve a runner. If we get an object with
           # runner details, we succeeded. If we get null, we failed.
-          take_runner_url=$monitor_api_base_url/profile/$self_hosted_image_name/take\?unique_id=$unique_id\&qualified_repo=${{ github.repository }}\&run_id=${{ github.run_id }}
+          take_runner_url=$monitor_api_base_url/select-runner\?unique_id=$unique_id\&qualified_repo=${{ github.repository }}\&run_id=${{ github.run_id }}
           result=$(mktemp)
           echo
           echo POST "$take_runner_url"
-          if curl -sS --fail-with-body --connect-timeout 5 --max-time 30 -X POST "$take_runner_url" \
-              -H 'Authorization: Bearer ${{ inputs.monitor-api-token }}' > $result \
+          if curl -sS --fail-with-body --connect-timeout 5 --max-time 30 -X POST "$take_runner_url" > $result \
               && jq -e . $result > /dev/null; then
             echo
             echo "selected_runner_label=reserved-for:$unique_id" | tee -a $GITHUB_OUTPUT
@@ -104,3 +130,9 @@ runs:
         echo
         echo 'No self-hosted runners available!'
         fall_back_to_github_hosted
+
+    - name: Publish artifact marking this job as done
+      uses: actions/upload-artifact@v4
+      with:
+        name: servo-ci-runners_${{ steps.init.outputs.unique_id }}_done
+        path: ${{ steps.decision.outputs.empty_file_path }}

--- a/.github/actions/runner-select/action.yml
+++ b/.github/actions/runner-select/action.yml
@@ -51,15 +51,18 @@ runs:
         if [ -n '${{ inputs.NO_SELF_HOSTED_RUNNERS }}' ]; then
           echo 'NO_SELF_HOSTED_RUNNERS is set!'
           echo "fall_back_to_github_hosted=true" | tee -a $GITHUB_OUTPUT
+          exit 0
         fi
 
         if [ '${{ inputs.force-github-hosted-runner }}' = true ]; then
           echo 'inputs.force-github-hosted-runner is set!'
           echo "fall_back_to_github_hosted=true" | tee -a $GITHUB_OUTPUT
+          exit 0
         fi
 
-        artifact_path=$(mktemp)
         echo "fall_back_to_github_hosted=false" | tee -a $GITHUB_OUTPUT
+
+        artifact_path=$(mktemp)
         echo "artifact_path=$artifact_path" | tee -a $GITHUB_OUTPUT
 
         echo "unique_id=$unique_id" | tee -a "$artifact_path"

--- a/.github/actions/runner-select/action.yml
+++ b/.github/actions/runner-select/action.yml
@@ -1,3 +1,4 @@
+# NOTE: requires `GITHUB_TOKEN: ${{ github.token }}` in `env`
 name: Select Self-hosted Runner
 inputs:
   github-hosted-runner-label:
@@ -72,7 +73,8 @@ runs:
         echo "qualified_repo=${{ github.repository }}" | tee -a "$artifact_path"
         echo "run_id=${{ github.run_id }}" | tee -a "$artifact_path"
 
-    - name: Publish artifact with args
+    - id: artifact
+      name: Publish artifact with args
       if: ${{ !fromJSON(steps.init.outputs.disabled) }}
       uses: actions/upload-artifact@v4
       with:
@@ -131,3 +133,12 @@ runs:
         echo
         echo 'No self-hosted runners available!'
         fall_back_to_github_hosted
+
+    - name: Delete args artifact
+      if: ${{ always() }}
+      shell: bash
+      run: |
+        artifact_id='${{ steps.artifact.outputs.artifact-id }}'
+        gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' \
+          -X DELETE '/repos/${{ github.repository }}/actions/artifacts/'"$artifact_id" \
+        || :  # Don’t fail the build if this fails

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -63,9 +63,8 @@ jobs:
       - name: Runner select
         id: select
         uses: ./.github/actions/runner-select
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         with:
+          GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: ubuntu-22.04
           self-hosted-image-name: servo-ubuntu2204-bench
           # You can disable self-hosted runners globally by creating a repository variable named

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Runner select
         id: select
         uses: ./.github/actions/runner-select
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           github-hosted-runner-label: ubuntu-22.04
           self-hosted-image-name: servo-ubuntu2204-bench

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -64,7 +64,6 @@ jobs:
         id: select
         uses: ./.github/actions/runner-select
         with:
-          monitor-api-token: ${{ secrets.SERVO_CI_MONITOR_API_TOKEN }}
           github-hosted-runner-label: ubuntu-22.04
           self-hosted-image-name: servo-ubuntu2204-bench
           # You can disable self-hosted runners globally by creating a repository variable named

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -117,9 +117,8 @@ jobs:
       - name: Runner select
         id: select
         uses: ./.github/actions/runner-select
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         with:
+          GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
           # that the system has a glibc version that is compatible with the one
           # used by the wpt.fyi runners.
@@ -327,9 +326,8 @@ jobs:
       - name: Runner select
         id: select
         uses: ./.github/actions/runner-select
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         with:
+          GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
           # that the system has a glibc version that is compatible with the one
           # used by the wpt.fyi runners.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,7 +118,6 @@ jobs:
         id: select
         uses: ./.github/actions/runner-select
         with:
-          monitor-api-token: ${{ secrets.SERVO_CI_MONITOR_API_TOKEN }}
           # Before updating the GH action runner image for the nightly job, ensure
           # that the system has a glibc version that is compatible with the one
           # used by the wpt.fyi runners.
@@ -327,7 +326,6 @@ jobs:
         id: select
         uses: ./.github/actions/runner-select
         with:
-          monitor-api-token: ${{ secrets.SERVO_CI_MONITOR_API_TOKEN }}
           # Before updating the GH action runner image for the nightly job, ensure
           # that the system has a glibc version that is compatible with the one
           # used by the wpt.fyi runners.

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -117,6 +117,8 @@ jobs:
       - name: Runner select
         id: select
         uses: ./.github/actions/runner-select
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           # Before updating the GH action runner image for the nightly job, ensure
           # that the system has a glibc version that is compatible with the one
@@ -325,6 +327,8 @@ jobs:
       - name: Runner select
         id: select
         uses: ./.github/actions/runner-select
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           # Before updating the GH action runner image for the nightly job, ensure
           # that the system has a glibc version that is compatible with the one

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -100,7 +100,6 @@ jobs:
         id: select
         uses: ./.github/actions/runner-select
         with:
-          monitor-api-token: ${{ secrets.SERVO_CI_MONITOR_API_TOKEN }}
           github-hosted-runner-label: macos-13
           self-hosted-image-name: servo-macos13
           # You can disable self-hosted runners globally by creating a repository variable named

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -99,9 +99,8 @@ jobs:
       - name: Runner select
         id: select
         uses: ./.github/actions/runner-select
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         with:
+          GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: macos-13
           self-hosted-image-name: servo-macos13
           # You can disable self-hosted runners globally by creating a repository variable named

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -99,6 +99,8 @@ jobs:
       - name: Runner select
         id: select
         uses: ./.github/actions/runner-select
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           github-hosted-runner-label: macos-13
           self-hosted-image-name: servo-macos13

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -90,9 +90,8 @@ jobs:
       - name: Runner select
         id: select
         uses: ./.github/actions/runner-select
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
         with:
+          GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: windows-2022
           self-hosted-image-name: servo-windows10
           # You can disable self-hosted runners globally by creating a repository variable named

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Runner select
         id: select
         uses: ./.github/actions/runner-select
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           github-hosted-runner-label: windows-2022
           self-hosted-image-name: servo-windows10

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -91,7 +91,6 @@ jobs:
         id: select
         uses: ./.github/actions/runner-select
         with:
-          monitor-api-token: ${{ secrets.SERVO_CI_MONITOR_API_TOKEN }}
           github-hosted-runner-label: windows-2022
           self-hosted-image-name: servo-windows10
           # You can disable self-hosted runners globally by creating a repository variable named


### PR DESCRIPTION
one of the biggest gaps in our self-hosted runner coverage is that pull request checks can’t run on self-hosted runners, because reserving a runner currently requires a MONITOR_API_TOKEN secret that is unavailable to pull requests.

this patch replaces the authenticated requests to POST /profile/&lt;image>/take?unique_id&amp;qualified_repo&amp;run_id with unauthenticated requests to [POST /select-runner?unique_id&amp;qualified_repo&amp;run_id](https://github.com/servo/ci-runners/commit/05c1f3955248c0726d28c7933003834b4568bc95#diff-b0e8b5236a6e3e0caf095b712a138e85b40d207453f8a436c43de989f4d5eabeR236), in the runner select jobs. to guard the CI monitors against abuse, the runner select job must prove that its request was genuine by uploading a small artifact containing the parameters of that request, which the monitors can then [verify](https://github.com/servo/ci-runners/commit/05c1f3955248c0726d28c7933003834b4568bc95#diff-b0e8b5236a6e3e0caf095b712a138e85b40d207453f8a436c43de989f4d5eabeR253-R286). once the job is marked as done, the monitors will [refuse](https://github.com/servo/ci-runners/commit/05c1f3955248c0726d28c7933003834b4568bc95#diff-b0e8b5236a6e3e0caf095b712a138e85b40d207453f8a436c43de989f4d5eabeR242-R252) further reservation requests.

note that the old authenticated endpoint still works, so this patch can be reverted if anything breaks, or we can turn it off with the usual methods (force-github-hosted-runner or NO_SELF_HOSTED_RUNNERS).

Testing:
- before (38min) <https://github.com/servo/servo/actions/runs/18547747551/job/52869138042>
- after (8min) <https://github.com/servo/servo/actions/runs/18834479889/job/53732619984>

Fixes: part of #38141