### PR TITLE
script: Fully initialize `ResizeObserverEntry` fields

### DIFF
--- a/tests/wpt/meta/resize-observer/multiple-observers-with-mutation-crash.html.ini
+++ b/tests/wpt/meta/resize-observer/multiple-observers-with-mutation-crash.html.ini
@@ -1,2 +1,0 @@
-[multiple-observers-with-mutation-crash.html]
-    expected: TIMEOUT

--- a/tests/wpt/meta/resize-observer/observe.html.ini
+++ b/tests/wpt/meta/resize-observer/observe.html.ini
@@ -20,9 +20,6 @@
   [test14: observe the same target but using a different box should override the previous one]
     expected: FAIL
 
-  [test15: an observation is fired with box dimensions 0 when element's display property is set to inline]
-    expected: FAIL
-
   [test16: observations fire once with 0x0 size for non-replaced inline elements]
     expected: FAIL
 


### PR DESCRIPTION
A `ResizeObserverEntry` stores of three different lists of size values:
* border box sizes (`border-box`)
* content box sizes (`content-box`)
* content box sizes, in integral device pixels (`device-pixel-content-box`)

Currently, servo only stores content box sizes and leaves the other two empty:
https://github.com/servo/servo/blob/205b049fcd4ea1fd998c8343e65e794941ff35d8/components/script/dom/resizeobserver.rs#L155-L163

It's worth noting that the `device-pixel-content-box` observation type is not supported yet, so the only size reported will be a zero-sized rectangle.

https://github.com/servo/servo/blob/205b049fcd4ea1fd998c8343e65e794941ff35d8/components/script/dom/resizeobserver.rs#L328-L329



Testing: New web platform tests start to pass
Fixes https://github.com/servo/servo/issues/38811
Part of #39790 
