### PR TITLE
xpath: Verify context node in XPathExpression::evaluate_internal

### DIFF
--- a/components/script/dom/xpathevaluator.rs
+++ b/components/script/dom/xpathevaluator.rs
@@ -6,9 +6,7 @@ use std::rc::Rc;
 
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
-use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId};
 
-use super::bindings::error::Error;
 use crate::dom::bindings::codegen::Bindings::XPathEvaluatorBinding::XPathEvaluatorMethods;
 use crate::dom::bindings::codegen::Bindings::XPathNSResolverBinding::XPathNSResolver;
 use crate::dom::bindings::error::Fallible;
@@ -94,21 +92,6 @@ impl XPathEvaluatorMethods<crate::DomTypeHolder> for XPathEvaluator {
         result: Option<&XPathResult>,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<XPathResult>> {
-        let is_allowed_context_node_type = matches!(
-            context_node.type_id(),
-            NodeTypeId::Attr |
-                NodeTypeId::CharacterData(
-                    CharacterDataTypeId::Comment |
-                        CharacterDataTypeId::Text(_) |
-                        CharacterDataTypeId::ProcessingInstruction
-                ) |
-                NodeTypeId::Document(_) |
-                NodeTypeId::Element(_)
-        );
-        if !is_allowed_context_node_type {
-            return Err(Error::NotSupported);
-        }
-
         let global = self.global();
         let window = global.as_window();
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13819,7 +13819,7 @@
      ]
     ],
     "invalid-xpath-context-nodes.html": [
-     "b306037d7fa8923af92d60a09c5df77e2937e4f6",
+     "214d44f605362f16a3f9dde00e4d092098e8d307",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/invalid-xpath-context-nodes.html
+++ b/tests/wpt/mozilla/tests/mozilla/invalid-xpath-context-nodes.html
@@ -16,6 +16,10 @@
         assert_throws_dom("NotSupportedError", () => {
           document.evaluate(".", root, null, XPathResult.ANY_TYPE, null);
         });
+        assert_throws_dom("NotSupportedError", () => {
+          let expression = (new XPathEvaluator).createExpression(".", null)
+          expression.evaluate(root, XPathResult.ANY_TYPE, null);
+        });
       }, "Using a ShadowRoot as a context node should throw a NotSupported Error");
     </script>
 </body>


### PR DESCRIPTION
`evaluate_internal` is the common code path used when evaluating an expression, so any verification that always applies must happen there.

Testing: This change adds a test
Fixes https://github.com/servo/servo/issues/40104
Part of #34527 
