### PR TITLE
script: Enter debugger global's realm when invoking public APIs from script thread.

### DIFF
--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -152,6 +152,7 @@ impl DebuggerGlobalScope {
         debuggee_pipeline_id: PipelineId,
         debuggee_worker_id: Option<WorkerId>,
     ) {
+        let _realm = enter_realm(self);
         let debuggee_pipeline_id =
             crate::dom::pipelineid::PipelineId::new(self.upcast(), debuggee_pipeline_id, can_gc);
         let event = DomRoot::upcast::<Event>(DebuggerAddDebuggeeEvent::new(
@@ -178,6 +179,7 @@ impl DebuggerGlobalScope {
                 .replace(Some(result_sender))
                 .is_none()
         );
+        let _realm = enter_realm(self);
         let event = DomRoot::upcast::<Event>(DebuggerGetPossibleBreakpointsEvent::new(
             self.upcast(),
             spidermonkey_id,


### PR DESCRIPTION
Any GC values traced as part of tracing a DOM object need to be same-compartment with the DOM object's reflector. This means wrapping into the compartment them upon creation, rather than wrapping them upon retrieving them like the previous implementation of DebuggerAddDebuggeeEvent::Global.

Since wrapping is an operation that reflects the active realm, we also need to ensure we're entering the appropriate realm before creating any new JS values like cross-compartment wrappers.

Testing: Fixes assertion failure on every automated test when using a debug mozjs build and full GC zeal. This configuration is not run in CI.
Fixes: #39945
