### PR TITLE
storage: Rename remaining references storage to webstorage

### DIFF
--- a/components/shared/storage/lib.rs
+++ b/components/shared/storage/lib.rs
@@ -16,17 +16,17 @@ pub mod webstorage_thread;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StorageThreads {
-    storage_thread: GenericSender<WebStorageThreadMsg>,
+    web_storage_thread: GenericSender<WebStorageThreadMsg>,
     idb_thread: IpcSender<IndexedDBThreadMsg>,
 }
 
 impl StorageThreads {
     pub fn new(
-        storage_thread: GenericSender<WebStorageThreadMsg>,
+        web_storage_thread: GenericSender<WebStorageThreadMsg>,
         idb_thread: IpcSender<IndexedDBThreadMsg>,
     ) -> StorageThreads {
         StorageThreads {
-            storage_thread,
+            web_storage_thread,
             idb_thread,
         }
     }
@@ -44,11 +44,11 @@ impl IpcSend<IndexedDBThreadMsg> for StorageThreads {
 
 impl GenericSend<WebStorageThreadMsg> for StorageThreads {
     fn send(&self, msg: WebStorageThreadMsg) -> SendResult {
-        self.storage_thread.send(msg)
+        self.web_storage_thread.send(msg)
     }
 
     fn sender(&self) -> GenericSender<WebStorageThreadMsg> {
-        self.storage_thread.clone()
+        self.web_storage_thread.clone()
     }
 }
 

--- a/components/storage/storage_thread.rs
+++ b/components/storage/storage_thread.rs
@@ -19,10 +19,10 @@ pub fn new_storage_threads(
     config_dir: Option<PathBuf>,
 ) -> (StorageThreads, StorageThreads) {
     let idb: IpcSender<IndexedDBThreadMsg> = IndexedDBThreadFactory::new(config_dir.clone());
-    let storage: GenericSender<WebStorageThreadMsg> =
+    let web_storage: GenericSender<WebStorageThreadMsg> =
         WebStorageThreadFactory::new(config_dir, mem_profiler_chan);
     (
-        StorageThreads::new(storage.clone(), idb.clone()),
-        StorageThreads::new(storage, idb),
+        StorageThreads::new(web_storage.clone(), idb.clone()),
+        StorageThreads::new(web_storage, idb),
     )
 }


### PR DESCRIPTION
Clarifies the remaining references to `storage` that actually refer to `webstorage`.

Testing: Refactor