### PR TITLE
layout: Add `Contents::Widget(NonReplacedContents)` for HTML widgets

### DIFF
--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -415,7 +415,7 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
             DisplayInside::Flow {
                 is_list_item: false,
             },
-            NonReplacedContents::OfPseudoElement(contents).into(),
+            Contents::for_pseudo_element(contents),
             box_slot,
         );
     }
@@ -559,15 +559,12 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
                 },
                 _ => BlockLevelCreator::Independent {
                     display_inside,
-                    contents: contents.into(),
+                    contents: Contents::NonReplaced(contents),
                 },
             },
-            Contents::Replaced(contents) => {
-                let contents = Contents::Replaced(contents);
-                BlockLevelCreator::Independent {
-                    display_inside,
-                    contents,
-                }
+            Contents::Replaced(_) | Contents::Widget(_) => BlockLevelCreator::Independent {
+                display_inside,
+                contents,
             },
         };
         self.block_level_boxes.push(BlockLevelJob {

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -1837,6 +1837,7 @@ fn automatic_inline_size<T>(
     is_table: bool,
     is_replaced: bool,
 ) -> Size<T> {
+    // TODO: Normal alignment shouldn't stretch widgets.
     match justify_self {
         AlignFlags::STRETCH => Size::Stretch,
         AlignFlags::NORMAL if !is_table && !is_replaced => Size::Stretch,

--- a/components/layout/flow/root.rs
+++ b/components/layout/flow/root.rs
@@ -21,7 +21,7 @@ use style_traits::CSSPixel;
 use crate::cell::ArcRefCell;
 use crate::context::LayoutContext;
 use crate::dom::{LayoutBox, NodeExt};
-use crate::dom_traversal::{Contents, NodeAndStyleInfo, NonReplacedContents};
+use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::flexbox::FlexLevelBox;
 use crate::flow::float::FloatBox;
 use crate::flow::inline::InlineItem;
@@ -30,7 +30,6 @@ use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::{FragmentFlags, FragmentTree};
 use crate::geom::{LogicalVec2, PhysicalSize};
 use crate::positioned::{AbsolutelyPositionedBox, PositioningContext};
-use crate::replaced::ReplacedContents;
 use crate::style_ext::{Display, DisplayGeneratingBox, DisplayInside};
 use crate::taffy::{TaffyItemBox, TaffyItemBoxInner};
 use crate::{DefiniteContainingBlock, PropagatedBoxTreeData};
@@ -184,8 +183,7 @@ fn construct_for_root_element(
         Display::GeneratingBox(display_generating_box) => display_generating_box.display_inside(),
     };
 
-    let contents = ReplacedContents::for_element(root_element, context)
-        .map_or_else(|| NonReplacedContents::OfElement.into(), Contents::Replaced);
+    let contents = Contents::for_element(root_element, context);
 
     let propagated_data = PropagatedBoxTreeData::default();
     let root_box = if box_style.position.is_absolutely_positioned() {
@@ -412,8 +410,7 @@ impl<'dom> IncrementalBoxTreeUpdate<'dom> {
     #[servo_tracing::instrument(name = "Box Tree Update From Dirty Root", skip_all)]
     fn update_from_dirty_root(&self, context: &LayoutContext) {
         let node = self.node.to_threadsafe();
-        let contents = ReplacedContents::for_element(node, context)
-            .map_or_else(|| NonReplacedContents::OfElement.into(), Contents::Replaced);
+        let contents = Contents::for_element(node, context);
 
         let info =
             NodeAndStyleInfo::new(node, self.primary_style.clone(), node.take_restyle_damage());

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -81,68 +81,68 @@ impl IndependentFormattingContext {
     ) -> Self {
         let mut base_fragment_info: BaseFragmentInfo = node_and_style_info.into();
 
-        match contents {
-            Contents::NonReplaced(non_replaced_contents) => {
-                let contents = match display_inside {
-                    DisplayInside::Flow { is_list_item } |
-                    DisplayInside::FlowRoot { is_list_item } => {
-                        IndependentFormattingContextContents::Flow(
-                            BlockFormattingContext::construct(
-                                context,
-                                node_and_style_info,
-                                non_replaced_contents,
-                                propagated_data,
-                                is_list_item,
-                            ),
-                        )
-                    },
-                    DisplayInside::Grid => {
-                        IndependentFormattingContextContents::Grid(TaffyContainer::construct(
-                            context,
-                            node_and_style_info,
-                            non_replaced_contents,
-                            propagated_data,
-                        ))
-                    },
-                    DisplayInside::Flex => {
-                        IndependentFormattingContextContents::Flex(FlexContainer::construct(
-                            context,
-                            node_and_style_info,
-                            non_replaced_contents,
-                            propagated_data,
-                        ))
-                    },
-                    DisplayInside::Table => {
-                        let table_grid_style = context
-                            .style_context
-                            .stylist
-                            .style_for_anonymous::<ServoLayoutElement>(
-                                &context.style_context.guards,
-                                &PseudoElement::ServoTableGrid,
-                                &node_and_style_info.style,
-                            );
-                        base_fragment_info.flags.insert(FragmentFlags::DO_NOT_PAINT);
-                        IndependentFormattingContextContents::Table(Table::construct(
-                            context,
-                            node_and_style_info,
-                            table_grid_style,
-                            non_replaced_contents,
-                            propagated_data,
-                        ))
-                    },
-                };
-                Self {
-                    base: LayoutBoxBase::new(base_fragment_info, node_and_style_info.style.clone()),
-                    contents,
-                }
-            },
+        let non_replaced_contents = match contents {
             Contents::Replaced(contents) => {
                 base_fragment_info.flags.insert(FragmentFlags::IS_REPLACED);
-                Self {
+                return Self {
                     base: LayoutBoxBase::new(base_fragment_info, node_and_style_info.style.clone()),
                     contents: IndependentFormattingContextContents::Replaced(contents),
-                }
+                };
             },
+            Contents::Widget(non_replaced_contents) => {
+                base_fragment_info.flags.insert(FragmentFlags::IS_WIDGET);
+                non_replaced_contents
+            },
+            Contents::NonReplaced(non_replaced_contents) => non_replaced_contents,
+        };
+        let contents = match display_inside {
+            DisplayInside::Flow { is_list_item } | DisplayInside::FlowRoot { is_list_item } => {
+                IndependentFormattingContextContents::Flow(BlockFormattingContext::construct(
+                    context,
+                    node_and_style_info,
+                    non_replaced_contents,
+                    propagated_data,
+                    is_list_item,
+                ))
+            },
+            DisplayInside::Grid => {
+                IndependentFormattingContextContents::Grid(TaffyContainer::construct(
+                    context,
+                    node_and_style_info,
+                    non_replaced_contents,
+                    propagated_data,
+                ))
+            },
+            DisplayInside::Flex => {
+                IndependentFormattingContextContents::Flex(FlexContainer::construct(
+                    context,
+                    node_and_style_info,
+                    non_replaced_contents,
+                    propagated_data,
+                ))
+            },
+            DisplayInside::Table => {
+                let table_grid_style = context
+                    .style_context
+                    .stylist
+                    .style_for_anonymous::<ServoLayoutElement>(
+                        &context.style_context.guards,
+                        &PseudoElement::ServoTableGrid,
+                        &node_and_style_info.style,
+                    );
+                base_fragment_info.flags.insert(FragmentFlags::DO_NOT_PAINT);
+                IndependentFormattingContextContents::Table(Table::construct(
+                    context,
+                    node_and_style_info,
+                    table_grid_style,
+                    non_replaced_contents,
+                    propagated_data,
+                ))
+            },
+        };
+        Self {
+            base: LayoutBoxBase::new(base_fragment_info, node_and_style_info.style.clone()),
+            contents,
         }
     }
 

--- a/components/layout/fragment_tree/base_fragment.rs
+++ b/components/layout/fragment_tree/base_fragment.rs
@@ -4,10 +4,10 @@
 
 use bitflags::bitflags;
 use html5ever::local_name;
+use layout_api::combine_id_with_fragment_type;
 use layout_api::wrapper_traits::{
     PseudoElementChain, ThreadSafeLayoutElement, ThreadSafeLayoutNode,
 };
-use layout_api::{LayoutElementType, LayoutNodeType, combine_id_with_fragment_type};
 use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
 use script::layout_dom::ServoThreadSafeLayoutNode;
@@ -114,15 +114,6 @@ impl From<ServoThreadSafeLayoutNode<'_>> for BaseFragmentInfo {
                 _ => {},
             }
 
-            if matches!(
-                element.type_id(),
-                Some(LayoutNodeType::Element(
-                    LayoutElementType::HTMLInputElement | LayoutElementType::HTMLTextAreaElement
-                ))
-            ) {
-                flags.insert(FragmentFlags::IS_TEXT_CONTROL);
-            }
-
             if ThreadSafeLayoutElement::is_root(&element) {
                 flags.insert(FragmentFlags::IS_ROOT_ELEMENT);
             }
@@ -152,8 +143,11 @@ bitflags! {
         const IS_BODY_ELEMENT_OF_HTML_ELEMENT_ROOT = 1 << 0;
         /// Whether or not the node that created this Fragment is a `<br>` element.
         const IS_BR_ELEMENT = 1 << 1;
-        /// Whether or not the node that created this Fragment is a `<input>` or `<textarea>` element.
-        const IS_TEXT_CONTROL = 1 << 2;
+        /// Whether or not the node that created this Fragment is a widget. Widgets behave similarly to
+        /// replaced elements, e.g. they are atomic when inline-level, and their automatic inline size
+        /// doesn't stretch when block-level.
+        /// <https://drafts.csswg.org/css-ui/#widget>
+        const IS_WIDGET = 1 << 2;
         /// Whether or not this Fragment is a flex item or a grid item.
         const IS_FLEX_OR_GRID_ITEM = 1 << 3;
         /// Whether or not this Fragment was created to contain a replaced element or is

--- a/components/layout/style_ext.rs
+++ b/components/layout/style_ext.rs
@@ -33,7 +33,7 @@ use unicode_bidi::Level;
 use webrender_api as wr;
 use webrender_api::units::LayoutTransform;
 
-use crate::dom_traversal::{Contents, NonReplacedContents};
+use crate::dom_traversal::Contents;
 use crate::fragment_tree::FragmentFlags;
 use crate::geom::{
     AuOrAuto, LengthPercentageOrAuto, LogicalSides, LogicalSides1D, LogicalVec2, PhysicalSides,
@@ -81,12 +81,10 @@ impl DisplayGeneratingBox {
                     is_list_item: false,
                 },
             }
-        } else if matches!(
-            contents,
-            Contents::NonReplaced(NonReplacedContents::OfTextControl)
-        ) {
-            // If it's an input or textarea, make sure the display-inside is flow-root.
+        } else if matches!(contents, Contents::Widget(_)) {
+            // If it's a widget, make sure the display-inside is flow-root.
             // <https://html.spec.whatwg.org/multipage/#form-controls>
+            // TODO: Do we want flow-root, or just an independent formatting context?
             if let DisplayGeneratingBox::OutsideInside { outside, .. } = self {
                 DisplayGeneratingBox::OutsideInside {
                     outside: *outside,
@@ -519,8 +517,7 @@ impl ComputedValuesExt for ComputedValues {
 
     fn is_inline_box(&self, fragment_flags: FragmentFlags) -> bool {
         self.get_box().display.is_inline_flow() &&
-            !fragment_flags
-                .intersects(FragmentFlags::IS_REPLACED | FragmentFlags::IS_TEXT_CONTROL)
+            !fragment_flags.intersects(FragmentFlags::IS_REPLACED | FragmentFlags::IS_WIDGET)
     }
 
     /// Returns true if this is a transformable element.

--- a/components/layout/table/construct.rs
+++ b/components/layout/table/construct.rs
@@ -771,10 +771,10 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                     let new_row_group_index = self.builder.table.row_groups.len() - 1;
                     self.current_row_group_index = Some(new_row_group_index);
 
-                    let Contents::NonReplaced(non_replaced_contents) = contents else {
-                        unreachable!("Replaced should not have a LayoutInternal display type.");
-                    };
-                    non_replaced_contents.traverse(self.context, info, self);
+                    contents
+                        .non_replaced_contents()
+                        .expect("Replaced should not have a LayoutInternal display type.")
+                        .traverse(self.context, info, self);
                     self.finish_anonymous_row_if_needed();
 
                     self.current_row_group_index = None;
@@ -791,10 +791,10 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                     let mut row_builder =
                         TableRowBuilder::new(self, info, self.current_propagated_data);
 
-                    let Contents::NonReplaced(non_replaced_contents) = contents else {
-                        unreachable!("Replaced should not have a LayoutInternal display type.");
-                    };
-                    non_replaced_contents.traverse(context, info, &mut row_builder);
+                    contents
+                        .non_replaced_contents()
+                        .expect("Replaced should not have a LayoutInternal display type.")
+                        .traverse(context, info, &mut row_builder);
                     row_builder.finish();
 
                     let row = ArcRefCell::new(TableTrack {
@@ -828,10 +828,10 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                         columns: Vec::new(),
                     };
 
-                    let Contents::NonReplaced(non_replaced_contents) = contents else {
-                        unreachable!("Replaced should not have a LayoutInternal display type.");
-                    };
-                    non_replaced_contents.traverse(self.context, info, &mut column_group_builder);
+                    contents
+                        .non_replaced_contents()
+                        .expect("Replaced should not have a LayoutInternal display type.")
+                        .traverse(self.context, info, &mut column_group_builder);
 
                     let first_column = self.builder.table.columns.len();
                     if column_group_builder.columns.is_empty() {
@@ -861,10 +861,6 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                     )));
                 },
                 DisplayLayoutInternal::TableCaption => {
-                    let Contents::NonReplaced(non_replaced_contents) = contents else {
-                        unreachable!("Replaced should not have a LayoutInternal display type.");
-                    };
-
                     let old_box = box_slot.take_layout_box_if_undamaged(info.damage);
                     let old_caption = old_box.and_then(|layout_box| match layout_box {
                         LayoutBox::TableLevelBox(TableLevelBox::Caption(caption)) => Some(caption),
@@ -872,6 +868,9 @@ impl<'dom> TraversalHandler<'dom> for TableBuilderTraversal<'_, 'dom> {
                     });
 
                     let caption = old_caption.unwrap_or_else(|| {
+                        let non_replaced_contents = contents
+                            .non_replaced_contents()
+                            .expect("Replaced should not have a LayoutInternal display type.");
                         let contents = IndependentFormattingContextContents::Flow(
                             BlockFormattingContext::construct(
                                 self.context,
@@ -1043,9 +1042,9 @@ impl<'dom> TraversalHandler<'dom> for TableRowBuilder<'_, '_, 'dom, '_> {
 
                         let propagated_data =
                             self.propagated_data.disallowing_percentage_table_columns();
-                        let Contents::NonReplaced(non_replaced_contents) = contents else {
-                            unreachable!("Replaced should not have a LayoutInternal display type.");
-                        };
+                        let non_replaced_contents = contents
+                            .non_replaced_contents()
+                            .expect("Replaced should not have a LayoutInternal display type.");
 
                         let contents = BlockFormattingContext::construct(
                             self.table_traversal.context,


### PR DESCRIPTION
Widgets like `<input>` and `<textarea>` have various behaviors similar to replaced elements, but aren't fully replaced.

Therefore, this adds a new case into the `Contents` enum so that it can represent the three states: non-replaced, fully replaced, and widget. This means that `NonReplacedContents::OfTextControl` can be dropped.

The code is refactored in order to centralize the logic to identify widgets in a single place.

This fixes some places where we weren't checking if the element was a widget, e.g. in `construct_for_root_element()`. But I think the change isn't currently observable in practice.

Testing: Unneeded, no behavior change.
This is part of #39927
