### PR TITLE
ci: Run lint jobs on self-hosted runners

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,37 +9,102 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  lint:
-    name: Lint
+  # Runs the underlying job (“workload”) on a self-hosted runner if available,
+  # with the help of a `runner-select` job and a `runner-timeout` job.
+  runner-select:
+    runs-on: ubuntu-22.04
+    outputs:
+      unique-id: ${{ steps.select.outputs.unique-id }}
+      selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
+      runner-type-label: ${{ steps.select.outputs.runner-type-label }}
+      is-self-hosted: ${{ steps.select.outputs.is-self-hosted }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: '.github'
+      - name: Runner select
+        id: select
+        uses: ./.github/actions/runner-select
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          # Before updating the GH action runner image for the nightly job, ensure
+          # that the system has a glibc version that is compatible with the one
+          # used by the wpt.fyi runners.
+          github-hosted-runner-label: ubuntu-22.04
+          self-hosted-image-name: servo-ubuntu2204
+          # You can disable self-hosted runners globally by creating a repository variable named
+          # NO_SELF_HOSTED_RUNNERS with any non-empty value.
+          # <https://github.com/servo/servo/settings/variables/actions>
+          NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
+          # Any other boolean conditions that disable self-hosted runners go here.
+          force-github-hosted-runner: ${{ inputs.upload || inputs.force-github-hosted-runner }}
+  runner-timeout:
+    needs:
+      - runner-select
+    if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: '.github'
+      - name: Runner timeout
+        uses: ./.github/actions/runner-timeout
+        with:
+          github_token: '${{ secrets.GITHUB_TOKEN }}'
+          unique-id: '${{ needs.runner-select.outputs.unique-id }}'
+
+  lint:
+    needs:
+      - runner-select
+    name: Lint [${{ needs.runner-select.outputs.unique-id }}]
+    runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
+    steps:
       - uses: actions/checkout@v4
-        if: github.event_name != 'pull_request_target'
+        if: ${{ runner.environment != 'self-hosted' && github.event_name != 'pull_request_target' }}
         with:
           fetch-depth: 2 # This is necessary for `test-tidy`.
       # This is necessary to checkout the pull request if this run was triggered via a
       # `pull_request_target` event.
       - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request_target'
+        if: ${{ runner.environment != 'self-hosted' && github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2 # This is necessary for `test-tidy`.
+      # Faster checkout for self-hosted runner that uses prebaked repo.
+      - if: ${{ runner.environment == 'self-hosted' && github.event_name != 'pull_request_target' }}
+        run: git fetch --depth=2 origin $GITHUB_SHA  # The depth is necessary for `test-tidy`.
+      - if: ${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request_target' }}
+        run: git fetch --depth=2 origin ${{ github.event.pull_request.head.sha }}  # The depth is necessary for `test-tidy`.
+      - if: ${{ runner.environment == 'self-hosted' }}
+        # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
+        # trees, in case the runner image was baked with a dirty working tree.
+        run: |
+          git switch --detach
+          git reset --hard FETCH_HEAD
+
       - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
+        if: ${{ runner.environment != 'self-hosted' }}
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
       - name: Setup Python
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: ./.github/actions/setup-python
       - name: Install taplo
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: baptiste0928/cargo-install@v3
         with:
           crate: taplo-cli
           locked: true
       - name: Install cargo-deny
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-deny
           version: 0.18.3
           locked: true
       - name: Bootstrap dependencies
+        if: ${{ runner.environment != 'self-hosted' }}
         run: |
           sudo apt update
           ./mach bootstrap --skip-nextest


### PR DESCRIPTION
this patch extends #39900, making lint jobs run on self-hosted runners if available.

Testing:
- before (15min) <https://github.com/servo/servo/actions/runs/18532931828/job/52820332815>
- after (&lt;3min) <https://github.com/servo/servo/actions/runs/18839433347/job/53748113347>

Fixes: part of #38141