### PR TITLE
cargo: Update linebender crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,7 +1153,7 @@ dependencies = [
  "fonts",
  "futures-intrusive",
  "ipc-channel",
- "kurbo",
+ "kurbo 0.12.0",
  "log",
  "net_traits",
  "peniko",
@@ -1182,7 +1182,7 @@ dependencies = [
  "fonts_traits",
  "glow",
  "ipc-channel",
- "kurbo",
+ "kurbo 0.12.0",
  "malloc_size_of_derive",
  "pixels",
  "serde",
@@ -2150,7 +2150,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2560,7 +2560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2640,8 +2640,9 @@ dependencies = [
 
 [[package]]
 name = "fearless_simd"
-version = "0.2.0"
-source = "git+https://github.com/linebender/fearless_simd?rev=f25206a#f25206a4fe58a8f6daae157d63b1abdafb3a1be2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
 dependencies = [
  "bytemuck",
 ]
@@ -2711,9 +2712,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "font-types"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a596f5713680923a2080d86de50fe472fb290693cf0f701187a1c8b36996b7"
+checksum = "511e2c18a516c666d27867d2f9821f76e7d591f762e9fc41dd6cc5c90fe54b0b"
 dependencies = [
  "bytemuck",
 ]
@@ -3158,7 +3159,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps 7.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3717,6 +3718,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
  "serde",
 ]
@@ -4641,7 +4644,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4809,6 +4812,17 @@ checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
 dependencies = [
  "arrayvec",
  "euclid",
+ "smallvec",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
+dependencies = [
+ "arrayvec",
+ "euclid",
  "serde",
  "smallvec",
 ]
@@ -4833,7 +4847,7 @@ dependencies = [
  "icu_segmenter",
  "ipc-channel",
  "itertools 0.14.0",
- "kurbo",
+ "kurbo 0.12.0",
  "layout_api",
  "log",
  "malloc_size_of_derive",
@@ -5665,7 +5679,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6374,13 +6388,13 @@ dependencies = [
 
 [[package]]
 name = "peniko"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b44f9ddd2f480176b34278eb653ec1c8062f3b143a4e16eeff5ffac3334e288"
+checksum = "b3c76095c9a636173600478e0373218c7b955335048c2bcd12dc6a79657649d8"
 dependencies = [
  "bytemuck",
  "color",
- "kurbo",
+ "kurbo 0.12.0",
  "linebender_resource_handle",
  "smallvec",
 ]
@@ -6970,9 +6984,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.33.1"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ea612a55c08586a1d15134be8a776186c440c312ebda3b9e8efbfe4255b7f4"
+checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
  "font-types",
@@ -7165,7 +7179,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7315,7 +7329,7 @@ dependencies = [
  "itertools 0.14.0",
  "jstraceable_derive",
  "keyboard-types",
- "kurbo",
+ "kurbo 0.12.0",
  "layout_api",
  "libc",
  "log",
@@ -8098,9 +8112,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skrifa"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576e60c7de4bb6a803a0312f9bef17e78cf1e8d25a80e1ade76770d7a0237955"
+checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -8542,7 +8556,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
 dependencies = [
- "kurbo",
+ "kurbo 0.11.3",
  "siphasher",
 ]
 
@@ -8664,7 +8678,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9363,7 +9377,7 @@ dependencies = [
  "flate2",
  "fontdb",
  "imagesize",
- "kurbo",
+ "kurbo 0.11.3",
  "log",
  "pico-args",
  "roxmltree",
@@ -9447,8 +9461,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vello"
-version = "0.5.0"
-source = "git+https://github.com/linebender/vello?rev=fdf025a88dd00c546c8fc534697cbf21dac7e12d#fdf025a88dd00c546c8fc534697cbf21dac7e12d"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71acbd6b5f7f19841425845c113a89a54bbf60556ae39e7d0182a6f80ce37f5b"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
@@ -9465,11 +9480,13 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
-version = "0.0.1"
-source = "git+https://github.com/linebender/vello?rev=fdf025a88dd00c546c8fc534697cbf21dac7e12d#fdf025a88dd00c546c8fc534697cbf21dac7e12d"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a235ba928b3109ad9e7696270edb09445a52ae1c7c08e6d31a19b1cdd6cbc24a"
 dependencies = [
  "bytemuck",
  "fearless_simd",
+ "hashbrown",
  "log",
  "peniko",
  "png",
@@ -9479,8 +9496,9 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.1"
-source = "git+https://github.com/linebender/vello?rev=fdf025a88dd00c546c8fc534697cbf21dac7e12d#fdf025a88dd00c546c8fc534697cbf21dac7e12d"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0bd1fcf9c1814f17a491e07113623d44e3ec1125a9f3401f5e047d6d326da21"
 dependencies = [
  "bytemuck",
  "vello_common",
@@ -9488,8 +9506,9 @@ dependencies = [
 
 [[package]]
 name = "vello_encoding"
-version = "0.5.0"
-source = "git+https://github.com/linebender/vello?rev=fdf025a88dd00c546c8fc534697cbf21dac7e12d#fdf025a88dd00c546c8fc534697cbf21dac7e12d"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd5e0b9fec91df34a09fbcbbed474cec68d05691b590a911c7af83c4860ae42"
 dependencies = [
  "bytemuck",
  "guillotiere",
@@ -9500,8 +9519,9 @@ dependencies = [
 
 [[package]]
 name = "vello_shaders"
-version = "0.5.0"
-source = "git+https://github.com/linebender/vello?rev=fdf025a88dd00c546c8fc534697cbf21dac7e12d#fdf025a88dd00c546c8fc534697cbf21dac7e12d"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c381dde4e7d0d7957df0c0e3f8a7cc0976762d3972d97da5c71464e57ffefd3"
 dependencies = [
  "bytemuck",
  "log",
@@ -10194,7 +10214,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ ipc-channel = "0.20.2"
 itertools = "0.14"
 js = { package = "mozjs", git = "https://github.com/servo/mozjs" }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
-kurbo = { version = "0.11.3", features = ["euclid"] }
+kurbo = { version = "0.12", features = ["euclid"] }
 layout_api = { path = "components/shared/layout" }
 libc = "0.2"
 log = "0.4.27"
@@ -110,7 +110,7 @@ num-traits = "0.2"
 num_cpus = "1.17.0"
 openxr = "0.19"
 parking_lot = "0.12"
-peniko = "0.4"
+peniko = "0.5"
 percent-encoding = "2.3"
 proc-macro2 = "1"
 profile_traits = { path = "components/shared/profile" }
@@ -118,7 +118,7 @@ quote = "1"
 rand = "0.9"
 raw-window-handle = "0.6"
 rayon = "1"
-read-fonts = "0.33.1"
+read-fonts = "0.35.0"
 regex = "1.12"
 resvg = "0.45.0"
 rustc-hash = "2.1.1"
@@ -136,7 +136,7 @@ servo-media-dummy = { git = "https://github.com/servo/media" }
 servo-media-gstreamer = { git = "https://github.com/servo/media" }
 servo-tracing = { path = "components/servo_tracing" }
 servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-10-01" }
-skrifa = "0.35.0"
+skrifa = "0.37.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
 string_cache = "0.8"
@@ -169,8 +169,8 @@ unicode-segmentation = "1.12.0"
 url = "2.5"
 urlpattern = "0.3"
 uuid = { version = "1.18.1", features = ["v4", "v5"] }
-vello = { git = "https://github.com/linebender/vello", rev = "fdf025a88dd00c546c8fc534697cbf21dac7e12d" }
-vello_cpu = { git = "https://github.com/linebender/vello", rev = "fdf025a88dd00c546c8fc534697cbf21dac7e12d" }
+vello = "0.6"
+vello_cpu = "0.0.4"
 webdriver = "0.53.0"
 webgpu_traits = { path = "components/shared/webgpu" }
 webpki-roots = "1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -194,9 +194,6 @@ skip = [
     "toml_datetime",
     "toml_edit",
 
-    # blurmac
-    "objc2-encode",
-
     # usvg depends on svgtypes, which depends on old version of kurbo
     "kurbo",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -193,8 +193,14 @@ skip = [
     # really just a build dep, so not a large problem.
     "toml_datetime",
     "toml_edit",
+
+    # blurmac
+    "objc2-encode",
+
+    # usvg depends on svgtypes, which depends on old version of kurbo
+    "kurbo",
 ]
 
 # github.com organizations to allow git sources for
 [sources.allow-org]
-github = ["servo", "linebender"]
+github = ["servo"]

--- a/tests/wpt/meta/html/canvas/element/path-objects/2d.path.rect.selfintersect.html.ini
+++ b/tests/wpt/meta/html/canvas/element/path-objects/2d.path.rect.selfintersect.html.ini
@@ -1,4 +1,0 @@
-[2d.path.rect.selfintersect.html]
-  [Canvas test: 2d.path.rect.selfintersect]
-    bug: https://github.com/linebender/vello/issues/1063  #issuecomment-2998084736
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/path-objects/2d.path.stroke.scale2.html.ini
+++ b/tests/wpt/meta/html/canvas/element/path-objects/2d.path.stroke.scale2.html.ini
@@ -1,3 +1,0 @@
-[2d.path.stroke.scale2.html]
-  [Stroke line widths are scaled by the current transformation matrix]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/path-objects/2d.path.rect.selfintersect.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/path-objects/2d.path.rect.selfintersect.html.ini
@@ -1,3 +1,0 @@
-[2d.path.rect.selfintersect.html]
-  [OffscreenCanvas test: 2d.path.rect.selfintersect]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/path-objects/2d.path.rect.selfintersect.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/path-objects/2d.path.rect.selfintersect.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.path.rect.selfintersect.worker.html]
-  [2d]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/path-objects/2d.path.stroke.scale2.html.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/path-objects/2d.path.stroke.scale2.html.ini
@@ -1,3 +1,0 @@
-[2d.path.stroke.scale2.html]
-  [Stroke line widths are scaled by the current transformation matrix]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/offscreen/path-objects/2d.path.stroke.scale2.worker.js.ini
+++ b/tests/wpt/meta/html/canvas/offscreen/path-objects/2d.path.stroke.scale2.worker.js.ini
@@ -1,3 +1,0 @@
-[2d.path.stroke.scale2.worker.html]
-  [Stroke line widths are scaled by the current transformation matrix]
-    expected: FAIL


### PR DESCRIPTION
Bump various linebender crates (most importantly kurbo and peniko). We will now use released versions of both vello and vello_cpu. Unfortunately new kurbo is not yet in svgtypes (on which we depends via usvg), so for now we need to duplicate it, but all in all I still think this bump is worth it.

This PR is mostly mechanical. I will do follow up to better use new peniko/kurbo options.

Testing: It should be covered by existing WPT tests
try run: https://github.com/sagudev/servo/actions/runs/18817103076