### PR TITLE
add CanGc as argument to safe_to_jsval

### DIFF
--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -241,7 +241,7 @@ fn html_constructor(
 
         JS_SetPrototype(*cx, element.handle(), prototype.handle());
 
-        result.safe_to_jsval(cx, MutableHandleValue::from_raw(call_args.rval()));
+        result.safe_to_jsval(cx, MutableHandleValue::from_raw(call_args.rval()), can_gc);
     }
     Ok(())
 }

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -77,7 +77,7 @@ pub(crate) fn throw_dom_exception(
         Ok(exception) => unsafe {
             assert!(!JS_IsExceptionPending(*cx));
             rooted!(in(*cx) let mut thrown = UndefinedValue());
-            exception.safe_to_jsval(cx, thrown.handle_mut());
+            exception.safe_to_jsval(cx, thrown.handle_mut(), can_gc);
             JS_SetPendingException(*cx, thrown.handle(), ExceptionStackBehavior::Capture);
         },
 

--- a/components/script/dom/bindings/structuredclone.rs
+++ b/components/script/dom/bindings/structuredclone.rs
@@ -669,7 +669,7 @@ pub(crate) fn write(
     unsafe {
         rooted!(in(*cx) let mut val = UndefinedValue());
         if let Some(transfer) = transfer {
-            transfer.safe_to_jsval(cx, val.handle_mut());
+            transfer.safe_to_jsval(cx, val.handle_mut(), CanGc::note());
         }
         let mut sc_writer = StructuredDataWriter::default();
         let sc_writer_ptr = &mut sc_writer as *mut _;

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -57,9 +57,9 @@ pub(crate) fn to_frozen_array<T: ToJSValConvertible>(
     convertibles: &[T],
     cx: SafeJSContext,
     mut rval: MutableHandleValue,
-    _can_gc: CanGc,
+    can_gc: CanGc,
 ) {
-    convertibles.safe_to_jsval(cx, rval.reborrow());
+    convertibles.safe_to_jsval(cx, rval.reborrow(), can_gc);
 
     rooted!(in(*cx) let obj = rval.to_object());
     unsafe { JS_FreezeObject(*cx, RawHandleObject::from(obj.handle())) };

--- a/components/script/dom/cryptokey.rs
+++ b/components/script/dom/cryptokey.rs
@@ -118,14 +118,14 @@ impl CryptoKey {
 
         // Create and store a cached object of algorithm
         rooted!(in(*cx) let mut algorithm_object_value: Value);
-        algorithm.safe_to_jsval(cx, algorithm_object_value.handle_mut());
+        algorithm.safe_to_jsval(cx, algorithm_object_value.handle_mut(), can_gc);
         crypto_key
             .algorithm_cached
             .set(algorithm_object_value.to_object());
 
         // Create and store a cached object of usages
         rooted!(in(*cx) let mut usages_object_value: Value);
-        usages.safe_to_jsval(cx, usages_object_value.handle_mut());
+        usages.safe_to_jsval(cx, usages_object_value.handle_mut(), can_gc);
         crypto_key
             .usages_cached
             .set(usages_object_value.to_object());
@@ -155,7 +155,7 @@ impl CryptoKey {
         // Create and store a cached object of usages
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let mut usages_object_value: Value);
-        usages.safe_to_jsval(cx, usages_object_value.handle_mut());
+        usages.safe_to_jsval(cx, usages_object_value.handle_mut(), CanGc::note());
         self.usages_cached.set(usages_object_value.to_object());
     }
 }

--- a/components/script/dom/debuggeradddebuggeeevent.rs
+++ b/components/script/dom/debuggeradddebuggeeevent.rs
@@ -51,7 +51,7 @@ impl DebuggerAddDebuggeeEvent {
         rooted!(in(*cx) let mut wrapped_global: Value);
         global
             .reflector()
-            .safe_to_jsval(cx, wrapped_global.handle_mut());
+            .safe_to_jsval(cx, wrapped_global.handle_mut(), can_gc);
         result.global.set(wrapped_global.to_object());
 
         result

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -258,7 +258,7 @@ impl EventSourceContext {
             let _ac = enter_realm(&*event_source);
             rooted!(in(*GlobalScope::get_cx()) let mut data = UndefinedValue());
             self.data
-                .safe_to_jsval(GlobalScope::get_cx(), data.handle_mut());
+                .safe_to_jsval(GlobalScope::get_cx(), data.handle_mut(), can_gc);
             MessageEvent::new(
                 &event_source.global(),
                 type_,

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -650,8 +650,8 @@ impl IDBObjectStoreMethods<crate::DomTypeHolder> for IDBObjectStore {
     // https://www.w3.org/TR/IndexedDB-2/#dom-idbobjectstore-keypath
     fn KeyPath(&self, cx: SafeJSContext, mut ret_val: MutableHandleValue) {
         match &self.key_path {
-            Some(KeyPath::String(path)) => path.safe_to_jsval(cx, ret_val),
-            Some(KeyPath::StringSequence(paths)) => paths.safe_to_jsval(cx, ret_val),
+            Some(KeyPath::String(path)) => path.safe_to_jsval(cx, ret_val, CanGc::note()),
+            Some(KeyPath::StringSequence(paths)) => paths.safe_to_jsval(cx, ret_val, CanGc::note()),
             None => ret_val.set(NullValue()),
         }
     }

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -177,7 +177,7 @@ impl IDBOpenDBRequest {
                 // Step 8.1
                 let _ac = enter_realm(&*conn);
                 rooted!(in(*cx) let mut connection_val = UndefinedValue());
-                conn.safe_to_jsval(cx, connection_val.handle_mut());
+                conn.safe_to_jsval(cx, connection_val.handle_mut(), CanGc::note());
                 this.idbrequest.set_result(connection_val.handle());
 
                 // Step 8.2
@@ -346,7 +346,7 @@ impl IDBOpenDBRequest {
 
                 let _ac = enter_realm(&*result);
                 rooted!(in(*cx) let mut result_val = UndefinedValue());
-                result.safe_to_jsval(cx, result_val.handle_mut());
+                result.safe_to_jsval(cx, result_val.handle_mut(), CanGc::note());
                 this.set_result(result_val.handle());
 
                 let event = Event::new(

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -147,7 +147,7 @@ impl RequestListener {
                         key_type_to_jsval(GlobalScope::get_cx(), &key, val.handle_mut(), can_gc);
                         array.push(Heap::boxed(val.get()));
                     }
-                    array.safe_to_jsval(cx, answer.handle_mut());
+                    array.safe_to_jsval(cx, answer.handle_mut(), can_gc);
                 },
                 IdbResult::Value(serialized_data) => {
                     let result = bincode::deserialize(&serialized_data)
@@ -177,7 +177,7 @@ impl RequestListener {
                         };
                         values.push(Heap::boxed(val.get()));
                     }
-                    values.safe_to_jsval(cx, answer.handle_mut());
+                    values.safe_to_jsval(cx, answer.handle_mut(), can_gc);
                 },
                 IdbResult::Count(count) => {
                     answer.handle_mut().set(DoubleValue(count as f64));

--- a/components/script/dom/messageport.rs
+++ b/components/script/dom/messageport.rs
@@ -212,14 +212,14 @@ impl MessagePort {
         &self,
         type_: &str,
         value: HandleValue,
-        _can_gc: CanGc,
+        can_gc: CanGc,
     ) -> ErrorResult {
         let cx = GlobalScope::get_cx();
 
         // Let message be OrdinaryObjectCreate(null).
         rooted!(in(*cx) let mut message = unsafe { JS_NewObject(*cx, ptr::null()) });
         rooted!(in(*cx) let mut type_string = UndefinedValue());
-        type_.safe_to_jsval(cx, type_string.handle_mut());
+        type_.safe_to_jsval(cx, type_string.handle_mut(), can_gc);
 
         // Perform ! CreateDataProperty(message, "type", type).
         set_dictionary_property(cx, message.handle(), "type", type_string.handle())
@@ -238,7 +238,7 @@ impl MessagePort {
 
         // Run the message port post message steps providing targetPort, message, and options.
         rooted!(in(*cx) let mut message_val = UndefinedValue());
-        message.safe_to_jsval(cx, message_val.handle_mut());
+        message.safe_to_jsval(cx, message_val.handle_mut(), can_gc);
         self.post_message_impl(cx, message_val.handle(), transfer)
     }
 }

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -160,11 +160,11 @@ impl Promise {
         global: &GlobalScope,
         cx: SafeJSContext,
         value: impl SafeToJSValConvertible,
-        _can_gc: CanGc,
+        can_gc: CanGc,
     ) -> Rc<Promise> {
         let _ac = JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
         rooted!(in(*cx) let mut rval = UndefinedValue());
-        value.safe_to_jsval(cx, rval.handle_mut());
+        value.safe_to_jsval(cx, rval.handle_mut(), can_gc);
         unsafe {
             rooted!(in(*cx) let p = CallOriginalPromiseResolve(*cx, rval.handle()));
             assert!(!p.handle().is_null());
@@ -178,11 +178,11 @@ impl Promise {
         global: &GlobalScope,
         cx: SafeJSContext,
         value: impl SafeToJSValConvertible,
-        _can_gc: CanGc,
+        can_gc: CanGc,
     ) -> Rc<Promise> {
         let _ac = JSAutoRealm::new(*cx, global.reflector().get_jsobject().get());
         rooted!(in(*cx) let mut rval = UndefinedValue());
-        value.safe_to_jsval(cx, rval.handle_mut());
+        value.safe_to_jsval(cx, rval.handle_mut(), can_gc);
         unsafe {
             rooted!(in(*cx) let p = CallOriginalPromiseReject(*cx, rval.handle()));
             assert!(!p.handle().is_null());
@@ -197,7 +197,7 @@ impl Promise {
         let cx = GlobalScope::get_cx();
         let _ac = enter_realm(self);
         rooted!(in(*cx) let mut v = UndefinedValue());
-        val.safe_to_jsval(cx, v.handle_mut());
+        val.safe_to_jsval(cx, v.handle_mut(), can_gc);
         self.resolve(cx, v.handle(), can_gc);
     }
 
@@ -218,7 +218,7 @@ impl Promise {
         let cx = GlobalScope::get_cx();
         let _ac = enter_realm(self);
         rooted!(in(*cx) let mut v = UndefinedValue());
-        val.safe_to_jsval(cx, v.handle_mut());
+        val.safe_to_jsval(cx, v.handle_mut(), can_gc);
         self.reject(cx, v.handle(), can_gc);
     }
 

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -1571,7 +1571,8 @@ impl ReadableStream {
         if self.is_errored() {
             let promise = Promise::new(global, can_gc);
             rooted!(in(*cx) let mut rval = UndefinedValue());
-            self.stored_error.safe_to_jsval(cx, rval.handle_mut());
+            self.stored_error
+                .safe_to_jsval(cx, rval.handle_mut(), can_gc);
             promise.reject_native(&rval.handle(), can_gc);
             return promise;
         }
@@ -2286,7 +2287,7 @@ impl CrossRealmTransformReadable {
         // Let error be a new "DataCloneError" DOMException.
         let error = DOMException::new(global, DOMErrorName::DataCloneError, can_gc);
         rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-        error.safe_to_jsval(cx, rooted_error.handle_mut());
+        error.safe_to_jsval(cx, rooted_error.handle_mut(), can_gc);
 
         // Perform ! CrossRealmTransformSendError(port, error).
         port.cross_realm_transform_send_error(rooted_error.handle(), can_gc);

--- a/components/script/dom/readablestreamdefaultcontroller.rs
+++ b/components/script/dom/readablestreamdefaultcontroller.rs
@@ -154,9 +154,11 @@ impl EnqueuedValue {
                 rooted!(in(*cx) let mut array_buffer_ptr = ptr::null_mut::<JSObject>());
                 create_buffer_source::<Uint8>(cx, chunk, array_buffer_ptr.handle_mut(), can_gc)
                     .expect("failed to create buffer source for native chunk.");
-                array_buffer_ptr.safe_to_jsval(cx, rval);
+                array_buffer_ptr.safe_to_jsval(cx, rval, can_gc);
             },
-            EnqueuedValue::Js(value_with_size) => value_with_size.value.safe_to_jsval(cx, rval),
+            EnqueuedValue::Js(value_with_size) => {
+                value_with_size.value.safe_to_jsval(cx, rval, can_gc)
+            },
             EnqueuedValue::CloseSentinel => {
                 unreachable!("The close sentinel is never made available as a js val.")
             },

--- a/components/script/dom/textencoderstream.rs
+++ b/components/script/dom/textencoderstream.rs
@@ -278,7 +278,7 @@ pub(crate) fn encode_and_enqueue_a_chunk(
     let chunk: Uint8Array = create_buffer_source(cx, output, js_object.handle_mut(), can_gc)
         .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(in(*cx) let mut rval = UndefinedValue());
-    chunk.safe_to_jsval(cx, rval.handle_mut());
+    chunk.safe_to_jsval(cx, rval.handle_mut(), can_gc);
     // Step 4.2.2.2 Enqueue chunk into encoder’s transform.
     controller.enqueue(cx, global, rval.handle(), can_gc)?;
     Ok(())
@@ -304,7 +304,7 @@ pub(crate) fn encode_and_flush(
                     Error::Type("Cannot convert byte sequence to Uint8Array".to_owned())
                 })?;
         rooted!(in(*cx) let mut rval = UndefinedValue());
-        chunk.safe_to_jsval(cx, rval.handle_mut());
+        chunk.safe_to_jsval(cx, rval.handle_mut(), can_gc);
         // Step 1.2 Enqueue chunk into encoder’s transform.
         return controller.enqueue(cx, global, rval.handle(), can_gc);
     }

--- a/components/script/dom/trustedtypepolicyfactory.rs
+++ b/components/script/dom/trustedtypepolicyfactory.rs
@@ -255,13 +255,14 @@ impl TrustedTypePolicyFactory {
         // Step 2: Let policyValue be the result of executing Get Trusted Type policy value,
         // with the following arguments:
         rooted!(in(*cx) let mut trusted_type_name_value = NullValue());
-        expected_type
-            .clone()
-            .as_ref()
-            .safe_to_jsval(cx, trusted_type_name_value.handle_mut());
+        expected_type.clone().as_ref().safe_to_jsval(
+            cx,
+            trusted_type_name_value.handle_mut(),
+            can_gc,
+        );
 
         rooted!(in(*cx) let mut sink_value = NullValue());
-        sink.safe_to_jsval(cx, sink_value.handle_mut());
+        sink.safe_to_jsval(cx, sink_value.handle_mut(), can_gc);
 
         let arguments = vec![trusted_type_name_value.handle(), sink_value.handle()];
         let policy_value = default_policy.get_trusted_type_policy_value(

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -694,10 +694,10 @@ impl WebGL2RenderingContext {
         if pname == constants::FRAMEBUFFER_ATTACHMENT_OBJECT_NAME {
             match fb.attachment(attachment) {
                 Some(Renderbuffer(rb)) => {
-                    rb.safe_to_jsval(cx, rval);
+                    rb.safe_to_jsval(cx, rval, CanGc::note());
                 },
                 Some(Texture(texture)) => {
-                    texture.safe_to_jsval(cx, rval);
+                    texture.safe_to_jsval(cx, rval, CanGc::note());
                 },
                 _ => rval.set(NullValue()),
             }
@@ -1042,11 +1042,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
     fn GetParameter(&self, cx: JSContext, parameter: u32, mut rval: MutableHandleValue) {
         match parameter {
             constants::VERSION => {
-                "WebGL 2.0".safe_to_jsval(cx, rval);
+                "WebGL 2.0".safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             constants::SHADING_LANGUAGE_VERSION => {
-                "WebGL GLSL ES 3.00".safe_to_jsval(cx, rval);
+                "WebGL GLSL ES 3.00".safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             constants::MAX_CLIENT_WAIT_TIMEOUT_WEBGL => {
@@ -1065,50 +1065,60 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                 let idx = (self.base.textures().active_unit_enum() - constants::TEXTURE0) as usize;
                 assert!(idx < self.samplers.len());
                 let sampler = self.samplers[idx].get();
-                sampler.safe_to_jsval(cx, rval);
+                sampler.safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             constants::COPY_READ_BUFFER_BINDING => {
-                self.bound_copy_read_buffer.get().safe_to_jsval(cx, rval);
+                self.bound_copy_read_buffer
+                    .get()
+                    .safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             constants::COPY_WRITE_BUFFER_BINDING => {
-                self.bound_copy_write_buffer.get().safe_to_jsval(cx, rval);
+                self.bound_copy_write_buffer
+                    .get()
+                    .safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             constants::PIXEL_PACK_BUFFER_BINDING => {
-                self.bound_pixel_pack_buffer.get().safe_to_jsval(cx, rval);
+                self.bound_pixel_pack_buffer
+                    .get()
+                    .safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             constants::PIXEL_UNPACK_BUFFER_BINDING => {
-                self.bound_pixel_unpack_buffer.get().safe_to_jsval(cx, rval);
+                self.bound_pixel_unpack_buffer
+                    .get()
+                    .safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             constants::TRANSFORM_FEEDBACK_BUFFER_BINDING => {
                 self.bound_transform_feedback_buffer
                     .get()
-                    .safe_to_jsval(cx, rval);
+                    .safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             constants::UNIFORM_BUFFER_BINDING => {
-                self.bound_uniform_buffer.get().safe_to_jsval(cx, rval);
+                self.bound_uniform_buffer
+                    .get()
+                    .safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             constants::TRANSFORM_FEEDBACK_BINDING => {
                 self.current_transform_feedback
                     .get()
-                    .safe_to_jsval(cx, rval);
+                    .safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             constants::ELEMENT_ARRAY_BUFFER_BINDING => {
                 let buffer = self.current_vao().element_array_buffer().get();
-                buffer.safe_to_jsval(cx, rval);
+                buffer.safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             constants::VERTEX_ARRAY_BINDING => {
                 let vao = self.current_vao();
                 let vao = vao.id().map(|_| &*vao);
-                vao.safe_to_jsval(cx, rval);
+                vao.safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             // NOTE: DRAW_FRAMEBUFFER_BINDING is the same as FRAMEBUFFER_BINDING, handled on the WebGL1 side
@@ -1116,7 +1126,7 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
                 self.base
                     .get_read_framebuffer_slot()
                     .get()
-                    .safe_to_jsval(cx, rval);
+                    .safe_to_jsval(cx, rval, CanGc::note());
                 return;
             },
             constants::READ_BUFFER => {
@@ -2072,7 +2082,10 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
 
         match target {
             constants::TRANSFORM_FEEDBACK_BUFFER_BINDING | constants::UNIFORM_BUFFER_BINDING => {
-                binding.buffer.get().safe_to_jsval(cx, retval)
+                binding
+                    .buffer
+                    .get()
+                    .safe_to_jsval(cx, retval, CanGc::note())
             },
             constants::TRANSFORM_FEEDBACK_BUFFER_START | constants::UNIFORM_BUFFER_START => {
                 retval.set(Int32Value(binding.start.get() as _))
@@ -4525,11 +4538,11 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
             constants::UNIFORM_OFFSET |
             constants::UNIFORM_ARRAY_STRIDE |
             constants::UNIFORM_MATRIX_STRIDE => {
-                values.safe_to_jsval(cx, rval);
+                values.safe_to_jsval(cx, rval, CanGc::note());
             },
             constants::UNIFORM_IS_ROW_MAJOR => {
                 let values = values.iter().map(|&v| v != 0).collect::<Vec<_>>();
-                values.safe_to_jsval(cx, rval);
+                values.safe_to_jsval(cx, rval, CanGc::note());
             },
             _ => unreachable!(),
         }

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -2143,24 +2143,32 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
 
         match parameter {
             constants::ARRAY_BUFFER_BINDING => {
-                self.bound_buffer_array.get().safe_to_jsval(cx, retval);
+                self.bound_buffer_array
+                    .get()
+                    .safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             constants::CURRENT_PROGRAM => {
-                self.current_program.get().safe_to_jsval(cx, retval);
+                self.current_program
+                    .get()
+                    .safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             constants::ELEMENT_ARRAY_BUFFER_BINDING => {
                 let buffer = self.current_vao().element_array_buffer().get();
-                buffer.safe_to_jsval(cx, retval);
+                buffer.safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             constants::FRAMEBUFFER_BINDING => {
-                self.bound_draw_framebuffer.get().safe_to_jsval(cx, retval);
+                self.bound_draw_framebuffer
+                    .get()
+                    .safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             constants::RENDERBUFFER_BINDING => {
-                self.bound_renderbuffer.get().safe_to_jsval(cx, retval);
+                self.bound_renderbuffer
+                    .get()
+                    .safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             constants::TEXTURE_BINDING_2D => {
@@ -2169,7 +2177,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     .active_texture_slot(constants::TEXTURE_2D, self.webgl_version())
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx, retval);
+                texture.safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             WebGL2RenderingContextConstants::TEXTURE_BINDING_2D_ARRAY => {
@@ -2181,7 +2189,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     )
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx, retval);
+                texture.safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             WebGL2RenderingContextConstants::TEXTURE_BINDING_3D => {
@@ -2193,7 +2201,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     )
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx, retval);
+                texture.safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             constants::TEXTURE_BINDING_CUBE_MAP => {
@@ -2202,12 +2210,12 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                     .active_texture_slot(constants::TEXTURE_CUBE_MAP, self.webgl_version())
                     .unwrap()
                     .get();
-                texture.safe_to_jsval(cx, retval);
+                texture.safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             OESVertexArrayObjectConstants::VERTEX_ARRAY_BINDING_OES => {
                 let vao = self.current_vao.get().filter(|vao| vao.id().is_some());
-                vao.safe_to_jsval(cx, retval);
+                vao.safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             // In readPixels we currently support RGBA/UBYTE only.  If
@@ -2238,15 +2246,15 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 return retval.set(ObjectValue(rval.get()));
             },
             constants::VERSION => {
-                "WebGL 1.0".safe_to_jsval(cx, retval);
+                "WebGL 1.0".safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             constants::RENDERER | constants::VENDOR => {
-                "Mozilla/Servo".safe_to_jsval(cx, retval);
+                "Mozilla/Servo".safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             constants::SHADING_LANGUAGE_VERSION => {
-                "WebGL GLSL ES 1.0".safe_to_jsval(cx, retval);
+                "WebGL GLSL ES 1.0".safe_to_jsval(cx, retval, CanGc::note());
                 return;
             },
             constants::UNPACK_FLIP_Y_WEBGL => {
@@ -2327,7 +2335,10 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             Parameter::Bool4(param) => {
                 let (sender, receiver) = webgl_channel().unwrap();
                 self.send_command(WebGLCommand::GetParameterBool4(param, sender));
-                receiver.recv().unwrap().safe_to_jsval(cx, retval);
+                receiver
+                    .recv()
+                    .unwrap()
+                    .safe_to_jsval(cx, retval, CanGc::note());
             },
             Parameter::Int(param) => {
                 let (sender, receiver) = webgl_channel().unwrap();
@@ -3366,11 +3377,11 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
             if let Some(webgl_attachment) = fb.attachment(attachment) {
                 match webgl_attachment {
                     WebGLFramebufferAttachmentRoot::Renderbuffer(rb) => {
-                        rb.safe_to_jsval(cx, retval);
+                        rb.safe_to_jsval(cx, retval, CanGc::note());
                         return;
                     },
                     WebGLFramebufferAttachmentRoot::Texture(texture) => {
-                        texture.safe_to_jsval(cx, retval);
+                        texture.safe_to_jsval(cx, retval, CanGc::note());
                         return;
                     },
                 }
@@ -3655,7 +3666,7 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 constants::VERTEX_ATTRIB_ARRAY_STRIDE => retval.set(Int32Value(data.stride as i32)),
                 constants::VERTEX_ATTRIB_ARRAY_BUFFER_BINDING => {
                     if let Some(buffer) = data.buffer() {
-                        buffer.safe_to_jsval(cx, retval.reborrow());
+                        buffer.safe_to_jsval(cx, retval.reborrow(), CanGc::note());
                     } else {
                         retval.set(NullValue());
                     }
@@ -4277,15 +4288,12 @@ impl WebGLRenderingContextMethods<crate::DomTypeHolder> for WebGLRenderingContex
                 triple,
                 WebGLCommand::GetUniformBool,
             ))),
-            constants::BOOL_VEC2 => {
-                uniform_get(triple, WebGLCommand::GetUniformBool2).safe_to_jsval(cx, rval)
-            },
-            constants::BOOL_VEC3 => {
-                uniform_get(triple, WebGLCommand::GetUniformBool3).safe_to_jsval(cx, rval)
-            },
-            constants::BOOL_VEC4 => {
-                uniform_get(triple, WebGLCommand::GetUniformBool4).safe_to_jsval(cx, rval)
-            },
+            constants::BOOL_VEC2 => uniform_get(triple, WebGLCommand::GetUniformBool2)
+                .safe_to_jsval(cx, rval, CanGc::note()),
+            constants::BOOL_VEC3 => uniform_get(triple, WebGLCommand::GetUniformBool3)
+                .safe_to_jsval(cx, rval, CanGc::note()),
+            constants::BOOL_VEC4 => uniform_get(triple, WebGLCommand::GetUniformBool4)
+                .safe_to_jsval(cx, rval, CanGc::note()),
             constants::INT |
             constants::SAMPLER_2D |
             constants::SAMPLER_CUBE |

--- a/components/script/dom/webrtc/rtcdatachannel.rs
+++ b/components/script/dom/webrtc/rtcdatachannel.rs
@@ -203,7 +203,7 @@ impl RTCDataChannel {
 
         match channel_message {
             DataChannelMessage::Text(text) => {
-                text.safe_to_jsval(cx, message.handle_mut());
+                text.safe_to_jsval(cx, message.handle_mut(), can_gc);
             },
             DataChannelMessage::Binary(data) => {
                 let binary_type = self.binary_type.borrow();
@@ -214,7 +214,7 @@ impl RTCDataChannel {
                             BlobImpl::new_from_bytes(data, "".to_owned()),
                             can_gc,
                         );
-                        blob.safe_to_jsval(cx, message.handle_mut());
+                        blob.safe_to_jsval(cx, message.handle_mut(), can_gc);
                     },
                     "arraybuffer" => {
                         rooted!(in(*cx) let mut array_buffer = ptr::null_mut::<JSObject>());
@@ -228,7 +228,7 @@ impl RTCDataChannel {
                                 .is_ok()
                             )
                         };
-                        (*array_buffer).safe_to_jsval(cx, message.handle_mut());
+                        (*array_buffer).safe_to_jsval(cx, message.handle_mut(), can_gc);
                 },
             _ => unreachable!(),)
             },

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -620,7 +620,7 @@ impl TaskOnce for MessageReceivedTask {
         let _ac = JSAutoRealm::new(*cx, ws.reflector().get_jsobject().get());
         rooted!(in(*cx) let mut message = UndefinedValue());
         match self.message {
-            MessageData::Text(text) => text.safe_to_jsval(cx, message.handle_mut()),
+            MessageData::Text(text) => text.safe_to_jsval(cx, message.handle_mut(), CanGc::note()),
             MessageData::Binary(data) => match ws.binary_type.get() {
                 BinaryType::Blob => {
                     let blob = Blob::new(
@@ -628,7 +628,7 @@ impl TaskOnce for MessageReceivedTask {
                         BlobImpl::new_from_bytes(data, "".to_owned()),
                         CanGc::note(),
                     );
-                    blob.safe_to_jsval(cx, message.handle_mut());
+                    blob.safe_to_jsval(cx, message.handle_mut(), CanGc::note());
                 },
                 BinaryType::Arraybuffer => {
                     rooted!(in(*cx) let mut array_buffer = ptr::null_mut::<JSObject>());
@@ -644,7 +644,7 @@ impl TaskOnce for MessageReceivedTask {
                         )
                     };
 
-                    (*array_buffer).safe_to_jsval(cx, message.handle_mut());
+                    (*array_buffer).safe_to_jsval(cx, message.handle_mut(), CanGc::note());
                 },
             },
         }

--- a/components/script/dom/webxr/xrinputsource.rs
+++ b/components/script/dom/webxr/xrinputsource.rs
@@ -91,7 +91,7 @@ impl XRInputSource {
         source
             .info
             .profiles
-            .safe_to_jsval(cx, profiles.handle_mut());
+            .safe_to_jsval(cx, profiles.handle_mut(), can_gc);
         source.profiles.set(profiles.get());
         source
     }

--- a/components/script/dom/webxr/xrviewerpose.rs
+++ b/components/script/dom/webxr/xrviewerpose.rs
@@ -183,7 +183,7 @@ impl XRViewerPose {
 
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let mut jsval = UndefinedValue());
-        views.safe_to_jsval(cx, jsval.handle_mut());
+        views.safe_to_jsval(cx, jsval.handle_mut(), can_gc);
         pose.views.set(jsval.get());
 
         pose

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1993,7 +1993,10 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     // https://dom.spec.whatwg.org/#dom-window-event
     fn Event(&self, cx: JSContext, rval: MutableHandleValue) {
         if let Some(ref event) = *self.current_event.borrow() {
-            event.reflector().get_jsobject().safe_to_jsval(cx, rval);
+            event
+                .reflector()
+                .get_jsobject()
+                .safe_to_jsval(cx, rval, CanGc::note());
         }
     }
 

--- a/components/script/dom/writablestream.rs
+++ b/components/script/dom/writablestream.rs
@@ -1205,7 +1205,7 @@ impl CrossRealmTransformWritable {
         // Let error be a new "DataCloneError" DOMException.
         let error = DOMException::new(global, DOMErrorName::DataCloneError, can_gc);
         rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-        error.safe_to_jsval(cx, rooted_error.handle_mut());
+        error.safe_to_jsval(cx, rooted_error.handle_mut(), can_gc);
 
         // Perform ! CrossRealmTransformSendError(port, error).
         port.cross_realm_transform_send_error(rooted_error.handle(), can_gc);

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -932,10 +932,10 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 if ready_state == XMLHttpRequestState::Done ||
                     ready_state == XMLHttpRequestState::Loading
                 {
-                    self.text_response().safe_to_jsval(cx, rval);
+                    self.text_response().safe_to_jsval(cx, rval, can_gc);
                 } else {
                     // Step 1
-                    "".safe_to_jsval(cx, rval);
+                    "".safe_to_jsval(cx, rval, can_gc);
                 }
             },
             // Step 1
@@ -943,14 +943,16 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
                 rval.set(NullValue());
             },
             // Step 2
-            XMLHttpRequestResponseType::Document => {
-                self.document_response(can_gc).safe_to_jsval(cx, rval)
-            },
+            XMLHttpRequestResponseType::Document => self
+                .document_response(can_gc)
+                .safe_to_jsval(cx, rval, can_gc),
             XMLHttpRequestResponseType::Json => self.json_response(cx, rval),
-            XMLHttpRequestResponseType::Blob => self.blob_response(can_gc).safe_to_jsval(cx, rval),
+            XMLHttpRequestResponseType::Blob => {
+                self.blob_response(can_gc).safe_to_jsval(cx, rval, can_gc)
+            },
             XMLHttpRequestResponseType::Arraybuffer => {
                 match self.arraybuffer_response(cx, can_gc) {
-                    Some(array_buffer) => array_buffer.safe_to_jsval(cx, rval),
+                    Some(array_buffer) => array_buffer.safe_to_jsval(cx, rval, can_gc),
                     None => rval.set(NullValue()),
                 }
             },

--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -31,18 +31,18 @@ use crate::inheritance::Castable;
 use crate::num::Finite;
 use crate::reflector::{DomObject, Reflector};
 use crate::root::DomRoot;
-use crate::script_runtime::JSContext as SafeJSContext;
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::str::{ByteString, DOMString, USVString};
 use crate::trace::RootedTraceableBox;
 use crate::utils::{DOMClass, DOMJSClass};
 
 /// A safe wrapper for `ToJSValConvertible`.
 pub trait SafeToJSValConvertible {
-    fn safe_to_jsval(&self, cx: SafeJSContext, rval: MutableHandleValue);
+    fn safe_to_jsval(&self, cx: SafeJSContext, rval: MutableHandleValue, can_gc: CanGc);
 }
 
 impl<T: ToJSValConvertible + ?Sized> SafeToJSValConvertible for T {
-    fn safe_to_jsval(&self, cx: SafeJSContext, rval: MutableHandleValue) {
+    fn safe_to_jsval(&self, cx: SafeJSContext, rval: MutableHandleValue, _can_gc: CanGc) {
         unsafe { self.to_jsval(*cx, rval) };
     }
 }


### PR DESCRIPTION
add CanGc as argument to safe_to_jsval

Testing: These changes do not require tests because they are a refactor.
Closes https://github.com/servo/servo/issues/39236