### PR TITLE
compositing: Fully implement pinch zoom

### DIFF
--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -22,6 +22,7 @@ pub use crate::compositor::{IOCompositor, WebRenderDebugOption};
 mod tracing;
 
 mod compositor;
+mod pinch_zoom;
 mod refresh_driver;
 mod render_notifier;
 mod screenshot;

--- a/components/compositing/pinch_zoom.rs
+++ b/components/compositing/pinch_zoom.rs
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use euclid::{Point2D, Rect, Scale, Transform2D, Vector2D};
+use webrender_api::ScrollLocation;
+use webrender_api::units::{DevicePixel, DevicePoint, DeviceRect, DeviceSize, DeviceVector2D};
+
+/// A [`PinchZoom`] describes the pinch zoom viewport of a `WebView`. This is used to
+/// track the current pinch zoom transformation and to clamp all pinching and panning
+/// to the unscaled `WebView` viewport.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct PinchZoom {
+    zoom_factor: f32,
+    transform: Transform2D<f32, DevicePixel, DevicePixel>,
+    unscaled_viewport_size: DeviceSize,
+}
+
+impl PinchZoom {
+    pub(crate) fn new(webview_rect: DeviceRect) -> Self {
+        Self {
+            zoom_factor: 1.0,
+            unscaled_viewport_size: webview_rect.size(),
+            transform: Transform2D::identity(),
+        }
+    }
+
+    pub(crate) fn transform(&self) -> Transform2D<f32, DevicePixel, DevicePixel> {
+        self.transform
+    }
+
+    pub(crate) fn zoom_factor(&self) -> Scale<f32, DevicePixel, DevicePixel> {
+        Scale::new(self.zoom_factor)
+    }
+
+    fn set_transform(&mut self, transform: Transform2D<f32, DevicePixel, DevicePixel>) {
+        let rect = Rect::new(
+            Point2D::origin(),
+            self.unscaled_viewport_size.to_vector().to_size(),
+        )
+        .cast_unit();
+        let mut rect = transform
+            .inverse()
+            .expect("Should always be able to invert provided transform")
+            .outer_transformed_rect(&rect);
+        rect.origin = rect.origin.clamp(
+            Point2D::origin(),
+            (self.unscaled_viewport_size - rect.size)
+                .to_vector()
+                .to_point(),
+        );
+        let scale = self.unscaled_viewport_size.width / rect.width();
+        self.transform = Transform2D::identity()
+            .then_translate(Vector2D::new(-rect.origin.x, -rect.origin.y))
+            .then_scale(scale, scale);
+    }
+
+    pub(crate) fn zoom(&mut self, magnification: f32, new_center: DevicePoint) {
+        const MINIMUM_PINCH_ZOOM: f32 = 1.0;
+        const MAXIMUM_PINCH_ZOOM: f32 = 10.0;
+        let new_factor =
+            (self.zoom_factor * magnification).clamp(MINIMUM_PINCH_ZOOM, MAXIMUM_PINCH_ZOOM);
+        let old_factor = std::mem::replace(&mut self.zoom_factor, new_factor);
+
+        if self.zoom_factor <= 1.0 {
+            self.transform = Transform2D::identity();
+            return;
+        }
+
+        let magnification = self.zoom_factor / old_factor;
+        let transform = self
+            .transform
+            .then_translate(Vector2D::new(-new_center.x, -new_center.y))
+            .then_scale(magnification, magnification)
+            .then_translate(Vector2D::new(new_center.x, new_center.y));
+        self.set_transform(transform);
+    }
+
+    /// Pan the pinch zoom viewoprt by the given [`ScrollLocation`] and if it is a delta,
+    /// modify the delta to reflect the remaining unused scroll delta.
+    pub(crate) fn pan(&mut self, scroll_location: &mut ScrollLocation) {
+        // TODO: The delta passed help in `ScrollLocation` is a LayoutVector2D, but is actually
+        // in DevicePixels! This should reflect reality.
+        match scroll_location {
+            ScrollLocation::Delta(delta) => {
+                let remaining =
+                    self.pan_with_delta(DeviceScroll::Delta(DeviceVector2D::new(delta.x, delta.y)));
+                *delta = Vector2D::new(remaining.x, remaining.y)
+            },
+            ScrollLocation::Start => {
+                self.pan_with_delta(DeviceScroll::Start);
+            },
+            ScrollLocation::End => {
+                self.pan_with_delta(DeviceScroll::End);
+            },
+        }
+    }
+
+    /// Pan the pinch zoom viewport by the given delta and return the remaining device
+    /// pixel value that was unused.
+    fn pan_with_delta(&mut self, scroll: DeviceScroll) -> DeviceVector2D {
+        let current_viewport = Rect::new(
+            Point2D::origin(),
+            self.unscaled_viewport_size.to_vector().to_size(),
+        );
+        let layout_viewport_in_device_pixels =
+            self.transform.outer_transformed_rect(&current_viewport);
+        let max_viewport_offset = -(layout_viewport_in_device_pixels.size -
+            self.unscaled_viewport_size.to_vector().to_size());
+        let max_delta = layout_viewport_in_device_pixels.origin - max_viewport_offset;
+
+        let delta = match scroll {
+            DeviceScroll::Delta(delta) => delta,
+            DeviceScroll::Start => DeviceVector2D::new(0.0, max_delta.y),
+            DeviceScroll::End => {
+                DeviceVector2D::new(0.0, -layout_viewport_in_device_pixels.origin.y)
+            },
+        };
+
+        let mut remaining = Vector2D::zero();
+        if delta.x < 0.0 {
+            remaining.x = (delta.x - layout_viewport_in_device_pixels.origin.x).min(0.0);
+        }
+        if delta.y < 0.0 {
+            remaining.y = (delta.y - layout_viewport_in_device_pixels.origin.y).min(0.0);
+        }
+        if delta.x > 0.0 {
+            remaining.x = (delta.x - max_delta.x).max(0.0);
+        }
+        if delta.y > 0.0 {
+            remaining.y = (delta.y - max_delta.y).max(0.0);
+        }
+
+        self.set_transform(
+            self.transform
+                .then_translate(Vector2D::new(-delta.x, -delta.y)),
+        );
+
+        remaining
+    }
+}
+
+enum DeviceScroll {
+    Delta(DeviceVector2D),
+    Start,
+    End,
+}

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -24,7 +24,7 @@ use servo_geometry::DeviceIndependentPixel;
 use style_traits::CSSPixel;
 use url::Url;
 use webrender_api::ScrollLocation;
-use webrender_api::units::{DeviceIntPoint, DevicePixel, DeviceRect};
+use webrender_api::units::{DeviceIntPoint, DevicePixel, DevicePoint, DeviceRect};
 
 use crate::clipboard_delegate::{ClipboardDelegate, DefaultClipboardDelegate};
 use crate::javascript_evaluator::JavaScriptEvaluator;
@@ -547,11 +547,11 @@ impl WebView {
     ///
     /// The final pinch zoom values will be clamped to reasonable defaults (currently to
     /// the inclusive range [1.0, 10.0]).
-    pub fn pinch_zoom(&self, pinch_zoom_delta: f32) {
+    pub fn pinch_zoom(&self, pinch_zoom_delta: f32, center: DevicePoint) {
         self.inner()
             .compositor
             .borrow_mut()
-            .pinch_zoom(self.id(), pinch_zoom_delta);
+            .pinch_zoom(self.id(), pinch_zoom_delta, center);
     }
 
     pub fn device_pixels_per_css_pixel(&self) -> Scale<f32, CSSPixel, DevicePixel> {

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -758,7 +758,7 @@ impl WindowPortsMethods for Window {
                 )));
             },
             WindowEvent::PinchGesture { delta, .. } => {
-                webview.pinch_zoom(delta as f32 + 1.0);
+                webview.pinch_zoom(delta as f32 + 1.0, self.webview_relative_mouse_point.get());
             },
             WindowEvent::CloseRequested => {
                 state.servo().start_shutting_down();

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -401,11 +401,11 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_pinchZoomStart<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
     factor: jfloat,
-    x: jint,
-    y: jint,
+    x: jfloat,
+    y: jfloat,
 ) {
     debug!("pinchZoomStart");
-    call(&mut env, |s| s.pinchzoom_start(factor, x as u32, y as u32));
+    call(&mut env, |s| s.pinchzoom_start(factor, x, y));
 }
 
 #[unsafe(no_mangle)]
@@ -413,11 +413,11 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_pinchZoom<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
     factor: jfloat,
-    x: jint,
-    y: jint,
+    x: jfloat,
+    y: jfloat,
 ) {
     debug!("pinchZoom");
-    call(&mut env, |s| s.pinchzoom(factor, x as u32, y as u32));
+    call(&mut env, |s| s.pinchzoom(factor, x, y));
 }
 
 #[unsafe(no_mangle)]
@@ -425,11 +425,11 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_pinchZoomEnd<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
     factor: jfloat,
-    x: jint,
-    y: jint,
+    x: jfloat,
+    y: jfloat,
 ) {
     debug!("pinchZoomEnd");
-    call(&mut env, |s| s.pinchzoom_end(factor, x as u32, y as u32));
+    call(&mut env, |s| s.pinchzoom_end(factor, x, y));
 }
 
 #[unsafe(no_mangle)]

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -17,7 +17,7 @@ use servo::base::id::WebViewId;
 use servo::ipc_channel::ipc::IpcSender;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::ScrollLocation;
-use servo::webrender_api::units::{DeviceIntRect, DeviceIntSize, DevicePixel};
+use servo::webrender_api::units::{DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint};
 use servo::{
     AllowOrDenyRequest, ContextMenuResult, ImeEvent, InputEvent, InputMethodType, KeyboardEvent,
     LoadStatus, MediaSessionActionType, MediaSessionEvent, MouseButton, MouseButtonAction,
@@ -852,22 +852,25 @@ impl RunningAppState {
 
     /// Start pinchzoom.
     /// x/y are pinch origin coordinates.
-    pub fn pinchzoom_start(&self, factor: f32, _x: u32, _y: u32) {
-        self.active_webview().pinch_zoom(factor);
+    pub fn pinchzoom_start(&self, factor: f32, x: f32, y: f32) {
+        self.active_webview()
+            .pinch_zoom(factor, DevicePoint::new(x, y));
         self.perform_updates();
     }
 
     /// Pinchzoom.
     /// x/y are pinch origin coordinates.
-    pub fn pinchzoom(&self, factor: f32, _x: u32, _y: u32) {
-        self.active_webview().pinch_zoom(factor);
+    pub fn pinchzoom(&self, factor: f32, x: f32, y: f32) {
+        self.active_webview()
+            .pinch_zoom(factor, DevicePoint::new(x, y));
         self.perform_updates();
     }
 
     /// End pinchzoom.
     /// x/y are pinch origin coordinates.
-    pub fn pinchzoom_end(&self, factor: f32, _x: u32, _y: u32) {
-        self.active_webview().pinch_zoom(factor);
+    pub fn pinchzoom_end(&self, factor: f32, x: f32, y: f32) {
+        self.active_webview()
+            .pinch_zoom(factor, DevicePoint::new(x, y));
         self.perform_updates();
     }
 

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
@@ -54,11 +54,11 @@ public class JNIServo {
 
     public native void touchCancel(float x, float y, int pointer_id);
 
-    public native void pinchZoomStart(float factor, int x, int y);
+    public native void pinchZoomStart(float factor, float x, float y);
 
-    public native void pinchZoom(float factor, int x, int y);
+    public native void pinchZoom(float factor, float x, float y);
 
-    public native void pinchZoomEnd(float factor, int x, int y);
+    public native void pinchZoomEnd(float factor, float x, float y);
 
     public native void click(float x, float y);
 
@@ -122,4 +122,3 @@ public class JNIServo {
         void onMediaSessionSetPositionState(float duration, float position, float playbackRate);
     }
 }
-

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
@@ -136,15 +136,15 @@ public class Servo {
         mRunCallback.inGLThread(() -> mJNI.touchCancel(x, y, pointerId));
     }
 
-    public void pinchZoomStart(float factor, int x, int y) {
+    public void pinchZoomStart(float factor, float x, float y) {
         mRunCallback.inGLThread(() -> mJNI.pinchZoomStart(factor, x, y));
     }
 
-    public void pinchZoom(float factor, int x, int y) {
+    public void pinchZoom(float factor, float x, float y) {
         mRunCallback.inGLThread(() -> mJNI.pinchZoom(factor, x, y));
     }
 
-    public void pinchZoomEnd(float factor, int x, int y) {
+    public void pinchZoomEnd(float factor, float x, float y) {
         mRunCallback.inGLThread(() -> mJNI.pinchZoomEnd(factor, x, y));
     }
 

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -55,6 +55,8 @@ public class ServoView extends SurfaceView
     private int mCurX = 0;
     private int mLastY = 0;
     private int mCurY = 0;
+    private float mFocusX = 0;
+    private float mFocusY = 0;
     private boolean mFlinging;
     private ScaleGestureDetector mScaleGestureDetector;
     private OverScroller mScroller;
@@ -179,7 +181,7 @@ public class ServoView extends SurfaceView
         }
 
         if (zoomNecessary) {
-            mServo.pinchZoom(mZoomFactor, 0, 0);
+            mServo.pinchZoom(mZoomFactor, mFocusX, mFocusY);
             mZoomFactor = 1;
         }
 
@@ -332,8 +334,10 @@ public class ServoView extends SurfaceView
     public boolean onScaleBegin(ScaleGestureDetector detector) {
         if (mScroller.isFinished()) {
             mZoomFactor = detector.getScaleFactor();
+            mFocusX = detector.getFocusX();
+            mFocusY = detector.getFocusY();
             mZooming = true;
-            mServo.pinchZoomStart(mZoomFactor, 0, 0);
+            mServo.pinchZoomStart(mZoomFactor, mFocusX, mFocusY);
             startLooping();
             return true;
         } else {
@@ -344,14 +348,18 @@ public class ServoView extends SurfaceView
     @Override
     public boolean onScale(ScaleGestureDetector detector) {
         mZoomFactor *= detector.getScaleFactor();
+        mFocusX = detector.getFocusX();
+        mFocusY = detector.getFocusY();
         return true;
     }
 
     @Override
     public void onScaleEnd(ScaleGestureDetector detector) {
         mZoomFactor = detector.getScaleFactor();
+        mFocusX = detector.getFocusX();
+        mFocusY = detector.getFocusY();
         mZooming = false;
-        mServo.pinchZoomEnd(mZoomFactor, 0, 0);
+        mServo.pinchZoomEnd(mZoomFactor, mFocusX, mFocusY);
     }
 
     private void initGestures(Context context) {


### PR DESCRIPTION
This change adds a full implementation of pinch zoom, including
center-aware zooming. Before this kind of pinch zooming was only enabled
on OpenHarmony. Now all pinch zooms must come with a focal point, which
determines the center point of the zoom. This enables full pinch zoom on
Android and has OpenHarmony use the same system for pinch zoom.

Every WebView now has a `PinchZoom` which describes the viewport of the
pinch zoom and handles panning with proper chaining of zoom viewport
panning to scroll layer scrolling.  In addition, the collection of touch
actions is simplified by storing an array and turning each into a
ScrollZoomEvent when appropriate.

Caveats:
-  We've noticed some hard to diagnose bugs with clamping the panning
  viewport, but we'll tackle those later once we figure out how to
  reliably reproduce them.
- Keyboard scroll events currently do not properly pan the pinch zoom
   viewport. This will be handled in a followup.

Testing: There are currently no tests for this kind of touch interaction
as there's no way to read the pinch zoom from a WebView. It's processed
asynchronously. Once that API is added, we should be able to add some
simple tests, but many things are still unaccessible such as the pan
position in the pinch zoom viewport.
Fixes #4224.
