### PR TITLE
mach: Android: Support custom profiles

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -77,7 +77,7 @@ class BuildType:
         return self.kind == BuildType.Kind.RELEASE
 
     def is_prod(self) -> bool:
-        return self.kind == BuildType.Kind.CUSTOM and self.profile == "production"
+        return self.is_custom() and (self.profile == "production" or self.profile == "production-stripped")
 
     def is_custom(self) -> bool:
         return self.kind == BuildType.Kind.CUSTOM

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -77,7 +77,7 @@ class BuildType:
         return self.kind == BuildType.Kind.RELEASE
 
     def is_prod(self) -> bool:
-        return self.is_custom() and (self.profile == "production" or self.profile == "production-stripped")
+        return self.is_custom() and (self.profile in ["production", "production-stripped"])
 
     def is_custom(self) -> bool:
         return self.kind == BuildType.Kind.CUSTOM

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -136,10 +136,14 @@ class PackageCommands(CommandBase):
 
             if build_type.is_dev():
                 build_type_string = "Debug"
-            elif build_type.is_release():
+            elif build_type.is_release() or build_type.is_prod():
                 build_type_string = "Release"
             else:
-                raise Exception("TODO what should this be?")
+                print(f"Servo was built with custom cargo profile `{build_type.profile}`.")
+                print("Using Debug build for gradle.")
+                build_type_string = "Debug"
+            # Inform the android build of where `libservoshell.so` is located.
+            env["SERVO_TARGET_DIR"] = target_dir
 
             flavor_name = "Basic"
             if flavor is not None:

--- a/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
+++ b/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
@@ -17,7 +17,7 @@ fun Project.getNativeTargetDir(debug: Boolean, arch: String): String {
     val basePath = project.rootDir.parentFile.parentFile.parentFile.absolutePath
     val fallback = basePath + "/target/" + getSubTargetDir(debug, arch)
     // Prefer the value provided by `mach`, which supports custom cargo profiles.
-    // The Fallback is for packaging in Android studio, after a mach build (only debug / release).
+    // The fallback is for packaging in Android studio, after a mach build (only debug / release).
     val target_dir = System.getenv("SERVO_TARGET_DIR") ?: fallback
     return target_dir
 }

--- a/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
+++ b/support/android/apk/buildSrc/src/main/kotlin/Interop.kt
@@ -15,7 +15,11 @@ fun Project.getTargetDir(debug: Boolean, arch: String): String {
 
 fun Project.getNativeTargetDir(debug: Boolean, arch: String): String {
     val basePath = project.rootDir.parentFile.parentFile.parentFile.absolutePath
-    return basePath + "/target/" + getSubTargetDir(debug, arch)
+    val fallback = basePath + "/target/" + getSubTargetDir(debug, arch)
+    // Prefer the value provided by `mach`, which supports custom cargo profiles.
+    // The Fallback is for packaging in Android studio, after a mach build (only debug / release).
+    val target_dir = System.getenv("SERVO_TARGET_DIR") ?: fallback
+    return target_dir
 }
 
 fun getSubTargetDir(debug: Boolean, arch: String): String {


### PR DESCRIPTION
Use Release mode for gradle for production builds and Debug for any other builds.
This fixes an exception when building for android with a custom cargo profile.
`SERVO_TARGET_DIR` is read in `apk/jni/Android.mk` and specifies the folder 
libservoshell.so is expected to be in.

Testing: Tested manually with `./mach build --android --production`
Fixes: #34564