### PR TITLE
touch events are alse one of the input events that require hit testing.

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -313,7 +313,7 @@ impl WebViewRenderer {
             InputEvent::MouseLeftViewport(_) => {
                 self.global.borrow_mut().last_mouse_move_position = None;
             },
-            InputEvent::MouseButton(_) | InputEvent::Wheel(_) => {},
+            InputEvent::Touch(_) | InputEvent::MouseButton(_) | InputEvent::Wheel(_) => {},
             _ => unreachable!("Unexpected input event type: {event:?}"),
         }
 


### PR DESCRIPTION
Touch events are also one of the input events that require hit testing.
Previously, they were mistakenly deleted.

Testing: The device no longer panics when touched.
Fixes: #40019 
