### PR TITLE
add CanGc as argument to key_type_to_jsval

### DIFF
--- a/components/script/dom/indexeddb/idbcursor.rs
+++ b/components/script/dom/indexeddb/idbcursor.rs
@@ -170,17 +170,17 @@ impl IDBCursorMethods<crate::DomTypeHolder> for IDBCursor {
     }
 
     /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbcursor-key>
-    fn Key(&self, cx: SafeJSContext, mut value: MutableHandleValue) {
+    fn Key(&self, cx: SafeJSContext, can_gc: CanGc, mut value: MutableHandleValue) {
         match self.key.borrow().as_ref() {
-            Some(key) => key_type_to_jsval(cx, key, value),
+            Some(key) => key_type_to_jsval(cx, key, value, can_gc),
             None => value.set(UndefinedValue()),
         }
     }
 
     /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbcursor-primarykey>
-    fn PrimaryKey(&self, cx: SafeJSContext, mut value: MutableHandleValue) {
+    fn PrimaryKey(&self, cx: SafeJSContext, can_gc: CanGc, mut value: MutableHandleValue) {
         match self.effective_key() {
-            Some(effective_key) => key_type_to_jsval(cx, &effective_key, value),
+            Some(effective_key) => key_type_to_jsval(cx, &effective_key, value, can_gc),
             None => value.set(UndefinedValue()),
         }
     }

--- a/components/script/dom/indexeddb/idbkeyrange.rs
+++ b/components/script/dom/indexeddb/idbkeyrange.rs
@@ -42,16 +42,16 @@ impl IDBKeyRange {
 
 impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-lower
-    fn Lower(&self, cx: SafeJSContext, answer: MutableHandleValue) {
+    fn Lower(&self, cx: SafeJSContext, can_gc: CanGc, answer: MutableHandleValue) {
         if let Some(lower) = self.inner.lower.as_ref() {
-            key_type_to_jsval(cx, lower, answer);
+            key_type_to_jsval(cx, lower, answer, can_gc);
         }
     }
 
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbkeyrange-upper
-    fn Upper(&self, cx: SafeJSContext, answer: MutableHandleValue) {
+    fn Upper(&self, cx: SafeJSContext, can_gc: CanGc, answer: MutableHandleValue) {
         if let Some(upper) = self.inner.upper.as_ref() {
-            key_type_to_jsval(cx, upper, answer);
+            key_type_to_jsval(cx, upper, answer, can_gc);
         }
     }
 

--- a/components/script/indexed_db.rs
+++ b/components/script/indexed_db.rs
@@ -18,6 +18,7 @@ use js::rust::wrappers::{IsArrayObject, JS_GetProperty, JS_HasOwnProperty, JS_Is
 use js::rust::{HandleValue, IntoHandle, IntoMutableHandle, MutableHandleValue};
 use profile_traits::ipc;
 use profile_traits::ipc::IpcReceiver;
+use script_bindings::script_runtime::CanGc;
 use serde::{Deserialize, Serialize};
 use storage_traits::indexeddb_thread::{BackendResult, IndexedDBKeyRange, IndexedDBKeyType};
 
@@ -54,6 +55,7 @@ pub fn key_type_to_jsval(
     cx: SafeJSContext,
     key: &IndexedDBKeyType,
     mut result: MutableHandleValue,
+    _can_gc: CanGc,
 ) {
     match key {
         IndexedDBKeyType::Number(n) => result.set(DoubleValue(*n)),
@@ -68,7 +70,7 @@ pub fn key_type_to_jsval(
             rooted_vec!(let mut values);
             for key in a {
                 rooted!(in(*cx) let mut value: JSVal);
-                key_type_to_jsval(cx, key, value.handle_mut());
+                key_type_to_jsval(cx, key, value.handle_mut(), _can_gc);
                 values.push(Heap::boxed(value.get()));
             }
             values.safe_to_jsval(cx, result);

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -474,6 +474,14 @@ DOMInterfaces = {
     'canGc': ['SetText']
 },
 
+'IDBCursor': {
+    'canGc': ['Key', 'PrimaryKey']
+},
+
+'IDBKeyRange': {
+    'canGc': ['Lower', 'Upper']
+},
+
 'IDBTransaction': {
     'canGc': ['ObjectStore']
 },


### PR DESCRIPTION
add CanGc as argument to key_type_to_jsval

Testing: These changes do not require tests because they are a refactor.
Closes https://github.com/servo/servo/issues/40140