### PR TITLE
xpath: Don't panic in node name test when namespace prefix is unknown

### DIFF
--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -152,12 +152,6 @@ impl xpath::Node for XPathWrapper<DomRoot<Node>> {
             .map(XPathWrapper)
     }
 
-    fn lookup_namespace_uri(&self, uri: Option<&str>) -> Option<String> {
-        self.0
-            .LookupNamespaceURI(uri.map(DOMString::from))
-            .map(String::from)
-    }
-
     fn get_root_node(&self) -> Self {
         XPathWrapper(self.0.GetRootNode(&GetRootNodeOptions::empty()))
     }
@@ -165,10 +159,6 @@ impl xpath::Node for XPathWrapper<DomRoot<Node>> {
 
 impl xpath::Document for XPathWrapper<DomRoot<Document>> {
     type Node = XPathWrapper<DomRoot<Node>>;
-
-    fn is_html_document(&self) -> bool {
-        self.0.is_html_document()
-    }
 
     fn get_elements_with_id(
         &self,
@@ -241,6 +231,10 @@ impl xpath::Element for XPathWrapper<DomRoot<Element>> {
 
     fn local_name(&self) -> LocalName {
         self.0.local_name().clone()
+    }
+
+    fn is_html_element_in_html_document(&self) -> bool {
+        self.0.is_html_element() && self.0.owner_document().is_html_document()
     }
 }
 

--- a/components/xpath/src/context.rs
+++ b/components/xpath/src/context.rs
@@ -4,7 +4,7 @@
 
 use std::fmt;
 
-use crate::{Dom, NamespaceResolver, Node};
+use crate::{Dom, NamespaceResolver};
 
 /// The context during evaluation of an XPath expression.
 pub(crate) struct EvaluationCtx<D: Dom> {
@@ -53,8 +53,7 @@ impl<D: Dom> EvaluationCtx<D> {
             }
         }
 
-        // Then, see if it's defined on the context node
-        Ok(self.context_node.lookup_namespace_uri(prefix))
+        Ok(None)
     }
 }
 

--- a/components/xpath/src/lib.rs
+++ b/components/xpath/src/lib.rs
@@ -55,7 +55,6 @@ pub trait Node: Eq + Clone + Debug {
     fn as_processing_instruction(&self) -> Option<Self::ProcessingInstruction>;
     fn as_attribute(&self) -> Option<Self::Attribute>;
     fn as_element(&self) -> Option<Self::Element>;
-    fn lookup_namespace_uri(&self, uri: Option<&str>) -> Option<String>;
     fn get_root_node(&self) -> Self;
 }
 
@@ -70,7 +69,6 @@ pub trait ProcessingInstruction {
 pub trait Document {
     type Node: Node<Document = Self>;
 
-    fn is_html_document(&self) -> bool;
     fn get_elements_with_id(&self, id: &str)
     -> impl Iterator<Item = <Self::Node as Node>::Element>;
 }
@@ -84,6 +82,7 @@ pub trait Element {
     fn namespace(&self) -> Namespace;
     fn local_name(&self) -> LocalName;
     fn attributes(&self) -> impl Iterator<Item = Self::Attribute>;
+    fn is_html_element_in_html_document(&self) -> bool;
 }
 
 pub trait Attribute {
@@ -257,9 +256,6 @@ mod dummy_implementation {
         fn as_element(&self) -> Option<Self::Element> {
             None
         }
-        fn lookup_namespace_uri(&self, _: Option<&str>) -> Option<String> {
-            None
-        }
         fn get_root_node(&self) -> Self {
             self.clone()
         }
@@ -274,9 +270,6 @@ mod dummy_implementation {
     impl Document for DummyDocument {
         type Node = DummyNode;
 
-        fn is_html_document(&self) -> bool {
-            true
-        }
         fn get_elements_with_id(
             &self,
             _: &str,
@@ -303,6 +296,9 @@ mod dummy_implementation {
         }
         fn attributes(&self) -> impl Iterator<Item = Self::Attribute> {
             iter::empty()
+        }
+        fn is_html_element_in_html_document(&self) -> bool {
+            true
         }
     }
 


### PR DESCRIPTION
We don't need to care about namespace prefixes in name tests because they are already resolved to namespaces at this point.

The old implementation was also masking a few other small bugs which I've fixed here. When the namespace resolver doesn't give us any results then we should not lookup the namespace on the node itself. In XPath, namespaces on html elements in html documents are compared a in a relaxed way, and we were previously also using the relaxed comparison mode on non-html elements in html documents (like svg).

Testing: Existing tests continue to pass (and the web platform tests contain numerous namespace tests which cover this behaviour)
Fixes https://github.com/servo/servo/issues/39939
Part of #34527 
