### PR TITLE
deps: Bump fontsan to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,8 +2818,8 @@ dependencies = [
 
 [[package]]
 name = "fontsan"
-version = "0.6.0"
-source = "git+https://github.com/servo/fontsan#212f15c9e36f701597847de94e1dafc9636bdf07"
+version = "0.6.1"
+source = "git+https://github.com/servo/fontsan#ec58e75f566648a256a4fe7264ea6ffa2b83f201"
 dependencies = [
  "cc",
  "fontsan-woff2",
@@ -2830,8 +2830,8 @@ dependencies = [
 
 [[package]]
 name = "fontsan-woff2"
-version = "0.1.0"
-source = "git+https://github.com/servo/fontsan#212f15c9e36f701597847de94e1dafc9636bdf07"
+version = "0.1.1"
+source = "git+https://github.com/servo/fontsan#ec58e75f566648a256a4fe7264ea6ffa2b83f201"
 dependencies = [
  "brotli-decompressor",
  "cc",


### PR DESCRIPTION
This fixes an issue when building servo with vendored dependencies. See https://github.com/servo/fontsan/pull/47.

Testing: Covered by existing CI tests. Offline build fix was manually tested offline build with `cargo vendor ../servo_vendor` and disconnected internet. 
Fixes: #40184
