### PR TITLE
CI: Let mac arm64 unit-tests also use nextest retries

### DIFF
--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -146,11 +146,9 @@ jobs:
         run: ./mach test-scripts
       - name: Unit tests
         if: ${{ inputs.unit-tests }}
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 40 # https://github.com/servo/servo/issues/30275
-          max_attempts: 3 # https://github.com/servo/servo/issues/30683
-          command: ./mach test-unit --${{ inputs.profile }}
+        env:
+          NEXTEST_RETRIES: 3 # https://github.com/servo/servo/issues/30683
+        run: ./mach test-unit --${{ inputs.profile }}
       - name: Devtools tests
         if: ${{ false && inputs.unit-tests }} # FIXME #39273
         run: ./mach test-devtools --${{ inputs.profile }}


### PR DESCRIPTION
The mac arm64 workflow was added after #39817, but we overlooked adding the change from #39817 to mac arm64. This PR fixes that, so we now consistently use the nextest retry mechanism for unit tests in CI.

Testing: Mac unitests in CI

