### PR TITLE
script: Trigger a rendering update when calling `IntersectionObserver.observe`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -292,10 +292,13 @@ bitflags! {
         /// When a `ResizeObserver` starts observing a target, this becomes true, which in turn is a
         /// signal to the [`ScriptThread`] that a rendering update should happen.
         const ResizeObserverStartedObservingTarget = 1 << 0;
+        /// When an `IntersectionObserver` starts observing a target, this becomes true, which in turn is a
+        /// signal to the [`ScriptThread`] that a rendering update should happen.
+        const IntersectionObserverStartedObservingTarget = 1 << 1;
         /// All web fonts have loaded and `fonts.ready` promise has been fulfilled. We want to trigger
         /// one more rendering update possibility after this happens, so that any potential screenshot
         /// reflects the up-to-date contents.
-        const FontReadyPromiseFulfilled = 1 << 1;
+        const FontReadyPromiseFulfilled = 1 << 2;
     }
 }
 

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -35,7 +35,7 @@ use crate::dom::bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::utils::to_frozen_array;
-use crate::dom::document::Document;
+use crate::dom::document::{Document, RenderingUpdateReason};
 use crate::dom::domrectreadonly::DOMRectReadOnly;
 use crate::dom::element::Element;
 use crate::dom::intersectionobserverentry::IntersectionObserverEntry;
@@ -284,6 +284,13 @@ impl IntersectionObserver {
         self.observation_targets
             .borrow_mut()
             .push(Dom::from_ref(target));
+
+        target
+            .owner_window()
+            .Document()
+            .add_rendering_update_reason(
+                RenderingUpdateReason::IntersectionObserverStartedObservingTarget,
+            );
     }
 
     /// <https://w3c.github.io/IntersectionObserver/#unobserve-target-element>

--- a/tests/wpt/meta/intersection-observer/cross-origin-tall-iframe.sub.html.ini
+++ b/tests/wpt/meta/intersection-observer/cross-origin-tall-iframe.sub.html.ini
@@ -1,4 +1,3 @@
 [cross-origin-tall-iframe.sub.html]
-  expected: TIMEOUT
   [Intersection observer with cross-origin iframe and tall viewport]
-    expected: TIMEOUT
+    expected: FAIL


### PR DESCRIPTION
Observers should trigger an observation when they are installed, but
this can only happen if a rendering update happens. This change makes
sure that a rendering opportunity is triggered. This isn't discused in
the specification because we only triggering rendering updates when
necessary for performance reasons.

Testing: This fixes a timeout in `/intersection-observer/cross-origin-tall-iframe.sub.html`.
Fixes #39831.
