### PR TITLE
CI: Install pre-compiled nextest for arm64 workflow

### DIFF
--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -123,6 +123,10 @@ jobs:
       - name: Install crown
         run: cargo install --path support/crown
 
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - if: runner.environment != 'self-hosted'
         name: Bootstrap
         run: |


### PR DESCRIPTION
We already do this for the other build workflows. This saves 2-3 minutes of CI time during bootstrap.

Testing: Trivial - Not necessary.