### PR TITLE
blurmac: Update objc2 to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ name = "blurmac"
 version = "0.1.0"
 dependencies = [
  "log",
- "objc2 0.2.7",
+ "objc2 0.4.1",
 ]
 
 [[package]]
@@ -5789,11 +5789,12 @@ checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
-version = "0.2.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612c08b52f6d8b11d8c199d0798bc38ab35c0a95da3be548a60808a4ae56d1f4"
+checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
 dependencies = [
- "malloc_buf",
+ "objc-sys",
+ "objc2-encode 3.0.0",
 ]
 
 [[package]]
@@ -5803,7 +5804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
  "objc-sys",
- "objc2-encode",
+ "objc2-encode 4.1.0",
 ]
 
 [[package]]
@@ -5812,7 +5813,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
- "objc2-encode",
+ "objc2-encode 4.1.0",
 ]
 
 [[package]]
@@ -5939,6 +5940,12 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
+
+[[package]]
+name = "objc2-encode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
 name = "objc2-encode"

--- a/deny.toml
+++ b/deny.toml
@@ -193,6 +193,9 @@ skip = [
     # really just a build dep, so not a large problem.
     "toml_datetime",
     "toml_edit",
+
+    # blurmac
+    "objc2-encode",
 ]
 
 # github.com organizations to allow git sources for

--- a/third_party/blurmac/Cargo.toml
+++ b/third_party/blurmac/Cargo.toml
@@ -16,8 +16,4 @@ crate-type = ["rlib"]
 
 [dependencies]
 log = "0.4"
-objc2 = "0.2"
-
-# Remove this when updating objc2 to a more recent version
-[lints.rust]
-unexpected_cfgs = { level = "allow" }
+objc2 = "0.4"

--- a/third_party/blurmac/src/adapter.rs
+++ b/third_party/blurmac/src/adapter.rs
@@ -8,7 +8,8 @@
 use std::error::Error;
 use std::os::raw::c_int;
 
-use objc2::runtime::{Object, YES};
+use objc2::ffi::YES;
+use objc2::runtime::AnyObject;
 
 use crate::delegate::bm;
 use crate::framework::{cb, io, ns};
@@ -16,8 +17,8 @@ use crate::utils::{NOT_SUPPORTED_ERROR, nsx};
 
 #[derive(Clone, Debug)]
 pub struct BluetoothAdapter {
-    pub(crate) manager: *mut Object,
-    pub(crate) delegate: *mut Object,
+    pub(crate) manager: *mut AnyObject,
+    pub(crate) delegate: *mut AnyObject,
 }
 // TODO: implement std::fmt::Debug and/or std::fmt::Display instead of derive?
 

--- a/third_party/blurmac/src/delegate.rs
+++ b/third_party/blurmac/src/delegate.rs
@@ -8,8 +8,8 @@
 use std::error::Error;
 use std::sync::Once;
 
-use objc2::declare::ClassDecl;
-use objc2::runtime::{Class, Object, Protocol, Sel};
+use objc2::declare::ClassBuilder;
+use objc2::runtime::{AnyClass, AnyObject, AnyProtocol, Sel};
 
 use crate::framework::{cb, nil, ns};
 use crate::utils::{NO_PERIPHERAL_FOUND, cbx, nsx, wait};
@@ -21,65 +21,65 @@ pub mod bm {
 
     const DELEGATE_PERIPHERALS_IVAR: &str = "_peripherals";
 
-    fn delegate_class() -> &'static Class {
+    fn delegate_class() -> &'static AnyClass {
         trace!("delegate_class");
         static REGISTER_DELEGATE_CLASS: Once = Once::new();
 
         REGISTER_DELEGATE_CLASS.call_once(|| {
-            let mut decl = ClassDecl::new("BlurMacDelegate", Class::get("NSObject").unwrap()).unwrap();
-            decl.add_protocol(Protocol::get("CBCentralManagerDelegate").unwrap());
+            let mut decl = ClassBuilder::new("BlurMacDelegate", AnyClass::get("NSAnyObject").unwrap()).unwrap();
+            decl.add_protocol(AnyProtocol::get("CBCentralManagerDelegate").unwrap());
 
-            decl.add_ivar::<*mut Object>(DELEGATE_PERIPHERALS_IVAR); /* NSMutableDictionary<NSString*, BlurMacPeripheralData*>* */
+            decl.add_ivar::<*mut AnyObject>(DELEGATE_PERIPHERALS_IVAR); /* NSMutableDictionary<NSString*, BlurMacPeripheralData*>* */
 
             unsafe {
-                decl.add_method(sel!(init), delegate_init as extern "C" fn(&mut Object, Sel) -> *mut Object);
-                decl.add_method(sel!(centralManagerDidUpdateState:), delegate_centralmanagerdidupdatestate as extern "C" fn(&mut Object, Sel, *mut Object));
-                // decl.add_method(sel!(centralManager:willRestoreState:), delegate_centralmanager_willrestorestate as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object));
-                decl.add_method(sel!(centralManager:didConnectPeripheral:), delegate_centralmanager_didconnectperipheral as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object));
-                decl.add_method(sel!(centralManager:didDisconnectPeripheral:error:), delegate_centralmanager_diddisconnectperipheral_error as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
-                // decl.add_method(sel!(centralManager:didFailToConnectPeripheral:error:), delegate_centralmanager_didfailtoconnectperipheral_error as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
-                decl.add_method(sel!(centralManager:didDiscoverPeripheral:advertisementData:RSSI:), delegate_centralmanager_diddiscoverperipheral_advertisementdata_rssi as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object, *mut Object));
+                decl.add_method(sel!(init), delegate_init as extern "C" fn(_, _) -> _);
+                decl.add_method(sel!(centralManagerDidUpdateState:), delegate_centralmanagerdidupdatestate as extern "C" fn(_, _, _));
+                // decl.add_method(sel!(centralManager:willRestoreState:), delegate_centralmanager_willrestorestate as extern "C" fn(_, _, _));
+                decl.add_method(sel!(centralManager:didConnectPeripheral:), delegate_centralmanager_didconnectperipheral as extern "C" fn(_, _ , _, _));
+                decl.add_method(sel!(centralManager:didDisconnectPeripheral:error:), delegate_centralmanager_diddisconnectperipheral_error as extern "C" fn(_, _, _, _, _));
+                // decl.add_method(sel!(centralManager:didFailToConnectPeripheral:error:), delegate_centralmanager_didfailtoconnectperipheral_error as extern "C" fn(_, Sel, _, _, _));
+                decl.add_method(sel!(centralManager:didDiscoverPeripheral:advertisementData:RSSI:), delegate_centralmanager_diddiscoverperipheral_advertisementdata_rssi as extern "C" fn(_, Sel, _, _, _, _));
 
-                decl.add_method(sel!(peripheral:didDiscoverServices:), delegate_peripheral_diddiscoverservices as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object));
-                decl.add_method(sel!(peripheral:didDiscoverIncludedServicesForService:error:), delegate_peripheral_diddiscoverincludedservicesforservice_error as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
-                decl.add_method(sel!(peripheral:didDiscoverCharacteristicsForService:error:), delegate_peripheral_diddiscovercharacteristicsforservice_error as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
-                decl.add_method(sel!(peripheral:didUpdateValueForCharacteristic:error:), delegate_peripheral_didupdatevalueforcharacteristic_error as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
-                decl.add_method(sel!(peripheral:didWriteValueForCharacteristic:error:), delegate_peripheral_didwritevalueforcharacteristic_error as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
-                decl.add_method(sel!(peripheral:didReadRSSI:error:), delegate_peripheral_didreadrssi_error as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
+                decl.add_method(sel!(peripheral:didDiscoverServices:), delegate_peripheral_diddiscoverservices as extern "C" fn(_, _, _, _));
+                decl.add_method(sel!(peripheral:didDiscoverIncludedServicesForService:error:), delegate_peripheral_diddiscoverincludedservicesforservice_error as extern "C" fn(_, _, _, _, _));
+                decl.add_method(sel!(peripheral:didDiscoverCharacteristicsForService:error:), delegate_peripheral_diddiscovercharacteristicsforservice_error as extern "C" fn(_, _, _, _, _));
+                decl.add_method(sel!(peripheral:didUpdateValueForCharacteristic:error:), delegate_peripheral_didupdatevalueforcharacteristic_error as extern "C" fn(_, _, _, _, _));
+                decl.add_method(sel!(peripheral:didWriteValueForCharacteristic:error:), delegate_peripheral_didwritevalueforcharacteristic_error as extern "C" fn(_, _, _, _, _));
+                decl.add_method(sel!(peripheral:didReadRSSI:error:), delegate_peripheral_didreadrssi_error as extern "C" fn(_, _, _, _, _));
             }
 
             decl.register();
         });
 
-        Class::get("BlurMacDelegate").unwrap()
+        AnyClass::get("BlurMacDelegate").unwrap()
     }
 
-    extern "C" fn delegate_init(delegate: &mut Object, _cmd: Sel) -> *mut Object {
+    extern "C" fn delegate_init(delegate: &mut AnyObject, _cmd: Sel) -> *mut AnyObject {
         trace!("delegate_init");
         unsafe {
-            delegate.set_ivar::<*mut Object>(DELEGATE_PERIPHERALS_IVAR, ns::mutabledictionary());
+            delegate.set_ivar::<*mut AnyObject>(DELEGATE_PERIPHERALS_IVAR, ns::mutabledictionary());
         }
         delegate
     }
 
     extern "C" fn delegate_centralmanagerdidupdatestate(
-        _delegate: &mut Object,
+        _delegate: &mut AnyObject,
         _cmd: Sel,
-        _central: *mut Object,
+        _central: *mut AnyObject,
     ) {
         trace!("delegate_centralmanagerdidupdatestate");
         // NOTE: this is a no-op but kept because it is a required method of the protocol
     }
 
-    // extern fn delegate_centralmanager_willrestorestate(_delegate: &mut Object, _cmd: Sel, _central: *mut Object, _dict: *mut Object) {
+    // extern fn delegate_centralmanager_willrestorestate(_delegate: &mut AnyObject, _cmd: Sel, _central: *mut AnyObject, _dict: *mut AnyObject) {
     //     trace!("delegate_centralmanager_willrestorestate");
     // }
 
     extern "C" fn delegate_centralmanager_didconnectperipheral(
-        delegate: &mut Object,
+        delegate: &mut AnyObject,
         _cmd: Sel,
-        _central: *mut Object,
-        peripheral: *mut Object,
+        _central: *mut AnyObject,
+        peripheral: *mut AnyObject,
     ) {
         trace!(
             "delegate_centralmanager_didconnectperipheral {}",
@@ -90,11 +90,11 @@ pub mod bm {
     }
 
     extern "C" fn delegate_centralmanager_diddisconnectperipheral_error(
-        delegate: &mut Object,
+        delegate: &mut AnyObject,
         _cmd: Sel,
-        _central: *mut Object,
-        peripheral: *mut Object,
-        _error: *mut Object,
+        _central: *mut AnyObject,
+        peripheral: *mut AnyObject,
+        _error: *mut AnyObject,
     ) {
         trace!(
             "delegate_centralmanager_diddisconnectperipheral_error {}",
@@ -106,17 +106,17 @@ pub mod bm {
         );
     }
 
-    // extern fn delegate_centralmanager_didfailtoconnectperipheral_error(_delegate: &mut Object, _cmd: Sel, _central: *mut Object, _peripheral: *mut Object, _error: *mut Object) {
+    // extern fn delegate_centralmanager_didfailtoconnectperipheral_error(_delegate: &mut AnyObject, _cmd: Sel, _central: *mut AnyObject, _peripheral: *mut AnyObject, _error: *mut AnyObject) {
     //     trace!("delegate_centralmanager_didfailtoconnectperipheral_error");
     // }
 
     extern "C" fn delegate_centralmanager_diddiscoverperipheral_advertisementdata_rssi(
-        delegate: &mut Object,
+        delegate: &mut AnyObject,
         _cmd: Sel,
-        _central: *mut Object,
-        peripheral: *mut Object,
-        adv_data: *mut Object,
-        rssi: *mut Object,
+        _central: *mut AnyObject,
+        peripheral: *mut AnyObject,
+        adv_data: *mut AnyObject,
+        rssi: *mut AnyObject,
     ) {
         trace!(
             "delegate_centralmanager_diddiscoverperipheral_advertisementdata_rssi {}",
@@ -163,10 +163,10 @@ pub mod bm {
     }
 
     extern "C" fn delegate_peripheral_diddiscoverservices(
-        delegate: &mut Object,
+        delegate: &mut AnyObject,
         _cmd: Sel,
-        peripheral: *mut Object,
-        error: *mut Object,
+        peripheral: *mut AnyObject,
+        error: *mut AnyObject,
     ) {
         trace!(
             "delegate_peripheral_diddiscoverservices {} {}",
@@ -193,11 +193,11 @@ pub mod bm {
     }
 
     extern "C" fn delegate_peripheral_diddiscoverincludedservicesforservice_error(
-        delegate: &mut Object,
+        delegate: &mut AnyObject,
         _cmd: Sel,
-        peripheral: *mut Object,
-        service: *mut Object,
-        error: *mut Object,
+        peripheral: *mut AnyObject,
+        service: *mut AnyObject,
+        error: *mut AnyObject,
     ) {
         trace!(
             "delegate_peripheral_diddiscoverincludedservicesforservice_error {} {} {}",
@@ -224,11 +224,11 @@ pub mod bm {
     }
 
     extern "C" fn delegate_peripheral_diddiscovercharacteristicsforservice_error(
-        delegate: &mut Object,
+        delegate: &mut AnyObject,
         _cmd: Sel,
-        peripheral: *mut Object,
-        service: *mut Object,
-        error: *mut Object,
+        peripheral: *mut AnyObject,
+        service: *mut AnyObject,
+        error: *mut AnyObject,
     ) {
         trace!(
             "delegate_peripheral_diddiscovercharacteristicsforservice_error {} {} {}",
@@ -255,11 +255,11 @@ pub mod bm {
     }
 
     extern "C" fn delegate_peripheral_didupdatevalueforcharacteristic_error(
-        delegate: &mut Object,
+        delegate: &mut AnyObject,
         _cmd: Sel,
-        peripheral: *mut Object,
-        characteristic: *mut Object,
-        error: *mut Object,
+        peripheral: *mut AnyObject,
+        characteristic: *mut AnyObject,
+        error: *mut AnyObject,
     ) {
         trace!(
             "delegate_peripheral_didupdatevalueforcharacteristic_error {} {} {}",
@@ -280,11 +280,11 @@ pub mod bm {
     }
 
     extern "C" fn delegate_peripheral_didwritevalueforcharacteristic_error(
-        delegate: &mut Object,
+        delegate: &mut AnyObject,
         _cmd: Sel,
-        peripheral: *mut Object,
-        characteristic: *mut Object,
-        error: *mut Object,
+        peripheral: *mut AnyObject,
+        characteristic: *mut AnyObject,
+        error: *mut AnyObject,
     ) {
         trace!(
             "delegate_peripheral_didwritevalueforcharacteristic_error {} {} {}",
@@ -304,29 +304,29 @@ pub mod bm {
         }
     }
 
-    // extern fn delegate_peripheral_didupdatenotificationstateforcharacteristic_error(_delegate: &mut Object, _cmd: Sel, _peripheral: *mut Object, _characteristic: *mut Object, _error: *mut Object) {
+    // extern fn delegate_peripheral_didupdatenotificationstateforcharacteristic_error(_delegate: &mut AnyObject, _cmd: Sel, _peripheral: *mut AnyObject, _characteristic: *mut AnyObject, _error: *mut AnyObject) {
     //     trace!("delegate_peripheral_didupdatenotificationstateforcharacteristic_error");
     //     // TODO: this is where notifications should be handled...
     // }
 
-    // extern fn delegate_peripheral_diddiscoverdescriptorsforcharacteristic_error(_delegate: &mut Object, _cmd: Sel, _peripheral: *mut Object, _characteristic: *mut Object, _error: *mut Object) {
+    // extern fn delegate_peripheral_diddiscoverdescriptorsforcharacteristic_error(_delegate: &mut AnyObject, _cmd: Sel, _peripheral: *mut AnyObject, _characteristic: *mut AnyObject, _error: *mut AnyObject) {
     //     trace!("delegate_peripheral_diddiscoverdescriptorsforcharacteristic_error");
     // }
 
-    // extern fn delegate_peripheral_didupdatevaluefordescriptor(_delegate: &mut Object, _cmd: Sel, _peripheral: *mut Object, _descriptor: *mut Object, _error: *mut Object) {
+    // extern fn delegate_peripheral_didupdatevaluefordescriptor(_delegate: &mut AnyObject, _cmd: Sel, _peripheral: *mut AnyObject, _descriptor: *mut AnyObject, _error: *mut AnyObject) {
     //     trace!("delegate_peripheral_didupdatevaluefordescriptor");
     // }
 
-    // extern fn delegate_peripheral_didwritevaluefordescriptor_error(_delegate: &mut Object, _cmd: Sel, _peripheral: *mut Object, _descriptor: *mut Object, _error: *mut Object) {
+    // extern fn delegate_peripheral_didwritevaluefordescriptor_error(_delegate: &mut AnyObject, _cmd: Sel, _peripheral: *mut AnyObject, _descriptor: *mut AnyObject, _error: *mut AnyObject) {
     //     trace!("delegate_peripheral_didwritevaluefordescriptor_error");
     // }
 
     extern "C" fn delegate_peripheral_didreadrssi_error(
-        delegate: &mut Object,
+        delegate: &mut AnyObject,
         _cmd: Sel,
-        peripheral: *mut Object,
-        rssi: *mut Object,
-        error: *mut Object,
+        peripheral: *mut AnyObject,
+        rssi: *mut AnyObject,
+        error: *mut AnyObject,
     ) {
         trace!(
             "delegate_peripheral_didreadrssi_error {}",
@@ -346,18 +346,19 @@ pub mod bm {
         }
     }
 
-    pub fn delegate() -> *mut Object {
+    pub fn delegate() -> *mut AnyObject {
         unsafe {
-            let mut delegate: *mut Object = msg_send![delegate_class(), alloc];
+            let mut delegate: *mut AnyObject = msg_send![delegate_class(), alloc];
             delegate = msg_send![delegate, init];
             delegate
         }
     }
 
-    pub fn delegate_peripherals(delegate: *mut Object) -> *mut Object {
+    pub fn delegate_peripherals(delegate: *mut AnyObject) -> *mut AnyObject {
         unsafe {
-            let peripherals: *mut Object =
-                *(*delegate).get_ivar::<*mut Object>(DELEGATE_PERIPHERALS_IVAR);
+            #[expect(deprecated)]
+            let peripherals: *mut AnyObject =
+                *(*delegate).get_ivar::<*mut AnyObject>(DELEGATE_PERIPHERALS_IVAR);
             peripherals
         }
     }
@@ -380,9 +381,9 @@ pub mod bmx {
     use super::*;
 
     pub fn peripheraldata(
-        delegate: *mut Object,
-        peripheral: *mut Object,
-    ) -> Result<*mut Object, Box<dyn Error>> {
+        delegate: *mut AnyObject,
+        peripheral: *mut AnyObject,
+    ) -> Result<*mut AnyObject, Box<dyn Error>> {
         let peripherals = bm::delegate_peripherals(delegate);
         let data = ns::dictionary_objectforkey(
             peripherals,
@@ -396,9 +397,9 @@ pub mod bmx {
     }
 
     pub fn peripheralevents(
-        delegate: *mut Object,
-        peripheral: *mut Object,
-    ) -> Result<*mut Object, Box<dyn Error>> {
+        delegate: *mut AnyObject,
+        peripheral: *mut AnyObject,
+    ) -> Result<*mut AnyObject, Box<dyn Error>> {
         let data = peripheraldata(delegate, peripheral)?;
         Ok(ns::dictionary_objectforkey(
             data,
@@ -406,29 +407,29 @@ pub mod bmx {
         ))
     }
 
-    pub fn includedservicesdiscoveredkey(service: *mut Object) -> *mut Object {
+    pub fn includedservicesdiscoveredkey(service: *mut AnyObject) -> *mut AnyObject {
         suffixedkey(
             service,
             bm::PERIPHERALEVENT_INCLUDEDSERVICESDISCOVEREDKEYSUFFIX,
         )
     }
 
-    pub fn characteristicsdiscoveredkey(service: *mut Object) -> *mut Object {
+    pub fn characteristicsdiscoveredkey(service: *mut AnyObject) -> *mut AnyObject {
         suffixedkey(
             service,
             bm::PERIPHERALEVENT_CHARACTERISTICSDISCOVEREDKEYSUFFIX,
         )
     }
 
-    pub fn valueupdatedkey(characteristic: *mut Object) -> *mut Object {
+    pub fn valueupdatedkey(characteristic: *mut AnyObject) -> *mut AnyObject {
         suffixedkey(characteristic, bm::PERIPHERALEVENT_VALUEUPDATEDKEYSUFFIX)
     }
 
-    pub fn valuewrittenkey(characteristic: *mut Object) -> *mut Object {
+    pub fn valuewrittenkey(characteristic: *mut AnyObject) -> *mut AnyObject {
         suffixedkey(characteristic, bm::PERIPHERALEVENT_VALUEWRITTENKEYSUFFIX)
     }
 
-    fn suffixedkey(attribute: *mut Object, suffix: &str) -> *mut Object {
+    fn suffixedkey(attribute: *mut AnyObject, suffix: &str) -> *mut AnyObject {
         let key = format!(
             "{}{}",
             cbx::uuid_to_canonical_uuid_string(cb::attribute_uuid(attribute)),

--- a/third_party/blurmac/src/device.rs
+++ b/third_party/blurmac/src/device.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::sync::Arc;
 
-use objc2::runtime::Object;
+use objc2::runtime::AnyObject;
 
 use crate::adapter::BluetoothAdapter;
 use crate::delegate::{bm, bmx};
@@ -19,7 +19,7 @@ use crate::utils::{NO_PERIPHERAL_FOUND, NOT_SUPPORTED_ERROR, cbx, nsx, wait};
 #[derive(Clone, Debug)]
 pub struct BluetoothDevice {
     pub(crate) adapter: Arc<BluetoothAdapter>,
-    pub(crate) peripheral: *mut Object,
+    pub(crate) peripheral: *mut AnyObject,
 }
 // TODO: implement std::fmt::Debug and/or std::fmt::Display instead of derive?
 
@@ -41,7 +41,7 @@ impl BluetoothDevice {
         }
     }
 
-    fn peripheral_by_uuid(delegate: *mut Object, uuid: &String) -> *mut Object {
+    fn peripheral_by_uuid(delegate: *mut AnyObject, uuid: &String) -> *mut AnyObject {
         let peripherals = bm::delegate_peripherals(delegate);
         let keys = ns::dictionary_allkeys(peripherals);
         for i in 0..ns::array_count(keys) {

--- a/third_party/blurmac/src/framework.rs
+++ b/third_party/blurmac/src/framework.rs
@@ -7,44 +7,45 @@
 
 use std::os::raw::{c_char, c_int, c_uint};
 
-use objc2::runtime::{BOOL, Class, Object};
+use objc2::ffi::BOOL;
+use objc2::runtime::{AnyClass, AnyObject};
 
 #[allow(non_upper_case_globals)]
-pub const nil: *mut Object = 0 as *mut Object;
+pub const nil: *mut AnyObject = 0 as *mut AnyObject;
 
 pub mod ns {
     use super::*;
 
-    // NSObject
+    // NSAnyObject
 
-    pub fn object_copy(nsobject: *mut Object) -> *mut Object {
+    pub fn object_copy(nsobject: *mut AnyObject) -> *mut AnyObject {
         unsafe {
-            let copy: *mut Object = msg_send![nsobject, copy];
+            let copy: *mut AnyObject = msg_send![nsobject, copy];
             copy
         }
     }
 
     // NSNumber
 
-    pub fn number_withbool(value: BOOL) -> *mut Object {
+    pub fn number_withbool(value: BOOL) -> *mut AnyObject {
         unsafe {
-            let nsnumber: *mut Object =
-                msg_send![Class::get("NSNumber").unwrap(), numberWithBool: value];
+            let nsnumber: *mut AnyObject =
+                msg_send![AnyClass::get("NSNumber").unwrap(), numberWithBool: value];
             nsnumber
         }
     }
 
-    pub fn number_withunsignedlonglong(value: u64) -> *mut Object {
+    pub fn number_withunsignedlonglong(value: u64) -> *mut AnyObject {
         unsafe {
-            let nsnumber: *mut Object = msg_send![
-                Class::get("NSNumber").unwrap(),
+            let nsnumber: *mut AnyObject = msg_send![
+                AnyClass::get("NSNumber").unwrap(),
                 numberWithUnsignedLongLong: value
             ];
             nsnumber
         }
     }
 
-    pub fn number_unsignedlonglongvalue(nsnumber: *mut Object) -> u64 {
+    pub fn number_unsignedlonglongvalue(nsnumber: *mut AnyObject) -> u64 {
         unsafe {
             let value: u64 = msg_send![nsnumber, unsignedLongLongValue];
             value
@@ -53,17 +54,17 @@ pub mod ns {
 
     // NSString
 
-    pub fn string(cstring: *const c_char) -> *mut Object /* NSString* */ {
+    pub fn string(cstring: *const c_char) -> *mut AnyObject /* NSString* */ {
         unsafe {
-            let nsstring: *mut Object = msg_send![
-                Class::get("NSString").unwrap(),
+            let nsstring: *mut AnyObject = msg_send![
+                AnyClass::get("NSString").unwrap(),
                 stringWithUTF8String: cstring
             ];
             nsstring
         }
     }
 
-    pub fn string_utf8string(nsstring: *mut Object) -> *const c_char {
+    pub fn string_utf8string(nsstring: *mut AnyObject) -> *const c_char {
         unsafe {
             let utf8string: *const c_char = msg_send![nsstring, UTF8String];
             utf8string
@@ -72,80 +73,80 @@ pub mod ns {
 
     // NSArray
 
-    pub fn array_count(nsarray: *mut Object) -> c_uint {
+    pub fn array_count(nsarray: *mut AnyObject) -> c_uint {
         unsafe {
             let count: c_uint = msg_send![nsarray, count];
             count
         }
     }
 
-    pub fn array_objectatindex(nsarray: *mut Object, index: c_uint) -> *mut Object {
+    pub fn array_objectatindex(nsarray: *mut AnyObject, index: c_uint) -> *mut AnyObject {
         unsafe {
-            let object: *mut Object = msg_send![nsarray, objectAtIndex: index];
+            let object: *mut AnyObject = msg_send![nsarray, objectAtIndex: index];
             object
         }
     }
 
     // NSDictionary
 
-    pub fn dictionary_allkeys(nsdict: *mut Object) -> *mut Object /* NSArray* */ {
+    pub fn dictionary_allkeys(nsdict: *mut AnyObject) -> *mut AnyObject /* NSArray* */ {
         unsafe {
-            let keys: *mut Object = msg_send![nsdict, allKeys];
+            let keys: *mut AnyObject = msg_send![nsdict, allKeys];
             keys
         }
     }
 
-    pub fn dictionary_objectforkey(nsdict: *mut Object, key: *mut Object) -> *mut Object {
+    pub fn dictionary_objectforkey(nsdict: *mut AnyObject, key: *mut AnyObject) -> *mut AnyObject {
         unsafe {
-            let object: *mut Object = msg_send![nsdict, objectForKey: key];
+            let object: *mut AnyObject = msg_send![nsdict, objectForKey: key];
             object
         }
     }
 
     // NSMutableDictionary : NSDictionary
 
-    pub fn mutabledictionary() -> *mut Object {
+    pub fn mutabledictionary() -> *mut AnyObject {
         unsafe {
-            let nsmutdict: *mut Object =
-                msg_send![Class::get("NSMutableDictionary").unwrap(), dictionaryWithCapacity:0];
+            let nsmutdict: *mut AnyObject =
+                msg_send![AnyClass::get("NSMutableDictionary").unwrap(), dictionaryWithCapacity:0];
             nsmutdict
         }
     }
 
-    pub fn mutabledictionary_removeobjectforkey(nsmutdict: *mut Object, key: *mut Object) {
+    pub fn mutabledictionary_removeobjectforkey(nsmutdict: *mut AnyObject, key: *mut AnyObject) {
         unsafe {
-            let () = msg_send![nsmutdict, removeObjectForKey: key];
+            let () = msg_send![nsmutdict, removeAnyObjectForKey: key];
         }
     }
 
     pub fn mutabledictionary_setobject_forkey(
-        nsmutdict: *mut Object,
-        object: *mut Object,
-        key: *mut Object,
+        nsmutdict: *mut AnyObject,
+        object: *mut AnyObject,
+        key: *mut AnyObject,
     ) {
         unsafe {
-            let () = msg_send![nsmutdict, setObject:object forKey:key];
+            let () = msg_send![nsmutdict, setAnyObject:object forKey:key];
         }
     }
 
     // NSData
 
-    pub fn data(bytes: *const u8, length: c_uint) -> *mut Object /* NSData* */ {
+    pub fn data(bytes: *const u8, length: c_uint) -> *mut AnyObject /* NSData* */ {
         unsafe {
-            let data: *mut Object =
-                msg_send![Class::get("NSData").unwrap(), dataWithBytes:bytes length:length];
+            let data: *mut AnyObject =
+                msg_send![AnyClass::get("NSData").unwrap(), dataWithBytes:bytes length:length];
             data
         }
     }
 
-    pub fn data_length(nsdata: *mut Object) -> c_uint {
+    pub fn data_length(nsdata: *mut AnyObject) -> c_uint {
         unsafe {
             let length: c_uint = msg_send![nsdata, length];
             length
         }
     }
 
-    pub fn data_bytes(nsdata: *mut Object) -> *const u8 {
+    pub fn data_bytes(nsdata: *mut AnyObject) -> *const u8 {
         unsafe {
             let bytes: *const u8 = msg_send![nsdata, bytes];
             bytes
@@ -154,9 +155,9 @@ pub mod ns {
 
     // NSUUID
 
-    pub fn uuid_uuidstring(nsuuid: *mut Object) -> *mut Object /* NSString* */ {
+    pub fn uuid_uuidstring(nsuuid: *mut AnyObject) -> *mut AnyObject /* NSString* */ {
         unsafe {
-            let uuidstring: *mut Object = msg_send![nsuuid, UUIDString];
+            let uuidstring: *mut AnyObject = msg_send![nsuuid, UUIDString];
             uuidstring
         }
     }
@@ -176,34 +177,34 @@ pub mod io {
 
     // IOBluetoothHostController
 
-    pub fn bluetoothhostcontroller_defaultcontroller() -> *mut Object /* IOBluetoothHostController* */
+    pub fn bluetoothhostcontroller_defaultcontroller() -> *mut AnyObject /* IOBluetoothHostController* */
     {
         unsafe {
-            let defaultcontroller: *mut Object = msg_send![
-                Class::get("IOBluetoothHostController").unwrap(),
+            let defaultcontroller: *mut AnyObject = msg_send![
+                AnyClass::get("IOBluetoothHostController").unwrap(),
                 defaultController
             ];
             defaultcontroller
         }
     }
 
-    pub fn bluetoothhostcontroller_nameasstring(iobthc: *mut Object) -> *mut Object /* NSString* */
+    pub fn bluetoothhostcontroller_nameasstring(iobthc: *mut AnyObject) -> *mut AnyObject /* NSString* */
     {
         unsafe {
-            let name: *mut Object = msg_send![iobthc, nameAsString];
+            let name: *mut AnyObject = msg_send![iobthc, nameAsString];
             name
         }
     }
 
-    pub fn bluetoothhostcontroller_addressasstring(iobthc: *mut Object) -> *mut Object /* NSString* */
+    pub fn bluetoothhostcontroller_addressasstring(iobthc: *mut AnyObject) -> *mut AnyObject /* NSString* */
     {
         unsafe {
-            let address: *mut Object = msg_send![iobthc, addressAsString];
+            let address: *mut AnyObject = msg_send![iobthc, addressAsString];
             address
         }
     }
 
-    pub fn bluetoothhostcontroller_classofdevice(iobthc: *mut Object) -> u32 {
+    pub fn bluetoothhostcontroller_classofdevice(iobthc: *mut AnyObject) -> u32 {
         unsafe {
             let classofdevice: u32 = msg_send![iobthc, classOfDevice];
             classofdevice
@@ -241,27 +242,28 @@ pub mod cb {
 
         #[link(name = "CoreBluetooth", kind = "framework")]
         unsafe extern "C" {
-            pub static CBAdvertisementDataServiceUUIDsKey: *mut Object;
+            pub static CBAdvertisementDataServiceUUIDsKey: *mut AnyObject;
 
-            pub static CBCentralManagerScanOptionAllowDuplicatesKey: *mut Object;
+            pub static CBCentralManagerScanOptionAllowDuplicatesKey: *mut AnyObject;
         }
     }
 
     // CBCentralManager
 
-    pub fn centralmanager(delegate: *mut Object, /*CBCentralManagerDelegate* */) -> *mut Object /*CBCentralManager* */
-    {
+    pub fn centralmanager(
+        delegate: *mut AnyObject, /*CBCentralManagerDelegate* */
+    ) -> *mut AnyObject /*CBCentralManager* */ {
         unsafe {
-            let cbcentralmanager: *mut Object =
-                msg_send![Class::get("CBCentralManager").unwrap(), alloc];
+            let cbcentralmanager: *mut AnyObject =
+                msg_send![AnyClass::get("CBCentralManager").unwrap(), alloc];
             let () = msg_send![cbcentralmanager, initWithDelegate:delegate queue:nil];
             cbcentralmanager
         }
     }
 
     pub fn centralmanager_scanforperipherals_options(
-        cbcentralmanager: *mut Object,
-        options: *mut Object, /* NSDictionary<NSString*,id> */
+        cbcentralmanager: *mut AnyObject,
+        options: *mut AnyObject, /* NSDictionary<NSString*,id> */
     ) {
         unsafe {
             let () =
@@ -269,15 +271,15 @@ pub mod cb {
         }
     }
 
-    pub fn centralmanager_stopscan(cbcentralmanager: *mut Object) {
+    pub fn centralmanager_stopscan(cbcentralmanager: *mut AnyObject) {
         unsafe {
             let () = msg_send![cbcentralmanager, stopScan];
         }
     }
 
     pub fn centralmanager_connectperipheral(
-        cbcentralmanager: *mut Object,
-        peripheral: *mut Object, /* CBPeripheral* */
+        cbcentralmanager: *mut AnyObject,
+        peripheral: *mut AnyObject, /* CBPeripheral* */
     ) {
         unsafe {
             let () = msg_send![cbcentralmanager, connectPeripheral:peripheral options:nil];
@@ -285,8 +287,8 @@ pub mod cb {
     }
 
     pub fn centralmanager_cancelperipheralconnection(
-        cbcentralmanager: *mut Object,
-        peripheral: *mut Object, /* CBPeripheral* */
+        cbcentralmanager: *mut AnyObject,
+        peripheral: *mut AnyObject, /* CBPeripheral* */
     ) {
         unsafe {
             let () = msg_send![cbcentralmanager, cancelPeripheralConnection: peripheral];
@@ -295,23 +297,23 @@ pub mod cb {
 
     // CBPeer
 
-    pub fn peer_identifier(cbpeer: *mut Object) -> *mut Object /* NSUUID* */ {
+    pub fn peer_identifier(cbpeer: *mut AnyObject) -> *mut AnyObject /* NSUUID* */ {
         unsafe {
-            let identifier: *mut Object = msg_send![cbpeer, identifier];
+            let identifier: *mut AnyObject = msg_send![cbpeer, identifier];
             identifier
         }
     }
 
     // CBPeripheral : CBPeer
 
-    pub fn peripheral_name(cbperipheral: *mut Object) -> *mut Object /* NSString* */ {
+    pub fn peripheral_name(cbperipheral: *mut AnyObject) -> *mut AnyObject /* NSString* */ {
         unsafe {
-            let name: *mut Object = msg_send![cbperipheral, name];
+            let name: *mut AnyObject = msg_send![cbperipheral, name];
             name
         }
     }
 
-    pub fn peripheral_state(cbperipheral: *mut Object) -> c_int {
+    pub fn peripheral_state(cbperipheral: *mut AnyObject) -> c_int {
         unsafe {
             let state: c_int = msg_send![cbperipheral, state];
             state
@@ -319,40 +321,40 @@ pub mod cb {
     }
 
     pub fn peripheral_setdelegate(
-        cbperipheral: *mut Object,
-        delegate: *mut Object, /* CBPeripheralDelegate* */
+        cbperipheral: *mut AnyObject,
+        delegate: *mut AnyObject, /* CBPeripheralDelegate* */
     ) {
         unsafe {
             let () = msg_send![cbperipheral, setDelegate: delegate];
         }
     }
 
-    pub fn peripheral_discoverservices(cbperipheral: *mut Object) {
+    pub fn peripheral_discoverservices(cbperipheral: *mut AnyObject) {
         unsafe {
             let () = msg_send![cbperipheral, discoverServices: nil];
         }
     }
 
     pub fn peripheral_discoverincludedservicesforservice(
-        cbperipheral: *mut Object,
-        service: *mut Object, /* CBService* */
+        cbperipheral: *mut AnyObject,
+        service: *mut AnyObject, /* CBService* */
     ) {
         unsafe {
             let () = msg_send![cbperipheral, discoverIncludedServices:nil forService:service];
         }
     }
 
-    pub fn peripheral_services(cbperipheral: *mut Object) -> *mut Object /* NSArray<CBService*>* */
+    pub fn peripheral_services(cbperipheral: *mut AnyObject) -> *mut AnyObject /* NSArray<CBService*>* */
     {
         unsafe {
-            let services: *mut Object = msg_send![cbperipheral, services];
+            let services: *mut AnyObject = msg_send![cbperipheral, services];
             services
         }
     }
 
     pub fn peripheral_discovercharacteristicsforservice(
-        cbperipheral: *mut Object,
-        service: *mut Object, /* CBService* */
+        cbperipheral: *mut AnyObject,
+        service: *mut AnyObject, /* CBService* */
     ) {
         unsafe {
             let () = msg_send![cbperipheral, discoverCharacteristics:nil forService:service];
@@ -360,8 +362,8 @@ pub mod cb {
     }
 
     pub fn peripheral_readvalueforcharacteristic(
-        cbperipheral: *mut Object,
-        characteristic: *mut Object, /* CBCharacteristic* */
+        cbperipheral: *mut AnyObject,
+        characteristic: *mut AnyObject, /* CBCharacteristic* */
     ) {
         unsafe {
             let () = msg_send![cbperipheral, readValueForCharacteristic: characteristic];
@@ -369,9 +371,9 @@ pub mod cb {
     }
 
     pub fn peripheral_writevalue_forcharacteristic(
-        cbperipheral: *mut Object,
-        value: *mut Object,          /* NSData* */
-        characteristic: *mut Object, /* CBCharacteristic* */
+        cbperipheral: *mut AnyObject,
+        value: *mut AnyObject,          /* NSData* */
+        characteristic: *mut AnyObject, /* CBCharacteristic* */
     ) {
         unsafe {
             let () =
@@ -381,9 +383,9 @@ pub mod cb {
     }
 
     pub fn peripheral_setnotifyvalue_forcharacteristic(
-        cbperipheral: *mut Object,
+        cbperipheral: *mut AnyObject,
         value: BOOL,
-        characteristic: *mut Object, /* CBCharacteristic* */
+        characteristic: *mut AnyObject, /* CBCharacteristic* */
     ) {
         unsafe {
             let () = msg_send![cbperipheral, setNotifyValue:value forCharacteristic:characteristic];
@@ -391,8 +393,8 @@ pub mod cb {
     }
 
     pub fn peripheral_discoverdescriptorsforcharacteristic(
-        cbperipheral: *mut Object,
-        characteristic: *mut Object, /* CBCharacteristic* */
+        cbperipheral: *mut AnyObject,
+        characteristic: *mut AnyObject, /* CBCharacteristic* */
     ) {
         unsafe {
             let () = msg_send![
@@ -408,55 +410,55 @@ pub mod cb {
 
     // CBAttribute
 
-    pub fn attribute_uuid(cbattribute: *mut Object) -> *mut Object /* CBUUID* */ {
+    pub fn attribute_uuid(cbattribute: *mut AnyObject) -> *mut AnyObject /* CBUUID* */ {
         unsafe {
-            let uuid: *mut Object = msg_send![cbattribute, UUID];
+            let uuid: *mut AnyObject = msg_send![cbattribute, UUID];
             uuid
         }
     }
 
     // CBService : CBAttribute
 
-    // pub fn service_isprimary(cbservice: *mut Object) -> BOOL {
+    // pub fn service_isprimary(cbservice: *mut AnyObject) -> BOOL {
     //     unsafe {
     //         let isprimary: BOOL = msg_send![cbservice, isPrimary];
     //         isprimary
     //     }
     // }
 
-    pub fn service_includedservices(cbservice: *mut Object) -> *mut Object /* NSArray<CBService*>* */
+    pub fn service_includedservices(cbservice: *mut AnyObject) -> *mut AnyObject /* NSArray<CBService*>* */
     {
         unsafe {
-            let includedservices: *mut Object = msg_send![cbservice, includedServices];
+            let includedservices: *mut AnyObject = msg_send![cbservice, includedServices];
             includedservices
         }
     }
 
-    pub fn service_characteristics(cbservice: *mut Object) -> *mut Object /* NSArray<CBCharacteristic*>* */
+    pub fn service_characteristics(cbservice: *mut AnyObject) -> *mut AnyObject /* NSArray<CBCharacteristic*>* */
     {
         unsafe {
-            let characteristics: *mut Object = msg_send![cbservice, characteristics];
+            let characteristics: *mut AnyObject = msg_send![cbservice, characteristics];
             characteristics
         }
     }
 
     // CBCharacteristic : CBAttribute
 
-    pub fn characteristic_isnotifying(cbcharacteristic: *mut Object) -> BOOL {
+    pub fn characteristic_isnotifying(cbcharacteristic: *mut AnyObject) -> BOOL {
         unsafe {
             let isnotifying: BOOL = msg_send![cbcharacteristic, isNotifying];
             isnotifying
         }
     }
 
-    pub fn characteristic_value(cbcharacteristic: *mut Object) -> *mut Object /* NSData* */ {
+    pub fn characteristic_value(cbcharacteristic: *mut AnyObject) -> *mut AnyObject /* NSData* */ {
         unsafe {
-            let value: *mut Object = msg_send![cbcharacteristic, value];
+            let value: *mut AnyObject = msg_send![cbcharacteristic, value];
             value
         }
     }
 
-    pub fn characteristic_properties(cbcharacteristic: *mut Object) -> c_uint {
+    pub fn characteristic_properties(cbcharacteristic: *mut AnyObject) -> c_uint {
         unsafe {
             let properties: c_uint = msg_send![cbcharacteristic, properties];
             properties
@@ -475,9 +477,9 @@ pub mod cb {
 
     // CBUUID
 
-    pub fn uuid_uuidstring(cbuuid: *mut Object) -> *mut Object /* NSString* */ {
+    pub fn uuid_uuidstring(cbuuid: *mut AnyObject) -> *mut AnyObject /* NSString* */ {
         unsafe {
-            let uuidstring: *mut Object = msg_send![cbuuid, UUIDString];
+            let uuidstring: *mut AnyObject = msg_send![cbuuid, UUIDString];
             uuidstring
         }
     }

--- a/third_party/blurmac/src/gatt_characteristic.rs
+++ b/third_party/blurmac/src/gatt_characteristic.rs
@@ -10,7 +10,8 @@ use std::os::raw::c_uint;
 use std::slice;
 use std::sync::Arc;
 
-use objc2::runtime::{NO, Object, YES};
+use objc2::ffi::{NO, YES};
+use objc2::runtime::AnyObject;
 
 use crate::delegate::bmx;
 use crate::framework::{cb, nil, ns};
@@ -20,7 +21,7 @@ use crate::utils::{NO_CHARACTERISTIC_FOUND, NOT_SUPPORTED_ERROR, cbx, wait};
 #[derive(Clone, Debug)]
 pub struct BluetoothGATTCharacteristic {
     pub(crate) service: Arc<BluetoothGATTService>,
-    pub(crate) characteristic: *mut Object,
+    pub(crate) characteristic: *mut AnyObject,
 }
 // TODO: implement std::fmt::Debug and/or std::fmt::Display instead of derive?
 
@@ -44,7 +45,7 @@ impl BluetoothGATTCharacteristic {
         }
     }
 
-    fn characteristic_by_uuid(service: *mut Object, uuid: &String) -> *mut Object {
+    fn characteristic_by_uuid(service: *mut AnyObject, uuid: &String) -> *mut AnyObject {
         if service != nil {
             let chars = cb::service_characteristics(service);
             for i in 0..ns::array_count(chars) {

--- a/third_party/blurmac/src/gatt_service.rs
+++ b/third_party/blurmac/src/gatt_service.rs
@@ -8,7 +8,7 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use objc2::runtime::Object;
+use objc2::runtime::AnyObject;
 
 use crate::delegate::bmx;
 use crate::device::BluetoothDevice;
@@ -18,7 +18,7 @@ use crate::utils::{NO_SERVICE_FOUND, cbx, wait};
 #[derive(Clone, Debug)]
 pub struct BluetoothGATTService {
     pub(crate) device: Arc<BluetoothDevice>,
-    pub(crate) service: *mut Object,
+    pub(crate) service: *mut AnyObject,
 }
 // TODO: implement std::fmt::Debug and/or std::fmt::Display instead of derive?
 
@@ -43,7 +43,7 @@ impl BluetoothGATTService {
         }
     }
 
-    fn service_by_uuid(peripheral: *mut Object, uuid: &String) -> *mut Object {
+    fn service_by_uuid(peripheral: *mut AnyObject, uuid: &String) -> *mut AnyObject {
         if peripheral != nil {
             // TODO: This function will most probably not find included services. Make it recursively
             // descend into included services if first loop did not find what it was looking for.

--- a/third_party/blurmac/src/utils.rs
+++ b/third_party/blurmac/src/utils.rs
@@ -10,7 +10,7 @@ use std::ffi::{CStr, CString};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{thread, time};
 
-use objc2::runtime::Object;
+use objc2::runtime::AnyObject;
 
 use crate::framework::{cb, nil, ns};
 
@@ -22,7 +22,7 @@ pub const NO_CHARACTERISTIC_FOUND: &str = "Error! No characteristic found!";
 pub mod nsx {
     use super::*;
 
-    pub fn string_to_string(nsstring: *mut Object) -> String {
+    pub fn string_to_string(nsstring: *mut AnyObject) -> String {
         if nsstring == nil {
             return String::from("nil");
         }
@@ -35,7 +35,7 @@ pub mod nsx {
         }
     }
 
-    pub fn string_from_str(string: &str) -> *mut Object {
+    pub fn string_from_str(string: &str) -> *mut AnyObject {
         let cstring = CString::new(string).unwrap();
         ns::string(cstring.as_ptr())
     }
@@ -44,7 +44,7 @@ pub mod nsx {
 pub mod cbx {
     use super::*;
 
-    pub fn uuid_to_canonical_uuid_string(cbuuid: *mut Object) -> String {
+    pub fn uuid_to_canonical_uuid_string(cbuuid: *mut AnyObject) -> String {
         // NOTE: CoreBluetooth tends to return uppercase UUID strings, and only 4 character long if the
         // UUID is short (16 bits). However, WebBluetooth mandates lowercase UUID strings. And Servo
         // seems to compare strings, not the binary representation.
@@ -57,7 +57,7 @@ pub mod cbx {
         long.to_lowercase()
     }
 
-    pub fn peripheral_debug(peripheral: *mut Object) -> String {
+    pub fn peripheral_debug(peripheral: *mut AnyObject) -> String {
         if peripheral == nil {
             return String::from("nil");
         }
@@ -74,7 +74,7 @@ pub mod cbx {
         }
     }
 
-    pub fn service_debug(service: *mut Object) -> String {
+    pub fn service_debug(service: *mut AnyObject) -> String {
         if service == nil {
             return String::from("nil");
         }
@@ -82,7 +82,7 @@ pub mod cbx {
         format!("CBService({})", nsx::string_to_string(uuid))
     }
 
-    pub fn characteristic_debug(characteristic: *mut Object) -> String {
+    pub fn characteristic_debug(characteristic: *mut AnyObject) -> String {
         if characteristic == nil {
             return String::from("nil");
         }
@@ -102,7 +102,7 @@ pub mod wait {
         TIMESTAMP.fetch_add(1, Ordering::SeqCst) as u64
     }
 
-    pub fn now() -> *mut Object {
+    pub fn now() -> *mut AnyObject {
         ns::number_withunsignedlonglong(get_timestamp())
     }
 


### PR DESCRIPTION
Bumps from 0.2.0 to 0.4.0, we have to temporarily duplicate `objc2-encode`, but the next PR will finish the upgrade and unduplicate that dependency.

Testing: No functionality changed, only a refactor