### PR TITLE
add CanGc as argument to methods in HTMLMediaElement

### DIFF
--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -2909,11 +2909,11 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-media-played
-    fn Played(&self) -> DomRoot<TimeRanges> {
+    fn Played(&self, can_gc: CanGc) -> DomRoot<TimeRanges> {
         TimeRanges::new(
             self.global().as_window(),
             self.played.borrow().clone(),
-            CanGc::note(),
+            can_gc,
         )
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -414,7 +414,7 @@ DOMInterfaces = {
 },
 
 'HTMLMediaElement': {
-    'canGc': ['AddTextTrack', 'AudioTracks', 'Buffered', 'FastSeek','Load', 'Pause', 'Play', 'Seekable', 'SetCurrentTime', 'SetSrcObject', 'SetCrossOrigin', 'TextTracks', 'VideoTracks'],
+    'canGc': ['AddTextTrack', 'AudioTracks', 'Buffered', 'FastSeek','Load', 'Pause', 'Play', 'Played', 'Seekable', 'SetCurrentTime', 'SetSrcObject', 'SetCrossOrigin', 'TextTracks', 'VideoTracks'],
     'inRealms': ['Play'],
 },
 


### PR DESCRIPTION
add CanGc as argument to methods in HTMLMediaElement

Testing: These changes do not require tests because they are a refactor.
Addresses part of https://github.com/servo/servo/issues/34573