### PR TITLE
libservo: Stop using the custom test harness and `run_api_tests`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4961,7 +4961,6 @@ dependencies = [
 name = "libservo"
 version = "0.0.1"
 dependencies = [
- "anyhow",
  "arboard",
  "background_hang_monitor",
  "base",

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -1243,7 +1243,7 @@ impl IOCompositor {
         self.set_needs_repaint(RepaintReason::Resize);
     }
 
-    pub fn on_zoom_window_event(&mut self, webview_id: WebViewId, new_zoom: f32) {
+    pub fn set_page_zoom(&mut self, webview_id: WebViewId, new_zoom: f32) {
         if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
             return;
         }
@@ -1251,6 +1251,13 @@ impl IOCompositor {
         if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
             webview_renderer.set_page_zoom(Scale::new(new_zoom));
         }
+    }
+
+    pub fn page_zoom(&mut self, webview_id: WebViewId) -> f32 {
+        self.webview_renderers
+            .get(webview_id)
+            .map(|webview_renderer| webview_renderer.page_zoom.get())
+            .unwrap_or_default()
     }
 
     /// Returns true if any animation callbacks (ie `requestAnimationFrame`) are waiting for a response.

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -138,7 +138,6 @@ gaol = "0.2.1"
 webxr = { path = "../webxr", features = ["ipc", "glwindow", "headless", "openxr-api"] }
 
 [dev-dependencies]
-anyhow = "1.0.97"
 http = { workspace = true }
 libservo = { path = ".", features = ["tracing"] }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
@@ -147,11 +146,9 @@ winit = { workspace = true }
 
 [[test]]
 name = "webview"
-harness = false
 
 [[test]]
 name = "servo"
-harness = false
 
 [[test]]
 name = "multiprocess"

--- a/components/servo/tests/servo.rs
+++ b/components/servo/tests/servo.rs
@@ -12,16 +12,10 @@
 #[allow(dead_code)]
 mod common;
 
-use anyhow::ensure;
-use common::{ServoTest, run_api_tests};
+use common::ServoTest;
 
-fn test_simple_servo_is_not_animating_by_default(
-    servo_test: &ServoTest,
-) -> Result<(), anyhow::Error> {
-    ensure!(!servo_test.servo().animating());
-    Ok(())
-}
-
-fn main() {
-    run_api_tests!(test_simple_servo_is_not_animating_by_default);
+#[test]
+fn test_simple_servo_is_not_animating_by_default() {
+    let servo_test = ServoTest::new();
+    assert!(!servo_test.servo().animating());
 }


### PR DESCRIPTION
The changes in #39812 seem to have completely disabled the API tests, so
this PR gets them running again by removing the custom test harness
(apart from the multiprocess test). The custom test harness is typically
not necessary now that all tests are run in their own process.

In addition, the behavior of the `WebView::page_zoom()` is fixed when
set via the `viewport` meta tag. This functionality was broken, but the
unit test wasn't catching it.

There is still one failing test, but that is tracked via #40129.

Testing: This change fixes the tests.
