### PR TITLE
layout: Cleanup clear_fragment_layout_cache()

### DIFF
--- a/components/layout/flexbox/mod.rs
+++ b/components/layout/flexbox/mod.rs
@@ -177,20 +177,6 @@ impl FlexLevelBox {
         }
     }
 
-    pub(crate) fn clear_fragment_layout_cache(&self) {
-        match self {
-            FlexLevelBox::FlexItem(flex_item_box) => flex_item_box
-                .independent_formatting_context
-                .base
-                .clear_fragment_layout_cache(),
-            FlexLevelBox::OutOfFlowAbsolutelyPositionedBox(positioned_box) => positioned_box
-                .borrow()
-                .context
-                .base
-                .clear_fragment_layout_cache(),
-        }
-    }
-
     pub(crate) fn with_base<T>(&self, callback: impl FnOnce(&LayoutBoxBase) -> T) -> T {
         match self {
             FlexLevelBox::FlexItem(flex_item_box) => {

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -248,33 +248,6 @@ impl InlineItem {
         }
     }
 
-    pub(crate) fn clear_fragment_layout_cache(&self) {
-        match self {
-            InlineItem::StartInlineBox(inline_box) => {
-                inline_box.borrow().base.clear_fragment_layout_cache()
-            },
-            InlineItem::EndInlineBox | InlineItem::TextRun(..) => {},
-            InlineItem::OutOfFlowAbsolutelyPositionedBox(positioned_box, ..) => {
-                positioned_box
-                    .borrow()
-                    .context
-                    .base
-                    .clear_fragment_layout_cache();
-            },
-            InlineItem::OutOfFlowFloatBox(float_box) => float_box
-                .borrow()
-                .contents
-                .base
-                .clear_fragment_layout_cache(),
-            InlineItem::Atomic(independent_formatting_context, ..) => {
-                independent_formatting_context
-                    .borrow()
-                    .base
-                    .clear_fragment_layout_cache()
-            },
-        }
-    }
-
     pub(crate) fn with_base<T>(&self, callback: impl FnOnce(&LayoutBoxBase) -> T) -> T {
         match self {
             InlineItem::StartInlineBox(inline_box) => callback(&inline_box.borrow().base),

--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -134,10 +134,6 @@ impl BlockLevelBox {
         }
     }
 
-    pub(crate) fn clear_fragment_layout_cache(&self) {
-        self.with_base(|base| base.clear_fragment_layout_cache());
-    }
-
     pub(crate) fn with_base<T>(&self, callback: impl FnOnce(&LayoutBoxBase) -> T) -> T {
         match self {
             BlockLevelBox::Independent(independent_formatting_context) => {

--- a/components/layout/table/mod.rs
+++ b/components/layout/table/mod.rs
@@ -397,21 +397,6 @@ pub(crate) enum TableLevelBox {
 }
 
 impl TableLevelBox {
-    pub(crate) fn clear_fragment_layout_cache(&self) {
-        match self {
-            TableLevelBox::Caption(caption) => {
-                caption.borrow().context.base.clear_fragment_layout_cache();
-            },
-            TableLevelBox::Cell(cell) => {
-                cell.borrow().base.clear_fragment_layout_cache();
-            },
-            TableLevelBox::TrackGroup(track_group) => {
-                track_group.borrow().base.clear_fragment_layout_cache()
-            },
-            TableLevelBox::Track(track) => track.borrow().base.clear_fragment_layout_cache(),
-        }
-    }
-
     pub(crate) fn with_base<T>(&self, callback: impl FnOnce(&LayoutBoxBase) -> T) -> T {
         match self {
             TableLevelBox::Caption(caption) => callback(&caption.borrow().context.base),

--- a/components/layout/taffy/mod.rs
+++ b/components/layout/taffy/mod.rs
@@ -128,25 +128,6 @@ impl TaffyItemBox {
         }
     }
 
-    pub(crate) fn clear_fragment_layout_cache(&mut self) {
-        self.taffy_layout = Default::default();
-        self.positioning_context = PositioningContext::default();
-        match self.taffy_level_box {
-            TaffyItemBoxInner::InFlowBox(ref independent_formatting_context) => {
-                independent_formatting_context
-                    .base
-                    .clear_fragment_layout_cache()
-            },
-            TaffyItemBoxInner::OutOfFlowAbsolutelyPositionedBox(ref positioned_box) => {
-                positioned_box
-                    .borrow()
-                    .context
-                    .base
-                    .clear_fragment_layout_cache()
-            },
-        }
-    }
-
     pub(crate) fn with_base<T>(&self, callback: impl FnOnce(&LayoutBoxBase) -> T) -> T {
         match self.taffy_level_box {
             TaffyItemBoxInner::InFlowBox(ref independent_formatting_context) => {


### PR DESCRIPTION
`LayoutBox::clear_fragment_layout_cache()` was just redirecting to the `clear_fragment_layout_cache()` method of inner structures, until reaching `LayoutBoxBase` where the work is actually done.

So this patch gets the `LayoutBoxBase` first, and then calls the method on it. To do so, `LayoutBox::with_base_fold()` is added as a non-mutable version of the existing `LayoutBox::with_base_mut_fold()`. But since we the return value doesn't matter, `LayoutBox::with_each_base()` is also added as a tiny helper around `LayoutBox::with_base_fold()`.

Testing: Not needed, no behavior change
