### PR TITLE
servoshell/desktop: Draw WebViews without using an egui::CentralPanel

### DIFF
--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -306,6 +306,7 @@ impl Painter {
             webgpu_image_map,
         };
         painter.assert_gl_framebuffer_complete();
+        painter.clear_background();
         painter
     }
 

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -10,9 +10,7 @@ use std::time::Instant;
 use dpi::PhysicalSize;
 use egui::text::{CCursor, CCursorRange};
 use egui::text_edit::TextEditState;
-use egui::{
-    Button, CentralPanel, Frame, Key, Label, Modifiers, PaintCallback, TopBottomPanel, Vec2, pos2,
-};
+use egui::{Button, Key, Label, LayerId, Modifiers, PaintCallback, TopBottomPanel, Vec2, pos2};
 use egui_glow::{CallbackFn, EguiGlow};
 use egui_winit::EventResponse;
 use euclid::{Box2D, Length, Point2D, Rect, Scale, Size2D};
@@ -152,16 +150,6 @@ impl Minibrowser {
         event: &WindowEvent,
     ) -> EventResponse {
         let mut result = self.context.on_window_event(window, event);
-
-        // For some reason, egui is eating all PinchGesture events, even when they happen
-        // on top of a WebView. Detect this situation and avoid sending those events to
-        // egui.
-        if matches!(event, WindowEvent::PinchGesture { .. }) &&
-            self.last_mouse_position
-                .is_some_and(|point| !self.is_in_egui_toolbar_rect(point))
-        {
-            return Default::default();
-        }
 
         if app_state.has_active_dialog() {
             result.consumed = true;
@@ -450,59 +438,50 @@ impl Minibrowser {
             let scale =
                 Scale::<_, DeviceIndependentPixel, DevicePixel>::new(ctx.pixels_per_point());
 
-            egui::CentralPanel::default().show(ctx, |_| {
-                state.for_each_active_dialog(|dialog| dialog.update(ctx));
-            });
+            state.for_each_active_dialog(|dialog| dialog.update(ctx));
 
             let Some(webview) = state.focused_webview() else {
                 return;
             };
-            CentralPanel::default().frame(Frame::NONE).show(ctx, |ui| {
-                // If the top parts of the GUI changed size, then update the size of the WebView and also
-                // the size of its RenderingContext.
-                let available_size = ui.available_size();
-                let size = Size2D::new(available_size.x, available_size.y) * scale;
-                let rect = Box2D::from_origin_and_size(Point2D::origin(), size);
-                if rect != webview.rect() {
-                    webview.move_resize(rect);
-                    // `rect` is sized to just the WebView viewport, which is required by
-                    // `OffscreenRenderingContext` See:
-                    // <https://github.com/servo/servo/issues/38369#issuecomment-3138378527>
-                    webview.resize(PhysicalSize::new(size.width as u32, size.height as u32))
-                }
 
-                let min = ui.cursor().min;
-                let size = ui.available_size();
-                let rect = egui::Rect::from_min_size(min, size);
-                ui.allocate_space(size);
+            // If the top parts of the GUI changed size, then update the size of the WebView and also
+            // the size of its RenderingContext.
+            let rect = ctx.available_rect();
+            let size = Size2D::new(rect.width(), rect.height()) * scale;
+            let rect = Box2D::from_origin_and_size(Point2D::origin(), size);
+            if rect != webview.rect() {
+                webview.move_resize(rect);
+                // `rect` is sized to just the WebView viewport, which is required by
+                // `OffscreenRenderingContext` See:
+                // <https://github.com/servo/servo/issues/38369#issuecomment-3138378527>
+                webview.resize(PhysicalSize::new(size.width as u32, size.height as u32))
+            }
 
-                if let Some(status_text) = &self.status_text {
-                    egui::Tooltip::always_open(
-                        ctx.clone(),
-                        ui.layer_id(),
-                        "tooltip layer".into(),
-                        pos2(0.0, ctx.available_rect().max.y),
-                    )
-                    .show(|ui| ui.add(Label::new(status_text.clone()).extend()))
-                    .map(|response| response.inner);
-                }
+            if let Some(status_text) = &self.status_text {
+                egui::Tooltip::always_open(
+                    ctx.clone(),
+                    LayerId::background(),
+                    "tooltip layer".into(),
+                    pos2(0.0, ctx.available_rect().max.y),
+                )
+                .show(|ui| ui.add(Label::new(status_text.clone()).extend()));
+            }
 
-                state.repaint_servo_if_necessary();
+            state.repaint_servo_if_necessary();
 
-                if let Some(render_to_parent) = rendering_context.render_to_parent_callback() {
-                    ui.painter().add(PaintCallback {
-                        rect,
-                        callback: Arc::new(CallbackFn::new(move |info, painter| {
-                            let clip = info.viewport_in_pixels();
-                            let rect_in_parent = Rect::new(
-                                Point2D::new(clip.left_px, clip.from_bottom_px),
-                                Size2D::new(clip.width_px, clip.height_px),
-                            );
-                            render_to_parent(painter.gl(), rect_in_parent)
-                        })),
-                    });
-                }
-            });
+            if let Some(render_to_parent) = rendering_context.render_to_parent_callback() {
+                ctx.layer_painter(LayerId::background()).add(PaintCallback {
+                    rect: ctx.available_rect(),
+                    callback: Arc::new(CallbackFn::new(move |info, painter| {
+                        let clip = info.viewport_in_pixels();
+                        let rect_in_parent = Rect::new(
+                            Point2D::new(clip.left_px, clip.from_bottom_px),
+                            Size2D::new(clip.width_px, clip.height_px),
+                        );
+                        render_to_parent(painter.gl(), rect_in_parent)
+                    })),
+                });
+            }
 
             *last_update = now;
         });

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -140,9 +140,6 @@ impl Minibrowser {
         std::mem::take(&mut self.event_queue)
     }
 
-    /// Preprocess the given [winit::event::WindowEvent], returning unconsumed for mouse events in
-    /// the Servo browser rect. This is needed because the CentralPanel we create for our webview
-    /// would otherwise make egui report events in that area as consumed.
     pub fn on_window_event(
         &mut self,
         window: &Window,
@@ -283,8 +280,6 @@ impl Minibrowser {
     }
 
     /// Update the minibrowser, but don’t paint.
-    /// If `servo_framebuffer_id` is given, set up a paint callback to blit its contents to our
-    /// CentralPanel when [`Minibrowser::paint`] is called.
     pub fn update(
         &mut self,
         window: &dyn WindowPortsMethods,

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -435,16 +435,14 @@ impl Minibrowser {
 
             state.for_each_active_dialog(|dialog| dialog.update(ctx));
 
-            let Some(webview) = state.focused_webview() else {
-                return;
-            };
-
             // If the top parts of the GUI changed size, then update the size of the WebView and also
             // the size of its RenderingContext.
             let rect = ctx.available_rect();
             let size = Size2D::new(rect.width(), rect.height()) * scale;
             let rect = Box2D::from_origin_and_size(Point2D::origin(), size);
-            if rect != webview.rect() {
+            if let Some(webview) = state.focused_webview() &&
+                rect != webview.rect()
+            {
                 webview.move_resize(rect);
                 // `rect` is sized to just the WebView viewport, which is required by
                 // `OffscreenRenderingContext` See:


### PR DESCRIPTION
Showing a CentralPanel causes egui to claim touch events over the WebView, making workarounds like that in [commit f182f74](https://github.com/servo/servo/commit/f182f748ab31e75e585c59681648739b3c77132a) necessary. Since we are only using the panel to determine the size of the WebView, we can also use ctx.available_rect() instead.

The reason I looked into this is that I noticed servoshell very often (but not always) panicking when I end touch events on my linux/wayland. It was pretty clear that this was triggered by touch start events not being forwarded to compositing/touch.rs such that the end events acted on inconsistent state. This happened because egui claimed to consume the start events, just like for pinch zoom in commit f182f74.

Extending the workaround to touch start events fixes my panics as well. But while I was at it, I looked into egui's code, where the decision to count all space as used by egui after adding a central panel happens [here](https://github.com/emilk/egui/blob/f6fa74c66578be17c1a2a80eb33b1704f17a3d5f/crates/egui/src/pass_state.rs#L360). It looks intentional - by adding a central panel, we are expressing our intention to let egui handle events not just in the side panels, but everywhere. I think this commit is therefore a cleaner way to handle this instead of extending the workaround - but I'm not certain and curious what y'all think!

The fact that the commit title of f182f74 mentions macOS and that the panics on ending touch events were not noticed when pinch gestures were added makes me worry that there is some platform dependency here that I do not understand, so it would probably be best if someone on different platforms tested this as well.

Finally, we were actually adding two central panels [in the previous code](https://github.com/servo/servo/blob/025abc855ef4f2225db4e2a28e5d29529dbf9894/ports/servoshell/desktop/minibrowser.rs#L453). I suspect that was unintentional, at least dialogs seem to work fine if I call `state.for_each_active_dialog(..)` outside of a panel.

Testing: Tested manually on linux/wayland.
Fixes: Intermittent panics on touch end events, see above.
