### PR TITLE
pixels: Store decoded images as RGBA premultiplied data

### DIFF
--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -680,7 +680,7 @@ impl WebGLRenderingContext {
                 };
 
                 let (alpha_treatment, y_axis_treatment) =
-                    self.get_current_unpack_state(Alpha::NotPremultiplied);
+                    self.get_current_unpack_state(snapshot.alpha_mode().alpha());
 
                 TexPixels::new(
                     snapshot.shared_memory(),

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -823,6 +823,7 @@ mod test {
             bytes: Arc::new(IpcSharedMemory::from_byte(1, 1)),
             frames: image_frames,
             cors_status: CorsStatus::Unsafe,
+            is_opaque: false,
         };
         let mut image_animation_state = ImageAnimationState::new(Arc::new(image), 0.0);
 

--- a/tests/wpt/meta/css/css-masking/clip-path/clip-path-contentBox-1a.html.ini
+++ b/tests/wpt/meta/css/css-masking/clip-path/clip-path-contentBox-1a.html.ini
@@ -1,2 +1,0 @@
-[clip-path-contentBox-1a.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-masking/clip-path/clip-path-contentBox-1c.html.ini
+++ b/tests/wpt/meta/css/css-masking/clip-path/clip-path-contentBox-1c.html.ini
@@ -1,2 +1,0 @@
-[clip-path-contentBox-1c.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-masking/clip-path/clip-path-paddingBox-1a.html.ini
+++ b/tests/wpt/meta/css/css-masking/clip-path/clip-path-paddingBox-1a.html.ini
@@ -1,2 +1,0 @@
-[clip-path-paddingBox-1a.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-masking/clip-path/clip-path-paddingBox-1c.html.ini
+++ b/tests/wpt/meta/css/css-masking/clip-path/clip-path-paddingBox-1c.html.ini
@@ -1,2 +1,0 @@
-[clip-path-paddingBox-1c.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/skew-test1.html.ini
+++ b/tests/wpt/meta/css/css-transforms/skew-test1.html.ini
@@ -1,2 +1,0 @@
-[skew-test1.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-transforms/ttwf-transform-skewy-001.html.ini
+++ b/tests/wpt/meta/css/css-transforms/ttwf-transform-skewy-001.html.ini
@@ -1,2 +1,0 @@
-[ttwf-transform-skewy-001.html]
-  expected: FAIL

--- a/tests/wpt/meta/png/apng/fcTL-blend-source-nearly-transparent.html.ini
+++ b/tests/wpt/meta/png/apng/fcTL-blend-source-nearly-transparent.html.ini
@@ -1,2 +1,0 @@
-[fcTL-blend-source-nearly-transparent.html]
-  expected: FAIL

--- a/tests/wpt/meta/png/apng/fdAT-8bit-gray-alpha.html.ini
+++ b/tests/wpt/meta/png/apng/fdAT-8bit-gray-alpha.html.ini
@@ -1,2 +1,0 @@
-[fdAT-8bit-gray-alpha.html]
-  expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/context/premultiplyalpha-test.html.ini
+++ b/tests/wpt/webgl/meta/conformance/context/premultiplyalpha-test.html.ini
@@ -1,0 +1,6 @@
+[premultiplyalpha-test.html]
+  [WebGL test #34]
+    expected: FAIL
+
+  [WebGL test #41]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/misc/gl-teximage.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/misc/gl-teximage.html.ini
@@ -1,0 +1,39 @@
+[gl-teximage.html]
+  [WebGL test #3]
+    expected: FAIL
+
+  [WebGL test #4]
+    expected: FAIL
+
+  [WebGL test #5]
+    expected: FAIL
+
+  [WebGL test #6]
+    expected: FAIL
+
+  [WebGL test #7]
+    expected: FAIL
+
+  [WebGL test #8]
+    expected: FAIL
+
+  [WebGL test #9]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #12]
+    expected: FAIL
+
+  [WebGL test #13]
+    expected: FAIL
+
+  [WebGL test #14]
+    expected: FAIL
+
+  [WebGL test #23]
+    expected: FAIL
+
+  [WebGL test #95]
+    expected: FAIL


### PR DESCRIPTION
Canvas expects input data to be in RGBA premultiplied format and
WebRender already supports RGBA and BGRA data as long as they are
premultiplied. Pre-multiplying up front allows:

- Avoiding many conversions when painting images to canvas.
- Passing the `RasterImage` IpcSharedMemory of the image instead of creating
  a new one with the premultiplied data every time we upload to
  WebRender. This is a big deal for animated gifs, because before every
  frame was creating a new shared memory segment.

It seems that for rasterized SVGs were were already putting
premultplied data into the `RasterImage` so it's quite likely SVGs were
being composited incorrectly.

Testing: This causes 8 tests to start passing and 2 tests to fail in the WebGL conformance suite. 
The failures are due to the fact that premultiplying alpha is lossy when alpha is 0. In that case,
the resulting color of a blend operation might be wrong. This is typically only a problem if you
use RGBA data as RGB data, which is pretty unusual. In the case that you are blending with 
RGBA the final color values will be 0 or close to 0 anyway. Gecko solves this issue by having a
cacheable surface generation API that can fetch both premulitplied and unpremulitplied data
from things like image elements. We do not have that yet, but I argue that this change
is important anyway due to the amount that it reduces memory and file descriptor usage
as well as the cost of copying image data so much in memory.