### PR TITLE
add CanGc as argument to methods in Credential

### DIFF
--- a/components/script/dom/credentialmanagement/credential.rs
+++ b/components/script/dom/credentialmanagement/credential.rs
@@ -59,15 +59,15 @@ impl CredentialMethods<DomTypeHolder> for Credential {
     }
 
     // https://www.w3.org/TR/credential-management-1/#dom-credential-isconditionalmediationavailable
-    fn IsConditionalMediationAvailable(_global: &Window) -> Rc<Promise> {
+    fn IsConditionalMediationAvailable(_global: &Window, can_gc: CanGc) -> Rc<Promise> {
         let in_realm_proof = AlreadyInRealm::assert::<DomTypeHolder>();
         // FIXME:(arihant2math) return false
-        Promise::new_in_current_realm(InRealm::Already(&in_realm_proof), CanGc::note())
+        Promise::new_in_current_realm(InRealm::Already(&in_realm_proof), can_gc)
     }
 
     // https://www.w3.org/TR/credential-management-1/#dom-credential-willrequestconditionalcreation
-    fn WillRequestConditionalCreation(_global: &Window) -> Rc<Promise> {
+    fn WillRequestConditionalCreation(_global: &Window, can_gc: CanGc) -> Rc<Promise> {
         let in_realm_proof = AlreadyInRealm::assert::<DomTypeHolder>();
-        Promise::new_in_current_realm(InRealm::Already(&in_realm_proof), CanGc::note())
+        Promise::new_in_current_realm(InRealm::Already(&in_realm_proof), can_gc)
     }
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -108,6 +108,10 @@ DOMInterfaces = {
     'canGc': ['GetSize'],
 },
 
+'Credential': {
+    'canGc': ['IsConditionalMediationAvailable', 'WillRequestConditionalCreation'],
+},
+
 'CSSGroupingRule': {
     'canGc': ['CssRules', 'DeleteRule', 'InsertRule'],
 },


### PR DESCRIPTION
add CanGc as argument to methods in Credential

Testing: These changes do not require tests because they are a refactor.
Addresses part of https://github.com/servo/servo/issues/34573.