### PR TITLE
add CanGc as argument to Validatable.validity_state

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -5035,7 +5035,7 @@ impl Element {
         if let Some(validatable) = self.as_maybe_validatable() {
             if needs_update {
                 validatable
-                    .validity_state()
+                    .validity_state(can_gc)
                     .perform_validation_and_update(ValidationFlags::all(), can_gc);
             }
             return validatable.is_instance_validatable() && !validatable.satisfies_constraints();

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -263,8 +263,8 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
 
         // Step 4: For each entry `flag` → `value` of `flags`, set element's validity flag with the name
         // `flag` to `value`.
-        self.validity_state().update_invalid_flags(bits);
-        self.validity_state().update_pseudo_classes(can_gc);
+        self.validity_state(can_gc).update_invalid_flags(bits);
+        self.validity_state(can_gc).update_pseudo_classes(can_gc);
 
         // Step 5: Set element's validation message to the empty string if message is not given
         // or all of element's validity flags are false, or to message otherwise.
@@ -317,11 +317,11 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     }
 
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-validity>
-    fn GetValidity(&self) -> Fallible<DomRoot<ValidityState>> {
+    fn GetValidity(&self, can_gc: CanGc) -> Fallible<DomRoot<ValidityState>> {
         if !self.is_target_form_associated() {
             return Err(Error::NotSupported);
         }
-        Ok(self.validity_state())
+        Ok(self.validity_state(can_gc))
     }
 
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-labels>
@@ -389,13 +389,13 @@ impl Validatable for ElementInternals {
         self.target_element.upcast::<Element>()
     }
 
-    fn validity_state(&self) -> DomRoot<ValidityState> {
+    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
         debug_assert!(self.is_target_form_associated());
         self.validity_state.or_init(|| {
             ValidityState::new(
                 &self.target_element.owner_window(),
                 self.target_element.upcast(),
-                CanGc::note(),
+                can_gc,
             )
         })
     }

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -179,8 +179,8 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validity
-    fn Validity(&self) -> DomRoot<ValidityState> {
-        self.validity_state()
+    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+        self.validity_state(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
@@ -199,8 +199,8 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity
-    fn SetCustomValidity(&self, error: DOMString) {
-        self.validity_state().set_custom_error_message(error);
+    fn SetCustomValidity(&self, error: DOMString, can_gc: CanGc) {
+        self.validity_state(can_gc).set_custom_error_message(error);
     }
 }
 
@@ -262,7 +262,7 @@ impl VirtualMethods for HTMLButtonElement {
                     },
                 }
                 el.update_sequentially_focusable_status(can_gc);
-                self.validity_state()
+                self.validity_state(can_gc)
                     .perform_validation_and_update(ValidationFlags::all(), can_gc);
             },
             local_name!("type") => match mutation {
@@ -273,7 +273,7 @@ impl VirtualMethods for HTMLButtonElement {
                         _ => ButtonType::Submit,
                     };
                     self.button_type.set(value);
-                    self.validity_state()
+                    self.validity_state(can_gc)
                         .perform_validation_and_update(ValidationFlags::all(), can_gc);
                 },
                 AttributeMutation::Removed => {
@@ -282,7 +282,7 @@ impl VirtualMethods for HTMLButtonElement {
             },
             local_name!("form") => {
                 self.form_attribute_mutated(mutation, can_gc);
-                self.validity_state()
+                self.validity_state(can_gc)
                     .perform_validation_and_update(ValidationFlags::empty(), can_gc);
             },
             _ => {},
@@ -333,9 +333,9 @@ impl Validatable for HTMLButtonElement {
         self.upcast()
     }
 
-    fn validity_state(&self) -> DomRoot<ValidityState> {
+    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/html/htmlfieldsetelement.rs
+++ b/components/script/dom/html/htmlfieldsetelement.rs
@@ -123,8 +123,8 @@ impl HTMLFieldSetElementMethods<crate::DomTypeHolder> for HTMLFieldSetElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validity
-    fn Validity(&self) -> DomRoot<ValidityState> {
-        self.validity_state()
+    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+        self.validity_state(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
@@ -143,8 +143,8 @@ impl HTMLFieldSetElementMethods<crate::DomTypeHolder> for HTMLFieldSetElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity
-    fn SetCustomValidity(&self, error: DOMString) {
-        self.validity_state().set_custom_error_message(error);
+    fn SetCustomValidity(&self, error: DOMString, can_gc: CanGc) {
+        self.validity_state(can_gc).set_custom_error_message(error);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-fieldset-type>
@@ -276,9 +276,9 @@ impl Validatable for HTMLFieldSetElement {
         self.upcast()
     }
 
-    fn validity_state(&self) -> DomRoot<ValidityState> {
+    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -2088,8 +2088,8 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validity
-    fn Validity(&self) -> DomRoot<ValidityState> {
-        self.validity_state()
+    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+        self.validity_state(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
@@ -2108,8 +2108,8 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity
-    fn SetCustomValidity(&self, error: DOMString) {
-        self.validity_state().set_custom_error_message(error);
+    fn SetCustomValidity(&self, error: DOMString, can_gc: CanGc) {
+        self.validity_state(can_gc).set_custom_error_message(error);
     }
 }
 
@@ -2142,7 +2142,7 @@ fn perform_radio_group_validation(elem: &HTMLInputElement, group: Option<&Atom>,
         .GetRootNode(&GetRootNodeOptions::empty());
     let form = elem.form_owner();
     for r in radio_group_iter(elem, group, form.as_deref(), &root) {
-        r.validity_state()
+        r.validity_state(can_gc)
             .perform_validation_and_update(ValidationFlags::all(), can_gc);
     }
 }
@@ -2781,7 +2781,7 @@ impl HTMLInputElement {
                 perform_radio_group_validation(self, self.radio_group_name().as_ref(), can_gc)
             },
             _ => {
-                self.validity_state()
+                self.validity_state(can_gc)
                     .perform_validation_and_update(ValidationFlags::all(), can_gc);
             },
         }
@@ -3179,12 +3179,12 @@ impl VirtualMethods for HTMLInputElement {
                 form_owner.as_deref(),
                 &root,
             ) {
-                r.validity_state()
+                r.validity_state(can_gc)
                     .perform_validation_and_update(ValidationFlags::all(), can_gc);
             }
         }
 
-        self.validity_state()
+        self.validity_state(can_gc)
             .perform_validation_and_update(ValidationFlags::all(), can_gc);
 
         if self.input_type() == InputType::Color {
@@ -3386,9 +3386,9 @@ impl Validatable for HTMLInputElement {
         self.upcast()
     }
 
-    fn validity_state(&self) -> DomRoot<ValidityState> {
+    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/html/htmlobjectelement.rs
+++ b/components/script/dom/html/htmlobjectelement.rs
@@ -107,8 +107,8 @@ impl HTMLObjectElementMethods<crate::DomTypeHolder> for HTMLObjectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validity
-    fn Validity(&self) -> DomRoot<ValidityState> {
-        self.validity_state()
+    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+        self.validity_state(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
@@ -127,8 +127,8 @@ impl HTMLObjectElementMethods<crate::DomTypeHolder> for HTMLObjectElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity
-    fn SetCustomValidity(&self, error: DOMString) {
-        self.validity_state().set_custom_error_message(error);
+    fn SetCustomValidity(&self, error: DOMString, can_gc: CanGc) {
+        self.validity_state(can_gc).set_custom_error_message(error);
     }
 }
 
@@ -137,9 +137,9 @@ impl Validatable for HTMLObjectElement {
         self.upcast()
     }
 
-    fn validity_state(&self) -> DomRoot<ValidityState> {
+    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/html/htmloptgroupelement.rs
+++ b/components/script/dom/html/htmloptgroupelement.rs
@@ -67,7 +67,7 @@ impl HTMLOptGroupElement {
     fn update_select_validity(&self, can_gc: CanGc) {
         if let Some(select) = self.owner_select_element() {
             select
-                .validity_state()
+                .validity_state(can_gc)
                 .perform_validation_and_update(ValidationFlags::all(), can_gc);
         }
     }
@@ -147,7 +147,7 @@ impl VirtualMethods for HTMLOptGroupElement {
 
         if let Some(select) = context.parent.downcast::<HTMLSelectElement>() {
             select
-                .validity_state()
+                .validity_state(can_gc)
                 .perform_validation_and_update(ValidationFlags::all(), can_gc);
         }
     }

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -129,7 +129,7 @@ impl HTMLOptionElement {
     fn update_select_validity(&self, can_gc: CanGc) {
         if let Some(select) = self.owner_select_element() {
             select
-                .validity_state()
+                .validity_state(can_gc)
                 .perform_validation_and_update(ValidationFlags::all(), can_gc);
         }
     }
@@ -371,7 +371,7 @@ impl VirtualMethods for HTMLOptionElement {
             .next()
         {
             select
-                .validity_state()
+                .validity_state(can_gc)
                 .perform_validation_and_update(ValidationFlags::all(), can_gc);
             select.ask_for_reset();
         }

--- a/components/script/dom/html/htmloutputelement.rs
+++ b/components/script/dom/html/htmloutputelement.rs
@@ -129,8 +129,8 @@ impl HTMLOutputElementMethods<crate::DomTypeHolder> for HTMLOutputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validity
-    fn Validity(&self) -> DomRoot<ValidityState> {
-        self.validity_state()
+    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+        self.validity_state(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
@@ -149,8 +149,8 @@ impl HTMLOutputElementMethods<crate::DomTypeHolder> for HTMLOutputElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity
-    fn SetCustomValidity(&self, error: DOMString) {
-        self.validity_state().set_custom_error_message(error);
+    fn SetCustomValidity(&self, error: DOMString, can_gc: CanGc) {
+        self.validity_state(can_gc).set_custom_error_message(error);
     }
 }
 
@@ -188,9 +188,9 @@ impl Validatable for HTMLOutputElement {
         self.upcast()
     }
 
-    fn validity_state(&self) -> DomRoot<ValidityState> {
+    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -568,7 +568,7 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-value>
-    fn SetValue(&self, value: DOMString) {
+    fn SetValue(&self, value: DOMString, can_gc: CanGc) {
         let mut opt_iter = self.list_of_options();
         // Reset until we find an <option> with a matching value
         for opt in opt_iter.by_ref() {
@@ -584,8 +584,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
             opt.set_selectedness(false);
         }
 
-        self.validity_state()
-            .perform_validation_and_update(ValidationFlags::VALUE_MISSING, CanGc::note());
+        self.validity_state(can_gc)
+            .perform_validation_and_update(ValidationFlags::VALUE_MISSING, can_gc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-select-selectedindex>
@@ -630,8 +630,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-validity>
-    fn Validity(&self) -> DomRoot<ValidityState> {
-        self.validity_state()
+    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+        self.validity_state(can_gc)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity>
@@ -650,8 +650,8 @@ impl HTMLSelectElementMethods<crate::DomTypeHolder> for HTMLSelectElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity>
-    fn SetCustomValidity(&self, error: DOMString) {
-        self.validity_state().set_custom_error_message(error);
+    fn SetCustomValidity(&self, error: DOMString, can_gc: CanGc) {
+        self.validity_state(can_gc).set_custom_error_message(error);
     }
 }
 
@@ -667,7 +667,7 @@ impl VirtualMethods for HTMLSelectElement {
             .attribute_mutated(attr, mutation, can_gc);
         match *attr.local_name() {
             local_name!("required") => {
-                self.validity_state()
+                self.validity_state(can_gc)
                     .perform_validation_and_update(ValidationFlags::VALUE_MISSING, can_gc);
             },
             local_name!("disabled") => {
@@ -684,7 +684,7 @@ impl VirtualMethods for HTMLSelectElement {
                     },
                 }
 
-                self.validity_state()
+                self.validity_state(can_gc)
                     .perform_validation_and_update(ValidationFlags::VALUE_MISSING, can_gc);
             },
             local_name!("form") => {
@@ -776,9 +776,9 @@ impl Validatable for HTMLSelectElement {
         self.upcast()
     }
 
-    fn validity_state(&self) -> DomRoot<ValidityState> {
+    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -344,7 +344,7 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-textarea-value
-    fn SetValue(&self, value: DOMString) {
+    fn SetValue(&self, value: DOMString, can_gc: CanGc) {
         {
             let mut textinput = self.textinput.borrow_mut();
 
@@ -363,8 +363,8 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
             }
         }
 
-        self.validity_state()
-            .perform_validation_and_update(ValidationFlags::all(), CanGc::note());
+        self.validity_state(can_gc)
+            .perform_validation_and_update(ValidationFlags::all(), can_gc);
         self.upcast::<Node>().dirty(NodeDamage::Other);
     }
 
@@ -441,8 +441,8 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-validity
-    fn Validity(&self) -> DomRoot<ValidityState> {
-        self.validity_state()
+    fn Validity(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
+        self.validity_state(can_gc)
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-checkvalidity
@@ -461,8 +461,8 @@ impl HTMLTextAreaElementMethods<crate::DomTypeHolder> for HTMLTextAreaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-cva-setcustomvalidity
-    fn SetCustomValidity(&self, error: DOMString) {
-        self.validity_state().set_custom_error_message(error);
+    fn SetCustomValidity(&self, error: DOMString, can_gc: CanGc) {
+        self.validity_state(can_gc).set_custom_error_message(error);
     }
 }
 
@@ -569,7 +569,7 @@ impl VirtualMethods for HTMLTextAreaElement {
             _ => {},
         }
 
-        self.validity_state()
+        self.validity_state(can_gc)
             .perform_validation_and_update(ValidationFlags::all(), can_gc);
     }
 
@@ -581,7 +581,7 @@ impl VirtualMethods for HTMLTextAreaElement {
         self.upcast::<Element>()
             .check_ancestors_disabled_state_for_form_control();
 
-        self.validity_state()
+        self.validity_state(can_gc)
             .perform_validation_and_update(ValidationFlags::all(), can_gc);
     }
 
@@ -616,7 +616,7 @@ impl VirtualMethods for HTMLTextAreaElement {
             el.check_disabled_attribute();
         }
 
-        self.validity_state()
+        self.validity_state(can_gc)
             .perform_validation_and_update(ValidationFlags::all(), can_gc);
     }
 
@@ -638,7 +638,7 @@ impl VirtualMethods for HTMLTextAreaElement {
             let mut textinput = el.textinput.borrow_mut();
             textinput.set_content(self.textinput.borrow().get_content());
         }
-        el.validity_state()
+        el.validity_state(can_gc)
             .perform_validation_and_update(ValidationFlags::all(), can_gc);
     }
 
@@ -749,7 +749,7 @@ impl VirtualMethods for HTMLTextAreaElement {
             }
         }
 
-        self.validity_state()
+        self.validity_state(can_gc)
             .perform_validation_and_update(ValidationFlags::all(), can_gc);
     }
 
@@ -780,9 +780,9 @@ impl Validatable for HTMLTextAreaElement {
         self.upcast()
     }
 
-    fn validity_state(&self) -> DomRoot<ValidityState> {
+    fn validity_state(&self, can_gc: CanGc) -> DomRoot<ValidityState> {
         self.validity_state
-            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), CanGc::note()))
+            .or_init(|| ValidityState::new(&self.owner_window(), self.upcast(), can_gc))
     }
 
     fn is_instance_validatable(&self) -> bool {

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1257,7 +1257,7 @@ fn handle_send_keys_non_typeable(
 
     // Step 4. If element is suffering from bad input, return ErrorStatus::InvalidArgument.
     if input_element
-        .Validity()
+        .Validity(can_gc)
         .invalid_flags()
         .contains(ValidationFlags::BAD_INPUT)
     {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -248,7 +248,7 @@ DOMInterfaces = {
 },
 
 'ElementInternals': {
-    'canGc': ['CheckValidity', 'GetLabels', 'SetValidity', 'ReportValidity', 'States'],
+    'canGc': ['CheckValidity', 'GetLabels', 'GetValidity', 'SetValidity', 'ReportValidity', 'States'],
 },
 
 'EventSource': {
@@ -353,7 +353,7 @@ DOMInterfaces = {
 },
 
 'HTMLButtonElement': {
-    'canGc': ['CheckValidity', 'ReportValidity','SetBackground'],
+    'canGc': ['CheckValidity', 'ReportValidity', 'SetBackground', 'SetCustomValidity', 'Validity'],
 },
 
 'HTMLCanvasElement': {
@@ -378,7 +378,7 @@ DOMInterfaces = {
 },
 
 'HTMLFieldSetElement': {
-    'canGc': ['CheckValidity', 'Elements', 'ReportValidity'],
+    'canGc': ['CheckValidity', 'Elements', 'ReportValidity', 'SetCustomValidity', 'Validity'],
 },
 
 'HTMLFontElement': {
@@ -402,7 +402,7 @@ DOMInterfaces = {
 },
 
 'HTMLInputElement': {
-    'canGc': ['ReportValidity', 'SetValue', 'SetValueAsNumber', 'SetValueAsDate', 'StepUp', 'StepDown', 'CheckValidity', 'ReportValidity', 'GetLabels'],
+    'canGc': ['ReportValidity', 'SetValue', 'SetValueAsNumber', 'SetValueAsDate', 'StepUp', 'StepDown', 'CheckValidity', 'ReportValidity', 'GetLabels', 'SetCustomValidity', 'Validity'],
 },
 
 'HTMLLinkElement': {
@@ -423,7 +423,7 @@ DOMInterfaces = {
 },
 
 'HTMLObjectElement': {
-    'canGc': ['CheckValidity', 'ReportValidity'],
+    'canGc': ['CheckValidity', 'ReportValidity', 'SetCustomValidity', 'Validity'],
 },
 
 'HTMLOptionElement': {
@@ -435,7 +435,7 @@ DOMInterfaces = {
 },
 
 'HTMLOutputElement': {
-    'canGc': ['ReportValidity', 'SetDefaultValue', 'SetValue', 'CheckValidity'],
+    'canGc': ['ReportValidity', 'SetDefaultValue', 'SetValue', 'CheckValidity', 'SetCustomValidity', 'Validity'],
 },
 
 'HTMLProgressElement': {
@@ -447,7 +447,7 @@ DOMInterfaces = {
 },
 
 'HTMLSelectElement': {
-    'canGc': ['ReportValidity', 'SetLength', 'IndexedSetter', 'CheckValidity', 'SetSelectedIndex'],
+    'canGc': ['ReportValidity', 'SetLength', 'IndexedSetter', 'CheckValidity', 'SetSelectedIndex', 'SetCustomValidity', 'SetValue', 'Validity'],
 },
 
 'HTMLTableElement': {
@@ -467,7 +467,7 @@ DOMInterfaces = {
 },
 
 'HTMLTextAreaElement': {
-    'canGc': ['ReportValidity', 'SetDefaultValue', 'CheckValidity'],
+    'canGc': ['ReportValidity', 'SetDefaultValue', 'CheckValidity', 'SetCustomValidity', 'SetValue', 'Validity'],
 },
 
 'HTMLTitleElement': {


### PR DESCRIPTION
add CanGc as argument to Validatable.validity_state

Testing: These changes do not require tests because they are a refactor.
Addresses part of https://github.com/servo/servo/issues/34573.