### PR TITLE
Add code-coverage option to mach run, test-wpt and test-devtools

### DIFF
--- a/etc/coverage_workspace_wrapper.py
+++ b/etc/coverage_workspace_wrapper.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+"""
+This is a simple script intended to be used as a `RUSTC_WORKSPACE_WRAPPER`, adding the
+required flags for code coverage instrumentation, only to the local libraries in our
+workspace. This reduces the runtime overhead and the profile size significantly.
+We are not interested in the code coverage metrics of outside dependencies anyway.
+"""
+
+import os
+import sys
+
+
+def main():
+    # The first argument is the path to rustc, followed by its arguments
+    args = sys.argv[1:]
+    args += ["-Cinstrument-coverage=true", "--cfg=coverage"]
+
+    # Execute rustc with the modified arguments
+    os.execvp(args[0], args)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -131,7 +131,14 @@ class MachCommands(CommandBase):
             print("Building with code coverage instrumentation...")
             # We don't want coverage for build-scripts and proc macros.
             kwargs["target_override"] = target_triple
-            env["RUSTFLAGS"] += " -Cinstrument-coverage=true --cfg=coverage"
+            this_dir = pathlib.Path(os.path.dirname(__file__))
+            servo_root_dir = this_dir.parent.parent
+            coverage_workspace_wrapper = servo_root_dir.joinpath("etc/coverage_workspace_wrapper.py")
+            if not coverage_workspace_wrapper.exists():
+                print(
+                    f"Could not find rustc workspace wrapper script at expected location: {coverage_workspace_wrapper}"
+                )
+            env["RUSTC_WORKSPACE_WRAPPER"] = str(coverage_workspace_wrapper)
 
         if sanitizer.is_some():
             self.build_sanitizer_env(env, opts, kwargs, target_triple, sanitizer)

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -127,6 +127,12 @@ class MachCommands(CommandBase):
         host = servo.platform.host_triple()
         target_triple = self.target.triple()
 
+        if self.enable_code_coverage:
+            print("Building with code coverage instrumentation...")
+            # We don't want coverage for build-scripts and proc macros.
+            kwargs["target_override"] = target_triple
+            env["RUSTFLAGS"] += " -Cinstrument-coverage=true --cfg=coverage"
+
         if sanitizer.is_some():
             self.build_sanitizer_env(env, opts, kwargs, target_triple, sanitizer)
 

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -29,7 +29,7 @@ from enum import Enum
 from glob import glob
 from os import path
 from subprocess import PIPE, CompletedProcess
-from typing import Any, Optional, Union, LiteralString, cast
+from typing import Any, Optional, Union, LiteralString, cast, List
 from collections.abc import Generator, Callable
 from xml.etree.ElementTree import XML
 
@@ -89,6 +89,14 @@ class BuildType:
             return "release"
         else:
             return self.profile
+
+    def as_cargo_arg(self) -> List[str]:
+        if self.is_dev():
+            return ["--debug"]
+        elif self.is_release():
+            return ["--release"]
+        else:
+            return ["--profile", self.profile]
 
     def __eq__(self, other: object) -> bool:
         raise Exception("BUG: do not compare BuildType with ==")

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -538,6 +538,7 @@ class CommandBase(object):
         build_type: bool = False,
         binary_selection: bool = False,
         package_configuration: bool = False,
+        coverage_report: bool = False,
     ) -> Callable:
         decorators = []
         if build_type or binary_selection:
@@ -692,6 +693,9 @@ class CommandBase(object):
 
                 if build_configuration or binary_selection:
                     self.enable_code_coverage = kwargs.pop("coverage", False)
+                    # In coverage report mode force-enable, so that the user doesn't need to
+                    # additionally specify `--coverage`.
+                    self.enable_code_coverage |= coverage_report
 
                 if binary_selection:
                     if "servo_binary" not in kwargs:

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -92,12 +92,7 @@ class BuildType:
             return self.profile
 
     def as_cargo_arg(self) -> List[str]:
-        if self.is_dev():
-            return ["--debug"]
-        elif self.is_release():
-            return ["--release"]
-        else:
-            return ["--profile", self.profile]
+        return ["--profile", self.profile]
 
     def __eq__(self, other: object) -> bool:
         raise Exception("BUG: do not compare BuildType with ==")

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -43,6 +43,7 @@ from servo.platform.build_target import AndroidTarget, BuildTarget, OpenHarmonyT
 from servo.util import download_file, get_default_cache_dir
 
 from python.servo.platform.build_target import SanitizerKind
+from python.servo.util import get_target_dir
 
 NIGHTLY_REPOSITORY_URL = "https://servo-builds2.s3.amazonaws.com/"
 ASAN_LEAK_SUPPRESSION_FILE = "support/suppressed_leaks_for_asan.txt"
@@ -704,6 +705,11 @@ class CommandBase(object):
                     # In coverage report mode force-enable, so that the user doesn't need to
                     # additionally specify `--coverage`.
                     self.enable_code_coverage |= coverage_report
+                    if self.enable_code_coverage:
+                        target_dir = get_target_dir()
+                        # See `cargo llvm-cov show-env`. We only need the profile file environment variable
+                        # The other variables are only required when creating a coverage report.
+                        os.environ["LLVM_PROFILE_FILE"] = f"{target_dir}/servo-%p-%14m.profraw"
 
                 if binary_selection:
                     if "servo_binary" not in kwargs:

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -106,11 +106,6 @@ class PostBuildCommands(CommandBase):
                 return
 
             env["LIBGL_ALWAYS_SOFTWARE"] = "1"
-        if self.enable_code_coverage:
-            target_dir = servo.util.get_target_dir()
-            # See `cargo llvm-cov show-env`. We only need the profile file environment variable
-            # The other variables are only required when creating a coverage report.
-            env["LLVM_PROFILE_FILE"] = f"{target_dir}/servo-%p-%14m.profraw"
         os.environ.update(env)
 
         # Make --debugger-cmd imply --debugger

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -33,6 +33,8 @@ from servo.command_base import (
 )
 from servo.platform.build_target import is_android
 
+from python.servo.command_base import BuildType
+
 ANDROID_APP_NAME = "org.servo.servoshell"
 
 
@@ -199,8 +201,8 @@ class PostBuildCommands(CommandBase):
 
     @Command("coverage-report", description="Create Servo Code Coverage report.", category="post-build")
     @CommandArgument("params", nargs="...", help="Command-line arguments to be passed through to cargo llvm-cov")
-    @CommandBase.common_command_arguments(binary_selection=True, coverage_report=True)
-    def coverage_report(self, params: Optional[List[str]] = None, **kwargs: Any) -> int:
+    @CommandBase.common_command_arguments(binary_selection=True, build_type=True, coverage_report=True)
+    def coverage_report(self, build_type: BuildType, params: Optional[List[str]] = None, **kwargs: Any) -> int:
         target_dir = servo.util.get_target_dir()
         # See `cargo llvm-cov show-env`. We only export the values required at runtime.
         os.environ["CARGO_LLVM_COV"] = "1"
@@ -208,6 +210,7 @@ class PostBuildCommands(CommandBase):
         os.environ["CARGO_LLVM_COV_TARGET_DIR"] = target_dir
         try:
             cargo_llvm_cov_cmd = ["cargo", "llvm-cov", "report", "--target", self.target.triple()]
+            cargo_llvm_cov_cmd.extend(build_type.as_cargo_arg())
             cargo_llvm_cov_cmd.extend(params or [])
             subprocess.check_call(cargo_llvm_cov_cmd)
         except subprocess.CalledProcessError as exception:

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -38,7 +38,7 @@ import servo.devtools_tests
 import servo.try_parser
 from servo.command_base import BuildType, CommandBase, call, check_call
 from servo.post_build_commands import PostBuildCommands
-from servo.util import delete
+from servo.util import delete, get_target_dir
 
 SCRIPT_PATH = os.path.split(__file__)[0]
 PROJECT_TOPLEVEL_PATH = os.path.abspath(os.path.join(SCRIPT_PATH, "..", ".."))
@@ -403,6 +403,11 @@ class MachCommands(CommandBase):
     @CommandBase.common_command_arguments(binary_selection=True)
     def test_devtools(self, servo_binary: str, test_names: list[str], **kwargs: Any) -> int:
         print("Running devtools tests...")
+        if self.enable_code_coverage:
+            target_dir = get_target_dir()
+            # See `cargo llvm-cov show-env`. We only need the profile file environment variable
+            # The other variables are only required when creating a coverage report.
+            os.environ["LLVM_PROFILE_FILE"] = f"{target_dir}/servo-%p-%14m.profraw"
         passed = servo.devtools_tests.run_tests(SCRIPT_PATH, servo_binary, test_names)
         return 0 if passed else 1
 
@@ -423,6 +428,11 @@ class MachCommands(CommandBase):
     )
     @CommandBase.common_command_arguments(binary_selection=True)
     def test_wpt(self, servo_binary: str, **kwargs: Any) -> int:
+        if self.enable_code_coverage:
+            target_dir = get_target_dir()
+            # See `cargo llvm-cov show-env`. We only need the profile file environment variable
+            # The other variables are only required when creating a coverage report.
+            os.environ["LLVM_PROFILE_FILE"] = f"{target_dir}/servo-%p-%14m.profraw"
         return self._test_wpt(servo_binary, **kwargs)
 
     @CommandBase.allow_target_configuration

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -38,7 +38,7 @@ import servo.devtools_tests
 import servo.try_parser
 from servo.command_base import BuildType, CommandBase, call, check_call
 from servo.post_build_commands import PostBuildCommands
-from servo.util import delete, get_target_dir
+from servo.util import delete
 
 SCRIPT_PATH = os.path.split(__file__)[0]
 PROJECT_TOPLEVEL_PATH = os.path.abspath(os.path.join(SCRIPT_PATH, "..", ".."))
@@ -403,11 +403,6 @@ class MachCommands(CommandBase):
     @CommandBase.common_command_arguments(binary_selection=True)
     def test_devtools(self, servo_binary: str, test_names: list[str], **kwargs: Any) -> int:
         print("Running devtools tests...")
-        if self.enable_code_coverage:
-            target_dir = get_target_dir()
-            # See `cargo llvm-cov show-env`. We only need the profile file environment variable
-            # The other variables are only required when creating a coverage report.
-            os.environ["LLVM_PROFILE_FILE"] = f"{target_dir}/servo-%p-%14m.profraw"
         passed = servo.devtools_tests.run_tests(SCRIPT_PATH, servo_binary, test_names)
         return 0 if passed else 1
 
@@ -428,11 +423,6 @@ class MachCommands(CommandBase):
     )
     @CommandBase.common_command_arguments(binary_selection=True)
     def test_wpt(self, servo_binary: str, **kwargs: Any) -> int:
-        if self.enable_code_coverage:
-            target_dir = get_target_dir()
-            # See `cargo llvm-cov show-env`. We only need the profile file environment variable
-            # The other variables are only required when creating a coverage report.
-            os.environ["LLVM_PROFILE_FILE"] = f"{target_dir}/servo-%p-%14m.profraw"
         return self._test_wpt(servo_binary, **kwargs)
 
     @CommandBase.allow_target_configuration


### PR DESCRIPTION
Add a `--coverage` flag to `./mach build` and a  `./mach coverage-report` command to use `cargo llvm-cov` to generate a coverage report from the raw profiles. 

The workflow is: 
```
./mach build --coverage [--profile <cargo_profile>]
# Or test-wpt or test-devtools
./mach run --coverage [--profile <cargo_profile>]
# Note, that coverage-report needs to know the cargo build profile.
./mach coverage-report [--profile <cargo_profile>] [optional parameters for cargo-llvm-cov]
```
According to the LLVM documentation on source based coverage, the optimization profile should not influence the accuracy of the coverage profile, so we can gather coverage data from optimized builds.

Note that `./mach test-devtools --coverage`  will not produce any coverage profiles yet, since the test runner kills the servo binary, which prevents writing the profile data at shutdown. 
The same problem also affects `test-wpt` with `servodriver`, which will be fixed by https://github.com/servo/servo/pull/40455.

Testing: Manually tested. A CI workflow to test wpt coverage will be added in a follow-up PR.

