### PR TITLE
pixels: Split `Snapshot` into `SharedSnapshot` and `Snapshot`

### DIFF
--- a/components/canvas/canvas_paint_thread.rs
+++ b/components/canvas/canvas_paint_thread.rs
@@ -270,7 +270,7 @@ impl CanvasPaintThread {
             },
             Canvas2dMsg::GetImageData(dest_rect, sender) => {
                 let snapshot = self.canvas(canvas_id).read_pixels(dest_rect);
-                sender.send(snapshot.as_ipc()).unwrap();
+                sender.send(snapshot.to_shared()).unwrap();
             },
             Canvas2dMsg::PutImageData(rect, snapshot) => {
                 self.canvas(canvas_id)

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -493,16 +493,17 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
     }
 }
 
-fn snapshot_as_pixmap(data: Snapshot) -> Arc<vello_cpu::Pixmap> {
-    let size = data.size().cast();
-    let (data, _, _) = data.to_vec(
-        Some(SnapshotAlphaMode::Transparent {
+fn snapshot_as_pixmap(mut snapshot: Snapshot) -> Arc<vello_cpu::Pixmap> {
+    let size = snapshot.size().cast();
+    snapshot.transform(
+        SnapshotAlphaMode::Transparent {
             premultiplied: true,
-        }),
-        Some(SnapshotPixelFormat::RGBA),
+        },
+        SnapshotPixelFormat::RGBA,
     );
+
     Arc::new(vello_cpu::Pixmap::from_parts(
-        bytemuck::cast_vec(data),
+        bytemuck::cast_vec(snapshot.into()),
         size.width,
         size.height,
     ))

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -964,7 +964,7 @@ impl ImageCache for ImageCacheImpl {
                 },
                 format: PixelFormat::RGBA8,
                 frames: vec![frame],
-                bytes: IpcSharedMemory::from_bytes(&bytes),
+                bytes: Arc::new(IpcSharedMemory::from_bytes(&bytes)),
                 id: None,
                 cors_status: vector_image.cors_status,
             };

--- a/components/pixels/snapshot.rs
+++ b/components/pixels/snapshot.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::ops::{Deref, DerefMut};
+use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
+use std::sync::Arc;
 
 use euclid::default::{Rect, Size2D};
 use image::codecs::jpeg::JpegEncoder;
@@ -81,20 +82,24 @@ impl SnapshotAlphaMode {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+/// The data in a [`Snapshot`]. If created via shared memory, this will be
+/// the `SharedMemory` variant, but otherwise it is the `Owned` variant.
+/// any attempt to mutate the [`Snapshot`] will convert it to the `Owned`
+/// variant.
+#[derive(Clone, Debug, MallocSizeOf)]
 pub enum SnapshotData {
-    // TODO: https://github.com/servo/servo/issues/36594
-    // IPC(IpcSharedMemory),
+    SharedMemory(
+        #[conditional_malloc_size_of] Arc<IpcSharedMemory>,
+        Range<usize>,
+    ),
     Owned(Vec<u8>),
 }
 
-impl Deref for SnapshotData {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
+impl SnapshotData {
+    fn to_vec(&self) -> Vec<u8> {
         match &self {
-            // Data::IPC(ipc_shared_memory) => ipc_shared_memory,
-            SnapshotData::Owned(items) => items,
+            SnapshotData::SharedMemory(data, byte_range) => Vec::from(&data[byte_range.clone()]),
+            SnapshotData::Owned(data) => data.clone(),
         }
     }
 }
@@ -102,13 +107,25 @@ impl Deref for SnapshotData {
 impl DerefMut for SnapshotData {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
-            // Data::IPC(ipc_shared_memory) => unsafe { ipc_shared_memory.deref_mut() },
+            SnapshotData::SharedMemory(..) => {
+                *self = SnapshotData::Owned(self.to_vec());
+                &mut *self
+            },
             SnapshotData::Owned(items) => items,
         }
     }
 }
 
-pub type IpcSnapshot = Snapshot<IpcSharedMemory>;
+impl Deref for SnapshotData {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        match &self {
+            SnapshotData::SharedMemory(data, byte_range) => &data[byte_range.clone()],
+            SnapshotData::Owned(items) => items,
+        }
+    }
+}
 
 /// Represents image bitmap with metadata, usually as snapshot of canvas
 ///
@@ -117,18 +134,18 @@ pub type IpcSnapshot = Snapshot<IpcSharedMemory>;
 ///
 /// Inspired by snapshot for concept in WebGPU spec:
 /// <https://gpuweb.github.io/gpuweb/#abstract-opdef-get-a-copy-of-the-image-contents-of-a-context>
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
-pub struct Snapshot<T = SnapshotData> {
+#[derive(Clone, Debug, MallocSizeOf)]
+pub struct Snapshot {
     size: Size2D<u32>,
     /// internal data (can be any format it will be converted on use if needed)
-    data: T,
+    data: SnapshotData,
     /// RGBA/BGRA (reflect internal data)
     format: SnapshotPixelFormat,
     /// How to treat alpha channel
     alpha_mode: SnapshotAlphaMode,
 }
 
-impl<T> Snapshot<T> {
+impl Snapshot {
     pub const fn size(&self) -> Size2D<u32> {
         self.size
     }
@@ -140,9 +157,7 @@ impl<T> Snapshot<T> {
     pub const fn alpha_mode(&self) -> SnapshotAlphaMode {
         self.alpha_mode
     }
-}
 
-impl Snapshot<SnapshotData> {
     pub fn empty() -> Self {
         Self {
             size: Size2D::zero(),
@@ -180,31 +195,35 @@ impl Snapshot<SnapshotData> {
         }
     }
 
-    pub fn get_rect(&self, rect: Rect<u32>) -> Self {
-        let data = rgba8_get_rect(self.as_raw_bytes(), self.size(), rect).to_vec();
-        Self::from_vec(rect.size, self.format, self.alpha_mode, data)
-    }
-
-    // TODO: https://github.com/servo/servo/issues/36594
-    /*
-    /// # Safety
-    ///
-    /// This is safe if data is owned by this process only
-    /// (ownership is transferred on send)
-    pub unsafe fn from_shared_memory(
+    pub fn from_shared_memory(
         size: Size2D<u32>,
-        format: PixelFormat,
-        alpha_mode: AlphaMode,
-        ism: IpcSharedMemory,
+        format: SnapshotPixelFormat,
+        alpha_mode: SnapshotAlphaMode,
+        data: Arc<IpcSharedMemory>,
+        byte_range_bounds: impl RangeBounds<usize>,
     ) -> Self {
+        let range_start = match byte_range_bounds.start_bound() {
+            Bound::Included(bound) => *bound,
+            Bound::Excluded(bound) => *bound + 1,
+            Bound::Unbounded => 0,
+        };
+        let range_end = match byte_range_bounds.end_bound() {
+            Bound::Included(bound) => *bound + 1,
+            Bound::Excluded(bound) => *bound,
+            Bound::Unbounded => data.len(),
+        };
         Self {
             size,
-            data: Data::IPC(ism),
+            data: SnapshotData::SharedMemory(data, range_start..range_end),
             format,
             alpha_mode,
         }
     }
-    */
+
+    pub fn get_rect(&self, rect: Rect<u32>) -> Self {
+        let data = rgba8_get_rect(self.as_raw_bytes(), self.size(), rect).to_vec();
+        Self::from_vec(rect.size, self.format, self.alpha_mode, data)
+    }
 
     /// Convert inner data of snapshot to target format and alpha mode.
     /// If data is already in target format and alpha mode no work will be done.
@@ -213,16 +232,19 @@ impl Snapshot<SnapshotData> {
         target_alpha_mode: SnapshotAlphaMode,
         target_format: SnapshotPixelFormat,
     ) {
+        if self.alpha_mode == target_alpha_mode && target_format == self.format {
+            return;
+        }
+
         let swap_rb = target_format != self.format;
         let multiply = match (self.alpha_mode, target_alpha_mode) {
             (SnapshotAlphaMode::Opaque, _) => Multiply::None,
-            (alpha_mode, SnapshotAlphaMode::Opaque) => {
-                if alpha_mode.alpha() == Alpha::Premultiplied {
-                    Multiply::UnMultiply
-                } else {
-                    Multiply::None
-                }
+            (alpha_mode, SnapshotAlphaMode::Opaque)
+                if alpha_mode.alpha() == Alpha::Premultiplied =>
+            {
+                Multiply::UnMultiply
             },
+            (_, SnapshotAlphaMode::Opaque) => Multiply::None,
             (
                 SnapshotAlphaMode::Transparent { premultiplied } |
                 SnapshotAlphaMode::AsOpaque { premultiplied },
@@ -242,8 +264,14 @@ impl Snapshot<SnapshotData> {
                 }
             },
         };
+
         let clear_alpha = !matches!(self.alpha_mode, SnapshotAlphaMode::Opaque) &&
             matches!(target_alpha_mode, SnapshotAlphaMode::Opaque);
+
+        if matches!(multiply, Multiply::None) && !swap_rb && !clear_alpha {
+            return;
+        }
+
         transform_inplace(self.data.deref_mut(), multiply, swap_rb, clear_alpha);
         self.alpha_mode = target_alpha_mode;
         self.format = target_format;
@@ -257,45 +285,19 @@ impl Snapshot<SnapshotData> {
         &mut self.data
     }
 
-    pub fn as_bytes(
-        &mut self,
-        target_alpha_mode: Option<SnapshotAlphaMode>,
-        target_format: Option<SnapshotPixelFormat>,
-    ) -> (&mut [u8], SnapshotAlphaMode, SnapshotPixelFormat) {
-        let target_alpha_mode = target_alpha_mode.unwrap_or(self.alpha_mode);
-        let target_format = target_format.unwrap_or(self.format);
-        self.transform(target_alpha_mode, target_format);
-        (&mut self.data, target_alpha_mode, target_format)
-    }
-
-    pub fn to_vec(
-        mut self,
-        target_alpha_mode: Option<SnapshotAlphaMode>,
-        target_format: Option<SnapshotPixelFormat>,
-    ) -> (Vec<u8>, SnapshotAlphaMode, SnapshotPixelFormat) {
-        let target_alpha_mode = target_alpha_mode.unwrap_or(self.alpha_mode);
-        let target_format = target_format.unwrap_or(self.format);
-        self.transform(target_alpha_mode, target_format);
-        let SnapshotData::Owned(data) = self.data;
-        (data, target_alpha_mode, target_format)
-    }
-
-    pub fn as_ipc(self) -> Snapshot<IpcSharedMemory> {
-        let Snapshot {
-            size,
-            data,
-            format,
-            alpha_mode,
-        } = self;
-        let data = match data {
-            // Data::IPC(ipc_shared_memory) => ipc_shared_memory,
-            SnapshotData::Owned(items) => IpcSharedMemory::from_bytes(&items),
+    pub fn to_shared(&self) -> SharedSnapshot {
+        let (data, byte_range) = match &self.data {
+            SnapshotData::SharedMemory(data, byte_range) => (data.clone(), byte_range.clone()),
+            SnapshotData::Owned(data) => {
+                (Arc::new(IpcSharedMemory::from_bytes(data)), 0..data.len())
+            },
         };
-        Snapshot {
-            size,
+        SharedSnapshot {
+            size: self.size,
             data,
-            format,
-            alpha_mode,
+            byte_range,
+            format: self.format,
+            alpha_mode: self.alpha_mode,
         }
     }
 
@@ -307,19 +309,17 @@ impl Snapshot<SnapshotData> {
     ) -> Result<(), ImageError> {
         let width = self.size.width;
         let height = self.size.height;
-
-        let (data, _, _) = self.as_bytes(
-            if *image_type == EncodedImageType::Jpeg {
-                Some(SnapshotAlphaMode::AsOpaque {
-                    premultiplied: true,
-                })
-            } else {
-                Some(SnapshotAlphaMode::Transparent {
-                    premultiplied: false,
-                })
+        let alpha_mode = match image_type {
+            EncodedImageType::Jpeg => SnapshotAlphaMode::AsOpaque {
+                premultiplied: true,
             },
-            Some(SnapshotPixelFormat::RGBA),
-        );
+            _ => SnapshotAlphaMode::Transparent {
+                premultiplied: false,
+            },
+        };
+
+        self.transform(alpha_mode, SnapshotPixelFormat::RGBA);
+        let data = &self.data;
 
         match image_type {
             EncodedImageType::Png => {
@@ -389,48 +389,73 @@ impl Snapshot<SnapshotData> {
     }
 }
 
-impl Snapshot<IpcSharedMemory> {
-    // TODO: https://github.com/servo/servo/issues/36594
-    /*
-    /// # Safety
-    ///
-    /// This is safe if data is owned by this process only
-    /// (ownership is transferred on send)
-    pub unsafe fn to_data(self) -> Snapshot<Data> {
-        let Snapshot {
-            size,
-            data,
-            format,
-            alpha_mode,
-        } = self;
-        Snapshot {
-            size,
-            data: Data::IPC(data),
-            format,
-            alpha_mode,
+impl From<Snapshot> for Vec<u8> {
+    fn from(value: Snapshot) -> Self {
+        match value.data {
+            SnapshotData::SharedMemory(..) => Vec::from(value.as_raw_bytes()),
+            SnapshotData::Owned(data) => data,
         }
     }
-    */
-    pub fn to_owned(self) -> Snapshot<SnapshotData> {
-        let Snapshot {
-            size,
-            data,
-            format,
-            alpha_mode,
-        } = self;
+}
+
+/// A version of [`Snapshot`] that can be sent across IPC channels.
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+pub struct SharedSnapshot {
+    /// The physical size of this [`SharedSnapshot`].
+    size: Size2D<u32>,
+    /// The shared data of this [`SharedSnapshot`].
+    #[conditional_malloc_size_of]
+    data: Arc<IpcSharedMemory>,
+    /// The byte range of the data within the shared memory segment. This is used to
+    /// send individual image frames of animated images.
+    byte_range: Range<usize>,
+    /// The [`SnapshotPixelFormat`] of this [`SharedSnapshot`]
+    format: SnapshotPixelFormat,
+    /// The [`SnapshotAlphaMode`] of this [`SharedSnapshot`].
+    alpha_mode: SnapshotAlphaMode,
+}
+
+impl SharedSnapshot {
+    pub fn to_owned(&self) -> Snapshot {
         Snapshot {
-            size,
-            data: SnapshotData::Owned(data.to_vec()),
-            format,
-            alpha_mode,
+            size: self.size,
+            data: SnapshotData::SharedMemory(self.data.clone(), self.byte_range.clone()),
+            format: self.format,
+            alpha_mode: self.alpha_mode,
         }
+    }
+
+    /// Returns snapshot with provided size that is black transparent alpha
+    pub fn cleared(size: Size2D<u32>) -> Self {
+        let length_in_bytes = size.area() as usize * 4;
+        Self {
+            size,
+            data: Arc::new(IpcSharedMemory::from_byte(0, length_in_bytes)),
+            byte_range: 0..length_in_bytes,
+            format: SnapshotPixelFormat::RGBA,
+            alpha_mode: SnapshotAlphaMode::Transparent {
+                premultiplied: true,
+            },
+        }
+    }
+
+    pub const fn size(&self) -> Size2D<u32> {
+        self.size
+    }
+
+    pub const fn format(&self) -> SnapshotPixelFormat {
+        self.format
+    }
+
+    pub const fn alpha_mode(&self) -> SnapshotAlphaMode {
+        self.alpha_mode
     }
 
     pub fn data(&self) -> &[u8] {
-        &self.data
+        &(&self.data)[self.byte_range.clone()]
     }
 
-    pub fn to_ipc_shared_memory(self) -> IpcSharedMemory {
-        self.data
+    pub fn shared_memory(&self) -> IpcSharedMemory {
+        (*self.data).clone()
     }
 }

--- a/components/script/dom/canvas/2d/canvaspattern.rs
+++ b/components/script/dom/canvas/2d/canvaspattern.rs
@@ -5,7 +5,7 @@
 use canvas_traits::canvas::{FillOrStrokeStyle, RepetitionStyle, SurfaceStyle};
 use dom_struct::dom_struct;
 use euclid::default::{Size2D, Transform2D};
-use pixels::{IpcSnapshot, Snapshot};
+use pixels::{SharedSnapshot, Snapshot};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::CanvasRenderingContext2DBinding::CanvasPatternMethods;
@@ -23,7 +23,7 @@ use crate::script_runtime::CanGc;
 pub(crate) struct CanvasPattern {
     reflector_: Reflector,
     #[no_trace]
-    surface_data: IpcSnapshot,
+    surface_data: SharedSnapshot,
     #[no_trace]
     surface_size: Size2D<u32>,
     repeat_x: bool,
@@ -49,7 +49,7 @@ impl CanvasPattern {
 
         CanvasPattern {
             reflector_: Reflector::new(),
-            surface_data: surface_data.as_ipc(),
+            surface_data: surface_data.to_shared(),
             surface_size,
             repeat_x: x,
             repeat_y: y,

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -11,7 +11,7 @@ use std::{char, mem};
 use app_units::Au;
 use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
-use euclid::default::{Point2D, Size2D};
+use euclid::default::Point2D;
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
 use js::jsapi::JSAutoRealm;
 use js::rust::HandleObject;
@@ -27,9 +27,7 @@ use net_traits::{
     ResourceFetchTiming, ResourceTimingType,
 };
 use num_traits::ToPrimitive;
-use pixels::{
-    CorsStatus, ImageMetadata, PixelFormat, Snapshot, SnapshotAlphaMode, SnapshotPixelFormat,
-};
+use pixels::{CorsStatus, ImageMetadata, Snapshot};
 use regex::Regex;
 use rustc_hash::FxHashSet;
 use servo_url::ServoUrl;
@@ -216,32 +214,11 @@ impl HTMLImageElement {
 
     /// Gets the copy of the raster image data.
     pub(crate) fn get_raster_image_data(&self) -> Option<Snapshot> {
-        let Some(img) = self.image_data()?.as_raster_image() else {
+        let Some(raster_image) = self.image_data()?.as_raster_image() else {
             warn!("Vector image is not supported as raster image source");
             return None;
         };
-
-        let size = Size2D::new(img.metadata.width, img.metadata.height);
-        let format = match img.format {
-            PixelFormat::BGRA8 => SnapshotPixelFormat::BGRA,
-            PixelFormat::RGBA8 => SnapshotPixelFormat::RGBA,
-            pixel_format => {
-                unimplemented!("unsupported pixel format ({:?})", pixel_format)
-            },
-        };
-
-        let alpha_mode = SnapshotAlphaMode::Transparent {
-            premultiplied: false,
-        };
-
-        let snapshot = Snapshot::from_vec(
-            size.cast(),
-            format,
-            alpha_mode,
-            img.first_frame().bytes.to_vec(),
-        );
-
-        Some(snapshot)
+        Some(raster_image.as_snapshot())
     }
 }
 

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -618,7 +618,7 @@ impl WebGLRenderingContext {
                     return Ok(None);
                 };
 
-                let snapshot = snapshot.as_ipc();
+                let snapshot = snapshot.to_shared();
                 let size = snapshot.size().cast();
                 let format = match snapshot.format() {
                     SnapshotPixelFormat::RGBA => PixelFormat::RGBA8,
@@ -632,7 +632,7 @@ impl WebGLRenderingContext {
                 // conversions will be made.
                 // <https://registry.khronos.org/webgl/specs/latest/1.0/#6.10>
                 TexPixels::new(
-                    snapshot.to_ipc_shared_memory(),
+                    snapshot.shared_memory(),
                     size,
                     format,
                     None,
@@ -672,7 +672,7 @@ impl WebGLRenderingContext {
                     return Ok(None);
                 };
 
-                let snapshot = snapshot.as_ipc();
+                let snapshot = snapshot.to_shared();
                 let size = snapshot.size().cast();
                 let format: PixelFormat = match snapshot.format() {
                     SnapshotPixelFormat::RGBA => PixelFormat::RGBA8,
@@ -683,7 +683,7 @@ impl WebGLRenderingContext {
                     self.get_current_unpack_state(Alpha::NotPremultiplied);
 
                 TexPixels::new(
-                    snapshot.to_ipc_shared_memory(),
+                    snapshot.shared_memory(),
                     size,
                     format,
                     alpha_treatment,
@@ -702,7 +702,7 @@ impl WebGLRenderingContext {
                     return Ok(None);
                 };
 
-                let snapshot = snapshot.as_ipc();
+                let snapshot = snapshot.to_shared();
                 let size = snapshot.size().cast();
                 let format = match snapshot.format() {
                     SnapshotPixelFormat::RGBA => PixelFormat::RGBA8,
@@ -713,7 +713,7 @@ impl WebGLRenderingContext {
                     self.get_current_unpack_state(snapshot.alpha_mode().alpha());
 
                 TexPixels::new(
-                    snapshot.to_ipc_shared_memory(),
+                    snapshot.shared_memory(),
                     size,
                     format,
                     alpha_treatment,
@@ -729,7 +729,7 @@ impl WebGLRenderingContext {
                     return Ok(None);
                 };
 
-                let snapshot = snapshot.as_ipc();
+                let snapshot = snapshot.to_shared();
                 let size = snapshot.size().cast();
                 let format: PixelFormat = match snapshot.format() {
                     SnapshotPixelFormat::RGBA => PixelFormat::RGBA8,
@@ -740,7 +740,7 @@ impl WebGLRenderingContext {
                     self.get_current_unpack_state(snapshot.alpha_mode().alpha());
 
                 TexPixels::new(
-                    snapshot.to_ipc_shared_memory(),
+                    snapshot.shared_memory(),
                     size,
                     format,
                     alpha_treatment,

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -14,7 +14,7 @@ use ipc_channel::ipc::IpcSender;
 use kurbo::{BezPath, ParamCurveNearest as _, PathEl, Point, Shape, Triangle};
 use malloc_size_of::MallocSizeOf;
 use malloc_size_of_derive::MallocSizeOf;
-use pixels::IpcSnapshot;
+use pixels::SharedSnapshot;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 use style::color::AbsoluteColor;
@@ -448,7 +448,7 @@ pub enum CanvasMsg {
 #[derive(Debug, Deserialize, Serialize, strum::Display)]
 pub enum Canvas2dMsg {
     DrawImage(
-        IpcSnapshot,
+        SharedSnapshot,
         Rect<f64>,
         Rect<f64>,
         bool,
@@ -508,8 +508,8 @@ pub enum Canvas2dMsg {
         CompositionOptions,
         Transform2D<f64>,
     ),
-    GetImageData(Option<Rect<u32>>, IpcSender<IpcSnapshot>),
-    PutImageData(Rect<u32>, IpcSnapshot),
+    GetImageData(Option<Rect<u32>>, IpcSender<SharedSnapshot>),
+    PutImageData(Rect<u32>, SharedSnapshot),
     StrokeRect(
         Rect<f32>,
         FillOrStrokeStyle,
@@ -597,7 +597,7 @@ impl RadialGradientStyle {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SurfaceStyle {
-    pub surface_data: IpcSnapshot,
+    pub surface_data: SharedSnapshot,
     pub surface_size: Size2D<u32>,
     pub repeat_x: bool,
     pub repeat_y: bool,
@@ -606,7 +606,7 @@ pub struct SurfaceStyle {
 
 impl SurfaceStyle {
     pub fn new(
-        surface_data: IpcSnapshot,
+        surface_data: SharedSnapshot,
         surface_size: Size2D<u32>,
         repeat_x: bool,
         repeat_y: bool,

--- a/components/shared/constellation/structured_data/serializable.rs
+++ b/components/shared/constellation/structured_data/serializable.rs
@@ -17,7 +17,7 @@ use base::id::{
 use euclid::default::Transform3D;
 use malloc_size_of_derive::MallocSizeOf;
 use net_traits::filemanager_thread::RelativePos;
-use pixels::Snapshot;
+use pixels::SharedSnapshot;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use servo_url::ImmutableOrigin;
@@ -451,7 +451,7 @@ impl BroadcastClone for SerializableQuotaExceededError {
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 /// A serializable version of the ImageBitmap interface.
 pub struct SerializableImageBitmap {
-    pub bitmap_data: Snapshot,
+    pub bitmap_data: SharedSnapshot,
 }
 
 impl BroadcastClone for SerializableImageBitmap {

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -383,7 +383,7 @@ pub struct Image {
     pub height: u32,
     pub format: PixelFormat,
     /// A shared memory block containing the data of one or more image frames.
-    data: IpcSharedMemory,
+    data: Arc<IpcSharedMemory>,
     range: Range<usize>,
 }
 
@@ -391,7 +391,7 @@ impl Image {
     pub fn new(
         width: u32,
         height: u32,
-        data: IpcSharedMemory,
+        data: Arc<IpcSharedMemory>,
         range: Range<usize>,
         format: PixelFormat,
     ) -> Self {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -820,7 +820,7 @@ mod test {
             },
             format: PixelFormat::BGRA8,
             id: None,
-            bytes: IpcSharedMemory::from_byte(1, 1),
+            bytes: Arc::new(IpcSharedMemory::from_byte(1, 1)),
             frames: image_frames,
             cors_status: CorsStatus::Unsafe,
         };

--- a/components/shared/webgpu/messages/recv.rs
+++ b/components/shared/webgpu/messages/recv.rs
@@ -9,7 +9,7 @@ use arrayvec::ArrayVec;
 use base::Epoch;
 use base::id::PipelineId;
 use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
-use pixels::IpcSnapshot;
+use pixels::SharedSnapshot;
 use serde::{Deserialize, Serialize};
 use webrender_api::ImageKey;
 use webrender_api::euclid::default::Size2D;
@@ -172,7 +172,7 @@ pub enum WebGPURequest {
     GetImage {
         context_id: WebGPUContextId,
         pending_texture: Option<PendingTexture>,
-        sender: IpcSender<IpcSnapshot>,
+        sender: IpcSender<SharedSnapshot>,
     },
     ValidateTextureDescriptor {
         device_id: DeviceId,


### PR DESCRIPTION
This splits `Snapshot` into two structs:

- `Snapshot`: A non-serializable owned image buffer that might contain
  either shared memory or a `Vec<u8>`. When mutated the shared memory
  version is converted into a `Vec<u8>` avoiding a copy of the data
  until absolutely necessary.
- `SharedSnapshot`: A serialzable version of `Snapshot` that contains
  only shared memory and is suitable for sending across IPC channels.
  This version is cheaply convertible from and to owned `Snapshot`s as
  long as the source is also a shared memory `Snapshot`.

In addition, it does copyless conversions of `RasterImage` into
`Snapshot`s (including for frame offsets in animated images). Finally,
there are a few minor changes to try harder not to have to do a
`transform()` operation.

Testing: This should not change observable behavior, so is covered by existing
tests. It should come with a mild performance improvement and open up the
opportunity for others.
Fixes: #36594.
