### PR TITLE
xpath: Replace `nom` with hand-written parsing rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10856,7 +10856,6 @@ dependencies = [
  "log",
  "malloc_size_of_derive",
  "markup5ever",
- "nom 8.0.0",
  "servo_malloc_size_of",
 ]
 

--- a/components/script/dom/xpathevaluator.rs
+++ b/components/script/dom/xpathevaluator.rs
@@ -62,12 +62,12 @@ impl XPathEvaluatorMethods<crate::DomTypeHolder> for XPathEvaluator {
     fn CreateExpression(
         &self,
         expression: DOMString,
-        _resolver: Option<Rc<XPathNSResolver>>,
+        resolver: Option<Rc<XPathNSResolver>>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<XPathExpression>> {
         let global = self.global();
         let window = global.as_window();
-        let parsed_expression = parse_expression(&expression.str())?;
+        let parsed_expression = parse_expression(&expression.str(), resolver)?;
         Ok(XPathExpression::new(
             window,
             None,
@@ -85,7 +85,7 @@ impl XPathEvaluatorMethods<crate::DomTypeHolder> for XPathEvaluator {
     /// <https://dom.spec.whatwg.org/#dom-xpathevaluatorbase-evaluate>
     fn Evaluate(
         &self,
-        expression_str: DOMString,
+        expression: DOMString,
         context_node: &Node,
         resolver: Option<Rc<XPathNSResolver>>,
         result_type: u16,
@@ -95,8 +95,8 @@ impl XPathEvaluatorMethods<crate::DomTypeHolder> for XPathEvaluator {
         let global = self.global();
         let window = global.as_window();
 
-        let parsed_expression = parse_expression(&expression_str.str())?;
+        let parsed_expression = parse_expression(&expression.str(), resolver)?;
         let expression = XPathExpression::new(window, None, can_gc, parsed_expression);
-        expression.evaluate_internal(context_node, result_type, result, resolver, can_gc)
+        expression.evaluate_internal(context_node, result_type, result, can_gc)
     }
 }

--- a/components/script/dom/xpathexpression.rs
+++ b/components/script/dom/xpathexpression.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId};
-use xpath::{Error as XPathError, Expression, evaluate_parsed_xpath};
+use xpath::{Expression, evaluate_parsed_xpath};
 
 use crate::dom::bindings::codegen::Bindings::XPathExpressionBinding::XPathExpressionMethods;
 use crate::dom::bindings::error::{Error, Fallible};

--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -258,12 +258,15 @@ impl xpath::Attribute for XPathWrapper<DomRoot<Attr>> {
     }
 }
 
-pub(crate) fn parse_expression(expression: &str) -> Fallible<xpath::Expression> {
-    xpath::parse::<Error>(expression).map_err(|error| match error {
-        xpath::Error::JsException(Error::JSFailed) => Error::JSFailed,
-        _ => Error::Syntax(Some(format!(
-            "Failed to parse {expression:?} as an XPath expression: {error:?}"
-        ))),
+pub(crate) fn parse_expression(
+    expression: &str,
+    resolver: Option<Rc<XPathNSResolver>>,
+) -> Fallible<xpath::Expression> {
+    xpath::parse::<XPathImplementation>(expression, resolver.map(XPathWrapper)).map_err(|error| {
+        match error {
+            xpath::ParserError::JsError(Error::JSFailed) => Error::JSFailed,
+            _ => Error::Syntax(Some(format!("Failed to parse XPath expression: {error:?}"))),
+        }
     })
 }
 

--- a/components/xpath/Cargo.toml
+++ b/components/xpath/Cargo.toml
@@ -9,7 +9,6 @@ rust-version.workspace = true
 
 [dependencies]
 log = { workspace = true }
-nom = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 markup5ever = { workspace = true }

--- a/components/xpath/src/ast.rs
+++ b/components/xpath/src/ast.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use malloc_size_of_derive::MallocSizeOf;
+use markup5ever::QualName;
 
 #[derive(Clone, Debug, MallocSizeOf, PartialEq)]
 pub enum Expression {
@@ -98,7 +99,7 @@ pub(crate) enum Axis {
 
 #[derive(Clone, Debug, MallocSizeOf, PartialEq)]
 pub(crate) enum NodeTest {
-    Name(QName),
+    Name(QualName),
     Wildcard,
     Kind(KindTest),
 }

--- a/components/xpath/src/context.rs
+++ b/components/xpath/src/context.rs
@@ -2,18 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::fmt;
-
-use crate::{Dom, NamespaceResolver};
+use crate::Dom;
 
 /// The context during evaluation of an XPath expression.
+#[derive(Debug)]
 pub(crate) struct EvaluationCtx<D: Dom> {
     /// The "current" node in the evaluation.
     pub(crate) context_node: D::Node,
     /// Details needed for evaluating a predicate list.
     pub(crate) predicate_ctx: Option<PredicateCtx>,
-    /// A list of known namespace prefixes.
-    pub(crate) resolver: Option<D::NamespaceResolver>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -23,46 +20,19 @@ pub(crate) struct PredicateCtx {
 }
 
 impl<D: Dom> EvaluationCtx<D> {
-    /// Prepares the context used while evaluating the XPath expression
-    pub(crate) fn new(context_node: D::Node, resolver: Option<D::NamespaceResolver>) -> Self {
+    /// Prepares the context used while evaluating the XPath expression.
+    pub(crate) fn new(context_node: D::Node) -> Self {
         EvaluationCtx {
             context_node,
             predicate_ctx: None,
-            resolver,
         }
     }
 
-    /// Creates a new context using the provided node as the context node
+    /// Creates a new context using the provided node as the context node.
     pub(crate) fn subcontext_for_node(&self, node: D::Node) -> Self {
         EvaluationCtx {
             context_node: node,
             predicate_ctx: self.predicate_ctx,
-            resolver: self.resolver.clone(),
         }
-    }
-
-    /// Resolve a namespace prefix using the context node's document
-    pub(crate) fn resolve_namespace(
-        &self,
-        prefix: Option<&str>,
-    ) -> Result<Option<String>, D::JsError> {
-        // First check if the prefix is known by our resolver function
-        if let Some(resolver) = self.resolver.as_ref() {
-            if let Some(namespace_uri) = resolver.resolve_namespace_prefix(prefix)? {
-                return Ok(Some(namespace_uri));
-            }
-        }
-
-        Ok(None)
-    }
-}
-
-impl<D: Dom> fmt::Debug for EvaluationCtx<D> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("EvaluationCtx")
-            .field("context_node", &self.context_node)
-            .field("predicate_ctx", &self.predicate_ctx)
-            .field("resolver", &"<callback function>")
-            .finish()
     }
 }

--- a/components/xpath/src/parser.rs
+++ b/components/xpath/src/parser.rs
@@ -2,732 +2,608 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use nom::branch::alt;
-use nom::bytes::complete::{tag, take_while1};
-use nom::character::complete::{char, digit1, multispace0};
-use nom::combinator::{map, opt, recognize, value};
-use nom::error::{Error as NomError, ErrorKind as NomErrorKind, ParseError as NomParseError};
-use nom::multi::{many0, separated_list0};
-use nom::sequence::{delimited, pair, preceded};
-use nom::{AsChar, Finish, IResult, Input, Parser};
+use std::fmt;
+use std::marker::PhantomData;
 
+use markup5ever::{LocalName, Namespace, Prefix, QualName};
+
+use crate::NamespaceResolver;
 use crate::ast::{
     Axis, BinaryOperator, CoreFunction, Expression, FilterExpression, KindTest, Literal,
-    LocationStepExpression, NodeTest, PathExpression, PredicateListExpression, QName,
+    LocationStepExpression, NodeTest, PathExpression, PredicateListExpression,
 };
-use crate::{is_valid_continuation, is_valid_start};
+use crate::tokenizer::{Error as TokenizerError, LiteralToken, OperatorToken, Token, tokenize};
 
-pub(crate) fn parse(input: &str) -> Result<Expression, OwnedParserError> {
-    let (_, ast) = expr(input).finish().map_err(OwnedParserError::from)?;
-    Ok(ast)
+#[derive(Clone, Debug)]
+pub enum Error<E> {
+    Tokenization(TokenizerError),
+    UnknownFunction,
+    ExpectedSeperatorBetweenFunctionArguments,
+    TooFewFunctionArguments,
+    TooManyFunctionArguments,
+    ExpectedClosingParenthesis,
+    ExpectedClosingBracket,
+    CannotUseVariables,
+    UnknownAxis,
+    TrailingInput,
+    UnknownNodeTest,
+    ExpectedNodeTest,
+    UnexpectedEndOfInput,
+    /// A JS exception that needs to be propagated to the caller.
+    JsError(E),
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct OwnedParserError {
-    pub input: String,
-    pub kind: NomErrorKind,
+impl<E> From<TokenizerError> for Error<E> {
+    fn from(value: TokenizerError) -> Self {
+        Self::Tokenization(value)
+    }
 }
 
-impl<'a> From<NomError<&'a str>> for OwnedParserError {
-    fn from(err: NomError<&'a str>) -> Self {
-        OwnedParserError {
-            input: err.input.to_string(),
-            kind: err.code,
+pub(crate) fn parse<E, N>(
+    input: &str,
+    namespace_resolver: Option<N>,
+) -> Result<Expression, Error<E>>
+where
+    E: fmt::Debug,
+    N: NamespaceResolver<E>,
+{
+    let mut parser = Parser::new(input, namespace_resolver)?;
+    let root_expression = parser.parse_expression()?;
+    if !parser.remaining().is_empty() {
+        log::debug!(
+            "Found trailing tokens after expression: {:?}",
+            parser.remaining()
+        );
+        return Err(Error::TrailingInput);
+    }
+
+    Ok(root_expression)
+}
+
+struct Parser<'a, E, N>
+where
+    N: NamespaceResolver<E>,
+{
+    tokens: Vec<Token<'a>>,
+    position: usize,
+    namespace_resolver: Option<N>,
+    marker: PhantomData<E>,
+}
+
+impl<'a, E, N> Parser<'a, E, N>
+where
+    E: fmt::Debug,
+    N: NamespaceResolver<E>,
+{
+    fn new(input: &'a str, namespace_resolver: Option<N>) -> Result<Self, TokenizerError> {
+        let tokens = tokenize(input)?;
+        Ok(Self {
+            tokens,
+            position: 0,
+            namespace_resolver,
+            marker: PhantomData,
+        })
+    }
+
+    fn expect_current_token(&self) -> Result<Token<'a>, Error<E>> {
+        self.tokens
+            .get(self.position)
+            .copied()
+            .ok_or(Error::UnexpectedEndOfInput)
+    }
+
+    fn peek(&self, n: usize) -> Option<Token<'a>> {
+        self.tokens.get(self.position + n).copied()
+    }
+
+    fn advance(&mut self, advance_by: usize) {
+        self.position += advance_by;
+    }
+
+    fn remaining(&self) -> &[Token<'a>] {
+        &self.tokens[self.position..]
+    }
+
+    fn resolve_qualified_name(&self, prefix: &str) -> Result<Option<Namespace>, E> {
+        let Some(namespace_resolver) = self.namespace_resolver.as_ref() else {
+            return Ok(None);
+        };
+
+        log::debug!("Resolving namespace prefix: {:?}", prefix);
+        namespace_resolver
+            .resolve_namespace_prefix(Some(prefix))
+            .map(|value| value.map(Namespace::from))
+    }
+
+    fn advance_if_current_token_equals(&mut self, wanted: Token<'a>) -> bool {
+        if self.peek(0).is_some_and(|token| token == wanted) {
+            self.position += 1;
+            true
+        } else {
+            false
         }
     }
-}
 
-impl std::fmt::Display for OwnedParserError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "error {:?} at: {}", self.kind, self.input)
-    }
-}
+    fn parse_expression(&mut self) -> Result<Expression, Error<E>> {
+        let mut result;
 
-impl std::error::Error for OwnedParserError {}
+        let mut expression_stack: Vec<(Expression, OperatorToken)> = vec![];
+        loop {
+            let mut negations = 0;
+            while self.advance_if_current_token_equals(Token::Operator(OperatorToken::Subtract)) {
+                negations += 1;
+            }
 
-/// Top-level parser
-fn expr(input: &str) -> IResult<&str, Expression> {
-    expr_single(input)
-}
+            result = self.parse_union_expression()?;
 
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-Expr>
-fn expr_single(input: &str) -> IResult<&str, Expression> {
-    or_expr(input)
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-OrExpr>
-fn or_expr(input: &str) -> IResult<&str, Expression> {
-    let (input, first) = and_expr(input)?;
-    let (input, rest) = many0(preceded(ws(tag("or")), and_expr)).parse(input)?;
-
-    Ok((
-        input,
-        rest.into_iter().fold(first, |acc, expr| {
-            Expression::Binary(Box::new(acc), BinaryOperator::Or, Box::new(expr))
-        }),
-    ))
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-AndExpr>
-fn and_expr(input: &str) -> IResult<&str, Expression> {
-    let (input, first) = equality_expr(input)?;
-    let (input, rest) = many0(preceded(ws(tag("and")), equality_expr)).parse(input)?;
-
-    Ok((
-        input,
-        rest.into_iter().fold(first, |acc, expr| {
-            Expression::Binary(Box::new(acc), BinaryOperator::And, Box::new(expr))
-        }),
-    ))
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-EqualityExpr>
-fn equality_expr(input: &str) -> IResult<&str, Expression> {
-    let (input, first) = relational_expr(input)?;
-    let (input, rest) = many0((
-        ws(alt((
-            map(tag("="), |_| BinaryOperator::Equal),
-            map(tag("!="), |_| BinaryOperator::NotEqual),
-        ))),
-        relational_expr,
-    ))
-    .parse(input)?;
-
-    Ok((
-        input,
-        rest.into_iter().fold(first, |acc, (op, expr)| {
-            Expression::Binary(Box::new(acc), op, Box::new(expr))
-        }),
-    ))
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-RelationalExpr>
-fn relational_expr(input: &str) -> IResult<&str, Expression> {
-    let (input, first) = additive_expr(input)?;
-    let (input, rest) = many0((
-        ws(alt((
-            map(tag("<="), |_| BinaryOperator::LessThanOrEqual),
-            map(tag(">="), |_| BinaryOperator::GreaterThanOrEqual),
-            map(tag("<"), |_| BinaryOperator::LessThan),
-            map(tag(">"), |_| BinaryOperator::GreaterThan),
-        ))),
-        additive_expr,
-    ))
-    .parse(input)?;
-
-    Ok((
-        input,
-        rest.into_iter().fold(first, |acc, (op, expr)| {
-            Expression::Binary(Box::new(acc), op, Box::new(expr))
-        }),
-    ))
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-AdditiveExpr>
-fn additive_expr(input: &str) -> IResult<&str, Expression> {
-    let (input, first) = multiplicative_expr(input)?;
-    let (input, rest) = many0((
-        ws(alt((
-            map(tag("+"), |_| BinaryOperator::Add),
-            map(tag("-"), |_| BinaryOperator::Subtract),
-        ))),
-        multiplicative_expr,
-    ))
-    .parse(input)?;
-
-    Ok((
-        input,
-        rest.into_iter().fold(first, |acc, (op, expr)| {
-            Expression::Binary(Box::new(acc), op, Box::new(expr))
-        }),
-    ))
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-MultiplicativeExpr>
-fn multiplicative_expr(input: &str) -> IResult<&str, Expression> {
-    let (input, first) = unary_expr(input)?;
-    let (input, rest) = many0((
-        ws(alt((
-            map(tag("*"), |_| BinaryOperator::Multiply),
-            map(tag("div"), |_| BinaryOperator::Divide),
-            map(tag("mod"), |_| BinaryOperator::Modulo),
-        ))),
-        unary_expr,
-    ))
-    .parse(input)?;
-
-    Ok((
-        input,
-        rest.into_iter().fold(first, |acc, (op, expr)| {
-            Expression::Binary(Box::new(acc), op, Box::new(expr))
-        }),
-    ))
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-UnaryExpr>
-fn unary_expr(input: &str) -> IResult<&str, Expression> {
-    let (input, minus_count) = many0(ws(char('-'))).parse(input)?;
-    let (input, expr) = union_expr(input)?;
-
-    Ok((
-        input,
-        (0..minus_count.len()).fold(expr, |acc, _| Expression::Negate(Box::new(acc))),
-    ))
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-UnionExpr>
-fn union_expr(input: &str) -> IResult<&str, Expression> {
-    let (input, first) = path_expr(input)?;
-    let (input, rest) = many0(preceded(ws(char('|')), path_expr)).parse(input)?;
-
-    Ok((
-        input,
-        rest.into_iter().fold(first, |acc, expr| {
-            Expression::Binary(Box::new(acc), BinaryOperator::Union, Box::new(expr))
-        }),
-    ))
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-PathExpr>
-fn path_expr(input: &str) -> IResult<&str, Expression> {
-    ws(alt((
-        // "//" RelativePathExpr
-        map(
-            pair(tag("//"), move |i| relative_path_expr(true, i)),
-            |(_, relative_path)| {
-                Expression::Path(PathExpression {
-                    is_absolute: true,
-                    has_implicit_descendant_or_self_step: true,
-                    steps: relative_path.steps,
-                })
-            },
-        ),
-        // "/" RelativePathExpr?
-        map(
-            pair(char('/'), opt(move |i| relative_path_expr(false, i))),
-            |(_, relative_path)| {
-                Expression::Path(PathExpression {
-                    is_absolute: true,
-                    has_implicit_descendant_or_self_step: false,
-                    steps: relative_path.map(|path| path.steps).unwrap_or_default(),
-                })
-            },
-        ),
-        // RelativePathExpr
-        map(
-            move |i| relative_path_expr(false, i),
-            |mut relative_path_expression| {
-                if relative_path_expression.steps.len() == 1 {
-                    relative_path_expression.steps.pop().unwrap()
+            if negations > 1 {
+                if negations % 2 == 0 {
+                    result = Expression::Function(CoreFunction::Number(Some(Box::new(result))))
                 } else {
-                    Expression::Path(relative_path_expression)
+                    result = Expression::Negate(Box::new(result))
                 }
-            },
-        ),
-    )))
-    .parse(input)
-}
+            }
 
-fn relative_path_expr(is_descendant: bool, input: &str) -> IResult<&str, PathExpression> {
-    let (input, first) = step_expr(is_descendant, input)?;
-    let (input, steps) = many0(pair(
-        ws(alt((value(true, tag("//")), value(false, char('/'))))),
-        ws(move |i| step_expr(false, i)),
-    ))
-    .parse(input)?;
+            // If the next token is not an operator then the expression ends here.
+            let Some(next_token) = self.peek(0) else {
+                break;
+            };
+            let Token::Operator(current_operator) = next_token else {
+                break;
+            };
+            self.advance(1);
 
-    let mut all_steps = vec![first];
-    for (implicit_descendant_or_self, step) in steps {
-        if implicit_descendant_or_self {
-            // Insert an implicit descendant-or-self::node() step
-            all_steps.push(Expression::LocationStep(LocationStepExpression {
-                axis: Axis::DescendantOrSelf,
-                node_test: NodeTest::Kind(KindTest::Node),
-                predicate_list: PredicateListExpression { predicates: vec![] },
-            }));
+            // Finish all ongoing expressions that have higher precedence
+            while let Some((lhs, operator)) = expression_stack
+                .pop_if(|(_, operator)| current_operator.precedence() <= operator.precedence())
+            {
+                result = create_binary_expression(Box::new(lhs), operator, Box::new(result));
+            }
+
+            expression_stack.push((result, current_operator));
         }
-        all_steps.push(step);
+
+        // Close any expressions that are still open
+        for (lhs, operator) in expression_stack.into_iter().rev() {
+            result = create_binary_expression(Box::new(lhs), operator, Box::new(result))
+        }
+
+        Ok(result)
     }
 
-    Ok((
-        input,
-        PathExpression {
-            is_absolute: false,
-            has_implicit_descendant_or_self_step: false,
-            steps: all_steps,
-        },
-    ))
-}
+    /// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-UnionExpr>
+    fn parse_union_expression(&mut self) -> Result<Expression, Error<E>> {
+        let mut result = self.parse_path_expression()?;
 
-fn step_expr(is_descendant: bool, input: &str) -> IResult<&str, Expression> {
-    alt((filter_expr, |i| axis_step(is_descendant, i))).parse(input)
-}
+        while self.advance_if_current_token_equals(Token::Union) {
+            let rhs = self.parse_path_expression()?;
+            result = Expression::Binary(Box::new(result), BinaryOperator::Union, Box::new(rhs));
+        }
 
-fn axis_step(is_descendant: bool, input: &str) -> IResult<&str, Expression> {
-    let (input, (step, predicates)) = pair(
-        alt((move |i| forward_step(is_descendant, i), reverse_step)),
-        predicate_list,
-    )
-    .parse(input)?;
+        Ok(result)
+    }
 
-    let (axis, node_test) = step;
-    Ok((
-        input,
-        Expression::LocationStep(LocationStepExpression {
+    /// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-PathExpr>
+    fn parse_path_expression(&mut self) -> Result<Expression, Error<E>> {
+        let current_token = self.expect_current_token()?;
+
+        let is_absolute = matches!(current_token, Token::Parent | Token::Ancestor);
+        let has_implicit_descendant_or_self_step = current_token == Token::Ancestor;
+
+        if is_absolute {
+            self.advance(1);
+
+            if !self
+                .peek(0)
+                .is_some_and(|token| token.is_start_of_location_step())
+            {
+                return Ok(Expression::Path(PathExpression {
+                    is_absolute,
+                    has_implicit_descendant_or_self_step,
+                    steps: vec![],
+                }));
+            }
+        }
+
+        let first_expression = if !is_absolute {
+            let expression = self.parse_filter_or_step_expression()?;
+
+            // If there are no further steps in this path expression then return it as-is.
+            if !self
+                .peek(0)
+                .is_some_and(|token| matches!(token, Token::Parent | Token::Ancestor))
+            {
+                return Ok(expression);
+            }
+
+            expression
+        } else {
+            self.parse_step_expression()?
+        };
+
+        let mut path_expression = PathExpression {
+            is_absolute,
+            has_implicit_descendant_or_self_step,
+            steps: vec![first_expression],
+        };
+
+        while let Some(current_token) = self.peek(0) {
+            match current_token {
+                Token::Ancestor => {
+                    self.advance(1);
+
+                    // Insert implicit "descendant-or-self" step
+                    path_expression
+                        .steps
+                        .push(Expression::LocationStep(LocationStepExpression {
+                            axis: Axis::DescendantOrSelf,
+                            node_test: NodeTest::Kind(KindTest::Node),
+                            predicate_list: PredicateListExpression { predicates: vec![] },
+                        }));
+                    true
+                },
+                Token::Parent => {
+                    self.advance(1);
+                    false
+                },
+                _ => {
+                    // The path expression ends here.
+                    return Ok(Expression::Path(path_expression));
+                },
+            };
+
+            let step_expression = self.parse_step_expression()?;
+            path_expression.steps.push(step_expression);
+        }
+
+        Ok(Expression::Path(path_expression))
+    }
+
+    /// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-FilterExpr>
+    ///
+    /// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-Step>
+    fn parse_filter_or_step_expression(&mut self) -> Result<Expression, Error<E>> {
+        let mut expression = match self.expect_current_token()? {
+            Token::FunctionCall(name) => {
+                self.advance(1);
+                self.parse_function_call(name)?
+            },
+            Token::OpeningParenthesis => {
+                self.advance(1);
+                let expression = self.parse_expression()?;
+                if !self.advance_if_current_token_equals(Token::ClosingParenthesis) {
+                    log::debug!("{:?}", self.expect_current_token()?);
+                    return Err(Error::ExpectedClosingParenthesis);
+                }
+                expression
+            },
+            Token::Literal(literal) => {
+                self.advance(1);
+                Expression::Literal(literal.into())
+            },
+            Token::VariableReference(_) => {
+                // TODO: Gecko does *something* here. Is it observable?
+                // https://searchfox.org/firefox-main/rev/054e2b072785984455b3b59acad9444ba1eeffb4/dom/xslt/xpath/txExprParser.cpp#349
+                return Err(Error::CannotUseVariables);
+            },
+            _ => self.parse_step_expression()?,
+        };
+
+        // Parse a potential list of predicates
+        let predicate_list = self.parse_predicates()?;
+        if !predicate_list.predicates.is_empty() {
+            expression = Expression::Filter(FilterExpression {
+                expression: Box::new(expression),
+                predicates: predicate_list,
+            });
+        }
+
+        Ok(expression)
+    }
+
+    /// <https://www.w3.org/TR/1999/REC-xpath-19991116/#section-Location-Steps>
+    fn parse_step_expression(&mut self) -> Result<Expression, Error<E>> {
+        let axis;
+        let mut node_test = None;
+
+        match self.expect_current_token()? {
+            Token::AxisIdentifier(axis_name) => {
+                self.advance(1);
+                axis = match axis_name {
+                    "ancestor" => Axis::Ancestor,
+                    "ancestor-or-self" => Axis::AncestorOrSelf,
+                    "attribute" => Axis::Attribute,
+                    "child" => Axis::Child,
+                    "descendant" => Axis::Descendant,
+                    "descendant-or-self" => Axis::DescendantOrSelf,
+                    "following" => Axis::Following,
+                    "following-sibling" => Axis::FollowingSibling,
+                    "namespace" => Axis::Namespace,
+                    "parent" => Axis::Parent,
+                    "preceding" => Axis::Preceding,
+                    "preceding-sibling" => Axis::PrecedingSibling,
+                    "self" => Axis::Self_,
+                    _ => {
+                        log::debug!("Unknown XPath axis name: {axis_name:?}");
+                        return Err(Error::UnknownAxis);
+                    },
+                };
+            },
+            Token::AtSign => {
+                // This is a shorthand for the attribute axis
+                self.advance(1);
+                axis = Axis::Attribute;
+            },
+            Token::ParentNode => {
+                self.advance(1);
+                axis = Axis::Parent;
+                node_test = Some(NodeTest::Kind(KindTest::Node));
+            },
+            Token::SelfNode => {
+                self.advance(1);
+                axis = Axis::Self_;
+                node_test = Some(NodeTest::Kind(KindTest::Node));
+            },
+            _ => {
+                axis = Axis::Child;
+            },
+        }
+
+        let node_test = if let Some(node_test) = node_test {
+            node_test
+        } else if let Token::CName(name_token) = self.expect_current_token()? {
+            self.advance(1);
+
+            if name_token.local_name == "*" {
+                NodeTest::Wildcard
+            } else {
+                let namespace = name_token
+                    .prefix
+                    .map(|prefix| {
+                        self.resolve_qualified_name(prefix)
+                            .inspect_err(|e| println!("{e:?}"))
+                            .map_err(Error::JsError)
+                    })
+                    .transpose()?
+                    .flatten();
+
+                let qualified_name = QualName {
+                    prefix: name_token.prefix.map(Prefix::from),
+                    ns: namespace.unwrap_or_default(),
+                    local: LocalName::from(name_token.local_name),
+                };
+
+                NodeTest::Name(qualified_name)
+            }
+        } else {
+            self.parse_node_test()?
+        };
+
+        let predicate_list = self.parse_predicates()?;
+        Ok(Expression::LocationStep(LocationStepExpression {
             axis,
             node_test,
-            predicate_list: predicates,
-        }),
-    ))
-}
-
-fn forward_step(is_descendant: bool, input: &str) -> IResult<&str, (Axis, NodeTest)> {
-    alt((pair(forward_axis, node_test), move |i| {
-        abbrev_forward_step(is_descendant, i)
-    }))
-    .parse(input)
-}
-
-fn forward_axis(input: &str) -> IResult<&str, Axis> {
-    let (input, axis) = alt((
-        value(Axis::Child, tag("child::")),
-        value(Axis::Descendant, tag("descendant::")),
-        value(Axis::Attribute, tag("attribute::")),
-        value(Axis::Self_, tag("self::")),
-        value(Axis::DescendantOrSelf, tag("descendant-or-self::")),
-        value(Axis::FollowingSibling, tag("following-sibling::")),
-        value(Axis::Following, tag("following::")),
-        value(Axis::Namespace, tag("namespace::")),
-    ))
-    .parse(input)?;
-
-    Ok((input, axis))
-}
-
-// <https://www.w3.org/TR/1999/REC-xpath-19991116/#path-abbrev>
-fn abbrev_forward_step(is_descendant: bool, input: &str) -> IResult<&str, (Axis, NodeTest)> {
-    let (input, attr) = opt(char('@')).parse(input)?;
-    let (input, test) = node_test(input)?;
-
-    let axis = if attr.is_some() {
-        Axis::Attribute
-    } else if is_descendant {
-        Axis::DescendantOrSelf
-    } else {
-        Axis::Child
-    };
-    Ok((input, (axis, test)))
-}
-
-fn reverse_step(input: &str) -> IResult<&str, (Axis, NodeTest)> {
-    alt((
-        // ReverseAxis NodeTest
-        pair(reverse_axis, node_test),
-        // AbbrevReverseStep
-        abbrev_reverse_step,
-    ))
-    .parse(input)
-}
-
-fn reverse_axis(input: &str) -> IResult<&str, Axis> {
-    alt((
-        value(Axis::Parent, tag("parent::")),
-        value(Axis::Ancestor, tag("ancestor::")),
-        value(Axis::PrecedingSibling, tag("preceding-sibling::")),
-        value(Axis::Preceding, tag("preceding::")),
-        value(Axis::AncestorOrSelf, tag("ancestor-or-self::")),
-    ))
-    .parse(input)
-}
-
-fn abbrev_reverse_step(input: &str) -> IResult<&str, (Axis, NodeTest)> {
-    map(tag(".."), |_| {
-        (Axis::Parent, NodeTest::Kind(KindTest::Node))
-    })
-    .parse(input)
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-NodeTest>
-fn node_test(input: &str) -> IResult<&str, NodeTest> {
-    alt((
-        map(kind_test, NodeTest::Kind),
-        map(name_test, |name| match name {
-            NameTest::Wildcard => NodeTest::Wildcard,
-            NameTest::QName(qname) => NodeTest::Name(qname),
-        }),
-    ))
-    .parse(input)
-}
-
-#[derive(Clone, Debug, PartialEq)]
-enum NameTest {
-    QName(QName),
-    Wildcard,
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-NameTest>
-fn name_test(input: &str) -> IResult<&str, NameTest> {
-    alt((
-        // NCName ":" "*"
-        map((ncname, char(':'), char('*')), |(prefix, _, _)| {
-            NameTest::QName(QName {
-                prefix: Some(prefix.to_string()),
-                local_part: "*".to_string(),
-            })
-        }),
-        // "*"
-        value(NameTest::Wildcard, char('*')),
-        // QName
-        map(qname, NameTest::QName),
-    ))
-    .parse(input)
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-FilterExpr>
-fn filter_expr(input: &str) -> IResult<&str, Expression> {
-    let (input, primary) = primary_expr(input)?;
-    let (input, predicate_list) = predicate_list(input)?;
-
-    if predicate_list.predicates.is_empty() {
-        return Ok((input, primary));
+            predicate_list,
+        }))
     }
 
-    Ok((
-        input,
-        Expression::Filter(FilterExpression {
-            expression: Box::new(primary),
-            predicates: predicate_list,
-        }),
-    ))
+    fn parse_node_test(&mut self) -> Result<NodeTest, Error<E>> {
+        let kind_test = match self.expect_current_token()? {
+            Token::CommentTest => {
+                self.advance(1);
+                KindTest::Comment
+            },
+            Token::NodeTest => {
+                self.advance(1);
+                KindTest::Node
+            },
+            Token::ProcessingInstructionTest => {
+                self.advance(1);
+                let name = if let Token::Literal(LiteralToken::String(name)) =
+                    self.expect_current_token()?
+                {
+                    self.advance(1);
+                    Some(name)
+                } else {
+                    None
+                };
+                KindTest::PI(name.map(String::from))
+            },
+            Token::TextTest => {
+                self.advance(1);
+                KindTest::Text
+            },
+            _ => {
+                return Err(Error::ExpectedNodeTest);
+            },
+        };
+
+        if !self.advance_if_current_token_equals(Token::ClosingParenthesis) {
+            return Err(Error::TooManyFunctionArguments);
+        }
+
+        Ok(NodeTest::Kind(kind_test))
+    }
+
+    /// <https://www.w3.org/TR/1999/REC-xpath-19991116/#predicates>
+    fn parse_predicates(&mut self) -> Result<PredicateListExpression, Error<E>> {
+        let mut predicates = vec![];
+        while self.advance_if_current_token_equals(Token::OpeningBracket) {
+            let expression = self.parse_expression()?;
+            predicates.push(expression);
+            if !self.advance_if_current_token_equals(Token::ClosingBracket) {
+                return Err(Error::ExpectedClosingBracket);
+            }
+        }
+        Ok(PredicateListExpression { predicates })
+    }
+
+    fn parse_function_call(&mut self, function_name: &str) -> Result<Expression, Error<E>> {
+        struct ArgumentIterator<'a, 'b, E, N>
+        where
+            N: NamespaceResolver<E>,
+        {
+            parser: &'b mut Parser<'a, E, N>,
+            done: bool,
+        }
+
+        impl<'a, 'b, E, N> ArgumentIterator<'a, 'b, E, N>
+        where
+            E: fmt::Debug,
+            N: NamespaceResolver<E>,
+        {
+            fn maybe_next(&mut self) -> Result<Option<Expression>, Error<E>> {
+                if self.done {
+                    return Ok(None);
+                }
+                let expression = self.parser.parse_expression()?;
+                if self
+                    .parser
+                    .advance_if_current_token_equals(Token::ClosingParenthesis)
+                {
+                    self.done = true;
+                } else if !self.parser.advance_if_current_token_equals(Token::Comma) {
+                    log::debug!("{:?}", self.parser.peek(0));
+                    return Err(Error::ExpectedSeperatorBetweenFunctionArguments);
+                }
+
+                Ok(Some(expression))
+            }
+
+            fn next(&mut self) -> Result<Expression, Error<E>> {
+                self.maybe_next()
+                    .and_then(|maybe_argument| maybe_argument.ok_or(Error::TooFewFunctionArguments))
+            }
+        }
+
+        let mut arguments = ArgumentIterator {
+            done: self.advance_if_current_token_equals(Token::ClosingParenthesis),
+            parser: self,
+        };
+
+        let core_fn = match function_name {
+            // Node Set Functions
+            "last" => CoreFunction::Last,
+            "position" => CoreFunction::Position,
+            "count" => CoreFunction::Count(Box::new(arguments.next()?)),
+            "id" => CoreFunction::Id(Box::new(arguments.next()?)),
+            "local-name" => CoreFunction::LocalName(arguments.maybe_next()?.map(Box::new)),
+            "namespace-uri" => CoreFunction::NamespaceUri(arguments.maybe_next()?.map(Box::new)),
+            "name" => CoreFunction::Name(arguments.maybe_next()?.map(Box::new)),
+
+            // String Functions
+            "string" => CoreFunction::String(arguments.maybe_next()?.map(Box::new)),
+            "concat" => {
+                let mut args = vec![];
+                while let Some(argument) = arguments.maybe_next()? {
+                    args.push(argument);
+                }
+                CoreFunction::Concat(args)
+            },
+            "starts-with" => {
+                CoreFunction::StartsWith(Box::new(arguments.next()?), Box::new(arguments.next()?))
+            },
+            "contains" => {
+                CoreFunction::Contains(Box::new(arguments.next()?), Box::new(arguments.next()?))
+            },
+            "substring-before" => CoreFunction::SubstringBefore(
+                Box::new(arguments.next()?),
+                Box::new(arguments.next()?),
+            ),
+            "substring-after" => CoreFunction::SubstringAfter(
+                Box::new(arguments.next()?),
+                Box::new(arguments.next()?),
+            ),
+            "substring" => CoreFunction::Substring(
+                Box::new(arguments.next()?),
+                Box::new(arguments.next()?),
+                arguments.maybe_next()?.map(Box::new),
+            ),
+            "string-length" => CoreFunction::StringLength(arguments.maybe_next()?.map(Box::new)),
+            "normalize-space" => {
+                CoreFunction::NormalizeSpace(arguments.maybe_next()?.map(Box::new))
+            },
+            "translate" => CoreFunction::Translate(
+                Box::new(arguments.next()?),
+                Box::new(arguments.next()?),
+                Box::new(arguments.next()?),
+            ),
+
+            // Number Functions
+            "number" => CoreFunction::Number(arguments.maybe_next()?.map(Box::new)),
+            "sum" => CoreFunction::Sum(Box::new(arguments.next()?)),
+            "floor" => CoreFunction::Floor(Box::new(arguments.next()?)),
+            "ceiling" => CoreFunction::Ceiling(Box::new(arguments.next()?)),
+            "round" => CoreFunction::Round(Box::new(arguments.next()?)),
+
+            // Boolean Functions
+            "boolean" => CoreFunction::Boolean(Box::new(arguments.next()?)),
+            "not" => CoreFunction::Not(Box::new(arguments.next()?)),
+            "true" => CoreFunction::True,
+            "false" => CoreFunction::False,
+            "lang" => CoreFunction::Lang(Box::new(arguments.next()?)),
+
+            // Unknown function
+            _ => return Err(Error::UnknownFunction),
+        };
+
+        // Ensure that there are no more arguments left
+        if !arguments.done {
+            return Err(Error::TooManyFunctionArguments);
+        }
+
+        Ok(Expression::Function(core_fn))
+    }
 }
 
-fn predicate_list(input: &str) -> IResult<&str, PredicateListExpression> {
-    let (input, predicates) = many0(predicate).parse(input)?;
-
-    Ok((input, PredicateListExpression { predicates }))
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-Predicate>
-fn predicate(input: &str) -> IResult<&str, Expression> {
-    let (input, expr) = delimited(ws(char('[')), expr, ws(char(']'))).parse(input)?;
-    Ok((input, expr))
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-PrimaryExpr>
-fn primary_expr(input: &str) -> IResult<&str, Expression> {
-    alt((
-        literal,
-        var_ref,
-        parenthesized_expr,
-        context_item_expr,
-        function_call,
-    ))
-    .parse(input)
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-Literal>
-fn literal(input: &str) -> IResult<&str, Expression> {
-    map(alt((numeric_literal, string_literal)), |lit| {
-        Expression::Literal(lit)
-    })
-    .parse(input)
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-Number>
-fn numeric_literal(input: &str) -> IResult<&str, Literal> {
-    alt((decimal_literal, integer_literal)).parse(input)
-}
-
-/// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-VariableReference>
-fn var_ref(input: &str) -> IResult<&str, Expression> {
-    let (input, _) = char('$').parse(input)?;
-    let (input, name) = qname(input)?;
-    Ok((input, Expression::Variable(name)))
-}
-
-fn parenthesized_expr(input: &str) -> IResult<&str, Expression> {
-    delimited(ws(char('(')), expr, ws(char(')'))).parse(input)
-}
-
-fn context_item_expr(input: &str) -> IResult<&str, Expression> {
-    map(char('.'), |_| Expression::ContextItem).parse(input)
-}
-
-fn function_call(input: &str) -> IResult<&str, Expression> {
-    let (input, name) = qname(input)?;
-    let (input, args) = delimited(
-        ws(char('(')),
-        separated_list0(ws(char(',')), expr_single),
-        ws(char(')')),
-    )
-    .parse(input)?;
-
-    // Helper to create error
-    let arity_error = || nom::Err::Error(NomError::new(input, NomErrorKind::Verify));
-
-    let core_fn = match name.local_part.as_str() {
-        // Node Set Functions
-        "last" => CoreFunction::Last,
-        "position" => CoreFunction::Position,
-        "count" => CoreFunction::Count(Box::new(args.into_iter().next().ok_or_else(arity_error)?)),
-        "id" => CoreFunction::Id(Box::new(args.into_iter().next().ok_or_else(arity_error)?)),
-        "local-name" => CoreFunction::LocalName(args.into_iter().next().map(Box::new)),
-        "namespace-uri" => CoreFunction::NamespaceUri(args.into_iter().next().map(Box::new)),
-        "name" => CoreFunction::Name(args.into_iter().next().map(Box::new)),
-
-        // String Functions
-        "string" => CoreFunction::String(args.into_iter().next().map(Box::new)),
-        "concat" => CoreFunction::Concat(args.into_iter().collect()),
-        "starts-with" => {
-            let mut args = args.into_iter();
-            CoreFunction::StartsWith(
-                Box::new(args.next().ok_or_else(arity_error)?),
-                Box::new(args.next().ok_or_else(arity_error)?),
-            )
-        },
-        "contains" => {
-            let mut args = args.into_iter();
-            CoreFunction::Contains(
-                Box::new(args.next().ok_or_else(arity_error)?),
-                Box::new(args.next().ok_or_else(arity_error)?),
-            )
-        },
-        "substring-before" => {
-            let mut args = args.into_iter();
-            CoreFunction::SubstringBefore(
-                Box::new(args.next().ok_or_else(arity_error)?),
-                Box::new(args.next().ok_or_else(arity_error)?),
-            )
-        },
-        "substring-after" => {
-            let mut args = args.into_iter();
-            CoreFunction::SubstringAfter(
-                Box::new(args.next().ok_or_else(arity_error)?),
-                Box::new(args.next().ok_or_else(arity_error)?),
-            )
-        },
-        "substring" => {
-            let mut args = args.into_iter();
-            CoreFunction::Substring(
-                Box::new(args.next().ok_or_else(arity_error)?),
-                Box::new(args.next().ok_or_else(arity_error)?),
-                args.next().map(Box::new),
-            )
-        },
-        "string-length" => CoreFunction::StringLength(args.into_iter().next().map(Box::new)),
-        "normalize-space" => CoreFunction::NormalizeSpace(args.into_iter().next().map(Box::new)),
-        "translate" => {
-            let mut args = args.into_iter();
-            CoreFunction::Translate(
-                Box::new(args.next().ok_or_else(arity_error)?),
-                Box::new(args.next().ok_or_else(arity_error)?),
-                Box::new(args.next().ok_or_else(arity_error)?),
-            )
-        },
-
-        // Number Functions
-        "number" => CoreFunction::Number(args.into_iter().next().map(Box::new)),
-        "sum" => CoreFunction::Sum(Box::new(args.into_iter().next().ok_or_else(arity_error)?)),
-        "floor" => CoreFunction::Floor(Box::new(args.into_iter().next().ok_or_else(arity_error)?)),
-        "ceiling" => {
-            CoreFunction::Ceiling(Box::new(args.into_iter().next().ok_or_else(arity_error)?))
-        },
-        "round" => CoreFunction::Round(Box::new(args.into_iter().next().ok_or_else(arity_error)?)),
-
-        // Boolean Functions
-        "boolean" => {
-            CoreFunction::Boolean(Box::new(args.into_iter().next().ok_or_else(arity_error)?))
-        },
-        "not" => CoreFunction::Not(Box::new(args.into_iter().next().ok_or_else(arity_error)?)),
-        "true" => CoreFunction::True,
-        "false" => CoreFunction::False,
-        "lang" => CoreFunction::Lang(Box::new(args.into_iter().next().ok_or_else(arity_error)?)),
-
-        // Unknown function
-        _ => return Err(nom::Err::Error(NomError::new(input, NomErrorKind::Verify))),
+fn create_binary_expression(
+    lhs: Box<Expression>,
+    operator: OperatorToken,
+    rhs: Box<Expression>,
+) -> Expression {
+    let binary_operator = match operator {
+        OperatorToken::And => BinaryOperator::And,
+        OperatorToken::Or => BinaryOperator::Or,
+        OperatorToken::Multiply => BinaryOperator::Multiply,
+        OperatorToken::Divide => BinaryOperator::Divide,
+        OperatorToken::Modulo => BinaryOperator::Modulo,
+        OperatorToken::Add => BinaryOperator::Add,
+        OperatorToken::Subtract => BinaryOperator::Subtract,
+        OperatorToken::Equal => BinaryOperator::Equal,
+        OperatorToken::NotEqual => BinaryOperator::NotEqual,
+        OperatorToken::GreaterThan => BinaryOperator::GreaterThan,
+        OperatorToken::GreaterThanOrEqual => BinaryOperator::GreaterThanOrEqual,
+        OperatorToken::LessThan => BinaryOperator::LessThan,
+        OperatorToken::LessThanOrEqual => BinaryOperator::LessThanOrEqual,
     };
 
-    Ok((input, Expression::Function(core_fn)))
+    Expression::Binary(lhs, binary_operator, rhs)
 }
 
-fn kind_test(input: &str) -> IResult<&str, KindTest> {
-    alt((pi_test, comment_test, text_test, any_kind_test)).parse(input)
-}
-
-fn any_kind_test(input: &str) -> IResult<&str, KindTest> {
-    map((tag("node"), ws(char('(')), ws(char(')'))), |_| {
-        KindTest::Node
-    })
-    .parse(input)
-}
-
-fn text_test(input: &str) -> IResult<&str, KindTest> {
-    map((tag("text"), ws(char('(')), ws(char(')'))), |_| {
-        KindTest::Text
-    })
-    .parse(input)
-}
-
-fn comment_test(input: &str) -> IResult<&str, KindTest> {
-    map((tag("comment"), ws(char('(')), ws(char(')'))), |_| {
-        KindTest::Comment
-    })
-    .parse(input)
-}
-
-fn pi_test(input: &str) -> IResult<&str, KindTest> {
-    map(
-        (
-            tag("processing-instruction"),
-            ws(char('(')),
-            opt(ws(string_literal)),
-            ws(char(')')),
-        ),
-        |(_, _, literal, _)| {
-            KindTest::PI(literal.map(|l| match l {
-                Literal::String(s) => s,
-                _ => unreachable!(),
-            }))
-        },
-    )
-    .parse(input)
-}
-
-fn ws<'a, F, O, E>(inner: F) -> impl Parser<&'a str, Output = O, Error = E>
-where
-    E: NomParseError<&'a str>,
-    F: Parser<&'a str, Output = O, Error = E>,
-{
-    delimited(multispace0, inner, multispace0)
-}
-
-fn integer_literal(input: &str) -> IResult<&str, Literal> {
-    map(recognize((opt(char('-')), digit1)), |s: &str| {
-        Literal::Integer(s.parse().unwrap())
-    })
-    .parse(input)
-}
-
-fn decimal_literal(input: &str) -> IResult<&str, Literal> {
-    map(
-        recognize((opt(char('-')), opt(digit1), char('.'), digit1)),
-        |s: &str| Literal::Decimal(s.parse().unwrap()),
-    )
-    .parse(input)
-}
-
-fn string_literal(input: &str) -> IResult<&str, Literal> {
-    alt((
-        delimited(
-            char('"'),
-            map(take_while1(|c| c != '"'), |s: &str| {
-                Literal::String(s.to_string())
-            }),
-            char('"'),
-        ),
-        delimited(
-            char('\''),
-            map(take_while1(|c| c != '\''), |s: &str| {
-                Literal::String(s.to_string())
-            }),
-            char('\''),
-        ),
-    ))
-    .parse(input)
-}
-
-/// <https://www.w3.org/TR/REC-xml-names/#NT-QName>
-fn qname(input: &str) -> IResult<&str, QName> {
-    let (input, prefix) = opt((ncname, char(':'))).parse(input)?;
-    let (input, local) = ncname(input)?;
-
-    Ok((
-        input,
-        QName {
-            prefix: prefix.map(|(p, _)| p.to_string()),
-            local_part: local.to_string(),
-        },
-    ))
-}
-
-/// <https://www.w3.org/TR/REC-xml-names/#NT-NCName>
-fn ncname(input: &str) -> IResult<&str, &str> {
-    fn name_start_character<T, E: NomParseError<T>>(input: T) -> IResult<T, T, E>
-    where
-        T: Input,
-        <T as Input>::Item: AsChar,
-    {
-        input.split_at_position1_complete(
-            |character| !is_valid_start(character.as_char()) || character.as_char() == ':',
-            NomErrorKind::OneOf,
-        )
+impl<'a> From<LiteralToken<'a>> for Literal {
+    fn from(value: LiteralToken<'a>) -> Self {
+        match value {
+            LiteralToken::Integer(integer) => Self::Integer(integer),
+            LiteralToken::Decimal(float) => Self::Decimal(float),
+            LiteralToken::String(string) => Self::String(string.to_owned()),
+        }
     }
-
-    fn name_character<T, E: NomParseError<T>>(input: T) -> IResult<T, T, E>
-    where
-        T: Input,
-        <T as Input>::Item: AsChar,
-    {
-        input.split_at_position1_complete(
-            |character| !is_valid_continuation(character.as_char()) || character.as_char() == ':',
-            NomErrorKind::OneOf,
-        )
-    }
-
-    recognize(pair(name_start_character, many0(name_character))).parse(input)
 }
 
 // Test functions to verify the parsers:
 #[cfg(test)]
 mod tests {
+    use markup5ever::{LocalName, QualName, local_name, namespace_prefix, ns};
+
     use super::*;
+    use crate::NamespaceResolver;
 
-    #[test]
-    fn test_node_tests() {
-        let cases = vec![
-            ("node()", NodeTest::Kind(KindTest::Node)),
-            ("text()", NodeTest::Kind(KindTest::Text)),
-            ("comment()", NodeTest::Kind(KindTest::Comment)),
-            (
-                "processing-instruction()",
-                NodeTest::Kind(KindTest::PI(None)),
-            ),
-            (
-                "processing-instruction('test')",
-                NodeTest::Kind(KindTest::PI(Some("test".to_string()))),
-            ),
-            ("*", NodeTest::Wildcard),
-            (
-                "prefix:*",
-                NodeTest::Name(QName {
-                    prefix: Some("prefix".to_string()),
-                    local_part: "*".to_string(),
-                }),
-            ),
-            (
-                "div",
-                NodeTest::Name(QName {
-                    prefix: None,
-                    local_part: "div".to_string(),
-                }),
-            ),
-            (
-                "ns:div",
-                NodeTest::Name(QName {
-                    prefix: Some("ns".to_string()),
-                    local_part: "div".to_string(),
-                }),
-            ),
-        ];
+    #[derive(Clone)]
+    struct DummyNamespaceResolver;
 
-        for (input, expected) in cases {
-            match node_test(input) {
-                Ok((remaining, result)) => {
-                    assert!(remaining.is_empty(), "Parser didn't consume all input");
-                    assert_eq!(result, expected, "{:?} was parsed incorrectly", input);
-                },
-                Err(e) => panic!("Failed to parse '{}': {:?}", input, e),
-            }
+    impl NamespaceResolver<()> for DummyNamespaceResolver {
+        fn resolve_namespace_prefix(&self, _: Option<&str>) -> Result<Option<String>, ()> {
+            Ok(Some("http://www.w3.org/1999/xhtml".to_owned()))
         }
     }
 
@@ -755,7 +631,7 @@ mod tests {
         ];
 
         for (input, expected) in cases {
-            match parse(input) {
+            match parse(input, Some(DummyNamespaceResolver)) {
                 Ok(result) => {
                     assert_eq!(result, expected, "{:?} was parsed incorrectly", input);
                 },
@@ -773,15 +649,16 @@ mod tests {
                     is_absolute: true,
                     has_implicit_descendant_or_self_step: true,
                     steps: vec![Expression::LocationStep(LocationStepExpression {
-                        axis: Axis::DescendantOrSelf,
+                        axis: Axis::Child,
                         node_test: NodeTest::Wildcard,
                         predicate_list: PredicateListExpression {
                             predicates: vec![Expression::Function(CoreFunction::Contains(
                                 Box::new(Expression::LocationStep(LocationStepExpression {
                                     axis: Axis::Attribute,
-                                    node_test: NodeTest::Name(QName {
+                                    node_test: NodeTest::Name(QualName {
                                         prefix: None,
-                                        local_part: "class".to_owned(),
+                                        ns: ns!(),
+                                        local: local_name!("class"),
                                     }),
                                     predicate_list: PredicateListExpression { predicates: vec![] },
                                 })),
@@ -798,10 +675,11 @@ mod tests {
                     has_implicit_descendant_or_self_step: true,
                     steps: vec![
                         Expression::LocationStep(LocationStepExpression {
-                            axis: Axis::DescendantOrSelf,
-                            node_test: NodeTest::Name(QName {
+                            axis: Axis::Child,
+                            node_test: NodeTest::Name(QualName {
                                 prefix: None,
-                                local_part: "div".to_owned(),
+                                ns: ns!(),
+                                local: local_name!("div"),
                             }),
                             predicate_list: PredicateListExpression {
                                 predicates: vec![Expression::Binary(
@@ -828,18 +706,20 @@ mod tests {
                     has_implicit_descendant_or_self_step: true,
                     steps: vec![
                         Expression::LocationStep(LocationStepExpression {
-                            axis: Axis::DescendantOrSelf,
-                            node_test: NodeTest::Name(QName {
+                            axis: Axis::Child,
+                            node_test: NodeTest::Name(QualName {
                                 prefix: None,
-                                local_part: "mu".to_owned(),
+                                ns: ns!(),
+                                local: LocalName::from("mu"),
                             }),
                             predicate_list: PredicateListExpression {
                                 predicates: vec![Expression::Binary(
                                     Box::new(Expression::LocationStep(LocationStepExpression {
                                         axis: Axis::Attribute,
-                                        node_test: NodeTest::Name(QName {
-                                            prefix: Some("xml".to_owned()),
-                                            local_part: "id".to_owned(),
+                                        node_test: NodeTest::Name(QualName {
+                                            prefix: Some(namespace_prefix!("xml")),
+                                            ns: ns!(html),
+                                            local: local_name!("id"),
                                         }),
                                         predicate_list: PredicateListExpression {
                                             predicates: vec![],
@@ -859,17 +739,19 @@ mod tests {
                         }),
                         Expression::LocationStep(LocationStepExpression {
                             axis: Axis::Child,
-                            node_test: NodeTest::Name(QName {
+                            node_test: NodeTest::Name(QualName {
                                 prefix: None,
-                                local_part: "rho".to_owned(),
+                                ns: ns!(),
+                                local: LocalName::from("rho"),
                             }),
                             predicate_list: PredicateListExpression {
                                 predicates: vec![
                                     Expression::LocationStep(LocationStepExpression {
                                         axis: Axis::Attribute,
-                                        node_test: NodeTest::Name(QName {
+                                        node_test: NodeTest::Name(QualName {
                                             prefix: None,
-                                            local_part: "title".to_owned(),
+                                            ns: ns!(),
+                                            local: local_name!("title"),
                                         }),
                                         predicate_list: PredicateListExpression {
                                             predicates: vec![],
@@ -879,9 +761,10 @@ mod tests {
                                         Box::new(Expression::LocationStep(
                                             LocationStepExpression {
                                                 axis: Axis::Attribute,
-                                                node_test: NodeTest::Name(QName {
-                                                    prefix: Some("xml".to_owned()),
-                                                    local_part: "lang".to_owned(),
+                                                node_test: NodeTest::Name(QualName {
+                                                    prefix: Some(namespace_prefix!("xml")),
+                                                    ns: ns!(html),
+                                                    local: local_name!("lang"),
                                                 }),
                                                 predicate_list: PredicateListExpression {
                                                     predicates: vec![],
@@ -902,12 +785,43 @@ mod tests {
         ];
 
         for (input, expected) in cases {
-            match parse(input) {
+            match parse(input, Some(DummyNamespaceResolver)) {
                 Ok(result) => {
                     assert_eq!(result, expected, "{:?} was parsed incorrectly", input);
                 },
                 Err(e) => panic!("Failed to parse '{}': {:?}", input, e),
             }
+        }
+    }
+
+    #[test]
+    fn parse_expression_in_parenthesis() {
+        let test_case = "(./span)";
+        let expected = Expression::Path(PathExpression {
+            is_absolute: false,
+            has_implicit_descendant_or_self_step: false,
+            steps: vec![
+                Expression::LocationStep(LocationStepExpression {
+                    axis: Axis::Self_,
+                    node_test: NodeTest::Kind(KindTest::Node),
+                    predicate_list: PredicateListExpression { predicates: vec![] },
+                }),
+                Expression::LocationStep(LocationStepExpression {
+                    axis: Axis::Child,
+                    node_test: NodeTest::Name(QualName {
+                        prefix: None,
+                        ns: ns!(),
+                        local: local_name!("span"),
+                    }),
+                    predicate_list: PredicateListExpression { predicates: vec![] },
+                }),
+            ],
+        });
+        match parse(test_case, Some(DummyNamespaceResolver)) {
+            Ok(result) => {
+                assert_eq!(result, expected, "{:?} was parsed incorrectly", test_case);
+            },
+            Err(e) => panic!("Failed to parse '{}': {:?}", test_case, e),
         }
     }
 }

--- a/components/xpath/src/parser.rs
+++ b/components/xpath/src/parser.rs
@@ -359,11 +359,7 @@ where
             } else {
                 let namespace = name_token
                     .prefix
-                    .map(|prefix| {
-                        self.resolve_qualified_name(prefix)
-                            .inspect_err(|e| println!("{e:?}"))
-                            .map_err(Error::JsError)
-                    })
+                    .map(|prefix| self.resolve_qualified_name(prefix).map_err(Error::JsError))
                     .transpose()?
                     .flatten();
 

--- a/components/xpath/src/tokenizer.rs
+++ b/components/xpath/src/tokenizer.rs
@@ -1,0 +1,557 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::{is_valid_continuation, is_valid_start};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// A variable reference (like `$foo`) failed to parse.
+    InvalidVariableReference,
+    InvalidNCName,
+    ExpectedOperator,
+    UnterminatedStringLiteral,
+    IllegalCharacter,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CNameToken<'a> {
+    pub(crate) prefix: Option<&'a str>,
+    pub(crate) local_name: &'a str,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OperatorToken {
+    And,
+    Or,
+    Multiply,
+    Modulo,
+    Divide,
+    Add,
+    Subtract,
+    LessThan,
+    LessThanOrEqual,
+    GreaterThan,
+    GreaterThanOrEqual,
+    Equal,
+    NotEqual,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum LiteralToken<'a> {
+    Integer(i64),
+    Decimal(f64),
+    String(&'a str),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum Token<'a> {
+    VariableReference(&'a str),
+    CName(CNameToken<'a>),
+    Operator(OperatorToken),
+    Literal(LiteralToken<'a>),
+    /// e.g. `child::`
+    AxisIdentifier(&'a str),
+    /// `..`
+    ParentNode,
+    /// `.`
+    SelfNode,
+    /// `/`
+    Parent,
+    /// `//`
+    Ancestor,
+    /// `foo(`
+    FunctionCall(&'a str),
+    /// `(`
+    OpeningParenthesis,
+    /// `)`
+    ClosingParenthesis,
+    /// `[`
+    OpeningBracket,
+    /// `]`
+    ClosingBracket,
+    /// `,`
+    Comma,
+    /// `@`
+    AtSign,
+    /// `processing-instruction(`
+    ProcessingInstructionTest,
+    /// `comment(`
+    CommentTest,
+    /// `node(`
+    NodeTest,
+    /// `text(`
+    TextTest,
+    /// `|`
+    Union,
+}
+
+struct Tokenizer<'a> {
+    remaining: &'a str,
+}
+
+impl<'a> Tokenizer<'a> {
+    /// If the result is `Err(_)` then `self.remaining` is unchanged.
+    fn consume_ncname(&mut self, allow_wildcard: bool) -> Result<&'a str, Error> {
+        if allow_wildcard && self.remaining.starts_with('*') {
+            self.remaining = &self.remaining[1..];
+            return Ok("*");
+        }
+
+        let mut chars = self.remaining.char_indices();
+
+        if !chars
+            .next()
+            .is_some_and(|(_, character)| is_valid_start(character) && character != ':')
+        {
+            return Err(Error::InvalidNCName);
+        }
+
+        let name_end = chars
+            .find(|(_, character)| !is_valid_continuation(*character) || *character == ':')
+            .map(|(index, _)| index)
+            .unwrap_or(self.remaining.len());
+
+        let (ncname, remaining) = self.remaining.split_at(name_end);
+        self.remaining = remaining;
+        Ok(ncname)
+    }
+
+    fn consume_single_token(&mut self, expect_operator_token: bool) -> Result<Token<'a>, Error> {
+        if self.remaining.starts_with('$') {
+            self.remaining = &self.remaining[1..];
+            let variable_name = self
+                .consume_ncname(false)
+                .map_err(|_| Error::InvalidVariableReference)?;
+            return Ok(Token::VariableReference(variable_name));
+        }
+
+        if let Ok(ncname) = self.consume_ncname(true) {
+            if expect_operator_token {
+                return match_operator_name(ncname).map(Token::Operator);
+            }
+
+            if self.remaining.starts_with(':') {
+                self.remaining = &self.remaining[1..];
+                if self.remaining.starts_with(':') {
+                    // This is an axis identifier
+                    self.remaining = &self.remaining[1..];
+                    return Ok(Token::AxisIdentifier(ncname));
+                }
+
+                // The previous name was the prefix of a qualified name (foo:bar)
+                return Ok(Token::CName(CNameToken {
+                    prefix: Some(ncname),
+                    local_name: self.consume_ncname(true)?,
+                }));
+            } else if self.remaining.starts_with('(') {
+                self.remaining = &self.remaining[1..];
+                let token = match ncname {
+                    "processing-instruction" => Token::ProcessingInstructionTest,
+                    "node" => Token::NodeTest,
+                    "text" => Token::TextTest,
+                    "comment" => Token::CommentTest,
+                    _ => Token::FunctionCall(ncname),
+                };
+                return Ok(token);
+            } else {
+                return Ok(Token::CName(CNameToken {
+                    prefix: None,
+                    local_name: ncname,
+                }));
+            }
+        }
+
+        match self.remaining.chars().next().unwrap() {
+            '0'..='9' => {
+                let number = self.consume_numeric_literal();
+                Ok(Token::Literal(number))
+            },
+            '\'' | '"' => {
+                let string = self.consume_string_literal()?;
+                Ok(Token::Literal(LiteralToken::String(string)))
+            },
+            '.' => {
+                // This is tricky: A period can either be
+                // the parent node (".."), a numeric literal (".123") or
+                // self-node (".").
+                match self.remaining.chars().nth(1) {
+                    Some('0'..='9') => Ok(Token::Literal(self.consume_numeric_literal())),
+                    Some('.') => {
+                        self.remaining = &self.remaining[2..];
+                        Ok(Token::ParentNode)
+                    },
+                    _ => {
+                        self.remaining = &self.remaining[1..];
+                        Ok(Token::SelfNode)
+                    },
+                }
+            },
+            '/' => {
+                if self.remaining.chars().nth(1).is_some_and(|c| c == '/') {
+                    self.remaining = &self.remaining[2..];
+                    Ok(Token::Ancestor)
+                } else {
+                    self.remaining = &self.remaining[1..];
+                    Ok(Token::Parent)
+                }
+            },
+            '-' => {
+                self.remaining = &self.remaining[1..];
+                Ok(Token::Operator(OperatorToken::Subtract))
+            },
+            '(' => {
+                self.remaining = &self.remaining[1..];
+                Ok(Token::OpeningParenthesis)
+            },
+            ')' => {
+                self.remaining = &self.remaining[1..];
+                Ok(Token::ClosingParenthesis)
+            },
+            '[' => {
+                self.remaining = &self.remaining[1..];
+                Ok(Token::OpeningBracket)
+            },
+            ']' => {
+                self.remaining = &self.remaining[1..];
+                Ok(Token::ClosingBracket)
+            },
+            ',' => {
+                self.remaining = &self.remaining[1..];
+                Ok(Token::Comma)
+            },
+            '@' => {
+                self.remaining = &self.remaining[1..];
+                Ok(Token::AtSign)
+            },
+            '<' => {
+                self.remaining = &self.remaining[1..];
+                if self.remaining.starts_with('=') {
+                    self.remaining = &self.remaining[1..];
+                    Ok(Token::Operator(OperatorToken::LessThanOrEqual))
+                } else {
+                    Ok(Token::Operator(OperatorToken::LessThan))
+                }
+            },
+            '>' => {
+                self.remaining = &self.remaining[1..];
+                if self.remaining.starts_with('=') {
+                    self.remaining = &self.remaining[1..];
+                    Ok(Token::Operator(OperatorToken::GreaterThanOrEqual))
+                } else {
+                    Ok(Token::Operator(OperatorToken::GreaterThan))
+                }
+            },
+            '!' => {
+                if self.remaining.starts_with("!=") {
+                    self.remaining = &self.remaining[2..];
+                    Ok(Token::Operator(OperatorToken::NotEqual))
+                } else {
+                    Err(Error::IllegalCharacter)
+                }
+            },
+            '=' => {
+                self.remaining = &self.remaining[1..];
+                Ok(Token::Operator(OperatorToken::Equal))
+            },
+            '|' => {
+                self.remaining = &self.remaining[1..];
+                Ok(Token::Union)
+            },
+            '+' => {
+                self.remaining = &self.remaining[1..];
+                Ok(Token::Operator(OperatorToken::Add))
+            },
+            other => {
+                println!("Illegal character: {other:?}");
+                Err(Error::IllegalCharacter)
+            },
+        }
+    }
+
+    fn consume_string_literal(&mut self) -> Result<&'a str, Error> {
+        let quote_character = self.remaining.chars().next().unwrap();
+        debug_assert!(quote_character == '\'' || quote_character == '"');
+        let Some((literal, remaining)) = self.remaining[1..].split_once(quote_character) else {
+            return Err(Error::UnterminatedStringLiteral);
+        };
+        self.remaining = remaining;
+        Ok(literal)
+    }
+
+    /// <https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-Number>
+    fn consume_numeric_literal(&mut self) -> LiteralToken<'a> {
+        let mut has_period = false;
+        let mut end = self.remaining.len();
+        for (index, c) in self.remaining.char_indices() {
+            let is_first_period = !has_period && c == '.';
+            if !c.is_ascii_digit() && !is_first_period {
+                end = index;
+                break;
+            }
+
+            has_period |= c == '.';
+        }
+
+        let (mut number, remaining) = self.remaining.split_at(end);
+        debug_assert!(
+            !(number.is_empty() || number == "."),
+            "Why did we even try to parse this as a literal",
+        );
+        self.remaining = remaining;
+
+        // Treat the literal as a float iff it has a period character
+        // that is not at the very end.
+        let mut is_integer_literal = !has_period;
+        if let Some(integer_literal) = number.strip_suffix('.') {
+            number = integer_literal;
+            is_integer_literal = true;
+        };
+
+        // FIXME: When the literal is negated, use a negative number in case
+        // of a parsing error.
+        if is_integer_literal {
+            let value = number
+                .parse()
+                .inspect_err(|error| {
+                    log::warn!(
+                        "Failed to parse numeric literal ({number:?}) that looked valid: {error:?}"
+                    )
+                })
+                .unwrap_or(i64::MAX);
+            LiteralToken::Integer(value)
+        } else {
+            let value = number
+                .parse()
+                .inspect_err(|error| {
+                    log::warn!(
+                        "Failed to parse numeric literal ({number:?}) that looked valid: {error:?}"
+                    )
+                })
+                .unwrap_or(f64::NAN);
+            LiteralToken::Decimal(value)
+        }
+    }
+
+    fn skip_whitespace(&mut self) {
+        self.remaining = self
+            .remaining
+            .trim_start_matches(|c: char| c.is_ascii_whitespace());
+    }
+}
+
+fn match_operator_name(operator_name: &str) -> Result<OperatorToken, Error> {
+    let operator = match operator_name {
+        "and" => OperatorToken::And,
+        "or" => OperatorToken::Or,
+        "mod" => OperatorToken::Modulo,
+        "div" => OperatorToken::Divide,
+        "*" => OperatorToken::Multiply,
+        _ => {
+            log::debug!("Expected Operator, found {operator_name:?}");
+            return Err(Error::ExpectedOperator);
+        },
+    };
+
+    Ok(operator)
+}
+
+impl OperatorToken {
+    /// Return a handle that can be used to compare two [OperatorToken]s in terms of precedence (binding order).
+    pub(crate) fn precedence(&self) -> impl Ord {
+        match self {
+            Self::Or => 0,
+            Self::And => 1,
+            Self::Equal | Self::NotEqual => 2,
+            Self::LessThan |
+            Self::LessThanOrEqual |
+            Self::GreaterThan |
+            Self::GreaterThanOrEqual => 3,
+            Self::Add | Self::Subtract => 4,
+            Self::Multiply | Self::Divide | Self::Modulo => 5,
+        }
+    }
+}
+
+impl<'a> Token<'a> {
+    pub(crate) fn is_start_of_location_step(&self) -> bool {
+        matches!(
+            self,
+            Self::AxisIdentifier(_) |
+                Self::AtSign |
+                Self::ParentNode |
+                Self::SelfNode |
+                Self::CName(_) |
+                Self::CommentTest |
+                Self::NodeTest |
+                Self::ProcessingInstructionTest |
+                Self::TextTest
+        )
+    }
+
+    /// Used to implement the first bullet point of <https://www.w3.org/TR/1999/REC-xpath-19991116/#exprlex>.
+    fn followed_by_operator(&self) -> bool {
+        matches!(
+            self,
+            Self::Literal(_) |
+                Self::CName(_) |
+                Self::VariableReference(_) |
+                Self::ParentNode |
+                Self::SelfNode |
+                Self::ClosingBracket |
+                Self::ClosingParenthesis
+        )
+    }
+}
+
+pub(crate) fn tokenize(input: &str) -> Result<Vec<Token<'_>>, Error> {
+    let mut tokenizer = Tokenizer { remaining: input };
+    let mut tokens: Vec<Token> = vec![];
+
+    // https://www.w3.org/TR/1999/REC-xpath-19991116/#exprlex:
+    // > If there is a preceding token and the preceding token is not one of @, ::, (, [, ,
+    // > or an Operator, then a * must be recognized as a MultiplyOperator and an NCName
+    // > must be recognized as an OperatorName.
+    let mut expect_operator_token = false;
+
+    tokenizer.skip_whitespace();
+    while !tokenizer.remaining.is_empty() {
+        let token = tokenizer.consume_single_token(expect_operator_token)?;
+        tokens.push(token);
+        expect_operator_token = token.followed_by_operator();
+        tokenizer.skip_whitespace();
+    }
+
+    Ok(tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_name_without_prefix() {
+        let mut tokenizer = Tokenizer { remaining: "foo" };
+        assert_eq!(
+            tokenizer.consume_single_token(false),
+            Ok(Token::CName(CNameToken {
+                prefix: None,
+                local_name: "foo"
+            }))
+        );
+        assert!(tokenizer.remaining.is_empty());
+    }
+
+    #[test]
+    fn parse_name_with_prefix() {
+        let mut tokenizer = Tokenizer {
+            remaining: "foo:bar",
+        };
+        assert_eq!(
+            tokenizer.consume_single_token(false),
+            Ok(Token::CName(CNameToken {
+                prefix: Some("foo"),
+                local_name: "bar"
+            }))
+        );
+        assert!(tokenizer.remaining.is_empty());
+    }
+
+    #[test]
+    fn parse_name_with_wildcard_prefix() {
+        let mut tokenizer = Tokenizer { remaining: "*:bar" };
+        assert_eq!(
+            tokenizer.consume_single_token(false),
+            Ok(Token::CName(CNameToken {
+                prefix: Some("*"),
+                local_name: "bar"
+            }))
+        );
+        assert!(tokenizer.remaining.is_empty());
+    }
+
+    #[test]
+    fn parse_name_with_wildcard_local_name() {
+        let mut tokenizer = Tokenizer { remaining: "*" };
+        assert_eq!(
+            tokenizer.consume_single_token(false),
+            Ok(Token::CName(CNameToken {
+                prefix: None,
+                local_name: "*"
+            }))
+        );
+        assert!(tokenizer.remaining.is_empty());
+    }
+
+    #[test]
+    fn parse_variable_reference() {
+        let mut tokenizer = Tokenizer {
+            remaining: "$servo",
+        };
+        assert_eq!(
+            tokenizer.consume_single_token(false),
+            Ok(Token::VariableReference("servo"))
+        );
+        assert!(tokenizer.remaining.is_empty());
+    }
+
+    #[test]
+    fn parse_floating_point_literal() {
+        let mut tokenizer = Tokenizer { remaining: "13.5" };
+        assert_eq!(
+            tokenizer.consume_numeric_literal(),
+            LiteralToken::Decimal(13.5)
+        );
+        assert!(tokenizer.remaining.is_empty());
+    }
+
+    #[test]
+    fn parse_floating_point_literal_without_leading_digit() {
+        let mut tokenizer = Tokenizer { remaining: ".42" };
+        assert_eq!(
+            tokenizer.consume_numeric_literal(),
+            LiteralToken::Decimal(0.42)
+        );
+        assert!(tokenizer.remaining.is_empty());
+    }
+
+    #[test]
+    fn parse_floating_point_literal_that_can_be_optimized_to_integer_literal() {
+        let mut tokenizer = Tokenizer { remaining: "42." };
+        assert_eq!(
+            tokenizer.consume_numeric_literal(),
+            LiteralToken::Integer(42)
+        );
+        assert!(tokenizer.remaining.is_empty());
+    }
+
+    #[test]
+    fn parse_integer_literal() {
+        let mut tokenizer = Tokenizer { remaining: "12" };
+        assert_eq!(
+            tokenizer.consume_numeric_literal(),
+            LiteralToken::Integer(12)
+        );
+        assert!(tokenizer.remaining.is_empty());
+    }
+
+    #[test]
+    fn parse_function_name() {
+        let mut tokenizer = Tokenizer { remaining: "foo(" };
+        assert_eq!(
+            tokenizer.consume_single_token(false),
+            Ok(Token::FunctionCall("foo"))
+        );
+        assert!(tokenizer.remaining.is_empty());
+    }
+
+    #[test]
+    fn parse_axis_identifier() {
+        let mut tokenizer = Tokenizer { remaining: "foo::" };
+        assert_eq!(
+            tokenizer.consume_single_token(false),
+            Ok(Token::AxisIdentifier("foo"))
+        );
+        assert!(tokenizer.remaining.is_empty());
+    }
+}

--- a/components/xpath/src/tokenizer.rs
+++ b/components/xpath/src/tokenizer.rs
@@ -117,6 +117,10 @@ impl<'a> Tokenizer<'a> {
         Ok(ncname)
     }
 
+    /// Parses a single token from the beginning and updates the remaining input accordingly.
+    ///
+    /// ## Panics
+    /// Panics when the remaining input is empty.
     fn consume_single_token(&mut self, expect_operator_token: bool) -> Result<Token<'a>, Error> {
         if self.remaining.starts_with('$') {
             self.remaining = &self.remaining[1..];
@@ -162,7 +166,12 @@ impl<'a> Tokenizer<'a> {
             }
         }
 
-        match self.remaining.chars().next().unwrap() {
+        match self
+            .remaining
+            .chars()
+            .next()
+            .expect("consume_single_token called with empty input")
+        {
             '0'..='9' => {
                 let number = self.consume_numeric_literal();
                 Ok(Token::Literal(number))
@@ -263,7 +272,7 @@ impl<'a> Tokenizer<'a> {
                 Ok(Token::Operator(OperatorToken::Add))
             },
             other => {
-                println!("Illegal character: {other:?}");
+                log::debug!("Illegal character: {other:?}");
                 Err(Error::IllegalCharacter)
             },
         }

--- a/tests/wpt/meta/domxpath/document.tentative.html.ini
+++ b/tests/wpt/meta/domxpath/document.tentative.html.ini
@@ -1,3 +1,0 @@
-[document.tentative.html]
-  [XPath parent of documentElement]
-    expected: FAIL

--- a/tests/wpt/meta/domxpath/resolver-callback-interface.html.ini
+++ b/tests/wpt/meta/domxpath/resolver-callback-interface.html.ini
@@ -1,20 +1,5 @@
 [resolver-callback-interface.html]
-  [callable resolver]
-    expected: FAIL
-
-  [callable resolver: result is not cached]
-    expected: FAIL
-
   [callable resolver: abrupt completion from Call]
-    expected: FAIL
-
-  [callable resolver: no 'lookupNamespaceURI' lookups]
-    expected: FAIL
-
-  [object resolver]
-    expected: FAIL
-
-  [object resolver: 'lookupNamespaceURI' is not cached]
     expected: FAIL
 
   [object resolver: abrupt completion from Get]

--- a/tests/wpt/meta/domxpath/resolver-non-string-result.html.ini
+++ b/tests/wpt/meta/domxpath/resolver-non-string-result.html.ini
@@ -5,12 +5,6 @@
   [null]
     expected: FAIL
 
-  [number]
-    expected: FAIL
-
-  [boolean]
-    expected: FAIL
-
   [symbol]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/find_element_from_element/find.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/find_element_from_element/find.py.ini
@@ -1,9 +1,3 @@
 [find.py]
   [test_no_browsing_context]
     expected: FAIL
-
-  [test_parent_htmldocument]
-    expected: FAIL
-
-  [test_parent_of_document_node_errors]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/find_elements_from_element/find.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/find_elements_from_element/find.py.ini
@@ -1,9 +1,3 @@
 [find.py]
   [test_no_browsing_context]
     expected: FAIL
-
-  [test_parent_htmldocument]
-    expected: FAIL
-
-  [test_parent_of_document_node_errors]
-    expected: FAIL


### PR DESCRIPTION
The new parser is more verbose, but also more correct and easier to reason about. Apologies for the size of the change, I don't think there's an alternative to swapping out the entire parser at once.

Testing: Covered by existing tests, new tests also start to pass
Fixes https://github.com/servo/servo/issues/38552
Fixes https://github.com/servo/servo/issues/38553
Fixes https://github.com/servo/servo/issues/39596
Closes https://github.com/servo/servo/issues/39602
Part of https://github.com/servo/servo/issues/34527
