### PR TITLE
profiling: Add abstraction over tracing-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,7 @@ dependencies = [
  "peniko",
  "pixels",
  "pollster",
+ "profile_traits",
  "range",
  "rustc-hash 2.1.1",
  "servo-tracing",

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -33,6 +33,7 @@ log = { workspace = true }
 net_traits = { workspace = true }
 peniko = { workspace = true, optional = true }
 pixels = { path = "../pixels" }
+profile_traits = { workspace = true }
 pollster = { version = "0.4", optional = true }
 range = { path = "../range" }
 rustc-hash = { workspace = true }

--- a/components/canvas/canvas_data.rs
+++ b/components/canvas/canvas_data.rs
@@ -317,12 +317,8 @@ impl<DrawTarget: GenericDrawTarget> CanvasData<DrawTarget> {
         };
 
         let (descriptor, data) = {
-            #[cfg(feature = "tracing")]
-            let _span = tracing::trace_span!(
-                "image_descriptor_and_serializable_data",
-                servo_profiling = true,
-            )
-            .entered();
+            let _span =
+                profile_traits::trace_span!("image_descriptor_and_serializable_data",).entered();
             self.draw_target.image_descriptor_and_serializable_data()
         };
 

--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -1026,12 +1026,8 @@ impl Painter {
             },
             display_list_descriptor,
         );
-        #[cfg(feature = "tracing")]
-        let _span = tracing::trace_span!(
-            "ScriptToCompositorMsg::BuiltDisplayList",
-            servo_profiling = true,
-        )
-        .entered();
+        let _span =
+            profile_traits::trace_span!("ScriptToCompositorMsg::BuiltDisplayList",).entered();
         let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
             return warn!("Could not find WebView for incoming display list");
         };

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -376,7 +376,8 @@ impl TouchHandler {
         };
         if velocity.length().abs() < FLING_MIN_SCREEN_PX {
             #[cfg(feature = "tracing")]
-            let _span = tracing::info_span!("TouchHandler::FlingEnd", servo_profiling = true,);
+            let _span =
+                profile_traits::info_span!("TouchHandler::FlingEnd", servo_profiling = true,);
             touch_sequence.state = Finished;
             // If we were flinging previously, there could still be a touch_up event result
             // coming in after we stopped flinging
@@ -386,11 +387,9 @@ impl TouchHandler {
             // TODO: Probably we should multiply with the current refresh rate (and divide on each frame)
             // or save a timestamp to account for a potentially changing display refresh rate.
             *velocity *= FLING_SCALING_FACTOR;
-            #[cfg(feature = "tracing")]
-            let _span = tracing::info_span!(
+            let _span = profile_traits::info_span!(
                 "TouchHandler::Flinging",
                 velocity = ?velocity,
-                servo_profiling = true,
             );
             debug_assert!(velocity.length() <= FLING_MAX_SCREEN_PX);
             Some(FlingAction {
@@ -442,11 +441,9 @@ impl TouchHandler {
                 } else if delta.x.abs() > TOUCH_PAN_MIN_SCREEN_PX ||
                     delta.y.abs() > TOUCH_PAN_MIN_SCREEN_PX
                 {
-                    #[cfg(feature = "tracing")]
-                    let _span = tracing::info_span!(
+                    let _span = profile_traits::info_span!(
                         "TouchHandler::ScrollBegin",
                         delta = ?delta,
-                        servo_profiling = true,
                     );
                     touch_sequence.state = Panning {
                         velocity: Vector2D::new(delta.x, delta.y),
@@ -527,11 +524,9 @@ impl TouchHandler {
             },
             Panning { velocity } => {
                 if velocity.length().abs() >= FLING_MIN_SCREEN_PX {
-                    #[cfg(feature = "tracing")]
-                    let _span = tracing::info_span!(
+                    let _span = profile_traits::info_span!(
                         "TouchHandler::FlingStart",
                         velocity = ?velocity,
-                        servo_profiling = true,
                     );
                     // TODO: point != old. Not sure which one is better to take as cursor for flinging.
                     debug!(
@@ -554,9 +549,7 @@ impl TouchHandler {
                         TouchMoveAllowed::Prevented => touch_sequence.state = Finished,
                     }
                 } else {
-                    #[cfg(feature = "tracing")]
-                    let _span =
-                        tracing::info_span!("TouchHandler::ScrollEnd", servo_profiling = true,);
+                    let _span = profile_traits::info_span!("TouchHandler::ScrollEnd");
                     touch_sequence.state = Finished;
                 }
             },

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1250,9 +1250,7 @@ where
             let oper = sel.select();
             let index = oper.index();
 
-            #[cfg(feature = "tracing")]
-            let _span =
-                tracing::trace_span!("handle_request::select", servo_profiling = true).entered();
+            let _span = profile_traits::trace_span!("handle_request::select").entered();
             match index {
                 0 => oper
                     .recv(&self.namespace_receiver)

--- a/components/fonts/system_font_service.rs
+++ b/components/fonts/system_font_service.rs
@@ -119,9 +119,7 @@ impl SystemFontService {
         loop {
             let msg = self.port.recv().unwrap();
 
-            #[cfg(feature = "tracing")]
-            let _span =
-                tracing::trace_span!("SystemFontServiceMessage", servo_profiling = true).entered();
+            let _span = profile_traits::trace_span!("SystemFontServiceMessage").entered();
             match msg {
                 SystemFontServiceMessage::GetFontTemplates(
                     font_descriptor,

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -190,9 +190,7 @@ impl DisplayListBuilder<'_> {
             webrender_display_list_builder.dump_serialized_display_list();
         }
 
-        #[cfg(feature = "tracing")]
-        let _span =
-            tracing::trace_span!("DisplayListBuilder::build", servo_profiling = true).entered();
+        let _span = profile_traits::trace_span!("DisplayListBuilder::build").entered();
         let mut builder = DisplayListBuilder {
             current_scroll_node_id: compositor_info.root_reference_frame_id,
             current_reference_frame_scroll_node_id: compositor_info.root_reference_frame_id,

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -1055,8 +1055,7 @@ impl LayoutThread {
         let recalc_style_traversal;
         let dirty_root;
         {
-            #[cfg(feature = "tracing")]
-            let _span = tracing::trace_span!("Styling", servo_profiling = true).entered();
+            let _span = profile_traits::trace_span!("Styling").entered();
 
             let original_dirty_root = unsafe {
                 ServoLayoutNode::new(&restyle.dirty_root.unwrap())

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -291,8 +291,7 @@ impl CSSStyleSheet {
 
         self.will_modify();
 
-        #[cfg(feature = "tracing")]
-        let _span = tracing::trace_span!("ParseStylesheet", servo_profiling = true).entered();
+        let _span = profile_traits::trace_span!("ParseStylesheet").entered();
         let sheet = self.style_stylesheet();
         let new_contents = StylesheetContents::from_str(
             &text,

--- a/components/script/dom/css/stylesheetcontentscache.rs
+++ b/components/script/dom/css/stylesheetcontentscache.rs
@@ -105,9 +105,7 @@ impl StylesheetContentsCache {
                 },
                 Entry::Vacant(vacant_entry) => {
                     let contents = {
-                        #[cfg(feature = "tracing")]
-                        let _span = tracing::trace_span!("ParseStylesheet", servo_profiling = true)
-                            .entered();
+                        let _span = profile_traits::trace_span!("ParseStylesheet").entered();
                         StylesheetContents::from_str(
                             stylesheet_text,
                             url_data,

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -137,8 +137,7 @@ impl StylesheetContext {
             .as_ref()
             .expect("Should never call parse without metadata.");
 
-        #[cfg(feature = "tracing")]
-        let _span = tracing::trace_span!("ParseStylesheet", servo_profiling = true).entered();
+        let _span = profile_traits::trace_span!("ParseStylesheet").entered();
         Arc::new(Stylesheet::from_bytes(
             &self.data,
             UrlExtraData(metadata.final_url.get_arc()),

--- a/components/shared/profile/lib.rs
+++ b/components/shared/profile/lib.rs
@@ -21,7 +21,7 @@ macro_rules! time_profile {
     ($category:expr, $meta:expr, $profiler_chan:expr, $($callback:tt)+) => {{
         let meta: Option<$crate::time::TimerMetadata> = $meta;
         #[cfg(feature = "tracing")]
-        let span = tracing::info_span!(
+        let span = $crate::servo_tracing::info_span!(
             $category.variant_name(),
             servo_profiling = true,
             url = meta.as_ref().map(|m| m.url.clone()),
@@ -31,3 +31,158 @@ macro_rules! time_profile {
         $crate::time::profile($category, meta, $profiler_chan, span, $($callback)+)
     }};
 }
+
+/// Provides API compatible dummies for the tracing-rs APIs we use
+/// if tracing is disabled. Hence, nothing will be traced
+pub mod dummy_tracing {
+    use std::fmt::Display;
+    use std::marker::PhantomData;
+
+    pub struct Span();
+
+    pub struct EnteredSpan(Span);
+    pub struct Entered<'a>(PhantomData<&'a Span>);
+
+    impl Span {
+        pub fn enter(&self) -> Entered<'_> {
+            Entered(PhantomData)
+        }
+
+        pub fn entered(self) -> EnteredSpan {
+            EnteredSpan(self)
+        }
+
+        pub fn in_scope<F: FnOnce() -> T, T>(&self, f: F) -> T {
+            // We still need to execute the function, even if tracing is disabled.
+            f()
+        }
+    }
+
+    impl EnteredSpan {}
+
+    impl Entered<'_> {}
+
+    #[derive(Debug)]
+    #[allow(dead_code)]
+    struct Level();
+
+    #[allow(dead_code)]
+    impl Level {
+        /// The "error" level.
+        ///
+        /// Designates very serious errors.
+        pub const ERROR: Level = Level();
+        /// The "warn" level.
+        ///
+        /// Designates hazardous situations.
+        pub const WARN: Level = Level();
+        /// The "info" level.
+        ///
+        /// Designates useful information.
+        pub const INFO: Level = Level();
+        /// The "debug" level.
+        ///
+        /// Designates lower priority information.
+        pub const DEBUG: Level = Level();
+        /// The "trace" level.
+        ///
+        /// Designates very low priority, often extremely verbose, information.
+        pub const TRACE: Level = Level();
+        /// Returns the string representation of the `Level`.
+        ///
+        /// This returns the same string as the `fmt::Display` implementation.
+        pub fn as_str(&self) -> &'static str {
+            "disabled"
+        }
+    }
+    impl Display for Level {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.as_str())
+        }
+    }
+}
+
+/// Constructs a span at the trace level
+///
+/// This macro creates a Span for the purpose of instrumenting code to measure
+/// the execution time of the span.
+/// If the `tracing` feature (of the crate using this macro) is disabled, then
+/// the Span implementation will be replaced with a dummy, that does not record
+/// anything.
+///
+/// Attention: This macro requires the user crate to have a `tracing` feature,
+/// which can be used to disable the effects of this macro.
+#[macro_export]
+macro_rules! trace_span {
+    ($span_name:literal, $($field:tt)*) => {
+        {
+        #[cfg(feature = "tracing")]
+        {
+            $crate::servo_tracing::trace_span!(
+                $span_name,
+                servo_profiling = true,
+                $($field)*
+            )
+        }
+        #[cfg(not(feature = "tracing"))]
+        { $crate::dummy_tracing::Span() }
+        }
+    };
+    ($span_name:literal) => {
+        {
+         #[cfg(feature = "tracing")]
+         {
+             $crate::servo_tracing::trace_span!(
+                $span_name,
+                servo_profiling = true,
+             )
+         }
+        #[cfg(not(feature = "tracing"))]
+        { $crate::dummy_tracing::Span() }
+        }
+    };
+}
+
+/// Constructs a span at the info level
+///
+/// This macro creates a Span for the purpose of instrumenting code to measure
+/// the execution time of the span.
+/// If the `tracing` feature (of the crate using this macro) is disabled, then
+/// the Span implementation will be replaced with a dummy, that does not record
+/// anything.
+///
+/// Attention: This macro requires the user crate to have a `tracing` feature,
+/// which can be used to disable the effects of this macro.
+#[macro_export]
+macro_rules! info_span {
+    ($span_name:literal, $($field:tt)*) => {
+        {
+        #[cfg(feature = "tracing")]
+        {
+            $crate::servo_tracing::info_span!(
+                $span_name,
+                servo_profiling = true,
+                $($field)*
+            )
+        }
+        #[cfg(not(feature = "tracing"))]
+        { $crate::dummy_tracing::Span() }
+        }
+    };
+    ($span_name:literal) => {
+        {
+         #[cfg(feature = "tracing")]
+         {
+             $crate::servo_tracing::info_span!(
+                $span_name,
+                servo_profiling = true,
+             )
+         }
+        #[cfg(not(feature = "tracing"))]
+        { $crate::dummy_tracing::Span() }
+        }
+    };
+}
+
+#[cfg(feature = "tracing")]
+pub use tracing as servo_tracing;


### PR DESCRIPTION
There are multiple motivating factors for this change:

1. `tracing-rs` can and is commonly used for structured logging, to gain understanding in what is happening in concurrent code. We would like to attempt to make a distinction of the performance tracing related usage and the logging related usage.
2. This reduces boilerplate code. We don't have to feature guard every span anymore, since the macro will do it for us. 
3. This makes it easier to add multiple options for the trace backend (i.e. exchanging tracing-rs for hitrace on OpenHarmony or System Tracing in Android), or something entirely custom. 
4. This makes it easier to add further compile-time options to control the amount of tracing. E.g. a future PR could add options to enable tracing based on environment variables set at compile time. Tracing adds runtime overhead, even if the runtime switch is disabled, so having more fine-grained options to partially enabled tracing could be useful.

Testing: Tested manually by building with and without the `tracing` feature. In CI we also build with the tracing feature in the HarmonyOS build. We don't have any automated tests for the correctness / presence of the traced entries.

