### PR TITLE
base: Do not print duplicate "RenderingGroup" in `fmt::Display` of `WebViewId`

### DIFF
--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -309,7 +309,7 @@ size_of_test!(Option<WebViewId>, 12);
 
 impl fmt::Display for WebViewId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "RenderingGroup {}, TopLevel{}", self.0, self.1)
+        write!(f, "{}, TopLevel{}", self.0, self.1)
     }
 }
 


### PR DESCRIPTION
We introduced `RenderingGroupId` in #39140 into `WebViewId`, but now the fmt::Display::fmt for `WebViewId` is like `
"RenderingGroup RenderingGroup: 1, TopLevelBrowsingContext(0,1)"`

Testing: This is used in webdriver for window handle retrieval. The print is proper now.
