### PR TITLE
add CanGc as argument to Validatable.satisfies_constraints

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -5038,11 +5038,12 @@ impl Element {
                     .validity_state(can_gc)
                     .perform_validation_and_update(ValidationFlags::all(), can_gc);
             }
-            return validatable.is_instance_validatable() && !validatable.satisfies_constraints();
+            return validatable.is_instance_validatable() &&
+                !validatable.satisfies_constraints(can_gc);
         }
 
         if let Some(internals) = self.get_element_internals() {
-            return internals.is_invalid();
+            return internals.is_invalid(can_gc);
         }
         false
     }

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -186,10 +186,10 @@ impl ElementInternals {
         }
     }
 
-    pub(crate) fn is_invalid(&self) -> bool {
+    pub(crate) fn is_invalid(&self, can_gc: CanGc) -> bool {
         self.is_target_form_associated() &&
             self.is_instance_validatable() &&
-            !self.satisfies_constraints()
+            !self.satisfies_constraints(can_gc)
     }
 
     pub(crate) fn custom_states(&self) -> Option<DomRoot<CustomStateSet>> {

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -34,15 +34,13 @@ pub(crate) trait Validatable {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-fv-valid>
-    fn satisfies_constraints(&self) -> bool {
-        self.validity_state(CanGc::note())
-            .invalid_flags()
-            .is_empty()
+    fn satisfies_constraints(&self, can_gc: CanGc) -> bool {
+        self.validity_state(can_gc).invalid_flags().is_empty()
     }
 
     /// <https://html.spec.whatwg.org/multipage/#check-validity-steps>
     fn check_validity(&self, can_gc: CanGc) -> bool {
-        if self.is_instance_validatable() && !self.satisfies_constraints() {
+        if self.is_instance_validatable() && !self.satisfies_constraints(can_gc) {
             self.as_element()
                 .upcast::<EventTarget>()
                 .fire_cancelable_event(atom!("invalid"), can_gc);
@@ -59,7 +57,7 @@ pub(crate) trait Validatable {
             return true;
         }
 
-        if self.satisfies_constraints() {
+        if self.satisfies_constraints(can_gc) {
             return true;
         }
 


### PR DESCRIPTION
add CanGc as argument to Validatable.satisfies_constraints

Testing: These changes do not require tests because they are a refactor.
Addresses part of https://github.com/servo/servo/issues/34573