### PR TITLE
compositing: Initialize the WebRender image handlers with the IOCompositor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,7 @@ dependencies = [
  "base",
  "bincode",
  "bitflags 2.10.0",
+ "canvas_traits",
  "compositing_traits",
  "constellation_traits",
  "crossbeam-channel",
@@ -1482,6 +1483,7 @@ dependencies = [
  "ipc-channel",
  "libc",
  "log",
+ "media",
  "pixels",
  "profile_traits",
  "rayon",
@@ -1495,9 +1497,12 @@ dependencies = [
  "surfman",
  "timers",
  "tracing",
+ "webgl",
+ "webgpu",
  "webrender",
  "webrender_api",
  "webxr",
+ "webxr-api",
  "wr_malloc_size_of",
 ]
 

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -14,7 +14,8 @@ path = "lib.rs"
 [features]
 default = []
 tracing = ["dep:tracing"]
-webxr = ["dep:webxr"]
+webgpu = ["dep:webgpu"]
+webxr = ["dep:webxr", "dep:webxr-api"]
 
 [lints.clippy]
 unwrap_used = "deny"
@@ -24,6 +25,7 @@ panic = "deny"
 base = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true }
+canvas_traits = { workspace = true }
 compositing_traits = { workspace = true }
 constellation_traits = { workspace = true }
 crossbeam-channel = { workspace = true }
@@ -35,6 +37,7 @@ image = { workspace = true }
 ipc-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
+media = { path = "../media" }
 malloc_size_of = { workspace = true }
 pixels = { path = "../pixels" }
 profile_traits = { workspace = true }
@@ -47,9 +50,12 @@ servo_geometry = { path = "../geometry" }
 stylo_traits = { workspace = true }
 timers = { path = "../timers" }
 tracing = { workspace = true, optional = true }
+webgl = { path = "../webgl" }
+webgpu = { path = "../webgpu", optional = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }
 webxr = { path = "../webxr", optional = true }
+webxr-api = { workspace = true, optional = true }
 wr_malloc_size_of = { workspace = true }
 
 [dev-dependencies]

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -8,7 +8,7 @@ use std::env;
 use std::fs::create_dir_all;
 use std::iter::once;
 use std::rc::Rc;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base::Epoch;
@@ -16,10 +16,12 @@ use base::cross_process_instant::CrossProcessInstant;
 use base::generic_channel::{GenericSender, RoutedReceiver};
 use base::id::{PipelineId, RenderingGroupId, WebViewId};
 use bitflags::bitflags;
+use canvas_traits::webgl::{GlType, WebGLThreads};
 use compositing_traits::display_list::{CompositorDisplayListInfo, ScrollTree, ScrollType};
 use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::{
     CompositionPipeline, CompositorMsg, ImageUpdate, PipelineExitSource, SendableFrameTree,
+    WebRenderExternalImageHandlers, WebRenderExternalImageRegistry, WebRenderImageHandlerType,
     WebViewTrait,
 };
 use constellation_traits::{EmbedderToConstellationMessage, PaintMetricEvent};
@@ -34,6 +36,7 @@ use gleam::gl::RENDERER;
 use image::RgbaImage;
 use ipc_channel::ipc::{self, IpcSharedMemory};
 use log::{debug, info, trace, warn};
+use media::WindowGLContext;
 use profile_traits::mem::{
     ProcessReports, ProfilerRegistration, Report, ReportKind, perform_memory_report,
 };
@@ -43,6 +46,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use servo_config::pref;
 use servo_geometry::DeviceIndependentPixel;
 use style_traits::CSSPixel;
+use webgl::WebGLComm;
 use webrender::{
     CaptureBits, ONE_TIME_USAGE_HINT, RenderApi, ShaderPrecacheFlags, Transaction, UploadMethod,
 };
@@ -89,7 +93,7 @@ pub struct ServoRenderer {
     compositor_receiver: RoutedReceiver<CompositorMsg>,
 
     /// The channel on which messages can be sent to the constellation.
-    pub(crate) constellation_sender: Sender<EmbedderToConstellationMessage>,
+    pub(crate) embedder_to_constellation_sender: Sender<EmbedderToConstellationMessage>,
 
     /// The channel on which messages can be sent to the time profiler.
     time_profiler_chan: profile_time::ProfilerChan,
@@ -103,10 +107,6 @@ pub struct ServoRenderer {
     /// The GL bindings for webrender
     webrender_gl: Rc<dyn gleam::gl::Gl>,
 
-    #[cfg(feature = "webxr")]
-    /// Some XR devices want to run on the main thread.
-    webxr_main_thread: webxr::MainThreadRegistry,
-
     /// The last position in the rendered view that the mouse moved over. This becomes `None`
     /// when the mouse leaves the rendered view.
     pub(crate) last_mouse_move_position: Option<DevicePoint>,
@@ -115,6 +115,20 @@ pub struct ServoRenderer {
     /// arrive before requesting a new frame, as these happen asynchronously with
     /// `ScriptThread` display list construction.
     frame_delayer: FrameDelayer,
+
+    /// The WebRender image registry from this renderer.
+    webrender_external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
+
+    #[cfg(feature = "webxr")]
+    /// Some XR devices want to run on the main thread.
+    webxr_main_thread: webxr::MainThreadRegistry,
+
+    /// The [`WebGLThreads`] for this renderer.
+    webgl_threads: WebGLThreads,
+
+    #[cfg(feature = "webgpu")]
+    /// The WebGPU image map for this renderer.
+    webgpu_image_map: webgpu::canvas_context::WGPUImageMap,
 }
 
 /// NB: Never block on the constellation, because sometimes the constellation blocks on us.
@@ -292,9 +306,71 @@ impl ServoRenderer {
 
 impl IOCompositor {
     pub fn new(state: InitialCompositorState) -> Self {
+        let rendering_context = state.rendering_context;
+        let webrender_gl = rendering_context.gleam_gl_api();
+
+        // Make sure the gl context is made current.
+        if let Err(err) = rendering_context.make_current() {
+            warn!("Failed to make the rendering context current: {:?}", err);
+        }
+        debug_assert_eq!(webrender_gl.get_error(), gleam::gl::NO_ERROR,);
+
+        // Create the webgl thread
+        let gl_type = match webrender_gl.get_type() {
+            gleam::gl::GlType::Gl => GlType::Gl,
+            gleam::gl::GlType::Gles => GlType::Gles,
+        };
+
+        let (external_image_handlers, webrender_external_images) =
+            WebRenderExternalImageHandlers::new();
+        let mut external_image_handlers = Box::new(external_image_handlers);
+
+        let WebGLComm {
+            webgl_threads,
+            #[cfg(feature = "webxr")]
+            webxr_layer_grand_manager,
+            image_handler,
+        } = WebGLComm::new(
+            rendering_context.clone(),
+            state.compositor_proxy.cross_process_compositor_api.clone(),
+            webrender_external_images.clone(),
+            gl_type,
+        );
+
+        // Set webrender external image handler for WebGL textures
+        external_image_handlers.set_handler(image_handler, WebRenderImageHandlerType::WebGl);
+
+        // Create the WebXR main thread
+        #[cfg(feature = "webxr")]
+        let mut webxr_main_thread = webxr::MainThreadRegistry::new(
+            state.event_loop_waker.clone(),
+            webxr_layer_grand_manager,
+        )
+        .expect("Failed to create WebXR device registry");
+        #[cfg(feature = "webxr")]
+        if pref!(dom_webxr_enabled) {
+            state.webxr_registry.register(&mut webxr_main_thread);
+        }
+
+        #[cfg(feature = "webgpu")]
+        let webgpu_image_map = {
+            let webgpu_image_handler = webgpu::WGPUExternalImages::default();
+            let webgpu_image_map = webgpu_image_handler.images.clone();
+            external_image_handlers.set_handler(
+                Box::new(webgpu_image_handler),
+                WebRenderImageHandlerType::WebGpu,
+            );
+            webgpu_image_map
+        };
+
+        WindowGLContext::initialize_image_handler(
+            &mut external_image_handlers,
+            webrender_external_images.clone(),
+        );
+
         let registration = state.mem_profiler_chan.prepare_memory_reporting(
             "compositor".into(),
-            state.sender.clone(),
+            state.compositor_proxy.clone(),
             CompositorMsg::CollectMemoryReport,
         );
 
@@ -303,11 +379,9 @@ impl IOCompositor {
             state.refresh_driver,
         ));
         let animation_refresh_driver_observer = Rc::new(AnimationRefreshDriverObserver::new(
-            state.constellation_chan.clone(),
+            state.embedder_to_constellation_sender.clone(),
         ));
 
-        let rendering_context = state.rendering_context;
-        let webrender_gl = rendering_context.gleam_gl_api();
         rendering_context.prepare_for_rendering();
         let clear_color = servo_config::pref!(shell_background_color_rgba);
         let clear_color = ColorF::new(
@@ -338,7 +412,7 @@ impl IOCompositor {
 
         let (mut webrender, webrender_api_sender) = webrender::create_webrender_instance(
             webrender_gl.clone(),
-            Box::new(RenderNotifier::new(state.sender.clone())),
+            Box::new(RenderNotifier::new(state.compositor_proxy.clone())),
             webrender::WebRenderOptions {
                 // We force the use of optimized shaders here because rendering is broken
                 // on Android emulators with unoptimized shaders. This is due to a known
@@ -365,7 +439,7 @@ impl IOCompositor {
         )
         .expect("Unable to initialize WebRender.");
 
-        webrender.set_external_image_handler(state.external_image_handlers);
+        webrender.set_external_image_handler(external_image_handlers);
 
         let webrender_api = webrender_api_sender.create_api();
         let webrender_document = webrender_api.add_document(rendering_context.size2d().to_i32());
@@ -376,15 +450,19 @@ impl IOCompositor {
                 animation_refresh_driver_observer,
                 shutdown_state: state.shutdown_state,
                 compositor_receiver: state.receiver,
-                constellation_sender: state.constellation_chan,
+                embedder_to_constellation_sender: state.embedder_to_constellation_sender,
                 time_profiler_chan: state.time_profiler_chan,
                 webrender_api,
                 webrender_document,
                 webrender_gl,
-                #[cfg(feature = "webxr")]
-                webxr_main_thread: state.webxr_main_thread,
                 last_mouse_move_position: None,
                 frame_delayer: Default::default(),
+                webrender_external_images,
+                webgl_threads,
+                #[cfg(feature = "webxr")]
+                webxr_main_thread,
+                #[cfg(feature = "webgpu")]
+                webgpu_image_map,
             })),
             webview_renderers: WebViewManager::default(),
             needs_repaint: Cell::default(),
@@ -421,6 +499,14 @@ impl IOCompositor {
         self.rendering_context.size2d()
     }
 
+    pub fn webgl_threads(&self) -> WebGLThreads {
+        self.global.borrow().webgl_threads.clone()
+    }
+
+    pub fn webrender_external_images(&self) -> Arc<Mutex<WebRenderExternalImageRegistry>> {
+        self.global.borrow().webrender_external_images.clone()
+    }
+
     pub fn webxr_running(&self) -> bool {
         #[cfg(feature = "webxr")]
         {
@@ -430,6 +516,16 @@ impl IOCompositor {
         {
             false
         }
+    }
+
+    #[cfg(feature = "webxr")]
+    pub fn webxr_main_thread_registry(&self) -> webxr_api::Registry {
+        self.global.borrow().webxr_main_thread.registry()
+    }
+
+    #[cfg(feature = "webgpu")]
+    pub fn webgpu_image_map(&self) -> webgpu::canvas_context::WGPUImageMap {
+        self.global.borrow().webgpu_image_map.clone()
     }
 
     pub(crate) fn webview_renderer(&self, webview_id: WebViewId) -> Option<&WebViewRenderer> {
@@ -770,7 +866,7 @@ impl IOCompositor {
                 global.send_transaction(transaction);
 
                 let waiting_pipelines = global.frame_delayer.take_waiting_pipelines();
-                let _ = global.constellation_sender.send(
+                let _ = global.embedder_to_constellation_sender.send(
                     EmbedderToConstellationMessage::NoLongerWaitingOnAsynchronousImageUpdates(
                         waiting_pipelines,
                     ),
@@ -788,7 +884,7 @@ impl IOCompositor {
                 let image_keys = (0..pref!(image_key_batch_size))
                     .map(|_| self.global.borrow().webrender_api.generate_image_key())
                     .collect();
-                if let Err(error) = self.global.borrow().constellation_sender.send(
+                if let Err(error) = self.global.borrow().embedder_to_constellation_sender.send(
                     EmbedderToConstellationMessage::SendImageKeysForPipeline(
                         pipeline_id,
                         image_keys,
@@ -822,7 +918,7 @@ impl IOCompositor {
                     global.frame_delayer.set_pending_frame(false);
                     self.generate_frame(&mut txn, RenderReasons::SCENE);
                     let waiting_pipelines = global.frame_delayer.take_waiting_pipelines();
-                    let _ = global.constellation_sender.send(
+                    let _ = global.embedder_to_constellation_sender.send(
                         EmbedderToConstellationMessage::NoLongerWaitingOnAsynchronousImageUpdates(
                             waiting_pipelines,
                         ),
@@ -1362,12 +1458,14 @@ impl IOCompositor {
                             paint_time = ?paint_time,
                             pipeline_id = ?pipeline_id,
                         );
-                        if let Err(error) = self.global.borrow().constellation_sender.send(
-                            EmbedderToConstellationMessage::PaintMetric(
-                                *pipeline_id,
-                                PaintMetricEvent::FirstPaint(paint_time, first_reflow),
-                            ),
-                        ) {
+                        if let Err(error) =
+                            self.global.borrow().embedder_to_constellation_sender.send(
+                                EmbedderToConstellationMessage::PaintMetric(
+                                    *pipeline_id,
+                                    PaintMetricEvent::FirstPaint(paint_time, first_reflow),
+                                ),
+                            )
+                        {
                             warn!(
                                 "Sending paint metric event to constellation failed ({error:?})."
                             );
@@ -1387,12 +1485,15 @@ impl IOCompositor {
                             paint_time = ?paint_time,
                             pipeline_id = ?pipeline_id,
                         );
-                        if let Err(error) = self.global.borrow().constellation_sender.send(
-                            EmbedderToConstellationMessage::PaintMetric(
+                        if let Err(error) = self
+                            .global
+                            .borrow()
+                            .embedder_to_constellation_sender
+                            .send(EmbedderToConstellationMessage::PaintMetric(
                                 *pipeline_id,
                                 PaintMetricEvent::FirstContentfulPaint(paint_time, first_reflow),
-                            ),
-                        ) {
+                            ))
+                        {
                             warn!(
                                 "Sending paint metric event to constellation failed ({error:?})."
                             );
@@ -1677,13 +1778,9 @@ impl IOCompositor {
             return;
         };
 
-        if let Err(error) =
-            global
-                .constellation_sender
-                .send(EmbedderToConstellationMessage::RefreshCursor(
-                    hit_test_result.pipeline_id,
-                ))
-        {
+        if let Err(error) = global.embedder_to_constellation_sender.send(
+            EmbedderToConstellationMessage::RefreshCursor(hit_test_result.pipeline_id),
+        ) {
             warn!("Sending event to constellation failed ({:?}).", error);
         }
     }
@@ -1720,7 +1817,7 @@ impl IOCompositor {
     ) {
         self.screenshot_taker
             .request_screenshot(webview_id, rect, callback);
-        let _ = self.global.borrow().constellation_sender.send(
+        let _ = self.global.borrow().embedder_to_constellation_sender.send(
             EmbedderToConstellationMessage::RequestScreenshotReadiness(webview_id),
         );
     }

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -10,11 +10,13 @@ use std::rc::Rc;
 
 use base::generic_channel::RoutedReceiver;
 use compositing_traits::rendering_context::RenderingContext;
-use compositing_traits::{CompositorMsg, CompositorProxy, WebrenderExternalImageHandlers};
+use compositing_traits::{CompositorMsg, CompositorProxy};
 use constellation_traits::EmbedderToConstellationMessage;
 use crossbeam_channel::Sender;
 use embedder_traits::{EventLoopWaker, RefreshDriver, ShutdownState};
 use profile_traits::{mem, time};
+#[cfg(feature = "webxr")]
+use webxr::WebXrRegistry;
 
 pub use crate::compositor::{IOCompositor, WebRenderDebugOption};
 
@@ -33,11 +35,11 @@ mod webview_renderer;
 /// Data used to construct a compositor.
 pub struct InitialCompositorState {
     /// A channel to the compositor.
-    pub sender: CompositorProxy,
+    pub compositor_proxy: CompositorProxy,
     /// A port on which messages inbound to the compositor can be received.
     pub receiver: RoutedReceiver<CompositorMsg>,
     /// A channel to the constellation.
-    pub constellation_chan: Sender<EmbedderToConstellationMessage>,
+    pub embedder_to_constellation_sender: Sender<EmbedderToConstellationMessage>,
     /// A channel to the time profiler thread.
     pub time_profiler_chan: time::ProfilerChan,
     /// A channel to the memory profiler thread.
@@ -47,8 +49,6 @@ pub struct InitialCompositorState {
     pub shutdown_state: Rc<Cell<ShutdownState>>,
     /// The target [`RenderingContext`] of this renderer.
     pub rendering_context: Rc<dyn RenderingContext>,
-    #[cfg(feature = "webxr")]
-    pub webxr_main_thread: webxr::MainThreadRegistry,
     /// An [`EventLoopWaker`] used in order to wake up the embedder when it is
     /// time to paint.
     pub event_loop_waker: Box<dyn EventLoopWaker>,
@@ -56,7 +56,7 @@ pub struct InitialCompositorState {
     pub refresh_driver: Option<Rc<dyn RefreshDriver>>,
     /// A [`PathBuf`] which can be used to override WebRender shaders.
     pub shaders_path: Option<PathBuf>,
-    /// [`WebrenderExternalImageHandlers`] for the renderer.
-    /// TODO: This should be managed from inside the renderer.
-    pub external_image_handlers: Box<WebrenderExternalImageHandlers>,
+    /// If WebXR is enabled, a [`WebXrRegistry`] to register WebXR threads.
+    #[cfg(feature = "webxr")]
+    pub webxr_registry: Box<dyn WebXrRegistry>,
 }

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -198,7 +198,7 @@ impl WebViewRenderer {
             return;
         }
 
-        let _ = self.global.borrow().constellation_sender.send(
+        let _ = self.global.borrow().embedder_to_constellation_sender.send(
             EmbedderToConstellationMessage::SetScrollStates(pipeline_id, scroll_offsets),
         );
     }
@@ -322,7 +322,7 @@ impl WebViewRenderer {
             _ => unreachable!("Unexpected input event type: {event:?}"),
         }
 
-        if let Err(error) = self.global.borrow().constellation_sender.send(
+        if let Err(error) = self.global.borrow().embedder_to_constellation_sender.send(
             EmbedderToConstellationMessage::ForwardInputEvent(self.id, event, hit_test_result),
         ) {
             warn!("Sending event to constellation failed ({error:?}).");
@@ -787,7 +787,12 @@ impl WebViewRenderer {
             event,
             Some(hit_test_result),
         );
-        if let Err(e) = self.global.borrow().constellation_sender.send(msg) {
+        if let Err(e) = self
+            .global
+            .borrow()
+            .embedder_to_constellation_sender
+            .send(msg)
+        {
             warn!("Sending scroll event to constellation failed ({:?}).", e);
         }
     }
@@ -866,7 +871,12 @@ impl WebViewRenderer {
             },
             WindowSizeType::Resize,
         );
-        if let Err(e) = self.global.borrow().constellation_sender.send(msg) {
+        if let Err(e) = self
+            .global
+            .borrow()
+            .embedder_to_constellation_sender
+            .send(msg)
+        {
             warn!("Sending window resize to constellation failed ({:?}).", e);
         }
     }

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -11,11 +11,11 @@ pub use crate::pref_util::PrefValue;
 
 static PREFERENCES: RwLock<Preferences> = RwLock::new(Preferences::const_default());
 
-pub trait Observer: Send + Sync {
+pub trait PreferencesObserver: Send + Sync {
     fn prefs_changed(&self, _changes: &[(&'static str, PrefValue)]) {}
 }
 
-static OBSERVERS: RwLock<Vec<Box<dyn Observer>>> = RwLock::new(Vec::new());
+static OBSERVERS: RwLock<Vec<Box<dyn PreferencesObserver>>> = RwLock::new(Vec::new());
 
 #[inline]
 /// Get the current set of global preferences for Servo.
@@ -23,7 +23,7 @@ pub fn get() -> RwLockReadGuard<'static, Preferences> {
     PREFERENCES.read().unwrap()
 }
 
-pub fn add_observer(observer: Box<dyn Observer>) {
+pub fn add_observer(observer: Box<dyn PreferencesObserver>) {
     OBSERVERS.write().unwrap().push(observer);
 }
 

--- a/components/media/lib.rs
+++ b/components/media/lib.rs
@@ -10,8 +10,8 @@ mod media_thread;
 use std::sync::{Arc, Mutex};
 
 use compositing_traits::{
-    ExternalImageSource, WebrenderExternalImageApi, WebrenderExternalImageHandlers,
-    WebrenderExternalImageRegistry, WebrenderImageHandlerType,
+    ExternalImageSource, WebRenderExternalImageApi, WebRenderExternalImageHandlers,
+    WebRenderExternalImageRegistry, WebRenderImageHandlerType,
 };
 use euclid::default::Size2D;
 use ipc_channel::ipc::{IpcReceiver, IpcSender, channel};
@@ -143,8 +143,8 @@ impl WindowGLContext {
     }
 
     pub fn initialize_image_handler(
-        external_image_handlers: &mut WebrenderExternalImageHandlers,
-        external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+        external_image_handlers: &mut WebRenderExternalImageHandlers,
+        external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
     ) {
         if !pref!(media_glvideo_enabled) {
             return;
@@ -164,7 +164,7 @@ impl WindowGLContext {
 
         let thread_sender = GLPlayerThread::start(external_images);
         let image_handler = Box::new(GLPlayerExternalImages::new(thread_sender.clone()));
-        external_image_handlers.set_handler(image_handler, WebrenderImageHandlerType::Media);
+        external_image_handlers.set_handler(image_handler, WebRenderImageHandlerType::Media);
         window_gl_context.glplayer_thread_sender = Some(thread_sender);
     }
 }
@@ -213,7 +213,7 @@ impl GLPlayerExternalImages {
     }
 }
 
-impl WebrenderExternalImageApi for GLPlayerExternalImages {
+impl WebRenderExternalImageApi for GLPlayerExternalImages {
     fn lock(&mut self, id: u64) -> (ExternalImageSource<'_>, Size2D<i32>) {
         // The GLPlayerMsgForward::Lock message inserts a fence in the
         // GLPlayer command queue.

--- a/components/media/media_thread.rs
+++ b/components/media/media_thread.rs
@@ -5,7 +5,7 @@
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use compositing_traits::{WebrenderExternalImageRegistry, WebrenderImageHandlerType};
+use compositing_traits::{WebRenderExternalImageRegistry, WebRenderImageHandlerType};
 use ipc_channel::ipc::{IpcSender, channel};
 use log::{trace, warn};
 use rustc_hash::FxHashMap;
@@ -22,11 +22,11 @@ pub struct GLPlayerThread {
     players: FxHashMap<u64, IpcSender<GLPlayerMsgForward>>,
     /// List of registered webrender external images.
     /// We use it to get an unique ID for new players.
-    external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+    external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
 }
 
 impl GLPlayerThread {
-    pub fn new(external_images: Arc<Mutex<WebrenderExternalImageRegistry>>) -> Self {
+    pub fn new(external_images: Arc<Mutex<WebRenderExternalImageRegistry>>) -> Self {
         GLPlayerThread {
             players: Default::default(),
             external_images,
@@ -34,7 +34,7 @@ impl GLPlayerThread {
     }
 
     pub fn start(
-        external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+        external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
     ) -> IpcSender<GLPlayerMsg> {
         let (sender, receiver) = channel().unwrap();
         thread::Builder::new()
@@ -64,7 +64,7 @@ impl GLPlayerThread {
                     .external_images
                     .lock()
                     .unwrap()
-                    .next_id(WebrenderImageHandlerType::Media)
+                    .next_id(WebRenderImageHandlerType::Media)
                     .0;
                 self.players.insert(id, sender.clone());
                 sender.send(GLPlayerMsgForward::PlayerId(id)).unwrap();

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -53,6 +53,7 @@ webgl_backtrace = [
 ]
 webgpu = [
     "script/webgpu",
+    "compositing/webgpu",
     "constellation/webgpu",
     "constellation_traits/webgpu",
 ]

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -29,7 +29,7 @@ use std::cell::{Cell, RefCell};
 use std::cmp::max;
 use std::path::PathBuf;
 use std::rc::{Rc, Weak};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use base::generic_channel::{GenericCallback, RoutedReceiver};
 pub use base::id::WebViewId;
@@ -38,17 +38,13 @@ use base::id::{PipelineNamespace, PipelineNamespaceId};
 use bluetooth::BluetoothThreadFactory;
 #[cfg(feature = "bluetooth")]
 use bluetooth_traits::BluetoothRequest;
-use canvas_traits::webgl::{GlType, WebGLThreads};
 use clipboard_delegate::StringRequest;
 pub use compositing::WebRenderDebugOption;
 use compositing::{IOCompositor, InitialCompositorState};
 pub use compositing_traits::rendering_context::{
     OffscreenRenderingContext, RenderingContext, SoftwareRenderingContext, WindowRenderingContext,
 };
-use compositing_traits::{
-    CompositorMsg, CompositorProxy, CrossProcessCompositorApi, WebrenderExternalImageHandlers,
-    WebrenderExternalImageRegistry, WebrenderImageHandlerType,
-};
+use compositing_traits::{CompositorMsg, CompositorProxy, CrossProcessCompositorApi};
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "ios"),
@@ -109,11 +105,6 @@ use servo_media::player::context::GlContext;
 use servo_url::ServoUrl;
 use storage::new_storage_threads;
 use style::global_style_data::StyleThreadPool;
-use webgl::WebGLComm;
-#[cfg(feature = "webgpu")]
-pub use webgpu;
-#[cfg(feature = "webgpu")]
-use webgpu::canvas_context::WGPUImageMap;
 use webview::WebViewInner;
 #[cfg(feature = "webxr")]
 pub use webxr;
@@ -253,6 +244,7 @@ impl Servo {
         let event_loop_waker = builder.event_loop_waker;
         let (compositor_proxy, compositor_receiver) =
             create_compositor_channel(event_loop_waker.clone());
+        let (constellation_proxy, embedder_to_constellation_receiver) = ConstellationProxy::new();
         let (embedder_proxy, embedder_receiver) = create_embedder_channel(event_loop_waker.clone());
         let time_profiler_chan = profile_time::Profiler::create(
             &opts.time_profiling,
@@ -277,107 +269,46 @@ impl Servo {
             None
         };
 
-        // Get GL bindings
-        let rendering_context = builder.rendering_context;
-        let webrender_gl = rendering_context.gleam_gl_api();
-
-        // Make sure the gl context is made current.
-        if let Err(err) = rendering_context.make_current() {
-            warn!("Failed to make the rendering context current: {:?}", err);
-        }
-        debug_assert_eq!(webrender_gl.get_error(), gleam::gl::NO_ERROR,);
-
-        // Create the webgl thread
-        let gl_type = match webrender_gl.get_type() {
-            gleam::gl::GlType::Gl => GlType::Gl,
-            gleam::gl::GlType::Gles => GlType::Gles,
-        };
-
-        let (external_image_handlers, external_images) = WebrenderExternalImageHandlers::new();
-        let mut external_image_handlers = Box::new(external_image_handlers);
-
-        let WebGLComm {
-            webgl_threads,
-            #[cfg(feature = "webxr")]
-            webxr_layer_grand_manager,
-            image_handler,
-        } = WebGLComm::new(
-            rendering_context.clone(),
-            compositor_proxy.cross_process_compositor_api.clone(),
-            external_images.clone(),
-            gl_type,
-        );
-
-        // Set webrender external image handler for WebGL textures
-        external_image_handlers.set_handler(image_handler, WebrenderImageHandlerType::WebGL);
-
-        // Create the WebXR main thread
-        #[cfg(feature = "webxr")]
-        let mut webxr_main_thread =
-            webxr::MainThreadRegistry::new(event_loop_waker.clone(), webxr_layer_grand_manager)
-                .expect("Failed to create WebXR device registry");
-        #[cfg(feature = "webxr")]
-        if pref!(dom_webxr_enabled) {
-            builder.webxr_registry.register(&mut webxr_main_thread);
-        }
-
-        #[cfg(feature = "webgpu")]
-        let wgpu_image_handler = webgpu::WGPUExternalImages::default();
-        #[cfg(feature = "webgpu")]
-        let wgpu_image_map = wgpu_image_handler.images.clone();
-        #[cfg(feature = "webgpu")]
-        external_image_handlers.set_handler(
-            Box::new(wgpu_image_handler),
-            WebrenderImageHandlerType::WebGPU,
-        );
-
-        WindowGLContext::initialize_image_handler(
-            &mut external_image_handlers,
-            external_images.clone(),
-        );
-
         // Create the constellation, which maintains the engine pipelines, including script and
         // layout, as well as the navigation context.
         let mut protocols = ProtocolRegistry::with_internal_protocols();
         protocols.merge(builder.protocol_registry);
 
-        let constellation_chan = create_constellation(
-            opts.config_dir.clone(),
-            embedder_proxy,
-            compositor_proxy.clone(),
-            time_profiler_chan.clone(),
-            mem_profiler_chan.clone(),
-            devtools_sender,
-            #[cfg(feature = "webxr")]
-            webxr_main_thread.registry(),
-            Some(webgl_threads),
-            external_images,
-            #[cfg(feature = "webgpu")]
-            wgpu_image_map,
-            protocols,
-            builder.user_content_manager,
-        );
-
         // The compositor coordinates with the client window to create the final
         // rendered page and display it somewhere.
         let shutdown_state = Rc::new(Cell::new(ShutdownState::NotShuttingDown));
         let compositor = IOCompositor::new(InitialCompositorState {
-            sender: compositor_proxy.clone(),
+            compositor_proxy: compositor_proxy.clone(),
             receiver: compositor_receiver,
-            constellation_chan: constellation_chan.clone(),
-            time_profiler_chan,
-            mem_profiler_chan,
-            rendering_context,
-            #[cfg(feature = "webxr")]
-            webxr_main_thread,
+            embedder_to_constellation_sender: constellation_proxy.sender().clone(),
+            time_profiler_chan: time_profiler_chan.clone(),
+            mem_profiler_chan: mem_profiler_chan.clone(),
+            rendering_context: builder.rendering_context,
             shutdown_state: shutdown_state.clone(),
             event_loop_waker,
             refresh_driver: builder.refresh_driver,
             shaders_path: opts.shaders_path.clone(),
-            external_image_handlers,
+            #[cfg(feature = "webxr")]
+            webxr_registry: builder.webxr_registry,
         });
 
-        let constellation_proxy = ConstellationProxy::new(constellation_chan);
+        create_constellation(
+            embedder_to_constellation_receiver,
+            &compositor,
+            opts.config_dir.clone(),
+            embedder_proxy,
+            compositor_proxy.clone(),
+            time_profiler_chan,
+            mem_profiler_chan,
+            devtools_sender,
+            protocols,
+            builder.user_content_manager,
+        );
+
+        if opts::get().multiprocess {
+            prefs::add_observer(Box::new(constellation_proxy.clone()));
+        }
+
         Self {
             delegate: RefCell::new(Rc::new(DefaultServoDelegate)),
             compositor: Rc::new(RefCell::new(compositor)),
@@ -1028,19 +959,17 @@ fn create_compositor_channel(
 
 #[allow(clippy::too_many_arguments)]
 fn create_constellation(
+    embedder_to_constellation_receiver: Receiver<EmbedderToConstellationMessage>,
+    compositor: &IOCompositor,
     config_dir: Option<PathBuf>,
     embedder_proxy: EmbedderProxy,
     compositor_proxy: CompositorProxy,
     time_profiler_chan: time::ProfilerChan,
     mem_profiler_chan: mem::ProfilerChan,
     devtools_sender: Option<Sender<devtools_traits::DevtoolsControlMsg>>,
-    #[cfg(feature = "webxr")] webxr_registry: webxr_api::Registry,
-    webgl_threads: Option<WebGLThreads>,
-    external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
-    #[cfg(feature = "webgpu")] wgpu_image_map: WGPUImageMap,
     protocols: ProtocolRegistry,
     user_content_manager: UserContentManager,
-) -> Sender<EmbedderToConstellationMessage> {
+) {
     // Global configuration options, parsed from the command line.
     let opts = opts::get();
 
@@ -1086,13 +1015,13 @@ fn create_constellation(
         time_profiler_chan,
         mem_profiler_chan,
         #[cfg(feature = "webxr")]
-        webxr_registry: Some(webxr_registry),
+        webxr_registry: Some(compositor.webxr_main_thread_registry()),
         #[cfg(not(feature = "webxr"))]
         webxr_registry: None,
-        webgl_threads,
-        webrender_external_images: external_images,
+        webgl_threads: Some(compositor.webgl_threads()),
+        webrender_external_images: compositor.webrender_external_images(),
         #[cfg(feature = "webgpu")]
-        wgpu_image_map,
+        wgpu_image_map: compositor.webgpu_image_map(),
         user_content_manager,
         async_runtime,
         privileged_urls,
@@ -1101,12 +1030,13 @@ fn create_constellation(
     let layout_factory = Arc::new(LayoutFactoryImpl());
 
     Constellation::<script::ScriptThread, script::ServiceWorkerManager>::start(
+        embedder_to_constellation_receiver,
         initial_state,
         layout_factory,
         opts.random_pipeline_closure_probability,
         opts.random_pipeline_closure_seed,
         opts.hard_fail,
-    )
+    );
 }
 
 // A logger that logs to two downstream loggers.

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -67,6 +67,7 @@ pub struct WebGLCommandBacktrace {
 }
 
 /// WebGL Threading API entry point that lives in the constellation.
+#[derive(Clone)]
 pub struct WebGLThreads(pub WebGLSender<WebGLMsg>);
 
 impl WebGLThreads {

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -432,31 +432,31 @@ impl CrossProcessCompositorApi {
 //
 /// This trait is used to notify lock/unlock messages and get the
 /// required info that WR needs.
-pub trait WebrenderExternalImageApi {
+pub trait WebRenderExternalImageApi {
     fn lock(&mut self, id: u64) -> (ExternalImageSource<'_>, UntypedSize2D<i32>);
     fn unlock(&mut self, id: u64);
 }
 
-/// Type of Webrender External Image Handler.
-pub enum WebrenderImageHandlerType {
-    WebGL,
+/// Type of WebRender External Image Handler.
+pub enum WebRenderImageHandlerType {
+    WebGl,
     Media,
-    WebGPU,
+    WebGpu,
 }
 
-/// List of Webrender external images to be shared among all external image
+/// List of WebRender external images to be shared among all external image
 /// consumers (WebGL, Media, WebGPU).
 /// It ensures that external image identifiers are unique.
 #[derive(Default)]
-pub struct WebrenderExternalImageRegistry {
+pub struct WebRenderExternalImageRegistry {
     /// Map of all generated external images.
-    external_images: FxHashMap<ExternalImageId, WebrenderImageHandlerType>,
+    external_images: FxHashMap<ExternalImageId, WebRenderImageHandlerType>,
     /// Id generator for the next external image identifier.
     next_image_id: u64,
 }
 
-impl WebrenderExternalImageRegistry {
-    pub fn next_id(&mut self, handler_type: WebrenderImageHandlerType) -> ExternalImageId {
+impl WebRenderExternalImageRegistry {
+    pub fn next_id(&mut self, handler_type: WebRenderImageHandlerType) -> ExternalImageId {
         self.next_image_id += 1;
         let key = ExternalImageId(self.next_image_id);
         self.external_images.insert(key, handler_type);
@@ -467,26 +467,26 @@ impl WebrenderExternalImageRegistry {
         self.external_images.remove(key);
     }
 
-    pub fn get(&self, key: &ExternalImageId) -> Option<&WebrenderImageHandlerType> {
+    pub fn get(&self, key: &ExternalImageId) -> Option<&WebRenderImageHandlerType> {
         self.external_images.get(key)
     }
 }
 
 /// WebRender External Image Handler implementation.
-pub struct WebrenderExternalImageHandlers {
+pub struct WebRenderExternalImageHandlers {
     /// WebGL handler.
-    webgl_handler: Option<Box<dyn WebrenderExternalImageApi>>,
+    webgl_handler: Option<Box<dyn WebRenderExternalImageApi>>,
     /// Media player handler.
-    media_handler: Option<Box<dyn WebrenderExternalImageApi>>,
+    media_handler: Option<Box<dyn WebRenderExternalImageApi>>,
     /// WebGPU handler.
-    webgpu_handler: Option<Box<dyn WebrenderExternalImageApi>>,
-    /// Webrender external images.
-    external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+    webgpu_handler: Option<Box<dyn WebRenderExternalImageApi>>,
+    /// WebRender external images.
+    external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
 }
 
-impl WebrenderExternalImageHandlers {
-    pub fn new() -> (Self, Arc<Mutex<WebrenderExternalImageRegistry>>) {
-        let external_images = Arc::new(Mutex::new(WebrenderExternalImageRegistry::default()));
+impl WebRenderExternalImageHandlers {
+    pub fn new() -> (Self, Arc<Mutex<WebRenderExternalImageRegistry>>) {
+        let external_images = Arc::new(Mutex::new(WebRenderExternalImageRegistry::default()));
         (
             Self {
                 webgl_handler: None,
@@ -500,18 +500,18 @@ impl WebrenderExternalImageHandlers {
 
     pub fn set_handler(
         &mut self,
-        handler: Box<dyn WebrenderExternalImageApi>,
-        handler_type: WebrenderImageHandlerType,
+        handler: Box<dyn WebRenderExternalImageApi>,
+        handler_type: WebRenderImageHandlerType,
     ) {
         match handler_type {
-            WebrenderImageHandlerType::WebGL => self.webgl_handler = Some(handler),
-            WebrenderImageHandlerType::Media => self.media_handler = Some(handler),
-            WebrenderImageHandlerType::WebGPU => self.webgpu_handler = Some(handler),
+            WebRenderImageHandlerType::WebGl => self.webgl_handler = Some(handler),
+            WebRenderImageHandlerType::Media => self.media_handler = Some(handler),
+            WebRenderImageHandlerType::WebGpu => self.webgpu_handler = Some(handler),
         }
     }
 }
 
-impl ExternalImageHandler for WebrenderExternalImageHandlers {
+impl ExternalImageHandler for WebRenderExternalImageHandlers {
     /// Lock the external image. Then, WR could start to read the
     /// image content.
     /// The WR client should not change the image content until the
@@ -527,7 +527,7 @@ impl ExternalImageHandler for WebrenderExternalImageHandlers {
             .get(&key)
             .expect("Tried to get unknown external image");
         match handler_type {
-            WebrenderImageHandlerType::WebGL => {
+            WebRenderImageHandlerType::WebGl => {
                 let (source, size) = self.webgl_handler.as_mut().unwrap().lock(key.0);
                 let texture_id = match source {
                     ExternalImageSource::NativeTexture(b) => b,
@@ -538,7 +538,7 @@ impl ExternalImageHandler for WebrenderExternalImageHandlers {
                     source: ExternalImageSource::NativeTexture(texture_id),
                 }
             },
-            WebrenderImageHandlerType::Media => {
+            WebRenderImageHandlerType::Media => {
                 let (source, size) = self.media_handler.as_mut().unwrap().lock(key.0);
                 let texture_id = match source {
                     ExternalImageSource::NativeTexture(b) => b,
@@ -549,7 +549,7 @@ impl ExternalImageHandler for WebrenderExternalImageHandlers {
                     source: ExternalImageSource::NativeTexture(texture_id),
                 }
             },
-            WebrenderImageHandlerType::WebGPU => {
+            WebRenderImageHandlerType::WebGpu => {
                 let (source, size) = self.webgpu_handler.as_mut().unwrap().lock(key.0);
                 ExternalImage {
                     uv: TexelRect::new(0.0, size.height as f32, size.width as f32, 0.0),
@@ -567,9 +567,9 @@ impl ExternalImageHandler for WebrenderExternalImageHandlers {
             .get(&key)
             .expect("Tried to get unknown external image");
         match handler_type {
-            WebrenderImageHandlerType::WebGL => self.webgl_handler.as_mut().unwrap().unlock(key.0),
-            WebrenderImageHandlerType::Media => self.media_handler.as_mut().unwrap().unlock(key.0),
-            WebrenderImageHandlerType::WebGPU => {
+            WebRenderImageHandlerType::WebGl => self.webgl_handler.as_mut().unwrap().unlock(key.0),
+            WebRenderImageHandlerType::Media => self.media_handler.as_mut().unwrap().unlock(key.0),
+            WebRenderImageHandlerType::WebGpu => {
                 self.webgpu_handler.as_mut().unwrap().unlock(key.0)
             },
         };

--- a/components/webgl/webgl_mode/inprocess.rs
+++ b/components/webgl/webgl_mode/inprocess.rs
@@ -8,8 +8,8 @@ use std::sync::{Arc, Mutex};
 use canvas_traits::webgl::{GlType, WebGLContextId, WebGLMsg, WebGLThreads, webgl_channel};
 use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::{
-    CrossProcessCompositorApi, ExternalImageSource, WebrenderExternalImageApi,
-    WebrenderExternalImageRegistry,
+    CrossProcessCompositorApi, ExternalImageSource, WebRenderExternalImageApi,
+    WebRenderExternalImageRegistry,
 };
 use euclid::default::Size2D;
 use log::debug;
@@ -25,7 +25,7 @@ use crate::webgl_thread::{WebGLThread, WebGLThreadInit};
 
 pub struct WebGLComm {
     pub webgl_threads: WebGLThreads,
-    pub image_handler: Box<dyn WebrenderExternalImageApi>,
+    pub image_handler: Box<dyn WebRenderExternalImageApi>,
     #[cfg(feature = "webxr")]
     pub webxr_layer_grand_manager: WebXRLayerGrandManager<WebXRSurfman>,
 }
@@ -35,7 +35,7 @@ impl WebGLComm {
     pub fn new(
         rendering_context: Rc<dyn RenderingContext>,
         compositor_api: CrossProcessCompositorApi,
-        external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+        external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
         api_type: GlType,
     ) -> WebGLComm {
         debug!("WebGLThreads::new()");
@@ -129,7 +129,7 @@ impl WebGLExternalImages {
     }
 }
 
-impl WebrenderExternalImageApi for WebGLExternalImages {
+impl WebRenderExternalImageApi for WebGLExternalImages {
     fn lock(&mut self, id: u64) -> (ExternalImageSource<'_>, Size2D<i32>) {
         let id = WebGLContextId(id);
         let (texture_id, size) = self.lock_swap_chain(id).unwrap_or_default();

--- a/components/webgl/webgl_thread.rs
+++ b/components/webgl/webgl_thread.rs
@@ -25,8 +25,8 @@ use canvas_traits::webgl::{
     WebGLVersion, WebGLVertexArrayId, YAxisTreatment,
 };
 use compositing_traits::{
-    CrossProcessCompositorApi, SerializableImageData, WebrenderExternalImageRegistry,
-    WebrenderImageHandlerType,
+    CrossProcessCompositorApi, SerializableImageData, WebRenderExternalImageRegistry,
+    WebRenderImageHandlerType,
 };
 use euclid::default::Size2D;
 use glow::{
@@ -215,7 +215,7 @@ pub(crate) struct WebGLThread {
     bound_context_id: Option<WebGLContextId>,
     /// List of registered webrender external images.
     /// We use it to get an unique ID for new WebGLContexts.
-    external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+    external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
     /// The receiver that will be used for processing WebGL messages.
     receiver: RoutedReceiver<WebGLMsg>,
     /// The receiver that should be used to send WebGL messages for processing.
@@ -232,7 +232,7 @@ pub(crate) struct WebGLThread {
 /// The data required to initialize an instance of the WebGLThread type.
 pub(crate) struct WebGLThreadInit {
     pub compositor_api: CrossProcessCompositorApi,
-    pub external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+    pub external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
     pub sender: WebGLSender<WebGLMsg>,
     pub receiver: WebGLReceiver<WebGLMsg>,
     pub webrender_swap_chains: SwapChains<WebGLContextId, Device>,
@@ -550,7 +550,7 @@ impl WebGLThread {
             self.external_images
                 .lock()
                 .expect("Lock poisoned?")
-                .next_id(WebrenderImageHandlerType::WebGL)
+                .next_id(WebRenderImageHandlerType::WebGl)
                 .0,
         );
 

--- a/components/webgpu/canvas_context.rs
+++ b/components/webgpu/canvas_context.rs
@@ -11,7 +11,7 @@ use arrayvec::ArrayVec;
 use base::Epoch;
 use compositing_traits::{
     CrossProcessCompositorApi, ExternalImageSource, SerializableImageData,
-    WebrenderExternalImageApi,
+    WebRenderExternalImageApi,
 };
 use euclid::default::Size2D;
 use ipc_channel::ipc::IpcSender;
@@ -314,7 +314,7 @@ pub struct WGPUExternalImages {
     pub locked_ids: FxHashMap<WebGPUContextId, PresentationStagingBuffer>,
 }
 
-impl WebrenderExternalImageApi for WGPUExternalImages {
+impl WebRenderExternalImageApi for WGPUExternalImages {
     fn lock(&mut self, id: u64) -> (ExternalImageSource<'_>, Size2D<i32>) {
         let id = WebGPUContextId(id);
         let presentation = {

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -15,7 +15,7 @@ mod wgpu_thread;
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
-use compositing_traits::{CrossProcessCompositorApi, WebrenderExternalImageRegistry};
+use compositing_traits::{CrossProcessCompositorApi, WebRenderExternalImageRegistry};
 use ipc_channel::ipc::{self, IpcReceiver};
 use servo_config::pref;
 
@@ -23,7 +23,7 @@ pub mod canvas_context;
 
 pub fn start_webgpu_thread(
     compositor_api: CrossProcessCompositorApi,
-    external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+    external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
     wgpu_image_map: WGPUImageMap,
 ) -> Option<(WebGPU, IpcReceiver<WebGPUMsg>)> {
     if !pref!(dom_webgpu_enabled) {

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 
 use base::id::PipelineId;
 use compositing_traits::{
-    CrossProcessCompositorApi, WebrenderExternalImageRegistry, WebrenderImageHandlerType,
+    CrossProcessCompositorApi, WebRenderExternalImageRegistry, WebRenderImageHandlerType,
 };
 use ipc_channel::ipc::{IpcReceiver, IpcSender, IpcSharedMemory};
 use log::{info, warn};
@@ -105,7 +105,7 @@ pub(crate) struct WGPU {
     /// (this is also reused for invalidation of command buffers)
     error_command_encoders: FxHashMap<id::CommandEncoderId, String>,
     pub(crate) compositor_api: CrossProcessCompositorApi,
-    pub(crate) external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+    pub(crate) external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
     pub(crate) wgpu_image_map: WGPUImageMap,
     /// Provides access to poller thread
     pub(crate) poller: Poller,
@@ -121,7 +121,7 @@ impl WGPU {
         sender: IpcSender<WebGPURequest>,
         script_sender: IpcSender<WebGPUMsg>,
         compositor_api: CrossProcessCompositorApi,
-        external_images: Arc<Mutex<WebrenderExternalImageRegistry>>,
+        external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
         wgpu_image_map: WGPUImageMap,
     ) -> Self {
         let backend_pref = pref!(dom_webgpu_wgpu_backend);
@@ -497,7 +497,7 @@ impl WGPU {
                             .external_images
                             .lock()
                             .expect("Lock poisoned?")
-                            .next_id(WebrenderImageHandlerType::WebGPU);
+                            .next_id(WebRenderImageHandlerType::WebGpu);
                         let image_key = self.compositor_api.generate_image_key_blocking().unwrap();
                         let context_id = WebGPUContextId(id.0);
                         if let Err(e) = sender.send((context_id, image_key)) {

--- a/ports/servoshell/desktop/webxr.rs
+++ b/ports/servoshell/desktop/webxr.rs
@@ -62,7 +62,7 @@ impl XrDiscoveryWebXrRegistry {
 
 struct XrPrefObserver(Arc<AtomicBool>);
 
-impl prefs::Observer for XrPrefObserver {
+impl prefs::PreferencesObserver for XrPrefObserver {
     fn prefs_changed(&self, changes: &[(&'static str, prefs::PrefValue)]) {
         if let Some((_, value)) = changes.iter().find(|(name, _)| *name == "dom_webxr_test") {
             let prefs::PrefValue::Bool(value) = value else {


### PR DESCRIPTION
In order to move all WebRender initialization closer to the renderer,
so that it can support multiple WebRender instances, move all external
image handler initialiazation into `compositing`.

This also modifies the order of initalization. Now the `IOCompositor`
(renderer) starts before the `Constellation`. This will be useful
when Servo construction can fail, so that we fail before starting a
`Constellation` thread.

Finally, replace all occurences of "Webrender" with "WebRender".

Testing: This should not change behavior so is covered by existing tests.
