### PR TITLE
script: cleanup memory reporting code inside dedicatedworkerglobalscope

### DIFF
--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -183,9 +183,7 @@ pub(crate) struct DedicatedWorkerGlobalScope {
     #[ignore_malloc_size_of = "Defined in std"]
     task_queue: TaskQueue<DedicatedWorkerScriptMsg>,
     own_sender: Sender<DedicatedWorkerScriptMsg>,
-    #[ignore_malloc_size_of = "Trusted<T> has unclear ownership like Dom<T>"]
     worker: DomRefCell<Option<TrustedWorkerAddress>>,
-    #[ignore_malloc_size_of = "Can't measure trait objects"]
     /// Sender to the parent thread.
     parent_event_loop_sender: ScriptEventLoopSender,
     #[ignore_malloc_size_of = "ImageCache"]

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -23,7 +23,6 @@ use net_traits::request::{
     CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata, Referrer, RequestBuilder,
     RequestMode,
 };
-use rand::random;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::thread_state::{self, ThreadState};
 
@@ -478,8 +477,6 @@ impl DedicatedWorkerGlobalScope {
                     pipeline_id,
                     Some(worker_id),
                 );
-                // FIXME(njn): workers currently don't have a unique ID suitable for using in reporter
-                // registration (#6631), so we instead use a random number and cross our fingers.
                 let scope = global.upcast::<WorkerGlobalScope>();
                 let global_scope = global.upcast::<GlobalScope>();
 
@@ -503,7 +500,7 @@ impl DedicatedWorkerGlobalScope {
                 )));
                 global_scope.fetch(request, context, task_source);
 
-                let reporter_name = format!("dedicated-worker-reporter-{}", random::<u64>());
+                let reporter_name = format!("dedicated-worker-reporter-{}", worker_id);
                 scope
                     .upcast::<GlobalScope>()
                     .mem_profiler_chan()


### PR DESCRIPTION
- Remove a couple of ignore_malloc_size_of since are not required anymore
- Avoid calling random and use the worker_id
- Pass DedicatedWorker event_loop_sender to run_with_memory_profiling

Testing: Covered by tests, only code related to memory reporting was changed.
Fixes: #11855
