### PR TITLE
Redesign `servo:newtab` page

### DIFF
--- a/resources/resource_protocol/newtab.css
+++ b/resources/resource_protocol/newtab.css
@@ -22,6 +22,7 @@ body {
 }
 
 img {
+  margin-bottom: 1em;
   width: 25vw;
 }
 
@@ -30,7 +31,13 @@ form {
 }
 
 input {
+  background-color: #333;
+  border-width: 0;
+  color: white;
+  border-radius: 5px;
+  height: 2.5em;
   width: 50vw;
+  text-indent: 3px;
 }
 
 a {
@@ -45,13 +52,25 @@ a:hover {
 
 /* This should not be needed but paper over missing default styles */
 button {
-  padding-block: 1px;
   padding-inline: 8px;
-  box-sizing: border-box;
+  border-radius: 5px;
+  border: none;
+  background-color: #333;
+  color: #42bf64;
+  /* Servo has trouble with button styling */
+  display: flex;
+  justify-items: center;
+  align-items: center;
+  line-height: 1;
+}
+
+button:hover {
+  background-color: #292929;
+  cursor: pointer;
 }
 
 form {
   display: flex;
   justify-items: center;
-  gap: 0.5em;
+  gap: 1.0em;
 }

--- a/resources/resource_protocol/newtab.html
+++ b/resources/resource_protocol/newtab.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <a href="https://servo.org">
-      <img src="resource:///servo-color-negative-no-container.png" />
+      <img src="resource:///servo-color-negative-no-container.png" draggable="false"/>
     </a>
     <form action="https://duckduckgo.com/html/">
       <input name="q" placeholder="Search the web…" autofocus />


### PR DESCRIPTION
Increases the size of the input/button for searching. Also it blends in the background colors of those to make it less jarring.

Before:
<img width="1136" height="880" alt="Screenshot 2025-10-24 at 10 23 24 AM" src="https://github.com/user-attachments/assets/7d178b48-431a-4f10-b107-04c691769a76" />

After:
<img width="1136" height="880" alt="Screenshot 2025-10-24 at 10 24 26 AM" src="https://github.com/user-attachments/assets/1eab2c14-8bda-4813-b31a-f1104c403e39" />
