### PR TITLE
constellation: Always include the `WebViewId` in `Pipeline` specific messages

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -295,11 +295,12 @@ pub struct Constellation<STF, SWF> {
 
     /// An IPC channel for script threads to send messages to the constellation.
     /// This is the script threads' view of `script_receiver`.
-    script_sender: GenericSender<(PipelineId, ScriptToConstellationMessage)>,
+    script_sender: GenericSender<(WebViewId, PipelineId, ScriptToConstellationMessage)>,
 
     /// A channel for the constellation to receive messages from script threads.
     /// This is the constellation's view of `script_sender`.
-    script_receiver: Receiver<Result<(PipelineId, ScriptToConstellationMessage), IpcError>>,
+    script_receiver:
+        Receiver<Result<(WebViewId, PipelineId, ScriptToConstellationMessage), IpcError>>,
 
     /// A handle to register components for hang monitoring.
     /// None when in multiprocess mode.
@@ -1008,6 +1009,7 @@ where
             opener,
             script_to_constellation_chan: ScriptToConstellationChan {
                 sender: self.script_sender.clone(),
+                webview_id,
                 pipeline_id,
             },
             script_to_embedder_chan,
@@ -1233,7 +1235,7 @@ where
         #[derive(Debug)]
         enum Request {
             PipelineNamespace(PipelineNamespaceRequest),
-            Script((PipelineId, ScriptToConstellationMessage)),
+            Script((WebViewId, PipelineId, ScriptToConstellationMessage)),
             BackgroundHangMonitor(HangMonitorAlert),
             Compositor(EmbedderToConstellationMessage),
             FromSWManager(SWManagerMsg),
@@ -1618,6 +1620,7 @@ where
         if pipeline
             .event_loop
             .send(ScriptThreadMessage::EvaluateJavaScript(
+                webview_id,
                 pipeline.id,
                 evaluation_id,
                 script,
@@ -1632,15 +1635,12 @@ where
     }
 
     #[servo_tracing::instrument(skip_all)]
-    fn handle_request_from_script(&mut self, message: (PipelineId, ScriptToConstellationMessage)) {
-        let (source_pipeline_id, content) = message;
+    fn handle_request_from_script(
+        &mut self,
+        message: (WebViewId, PipelineId, ScriptToConstellationMessage),
+    ) {
+        let (webview_id, source_pipeline_id, content) = message;
         trace_script_msg!(content, "{source_pipeline_id}: {content:?}");
-
-        let get_webview_id = || {
-            self.pipelines
-                .get(&source_pipeline_id)
-                .map(|pipeline| pipeline.webview_id)
-        };
 
         match content {
             ScriptToConstellationMessage::CompleteMessagePortTransfer(router_id, ports) => {
@@ -1743,21 +1743,9 @@ where
                 self.handle_pipeline_exited(source_pipeline_id);
             },
             ScriptToConstellationMessage::DiscardDocument => {
-                let Some(webview_id) = get_webview_id() else {
-                    return warn!(
-                        "{}: DiscardDocument from closed pipeline",
-                        source_pipeline_id
-                    );
-                };
                 self.handle_discard_document(webview_id, source_pipeline_id);
             },
             ScriptToConstellationMessage::DiscardTopLevelBrowsingContext => {
-                let Some(webview_id) = get_webview_id() else {
-                    return warn!(
-                        "{}: DiscardTopLevelBrowsingContext from closed pipeline",
-                        source_pipeline_id
-                    );
-                };
                 self.handle_close_top_level_browsing_context(webview_id);
             },
             ScriptToConstellationMessage::ScriptLoadedURLInIFrame(load_info) => {
@@ -1774,9 +1762,6 @@ where
             },
             // Ask the embedder for permission to load a new page.
             ScriptToConstellationMessage::LoadUrl(load_data, history_handling) => {
-                let Some(webview_id) = get_webview_id() else {
-                    return warn!("{}: LoadUrl from closed pipeline", source_pipeline_id);
-                };
                 self.schedule_navigation(
                     webview_id,
                     source_pipeline_id,
@@ -1789,9 +1774,6 @@ where
             },
             // A page loaded has completed all parsing, script, and reflow messages have been sent.
             ScriptToConstellationMessage::LoadComplete => {
-                let Some(webview_id) = get_webview_id() else {
-                    return warn!("{}: LoadComplete from closed pipeline", source_pipeline_id);
-                };
                 self.handle_load_complete_msg(webview_id, source_pipeline_id)
             },
             // Handle navigating to a fragment
@@ -1800,12 +1782,6 @@ where
             },
             // Handle a forward or back request
             ScriptToConstellationMessage::TraverseHistory(direction) => {
-                let Some(webview_id) = get_webview_id() else {
-                    return warn!(
-                        "{}: TraverseHistory from closed pipeline",
-                        source_pipeline_id
-                    );
-                };
                 self.handle_traverse_history_msg(webview_id, direction);
             },
             // Handle a push history state request.
@@ -1817,12 +1793,6 @@ where
             },
             // Handle a joint session history length request.
             ScriptToConstellationMessage::JointSessionHistoryLength(response_sender) => {
-                let Some(webview_id) = get_webview_id() else {
-                    return warn!(
-                        "{}: JointSessionHistoryLength from closed pipeline",
-                        source_pipeline_id
-                    );
-                };
                 self.handle_joint_session_history_length(webview_id, response_sender);
             },
             // Notification that the new document is ready to become active
@@ -1879,9 +1849,6 @@ where
                 self.document_states.insert(source_pipeline_id, state);
             },
             ScriptToConstellationMessage::LogEntry(thread_name, entry) => {
-                let Some(webview_id) = get_webview_id() else {
-                    return warn!("{}: LogEntry from closed pipeline", source_pipeline_id);
-                };
                 self.handle_log_entry(Some(webview_id), thread_name, entry);
             },
             ScriptToConstellationMessage::GetBrowsingContextInfo(pipeline_id, response_sender) => {
@@ -1957,12 +1924,6 @@ where
                 );
             },
             ScriptToConstellationMessage::MediaSessionEvent(pipeline_id, event) => {
-                let Some(webview_id) = get_webview_id() else {
-                    return warn!(
-                        "{}: MediaSessionEvent from closed pipeline",
-                        source_pipeline_id
-                    );
-                };
                 // Unlikely at this point, but we may receive events coming from
                 // different media sessions, so we set the active media session based
                 // on Playing events.
@@ -1984,30 +1945,19 @@ where
                     .send(EmbedderMsg::MediaSessionEvent(webview_id, event));
             },
             #[cfg(feature = "webgpu")]
-            ScriptToConstellationMessage::RequestAdapter(response_sender, options, ids) => {
-                let Some(webview_id) = get_webview_id() else {
-                    return warn!(
-                        "{}: RequestAdapter from closed pipeline",
-                        source_pipeline_id
-                    );
-                };
-                self.handle_wgpu_request(
+            ScriptToConstellationMessage::RequestAdapter(response_sender, options, ids) => self
+                .handle_wgpu_request(
                     source_pipeline_id,
                     BrowsingContextId::from(webview_id),
                     ScriptToConstellationMessage::RequestAdapter(response_sender, options, ids),
-                )
-            },
+                ),
             #[cfg(feature = "webgpu")]
-            ScriptToConstellationMessage::GetWebGPUChan(response_sender) => {
-                let Some(webview_id) = get_webview_id() else {
-                    return warn!("{}: GetWebGPUChan from closed pipeline", source_pipeline_id);
-                };
-                self.handle_wgpu_request(
+            ScriptToConstellationMessage::GetWebGPUChan(response_sender) => self
+                .handle_wgpu_request(
                     source_pipeline_id,
                     BrowsingContextId::from(webview_id),
                     ScriptToConstellationMessage::GetWebGPUChan(response_sender),
-                )
-            },
+                ),
             ScriptToConstellationMessage::TitleChanged(pipeline, title) => {
                 if let Some(pipeline) = self.pipelines.get_mut(&pipeline) {
                     pipeline.title = title;
@@ -4538,36 +4488,31 @@ where
 
     #[servo_tracing::instrument(skip_all)]
     fn handle_set_throttled_complete(&mut self, pipeline_id: PipelineId, throttled: bool) {
-        let browsing_context_id = match self.pipelines.get(&pipeline_id) {
-            Some(pipeline) => pipeline.browsing_context_id,
-            None => {
-                return warn!(
-                    "{}: Visibility change for closed browsing context",
-                    pipeline_id
-                );
-            },
+        let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
+            return warn!("{pipeline_id}: Visibility change for closed browsing context",);
         };
-        let parent_pipeline_id = match self.browsing_contexts.get(&browsing_context_id) {
-            Some(ctx) => ctx.parent_pipeline_id,
-            None => {
-                return warn!("{}: Visibility change for closed pipeline", pipeline_id);
-            },
+        let Some(browsing_context) = self.browsing_contexts.get(&pipeline.browsing_context_id)
+        else {
+            return warn!("{}: Visibility change for closed pipeline", pipeline_id);
+        };
+        let Some(parent_pipeline_id) = browsing_context.parent_pipeline_id else {
+            return;
         };
 
-        if let Some(parent_pipeline_id) = parent_pipeline_id {
-            let msg = ScriptThreadMessage::SetThrottledInContainingIframe(
-                parent_pipeline_id,
-                browsing_context_id,
-                throttled,
-            );
-            let result = match self.pipelines.get(&parent_pipeline_id) {
-                None => return warn!("{}: Parent pipeline closed", parent_pipeline_id),
-                Some(parent_pipeline) => parent_pipeline.event_loop.send(msg),
-            };
+        let msg = ScriptThreadMessage::SetThrottledInContainingIframe(
+            pipeline.webview_id,
+            parent_pipeline_id,
+            browsing_context.id,
+            throttled,
+        );
 
-            if let Err(e) = result {
-                self.handle_send_error(parent_pipeline_id, e);
-            }
+        let result = match self.pipelines.get(&parent_pipeline_id) {
+            None => return warn!("{}: Parent pipeline closed", parent_pipeline_id),
+            Some(parent_pipeline) => parent_pipeline.event_loop.send(msg),
+        };
+
+        if let Err(e) = result {
+            self.handle_send_error(parent_pipeline_id, e);
         }
     }
 
@@ -5150,26 +5095,29 @@ where
                 return;
             }
 
-            *screenshot_request.pipeline_states.borrow_mut() = self
-                .fully_active_browsing_contexts_iter(screenshot_request.webview_id)
-                .filter_map(|browsing_context| {
-                    let pipeline_id = browsing_context.pipeline_id;
-                    let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
-                        // This can happen while Servo is shutting down, so just ignore it for now.
-                        return None;
-                    };
-                    // If the rectangle for this BrowsingContext is zero, it will never be
-                    // painted. In this case, don't query screenshot readiness as it won't
-                    // contribute to the final output image.
-                    if browsing_context.viewport_details.size == Size2D::zero() {
-                        return None;
-                    }
-                    let _ = pipeline
-                        .event_loop
-                        .send(ScriptThreadMessage::RequestScreenshotReadiness(pipeline_id));
-                    Some((pipeline_id, None))
-                })
-                .collect();
+            *screenshot_request.pipeline_states.borrow_mut() =
+                self.fully_active_browsing_contexts_iter(screenshot_request.webview_id)
+                    .filter_map(|browsing_context| {
+                        let pipeline_id = browsing_context.pipeline_id;
+                        let Some(pipeline) = self.pipelines.get(&pipeline_id) else {
+                            // This can happen while Servo is shutting down, so just ignore it for now.
+                            return None;
+                        };
+                        // If the rectangle for this BrowsingContext is zero, it will never be
+                        // painted. In this case, don't query screenshot readiness as it won't
+                        // contribute to the final output image.
+                        if browsing_context.viewport_details.size == Size2D::zero() {
+                            return None;
+                        }
+                        let _ = pipeline.event_loop.send(
+                            ScriptThreadMessage::RequestScreenshotReadiness(
+                                pipeline.webview_id,
+                                pipeline_id,
+                            ),
+                        );
+                        Some((pipeline_id, None))
+                    })
+                    .collect();
             screenshot_request
                 .state
                 .set(ScreenshotRequestState::WaitingOnScript);

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -463,7 +463,7 @@ impl Pipeline {
     /// Set whether to make pipeline use less resources, by stopping animations and
     /// running timers at a heavily limited rate.
     pub fn set_throttled(&self, throttled: bool) {
-        let script_msg = ScriptThreadMessage::SetThrottled(self.id, throttled);
+        let script_msg = ScriptThreadMessage::SetThrottled(self.webview_id, self.id, throttled);
         let compositor_msg = CompositorMsg::SetThrottled(self.webview_id, self.id, throttled);
         let err = self.event_loop.send(script_msg);
         if let Err(e) = err {

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use base::id::PipelineId;
+use base::id::{PipelineId, WebViewId};
 use crossbeam_channel::{Sender, unbounded};
 use dom_struct::dom_struct;
 use euclid::{Scale, Size2D};
@@ -87,6 +87,7 @@ pub(crate) struct PaintWorkletGlobalScope {
 impl PaintWorkletGlobalScope {
     #[allow(unsafe_code)]
     pub(crate) fn new(
+        webview_id: WebViewId,
         pipeline_id: PipelineId,
         base_url: ServoUrl,
         executor: WorkletExecutor,
@@ -98,6 +99,7 @@ impl PaintWorkletGlobalScope {
         );
         let global = Box::new(PaintWorkletGlobalScope {
             worklet_global: WorkletGlobalScope::new_inherited(
+                webview_id,
                 pipeline_id,
                 base_url,
                 executor,

--- a/components/script/dom/testing/testworkletglobalscope.rs
+++ b/components/script/dom/testing/testworkletglobalscope.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use base::id::PipelineId;
+use base::id::{PipelineId, WebViewId};
 use crossbeam_channel::Sender;
 use dom_struct::dom_struct;
 use servo_url::ServoUrl;
@@ -31,6 +31,7 @@ pub(crate) struct TestWorkletGlobalScope {
 impl TestWorkletGlobalScope {
     #[allow(unsafe_code)]
     pub(crate) fn new(
+        webview_id: WebViewId,
         pipeline_id: PipelineId,
         base_url: ServoUrl,
         executor: WorkletExecutor,
@@ -42,6 +43,7 @@ impl TestWorkletGlobalScope {
         );
         let global = Box::new(TestWorkletGlobalScope {
             worklet_global: WorkletGlobalScope::new_inherited(
+                webview_id,
                 pipeline_id,
                 base_url,
                 executor,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2978,7 +2978,12 @@ impl Window {
             }
 
             // Step 13
-            ScriptThread::navigate(pipeline_id, load_data, resolved_history_handling);
+            ScriptThread::navigate(
+                self.webview_id,
+                pipeline_id,
+                load_data,
+                resolved_history_handling,
+            );
         };
     }
 

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -459,6 +459,7 @@ impl WindowProxy {
             None => {
                 let sender_pipeline_id = self.currently_active().unwrap();
                 match ScriptThread::get_top_level_for_browsing_context(
+                    self.webview_id(),
                     sender_pipeline_id,
                     opener_id,
                 ) {

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::{AtomicIsize, Ordering};
 use std::thread;
 
 use base::IpcSend;
-use base::id::PipelineId;
+use base::id::{PipelineId, WebViewId};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use dom_struct::dom_struct;
 use js::jsapi::{GCReason, JS_GC, JS_GetGCParameter, JSGCParamKey, JSTracer};
@@ -159,6 +159,7 @@ impl WorkletMethods<crate::DomTypeHolder> for Worklet {
             .thread_pool
             .get_or_init(|| ScriptThread::worklet_thread_pool(self.global().image_cache()))
             .fetch_and_invoke_a_worklet_script(
+                self.window.webview_id(),
                 self.window.pipeline_id(),
                 self.droppable_field.worklet_id,
                 self.global_type,
@@ -317,6 +318,7 @@ impl WorkletThreadPool {
     #[allow(clippy::too_many_arguments)]
     fn fetch_and_invoke_a_worklet_script(
         &self,
+        webview_id: WebViewId,
         pipeline_id: PipelineId,
         worklet_id: WorkletId,
         global_type: WorkletGlobalScopeType,
@@ -335,6 +337,7 @@ impl WorkletThreadPool {
             &self.control_sender_2,
         ] {
             let _ = sender.send(WorkletControl::FetchAndInvokeAWorkletScript {
+                webview_id,
                 pipeline_id,
                 worklet_id,
                 global_type,
@@ -391,6 +394,7 @@ enum WorkletData {
 enum WorkletControl {
     ExitWorklet(WorkletId),
     FetchAndInvokeAWorkletScript {
+        webview_id: WebViewId,
         pipeline_id: PipelineId,
         worklet_id: WorkletId,
         global_type: WorkletGlobalScopeType,
@@ -622,6 +626,7 @@ impl WorkletThread {
     /// Creates the worklet global scope if it doesn't exist.
     fn get_worklet_global_scope(
         &mut self,
+        webview_id: WebViewId,
         pipeline_id: PipelineId,
         worklet_id: WorkletId,
         global_type: WorkletGlobalScopeType,
@@ -634,6 +639,7 @@ impl WorkletThread {
                 let executor = WorkletExecutor::new(worklet_id, self.primary_sender.clone());
                 let result = WorkletGlobalScope::new(
                     global_type,
+                    webview_id,
                     pipeline_id,
                     base_url,
                     executor,
@@ -735,6 +741,7 @@ impl WorkletThread {
                 self.global_scopes.remove(&worklet_id);
             },
             WorkletControl::FetchAndInvokeAWorkletScript {
+                webview_id,
                 pipeline_id,
                 worklet_id,
                 global_type,
@@ -746,8 +753,13 @@ impl WorkletThread {
                 pending_tasks_struct,
                 promise,
             } => {
-                let global =
-                    self.get_worklet_global_scope(pipeline_id, worklet_id, global_type, base_url);
+                let global = self.get_worklet_global_scope(
+                    webview_id,
+                    pipeline_id,
+                    worklet_id,
+                    global_type,
+                    base_url,
+                );
                 self.fetch_and_invoke_a_worklet_script(
                     &global,
                     pipeline_id,

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -9,7 +9,7 @@ use std::option::Option;
 use std::result::Result;
 
 use base::generic_channel::{GenericSender, RoutedReceiver};
-use base::id::PipelineId;
+use base::id::{PipelineId, WebViewId};
 #[cfg(feature = "bluetooth")]
 use bluetooth_traits::BluetoothRequest;
 use constellation_traits::ScriptToConstellationMessage;
@@ -70,8 +70,8 @@ impl MixedMessage {
                 ScriptThreadMessage::Viewport(id, ..) => Some(*id),
                 ScriptThreadMessage::GetTitle(id) => Some(*id),
                 ScriptThreadMessage::SetDocumentActivity(id, ..) => Some(*id),
-                ScriptThreadMessage::SetThrottled(id, ..) => Some(*id),
-                ScriptThreadMessage::SetThrottledInContainingIframe(id, ..) => Some(*id),
+                ScriptThreadMessage::SetThrottled(_, id, ..) => Some(*id),
+                ScriptThreadMessage::SetThrottledInContainingIframe(_, id, ..) => Some(*id),
                 ScriptThreadMessage::NavigateIframe(id, ..) => Some(*id),
                 ScriptThreadMessage::PostMessage { target: id, .. } => Some(*id),
                 ScriptThreadMessage::UpdatePipelineId(_, _, _, id, _) => Some(*id),
@@ -97,12 +97,12 @@ impl MixedMessage {
                 #[cfg(feature = "webgpu")]
                 ScriptThreadMessage::SetWebGPUPort(..) => None,
                 ScriptThreadMessage::SetScrollStates(id, ..) => Some(*id),
-                ScriptThreadMessage::EvaluateJavaScript(id, _, _) => Some(*id),
+                ScriptThreadMessage::EvaluateJavaScript(_, id, _, _) => Some(*id),
                 ScriptThreadMessage::SendImageKeysBatch(..) => None,
                 ScriptThreadMessage::PreferencesUpdated(..) => None,
                 ScriptThreadMessage::NoLongerWaitingOnAsychronousImageUpdates(_) => None,
                 ScriptThreadMessage::ForwardKeyboardScroll(id, _) => Some(*id),
-                ScriptThreadMessage::RequestScreenshotReadiness(id) => Some(*id),
+                ScriptThreadMessage::RequestScreenshotReadiness(_, id) => Some(*id),
                 ScriptThreadMessage::EmbedderControlResponse(id, _) => Some(id.pipeline_id),
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
@@ -346,7 +346,7 @@ pub(crate) struct ScriptThreadSenders {
     /// particular pipelines.
     #[no_trace]
     pub(crate) pipeline_to_constellation_sender:
-        GenericSender<(PipelineId, ScriptToConstellationMessage)>,
+        GenericSender<(WebViewId, PipelineId, ScriptToConstellationMessage)>,
 
     /// A channel to send messages to the Embedder.
     #[no_trace]

--- a/components/script/script_window_proxies.rs
+++ b/components/script/script_window_proxies.rs
@@ -72,7 +72,7 @@ impl ScriptWindowProxies {
         opener: Option<BrowsingContextId>,
     ) -> Option<DomRoot<WindowProxy>> {
         let (browsing_context_id, parent_pipeline_id) =
-            self.ask_constellation_for_browsing_context_info(senders, pipeline_id)?;
+            self.ask_constellation_for_browsing_context_info(senders, webview_id, pipeline_id)?;
         if let Some(window_proxy) = self.get(browsing_context_id) {
             return Some(window_proxy);
         }
@@ -158,13 +158,14 @@ impl ScriptWindowProxies {
     fn ask_constellation_for_browsing_context_info(
         &self,
         senders: &ScriptThreadSenders,
+        webview_id: WebViewId,
         pipeline_id: PipelineId,
     ) -> Option<(BrowsingContextId, Option<PipelineId>)> {
         let (result_sender, result_receiver) = ipc::channel().unwrap();
         let msg = ScriptToConstellationMessage::GetBrowsingContextInfo(pipeline_id, result_sender);
         senders
             .pipeline_to_constellation_sender
-            .send((pipeline_id, msg))
+            .send((webview_id, pipeline_id, msg))
             .expect("Failed to send to constellation.");
         result_receiver
             .recv()

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -49,15 +49,17 @@ use crate::{
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct ScriptToConstellationChan {
     /// Sender for communicating with constellation thread.
-    pub sender: GenericSender<(PipelineId, ScriptToConstellationMessage)>,
-    /// Used to identify the origin of the message.
+    pub sender: GenericSender<(WebViewId, PipelineId, ScriptToConstellationMessage)>,
+    /// Used to identify the origin `WebView` of the message.
+    pub webview_id: WebViewId,
+    /// Used to identify the origin `Pipeline` of the message.
     pub pipeline_id: PipelineId,
 }
 
 impl ScriptToConstellationChan {
     /// Send ScriptMsg and attach the pipeline_id to the message.
     pub fn send(&self, msg: ScriptToConstellationMessage) -> SendResult {
-        self.sender.send((self.pipeline_id, msg))
+        self.sender.send((self.webview_id, self.pipeline_id, msg))
     }
 }
 

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -160,9 +160,9 @@ pub enum ScriptThreadMessage {
     /// Notifies script thread of a change to one of its document's activity
     SetDocumentActivity(PipelineId, DocumentActivity),
     /// Set whether to use less resources by running timers at a heavily limited rate.
-    SetThrottled(PipelineId, bool),
+    SetThrottled(WebViewId, PipelineId, bool),
     /// Notify the containing iframe (in PipelineId) that the nested browsing context (BrowsingContextId) is throttled.
-    SetThrottledInContainingIframe(PipelineId, BrowsingContextId, bool),
+    SetThrottledInContainingIframe(WebViewId, PipelineId, BrowsingContextId, bool),
     /// Notifies script thread that a url should be loaded in this iframe.
     /// PipelineId is for the parent, BrowsingContextId is for the nested browsing context
     NavigateIframe(
@@ -259,7 +259,7 @@ pub enum ScriptThreadMessage {
     SetScrollStates(PipelineId, FxHashMap<ExternalScrollId, LayoutVector2D>),
     /// Evaluate the given JavaScript and return a result via a corresponding message
     /// to the Constellation.
-    EvaluateJavaScript(PipelineId, JavaScriptEvaluationId, String),
+    EvaluateJavaScript(WebViewId, PipelineId, JavaScriptEvaluationId, String),
     /// A new batch of keys for the image cache for the specific pipeline.
     SendImageKeysBatch(PipelineId, Vec<ImageKey>),
     /// Preferences were updated in the parent process.
@@ -273,7 +273,7 @@ pub enum ScriptThreadMessage {
     /// Request readiness for a screenshot from the given pipeline. The pipeline will
     /// respond when it is ready to take the screenshot or will not be able to take it
     /// in the future.
-    RequestScreenshotReadiness(PipelineId),
+    RequestScreenshotReadiness(WebViewId, PipelineId),
     /// A response to a request to show an embedder user interface control.
     EmbedderControlResponse(EmbedderControlId, EmbedderControlResponse),
 }


### PR DESCRIPTION
It would be useful for  the Constellation is ever going to store data
per-WebView for the purposes of making cleanup and resource management
easier. If that's ever going to happen the `WebView` needs to be passed
with all messages that need it. This change makes it so that messages to
the Constellation that require a Pipeline also carry a WebViewId. This
eliminates one way in which message handling might go wrong.

This avoids making the Constelaltion look up the `WebViewId` for many messages
that it receives.

Testing: This should not change observable behavior, so should be covered by existing tests.
