### PR TITLE
bluetooth: Enable bluetooth feature when testing bluetooth on WPT and test on CI

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -5,6 +5,8 @@ skip: true
   skip: false
 [beacon]
   skip: false
+[bluetooth]
+  skip: false
 [clipboard-apis]
   skip: false
 [console]

--- a/tests/wpt/meta/bluetooth/__dir__.ini
+++ b/tests/wpt/meta/bluetooth/__dir__.ini
@@ -1,0 +1,1 @@
+prefs: [dom_bluetooth_enabled: true]

--- a/tests/wpt/meta/bluetooth/bidi/adapter/adapter-absent-getAvailability.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/adapter/adapter-absent-getAvailability.https.window.js.ini
@@ -1,0 +1,3 @@
+[adapter-absent-getAvailability.https.window.html]
+  [getAvailability() resolves with false if the system does not have an adapter.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/adapter/adapter-powered-off-getAvailability.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/adapter/adapter-powered-off-getAvailability.https.window.js.ini
@@ -1,0 +1,3 @@
+[adapter-powered-off-getAvailability.https.window.html]
+  [getAvailability() resolves with true if the Bluetooth radio is powered off, but the platform that supports Bluetooth LE.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/adapter/adapter-powered-on-getAvailability.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/adapter/adapter-powered-on-getAvailability.https.window.js.ini
@@ -1,0 +1,3 @@
+[adapter-powered-on-getAvailability.https.window.html]
+  [getAvailability() resolves with true if the Bluetooth radio is powered on and the platform supports Bluetooth LE.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/adapter/cross-origin-iframe-getAvailability.sub.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/adapter/cross-origin-iframe-getAvailability.sub.https.window.js.ini
@@ -1,0 +1,3 @@
+[cross-origin-iframe-getAvailability.sub.https.window.html]
+  [getAvailability() resolves with false if called from a unique origin]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/characteristicProperties.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/characteristicProperties.https.window.js.ini
@@ -1,0 +1,3 @@
+[characteristicProperties.https.window.html]
+  [HeartRate device properties]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptor/gen-characteristic-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptor/gen-characteristic-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-characteristic-is-removed.https.window.html]
+  [Characteristic gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptor/gen-descriptor-get-same-object.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptor/gen-descriptor-get-same-object.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-descriptor-get-same-object.https.window.html]
+  [Calls to getDescriptor should return the same object.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptor/gen-service-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptor/gen-service-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-service-is-removed.https.window.html]
+  [Service is removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptors/gen-characteristic-is-removed-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptors/gen-characteristic-is-removed-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-characteristic-is-removed-with-uuid.https.window.html]
+  [Characteristic gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptors/gen-characteristic-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptors/gen-characteristic-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-characteristic-is-removed.https.window.html]
+  [Characteristic gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptors/gen-descriptor-get-same-object.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptors/gen-descriptor-get-same-object.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-descriptor-get-same-object.https.window.html]
+  [Calls to getDescriptors should return the same object.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptors/gen-service-is-removed-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptors/gen-service-is-removed-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-service-is-removed-with-uuid.https.window.html]
+  [Service is removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptors/gen-service-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/getDescriptors/gen-service-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-service-is-removed.https.window.html]
+  [Service is removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/notifications/characteristic-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/notifications/characteristic-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[characteristic-is-removed.https.window.html]
+  [Characteristic is removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/notifications/service-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/notifications/service-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[service-is-removed.https.window.html]
+  [Service is removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/add-multiple-event-listeners.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/add-multiple-event-listeners.https.window.js.ini
@@ -1,0 +1,3 @@
+[add-multiple-event-listeners.https.window.html]
+  [Add multiple event listeners then readValue().]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/characteristic-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/characteristic-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[characteristic-is-removed.https.window.html]
+  [Characteristic gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/event-is-fired.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/event-is-fired.https.window.js.ini
@@ -1,0 +1,3 @@
+[event-is-fired.https.window.html]
+  [Reading a characteristic should fire an event.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/gen-characteristic-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/gen-characteristic-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-characteristic-is-removed.https.window.html]
+  [Characteristic gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/read-succeeds.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/read-succeeds.https.window.js.ini
@@ -1,0 +1,3 @@
+[read-succeeds.https.window.html]
+  [A read request succeeds and returns the characteristic's value.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/read-updates-value.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/read-updates-value.https.window.js.ini
@@ -1,0 +1,3 @@
+[read-updates-value.https.window.html]
+  [Succesful read should update characteristic.value]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/service-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/readValue/service-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[service-is-removed.https.window.html]
+  [Service gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/service-same-from-2-characteristics.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/service-same-from-2-characteristics.https.window.js.ini
@@ -1,0 +1,3 @@
+[service-same-from-2-characteristics.https.window.html]
+  [Same parent service returned from multiple characteristics.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/service-same-object.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/service-same-object.https.window.js.ini
@@ -1,0 +1,3 @@
+[service-same-object.https.window.html]
+  [[SameObject\] test for BluetoothRemoteGATTCharacteristic service.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/startNotifications/gen-characteristic-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/startNotifications/gen-characteristic-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-characteristic-is-removed.https.window.html]
+  [Characteristic gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/writeValue/gen-characteristic-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/writeValue/gen-characteristic-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-characteristic-is-removed.https.window.html]
+  [Characteristic gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithResponse/characteristic-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithResponse/characteristic-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[characteristic-is-removed.https.window.html]
+  [Characteristic gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithResponse/gen-characteristic-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithResponse/gen-characteristic-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-characteristic-is-removed.https.window.html]
+  [Characteristic gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithResponse/service-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithResponse/service-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[service-is-removed.https.window.html]
+  [Service gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithResponse/write-succeeds.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithResponse/write-succeeds.https.window.js.ini
@@ -1,0 +1,3 @@
+[write-succeeds.https.window.html]
+  [A regular write request to a writable characteristic should succeed.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithoutResponse/characteristic-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithoutResponse/characteristic-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[characteristic-is-removed.https.window.html]
+  [Characteristic gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithoutResponse/gen-characteristic-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithoutResponse/gen-characteristic-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-characteristic-is-removed.https.window.html]
+  [Characteristic gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithoutResponse/service-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/characteristic/writeValueWithoutResponse/service-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[service-is-removed.https.window.html]
+  [Service gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/descriptor/readValue/gen-service-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/descriptor/readValue/gen-service-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-service-is-removed.https.window.html]
+  [Service gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/descriptor/readValue/read-succeeds.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/descriptor/readValue/read-succeeds.https.window.js.ini
@@ -1,0 +1,3 @@
+[read-succeeds.https.window.html]
+  [A read request succeeds and returns the descriptor's value.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/descriptor/writeValue/gen-service-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/descriptor/writeValue/gen-service-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-service-is-removed.https.window.html]
+  [Service gets removed. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/device/forget/connect-after-forget.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/device/forget/connect-after-forget.https.window.js.ini
@@ -1,0 +1,3 @@
+[connect-after-forget.https.window.html]
+  [gatt.connect() rejects after forget().]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/device/forget/getDevices.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/device/forget/getDevices.https.window.js.ini
@@ -1,0 +1,3 @@
+[getDevices.https.window.html]
+  [forget() removes devices from getDevices().]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/device/gattserverdisconnected-event/disconnected.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/device/gattserverdisconnected-event/disconnected.https.window.js.ini
@@ -1,0 +1,3 @@
+[disconnected.https.window.html]
+  [A device disconnecting while connected should fire the gattserverdisconnected event.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/device/gattserverdisconnected-event/disconnected_gc.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/device/gattserverdisconnected-event/disconnected_gc.https.window.js.ini
@@ -1,0 +1,3 @@
+[disconnected_gc.https.window.html]
+  [A device disconnecting after the BluetoothDevice object has been GC'ed should not access freed memory.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/device/gattserverdisconnected-event/one-event-per-disconnection.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/device/gattserverdisconnected-event/one-event-per-disconnection.https.window.js.ini
@@ -1,0 +1,3 @@
+[one-event-per-disconnection.https.window.html]
+  [If a site disconnects from a device while the platform is disconnecting that device, only one gattserverdisconnected event should fire.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/device/gattserverdisconnected-event/reconnect-during-disconnected-event.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/device/gattserverdisconnected-event/reconnect-during-disconnected-event.https.window.js.ini
@@ -1,0 +1,3 @@
+[reconnect-during-disconnected-event.https.window.html]
+  [A device that reconnects during the gattserverdisconnected event should still receive gattserverdisconnected events after re-connection.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/getDevices/granted-devices-with-services.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/getDevices/granted-devices-with-services.https.window.js.ini
@@ -1,0 +1,3 @@
+[granted-devices-with-services.https.window.html]
+  [getDevices() resolves with permitted devices that can be GATT connected to.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/getDevices/no-granted-devices.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/getDevices/no-granted-devices.https.window.js.ini
@@ -1,0 +1,3 @@
+[no-granted-devices.https.window.html]
+  [getDevices() resolves with empty array if no device permissions have been granted.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/getDevices/reject_opaque_origin.https.html.ini
+++ b/tests/wpt/meta/bluetooth/bidi/getDevices/reject_opaque_origin.https.html.ini
@@ -1,0 +1,3 @@
+[reject_opaque_origin.https.html]
+  [Calls to Bluetooth APIs from an origin with opaque top origin get blocked.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/getDevices/returns-same-bluetooth-device-object.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/getDevices/returns-same-bluetooth-device-object.https.window.js.ini
@@ -1,0 +1,3 @@
+[returns-same-bluetooth-device-object.https.window.html]
+  [multiple calls to getDevices() resolves with the sameBluetoothDevice objects for each granted Bluetooth device.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/idl/idl-Bluetooth.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/idl/idl-Bluetooth.https.window.js.ini
@@ -1,0 +1,3 @@
+[idl-Bluetooth.https.window.html]
+  [Bluetooth IDL test]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/idl/idl-BluetoothDevice.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/idl/idl-BluetoothDevice.https.window.js.ini
@@ -1,0 +1,3 @@
+[idl-BluetoothDevice.https.window.html]
+  [BluetoothDevice attributes.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/idl/idl-NavigatorBluetooth.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/idl/idl-NavigatorBluetooth.window.js.ini
@@ -1,0 +1,3 @@
+[idl-NavigatorBluetooth.window.html]
+  [navigator.bluetooth not available in insecure contexts]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/idl/idlharness.tentative.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/idl/idlharness.tentative.https.window.js.ini
@@ -1,0 +1,180 @@
+[idlharness.tentative.https.window.html]
+  [Bluetooth interface: attribute referringDevice]
+    expected: FAIL
+
+  [Bluetooth interface: operation getDevices()]
+    expected: FAIL
+
+  [Bluetooth interface: attribute onadvertisementreceived]
+    expected: FAIL
+
+  [Bluetooth interface: attribute ongattserverdisconnected]
+    expected: FAIL
+
+  [Bluetooth interface: attribute oncharacteristicvaluechanged]
+    expected: FAIL
+
+  [Bluetooth interface: attribute onserviceadded]
+    expected: FAIL
+
+  [Bluetooth interface: attribute onservicechanged]
+    expected: FAIL
+
+  [Bluetooth interface: attribute onserviceremoved]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "referringDevice" with the proper type]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "getDevices()" with the proper type]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "onadvertisementreceived" with the proper type]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "ongattserverdisconnected" with the proper type]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "oncharacteristicvaluechanged" with the proper type]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "onserviceadded" with the proper type]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "onservicechanged" with the proper type]
+    expected: FAIL
+
+  [Bluetooth interface: navigator.bluetooth must inherit property "onserviceremoved" with the proper type]
+    expected: FAIL
+
+  [BluetoothPermissionResult interface: attribute devices]
+    expected: FAIL
+
+  [ValueEvent interface: existence and properties of interface object]
+    expected: FAIL
+
+  [ValueEvent interface object length]
+    expected: FAIL
+
+  [ValueEvent interface object name]
+    expected: FAIL
+
+  [ValueEvent interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [ValueEvent interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [ValueEvent interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [ValueEvent interface: attribute value]
+    expected: FAIL
+
+  [BluetoothDevice interface: operation forget()]
+    expected: FAIL
+
+  [BluetoothDevice interface: attribute onadvertisementreceived]
+    expected: FAIL
+
+  [BluetoothDevice interface: attribute oncharacteristicvaluechanged]
+    expected: FAIL
+
+  [BluetoothDevice interface: attribute onserviceadded]
+    expected: FAIL
+
+  [BluetoothDevice interface: attribute onservicechanged]
+    expected: FAIL
+
+  [BluetoothDevice interface: attribute onserviceremoved]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface: existence and properties of interface object]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface object length]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface object name]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [BluetoothManufacturerDataMap interface: maplike<unsigned short, DataView>]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface: existence and properties of interface object]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface object length]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface object name]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface: existence and properties of interface prototype object]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface: existence and properties of interface prototype object's "constructor" property]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface: existence and properties of interface prototype object's @@unscopables property]
+    expected: FAIL
+
+  [BluetoothServiceDataMap interface: maplike<UUID, DataView>]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: attribute uuids]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: attribute manufacturerData]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: attribute serviceData]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent must be primary interface of event]
+    expected: FAIL
+
+  [Stringification of event]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "device" with the proper type]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "uuids" with the proper type]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "name" with the proper type]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "appearance" with the proper type]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "txPower" with the proper type]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "rssi" with the proper type]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "manufacturerData" with the proper type]
+    expected: FAIL
+
+  [BluetoothAdvertisingEvent interface: event must inherit property "serviceData" with the proper type]
+    expected: FAIL
+
+  [BluetoothRemoteGATTService interface: attribute oncharacteristicvaluechanged]
+    expected: FAIL
+
+  [BluetoothRemoteGATTCharacteristic interface: operation writeValueWithResponse(BufferSource)]
+    expected: FAIL
+
+  [BluetoothRemoteGATTCharacteristic interface: operation writeValueWithoutResponse(BufferSource)]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/acceptAllDevices/device-with-empty-name.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/acceptAllDevices/device-with-empty-name.https.window.js.ini
@@ -1,0 +1,3 @@
+[device-with-empty-name.https.window.html]
+  [Device with empty name and no UUIDs nearby. Should be found if acceptAllDevices is true.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/acceptAllDevices/device-with-name.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/acceptAllDevices/device-with-name.https.window.js.ini
@@ -1,0 +1,3 @@
+[device-with-name.https.window.html]
+  [A device with name and no UUIDs nearby. Should be found if acceptAllDevices is true.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/acceptAllDevices/optional-services-missing.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/acceptAllDevices/optional-services-missing.https.window.js.ini
@@ -1,0 +1,3 @@
+[optional-services-missing.https.window.html]
+  [requestDevice called with acceptAllDevices: true and with no optionalServices. Should not get access to any services.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/acceptAllDevices/optional-services-present.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/acceptAllDevices/optional-services-present.https.window.js.ini
@@ -1,0 +1,3 @@
+[optional-services-present.https.window.html]
+  [requestDevice called with acceptAllDevices: true and with optionalServices. Should get access to services.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/blocklisted-manufacturer-data-in-filter.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/blocklisted-manufacturer-data-in-filter.https.window.js.ini
@@ -1,0 +1,3 @@
+[blocklisted-manufacturer-data-in-filter.https.window.html]
+  [Reject with SecurityError if requesting a blocklisted manufacturer data.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/blocklisted-service-in-filter.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/blocklisted-service-in-filter.https.window.js.ini
@@ -1,0 +1,3 @@
+[blocklisted-service-in-filter.https.window.html]
+  [Reject with SecurityError if requesting a blocklisted service.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/blocklisted-service-in-optionalServices.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/blocklisted-service-in-optionalServices.https.window.js.ini
@@ -1,0 +1,3 @@
+[blocklisted-service-in-optionalServices.https.window.html]
+  [Blocklisted UUID in optionalServices is removed and access not granted.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/data-prefix-and-mask-size.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/data-prefix-and-mask-size.https.window.js.ini
@@ -1,0 +1,3 @@
+[data-prefix-and-mask-size.https.window.html]
+  [Manufacturer data mask size must be equal to dataPrefix size.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/dataPrefix-buffer-is-detached.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/dataPrefix-buffer-is-detached.https.window.js.ini
@@ -1,0 +1,3 @@
+[dataPrefix-buffer-is-detached.https.window.html]
+  [dataPrefix value buffer must not be detached]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/device-name-longer-than-29-bytes.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/device-name-longer-than-29-bytes.https.window.js.ini
@@ -1,0 +1,3 @@
+[device-name-longer-than-29-bytes.https.window.html]
+  [A device name between 29 and 248 bytes is valid.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-dataPrefix.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-dataPrefix.https.window.js.ini
@@ -1,0 +1,3 @@
+[empty-dataPrefix.https.window.html]
+  [dataPrefix when present must be non-empty]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-exclusion-filter.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-exclusion-filter.https.window.js.ini
@@ -1,0 +1,3 @@
+[empty-exclusion-filter.https.window.html]
+  [An exclusion filter must restrict the devices in some way.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-exclusion-filters-member.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-exclusion-filters-member.https.window.js.ini
@@ -1,0 +1,3 @@
+[empty-exclusion-filters-member.https.window.html]
+  [An empty |exclusionFilters| member should result in a TypeError]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-filter.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-filter.https.window.js.ini
@@ -1,0 +1,3 @@
+[empty-filter.https.window.html]
+  [A filter must restrict the devices in some way.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-filters-member.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-filters-member.https.window.js.ini
@@ -1,0 +1,3 @@
+[empty-filters-member.https.window.html]
+  [An empty |filters| member should result in a TypeError]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-manufacturerData-member.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-manufacturerData-member.https.window.js.ini
@@ -1,0 +1,3 @@
+[empty-manufacturerData-member.https.window.html]
+  [requestDevice with empty manufacturerData. Should reject with TypeError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-namePrefix.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-namePrefix.https.window.js.ini
@@ -1,0 +1,3 @@
+[empty-namePrefix.https.window.html]
+  [requestDevice with empty namePrefix. Should reject with TypeError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-services-member.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/empty-services-member.https.window.js.ini
@@ -1,0 +1,3 @@
+[empty-services-member.https.window.html]
+  [Services member must contain at least one service.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/exclusion-filters-require-filters.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/exclusion-filters-require-filters.https.window.js.ini
@@ -1,0 +1,3 @@
+[exclusion-filters-require-filters.https.window.html]
+  [RequestDeviceOptions should have 'filters' if 'exclusionFilters' is present. Reject with TypeError if not.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/filters-xor-acceptAllDevices.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/filters-xor-acceptAllDevices.https.window.js.ini
@@ -1,0 +1,3 @@
+[filters-xor-acceptAllDevices.https.window.html]
+  [RequestDeviceOptions should have exactly one of 'filters' or 'acceptAllDevices:true'. Reject with TypeError if not.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/invalid-companyIdentifier.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/invalid-companyIdentifier.https.window.js.ini
@@ -1,0 +1,3 @@
+[invalid-companyIdentifier.https.window.html]
+  [companyIdentifier must be in the [0, 65535\] range]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/mask-buffer-is-detached.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/mask-buffer-is-detached.https.window.js.ini
@@ -1,0 +1,3 @@
+[mask-buffer-is-detached.https.window.html]
+  [mask value buffer must not be detached]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-exceeded-name-unicode.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-exceeded-name-unicode.https.window.js.ini
@@ -1,0 +1,3 @@
+[max-length-exceeded-name-unicode.https.window.html]
+  [Unicode string with utf8 representation longer than 248 bytes in 'name' must throw TypeError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-exceeded-name.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-exceeded-name.https.window.js.ini
@@ -1,0 +1,3 @@
+[max-length-exceeded-name.https.window.html]
+  [A device name longer than 248 must reject.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-exceeded-namePrefix-unicode.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-exceeded-namePrefix-unicode.https.window.js.ini
@@ -1,0 +1,3 @@
+[max-length-exceeded-namePrefix-unicode.https.window.html]
+  [Unicode string with utf8 representation longer than 248 bytes in 'namePrefix' must throw NotFoundError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-exceeded-namePrefix.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-exceeded-namePrefix.https.window.js.ini
@@ -1,0 +1,3 @@
+[max-length-exceeded-namePrefix.https.window.html]
+  [A device name prefix longer than 248 must reject.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-name-unicode.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-name-unicode.https.window.js.ini
@@ -1,0 +1,3 @@
+[max-length-name-unicode.https.window.html]
+  [A unicode device name of 248 bytes is valid.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-name.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-name.https.window.js.ini
@@ -1,0 +1,3 @@
+[max-length-name.https.window.html]
+  [A device name of 248 bytes is valid.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-namePrefix-unicode.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-namePrefix-unicode.https.window.js.ini
@@ -1,0 +1,3 @@
+[max-length-namePrefix-unicode.https.window.html]
+  [A unicode device namePrefix of 248 bytes is valid.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-namePrefix.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/max-length-namePrefix.https.window.js.ini
@@ -1,0 +1,3 @@
+[max-length-namePrefix.https.window.html]
+  [A device namePrefix of 248 bytes is valid.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/no-arguments.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/no-arguments.https.window.js.ini
@@ -1,0 +1,3 @@
+[no-arguments.https.window.html]
+  [requestDevice() requires an argument.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/same-company-identifier.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/same-company-identifier.https.window.js.ini
@@ -1,0 +1,3 @@
+[same-company-identifier.https.window.html]
+  [Manufacturer data company identifier must be unique.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/unicode-valid-length-name-name.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/unicode-valid-length-name-name.https.window.js.ini
@@ -1,0 +1,3 @@
+[unicode-valid-length-name-name.https.window.html]
+  [A name containing unicode characters whose utf8 length is less than 30 must not throw an error.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/unicode-valid-length-name-namePrefix.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/unicode-valid-length-name-namePrefix.https.window.js.ini
@@ -1,0 +1,3 @@
+[unicode-valid-length-name-namePrefix.https.window.html]
+  [A namePrefix containing unicode characters whose utf8 length is less than 30 must not throw an error.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/wrong-service-in-optionalServices-member.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/wrong-service-in-optionalServices-member.https.window.js.ini
@@ -1,0 +1,3 @@
+[wrong-service-in-optionalServices-member.https.window.html]
+  [Invalid optional service must reject the promise.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/wrong-service-in-services-member.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/canonicalizeFilter/wrong-service-in-services-member.https.window.js.ini
@@ -1,0 +1,3 @@
+[wrong-service-in-services-member.https.window.html]
+  [Invalid service must reject the promise.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/cross-origin-iframe.sub.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/cross-origin-iframe.sub.https.window.js.ini
@@ -1,0 +1,3 @@
+[cross-origin-iframe.sub.https.window.html]
+  [Request device from a unique origin. Should reject with SecurityError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/discovery-succeeds.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/discovery-succeeds.https.window.js.ini
@@ -1,0 +1,3 @@
+[discovery-succeeds.https.window.html]
+  [Discover a device using alias, name, or UUID.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/doesnt-consume-user-gesture.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/doesnt-consume-user-gesture.https.window.js.ini
@@ -1,0 +1,3 @@
+[doesnt-consume-user-gesture.https.window.html]
+  [requestDevice calls do not consume user gestures.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/filter-matches.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/filter-matches.https.window.js.ini
@@ -1,0 +1,3 @@
+[filter-matches.https.window.html]
+  [Matches a filter if all present members match.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/name-empty-device-from-name-empty-filter.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/name-empty-device-from-name-empty-filter.https.window.js.ini
@@ -1,0 +1,3 @@
+[name-empty-device-from-name-empty-filter.https.window.html]
+  [An empty name device can be obtained by empty name filter.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/not-processing-user-gesture.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/not-processing-user-gesture.https.window.js.ini
@@ -1,0 +1,3 @@
+[not-processing-user-gesture.https.window.html]
+  [Requires a user gesture.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/radio-not-present.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/radio-not-present.https.window.js.ini
@@ -1,0 +1,3 @@
+[radio-not-present.https.window.html]
+  [Reject with NotFoundError if there is no BT radio present.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/reject_opaque_origin.https.html.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/reject_opaque_origin.https.html.ini
@@ -1,0 +1,3 @@
+[reject_opaque_origin.https.html]
+  [Calls to Bluetooth APIs from an origin with opaque top origin get blocked.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/same-device.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/same-device.https.window.js.ini
@@ -1,0 +1,3 @@
+[same-device.https.window.html]
+  [Returned device should always be the same.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/requestDevice/single-filter-single-service.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/requestDevice/single-filter-single-service.https.window.js.ini
@@ -1,0 +1,3 @@
+[single-filter-single-service.https.window.html]
+  [Simple filter selects matching device.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/connect/connection-succeeds.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/connect/connection-succeeds.https.window.js.ini
@@ -1,0 +1,3 @@
+[connection-succeeds.https.window.html]
+  [Device will connect]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/connect/garbage-collection-ran-during-success.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/connect/garbage-collection-ran-during-success.https.window.js.ini
@@ -1,0 +1,3 @@
+[garbage-collection-ran-during-success.https.window.html]
+  [Garbage Collection ran during a connect call that succeeds. Should not crash.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/connect/get-same-gatt-server.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/connect/get-same-gatt-server.https.window.js.ini
@@ -1,0 +1,3 @@
+[get-same-gatt-server.https.window.html]
+  [Multiple connects should return the same gatt object.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/device-same-object.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/device-same-object.https.window.js.ini
@@ -1,0 +1,3 @@
+[device-same-object.https.window.html]
+  [[SameObject\] test for BluetoothRemoteGATTServer's device.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/disconnect/connect-disconnect-twice.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/disconnect/connect-disconnect-twice.https.window.js.ini
@@ -1,0 +1,3 @@
+[connect-disconnect-twice.https.window.html]
+  [Connect + Disconnect twice still results in 'connected' being false.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/disconnect/disconnect-twice-in-a-row.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/disconnect/disconnect-twice-in-a-row.https.window.js.ini
@@ -1,0 +1,3 @@
+[disconnect-twice-in-a-row.https.window.html]
+  [Calling disconnect twice in a row still results in 'connected' being false.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-disconnect-called-before.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-disconnect-called-before.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnect-called-before.https.window.html]
+  [disconnect() called before getPrimaryService. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-disconnect-called-during-error.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-disconnect-called-during-error.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnect-called-during-error.https.window.html]
+  [disconnect() called during a getPrimaryService call that fails. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-disconnect-called-during-success.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-disconnect-called-during-success.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnect-called-during-success.https.window.html]
+  [disconnect() called during a getPrimaryService call that succeeds. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-disconnect-invalidates-objects.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-disconnect-invalidates-objects.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnect-invalidates-objects.https.window.html]
+  [Calls on services after we disconnect and connect again. Should reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-disconnected-device.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-disconnected-device.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnected-device.https.window.html]
+  [getPrimaryService called before connecting. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-garbage-collection-ran-during-error.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-garbage-collection-ran-during-error.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-garbage-collection-ran-during-error.https.window.html]
+  [Garbage Collection ran during a getPrimaryService call that failed. Should not crash.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-garbage-collection-ran-during-success.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-garbage-collection-ran-during-success.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-garbage-collection-ran-during-success.https.window.html]
+  [Garbage Collection ran during a getPrimaryService call that succeeds. Should not crash.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-get-different-service-after-reconnection.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-get-different-service-after-reconnection.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-get-different-service-after-reconnection.https.window.html]
+  [Calls to getPrimaryService after a disconnection should return a different object.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-get-same-object.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-get-same-object.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-get-same-object.https.window.html]
+  [Calls to getPrimaryService should return the same object.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-invalid-service-name.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-invalid-service-name.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-invalid-service-name.https.window.html]
+  [Wrong Service name. Reject with TypeError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-service-not-found.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/gen-service-not-found.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-service-not-found.https.window.html]
+  [Request for absent service. Reject with NotFoundError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/service-found.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryService/service-found.https.window.js.ini
@@ -1,0 +1,3 @@
+[service-found.https.window.html]
+  [Request for service. Should return right service]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/blocklisted-services-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/blocklisted-services-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[blocklisted-services-with-uuid.https.window.html]
+  [Request for services. Does not return blocklisted service.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/blocklisted-services.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/blocklisted-services.https.window.js.ini
@@ -1,0 +1,3 @@
+[blocklisted-services.https.window.html]
+  [Request for services. Does not return blocklisted service.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-called-before-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-called-before-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnect-called-before-with-uuid.https.window.html]
+  [disconnect() called before getPrimaryServices. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-called-before.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-called-before.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnect-called-before.https.window.html]
+  [disconnect() called before getPrimaryServices. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-called-during-error-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-called-during-error-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnect-called-during-error-with-uuid.https.window.html]
+  [disconnect() called during a getPrimaryServices call that fails. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-called-during-error.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-called-during-error.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnect-called-during-error.https.window.html]
+  [disconnect() called during a getPrimaryServices call that fails. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-called-during-success-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-called-during-success-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnect-called-during-success-with-uuid.https.window.html]
+  [disconnect() called during a getPrimaryServices call that succeeds. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-called-during-success.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-called-during-success.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnect-called-during-success.https.window.html]
+  [disconnect() called during a getPrimaryServices call that succeeds. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-invalidates-objects-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-invalidates-objects-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnect-invalidates-objects-with-uuid.https.window.html]
+  [Calls on services after we disconnect and connect again. Should reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-invalidates-objects.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnect-invalidates-objects.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnect-invalidates-objects.https.window.html]
+  [Calls on services after we disconnect and connect again. Should reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnected-device-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnected-device-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnected-device-with-uuid.https.window.html]
+  [getPrimaryServices called before connecting. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnected-device.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-disconnected-device.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-disconnected-device.https.window.html]
+  [getPrimaryServices called before connecting. Reject with NetworkError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-garbage-collection-ran-during-error-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-garbage-collection-ran-during-error-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-garbage-collection-ran-during-error-with-uuid.https.window.html]
+  [Garbage Collection ran during a getPrimaryServices call that failed. Should not crash.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-garbage-collection-ran-during-error.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-garbage-collection-ran-during-error.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-garbage-collection-ran-during-error.https.window.html]
+  [Garbage Collection ran during a getPrimaryServices call that failed. Should not crash.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-garbage-collection-ran-during-success-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-garbage-collection-ran-during-success-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-garbage-collection-ran-during-success-with-uuid.https.window.html]
+  [Garbage Collection ran during a getPrimaryServices call that succeeds. Should not crash.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-garbage-collection-ran-during-success.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-garbage-collection-ran-during-success.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-garbage-collection-ran-during-success.https.window.html]
+  [Garbage Collection ran during a getPrimaryServices call that succeeds. Should not crash.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-get-different-service-after-reconnection-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-get-different-service-after-reconnection-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-get-different-service-after-reconnection-with-uuid.https.window.html]
+  [Calls to getPrimaryServices after a disconnection should return a different object.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-get-different-service-after-reconnection.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-get-different-service-after-reconnection.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-get-different-service-after-reconnection.https.window.html]
+  [Calls to getPrimaryServices after a disconnection should return a different object.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-get-same-object-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-get-same-object-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-get-same-object-with-uuid.https.window.html]
+  [Calls to getPrimaryServices should return the same object.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-get-same-object.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-get-same-object.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-get-same-object.https.window.html]
+  [Calls to getPrimaryServices should return the same object.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-invalid-service-name.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-invalid-service-name.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-invalid-service-name.https.window.html]
+  [Wrong Service name. Reject with TypeError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-service-not-found-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/gen-service-not-found-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-service-not-found-with-uuid.https.window.html]
+  [Request for absent service. Reject with NotFoundError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/services-not-found.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/server/getPrimaryServices/services-not-found.https.window.js.ini
@@ -1,0 +1,3 @@
+[services-not-found.https.window.html]
+  [Request for services in a device with no services. Reject with NotFoundError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/device-same-object.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/device-same-object.https.window.js.ini
@@ -1,0 +1,3 @@
+[device-same-object.https.window.html]
+  [[SameObject\] test for BluetoothRemoteGATTService device.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristic/characteristic-found.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristic/characteristic-found.https.window.js.ini
@@ -1,0 +1,3 @@
+[characteristic-found.https.window.html]
+  [Request for characteristic. Should return right characteristic.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristic/gen-blocklisted-characteristic.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristic/gen-blocklisted-characteristic.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-blocklisted-characteristic.https.window.html]
+  [Serial Number String characteristic is blocklisted. Should reject with SecurityError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristic/gen-garbage-collection-ran-during-error.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristic/gen-garbage-collection-ran-during-error.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-garbage-collection-ran-during-error.https.window.html]
+  [Garbage Collection ran during getCharacteristic call that fails. Should not crash]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristic/gen-get-same-object.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristic/gen-get-same-object.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-get-same-object.https.window.html]
+  [Calls to getCharacteristic should return the same object.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristic/gen-invalid-characteristic-name.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristic/gen-invalid-characteristic-name.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-invalid-characteristic-name.https.window.html]
+  [Wrong Characteristic name. Reject with TypeError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristic/gen-service-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristic/gen-service-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-service-is-removed.https.window.html]
+  [Service is removed before getCharacteristic call. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/blocklisted-characteristics.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/blocklisted-characteristics.https.window.js.ini
@@ -1,0 +1,3 @@
+[blocklisted-characteristics.https.window.html]
+  [The Device Information service is composed of blocklisted characteristics so we shouldn't find any.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-blocklisted-characteristic-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-blocklisted-characteristic-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-blocklisted-characteristic-with-uuid.https.window.html]
+  [Serial Number String characteristic is blocklisted. Should reject with SecurityError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-garbage-collection-ran-during-error-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-garbage-collection-ran-during-error-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-garbage-collection-ran-during-error-with-uuid.https.window.html]
+  [Garbage Collection ran during getCharacteristics call that fails. Should not crash]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-garbage-collection-ran-during-error.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-garbage-collection-ran-during-error.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-garbage-collection-ran-during-error.https.window.html]
+  [Garbage Collection ran during getCharacteristics call that fails. Should not crash]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-get-same-object-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-get-same-object-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-get-same-object-with-uuid.https.window.html]
+  [Calls to getCharacteristics should return the same object.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-get-same-object.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-get-same-object.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-get-same-object.https.window.html]
+  [Calls to getCharacteristics should return the same object.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-invalid-characteristic-name.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-invalid-characteristic-name.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-invalid-characteristic-name.https.window.html]
+  [Wrong Characteristic name. Reject with TypeError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-service-is-removed-with-uuid.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-service-is-removed-with-uuid.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-service-is-removed-with-uuid.https.window.html]
+  [Service is removed before getCharacteristics call. Reject with InvalidStateError.]
+    expected: FAIL

--- a/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-service-is-removed.https.window.js.ini
+++ b/tests/wpt/meta/bluetooth/bidi/service/getCharacteristics/gen-service-is-removed.https.window.js.ini
@@ -1,0 +1,3 @@
+[gen-service-is-removed.https.window.html]
+  [Service is removed before getCharacteristics call. Reject with InvalidStateError.]
+    expected: FAIL


### PR DESCRIPTION
Allows for local testing to actually test the bluetooth wpt coverage.

Since bluetooth is skipped, the CI won't be affected by this.