### PR TITLE
Add IndexedDB preference to servo:preferences

### DIFF
--- a/resources/resource_protocol/preferences.html
+++ b/resources/resource_protocol/preferences.html
@@ -52,7 +52,7 @@
       const prefs = {
           "experimental": [],
           "http-cache": ["network_http_cache_disabled"],
-          "more-experimental": ["dom_abort_controller_enabled"],
+          "more-experimental": ["dom_abort_controller_enabled", "dom_indexeddb_enabled"],
           "user-agent": ["user_agent"],
       };
 


### PR DESCRIPTION
Add IndexedDB preference to servo:preferences, making it easy to enable at runtime for testing site compatibility

Fixes: #39792 
