### PR TITLE
webgpu: Add the latest spec compliant GPUAdapterInfo

### DIFF
--- a/components/script/dom/webgpu/gpuadapterinfo.rs
+++ b/components/script/dom/webgpu/gpuadapterinfo.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use wgpu_types::AdapterInfo;
 
 use crate::dom::bindings::codegen::Bindings::WebGPUBinding::GPUAdapterInfoMethods;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
@@ -15,43 +14,116 @@ use crate::script_runtime::CanGc;
 #[dom_struct]
 pub(crate) struct GPUAdapterInfo {
     reflector_: Reflector,
-    #[ignore_malloc_size_of = "defined in wgpu-types"]
-    #[no_trace]
-    info: AdapterInfo,
+    vendor: DOMString,
+    architecture: DOMString,
+    device: DOMString,
+    description: DOMString,
+    subgroup_min_size: u32,
+    subgroup_max_size: u32,
+    is_fallback_adapter: bool,
 }
 
 impl GPUAdapterInfo {
-    fn new_inherited(info: AdapterInfo) -> Self {
+    fn new_inherited(
+        vendor: DOMString,
+        architecture: DOMString,
+        device: DOMString,
+        description: DOMString,
+        subgroup_min_size: u32,
+        subgroup_max_size: u32,
+        is_fallback_adapter: bool,
+    ) -> Self {
         Self {
             reflector_: Reflector::new(),
-            info,
+            vendor,
+            architecture,
+            device,
+            description,
+            subgroup_min_size,
+            subgroup_max_size,
+            is_fallback_adapter,
         }
     }
 
-    pub(crate) fn new(global: &GlobalScope, info: AdapterInfo, can_gc: CanGc) -> DomRoot<Self> {
-        reflect_dom_object(Box::new(Self::new_inherited(info)), global, can_gc)
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        global: &GlobalScope,
+        vendor: DOMString,
+        architecture: DOMString,
+        device: DOMString,
+        description: DOMString,
+        subgroup_min_size: u32,
+        subgroup_max_size: u32,
+        is_fallback_adapter: bool,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        reflect_dom_object(
+            Box::new(Self::new_inherited(
+                vendor,
+                architecture,
+                device,
+                description,
+                subgroup_min_size,
+                subgroup_max_size,
+                is_fallback_adapter,
+            )),
+            global,
+            can_gc,
+        )
+    }
+
+    pub(crate) fn clone_from(
+        global: &GlobalScope,
+        info: &GPUAdapterInfo,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        Self::new(
+            global,
+            info.vendor.clone(),
+            info.architecture.clone(),
+            info.device.clone(),
+            info.description.clone(),
+            info.subgroup_min_size,
+            info.subgroup_max_size,
+            info.is_fallback_adapter,
+            can_gc,
+        )
     }
 }
 
-// TODO: wgpu does not expose right fields right now
 impl GPUAdapterInfoMethods<crate::DomTypeHolder> for GPUAdapterInfo {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-vendor>
     fn Vendor(&self) -> DOMString {
-        DOMString::new()
+        self.vendor.clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-architecture>
     fn Architecture(&self) -> DOMString {
-        DOMString::new()
+        self.architecture.clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-device>
     fn Device(&self) -> DOMString {
-        DOMString::new()
+        self.device.clone()
     }
 
     /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-description>
     fn Description(&self) -> DOMString {
-        DOMString::from_string(self.info.driver_info.clone())
+        self.description.clone()
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-subgroupminsize>
+    fn SubgroupMinSize(&self) -> u32 {
+        self.subgroup_min_size
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-subgroupmaxsize>
+    fn SubgroupMaxSize(&self) -> u32 {
+        self.subgroup_max_size
+    }
+
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-isfallbackadapter>
+    fn IsFallbackAdapter(&self) -> bool {
+        self.is_fallback_adapter
     }
 }

--- a/components/script/dom/webgpu/gpusupportedfeatures.rs
+++ b/components/script/dom/webgpu/gpusupportedfeatures.rs
@@ -82,6 +82,13 @@ impl GPUSupportedFeatures {
         if features.contains(Features::DUAL_SOURCE_BLENDING) {
             set.insert(GPUFeatureName::Dual_source_blending);
         }
+        // While this feature exists in wgpu, it's not supported by naga yet
+        // https://github.com/gfx-rs/wgpu/issues/5555
+        /*
+        if features.contains(Features::SUBGROUP) {
+            set.insert(GPUFeatureName::Subgroups);
+        }
+        */
 
         reflect_dom_object_with_proto(
             Box::new(GPUSupportedFeatures {
@@ -107,8 +114,8 @@ impl GPUSupportedFeatures {
 }
 
 impl GPUSupportedFeatures {
-    pub(crate) fn wgpu_features(&self) -> Features {
-        self.features
+    pub(crate) fn wgpu_features(&self) -> &Features {
+        &self.features
     }
 }
 
@@ -136,6 +143,9 @@ pub(crate) fn gpu_to_wgt_feature(feature: GPUFeatureName) -> Option<Features> {
         GPUFeatureName::Dual_source_blending => Some(Features::DUAL_SOURCE_BLENDING),
         GPUFeatureName::Texture_compression_bc_sliced_3d => None,
         GPUFeatureName::Clip_distances => None,
+        // While this feature exists in wgpu, it's not supported by naga yet
+        // https://github.com/gfx-rs/wgpu/issues/5555
+        GPUFeatureName::Subgroups => None,
     }
 }
 

--- a/components/script/dom/webgpu/gpusupportedlimits.rs
+++ b/components/script/dom/webgpu/gpusupportedlimits.rs
@@ -34,6 +34,12 @@ impl GPUSupportedLimits {
     }
 }
 
+impl GPUSupportedLimits {
+    pub(crate) fn wgpu_limits(&self) -> &Limits {
+        &self.limits
+    }
+}
+
 impl GPUSupportedLimitsMethods<crate::DomTypeHolder> for GPUSupportedLimits {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension1d>
     fn MaxTextureDimension1D(&self) -> u32 {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -295,8 +295,8 @@ DOMInterfaces = {
 },
 
 'GPUAdapter': {
-    'inRealms': ['RequestAdapterInfo', 'RequestDevice'],
-    'canGc': ['RequestAdapterInfo', 'RequestDevice'],
+    'inRealms': ['RequestDevice'],
+    'canGc': ['RequestDevice'],
 },
 
 'GPUBuffer': {

--- a/components/script_bindings/webidls/WebGPU.webidl
+++ b/components/script_bindings/webidls/WebGPU.webidl
@@ -67,6 +67,9 @@ interface GPUAdapterInfo {
     readonly attribute DOMString architecture;
     readonly attribute DOMString device;
     readonly attribute DOMString description;
+    readonly attribute unsigned long subgroupMinSize;
+    readonly attribute unsigned long subgroupMaxSize;
+    readonly attribute boolean isFallbackAdapter;
 };
 
 interface mixin NavigatorGPU {
@@ -98,12 +101,10 @@ enum GPUPowerPreference {
 interface GPUAdapter {
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
-    readonly attribute boolean isFallbackAdapter;
+    [SameObject] readonly attribute GPUAdapterInfo info;
 
     [NewObject]
     Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor = {});
-    [NewObject]
-    Promise<GPUAdapterInfo> requestAdapterInfo(optional sequence<DOMString> unmaskHints = []);
 };
 
 dictionary GPUDeviceDescriptor: GPUObjectDescriptorBase {
@@ -126,12 +127,14 @@ enum GPUFeatureName {
     "float32-filterable",
     "clip-distances",
     "dual-source-blending",
+    "subgroups",
 };
 
-[Exposed=(Window, DedicatedWorker), /*Serializable,*/ Pref="dom_webgpu_enabled"]
+[Exposed=(Window, DedicatedWorker), Pref="dom_webgpu_enabled"]
 interface GPUDevice: EventTarget {
     [SameObject] readonly attribute GPUSupportedFeatures features;
     [SameObject] readonly attribute GPUSupportedLimits limits;
+    [SameObject] readonly attribute GPUAdapterInfo adapterInfo;
 
     // Overriding the name to avoid collision with `class Queue` in gcc
     [SameObject, BinaryName="getQueue"] readonly attribute GPUQueue queue;


### PR DESCRIPTION
According to the WebGPU specification there are some missing readonly attributes (subgroupMinSize, subgroupMaxSize, isFallbackAdapter) for GPUAdapterInfo IDL interface.

See https://gpuweb.github.io/gpuweb/#gpuadapterinfo

Added the new readonly attributes:
- GPUAdapter 'info' attribute
  https://gpuweb.github.io/gpuweb/#dom-gpuadapter-info
- GPUDevice 'adapterInfo' attribute
  https://gpuweb.github.io/gpuweb/#dom-gpudevice-adapterinfo

Removed marked as the deprecated the following method and attribute from GPUAdapter interface:
- 'requestAdapterInfo' method
- 'isFallbackAdapter' attribute

Testing: Improvements in WebGPU CTS expectations
- webgpu:api,operation,adapter,info:adapter_info:*
- webgpu:api,operation,adapter,info:device_matches_adapter:*
- webgpu:api,operation,adapter,info:same_object:*
- webgpu:api,operation,adapter,info:subgroup_sizes:*
- webgpu:api,operation,adapter,requestAdapter:requestAdapter:*
- webgpu:idl,javascript:*