### PR TITLE
config: Enable AbortController/AbortSignal by default.

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -277,7 +277,7 @@ impl Preferences {
             css_animations_testing_enabled: false,
             devtools_server_enabled: false,
             devtools_server_port: 0,
-            dom_abort_controller_enabled: false,
+            dom_abort_controller_enabled: true,
             dom_adoptedstylesheet_enabled: false,
             dom_allow_scripts_to_close_windows: false,
             dom_async_clipboard_enabled: false,

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -25,7 +25,6 @@ use url::Url;
 use crate::VERSION;
 
 pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
-    "dom_abort_controller_enabled",
     "dom_async_clipboard_enabled",
     "dom_fontface_enabled",
     "dom_intersection_observer_enabled",

--- a/tests/wpt/meta/fetch/fetch-later/__dir__.ini
+++ b/tests/wpt/meta/fetch/fetch-later/__dir__.ini
@@ -1,3 +1,0 @@
-prefs: [
-  "dom_abort_controller_enabled:true",
-]


### PR DESCRIPTION
Make the engine default to enabling the AbortController implementation.

Testing: No behaviour change to tests, just flipping defaults.
Fixes: #34866
