### PR TITLE
xpath: Provide error message when throwing SyntaxError from parsing

### DIFF
--- a/components/script/dom/xpathevaluator.rs
+++ b/components/script/dom/xpathevaluator.rs
@@ -20,6 +20,7 @@ use crate::dom::window::Window;
 use crate::dom::xpathexpression::XPathExpression;
 use crate::dom::xpathresult::XPathResult;
 use crate::script_runtime::CanGc;
+use crate::xpath::parse_expression;
 
 #[dom_struct]
 pub(crate) struct XPathEvaluator {
@@ -68,10 +69,7 @@ impl XPathEvaluatorMethods<crate::DomTypeHolder> for XPathEvaluator {
     ) -> Fallible<DomRoot<XPathExpression>> {
         let global = self.global();
         let window = global.as_window();
-        // NB: this function is *not* Fallible according to the spec, so we swallow any parsing errors and
-        // just pass a None as the expression... it's not great.
-        let parsed_expression =
-            xpath::parse::<()>(&expression.str()).map_err(|_e| Error::Syntax(None))?;
+        let parsed_expression = parse_expression(&expression.str())?;
         Ok(XPathExpression::new(
             window,
             None,
@@ -114,8 +112,7 @@ impl XPathEvaluatorMethods<crate::DomTypeHolder> for XPathEvaluator {
         let global = self.global();
         let window = global.as_window();
 
-        let parsed_expression =
-            xpath::parse::<()>(&expression_str.str()).map_err(|_| Error::Syntax(None))?;
+        let parsed_expression = parse_expression(&expression_str.str())?;
         let expression = XPathExpression::new(window, None, can_gc, parsed_expression);
         expression.evaluate_internal(context_node, result_type, result, resolver, can_gc)
     }


### PR DESCRIPTION
This change was split of from https://github.com/servo/servo/pull/39977 to make that PR easier to review.

The `Debug` impl for the error is not very useful yet, but https://github.com/servo/servo/pull/39977 swaps out the error type itself, so there's no point in improving it here.

Testing: I've manually tested that the error message appears. I don't think we have tests for error messages.
Part of #34527 
