### PR TITLE
servoshell: Add CFBundleSupportedPlatforms to Info.plist

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -24,5 +24,9 @@
 	<string>NSApplication</string>
 	<key>NSQuitAlwaysKeepsWindows</key>
 	<false/>
+	<key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
 </dict>
 </plist>


### PR DESCRIPTION
Corrects Info.plist to correctly report supported system type on macOS.

Fixes: #40025
