### PR TITLE
script: use `run_a_classic_script` algorithm for worker scripts

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3543,10 +3543,10 @@ impl GlobalScope {
         // does not have its sandboxed scripts browsing context flag set.
         if let Some(window) = self.downcast::<Window>() {
             let doc = window.Document();
-            return doc.is_fully_active() ||
+            doc.is_fully_active() ||
                 !doc.has_active_sandboxing_flag(
                     SandboxingFlagSet::SANDBOXED_SCRIPTS_BROWSING_CONTEXT_FLAG,
-                );
+                )
         } else {
             true
         }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3529,7 +3529,7 @@ impl GlobalScope {
         );
     }
 
-    /// <https://html.spec.whatwg.org/multipage/webappapis.html#check-if-we-can-run-script>
+    /// <https://html.spec.whatwg.org/multipage/#check-if-we-can-run-script>
     fn can_run_script(&self) -> bool {
         // If the global object specified by settings is a Window object whose Document object is not fully active
         // or it's active sandboxing flag set does not have its sandboxed scripts browsing context flag set.

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3352,6 +3352,10 @@ impl GlobalScope {
         );
     }
 
+    pub(crate) fn unminify_js(&self) -> bool {
+        self.unminified_js_dir.is_some()
+    }
+
     pub(crate) fn unminified_js_dir(&self) -> Option<String> {
         self.unminified_js_dir.clone()
     }

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -91,7 +91,6 @@ use crate::network_listener::{PreInvoke, ResourceTimingListener, submit_timing};
 use crate::realms::{InRealm, enter_realm};
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{CanGc, IntroductionType, JSContext, JSContextHelper, Runtime};
-use crate::script_thread::ScriptThread;
 use crate::task::TaskCanceller;
 use crate::timers::{IsInterval, TimerCallback};
 use crate::unminify::unminify_js;
@@ -115,6 +114,7 @@ pub(crate) fn prepare_workerscope_init(
         origin: global.origin().immutable().clone(),
         creation_url: global.creation_url().clone(),
         inherited_secure_context: Some(global.is_secure_context()),
+        unminify_js: global.unminify_js(),
     }
 }
 
@@ -373,7 +373,7 @@ impl WorkerGlobalScope {
                 #[cfg(feature = "webgpu")]
                 gpu_id_hub,
                 init.inherited_secure_context,
-                ScriptThread::unminify_js(),
+                init.unminify_js,
                 font_context,
             ),
             worker_id: init.worker_id,

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -94,6 +94,7 @@ use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{CanGc, IntroductionType, JSContext, JSContextHelper, Runtime};
 use crate::task::TaskCanceller;
 use crate::timers::{IsInterval, TimerCallback};
+use crate::unminify::unminify_js;
 
 pub(crate) fn prepare_workerscope_init(
     global: &GlobalScope,
@@ -593,13 +594,14 @@ impl WorkerGlobalScope {
             return;
         }
 
-        let script = ScriptOrigin::external(
+        let mut script = ScriptOrigin::external(
             Rc::new(DOMString::from(script)),
             self.worker_url.borrow().clone(),
             ScriptFetchOptions::default_classic_script(global),
             ScriptType::Classic,
             global.unminified_js_dir(),
         );
+        unminify_js(&mut script);
 
         {
             let _ar = AutoWorkerReset::new(dedicated_worker_scope, worker);

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -91,6 +91,7 @@ use crate::network_listener::{PreInvoke, ResourceTimingListener, submit_timing};
 use crate::realms::{InRealm, enter_realm};
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{CanGc, IntroductionType, JSContext, JSContextHelper, Runtime};
+use crate::script_thread::ScriptThread;
 use crate::task::TaskCanceller;
 use crate::timers::{IsInterval, TimerCallback};
 use crate::unminify::unminify_js;
@@ -372,7 +373,7 @@ impl WorkerGlobalScope {
                 #[cfg(feature = "webgpu")]
                 gpu_id_hub,
                 init.inherited_secure_context,
-                false,
+                ScriptThread::unminify_js(),
                 font_context,
             ),
             worker_id: init.worker_id,

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -55,12 +55,11 @@ use crate::dom::bindings::codegen::UnionTypes::{
     RequestOrUSVString, TrustedScriptOrString, TrustedScriptOrStringOrFunction,
     TrustedScriptURLOrUSVString,
 };
-use crate::dom::bindings::error::{Error, ErrorResult, Fallible, report_pending_exception};
+use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, DomObject};
 use crate::dom::bindings::root::{DomRoot, MutNullableDom};
-use crate::dom::bindings::settings_stack::AutoEntryScript;
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::bindings::trace::RootedTraceableBox;
 use crate::dom::bindings::utils::define_all_exposed_interfaces;
@@ -571,7 +570,6 @@ impl WorkerGlobalScope {
         worker: TrustedWorkerAddress,
         can_gc: CanGc,
     ) {
-        let global = self.upcast::<GlobalScope>();
         let dedicated_worker_scope = self
             .downcast::<DedicatedWorkerGlobalScope>()
             .expect("Only DedicatedWorkerGlobalScope is supported for now");
@@ -594,15 +592,6 @@ impl WorkerGlobalScope {
             return;
         }
 
-        let mut script = ScriptOrigin::external(
-            Rc::new(DOMString::from(script)),
-            self.worker_url.borrow().clone(),
-            ScriptFetchOptions::default_classic_script(global),
-            ScriptType::Classic,
-            global.unminified_js_dir(),
-        );
-        unminify_js(&mut script);
-
         {
             let _ar = AutoWorkerReset::new(dedicated_worker_scope, worker);
             let realm = enter_realm(self);
@@ -612,7 +601,7 @@ impl WorkerGlobalScope {
                 can_gc,
             );
             self.execution_ready.store(true, Ordering::Relaxed);
-            global.run_a_classic_script(&script, 1, Some(IntroductionType::WORKER), can_gc);
+            self.execute_script(DOMString::from(script), can_gc);
             dedicated_worker_scope.fire_queued_messages(can_gc);
         }
     }
@@ -916,44 +905,18 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
 }
 
 impl WorkerGlobalScope {
-    #[allow(unsafe_code)]
     pub(crate) fn execute_script(&self, source: DOMString, can_gc: CanGc) {
-        let _aes = AutoEntryScript::new(self.upcast());
-        let cx = self.runtime.borrow().as_ref().unwrap().cx();
-        rooted!(in(cx) let mut rval = UndefinedValue());
-        let mut options = self
-            .runtime
-            .borrow()
-            .as_ref()
-            .unwrap()
-            .new_compile_options(self.worker_url.borrow().as_str(), 1);
-        options.set_introduction_type(IntroductionType::WORKER);
-        match self.runtime.borrow().as_ref().unwrap().evaluate_script(
-            self.reflector().get_jsobject(),
-            &source.str(),
-            rval.handle_mut(),
-            options,
-        ) {
-            Ok(_) => (),
-            Err(_) => {
-                if self.is_closing() {
-                    println!("evaluate_script failed (terminated)");
-                } else {
-                    // TODO: An error needs to be dispatched to the parent.
-                    // https://github.com/servo/servo/issues/6422
-                    println!("evaluate_script failed");
-                    unsafe {
-                        let ar = enter_realm(self);
-                        report_pending_exception(
-                            JSContext::from_ptr(cx),
-                            true,
-                            InRealm::Entered(&ar),
-                            can_gc,
-                        );
-                    }
-                }
-            },
-        }
+        let global = self.upcast::<GlobalScope>();
+        let mut script = ScriptOrigin::external(
+            Rc::new(source),
+            self.worker_url.borrow().clone(),
+            ScriptFetchOptions::default_classic_script(global),
+            ScriptType::Classic,
+            global.unminified_js_dir(),
+        );
+        unminify_js(&mut script);
+
+        global.run_a_classic_script(&script, 1, Some(IntroductionType::WORKER), can_gc);
     }
 
     pub(crate) fn new_script_pair(&self) -> (ScriptEventLoopSender, ScriptEventLoopReceiver) {

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -612,7 +612,7 @@ impl WorkerGlobalScope {
                 can_gc,
             );
             self.execution_ready.store(true, Ordering::Relaxed);
-            global.run_a_classic_script(&script, 1, None, can_gc);
+            global.run_a_classic_script(&script, 1, Some(IntroductionType::WORKER), can_gc);
             dedicated_worker_scope.fire_queued_messages(can_gc);
         }
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -701,10 +701,6 @@ impl ScriptThread {
         with_script_thread(|script_thread| script_thread.is_user_interacting.get())
     }
 
-    pub(crate) fn unminify_js() -> bool {
-        with_script_thread(|script_thread| script_thread.unminify_js)
-    }
-
     pub(crate) fn get_fully_active_document_ids(&self) -> FxHashSet<PipelineId> {
         self.documents
             .borrow()

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -701,6 +701,10 @@ impl ScriptThread {
         with_script_thread(|script_thread| script_thread.is_user_interacting.get())
     }
 
+    pub(crate) fn unminify_js() -> bool {
+        with_script_thread(|script_thread| script_thread.unminify_js)
+    }
+
     pub(crate) fn get_fully_active_document_ids(&self) -> FxHashSet<PipelineId> {
         self.documents
             .borrow()

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -454,6 +454,8 @@ pub struct WorkerGlobalScopeInit {
     pub creation_url: ServoUrl,
     /// True if secure context
     pub inherited_secure_context: Option<bool>,
+    /// Unminify Javascript.
+    pub unminify_js: bool,
 }
 
 /// Common entities representing a network load origin


### PR DESCRIPTION
Workers now call `run_a_classic_worker_script`, also scripts gets unminified.

Testing: no new tests passes are expected
