### PR TITLE
layout: Use content area rect for content box queries.

### DIFF
--- a/components/layout/fragment_tree/box_fragment.rs
+++ b/components/layout/fragment_tree/box_fragment.rs
@@ -313,7 +313,7 @@ impl BoxFragment {
     }
 
     pub(crate) fn cumulative_content_box_rect(&self) -> PhysicalRect<Au> {
-        self.offset_by_containing_block(&self.margin_rect())
+        self.offset_by_containing_block(&self.content_rect)
     }
 
     pub(crate) fn cumulative_padding_box_rect(&self) -> PhysicalRect<Au> {

--- a/tests/wpt/meta/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-img-element/naturalWidth-naturalHeight-width-height.tentative.html.ini
@@ -1,14 +1,5 @@
 [naturalWidth-naturalHeight-width-height.tentative.html]
-  [raster image]
-    expected: FAIL
-
-  [raster image with width/height attributes]
-    expected: FAIL
-
   [raster image with width/height attributes (when not rendered)]
-    expected: FAIL
-
-  [non existent image with width/height attributes, no natural dimensions]
     expected: FAIL
 
   [non existent image with width/height attributes, no natural dimensions (when not rendered)]
@@ -116,18 +107,6 @@
   [SVG image, with natural height, and aspect ratio from viewBox (when not rendered)]
     expected: FAIL
 
-  [SVG image, with natural width of 0, and aspect ratio from viewBox]
-    expected: FAIL
-
-  [SVG image, with natural height of 0, and aspect ratio from viewBox]
-    expected: FAIL
-
-  [SVG image, with natural width being negative, and aspect ratio from viewBox]
-    expected: FAIL
-
-  [SVG image, with natural height being negative, and aspect ratio from viewBox]
-    expected: FAIL
-
   [SVG image, no natural dimensions, viewBox with 0 width/height]
     expected: FAIL
 
@@ -182,28 +161,7 @@
   [SVG image, with natural height, viewBox with 0 height (when not rendered)]
     expected: FAIL
 
-  [SVG image, with natural width and height]
-    expected: FAIL
-
-  [SVG image, with natural width and height, and aspect ratio from viewBox]
-    expected: FAIL
-
-  [SVG image, with natural width and height of 0, and aspect ratio from viewBox]
-    expected: FAIL
-
-  [SVG image, with natural width and height being negative, and aspect ratio from viewBox]
-    expected: FAIL
-
-  [raster image (with srcset/1x)]
-    expected: FAIL
-
-  [raster image with width/height attributes (with srcset/1x)]
-    expected: FAIL
-
   [raster image with width/height attributes (with srcset/1x) (when not rendered)]
-    expected: FAIL
-
-  [non existent image with width/height attributes, no natural dimensions (with srcset/1x)]
     expected: FAIL
 
   [non existent image with width/height attributes, no natural dimensions (with srcset/1x) (when not rendered)]
@@ -311,18 +269,6 @@
   [SVG image, with natural height, and aspect ratio from viewBox (with srcset/1x) (when not rendered)]
     expected: FAIL
 
-  [SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/1x)]
-    expected: FAIL
-
-  [SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/1x)]
-    expected: FAIL
-
-  [SVG image, with natural width being negative, and aspect ratio from viewBox (with srcset/1x)]
-    expected: FAIL
-
-  [SVG image, with natural height being negative, and aspect ratio from viewBox (with srcset/1x)]
-    expected: FAIL
-
   [SVG image, no natural dimensions, viewBox with 0 width/height (with srcset/1x)]
     expected: FAIL
 
@@ -377,31 +323,10 @@
   [SVG image, with natural height, viewBox with 0 height (with srcset/1x) (when not rendered)]
     expected: FAIL
 
-  [SVG image, with natural width and height (with srcset/1x)]
-    expected: FAIL
-
-  [SVG image, with natural width and height, and aspect ratio from viewBox (with srcset/1x)]
-    expected: FAIL
-
-  [SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/1x)]
-    expected: FAIL
-
-  [SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/1x)]
-    expected: FAIL
-
-  [raster image (with srcset/2x)]
-    expected: FAIL
-
   [raster image (with srcset/2x) (when not rendered)]
     expected: FAIL
 
-  [raster image with width/height attributes (with srcset/2x)]
-    expected: FAIL
-
   [raster image with width/height attributes (with srcset/2x) (when not rendered)]
-    expected: FAIL
-
-  [non existent image with width/height attributes, no natural dimensions (with srcset/2x)]
     expected: FAIL
 
   [non existent image with width/height attributes, no natural dimensions (with srcset/2x) (when not rendered)]
@@ -509,18 +434,6 @@
   [SVG image, with natural height, and aspect ratio from viewBox (with srcset/2x) (when not rendered)]
     expected: FAIL
 
-  [SVG image, with natural width of 0, and aspect ratio from viewBox (with srcset/2x)]
-    expected: FAIL
-
-  [SVG image, with natural height of 0, and aspect ratio from viewBox (with srcset/2x)]
-    expected: FAIL
-
-  [SVG image, with natural width being negative, and aspect ratio from viewBox (with srcset/2x)]
-    expected: FAIL
-
-  [SVG image, with natural height being negative, and aspect ratio from viewBox (with srcset/2x)]
-    expected: FAIL
-
   [SVG image, no natural dimensions, viewBox with 0 width/height (with srcset/2x)]
     expected: FAIL
 
@@ -575,20 +488,8 @@
   [SVG image, with natural height, viewBox with 0 height (with srcset/2x) (when not rendered)]
     expected: FAIL
 
-  [SVG image, with natural width and height (with srcset/2x)]
-    expected: FAIL
-
   [SVG image, with natural width and height (with srcset/2x) (when not rendered)]
     expected: FAIL
 
-  [SVG image, with natural width and height, and aspect ratio from viewBox (with srcset/2x)]
-    expected: FAIL
-
   [SVG image, with natural width and height, and aspect ratio from viewBox (with srcset/2x) (when not rendered)]
-    expected: FAIL
-
-  [SVG image, with natural width and height of 0, and aspect ratio from viewBox (with srcset/2x)]
-    expected: FAIL
-
-  [SVG image, with natural width and height being negative, and aspect ratio from viewBox (with srcset/2x)]
     expected: FAIL

--- a/tests/wpt/meta/resize-observer/scrollbars-2.html.ini
+++ b/tests/wpt/meta/resize-observer/scrollbars-2.html.ini
@@ -1,3 +1,0 @@
-[scrollbars-2.html]
-  [ResizeObserver content-box size and scrollbars]
-    expected: FAIL


### PR DESCRIPTION
Using the margin rect when querying the content box of an element doesn't make sense.

Testing: Fixes various test failures in resize-observer tests and some image tests.
Fixes: #40110
