### PR TITLE
script: Don't use StyleSheet::update_from_str.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7506,7 +7506,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.32.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.2"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8347,7 +8347,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8404,7 +8404,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8413,12 +8413,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 
 [[package]]
 name = "stylo_derive"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8430,7 +8430,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8439,7 +8439,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8456,12 +8456,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 
 [[package]]
 name = "stylo_traits"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -8876,7 +8876,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -8889,7 +8889,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#305841d983183e06a3450fab0c800494ac578b58"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -538,7 +538,7 @@ impl FontContextWebFontMethods for Arc<FontContext> {
         finished_callback: StylesheetWebFontLoadFinishedCallback,
     ) -> usize {
         let mut number_loading = 0;
-        for rule in stylesheet.effective_rules(device, guard) {
+        for rule in stylesheet.contents(guard).effective_rules(device, guard) {
             let CssRule::FontFace(ref lock) = *rule else {
                 continue;
             };

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -14,7 +14,6 @@ use script_bindings::error::{Error, ErrorResult};
 use script_bindings::script_runtime::JSContext;
 use servo_arc::Arc;
 use servo_config::pref;
-use style::invalidation::media_queries::{MediaListKey, ToMediaListKey};
 use style::media_queries::MediaList;
 use style::shared_lock::{SharedRwLock as StyleSharedRwLock, SharedRwLockReadGuard};
 use style::stylesheets::scope_rule::ImplicitScopeRoot;
@@ -100,12 +99,6 @@ impl PartialEq for ServoStylesheetInDocument {
     }
 }
 
-impl ToMediaListKey for ServoStylesheetInDocument {
-    fn to_media_list_key(&self) -> MediaListKey {
-        self.sheet.contents.to_media_list_key()
-    }
-}
-
 impl ::style::stylesheets::StylesheetInDocument for ServoStylesheetInDocument {
     fn enabled(&self) -> bool {
         self.sheet.enabled()
@@ -115,8 +108,8 @@ impl ::style::stylesheets::StylesheetInDocument for ServoStylesheetInDocument {
         self.sheet.media(guard)
     }
 
-    fn contents(&self) -> &StylesheetContents {
-        self.sheet.contents()
+    fn contents<'a>(&'a self, guard: &'a SharedRwLockReadGuard) -> &'a StylesheetContents {
+        self.sheet.contents(guard)
     }
 
     fn implicit_scope_root(&self) -> Option<ImplicitScopeRoot> {

--- a/tests/unit/style/rule_tree/bench.rs
+++ b/tests/unit/style/rule_tree/bench.rs
@@ -13,7 +13,9 @@ use style::properties::{Importance, PropertyDeclaration, PropertyDeclarationBloc
 use style::rule_tree::{CascadeLevel, RuleTree, StrongRuleNode, StyleSource};
 use style::shared_lock::{SharedRwLock, StylesheetGuards};
 use style::stylesheets::layer_rule::LayerOrder;
-use style::stylesheets::{AllowImportRules, CssRule, Origin, Stylesheet, UrlExtraData};
+use style::stylesheets::{
+    AllowImportRules, CssRule, Origin, Stylesheet, StylesheetInDocument, UrlExtraData,
+};
 use style::thread_state::{self, ThreadState};
 use test::{self, Bencher};
 use url::Url;
@@ -77,7 +79,7 @@ fn parse_rules(lock: &SharedRwLock, css: &str) -> Vec<(StyleSource, CascadeLevel
         AllowImportRules::Yes,
     );
     let guard = s.shared_lock.read();
-    let rules = s.contents.rules.read_with(&guard);
+    let rules = s.contents(&guard).rules.read_with(&guard);
     rules
         .0
         .iter()

--- a/tests/unit/style/stylesheets.rs
+++ b/tests/unit/style/stylesheets.rs
@@ -10,7 +10,9 @@ use style::context::QuirksMode;
 use style::error_reporting::{ContextualParseError, ParseErrorReporter};
 use style::media_queries::MediaList;
 use style::shared_lock::SharedRwLock;
-use style::stylesheets::{AllowImportRules, Origin, Stylesheet, UrlExtraData};
+use style::stylesheets::{
+    AllowImportRules, Origin, Stylesheet, StylesheetInDocument, UrlExtraData,
+};
 use url::Url;
 
 #[derive(Debug)]
@@ -193,14 +195,15 @@ fn test_source_map_url() {
             url.into(),
             Origin::UserAgent,
             media,
-            lock,
+            lock.clone(),
             None,
             None,
             QuirksMode::NoQuirks,
             AllowImportRules::Yes,
         );
-        let url_opt = stylesheet.contents.source_map_url.read();
-        assert_eq!(*url_opt, test.1);
+        let guard = lock.read();
+        let url_opt = stylesheet.contents(&guard).source_map_url.clone();
+        assert_eq!(url_opt, test.1);
     }
 }
 
@@ -220,13 +223,14 @@ fn test_source_url() {
             url.into(),
             Origin::UserAgent,
             media,
-            lock,
+            lock.clone(),
             None,
             None,
             QuirksMode::NoQuirks,
             AllowImportRules::Yes,
         );
-        let url_opt = stylesheet.contents.source_url.read();
-        assert_eq!(*url_opt, test.1);
+        let guard = lock.read();
+        let url_opt = stylesheet.contents(&guard).source_url.clone();
+        assert_eq!(url_opt, test.1);
     }
 }


### PR DESCRIPTION
I want to remove this stylo API and this is the only consumer. Instead just parse a new style stylesheet.

Shouldn't change behavior.