### PR TITLE
servoview: Focus the view when a touch input occurs.

### DIFF
--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -272,6 +272,7 @@ public class ServoView extends SurfaceView
 
     @Override
     public boolean onTouchEvent(final MotionEvent e) {
+        requestFocus();
         mGestureDetector.onTouchEvent(e);
         mScaleGestureDetector.onTouchEvent(e);
 


### PR DESCRIPTION
Focusing the location bar in the Android app shows the onscreen keyboard, but clicking on a link in the current document does not make it disappear. This change ensures the input focus is reset appropriately and ensures the keyboard disappear when the location bar is not being edited.

Testing: Manually tested. No automated tests for Android app at this time.
Fixes: #40008