### PR TITLE
layout: Simplify `InlineFormattingContextBuilder::start_inline_box()`

### DIFF
--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -477,11 +477,7 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
         // Otherwise, this is just a normal inline box. Whatever happened before, all we need to do
         // before recurring is to remember this ongoing inline level box.
         self.ensure_inline_formatting_context_builder()
-            .start_inline_box(
-                || ArcRefCell::new(InlineBox::new(info)),
-                None,
-                old_layout_box,
-            );
+            .start_inline_box(|| ArcRefCell::new(InlineBox::new(info)), old_layout_box);
 
         if is_list_item {
             if let Some((marker_info, marker_contents)) =

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -219,7 +219,6 @@ impl InlineFormattingContextBuilder {
     pub(crate) fn start_inline_box(
         &mut self,
         inline_box_creator: impl FnOnce() -> ArcRefCell<InlineBox>,
-        block_in_inline_splits: Option<Vec<ArcRefCell<InlineItem>>>,
         old_layout_box: Option<LayoutBox>,
     ) {
         // If there is an existing undamaged layout box that's compatible, use the `InlineBox` within it.
@@ -239,17 +238,13 @@ impl InlineFormattingContextBuilder {
                 "Create inline box with incompatible `old_layout_box`"
             );
 
-            self.start_inline_box_internal(
-                inline_box_creator,
-                block_in_inline_splits,
-                old_block_in_inline_splits,
-            );
+            self.start_inline_box_internal(inline_box_creator, None, old_block_in_inline_splits);
         } else {
-            self.start_inline_box_internal(inline_box_creator, block_in_inline_splits, vec![]);
+            self.start_inline_box_internal(inline_box_creator, None, vec![]);
         }
     }
 
-    pub fn start_inline_box_internal(
+    fn start_inline_box_internal(
         &mut self,
         inline_box_creator: impl FnOnce() -> ArcRefCell<InlineBox>,
         block_in_inline_splits: Option<Vec<ArcRefCell<InlineItem>>>,


### PR DESCRIPTION
This patch removes the `block_in_inline_splits` parameter, since the single caller was just passing None. Then this parameter will only be provided for `start_inline_box_internal()`, which is made private since its an internal method as the name indicates.

Testing: Not needed, no behavior change
