### PR TITLE
add CanGc as argument to methods in BluetoothDevice

### DIFF
--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -791,7 +791,7 @@ impl PermissionAlgorithm for Bluetooth {
                 continue;
             }
             // Step 2.2 - 2.4
-            let _ = device.get_gatt().Disconnect(can_gc);
+            let _ = device.get_gatt(can_gc).Disconnect(can_gc);
         }
     }
 }

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -119,7 +119,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
             BluetoothUUID::descriptor,
             Some(descriptor),
             self.get_instance_id(),
-            self.Service().Device().get_gatt().Connected(),
+            self.Service().Device().get_gatt(can_gc).Connected(),
             GATTType::Descriptor,
             can_gc,
         )
@@ -137,7 +137,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
             BluetoothUUID::descriptor,
             descriptor,
             self.get_instance_id(),
-            self.Service().Device().get_gatt().Connected(),
+            self.Service().Device().get_gatt(can_gc).Connected(),
             GATTType::Descriptor,
             can_gc,
         )
@@ -159,7 +159,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         }
 
         // Step 2.
-        if !self.Service().Device().get_gatt().Connected() {
+        if !self.Service().Device().get_gatt(can_gc).Connected() {
             p.reject_error(Network, can_gc);
             return p;
         }
@@ -208,7 +208,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         }
 
         // Step 4.
-        if !self.Service().Device().get_gatt().Connected() {
+        if !self.Service().Device().get_gatt(can_gc).Connected() {
             p.reject_error(Network, can_gc);
             return p;
         }
@@ -248,7 +248,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         }
 
         // Step 2.
-        if !self.Service().Device().get_gatt().Connected() {
+        if !self.Service().Device().get_gatt(can_gc).Connected() {
             p.reject_error(Network, can_gc);
             return p;
         }

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -111,7 +111,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
             .Characteristic()
             .Service()
             .Device()
-            .get_gatt()
+            .get_gatt(can_gc)
             .Connected()
         {
             p.reject_error(Network, can_gc);
@@ -158,7 +158,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
             .Characteristic()
             .Service()
             .Device()
-            .get_gatt()
+            .get_gatt(can_gc)
             .Connected()
         {
             p.reject_error(Network, can_gc);

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -109,7 +109,7 @@ impl BluetoothRemoteGATTServerMethods<crate::DomTypeHolder> for BluetoothRemoteG
         self.Device().clean_up_disconnected_device(can_gc);
 
         // Step 4 - 5:
-        self.Device().garbage_collect_the_connection()
+        self.Device().garbage_collect_the_connection(can_gc)
     }
 
     // https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattserver-getprimaryservice
@@ -121,7 +121,7 @@ impl BluetoothRemoteGATTServerMethods<crate::DomTypeHolder> for BluetoothRemoteG
             BluetoothUUID::service,
             Some(service),
             String::from(self.Device().Id()),
-            self.Device().get_gatt().Connected(),
+            self.Device().get_gatt(can_gc).Connected(),
             GATTType::PrimaryService,
             can_gc,
         )
@@ -154,7 +154,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
             BluetoothResponse::GATTServerConnect(connected) => {
                 // Step 5.2.3
                 if self.Device().is_represented_device_null() {
-                    if let Err(e) = self.Device().garbage_collect_the_connection() {
+                    if let Err(e) = self.Device().garbage_collect_the_connection(can_gc) {
                         return promise.reject_error(e, can_gc);
                     }
                     return promise.reject_error(Error::Network, can_gc);

--- a/components/script/dom/bluetooth/bluetoothremotegattservice.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattservice.rs
@@ -98,7 +98,7 @@ impl BluetoothRemoteGATTServiceMethods<crate::DomTypeHolder> for BluetoothRemote
             BluetoothUUID::characteristic,
             Some(characteristic),
             self.get_instance_id(),
-            self.Device().get_gatt().Connected(),
+            self.Device().get_gatt(can_gc).Connected(),
             GATTType::Characteristic,
             can_gc,
         )
@@ -116,7 +116,7 @@ impl BluetoothRemoteGATTServiceMethods<crate::DomTypeHolder> for BluetoothRemote
             BluetoothUUID::characteristic,
             characteristic,
             self.get_instance_id(),
-            self.Device().get_gatt().Connected(),
+            self.Device().get_gatt(can_gc).Connected(),
             GATTType::Characteristic,
             can_gc,
         )
@@ -130,7 +130,7 @@ impl BluetoothRemoteGATTServiceMethods<crate::DomTypeHolder> for BluetoothRemote
             BluetoothUUID::service,
             Some(service),
             self.get_instance_id(),
-            self.Device().get_gatt().Connected(),
+            self.Device().get_gatt(can_gc).Connected(),
             GATTType::IncludedService,
             can_gc,
         )
@@ -148,7 +148,7 @@ impl BluetoothRemoteGATTServiceMethods<crate::DomTypeHolder> for BluetoothRemote
             BluetoothUUID::service,
             service,
             self.get_instance_id(),
-            self.Device().get_gatt().Connected(),
+            self.Device().get_gatt(can_gc).Connected(),
             GATTType::IncludedService,
             can_gc,
         )
@@ -191,14 +191,18 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTService {
             BluetoothResponse::GetIncludedServices(services_vec, single) => {
                 if single {
                     return promise.resolve_native(
-                        &device.get_or_create_service(&services_vec[0], &device.get_gatt(), can_gc),
+                        &device.get_or_create_service(
+                            &services_vec[0],
+                            &device.get_gatt(can_gc),
+                            can_gc,
+                        ),
                         can_gc,
                     );
                 }
                 let mut services = vec![];
                 for service in services_vec {
                     let bt_service =
-                        device.get_or_create_service(&service, &device.get_gatt(), can_gc);
+                        device.get_or_create_service(&service, &device.get_gatt(can_gc), can_gc);
                     services.push(bt_service);
                 }
                 promise.resolve_native(&services, can_gc);

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -58,7 +58,7 @@ DOMInterfaces = {
 
 'BluetoothDevice': {
     'inRealms': ['WatchAdvertisements'],
-    'canGc': ['WatchAdvertisements'],
+    'canGc': ['GetGatt', 'WatchAdvertisements'],
 },
 
 'BluetoothRemoteGATTCharacteristic': {


### PR DESCRIPTION
add CanGc as argument to methods in BluetoothDevice

Testing: These changes do not require tests because they are a refactor.
Addresses part of https://github.com/servo/servo/issues/34573.