### PR TITLE
constellation: Send a `WebViewDelegate::notify_history_changed` method when history state is replaced

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4223,6 +4223,7 @@ where
 
         let session_history = self.get_joint_session_history(webview_id);
         session_history.replace_history_state(pipeline_id, history_state_id, url);
+        self.notify_history_changed(webview_id);
     }
 
     #[servo_tracing::instrument(skip_all)]

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -576,6 +576,10 @@ impl WebViewDelegate for RunningAppState {
         self.inner_mut().need_update = true;
     }
 
+    fn notify_history_changed(&self, _webview: WebView, _entries: Vec<Url>, _current: usize) {
+        self.inner_mut().need_update = true;
+    }
+
     fn notify_page_title_changed(&self, webview: servo::WebView, title: Option<String>) {
         if webview.focused() {
             let window_title = format!("{} - Servo", title.clone().unwrap_or_default());


### PR DESCRIPTION
Location bar was not updated on `history.replaceState()`, `history.pushState()`, `history.back()` and `history.forward()`.

These changes add a `notify_history_changed()` in `handle_replace_history_state_msg()` of constellation and mark servoshell's interface to be updated on changes in history.

Testing: servoshell was tested manually
Fixes: #39757
