### PR TITLE
compositing: Move WebRender initialization to `IOCompositor` creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1484,6 +1484,7 @@ dependencies = [
  "log",
  "pixels",
  "profile_traits",
+ "rayon",
  "rustc-hash 2.1.1",
  "servo-tracing",
  "servo_allocator",

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -38,6 +38,7 @@ log = { workspace = true }
 malloc_size_of = { workspace = true }
 pixels = { path = "../pixels" }
 profile_traits = { workspace = true }
+rayon = { workspace = true }
 rustc-hash = { workspace = true }
 servo-tracing = { workspace = true }
 servo_allocator = { path = "../allocator" }

--- a/components/compositing/render_notifier.rs
+++ b/components/compositing/render_notifier.rs
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use compositing_traits::{CompositorMsg, CompositorProxy};
+use webrender_api::{DocumentId, FramePublishId, FrameReadyParams};
+
+#[derive(Clone)]
+pub(crate) struct RenderNotifier {
+    compositor_proxy: CompositorProxy,
+}
+
+impl RenderNotifier {
+    pub(crate) fn new(compositor_proxy: CompositorProxy) -> RenderNotifier {
+        RenderNotifier { compositor_proxy }
+    }
+}
+
+impl webrender_api::RenderNotifier for RenderNotifier {
+    fn clone(&self) -> Box<dyn webrender_api::RenderNotifier> {
+        Box::new(RenderNotifier::new(self.compositor_proxy.clone()))
+    }
+
+    fn wake_up(&self, _composite_needed: bool) {}
+
+    fn new_frame_ready(
+        &self,
+        document_id: DocumentId,
+        _: FramePublishId,
+        frame_ready_params: &FrameReadyParams,
+    ) {
+        self.compositor_proxy
+            .send(CompositorMsg::NewWebRenderFrameReady(
+                document_id,
+                frame_ready_params.render,
+            ));
+    }
+}

--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -61,7 +61,7 @@ pub struct Opts {
     pub random_pipeline_closure_seed: Option<usize>,
 
     /// Load shaders from disk.
-    pub shaders_dir: Option<PathBuf>,
+    pub shaders_path: Option<PathBuf>,
 
     /// Directory for a default config directory
     pub config_dir: Option<PathBuf>,
@@ -175,7 +175,7 @@ impl Default for Opts {
             sandbox: false,
             debug: Default::default(),
             config_dir: None,
-            shaders_dir: None,
+            shaders_path: None,
             certificate_path: None,
             ignore_certificate_errors: false,
             unminify_js: false,

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -177,9 +177,8 @@ use style::global_style_data::StyleThreadPool;
 use webgpu::canvas_context::WGPUImageMap;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::{WebGPU, WebGPURequest};
-use webrender::RenderApiSender;
 use webrender_api::units::LayoutVector2D;
-use webrender_api::{DocumentId, ExternalScrollId, ImageKey};
+use webrender_api::{ExternalScrollId, ImageKey};
 
 use crate::broadcastchannel::BroadcastChannels;
 use crate::browsingcontext::{
@@ -550,12 +549,6 @@ pub struct InitialConstellationState {
 
     /// A channel to the memory profiler thread.
     pub mem_profiler_chan: mem::ProfilerChan,
-
-    /// Webrender document ID.
-    pub webrender_document: DocumentId,
-
-    /// Webrender API.
-    pub webrender_api_sender: RenderApiSender,
 
     /// Webrender external images
     pub webrender_external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,

--- a/components/webgl/webgl_mode/inprocess.rs
+++ b/components/webgl/webgl_mode/inprocess.rs
@@ -16,7 +16,6 @@ use log::debug;
 use rustc_hash::FxHashMap;
 use surfman::chains::{SwapChainAPI, SwapChains, SwapChainsAPI};
 use surfman::{Device, SurfaceTexture};
-use webrender::RenderApiSender;
 #[cfg(feature = "webxr")]
 use webxr::SurfmanGL as WebXRSurfman;
 #[cfg(feature = "webxr")]
@@ -36,7 +35,6 @@ impl WebGLComm {
     pub fn new(
         rendering_context: Rc<dyn RenderingContext>,
         compositor_api: CrossProcessCompositorApi,
-        webrender_api_sender: RenderApiSender,
         external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
         api_type: GlType,
     ) -> WebGLComm {
@@ -57,7 +55,6 @@ impl WebGLComm {
         // This implementation creates a single `WebGLThread` for all the pipelines.
         let init = WebGLThreadInit {
             compositor_api,
-            webrender_api_sender,
             external_images,
             sender: sender.clone(),
             receiver,

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -720,7 +720,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         random_pipeline_closure_probability: cmd_args.random_pipeline_closure_probability,
         random_pipeline_closure_seed: cmd_args.random_pipeline_closure_seed,
         config_dir: config_dir.clone(),
-        shaders_dir: cmd_args.shaders,
+        shaders_path: cmd_args.shaders,
         certificate_path: cmd_args
             .certificate_path
             .map(|p| p.to_string_lossy().into_owned()),


### PR DESCRIPTION
In order to support multiple WebRender instances in the renderer, we
need the ability for the renderer itself to manage their creation and
destruction. This change moves the initialization of the (currently)
single WebRender instances to the renderer initialization.

Testing: This should not change behavior, so is covered by existing tests.
