### PR TITLE
add CanGc as argument to methods in HTMLLinkElement

### DIFF
--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -814,15 +814,16 @@ impl HTMLLinkElement {
     pub(crate) fn fire_event_after_response(
         &self,
         response: Result<ResourceFetchTiming, NetworkError>,
+        can_gc: CanGc,
     ) {
         // Step 3.1 If response is a network error, fire an event named error at el.
         // Otherwise, fire an event named load at el.
         if response.is_err() {
             self.upcast::<EventTarget>()
-                .fire_event(atom!("error"), CanGc::note());
+                .fire_event(atom!("error"), can_gc);
         } else {
             self.upcast::<EventTarget>()
-                .fire_event(atom!("load"), CanGc::note());
+                .fire_event(atom!("load"), can_gc);
         }
     }
 }

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -521,7 +521,8 @@ impl FetchResponseListener for LinkFetchContext {
         //
         // Part of Prefetch
         if let Some(link) = self.link.as_ref() {
-            link.root().fire_event_after_response(response_result);
+            link.root()
+                .fire_event_after_response(response_result, CanGc::note());
         }
     }
 


### PR DESCRIPTION
add CanGc as argument to methods in HTMLLinkElement

Testing: These changes do not require tests because they are a refactor.
Addresses part of https://github.com/servo/servo/issues/34573