### PR TITLE
webdriver: Report error instead of panic for invalid `WebElement`&`ShadowRoot` reference 

### DIFF
--- a/components/webdriver_server/script_argument_extraction.rs
+++ b/components/webdriver_server/script_argument_extraction.rs
@@ -49,7 +49,7 @@ impl Handler {
         // Step 2. Let reference be the result of getting the web element identifier property from object.
         let element_ref = match element {
             Value::String(string) => string.clone(),
-            _ => unreachable!(),
+            _ => return Err(WebDriverError::new(ErrorStatus::InvalidArgument, "")),
         };
 
         // Step 3. Let element be the result of trying to get a known element with session and reference.
@@ -71,7 +71,7 @@ impl Handler {
         // Step 2. Let reference be the result of getting the shadow root identifier property from object.
         let shadow_root_ref = match shadow_root {
             Value::String(string) => string.clone(),
-            _ => unreachable!(),
+            _ => return Err(WebDriverError::new(ErrorStatus::InvalidArgument, "")),
         };
 
         // Step 3. Let element be the result of trying to get a known element with session and reference.

--- a/tests/wpt/tests/webdriver/tests/classic/execute_async_script/arguments.py
+++ b/tests/wpt/tests/webdriver/tests/classic/execute_async_script/arguments.py
@@ -162,9 +162,9 @@ def test_stale_element_reference(session, stale_element, as_frame):
     assert_error(result, "stale element reference")
 
 
-@pytest.mark.parametrize("type", [WebFrame, WebWindow], ids=["frame", "window"])
+@pytest.mark.parametrize("type", [WebFrame, WebWindow, WebElement, ShadowRoot], ids=["frame", "window", "element", "shadow_root"])
 @pytest.mark.parametrize("value", [None, False, 42, [], {}])
-def test_invalid_argument_for_window_with_invalid_type(session, type, value):
+def test_invalid_argument_for_reference_with_invalid_type(session, type, value):
     reference = type(session, value)
 
     result = execute_async_script(session, "arguments[1](true)", args=(reference,))

--- a/tests/wpt/tests/webdriver/tests/classic/execute_script/arguments.py
+++ b/tests/wpt/tests/webdriver/tests/classic/execute_script/arguments.py
@@ -150,9 +150,9 @@ def test_stale_element_reference(session, stale_element, as_frame):
     assert_error(result, "stale element reference")
 
 
-@pytest.mark.parametrize("type", [WebFrame, WebWindow], ids=["frame", "window"])
+@pytest.mark.parametrize("type", [WebFrame, WebWindow, WebElement, ShadowRoot], ids=["frame", "window", "element", "shadow_root"])
 @pytest.mark.parametrize("value", [None, False, 42, [], {}])
-def test_invalid_argument_for_window_with_invalid_type(session, type, value):
+def test_invalid_argument_for_reference_with_invalid_type(session, type, value):
     reference = type(session, value)
 
     result = execute_script(session, "return true", args=(reference,))


### PR DESCRIPTION
It is possible that the reference of `WebElement` and `ShadowRoot` in the request is not String. Instead of panic, we should return "invalid argument" same as the `WebWindow` and `WebFrame`.

Testing: Added 4 new subtests. There was only tests for `WebWindow` and `WebFrame` somehow.