### PR TITLE
script: Include target in resize observer depth calculation.

### DIFF
--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -327,7 +327,7 @@ impl ResizeObservation {
 /// <https://drafts.csswg.org/resize-observer/#calculate-depth-for-node>
 fn calculate_depth_for_node(target: &Element) -> ResizeObservationDepth {
     let node = target.upcast::<Node>();
-    let depth = node.inclusive_ancestors_in_flat_tree().count() - 1;
+    let depth = node.inclusive_ancestors_in_flat_tree().count();
     ResizeObservationDepth(depth)
 }
 

--- a/tests/wpt/meta/resize-observer/notify.html.ini
+++ b/tests/wpt/meta/resize-observer/notify.html.ini
@@ -1,7 +1,16 @@
 [notify.html]
   expected: ERROR
-  [guard]
-    expected: NOTRUN
+  [test3: dimensions match]
+    expected: FAIL
 
-  [test2: remove/appendChild trigger notification]
+  [test4: transform do not cause notifications]
+    expected: FAIL
+
+  [test6: inline element notifies once with 0x0.]
+    expected: FAIL
+
+  [test11: display:none element should be notified]
+    expected: FAIL
+
+  [test12: element sized 0x0 should be notified]
     expected: FAIL


### PR DESCRIPTION
The spec wants the path from the target to the root inclusive, not exclusive like the current calculation.

Testing: Enables a test to run to completion.
Fixes: #40111
