### PR TITLE
script: Validate worker_type in `WorkerGlobalScope::ImportScripts`

### DIFF
--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -637,9 +637,17 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
         url_strings: Vec<TrustedScriptURLOrUSVString>,
         can_gc: CanGc,
     ) -> ErrorResult {
-        // Step 1: Let urlStrings be « ».
+        // https://html.spec.whatwg.org/multipage/#import-scripts-into-worker-global-scope
+        // Step 1: If worker global scope's type is "module", throw a TypeError exception.
+        if self.worker_type == WorkerType::Module {
+            return Err(Error::Type(
+                "importScripts() is not allowed in module workers".to_string(),
+            ));
+        }
+
+        // Step 4: Let urlStrings be « ».
         let mut urls = Vec::with_capacity(url_strings.len());
-        // Step 2: For each url of urls:
+        // Step 5: For each url of urls:
         for url in url_strings {
             // Step 3: Append the result of invoking the Get Trusted Type compliant string algorithm
             // with TrustedScriptURL, this's relevant global object, url, "WorkerGlobalScope importScripts",

--- a/tests/wpt/meta/service-workers/service-worker/worker-interception-redirect.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/worker-interception-redirect.https.html.ini
@@ -44,9 +44,6 @@
   [Case #1: network scope1->scope2 (classic DedicatedWorker, fetch())]
     expected: FAIL
 
-  [Case #1: network scope1->scope2 (module DedicatedWorker, importScripts())]
-    expected: FAIL
-
   [Case #1: network scope1->scope2 (module DedicatedWorker, fetch())]
     expected: FAIL
 
@@ -54,9 +51,6 @@
     expected: FAIL
 
   [Case #2: network scope1->out-scope (classic DedicatedWorker, fetch())]
-    expected: FAIL
-
-  [Case #2: network scope1->out-scope (module DedicatedWorker, importScripts())]
     expected: FAIL
 
   [Case #2: network scope1->out-scope (module DedicatedWorker, fetch())]


### PR DESCRIPTION
Implement the first step of the "import scripts into worker global scope": throw a `TypeError` when `importScripts()` is called in a module worker.

According to the [spec](https://html.spec.whatwg.org/multipage/workers.html#import-scripts-into-worker-global-scope):
> If worker global scope's type is "module", throw a TypeError exception.

This check is performed at the beginning of `ImportScripts()`, before any URL parsing or network operations.

Fixes: #40035

[Try build](https://github.com/WaterWhisperer/servo/actions/runs/18712341350)