### PR TITLE
CI: Don't run macos (x86) in full

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           {
             echo 'result<<EOF'
-            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'fail-fast full bencher production-bencher coverage' || 'fail-fast full' }}
+            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'fail-fast full macos bencher production-bencher coverage' || 'fail-fast full' }}
             echo EOF
            } >> $GITHUB_OUTPUT
 

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -69,6 +69,8 @@ class JobConfig(object):
             self.name = "Linux"
         elif self.workflow is Workflow.MACOS:
             self.name = "MacOS"
+        elif self.workflow is Workflow.MACOS_ARM:
+            self.name = "MacOS Arm64"
         elif self.workflow is Workflow.WINDOWS:
             self.name = "Windows"
         elif self.workflow is Workflow.ANDROID:
@@ -203,10 +205,8 @@ class Config(object):
                 continue  # skip over keyword
             if word == "full":
                 words.extend(["linux-unit-tests", "linux-wpt", "linux-bencher"])
-                words.extend(
-                    ["macos-arm-unit-tests", "macos-unit-tests", "windows-unit-tests", "android", "ohos", "lint"]
-                )
-                words.extend(["linux-build-libservo", "macos-build-libservo", "windows-build-libservo"])
+                words.extend(["macos-arm-unit-tests", "windows-unit-tests", "android", "ohos", "lint"])
+                words.extend(["linux-build-libservo", "macos-arm-build-libservo", "windows-build-libservo"])
                 continue  # skip over keyword
             if word == "bencher":
                 words.extend(
@@ -308,21 +308,8 @@ class TestParser(unittest.TestCase):
                         "number_of_wpt_chunks": 20,
                     },
                     {
-                        "name": "MacOS Arm64 (Unit Tests)",
+                        "name": "MacOS Arm64 (Unit Tests, Build libservo)",
                         "workflow": "macos-arm64",
-                        "wpt": False,
-                        "profile": "release",
-                        "unit_tests": True,
-                        "build_libservo": False,
-                        "bencher": False,
-                        "build_args": "",
-                        "coverage": False,
-                        "wpt_args": "",
-                        "number_of_wpt_chunks": 20,
-                    },
-                    {
-                        "name": "MacOS (Unit Tests, Build libservo)",
-                        "workflow": "macos",
                         "wpt": False,
                         "profile": "release",
                         "unit_tests": True,


### PR DESCRIPTION
Only do x86 builds on macos on push and on nightly builds. Also test building libservo on arm mac instead of x86 mac. Also fixes an issue when merging macos arm jobs in the try parser. 
The main goal of this PR is to improve CI merge times again (since the concurrency limit of github-hosted runners, has been slowing down the MQ a lot).

Testing: This changes a CI workflow.
