### PR TITLE
constellation: Update the stored URL when discarding a document.

### DIFF
--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-redirect-on-history.tentative.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/performance-navigation-timing-redirect-on-history.tentative.window.js.ini
@@ -1,4 +1,3 @@
 [performance-navigation-timing-redirect-on-history.tentative.window.html]
-  expected: TIMEOUT
   [RemoteContextHelper navigation using BFCache]
-    expected: TIMEOUT
+    expected: FAIL


### PR DESCRIPTION
When discarding a document, we need to ensure that any attempt to traverse the session history ends up navigating to the most recent URL associated with that document. 

Testing: New tests running to completion.
Fixes: #39903