### PR TITLE
script: Use InputEvent for input events

### DIFF
--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -14,7 +14,9 @@ use crate::dom::bindings::error::Fallible;
 use crate::dom::bindings::reflector::reflect_dom_object_with_proto;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
+use crate::dom::datatransfer::DataTransfer;
 use crate::dom::node::Node;
+use crate::dom::staticrange::StaticRange;
 use crate::dom::uievent::UIEvent;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
@@ -24,11 +26,12 @@ pub(crate) struct InputEvent {
     uievent: UIEvent,
     data: Option<DOMString>,
     is_composing: bool,
+    input_type: DOMString,
 }
 
 impl InputEvent {
     #[allow(clippy::too_many_arguments)]
-    fn new(
+    pub(crate) fn new(
         window: &Window,
         proto: Option<HandleObject>,
         type_: DOMString,
@@ -38,6 +41,7 @@ impl InputEvent {
         detail: i32,
         data: Option<DOMString>,
         is_composing: bool,
+        input_type: DOMString,
         can_gc: CanGc,
     ) -> DomRoot<InputEvent> {
         let ev = reflect_dom_object_with_proto(
@@ -45,6 +49,7 @@ impl InputEvent {
                 uievent: UIEvent::new_inherited(),
                 data,
                 is_composing,
+                input_type,
             }),
             window,
             proto,
@@ -75,6 +80,7 @@ impl InputEventMethods<crate::DomTypeHolder> for InputEvent {
             init.parent.detail,
             init.data.clone(),
             init.isComposing,
+            init.inputType.clone(),
             can_gc,
         );
         Ok(event)
@@ -88,6 +94,23 @@ impl InputEventMethods<crate::DomTypeHolder> for InputEvent {
     /// <https://w3c.github.io/uievents/#dom-inputevent-iscomposing>
     fn IsComposing(&self) -> bool {
         self.is_composing
+    }
+
+    // https://w3c.github.io/uievents/#dom-inputevent-inputtype
+    fn InputType(&self) -> DOMString {
+        self.input_type.clone()
+    }
+
+    // https://w3c.github.io/input-events/#dom-inputevent-datatransfer
+    // TODO: Populate dataTransfer for contenteditable
+    fn GetDataTransfer(&self) -> Option<DomRoot<DataTransfer>> {
+        None
+    }
+
+    // https://w3c.github.io/input-events/#dom-inputevent-gettargetranges
+    // TODO: Populate targetRanges for contenteditable
+    fn GetTargetRanges(&self) -> Vec<DomRoot<StaticRange>> {
+        Vec::new()
     }
 
     /// <https://dom.spec.whatwg.org/#dom-event-istrusted>

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -96,20 +96,20 @@ impl InputEventMethods<crate::DomTypeHolder> for InputEvent {
         self.is_composing
     }
 
-    // https://w3c.github.io/uievents/#dom-inputevent-inputtype
+    /// <https://w3c.github.io/uievents/#dom-inputevent-inputtype>
     fn InputType(&self) -> DOMString {
         self.input_type.clone()
     }
 
-    // https://w3c.github.io/input-events/#dom-inputevent-datatransfer
-    // TODO: Populate dataTransfer for contenteditable
+    /// <https://w3c.github.io/input-events/#dom-inputevent-datatransfer>
     fn GetDataTransfer(&self) -> Option<DomRoot<DataTransfer>> {
+        // TODO: Populate dataTransfer for contenteditable
         None
     }
 
-    // https://w3c.github.io/input-events/#dom-inputevent-gettargetranges
-    // TODO: Populate targetRanges for contenteditable
+    /// <https://w3c.github.io/input-events/#dom-inputevent-gettargetranges>
     fn GetTargetRanges(&self) -> Vec<DomRoot<StaticRange>> {
+        // TODO: Populate targetRanges for contenteditable
         Vec::new()
     }
 

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -1028,7 +1028,11 @@ impl<T: ClipboardProvider> TextInput<T> {
                         InputType::InsertFromPaste,
                     )
                 } else {
-                    KeyReaction::DispatchInput(None, IsComposing::NotComposing, InputType::Nothing)
+                    KeyReaction::DispatchInput(
+                        Some("".to_string()),
+                        IsComposing::NotComposing,
+                        InputType::InsertFromPaste,
+                    )
                 }
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::Delete), || {
@@ -1150,7 +1154,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                 if matches!(key, Key::Named(NamedKey::Process)) {
                     return KeyReaction::DispatchInput(
                         None,
-                        IsComposing::NotComposing,
+                        IsComposing::Composing,
                         InputType::Nothing,
                     );
                 }

--- a/components/script/textinput.rs
+++ b/components/script/textinput.rs
@@ -17,12 +17,17 @@ use unicode_segmentation::UnicodeSegmentation;
 use crate::clipboard_provider::ClipboardProvider;
 use crate::dom::bindings::codegen::Bindings::EventBinding::Event_Binding::EventMethods;
 use crate::dom::bindings::inheritance::Castable;
+use crate::dom::bindings::refcounted::Trusted;
+use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::compositionevent::CompositionEvent;
 use crate::dom::event::Event;
+use crate::dom::eventtarget::EventTarget;
+use crate::dom::inputevent::InputEvent;
 use crate::dom::keyboardevent::KeyboardEvent;
 use crate::dom::types::ClipboardEvent;
 use crate::drag_data_store::Kind;
+use crate::script_runtime::CanGc;
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum Selection {
@@ -203,10 +208,53 @@ pub struct TextInput<T: ClipboardProvider> {
     was_last_change_by_set_content: bool,
 }
 
+#[derive(Clone, Copy, PartialEq)]
+pub enum IsComposing {
+    Composing,
+    NotComposing,
+}
+
+impl From<IsComposing> for bool {
+    fn from(is_composing: IsComposing) -> Self {
+        match is_composing {
+            IsComposing::Composing => true,
+            IsComposing::NotComposing => false,
+        }
+    }
+}
+
+/// <https://www.w3.org/TR/input-events-2/#interface-InputEvent-Attributes>
+#[derive(Clone, Copy, PartialEq)]
+pub enum InputType {
+    InsertText,
+    InsertLineBreak,
+    InsertFromPaste,
+    InsertCompositionText,
+    DeleteByCut,
+    DeleteContentBackward,
+    DeleteContentForward,
+    Nothing,
+}
+
+impl InputType {
+    fn as_str(&self) -> &str {
+        match *self {
+            InputType::InsertText => "insertText",
+            InputType::InsertLineBreak => "insertLineBreak",
+            InputType::InsertFromPaste => "insertFromPaste",
+            InputType::InsertCompositionText => "insertCompositionText",
+            InputType::DeleteByCut => "deleteByCut",
+            InputType::DeleteContentBackward => "deleteContentBackward",
+            InputType::DeleteContentForward => "deleteContentForward",
+            InputType::Nothing => "",
+        }
+    }
+}
+
 /// Resulting action to be taken by the owner of a text input that is handling an event.
 pub enum KeyReaction {
     TriggerDefaultAction,
-    DispatchInput,
+    DispatchInput(Option<String>, IsComposing, InputType),
     RedrawSelection,
     Nothing,
 }
@@ -214,9 +262,40 @@ pub enum KeyReaction {
 bitflags! {
     /// Resulting action to be taken by the owner of a text input that is handling a clipboard
     /// event.
-    pub struct ClipboardEventReaction: u8 {
+    #[derive(Clone, Copy)]
+    pub struct ClipboardEventFlags: u8 {
         const QueueInputEvent = 1 << 0;
         const FireClipboardChangedEvent = 1 << 1;
+    }
+}
+
+pub struct ClipboardEventReaction {
+    pub flags: ClipboardEventFlags,
+    pub text: Option<String>,
+    pub input_type: InputType,
+}
+
+impl ClipboardEventReaction {
+    fn new(flags: ClipboardEventFlags) -> Self {
+        Self {
+            flags,
+            text: None,
+            input_type: InputType::Nothing,
+        }
+    }
+
+    fn with_text(mut self, text: String) -> Self {
+        self.text = Some(text);
+        self
+    }
+
+    fn with_input_type(mut self, input_type: InputType) -> Self {
+        self.input_type = input_type;
+        self
+    }
+
+    fn empty() -> Self {
+        Self::new(ClipboardEventFlags::empty())
     }
 }
 
@@ -743,7 +822,7 @@ impl<T: ClipboardProvider> TextInput<T> {
             KeyReaction::TriggerDefaultAction
         } else {
             self.insert_char('\n');
-            KeyReaction::DispatchInput
+            KeyReaction::DispatchInput(None, IsComposing::NotComposing, InputType::InsertLineBreak)
         }
     }
 
@@ -931,31 +1010,45 @@ impl<T: ClipboardProvider> TextInput<T> {
                     self.clipboard_provider.set_text(text);
                     self.delete_char(Direction::Backward);
                 }
-                KeyReaction::DispatchInput
+                KeyReaction::DispatchInput(None, IsComposing::NotComposing, InputType::DeleteByCut)
             })
             .shortcut(CMD_OR_CONTROL, 'C', || {
                 // TODO(stevennovaryo): we should not provide text to clipboard for type=password
                 if let Some(text) = self.get_selection_text() {
                     self.clipboard_provider.set_text(text);
                 }
-                KeyReaction::DispatchInput
+                KeyReaction::DispatchInput(None, IsComposing::NotComposing, InputType::Nothing)
             })
             .shortcut(CMD_OR_CONTROL, 'V', || {
                 if let Ok(text_content) = self.clipboard_provider.get_text() {
-                    self.insert_string(text_content);
+                    self.insert_string(&text_content);
+                    KeyReaction::DispatchInput(
+                        Some(text_content),
+                        IsComposing::NotComposing,
+                        InputType::InsertFromPaste,
+                    )
+                } else {
+                    KeyReaction::DispatchInput(None, IsComposing::NotComposing, InputType::Nothing)
                 }
-                KeyReaction::DispatchInput
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::Delete), || {
                 if self.delete_char(Direction::Forward) {
-                    KeyReaction::DispatchInput
+                    KeyReaction::DispatchInput(
+                        None,
+                        IsComposing::NotComposing,
+                        InputType::DeleteContentForward,
+                    )
                 } else {
                     KeyReaction::Nothing
                 }
             })
             .shortcut(Modifiers::empty(), Key::Named(NamedKey::Backspace), || {
                 if self.delete_char(Direction::Backward) {
-                    KeyReaction::DispatchInput
+                    KeyReaction::DispatchInput(
+                        None,
+                        IsComposing::NotComposing,
+                        InputType::DeleteContentBackward,
+                    )
                 } else {
                     KeyReaction::Nothing
                 }
@@ -1048,10 +1141,18 @@ impl<T: ClipboardProvider> TextInput<T> {
             .otherwise(|| {
                 if let Key::Character(ref c) = key {
                     self.insert_string(c.as_str());
-                    return KeyReaction::DispatchInput;
+                    return KeyReaction::DispatchInput(
+                        Some(c.to_string()),
+                        IsComposing::NotComposing,
+                        InputType::InsertText,
+                    );
                 }
                 if matches!(key, Key::Named(NamedKey::Process)) {
-                    return KeyReaction::DispatchInput;
+                    return KeyReaction::DispatchInput(
+                        None,
+                        IsComposing::NotComposing,
+                        InputType::Nothing,
+                    );
                 }
                 KeyReaction::Nothing
             })
@@ -1059,19 +1160,29 @@ impl<T: ClipboardProvider> TextInput<T> {
     }
 
     pub(crate) fn handle_compositionend(&mut self, event: &CompositionEvent) -> KeyReaction {
-        self.insert_string(event.data().str());
-        KeyReaction::DispatchInput
+        let ch = event.data().str();
+        self.insert_string(ch.as_ref());
+        KeyReaction::DispatchInput(
+            Some(ch.to_string()),
+            IsComposing::NotComposing,
+            InputType::InsertCompositionText,
+        )
     }
 
     pub(crate) fn handle_compositionupdate(&mut self, event: &CompositionEvent) -> KeyReaction {
+        let ch = event.data().str();
         let start = self.selection_start_offset().0;
-        self.insert_string(event.data().str());
+        self.insert_string(ch.as_ref());
         self.set_selection_range(
             start as u32,
             (start + event.data().len_utf8().0) as u32,
             SelectionDirection::Forward,
         );
-        KeyReaction::DispatchInput
+        KeyReaction::DispatchInput(
+            Some(ch.to_string()),
+            IsComposing::Composing,
+            InputType::InsertCompositionText,
+        )
     }
 
     /// Whether the content is empty.
@@ -1262,7 +1373,7 @@ impl<T: ClipboardProvider> TextInput<T> {
                 }
 
                 // Step 3.2 Fire a clipboard event named clipboardchange
-                ClipboardEventReaction::FireClipboardChangedEvent
+                ClipboardEventReaction::new(ClipboardEventFlags::FireClipboardChangedEvent)
             },
             "cut" => {
                 // These steps are from <https://www.w3.org/TR/clipboard-apis/#cut-action>:
@@ -1282,8 +1393,11 @@ impl<T: ClipboardProvider> TextInput<T> {
 
                 // Step 3.1.3 Fire a clipboard event named clipboardchange
                 // Step 3.1.4 Queue tasks to fire any events that should fire due to the modification.
-                ClipboardEventReaction::FireClipboardChangedEvent
-                    | ClipboardEventReaction::QueueInputEvent
+                ClipboardEventReaction::new(
+                    ClipboardEventFlags::FireClipboardChangedEvent |
+                        ClipboardEventFlags::QueueInputEvent,
+                )
+                .with_input_type(InputType::DeleteByCut)
             },
             "paste" => {
                 // These steps are from <https://www.w3.org/TR/clipboard-apis/#paste-action>:
@@ -1317,12 +1431,49 @@ impl<T: ClipboardProvider> TextInput<T> {
                     return ClipboardEventReaction::empty();
                 }
 
-                self.insert_string(text_content);
+                self.insert_string(&text_content);
 
                 // Step 3.1.2: Queue tasks to fire any events that should fire due to the
                 // modification, see § 5.3 Integration with other scripts and events for details.
-                ClipboardEventReaction::QueueInputEvent
+                ClipboardEventReaction::new(ClipboardEventFlags::QueueInputEvent)
+                    .with_text(text_content)
+                    .with_input_type(InputType::InsertFromPaste)
             },
         _ => ClipboardEventReaction::empty(),)
+    }
+
+    /// <https://w3c.github.io/uievents/#event-type-input>
+    pub(crate) fn queue_input_event(
+        &self,
+        target: &EventTarget,
+        data: Option<String>,
+        is_composing: IsComposing,
+        input_type: InputType,
+    ) {
+        let global = target.global();
+        let target = Trusted::new(target);
+        global.task_manager().user_interaction_task_source().queue(
+            task!(fire_input_event: move || {
+                let target = target.root();
+                let global = target.global();
+                let window = global.as_window();
+                let event = InputEvent::new(
+                    window,
+                    None,
+                    DOMString::from("input"),
+                    true,
+                    false,
+                    Some(window),
+                    0,
+                    data.map(DOMString::from),
+                    is_composing.into(),
+                    input_type.as_str().into(),
+                    CanGc::note(),
+                );
+                let event = event.upcast::<Event>();
+                event.set_composed(true);
+                event.fire(&target, CanGc::note());
+            }),
+        );
     }
 }

--- a/components/script_bindings/webidls/InputEvent.webidl
+++ b/components/script_bindings/webidls/InputEvent.webidl
@@ -13,10 +13,16 @@ interface InputEvent : UIEvent {
   [Throws] constructor(DOMString type, optional InputEventInit eventInitDict = {});
   readonly attribute DOMString? data;
   readonly attribute boolean isComposing;
+  readonly attribute DOMString inputType;
+  readonly attribute DataTransfer? dataTransfer;
+  sequence<StaticRange> getTargetRanges();
 };
 
 // https://w3c.github.io/uievents/#idl-inputeventinit
 dictionary InputEventInit : UIEventInit {
   DOMString? data = null;
   boolean isComposing = false;
+  DOMString inputType = "";
+  DataTransfer? dataTransfer = null;
+  sequence<StaticRange> targetRanges = [];
 };

--- a/tests/wpt/meta/html/semantics/forms/input-change-event-properties.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/input-change-event-properties.html.ini
@@ -1,10 +1,4 @@
 [input-change-event-properties.html]
-  [<input type="checkbox"> click()]
-    expected: FAIL
-
-  [<input type="radio"> click()]
-    expected: FAIL
-
   [<input type="text"> typing]
     expected: FAIL
 

--- a/tests/wpt/meta/uievents/idlharness.window.js.ini
+++ b/tests/wpt/meta/uievents/idlharness.window.js.ini
@@ -5,12 +5,6 @@
   [MouseEvent interface: operation initMouseEvent(DOMString, optional boolean, optional boolean, optional Window?, optional long, optional long, optional long, optional long, optional long, optional boolean, optional boolean, optional boolean, optional boolean, optional short, optional EventTarget?)]
     expected: FAIL
 
-  [InputEvent interface: attribute inputType]
-    expected: FAIL
-
-  [InputEvent interface: new InputEvent("event") must inherit property "inputType" with the proper type]
-    expected: FAIL
-
   [KeyboardEvent interface: operation initKeyboardEvent(DOMString, optional boolean, optional boolean, optional Window?, optional DOMString, optional unsigned long, optional boolean, optional boolean, optional boolean, optional boolean)]
     expected: FAIL
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -12876,6 +12876,26 @@
      ]
     ]
    },
+   "input-events": {
+    "input-events-textarea-cut-paste.html": [
+     "7e1151d222b5a5210921345a3e60434194cd1794",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ],
+    "input-events-textarea-typing.html": [
+     "19d8f6be9537f4a286471ddd483a75c01a34e912",
+     [
+      null,
+      {
+       "testdriver": true
+      }
+     ]
+    ]
+   },
    "mozilla": {
     "Channel_postMessage_with_second_transfer_in_timeout.window.js": [
      "4ee3f64beb095963f06fc53c1d53dad2244109f9",

--- a/tests/wpt/mozilla/tests/input-events/input-events-textarea-cut-paste.html
+++ b/tests/wpt/mozilla/tests/input-events/input-events-textarea-cut-paste.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cut and Paste should trigger corresponding InputEvent</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script type="text/javascript" src="pointerevent_support.js"></script>
+<textarea id="test1_plain">plain</textarea>
+<script>
+
+function resolveWhen(condition) {
+  return new Promise((resolve, reject) => {
+    function tick() {
+      if (condition())
+        resolve();
+      else
+        requestAnimationFrame(tick.bind(this));
+    }
+    tick();
+  });
+}
+
+let modifier_key = "\uE009";
+if(navigator.platform.includes('Mac'))
+    modifier_key = "\uE03D";
+const commands = {
+    COPY: 'copy',
+    CUT: 'cut',
+    PASTE: 'paste',
+}
+function selectTextCommand(target, command) {
+  let command_key = "";
+  if(command == "copy")
+    command_key = "c";
+  else if (command == "cut")
+    command_key = "x";
+  else if (command == "paste")
+    command_key = "v";
+  target.focus();
+  return new test_driver.Actions()
+      .keyDown(modifier_key)
+      .keyDown("a")
+      .keyUp("a")
+      .keyDown(command_key)
+      .keyUp(command_key)
+      .keyUp(modifier_key)
+      .send();
+}
+
+function selectTextCutAndPaste(target1, target2) {
+  return selectTextCommand(target1, commands.CUT).then(() => {
+    return selectTextCommand(target2, commands.PASTE);
+  })
+}
+
+promise_test(async test => {
+  const expectedEventLog = ['input-deleteByCut', 'input-insertFromPaste'];
+  const actualEventLog = [];
+  const text1 = document.getElementById("test1_plain");
+
+  text1.addEventListener('input', test.step_func(function() {
+      actualEventLog.push(`${event.type}-${event.inputType || '[null]'}`);
+  }));
+  await selectTextCutAndPaste(text1, text1);
+  await resolveWhen(() => { return actualEventLog.length == expectedEventLog.length });
+  assert_array_equals(actualEventLog, expectedEventLog,
+                      `Expected: ${expectedEventLog}; Actual: ${actualEventLog}.`);
+}, 'Event order and data on textarea.');
+</script>

--- a/tests/wpt/mozilla/tests/input-events/input-events-textarea-typing.html
+++ b/tests/wpt/mozilla/tests/input-events/input-events-textarea-typing.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Input Event typing tests</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<textarea id="plain"></textarea>
+<script>
+let inputEventsLog = [];
+const plain = document.getElementById('plain');
+
+function log(event) {
+    const clone = new event.constructor(event.type, event);
+    inputEventsLog.push(clone);
+}
+
+function resetPlain() {
+    inputEventsLog = [];
+    plain.value = '';
+}
+
+plain.addEventListener('input', log);
+
+promise_test(async function() {
+    this.add_cleanup(resetPlain);
+    plain.focus();
+    const message = 'Hello';
+    await test_driver.send_keys(plain, message);
+    assert_equals(inputEventsLog.length, 5);
+    for (let i = 0; i < inputEventsLog.length; i += 1) {
+        const inputEvent = inputEventsLog[i];
+        assert_equals(inputEvent.type, 'input');
+        assert_equals(inputEvent.inputType, 'insertText');
+        assert_equals(inputEvent.data, message[i]);
+    }
+}, 'It triggers input events on text typing');
+
+promise_test(async function() {
+    this.add_cleanup(resetPlain);
+    const expectedResult = [
+        // Pressing 'a'
+        'insertText',
+        // Return
+        'insertLineBreak'
+    ];
+
+    await test_driver.click(plain);
+    await test_driver.send_keys(plain,"a");
+    await test_driver.send_keys(plain,'\uE006'); // Return
+    assert_equals(inputEventsLog.length, expectedResult.length);
+    expectedResult.forEach((er, index) => assert_equals(inputEventsLog[index].inputType, er));
+}, 'Newline character in plain text editing should get insertLinebreak input event');
+
+promise_test(async function() {
+    this.add_cleanup(resetPlain);
+    plain.value = 'Preexisting content';
+    plain.focus();
+    await test_driver.send_keys(plain, "\uE012"); // Left
+    await test_driver.send_keys(plain, "\uE017"); // Delete
+
+    assert_equals(inputEventsLog.length, 1);
+    const [inputEvent] = inputEventsLog;
+    assert_equals(inputEvent.type, 'input');
+    assert_equals(inputEvent.inputType, 'deleteContentForward');
+    assert_equals(inputEvent.data, null);
+}, 'It triggers input events on typing DELETE with pre-existing content');
+
+promise_test(async function() {
+    this.add_cleanup(resetPlain);
+    plain.value = 'Preexisting content';
+    plain.focus();
+    await test_driver.send_keys(plain, "\uE012"); // Left
+    await test_driver.send_keys(plain, "\uE003"); // Back Space
+
+    assert_equals(inputEventsLog.length, 1);
+    const [inputEvent] = inputEventsLog;
+    assert_equals(inputEvent.type, 'input');
+    assert_equals(inputEvent.inputType, 'deleteContentBackward');
+    assert_equals(inputEvent.data, null);
+}, 'It triggers input events on typing BACK_SPACE with pre-existing content');
+
+promise_test(async function () {
+    this.add_cleanup(resetPlain);
+    plain.value = 'Preexisting Content';
+
+    const expectedResult = [
+        // Pressing 'a', 'b'
+        'insertText',
+        'insertText',
+        // Delete twice
+        'deleteContentForward',
+        'deleteContentForward',
+        // Pressing 'c', 'd'
+        'insertText',
+        'insertText',
+        // Backspace
+        'deleteContentBackward'
+    ];
+    const result = [];
+
+    plain.addEventListener("input", (inputEvent) => {
+      result.push(inputEvent.inputType);
+    });
+
+    plain.focus();
+    for (let i = 0; i < 7; i += 1) {
+      await test_driver.send_keys(plain, "\uE012"); // Left
+    }
+    await test_driver.send_keys(plain, "a"); // Preexisting a|Content
+    await test_driver.send_keys(plain, "b"); // Preexisting ab|Content
+    // Delete
+    await test_driver.send_keys(plain, "\uE017"); // Preexisting ab|ontent
+    // Delete
+    await test_driver.send_keys(plain, "\uE017"); // Preexisting ab|ntent
+    await test_driver.send_keys(plain, "c"); // Preexisting abc|ntent
+    await test_driver.send_keys(plain, "d"); // Preexisting abcd|ntent
+    // Backspace
+    await test_driver.send_keys(plain, "\uE003"); // Preexisting abc|ntent
+
+    assert_equals(result.length, expectedResult.length);
+    expectedResult.forEach((er, index) => assert_equals(result[index], er));
+}, 'Input events have correct inputType updated when different inputs are typed');
+
+promise_test(async function () {
+    this.add_cleanup(resetPlain);
+    plain.value = 'Preexisting content';
+
+    const expectedResult = [
+        // Remove selected text with Backspace
+        'deleteContentBackward',
+        // Remove selected text with Delete
+        'deleteContentForward'
+    ];
+    const result = [];
+
+    plain.addEventListener("input", (inputEvent) => {
+      result.push(inputEvent.inputType);
+    });
+
+    // Move caret before "content"
+    plain.focus();
+    for (let i = 0; i < 7; i += 1) {
+      await test_driver.send_keys(plain, "\uE012"); // Left
+    }
+    // Select text to the left
+    await new test_driver.Actions()
+        .keyDown('\uE008') // Shift
+        .keyDown('\uE012') // Arrow Left
+        .keyUp('\uE012')
+        .keyUp('\uE008')
+        .send(); // Preexisting| ^content
+    // Backspace
+    await test_driver.send_keys(plain, "\uE003"); // Preexisting|content
+    // Select text to the right
+    await new test_driver.Actions()
+        .keyDown('\uE008') // Shift
+        .keyDown('\uE014') // Arrow Right
+        .keyUp('\uE014')
+        .keyUp('\uE008')
+        .send(); // Preexisting^c|ontent
+    // Delete
+    await test_driver.send_keys(plain, "\uE017"); // Preexistingontent
+
+    assert_equals(result.length, expectedResult.length);
+    expectedResult.forEach((er, index) => assert_equals(result[index], er));
+}, 'Input events have correct inputType when selected text is removed with Backspace or Delete');
+
+promise_test(async function() {
+    this.add_cleanup(resetPlain);
+    const expectedResult = [
+        // Pressing 'a'.
+        'plain-keydown-a',
+        'plain-keypress-a',
+        'plain-input-a-null',
+        'plain-keyup-a',
+    ];
+    const result = [];
+
+    for (const eventType of ['input', 'keydown', 'keypress', 'keyup']) {
+        const listener = event => {
+            if (event.key === 'Shift') return;
+            const eventInfo = [event.target.id, event.type, event.data || event.key];
+            if (event instanceof InputEvent) eventInfo.push(String(event.dataTransfer));
+            result.push(eventInfo.join('-'));
+        }
+        plain.addEventListener(eventType, listener);
+    }
+
+    plain.focus();
+    await new test_driver.Actions()
+        .keyDown('a')
+        .keyUp('a')
+        .send();
+
+    console.log(result);
+    assert_equals(result.length, expectedResult.length);
+    expectedResult.forEach((er, index) => assert_equals(result[index], er));
+}, 'InputEvents have correct data/order when typing on textarea');
+</script>


### PR DESCRIPTION
Use `InputEvent` for text input and set appropriate values for the `composed`, `data`, `isComposing`, and `inputType` attributes. Use a placeholder for `dataTransfer` attribute and `getTargetRanges` function, as they are only applicable to contenteditable, which isn't implemented.

Testing: I added two tests under `tests/wpt/mozilla/tests/input-events` based on the similarly named ones for contenteditable under `tests/wpt/tests/input-events`.
Fixes: https://github.com/servo/servo/issues/36398