### PR TITLE
script: Restrict scope of mutable borrow in IDBTransaction::ObjectStore.

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -470,6 +470,10 @@ DOMInterfaces = {
     'canGc': ['SetText']
 },
 
+'IDBTransaction': {
+    'canGc': ['ObjectStore']
+},
+
 'IntersectionObserver': {
     'canGc': ['Thresholds']
 },


### PR DESCRIPTION
This avoids a borrow hazard when we create a new IDBObjectStore object and that triggers a GC.

Testing: Many IndexedDB tests no longer crash when using a debug mozjs build and full GC zeal. This configuration is not run in CI.
Fixes: #39946
