### PR TITLE
OHOS/Android: Implement WebDriverCommandMsg::GetViewportSize in egl app_state.

### DIFF
--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -750,6 +750,10 @@ impl RunningAppState {
                             webview_id, text
                         );
                     },
+                    WebDriverCommandMsg::GetViewportSize(webview_id, response_sender) => {
+                        info!("Handling GetViewportSize for webview {}", webview_id);
+                        let _ = response_sender.send(self.rendering_context.size2d());
+                    },
                     _ => {
                         info!("Received WebDriver command: {:?}", msg);
                     },


### PR DESCRIPTION
Implement WebDriverCommandMsg::GetViewportSize for egl.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Tested a local script on an OHOS device.
