### PR TITLE
net: Add warning log for failed HTTP requests.

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -846,6 +846,7 @@ async fn obtain_response(
                 )))
             })
             .map_err(move |error| {
+                warn!("network error: {error:?}");
                 NetworkError::from_hyper_error(
                     &error,
                     override_manager.remove_certificate_failing_verification(host.as_str()),


### PR DESCRIPTION
We currently lose information when there are connection issues with HTTP requests. Until we figure out a better architecture for exposing error data from crates that we don't control, we can at least log messages like `WARN  net::http_loader] network error: hyper_util::client::legacy::Error(Connect, Custom { kind: Other, error: Custom { kind: InvalidData, error: AlertReceived(HandshakeFailure) } }`.

Testing: Manually confirmed console output for fsf.org with RUST_LOG=net.