### PR TITLE
Fix nightly upload with arm64

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,6 +72,7 @@ jobs:
       - upload-linux
       - upload-win
       - upload-mac
+      - upload-mac-arm64
       - upload-android
       - upload-ohos
 


### PR DESCRIPTION
Changes the asset name on github releases to include the platform. We map the default platform name (e.g. linux) to something closer to the target triple (x86_64-linux-gnu), since the architecture and env are important details.
This allows uploading more than one artifact per OS, which is important for macos nightlies now.

We additionally continue uploading the artifacts under the old name, which effectively duplicates assets, to keep the asset name stable during a transition period. This is useful for easily bisecting servo using release assets, without needing to consider name changes.

Testing: Tested by manually triggering a release workflow
Fixes: #39973
