### PR TITLE
add CanGc as argument to methods in PaintRenderingContext2D

### DIFF
--- a/components/script/dom/canvas/2d/paintrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/paintrenderingcontext2d.rs
@@ -366,9 +366,10 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
         y0: Finite<f64>,
         x1: Finite<f64>,
         y1: Finite<f64>,
+        can_gc: CanGc,
     ) -> DomRoot<CanvasGradient> {
         self.canvas_state
-            .create_linear_gradient(&self.global(), x0, y0, x1, y1, CanGc::note())
+            .create_linear_gradient(&self.global(), x0, y0, x1, y1, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createradialgradient
@@ -380,17 +381,10 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
         x1: Finite<f64>,
         y1: Finite<f64>,
         r1: Finite<f64>,
+        can_gc: CanGc,
     ) -> Fallible<DomRoot<CanvasGradient>> {
-        self.canvas_state.create_radial_gradient(
-            &self.global(),
-            x0,
-            y0,
-            r0,
-            x1,
-            y1,
-            r1,
-            CanGc::note(),
-        )
+        self.canvas_state
+            .create_radial_gradient(&self.global(), x0, y0, r0, x1, y1, r1, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-createpattern
@@ -398,9 +392,10 @@ impl PaintRenderingContext2DMethods<crate::DomTypeHolder> for PaintRenderingCont
         &self,
         image: CanvasImageSource,
         repetition: DOMString,
+        can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<CanvasPattern>>> {
         self.canvas_state
-            .create_pattern(&self.global(), image, repetition, CanGc::note())
+            .create_pattern(&self.global(), image, repetition, can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-linewidth

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -540,7 +540,7 @@ DOMInterfaces = {
 },
 
 'PaintRenderingContext2D': {
-    'canGc': ['GetTransform'],
+    'canGc': ['CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient', 'GetTransform'],
 },
 
 'Performance': {


### PR DESCRIPTION
add CanGc as argument to methods in PaintRenderingContext2D

Testing: These changes do not require tests because they are a refactor.
Addresses part of https://github.com/servo/servo/issues/34573.