### PR TITLE
Use rooted_fixed_array and rooted_dynamic_array to prevent unsafe use of RootedVec containing GC values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5338,7 +5338,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#bbbbf315e89cf91428f3b652ac68146687737259"
+source = "git+https://github.com/Taym95/mozjs?branch=define-RootedFixedValueArray#d6891a6a7e4b9aef52a32d1b71c7ebddcb2d9bd2"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -5351,7 +5351,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.140.0-6"
-source = "git+https://github.com/servo/mozjs#bbbbf315e89cf91428f3b652ac68146687737259"
+source = "git+https://github.com/Taym95/mozjs?branch=define-RootedFixedValueArray#d6891a6a7e4b9aef52a32d1b71c7ebddcb2d9bd2"
 dependencies = [
  "bindgen 0.71.1",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }
 ipc-channel = "0.20.2"
 itertools = "0.14"
-js = { package = "mozjs", git = "https://github.com/servo/mozjs" }
+js = { package = "mozjs", git = "https://github.com/Taym95/mozjs", branch = "define-RootedFixedValueArray" }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.11.3", features = ["euclid"] }
 layout_api = { path = "components/shared/layout" }

--- a/components/script/dom/defaultteeunderlyingsource.rs
+++ b/components/script/dom/defaultteeunderlyingsource.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
-use js::jsapi::{HandleValueArray, Heap, NewArrayObject, Value};
+use js::jsapi::{Heap, NewArrayObject, Value};
 use js::jsval::{ObjectValue, UndefinedValue};
 use js::rust::HandleValue as SafeHandleValue;
 
@@ -196,11 +196,11 @@ impl DefaultTeeUnderlyingSource {
     #[allow(unsafe_code)]
     fn resolve_cancel_promise(&self, cx: SafeJSContext, global: &GlobalScope, can_gc: CanGc) {
         // Let compositeReason be ! CreateArrayFromList(« reason_1, reason_2 »).
-        rooted_vec!(let mut reasons_values);
+        rooted_fixed_array!(let mut reasons_values: 2);
         reasons_values.push(self.reason_1.get());
         reasons_values.push(self.reason_2.get());
+        let reasons_values_array = reasons_values.as_handle_value_array();
 
-        let reasons_values_array = HandleValueArray::from(&reasons_values);
         rooted!(in(*cx) let reasons = unsafe { NewArrayObject(*cx, &reasons_values_array) });
         rooted!(in(*cx) let reasons_value = ObjectValue(reasons.get()));
 

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -312,22 +312,26 @@ impl PaintWorkletGlobalScope {
         // TODO: Step 10
         // Steps 11-12
         debug!("Invoking paint function {}.", name);
-        rooted_vec!(let mut arguments_values);
+        let size = arguments.len();
+        rooted_dynamic_array!(let mut arguments_values: size);
         for argument in arguments {
             let style_value = CSSStyleValue::new(self.upcast(), argument.clone(), can_gc);
             arguments_values.push(ObjectValue(style_value.reflector().get_jsobject().get()));
         }
-        let arguments_value_array = HandleValueArray::from(&arguments_values);
-        rooted!(in(*cx) let argument_object = unsafe { NewArrayObject(*cx, &arguments_value_array) });
+        let arguments_value_array = arguments_values.as_handle_value_array();
+        rooted!(in(*cx) let argument_object = unsafe {
+            NewArrayObject(*cx, &arguments_value_array)
+        });
 
-        rooted_vec!(let mut callback_args);
+        rooted_fixed_array!(let mut callback_args: 4);
         callback_args.push(ObjectValue(
             rendering_context.reflector().get_jsobject().get(),
         ));
         callback_args.push(ObjectValue(paint_size.reflector().get_jsobject().get()));
         callback_args.push(ObjectValue(properties.reflector().get_jsobject().get()));
         callback_args.push(ObjectValue(argument_object.get()));
-        let args = HandleValueArray::from(&callback_args);
+
+        let args = callback_args.as_handle_value_array();
 
         rooted!(in(*cx) let mut result = UndefinedValue());
         unsafe {


### PR DESCRIPTION
Use rooted_fixed_array and rooted_dynamic_array to prevent unsafe use of RootedVec containing GC values

Testing: existing test should pass.
Fixes: #40141 


Depends on https://github.com/servo/mozjs/pull/630