### PR TITLE
xpath: Compare local names in html documents case-insensitively when there's no prefix

### DIFF
--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -261,8 +261,9 @@ impl xpath::Attribute for XPathWrapper<DomRoot<Attr>> {
 pub(crate) fn parse_expression(
     expression: &str,
     resolver: Option<Rc<XPathNSResolver>>,
+    is_in_html_document: bool,
 ) -> Fallible<xpath::Expression> {
-    xpath::parse::<XPathImplementation>(expression, resolver.map(XPathWrapper)).map_err(|error| {
+    xpath::parse(expression, resolver.map(XPathWrapper), is_in_html_document).map_err(|error| {
         match error {
             xpath::ParserError::JsError(Error::JSFailed) => Error::JSFailed,
             _ => Error::Syntax(Some(format!("Failed to parse XPath expression: {error:?}"))),

--- a/components/xpath/src/eval.rs
+++ b/components/xpath/src/eval.rs
@@ -168,8 +168,8 @@ pub(crate) enum NameTestComparisonMode {
 }
 
 pub(crate) fn element_name_test(
-    expected_name: QualName,
-    element_qualname: QualName,
+    expected_name: &QualName,
+    actual_name: QualName,
     comparison_mode: NameTestComparisonMode,
 ) -> bool {
     if expected_name.prefix.is_none() && expected_name.local == local_name!("*") {
@@ -178,7 +178,7 @@ pub(crate) fn element_name_test(
 
     let should_compare_namespaces =
         comparison_mode == NameTestComparisonMode::XHtml || expected_name.ns != ns!();
-    if should_compare_namespaces && expected_name.ns != element_qualname.ns {
+    if should_compare_namespaces && expected_name.ns != actual_name.ns {
         return false;
     }
 
@@ -186,33 +186,33 @@ pub(crate) fn element_name_test(
         return true;
     }
 
-    expected_name.local == element_qualname.local
+    expected_name.local == actual_name.local
 }
 
 fn apply_node_test<D: Dom>(test: &NodeTest, node: &D::Node) -> Result<bool, Error<D::JsError>> {
     let result = match test {
-        NodeTest::Name(qname) => {
+        NodeTest::Name(expected_name) => {
             if let Some(element) = node.as_element() {
                 let comparison_mode = if element.is_html_element_in_html_document() {
                     NameTestComparisonMode::Html
                 } else {
                     NameTestComparisonMode::XHtml
                 };
-                let element_qualname = QualName::new(
+                let actual_name = QualName::new(
                     element.prefix(),
                     element.namespace().clone(),
                     element.local_name().clone(),
                 );
-                element_name_test(qname.clone(), element_qualname, comparison_mode)
+                element_name_test(expected_name, actual_name, comparison_mode)
             } else if let Some(attribute) = node.as_attribute() {
-                let attr_qualname = QualName::new(
+                let actual_name = QualName::new(
                     attribute.prefix(),
                     attribute.namespace().clone(),
                     attribute.local_name().clone(),
                 );
                 // attributes are always compared with strict namespace matching
                 let comparison_mode = NameTestComparisonMode::XHtml;
-                element_name_test(qname.clone(), attr_qualname, comparison_mode)
+                element_name_test(expected_name, actual_name, comparison_mode)
             } else {
                 false
             }

--- a/components/xpath/src/lib.rs
+++ b/components/xpath/src/lib.rs
@@ -10,26 +10,25 @@ mod parser;
 mod tokenizer;
 mod value;
 
-use std::fmt::Debug;
+use std::fmt;
 use std::hash::Hash;
 
 pub use ast::Expression;
 use ast::QName;
 use context::EvaluationCtx;
 use markup5ever::{LocalName, Namespace, Prefix};
-pub use parser::Error as ParserError;
-use parser::parse as parse_impl;
+pub use parser::{Error as ParserError, parse};
 pub use value::{NodesetHelpers, Value};
 
 pub trait Dom {
     type Node: Node;
     /// An exception that can occur during JS evaluation.
-    type JsError: Debug;
+    type JsError: fmt::Debug;
     type NamespaceResolver: NamespaceResolver<Self::JsError>;
 }
 
 /// A handle to a DOM node exposing all functionality needed by xpath.
-pub trait Node: Eq + Clone + Debug {
+pub trait Node: Eq + Clone + fmt::Debug {
     type ProcessingInstruction: ProcessingInstruction;
     type Document: Document<Node = Self>;
     type Attribute: Attribute<Node = Self>;
@@ -94,23 +93,6 @@ pub trait Attribute {
     fn prefix(&self) -> Option<Prefix>;
     fn namespace(&self) -> Namespace;
     fn local_name(&self) -> LocalName;
-}
-
-/// Parse an XPath expression from a string
-pub fn parse<D: Dom>(
-    xpath: &str,
-    resolver: Option<D::NamespaceResolver>,
-) -> Result<Expression, ParserError<D::JsError>> {
-    match parse_impl(xpath, resolver) {
-        Ok(expression) => {
-            log::debug!("Parsed XPath: {expression:?}");
-            Ok(expression)
-        },
-        Err(error) => {
-            log::debug!("Unable to parse XPath: {error:?}");
-            Err(error)
-        },
-    }
 }
 
 /// Evaluate an already-parsed XPath expression

--- a/tests/wpt/meta/domxpath/text-html-attributes.html.ini
+++ b/tests/wpt/meta/domxpath/text-html-attributes.html.ini
@@ -1,9 +1,9 @@
 [text-html-attributes.html]
-  [Select html element based on attribute mixed case]
-    expected: FAIL
-
-  [Select HTML element with non-ascii attribute 3]
-    expected: FAIL
-
   [Select both HTML and SVG elements based on mixed case attribute]
+    expected: FAIL
+
+  [Select SVG element based on mixed case attribute]
+    expected: FAIL
+
+  [Select SVG elements with refX attribute]
     expected: FAIL

--- a/tests/wpt/meta/domxpath/text-html-elements.html.ini
+++ b/tests/wpt/meta/domxpath/text-html-elements.html.ini
@@ -1,9 +1,3 @@
 [text-html-elements.html]
-  [HTML elements mixed case]
-    expected: FAIL
-
-  [Non-ascii HTML element3]
-    expected: FAIL
-
   [Throw with invalid prefix]
     expected: FAIL


### PR DESCRIPTION
Relevant gecko code: https://searchfox.org/firefox-main/rev/16707ce1df112d9e067175ed8e16be717ab684c4/dom/xslt/xpath/txExprParser.cpp#839.

Testing: New tests start to pass
Part of #34527 
