### PR TITLE
layout: Handle `<select>` as a widget

### DIFF
--- a/components/layout/dom_traversal.rs
+++ b/components/layout/dom_traversal.rs
@@ -284,11 +284,12 @@ impl Contents {
         if let Some(replaced) = ReplacedContents::for_element(node, context) {
             return Self::Replaced(replaced);
         }
-        // TODO(#39927): <select> should also be a widget.
         let is_widget = matches!(
             node.type_id(),
             Some(LayoutNodeType::Element(
-                LayoutElementType::HTMLInputElement | LayoutElementType::HTMLTextAreaElement
+                LayoutElementType::HTMLInputElement |
+                    LayoutElementType::HTMLSelectElement |
+                    LayoutElementType::HTMLTextAreaElement
             ))
         );
         if is_widget {

--- a/tests/wpt/tests/html/rendering/replaced-elements/the-select-element/select-display-inline-ref.html
+++ b/tests/wpt/tests/html/rendering/replaced-elements/the-select-element/select-display-inline-ref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>Test Reference</title>
+<link rel="author" title="Oriol Brufau" href="obrufau:obrufau@igalia.com">
+
+<select style="margin-left: 100px">
+  <option>option</option>
+</select>

--- a/tests/wpt/tests/html/rendering/replaced-elements/the-select-element/select-display-inline.html
+++ b/tests/wpt/tests/html/rendering/replaced-elements/the-select-element/select-display-inline.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>&lt;select&gt; with display:inline</title>
+<link rel="author" title="Oriol Brufau" href="obrufau:obrufau@igalia.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#the-select-element-2">
+<link rel="help" href="https://github.com/servo/servo/issues/39927">
+<link rel="match" href="select-display-inline-ref.html">
+<meta name="assert" content="
+  A <select> is a widget, so it's atomic when it has display:inline.
+  In particular, this implies that it's transformable.
+">
+
+<select style="display: inline; transform: translateX(100px)">
+  <option>option</option>
+</select>


### PR DESCRIPTION
For example, it will now be atomic with `display: inline`, so its block-level contents won't be able to split it, and it will be transformable.

Testing: Adding new test
Fixes: #39927
