### PR TITLE
add CanGc as argument to methods in OscillatorNode and StereoPannerNode

### DIFF
--- a/components/script/dom/audio/oscillatornode.rs
+++ b/components/script/dom/audio/oscillatornode.rs
@@ -46,6 +46,7 @@ impl OscillatorNode {
         window: &Window,
         context: &BaseAudioContext,
         options: &OscillatorOptions,
+        can_gc: CanGc,
     ) -> Fallible<OscillatorNode> {
         let node_options =
             options
@@ -69,7 +70,7 @@ impl OscillatorNode {
             440.,
             f32::MIN,
             f32::MAX,
-            CanGc::note(),
+            can_gc,
         );
         let detune = AudioParam::new(
             window,
@@ -81,7 +82,7 @@ impl OscillatorNode {
             0.,
             -440. / 2.,
             440. / 2.,
-            CanGc::note(),
+            can_gc,
         );
         Ok(OscillatorNode {
             source_node,
@@ -108,7 +109,7 @@ impl OscillatorNode {
         options: &OscillatorOptions,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<OscillatorNode>> {
-        let node = OscillatorNode::new_inherited(window, context, options)?;
+        let node = OscillatorNode::new_inherited(window, context, options, can_gc)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,

--- a/components/script/dom/audio/stereopannernode.rs
+++ b/components/script/dom/audio/stereopannernode.rs
@@ -38,6 +38,7 @@ impl StereoPannerNode {
         window: &Window,
         context: &BaseAudioContext,
         options: &StereoPannerOptions,
+        can_gc: CanGc,
     ) -> Fallible<StereoPannerNode> {
         let node_options = options.parent.unwrap_or(
             2,
@@ -69,7 +70,7 @@ impl StereoPannerNode {
             pan,
             -1.,
             1.,
-            CanGc::note(),
+            can_gc,
         );
 
         Ok(StereoPannerNode {
@@ -95,7 +96,7 @@ impl StereoPannerNode {
         options: &StereoPannerOptions,
         can_gc: CanGc,
     ) -> Fallible<DomRoot<StereoPannerNode>> {
-        let node = StereoPannerNode::new_inherited(window, context, options)?;
+        let node = StereoPannerNode::new_inherited(window, context, options, can_gc)?;
         Ok(reflect_dom_object_with_proto(
             Box::new(node),
             window,


### PR DESCRIPTION
add CanGc as argument to methods in OscillatorNode and StereoPannerNode

Testing: These changes do not require tests because they are a refactor.
Addresses part of https://github.com/servo/servo/issues/34573.