### PR TITLE
dependabot + cargo: Update `strum*` as a group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,10 @@ updates:
     servo-media-related:
       patterns:
         - "servo-media*"
+    strum-related:
+      patterns:
+        - "strum"
+        - "strum_macros"
   ignore:
   # Ignore all stylo crates as their upgrades are coordinated via companion PRs.
   - dependency-name: selectors

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8306,23 +8306,22 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,8 +140,8 @@ skrifa = "0.35.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
 string_cache = "0.8"
-strum = "0.26"
-strum_macros = "0.26"
+strum = "0.27"
+strum_macros = "0.27"
 stylo = { git = "https://github.com/servo/stylo", branch = "2025-10-01" }
 stylo_atoms = { git = "https://github.com/servo/stylo", branch = "2025-10-01" }
 stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-10-01" }


### PR DESCRIPTION
- Add strum and strum_macros as a group for dependabot.
- Manually update both. This removes one extra dependency.

Fixes: #40000