### PR TITLE
libservo: Merge input method activation into the EmbedderControl API

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -16,7 +16,6 @@ use app_units::Au;
 use cssparser::match_ignore_ascii_case;
 use devtools_traits::AttrInfo;
 use dom_struct::dom_struct;
-use embedder_traits::InputMethodType;
 use euclid::default::{Rect, Size2D};
 use html5ever::serialize::TraversalScope;
 use html5ever::serialize::TraversalScope::{ChildrenOnly, IncludeNode};
@@ -1700,22 +1699,6 @@ impl Element {
             }
         }
         None
-    }
-
-    // Returns the kind of IME control needed for a focusable element, if any.
-    pub(crate) fn input_method_type(&self) -> Option<InputMethodType> {
-        if !self.is_focusable_area() {
-            return None;
-        }
-
-        if let Some(input) = self.downcast::<HTMLInputElement>() {
-            input.input_type().as_ime_type()
-        } else if self.is::<HTMLTextAreaElement>() {
-            Some(InputMethodType::Text)
-        } else {
-            // Other focusable elements that are not input fields.
-            None
-        }
     }
 
     /// <https://dom.spec.whatwg.org/#document-element>

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -347,11 +347,11 @@ impl InputType {
     }
 }
 
-impl TryInto<InputMethodType> for InputType {
+impl TryFrom<InputType> for InputMethodType {
     type Error = &'static str;
 
-    fn try_into(self) -> Result<InputMethodType, Self::Error> {
-        match self {
+    fn try_from(input_type: InputType) -> Result<Self, Self::Error> {
+        match input_type {
             InputType::Color => Ok(InputMethodType::Color),
             InputType::Date => Ok(InputMethodType::Date),
             InputType::DatetimeLocal => Ok(InputMethodType::DatetimeLocal),
@@ -2883,7 +2883,7 @@ impl HTMLInputElement {
     }
 
     fn handle_focus(&self) {
-        let Ok(ime_type) = self.input_type().try_into() else {
+        let Ok(input_method_type) = self.input_type().try_into() else {
             return;
         };
 
@@ -2892,7 +2892,7 @@ impl HTMLInputElement {
             .show_embedder_control(
                 ControlElement::Ime(DomRoot::from_ref(self.upcast())),
                 EmbedderControlRequest::InputMethod(InputMethodRequest {
-                    ime_type,
+                    input_method_type,
                     text: self.Value().to_string(),
                     insertion_point: self.GetSelectionEnd(),
                     multiline: false,

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -7,6 +7,7 @@ use std::default::Default;
 use std::ops::Range;
 
 use dom_struct::dom_struct;
+use embedder_traits::{EmbedderControlRequest, InputMethodRequest, InputMethodType};
 use html5ever::{LocalName, Prefix, local_name, ns};
 use js::rust::HandleObject;
 use style::attr::AttrValue;
@@ -26,6 +27,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::clipboardevent::ClipboardEvent;
 use crate::dom::compositionevent::CompositionEvent;
 use crate::dom::document::Document;
+use crate::dom::document_embedder_controls::ControlElement;
 use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
 use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::html::htmlelement::HTMLElement;
@@ -38,6 +40,7 @@ use crate::dom::node::{
 };
 use crate::dom::nodelist::NodeList;
 use crate::dom::textcontrol::{TextControlElement, TextControlSelection};
+use crate::dom::types::FocusEvent;
 use crate::dom::validation::{Validatable, is_barred_by_datalist_ancestor};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::dom::virtualmethods::VirtualMethods;
@@ -207,6 +210,20 @@ impl HTMLTextAreaElement {
         // https://html.spec.whatwg.org/multipage/#the-textarea-element%3Aconcept-fe-mutable
         // https://html.spec.whatwg.org/multipage/#the-readonly-attribute:concept-fe-mutable
         !(self.upcast::<Element>().disabled_state() || self.ReadOnly())
+    }
+
+    fn handle_focus(&self) {
+        self.owner_document()
+            .embedder_controls()
+            .show_embedder_control(
+                ControlElement::Ime(DomRoot::from_ref(self.upcast())),
+                EmbedderControlRequest::InputMethod(InputMethodRequest {
+                    ime_type: InputMethodType::Text,
+                    text: self.Value().to_string(),
+                    insertion_point: self.GetSelectionEnd(),
+                    multiline: false,
+                }),
+            );
     }
 }
 
@@ -720,6 +737,15 @@ impl VirtualMethods for HTMLTextAreaElement {
             }
             if !reaction.is_empty() {
                 self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
+            }
+        } else if let Some(event) = event.downcast::<FocusEvent>() {
+            if *event.upcast::<Event>().type_() == *"blur" {
+                self.owner_document()
+                    .embedder_controls()
+                    .hide_embedder_control(self.upcast());
+            }
+            if *event.upcast::<Event>().type_() == *"focus" {
+                self.handle_focus();
             }
         }
 

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -218,7 +218,7 @@ impl HTMLTextAreaElement {
             .show_embedder_control(
                 ControlElement::Ime(DomRoot::from_ref(self.upcast())),
                 EmbedderControlRequest::InputMethod(InputMethodRequest {
-                    ime_type: InputMethodType::Text,
+                    input_method_type: InputMethodType::Text,
                     text: self.Value().to_string(),
                     insertion_point: self.GetSelectionEnd(),
                     multiline: false,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -133,7 +133,7 @@ use crate::webview::MINIMUM_WEBVIEW_SIZE;
 pub use crate::webview::{WebView, WebViewBuilder};
 pub use crate::webview_delegate::{
     AllowOrDenyRequest, AuthenticationRequest, ColorPicker, EmbedderControl, FilePicker,
-    InputMethod, NavigationRequest, PermissionRequest, SelectElement, WebResourceLoad,
+    InputMethodControl, NavigationRequest, PermissionRequest, SelectElement, WebResourceLoad,
     WebViewDelegate,
 };
 
@@ -895,9 +895,9 @@ impl Servo {
                             })
                         },
                         EmbedderControlRequest::InputMethod(input_method_request) => {
-                            EmbedderControl::InputMethod(InputMethod {
+                            EmbedderControl::InputMethod(InputMethodControl {
                                 id: control_id,
-                                ime_type: input_method_request.ime_type,
+                                input_method_type: input_method_request.input_method_type,
                                 text: input_method_request.text,
                                 insertion_point: input_method_request.insertion_point,
                                 position,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -133,7 +133,8 @@ use crate::webview::MINIMUM_WEBVIEW_SIZE;
 pub use crate::webview::{WebView, WebViewBuilder};
 pub use crate::webview_delegate::{
     AllowOrDenyRequest, AuthenticationRequest, ColorPicker, EmbedderControl, FilePicker,
-    NavigationRequest, PermissionRequest, SelectElement, WebResourceLoad, WebViewDelegate,
+    InputMethod, NavigationRequest, PermissionRequest, SelectElement, WebResourceLoad,
+    WebViewDelegate,
 };
 
 #[cfg(feature = "media-gstreamer")]
@@ -814,22 +815,6 @@ impl Servo {
                         .request_permission(webview, permission_request);
                 }
             },
-            EmbedderMsg::ShowIME(webview_id, input_method_type, text, multiline, position) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview.delegate().show_ime(
-                        webview,
-                        input_method_type,
-                        text,
-                        multiline,
-                        position,
-                    );
-                }
-            },
-            EmbedderMsg::HideIME(webview_id) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview.delegate().hide_ime(webview);
-                }
-            },
             EmbedderMsg::ReportProfile(_items) => {},
             EmbedderMsg::MediaSessionEvent(webview_id, media_session_event) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
@@ -907,6 +892,16 @@ impl Servo {
                                 position,
                                 constellation_proxy,
                                 response_sent: false,
+                            })
+                        },
+                        EmbedderControlRequest::InputMethod(input_method_request) => {
+                            EmbedderControl::InputMethod(InputMethod {
+                                id: control_id,
+                                ime_type: input_method_request.ime_type,
+                                text: input_method_request.text,
+                                insertion_point: input_method_request.insertion_point,
+                                position,
+                                multiline: input_method_request.multiline,
                             })
                         },
                         EmbedderControlRequest::FilePicker { .. } => unreachable!(

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -305,6 +305,8 @@ pub enum EmbedderControl {
     ColorPicker(ColorPicker),
     /// The picker of a `<input type=file>` element.
     FilePicker(FilePicker),
+    /// The input method interface.
+    InputMethod(InputMethod),
 }
 
 impl EmbedderControl {
@@ -313,10 +315,10 @@ impl EmbedderControl {
             EmbedderControl::SelectElement(select_element) => select_element.id,
             EmbedderControl::ColorPicker(color_picker) => color_picker.id,
             EmbedderControl::FilePicker(file_picker) => file_picker.id,
+            EmbedderControl::InputMethod(input_method) => input_method.id,
         }
     }
 }
-
 /// Represents a dialog triggered by clicking a `<select>` element.
 pub struct SelectElement {
     pub(crate) id: EmbedderControlId,
@@ -491,6 +493,47 @@ impl Drop for FilePicker {
     }
 }
 
+/// Represents a request to enable the system input method interface.
+pub struct InputMethod {
+    pub(crate) id: EmbedderControlId,
+    pub(crate) ime_type: InputMethodType,
+    pub(crate) text: String,
+    pub(crate) insertion_point: Option<u32>,
+    pub(crate) position: DeviceIntRect,
+    pub(crate) multiline: bool,
+}
+
+impl InputMethod {
+    /// Return the type of input method that initated this request.
+    pub fn ime_type(self) -> InputMethodType {
+        self.ime_type
+    }
+
+    /// Return the current string value of the input field.
+    pub fn text(&self) -> String {
+        self.text.clone()
+    }
+
+    /// The current insertion point / cursor position if it is within the field or
+    /// `None` if it is not.
+    pub fn insertion_point(&self) -> Option<u32> {
+        self.insertion_point
+    }
+
+    /// Get the area occupied by the `<input>` element that triggered the input method.
+    ///
+    /// The embedder should use this value to position the input method interface that is
+    /// shown to the user.
+    pub fn position(&self) -> DeviceIntRect {
+        self.position
+    }
+
+    /// Whether or not this field is a multiline field.
+    pub fn multiline(&self) -> bool {
+        self.multiline
+    }
+}
+
 pub trait WebViewDelegate {
     /// Get the [`ScreenGeometry`] for this [`WebView`]. If this is unimplemented or returns `None`
     /// the screen will have the size of the [`WebView`]'s `RenderingContext` and `WebView` will be
@@ -625,23 +668,6 @@ pub trait WebViewDelegate {
     ) {
         let _ = response_sender.send(None);
     }
-
-    /// Request to present an IME to the user when an editable element is focused.
-    /// If `type` is [`InputMethodType::Text`], then the `text` parameter specifies
-    /// the pre-existing text content and the zero-based index into the string
-    /// of the insertion point.
-    fn show_ime(
-        &self,
-        _webview: WebView,
-        _type: InputMethodType,
-        _text: Option<(String, i32)>,
-        _multiline: bool,
-        _position: DeviceIntRect,
-    ) {
-    }
-
-    /// Request to hide the IME when the editable element is blurred.
-    fn hide_ime(&self, _webview: WebView) {}
 
     /// Request that the embedder show UI elements for form controls that are not integrated
     /// into page content, such as dropdowns for `<select>` elements.

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -305,7 +305,8 @@ pub enum EmbedderControl {
     ColorPicker(ColorPicker),
     /// The picker of a `<input type=file>` element.
     FilePicker(FilePicker),
-    /// The input method interface.
+    /// Request to present an input method (IME) interface to the user when an
+    /// editable element is focused.
     InputMethod(InputMethodControl),
 }
 
@@ -514,8 +515,8 @@ impl InputMethodControl {
         self.text.clone()
     }
 
-    /// The current insertion point / cursor position if it is within the field or
-    /// `None` if it is not.
+    /// The current zero-based insertion point / cursor position if it is within the field or `None`
+    /// if it is not.
     pub fn insertion_point(&self) -> Option<u32> {
         self.insertion_point
     }

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -306,7 +306,7 @@ pub enum EmbedderControl {
     /// The picker of a `<input type=file>` element.
     FilePicker(FilePicker),
     /// The input method interface.
-    InputMethod(InputMethod),
+    InputMethod(InputMethodControl),
 }
 
 impl EmbedderControl {
@@ -494,19 +494,19 @@ impl Drop for FilePicker {
 }
 
 /// Represents a request to enable the system input method interface.
-pub struct InputMethod {
+pub struct InputMethodControl {
     pub(crate) id: EmbedderControlId,
-    pub(crate) ime_type: InputMethodType,
+    pub(crate) input_method_type: InputMethodType,
     pub(crate) text: String,
     pub(crate) insertion_point: Option<u32>,
     pub(crate) position: DeviceIntRect,
     pub(crate) multiline: bool,
 }
 
-impl InputMethod {
+impl InputMethodControl {
     /// Return the type of input method that initated this request.
-    pub fn ime_type(self) -> InputMethodType {
-        self.ime_type
+    pub fn input_method_type(&self) -> InputMethodType {
+        self.input_method_type
     }
 
     /// Return the current string value of the input field.

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -554,6 +554,9 @@ pub enum EmbedderControlRequest {
     InputMethod(InputMethodRequest),
 }
 
+/// Request to present an IME to the user when an editable element is focused. If `type` is
+/// [`InputMethodType::Text`], then the `text` parameter specifies the pre-existing text content and
+/// `insertion_point` the zero-based index into the string of the insertion point.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct InputMethodRequest {
     pub input_method_type: InputMethodType,
@@ -675,7 +678,7 @@ pub enum PermissionFeature {
 /// Used to specify the kind of input method editor appropriate to edit a field.
 /// This is a subset of htmlinputelement::InputType because some variants of InputType
 /// don't make sense in this context.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum InputMethodType {
     Color,
     Date,

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -556,7 +556,7 @@ pub enum EmbedderControlRequest {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct InputMethodRequest {
-    pub ime_type: InputMethodType,
+    pub input_method_type: InputMethodType,
     pub text: String,
     pub insertion_point: Option<u32>,
     pub multiline: bool,
@@ -675,7 +675,7 @@ pub enum PermissionFeature {
 /// Used to specify the kind of input method editor appropriate to edit a field.
 /// This is a subset of htmlinputelement::InputType because some variants of InputType
 /// don't make sense in this context.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum InputMethodType {
     Color,
     Date,

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -493,19 +493,6 @@ pub enum EmbedderMsg {
     ),
     /// Open interface to request permission specified by prompt.
     PromptPermission(WebViewId, PermissionFeature, GenericSender<AllowOrDeny>),
-    /// Request to present an IME to the user when an editable element is focused.
-    /// If the input is text, the second parameter defines the pre-existing string
-    /// text content and the zero-based index into the string locating the insertion point.
-    /// bool is true for multi-line and false otherwise.
-    ShowIME(
-        WebViewId,
-        InputMethodType,
-        Option<(String, i32)>,
-        bool,
-        DeviceIntRect,
-    ),
-    /// Request to hide the IME when the editable element is blurred.
-    HideIME(WebViewId),
     /// Report a complete sampled profile
     ReportProfile(Vec<u8>),
     /// Notifies the embedder about media session events
@@ -562,6 +549,17 @@ pub enum EmbedderControlRequest {
     ColorPicker(RgbColor),
     /// Indicates that the user has activated a `<input type=file>` element.
     FilePicker(FilePickerRequest),
+    /// Indicates that the the user has activated a text or input control that should show
+    /// an IME.
+    InputMethod(InputMethodRequest),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InputMethodRequest {
+    pub ime_type: InputMethodType,
+    pub text: String,
+    pub insertion_point: Option<u32>,
+    pub multiline: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -18,8 +18,8 @@ use servo::ipc_channel::ipc::IpcSender;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 use servo::{
     AllowOrDenyRequest, AuthenticationRequest, EmbedderControl, EmbedderControlId,
-    GamepadHapticEffectType, InputEvent, InputEventId, InputEventResult, JSValue, LoadStatus,
-    PermissionRequest, Servo, ServoDelegate, ServoError, SimpleDialog, TraversalId,
+    GamepadHapticEffectType, InputEvent, InputEventId, InputEventResult, InputMethod, JSValue,
+    LoadStatus, PermissionRequest, Servo, ServoDelegate, ServoError, SimpleDialog, TraversalId,
     WebDriverCommandMsg, WebDriverJSResult, WebDriverLoadStatus, WebDriverSenders,
     WebDriverUserPrompt, WebView, WebViewBuilder, WebViewDelegate,
 };
@@ -97,6 +97,9 @@ pub struct RunningAppStateInner {
     /// to inform the WebDriver server when the event has been fully handled. This map is used
     /// to report back to WebDriver when that happens.
     pending_webdriver_events: HashMap<InputEventId, Sender<()>>,
+
+    /// A list of showing [`InputMethod`] interfaces.
+    visible_input_method: Vec<EmbedderControlId>,
 }
 
 impl Drop for RunningAppState {
@@ -136,6 +139,7 @@ impl RunningAppState {
                 pending_favicon_loads: Default::default(),
                 achieved_stable_image: Default::default(),
                 pending_webdriver_events: Default::default(),
+                visible_input_method: Default::default(),
             }),
         }
     }
@@ -394,11 +398,27 @@ impl RunningAppState {
         }
     }
 
-    pub(crate) fn dismiss_active_dialogs_with_control_id(
+    fn show_ime(&self, id: EmbedderControlId, input_method: InputMethod) {
+        self.inner_mut().visible_input_method.push(id);
+        self.inner().window.show_ime(input_method);
+    }
+
+    pub(crate) fn dismiss_control_with_control_id(
         &self,
         webview_id: WebViewId,
         control_id: EmbedderControlId,
     ) {
+        {
+            let mut inner_mut = self.inner_mut();
+            if let Some(index) = inner_mut
+                .visible_input_method
+                .iter()
+                .position(|visible_id| *visible_id == control_id)
+            {
+                inner_mut.visible_input_method.remove(index);
+                inner_mut.window.hide_ime();
+            }
+        }
         if let Some(dialogs) = self.inner_mut().dialogs.get_mut(&webview_id) {
             dialogs.retain(|dialog| dialog.embedder_control_id() != Some(control_id));
         }
@@ -791,22 +811,6 @@ impl WebViewDelegate for RunningAppState {
         };
         let _ = haptic_stop_sender.send(stopped);
     }
-    fn show_ime(
-        &self,
-        _webview: WebView,
-        input_type: servo::InputMethodType,
-        text: Option<(String, i32)>,
-        multiline: bool,
-        position: servo::webrender_api::units::DeviceIntRect,
-    ) {
-        self.inner()
-            .window
-            .show_ime(input_type, text, multiline, position);
-    }
-
-    fn hide_ime(&self, _webview: WebView) {
-        self.inner().window.hide_ime();
-    }
 
     fn show_embedder_control(&self, webview: WebView, embedder_control: EmbedderControl) {
         if self.servoshell_preferences.headless &&
@@ -815,6 +819,7 @@ impl WebViewDelegate for RunningAppState {
             return;
         }
 
+        let control_id = embedder_control.id();
         match embedder_control {
             EmbedderControl::SelectElement(prompt) => {
                 // FIXME: Reading the toolbar height is needed here to properly position the select dialog.
@@ -831,6 +836,7 @@ impl WebViewDelegate for RunningAppState {
                     Dialog::new_color_picker_dialog(color_picker, offset),
                 );
             },
+            EmbedderControl::InputMethod(input_method) => self.show_ime(control_id, input_method),
             EmbedderControl::FilePicker(file_picker) => {
                 self.add_dialog(webview, Dialog::new_file_dialog(file_picker));
             },
@@ -838,7 +844,7 @@ impl WebViewDelegate for RunningAppState {
     }
 
     fn hide_embedder_control(&self, webview: WebView, control_id: servo::EmbedderControlId) {
-        self.dismiss_active_dialogs_with_control_id(webview.id(), control_id);
+        self.dismiss_control_with_control_id(webview.id(), control_id);
     }
 
     fn notify_favicon_changed(&self, webview: WebView) {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -23,8 +23,8 @@ use servo::servo_geometry::{
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel};
 use servo::{
-    Cursor, ImeEvent, InputEvent, InputEventId, InputEventResult, Key, KeyState, KeyboardEvent,
-    Modifiers, MouseButton as ServoMouseButton, MouseButtonAction, MouseButtonEvent,
+    Cursor, ImeEvent, InputEvent, InputEventId, InputEventResult, InputMethod, Key, KeyState,
+    KeyboardEvent, Modifiers, MouseButton as ServoMouseButton, MouseButtonAction, MouseButtonEvent,
     MouseLeftViewportEvent, MouseMoveEvent, NamedKey, OffscreenRenderingContext, RenderingContext,
     ScreenGeometry, Theme, TouchEvent, TouchEventType, TouchId, WebRenderDebugOption, WebView,
     WheelDelta, WheelEvent, WheelMode, WindowRenderingContext,
@@ -863,13 +863,8 @@ impl WindowPortsMethods for Window {
         self.rendering_context.clone()
     }
 
-    fn show_ime(
-        &self,
-        _input_type: servo::InputMethodType,
-        _text: Option<(String, i32)>,
-        _multiline: bool,
-        position: servo::webrender_api::units::DeviceIntRect,
-    ) {
+    fn show_ime(&self, input_method: InputMethod) {
+        let position = input_method.position();
         self.winit_window.set_ime_allowed(true);
         self.winit_window.set_ime_cursor_area(
             LogicalPosition::new(

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -23,11 +23,11 @@ use servo::servo_geometry::{
 use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel};
 use servo::{
-    Cursor, ImeEvent, InputEvent, InputEventId, InputEventResult, InputMethod, Key, KeyState,
-    KeyboardEvent, Modifiers, MouseButton as ServoMouseButton, MouseButtonAction, MouseButtonEvent,
-    MouseLeftViewportEvent, MouseMoveEvent, NamedKey, OffscreenRenderingContext, RenderingContext,
-    ScreenGeometry, Theme, TouchEvent, TouchEventType, TouchId, WebRenderDebugOption, WebView,
-    WheelDelta, WheelEvent, WheelMode, WindowRenderingContext,
+    Cursor, ImeEvent, InputEvent, InputEventId, InputEventResult, InputMethodControl, Key,
+    KeyState, KeyboardEvent, Modifiers, MouseButton as ServoMouseButton, MouseButtonAction,
+    MouseButtonEvent, MouseLeftViewportEvent, MouseMoveEvent, NamedKey, OffscreenRenderingContext,
+    RenderingContext, ScreenGeometry, Theme, TouchEvent, TouchEventType, TouchId,
+    WebRenderDebugOption, WebView, WheelDelta, WheelEvent, WheelMode, WindowRenderingContext,
 };
 use url::Url;
 use winit::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
@@ -863,7 +863,7 @@ impl WindowPortsMethods for Window {
         self.rendering_context.clone()
     }
 
-    fn show_ime(&self, input_method: InputMethod) {
+    fn show_ime(&self, input_method: InputMethodControl) {
         let position = input_method.position();
         self.winit_window.set_ime_allowed(true);
         self.winit_window.set_ime_cursor_area(

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -11,7 +11,8 @@ use euclid::{Length, Scale};
 use servo::servo_geometry::{DeviceIndependentIntRect, DeviceIndependentPixel};
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize, DevicePixel};
 use servo::{
-    Cursor, InputEventId, InputEventResult, InputMethod, RenderingContext, ScreenGeometry, WebView,
+    Cursor, InputEventId, InputEventResult, InputMethodControl, RenderingContext, ScreenGeometry,
+    WebView,
 };
 
 use super::app_state::RunningAppState;
@@ -57,7 +58,7 @@ pub trait WindowPortsMethods {
     fn set_toolbar_height(&self, height: Length<f32, DeviceIndependentPixel>);
     /// This returns [`RenderingContext`] matching the viewport.
     fn rendering_context(&self) -> Rc<dyn RenderingContext>;
-    fn show_ime(&self, _input_method: InputMethod) {}
+    fn show_ime(&self, _input_method: InputMethodControl) {}
     fn hide_ime(&self) {}
     fn theme(&self) -> servo::Theme {
         servo::Theme::Light

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -10,7 +10,9 @@ use std::rc::Rc;
 use euclid::{Length, Scale};
 use servo::servo_geometry::{DeviceIndependentIntRect, DeviceIndependentPixel};
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize, DevicePixel};
-use servo::{Cursor, InputEventId, InputEventResult, RenderingContext, ScreenGeometry, WebView};
+use servo::{
+    Cursor, InputEventId, InputEventResult, InputMethod, RenderingContext, ScreenGeometry, WebView,
+};
 
 use super::app_state::RunningAppState;
 
@@ -55,14 +57,7 @@ pub trait WindowPortsMethods {
     fn set_toolbar_height(&self, height: Length<f32, DeviceIndependentPixel>);
     /// This returns [`RenderingContext`] matching the viewport.
     fn rendering_context(&self) -> Rc<dyn RenderingContext>;
-    fn show_ime(
-        &self,
-        _input_type: servo::InputMethodType,
-        _text: Option<(String, i32)>,
-        _multiline: bool,
-        _position: servo::webrender_api::units::DeviceIntRect,
-    ) {
-    }
+    fn show_ime(&self, _input_method: InputMethod) {}
     fn hide_ime(&self) {}
     fn theme(&self) -> servo::Theme {
         servo::Theme::Light

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -21,10 +21,10 @@ use raw_window_handle::{
     AndroidDisplayHandle, AndroidNdkWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
 use servo::{
-    AlertResponse, EventLoopWaker, LoadStatus, MediaSessionActionType, MouseButton,
-    PermissionRequest, PrefValue, SimpleDialog, WebView,
+    AlertResponse, EventLoopWaker, InputMethodControl, LoadStatus, MediaSessionActionType,
+    MouseButton, PermissionRequest, PrefValue, SimpleDialog, WebView,
 };
-use simpleservo::{APP, DeviceIntRect, InitOptions, InputMethodType, MediaSessionPlaybackState};
+use simpleservo::{APP, InitOptions, MediaSessionPlaybackState};
 
 use super::app_state::{Coordinates, RunningAppState};
 use super::host_trait::HostTrait;
@@ -679,13 +679,7 @@ impl HostTrait for HostCallbacks {
         .unwrap();
     }
 
-    fn on_ime_show(
-        &self,
-        _input_type: InputMethodType,
-        _text: Option<(String, i32)>,
-        _multiline: bool,
-        _rect: DeviceIntRect,
-    ) {
+    fn on_ime_show(&self, _: InputMethodControl) {
         let mut env = self.jvm.get_env().unwrap();
         env.call_method(self.callbacks.as_obj(), "onImeShow", "()V", &[])
             .unwrap();

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -9,9 +9,8 @@ use std::rc::Rc;
 use crossbeam_channel::unbounded;
 use dpi::PhysicalSize;
 use raw_window_handle::{DisplayHandle, RawDisplayHandle, RawWindowHandle, WindowHandle};
-pub use servo::webrender_api::units::DeviceIntRect;
 use servo::{self, EventLoopWaker, ServoBuilder, resources};
-pub use servo::{InputMethodType, MediaSessionPlaybackState, WindowRenderingContext};
+pub use servo::{MediaSessionPlaybackState, WindowRenderingContext};
 
 use crate::egl::android::resources::ResourceReaderInstance;
 #[cfg(feature = "webxr")]

--- a/ports/servoshell/egl/host_trait.rs
+++ b/ports/servoshell/egl/host_trait.rs
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use servo::webrender_api::units::DeviceIntRect;
 use servo::{
-    InputMethodType, LoadStatus, MediaSessionPlaybackState, PermissionRequest, SimpleDialog,
+    InputMethodControl, LoadStatus, MediaSessionPlaybackState, PermissionRequest, SimpleDialog,
     WebView,
 };
 
@@ -59,13 +58,7 @@ pub trait HostTrait {
     /// Servo finished shutting down.
     fn on_shutdown_complete(&self);
     /// A text input is focused.
-    fn on_ime_show(
-        &self,
-        input_type: InputMethodType,
-        text: Option<(String, i32)>,
-        multiline: bool,
-        bounds: DeviceIntRect,
-    );
+    fn on_ime_show(&self, input_method_control: InputMethodControl);
     /// Input lost focus
     fn on_ime_hide(&self);
     /// Called when we get the media session metadata/

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -26,8 +26,8 @@ use ohos_ime::{
 use ohos_ime_sys::types::InputMethod_EnterKeyType;
 use servo::style::Zero;
 use servo::{
-    AlertResponse, EventLoopWaker, InputMethodType, LoadStatus, MediaSessionPlaybackState,
-    PermissionRequest, SimpleDialog, WebView, WebViewId,
+    AlertResponse, EventLoopWaker, InputMethodControl, InputMethodType, LoadStatus,
+    MediaSessionPlaybackState, PermissionRequest, SimpleDialog, WebView, WebViewId,
 };
 use xcomponent_sys::{
     OH_NativeXComponent, OH_NativeXComponent_Callback, OH_NativeXComponent_GetKeyEvent,
@@ -999,23 +999,18 @@ impl HostTrait for HostCallbacks {
     /// and shows the soft keyboard with default settings.
     /// When the keyboard cannot be shown (because the application is not in focus)
     /// we just continue and try next time.
-    fn on_ime_show(
-        &self,
-        input_type: InputMethodType,
-        _text: Option<(String, i32)>,
-        multiline: bool,
-        _bounds: servo::webrender_api::units::DeviceIntRect,
-    ) {
+    fn on_ime_show(&self, control: InputMethodControl) {
         debug!("IME show!");
         let mut ime_proxy = self.ime_proxy.borrow_mut();
         if ime_proxy.is_none() {
-            *ime_proxy = match self.try_create_ime_proxy(input_type, multiline) {
-                Err(ref e) => {
-                    error!("Could not show keyboard because of {e:?}");
-                    None
-                },
-                Ok(proxy) => Some(proxy),
-            };
+            *ime_proxy =
+                match self.try_create_ime_proxy(control.input_method_type(), control.multiline()) {
+                    Err(ref e) => {
+                        error!("Could not show keyboard because of {e:?}");
+                        None
+                    },
+                    Ok(proxy) => Some(proxy),
+                };
         }
 
         if let Some(ref ime) = *ime_proxy {


### PR DESCRIPTION
Input methods are very similar to other kinds of embedder controls such
as file selection boxes, so merge them into the same libservo API. This
simplfiies the API surface a bit.

Testing: This change comes with a new unit test.
