### PR TITLE
cargo-deny: add exceptions for 'unic-*' crates.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,16 @@ feature-depth = 1
 ignore = [
     # The crate `paste` is no longer maintained.
     "RUSTSEC-2024-0436",
+    # The crate `unic-char-range` is unmaintained.
+    "RUSTSEC-2025-0075",
+    # The crate `unic-common` is unmaintained.
+    "RUSTSEC-2025-0080",
+    # The crate `unic-char-property` is unmaintained.
+    "RUSTSEC-2025-0081",
+    # The crate `unic-ucd-version` is unmaintained.
+    "RUSTSEC-2025-0098",
+    # The crate `unic-ucd-ident` is unmaintained.
+    "RUSTSEC-2025-0100",
 ]
 
 # This section is considered when running `cargo deny check licenses`


### PR DESCRIPTION
These crates are now marked as 'unmaintained' and cause `test-tidy` to fail on CI. They are pulled in by the `urlpattern 0.3` crate which needs to be upgraded to `0.4` but that is blocked to the duplication of some icu4x crates (which need to be upgraded to 2.0) and a few other crates.

Testing:  No testing needed.

