### PR TITLE
compositor: Do not panic on touch events

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -313,7 +313,7 @@ impl WebViewRenderer {
             InputEvent::MouseLeftViewport(_) => {
                 self.global.borrow_mut().last_mouse_move_position = None;
             },
-            InputEvent::MouseButton(_) | InputEvent::Wheel(_) => {},
+            InputEvent::MouseButton(_) | InputEvent::Wheel(_) | InputEvent::Touch(_) => {},
             _ => unreachable!("Unexpected input event type: {event:?}"),
         }
 


### PR DESCRIPTION
A recent PR (#39811) introduced an unconditional panic on touch events.
This change fixes that issue.

Testing: This can be verified manually by triggering any touch event.
Fixes: #40016
