### PR TITLE
xpath: Infer result type when reusing result value

### DIFF
--- a/components/script/dom/xpathresult.rs
+++ b/components/script/dom/xpathresult.rs
@@ -106,19 +106,6 @@ impl XPathResult {
         result_type: XPathResultType,
         value: XPathResultValue,
     ) -> XPathResult {
-        // TODO(vlindhol): if the wanted result type is AnyUnorderedNode | FirstOrderedNode,
-        // we could drop all nodes except one to save memory.
-        let inferred_result_type = if result_type == XPathResultType::Any {
-            match value {
-                XPathResultValue::Boolean(_) => XPathResultType::Boolean,
-                XPathResultValue::Number(_) => XPathResultType::Number,
-                XPathResultValue::String(_) => XPathResultType::String,
-                XPathResultValue::Nodeset(_) => XPathResultType::UnorderedNodeIterator,
-            }
-        } else {
-            result_type
-        };
-
         XPathResult {
             reflector_: Reflector::new(),
             window: Dom::from_ref(window),
@@ -128,7 +115,7 @@ impl XPathResult {
                     .upcast::<Node>()
                     .inclusive_descendants_version(),
             ),
-            result_type: Cell::new(inferred_result_type),
+            result_type: Cell::new(result_type),
             iterator_pos: Cell::new(0),
             value: RefCell::new(value),
         }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14661,6 +14661,13 @@
       {}
      ]
     ],
+    "xpath-reuse-result-iterator.html": [
+     "5f97115a82dba24ae4ca807b1e60ee93b3a526ea",
+     [
+      null,
+      {}
+     ]
+    ],
     "zero_size_canvas_crash.html": [
      "45eb9b559e8d6105baca5ab4d336de520d33b36b",
      [

--- a/tests/wpt/mozilla/tests/mozilla/xpath-reuse-result-iterator.html
+++ b/tests/wpt/mozilla/tests/mozilla/xpath-reuse-result-iterator.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<head>
+    <title>Reusing XPath iterator results</title>
+    <link rel="help" href="https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathEvaluator-evaluate">
+    <link rel="author" title="Simon Wülker" href="simon.wuelker@arcor.de">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<script>
+test(function() {
+  var result = document.evaluate(".", // expression
+                                document.documentElement, // context node
+                                null, // resolver
+                                XPathResult.ANY_TYPE, // type
+                                null); // result
+  assert_equals(result.iterateNext(), document.documentElement);
+  assert_equals(result.iterateNext(), null);
+
+  // Evaluate again, but reuse result from previous evaluation.
+  result = document.evaluate(".", // expression
+                            document.documentElement, // context node
+                            null, // resolver
+                            XPathResult.ANY_TYPE, // type
+                            result); // result
+  assert_equals(result.iterateNext(), document.documentElement);
+  assert_equals(result.iterateNext(), null);
+}, "Reusing an iterator result should work and yield correct elements");
+</script>


### PR DESCRIPTION
When the provided xpath result type is `XPathResult.ANY_TYPE` then we need to infer the result type from the result value. Previously we were doing this in the XPathResult constructor, but that isn't being called when we reuse a result. Instead, we move the inferring to right after we evaluate an expression.

Testing: This change adds a new test
Fixes https://github.com/servo/servo/issues/39955
Part of #34527 
