### PR TITLE
script: Delay screenshots until the first rendering update after `fonts.ready`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::WebViewId;
 use base::{Epoch, IpcSend, generic_channel};
+use bitflags::bitflags;
 use canvas_traits::canvas::CanvasId;
 use canvas_traits::webgl::{WebGLContextId, WebGLMsg};
 use chrono::Local;
@@ -282,6 +283,23 @@ pub(crate) enum DeclarativeRefresh {
         time: u64,
     },
     CreatedAfterLoad,
+}
+
+/// Reasons why a [`Document`] might need a rendering update that is otherwise
+/// untracked via other [`Document`] properties.
+#[derive(Clone, Copy, Debug, Default, JSTraceable, MallocSizeOf)]
+pub(crate) struct RenderingUpdateReason(u8);
+
+bitflags! {
+    impl RenderingUpdateReason: u8 {
+        /// When a `ResizeObserver` starts observing a target, this becomes true, which in turn is a
+        /// signal to the [`ScriptThread`] that a rendering update should happen.
+        const ResizeObserverStartedObservingTarget = 1 << 0;
+        /// All web fonts have loaded and `fonts.ready` promise has been fulfilled. We want to trigger
+        /// one more rendering update possibility after this happens, so that any potential screenshot
+        /// reflects the up-to-date contents.
+        const FontReadyPromiseFulfilled = 1 << 1;
+    }
 }
 
 /// <https://dom.spec.whatwg.org/#document>
@@ -560,9 +578,8 @@ pub(crate) struct Document {
     adopted_stylesheets_frozen_types: CachedFrozenArray,
     /// <https://drafts.csswg.org/cssom-view/#document-pending-scroll-event-targets>
     pending_scroll_event_targets: DomRefCell<Vec<Dom<EventTarget>>>,
-    /// When a `ResizeObserver` starts observing a target, this becomes true, which in turn is a
-    /// signal to the [`ScriptThread`] that a rendering update should happen.
-    resize_observer_started_observing_target: Cell<bool>,
+    /// Other reasons that a rendering update might be required for this [`Document`].
+    rendering_update_reasons: Cell<RenderingUpdateReason>,
     /// Whether or not this [`Document`] is waiting on canvas image updates. If it is
     /// waiting it will not do any new layout until the canvas images are up-to-date in
     /// the renderer.
@@ -2726,7 +2743,7 @@ impl Document {
         {
             return true;
         }
-        if self.resize_observer_started_observing_target.get() {
+        if !self.rendering_update_reasons.get().is_empty() {
             return true;
         }
         if self.event_handler.has_pending_input_events() {
@@ -2885,7 +2902,20 @@ impl Document {
         if !self.restyle_reason().is_empty() {
             return false;
         }
-        fonts.fulfill_ready_promise_if_needed(can_gc)
+        if !self.rendering_update_reasons.get().is_empty() {
+            return false;
+        }
+
+        let result = fonts.fulfill_ready_promise_if_needed(can_gc);
+
+        // Add a rendering update after the `fonts.ready` promise is fulfilled just for
+        // the sake of taking screenshots. This has the effect of delaying screenshots
+        // until layout has taken a shot at updating the rendering.
+        if result {
+            self.add_rendering_update_reason(RenderingUpdateReason::FontReadyPromiseFulfilled);
+        }
+
+        result
     }
 
     pub(crate) fn id_map(
@@ -3549,7 +3579,7 @@ impl Document {
             adopted_stylesheets: Default::default(),
             adopted_stylesheets_frozen_types: CachedFrozenArray::new(),
             pending_scroll_event_targets: Default::default(),
-            resize_observer_started_observing_target: Cell::new(false),
+            rendering_update_reasons: Default::default(),
             waiting_on_canvas_image_updates: Cell::new(false),
             current_rendering_epoch: Default::default(),
             custom_element_reaction_stack,
@@ -3592,8 +3622,17 @@ impl Document {
         !self.pending_scroll_event_targets.borrow().is_empty()
     }
 
-    pub(crate) fn set_resize_observer_started_observing_target(&self, value: bool) {
-        self.resize_observer_started_observing_target.set(value);
+    /// Add a [`RenderingUpdateReason`] to this [`Document`] which will trigger a
+    /// rendering update at a later time.
+    pub(crate) fn add_rendering_update_reason(&self, reason: RenderingUpdateReason) {
+        self.rendering_update_reasons
+            .set(self.rendering_update_reasons.get().union(reason));
+    }
+
+    /// Clear all [`RenderingUpdateReason`]s from this [`Document`].
+    pub(crate) fn clear_rendering_update_reasons(&self) {
+        self.rendering_update_reasons
+            .set(RenderingUpdateReason::empty())
     }
 
     /// Prevent any JS or layout from running until the corresponding call to

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -18,6 +18,7 @@ use crate::dom::bindings::codegen::Bindings::WindowBinding::WindowMethods;
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{Dom, DomRoot};
+use crate::dom::document::RenderingUpdateReason;
 use crate::dom::domrectreadonly::DOMRectReadOnly;
 use crate::dom::element::Element;
 use crate::dom::node::{Node, NodeTraits};
@@ -229,7 +230,9 @@ impl ResizeObserverMethods<crate::DomTypeHolder> for ResizeObserver {
         target
             .owner_window()
             .Document()
-            .set_resize_observer_started_observing_target(true);
+            .add_rendering_update_reason(
+                RenderingUpdateReason::ResizeObserverStartedObservingTarget,
+            );
     }
 
     /// <https://drafts.csswg.org/resize-observer/#dom-resizeobserver-unobserve>

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2474,12 +2474,12 @@ impl Window {
         reflow_result.reflow_phases_run
     }
 
-    pub(crate) fn request_screenshot_readiness(&self) {
+    pub(crate) fn request_screenshot_readiness(&self, can_gc: CanGc) {
         self.has_pending_screenshot_readiness_request.set(true);
-        self.maybe_resolve_pending_screenshot_readiness_requests();
+        self.maybe_resolve_pending_screenshot_readiness_requests(can_gc);
     }
 
-    pub(crate) fn maybe_resolve_pending_screenshot_readiness_requests(&self) {
+    pub(crate) fn maybe_resolve_pending_screenshot_readiness_requests(&self, can_gc: CanGc) {
         let pending_request = self.has_pending_screenshot_readiness_request.get();
         if !pending_request {
             return;
@@ -2505,6 +2505,10 @@ impl Window {
         }
 
         if self.font_context().web_fonts_still_loading() != 0 {
+            return;
+        }
+
+        if self.Document().Fonts(can_gc).waiting_to_fullfill_promise() {
             return;
         }
 

--- a/tests/wpt/meta/intersection-observer/intersection-ratio-ib-split.html.ini
+++ b/tests/wpt/meta/intersection-observer/intersection-ratio-ib-split.html.ini
@@ -1,4 +1,0 @@
-[intersection-ratio-ib-split.html]
-  expected: TIMEOUT
-  [IntersectionObserver on an IB split gets the right intersection ratio - BLOCK]
-    expected: TIMEOUT


### PR DESCRIPTION
This fixes a regression (likely from #39583) that made the result of many font loading
tests intermittent. The issues here is that the count of fonts loading
is decremented synchronously in the `FontContext`, but the notification
to the `ScriptThread` happens asynchronously. In between the time the
decrement happens and the `ScriptThread` is notified, a rendering update
could happen which could mark a screenshot as ready to take too soon.

The solution here is to wait until the `fonts.ready` promise is
resolved, which is guaranteed to fire after all fonts have loaded. In
addition, a rendering update is queued after this happens. This means
that the screenshot will wait until that final rendering update to be
ready.

This should remove the flakiness of font load tests.

Testing: This should fix many flaky tests.
Fixes: #39953.
Fixes: #39951.
Fixes #38956.
Fixes #39408.
Fixes #39429.
Fixes #39592.
Fixes #39636.
Fixes #39650.
Fixes #39666.
Fixes #39667.
Fixes #39706.
Fixes #39750.
Fixes #39801.
Fixes #39853.
Fixes #39881.
Fixes #39950.
 
