### PR TITLE
Box tree construction: only unset pseudo elements if the box is rebuilt

### DIFF
--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -162,10 +162,12 @@ fn traverse_element<'dom>(
     context: &LayoutContext,
     handler: &mut impl TraversalHandler<'dom>,
 ) {
-    element.unset_all_pseudo_boxes();
+    let damage = element.take_restyle_damage();
+    if damage.has_box_damage() {
+        element.unset_all_pseudo_boxes();
+    }
 
     let style = element.style(&context.style_context);
-    let damage = element.take_restyle_damage();
     let info = NodeAndStyleInfo::new(element, style, damage);
 
     match Display::from(info.style.get_box().display) {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12672,6 +12672,15 @@
        {}
       ]
      ],
+     "pseudo-element-transition-continues-on-box-tree-re-construction.html": [
+      "131c49a9780ec215a8cf8964d148473f85207dd0",
+      [
+       null,
+       {
+        "testdriver": true
+       }
+      ]
+     ],
      "transition-events.html": [
       "b561fc8353276e6bdd13a9d1b965f57733ecd19b",
       [

--- a/tests/wpt/mozilla/tests/css/animations/pseudo-element-transition-continues-on-box-tree-re-construction.html
+++ b/tests/wpt/mozilla/tests/css/animations/pseudo-element-transition-continues-on-box-tree-re-construction.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>::before transition keeps updating while pointer moves to another element (IntersectionObserver)</title>
+<link rel="author" title="batu_hoang" href="https://github.com/longvatrong111">
+<link rel="help" href="https://w3c.github.io/IntersectionObserver/">
+<link rel="help" href="https://github.com/servo/servo/issues/39225"/>
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<style>
+  .scene {
+    position: relative;
+    width: 400px;
+    height: 120px;
+    margin: 16px;
+    outline: 1px dashed #ccc;
+  }
+
+  #host {
+    display: inline-block;
+    position: absolute;
+    left: 10px;
+    top: 20px;
+    height: 60px;
+    border: 1px solid #666;
+    background: #fafafa;
+    vertical-align: top;
+  }
+
+  /* Animated pseudo element */
+  #host::before {
+    content: "";
+    display: block;
+    width: 0px;                 /* start at 0px */
+    height: 10px;
+    background: red;
+    transition: width 1s linear; /* duration: 1s */
+  }
+  #host.active::before {
+    width: 100px;               /* end at 100px */
+  }
+
+  #other {
+    position: absolute;
+    left: 95px;
+    top: 20px;
+    width: 100px;
+    height: 60px;
+    border: 1px solid #09c;
+    background: #eef7ff;
+  }
+</style>
+
+<div class="scene">
+  <div id="host">Host</div>
+  <div id="other">Other</div>
+</div>
+
+<script>
+promise_test(async t => {
+  const host = document.getElementById('host');
+  const other = document.getElementById('other');
+
+  // Sanity: initial ::before width is 0px and no intersection yet.
+  assert_equals(getComputedStyle(host, '::before').width, '0px', 'Initial ::before width should be 0px');
+  const rectH = host.getBoundingClientRect();
+  const rectO = other.getBoundingClientRect();
+  const initiallyIntersecting =
+    rectH.left + rectH.width > rectO.left &&
+    rectH.top < rectO.bottom &&
+    rectH.bottom > rectO.top;
+  assert_false(initiallyIntersecting, 'Host should not intersect other before animation');
+
+  // Observe when "other" starts intersecting the host’s border box.
+  const intersectionReached = new Promise(resolve => {
+    const io = new IntersectionObserver(entries => {
+      for (const e of entries) {
+        if (e.isIntersecting) {
+          io.disconnect();
+          resolve();
+          break;
+        }
+      }
+    }, { root: host, threshold: 0.01 });
+    io.observe(other);
+  });
+
+  // Start the transition by clicking host (once).
+  host.addEventListener('click', () => host.classList.add('active'), { once: true });
+  await new test_driver.Actions()
+    .pointerMove(15, 15, { origin: host })
+    .pointerDown()
+    .pointerUp()
+    .send();
+
+  // Let the transition run briefly, then move pointer to "other" while transition is in progress.
+  // to force layout/reflow
+  await new Promise(r => t.step_timeout(r, 200));
+  await new test_driver.Actions()
+    .pointerMove(15, 15, { origin: other })
+    .send();
+  await new test_driver.Actions()
+    .pointerMove(35, 55, { origin: other })
+    .send();
+
+  // Wait until the growing host intersects "other" (i.e., ::before expansion continued).
+  const guard = new Promise((_, rej) => t.step_timeout(() => rej(new Error('intersection timeout')), 3000));
+  await Promise.race([intersectionReached, guard]);
+}, '::before width transition continues while pointer moves');
+</script>


### PR DESCRIPTION
Box Tree re-construction may cause the loss of pseudo element: https://github.com/servo/servo/issues/39225#issuecomment-3404462089, then causes transition stucks.
We should only unset  pseudo elements if the box is rebuilt.

Testing: fix manual test in https://github.com/servo/servo/issues/39225, CI reports no regression: [action](https://github.com/longvatrong111/servo/actions/runs/18572401080)
Fixes: https://github.com/servo/servo/issues/39225

cc: @xiaochengh 
