### PR TITLE
Fix updating slottables when slots are removed from a shadowtree

### DIFF
--- a/tests/wpt/meta/shadow-dom/event-with-related-target.html.ini
+++ b/tests/wpt/meta/shadow-dom/event-with-related-target.html.ini
@@ -1,6 +1,0 @@
-[event-with-related-target.html]
-  [Firing an event at B1a with relatedNode at A1a (detached) with open mode shadow trees]
-    expected: FAIL
-
-  [Firing an event at B1a with relatedNode at A1a (detached) with closed mode shadow trees]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/imperative-slot-api-slotchange.html.ini
+++ b/tests/wpt/meta/shadow-dom/imperative-slot-api-slotchange.html.ini
@@ -1,10 +1,4 @@
 [imperative-slot-api-slotchange.html]
   expected: TIMEOUT
-  [Fire slotchange event when removing a slot from Shadows Root that changes its assigned nodes.]
-    expected: TIMEOUT
-
   [Fire slotchange event when assign node to nested slot, ensure event bubbles ups.]
     expected: TIMEOUT
-
-  [Signal a slot change should be done in tree order.]
-    expected: NOTRUN

--- a/tests/wpt/meta/shadow-dom/imperative-slot-api.html.ini
+++ b/tests/wpt/meta/shadow-dom/imperative-slot-api.html.ini
@@ -2,12 +2,6 @@
   [Assigning invalid nodes should be allowed.]
     expected: FAIL
 
-  [Moving a slot to a new host, the slot loses its previously assigned slottables.]
-    expected: FAIL
-
-  [Moving a slot's tree order position within a shadow host has no impact on its assigned slottables.]
-    expected: FAIL
-
   [Nodes can be assigned even if slots or nodes aren't in the same tree.]
     expected: FAIL
 

--- a/tests/wpt/meta/shadow-dom/slots-fallback.html.ini
+++ b/tests/wpt/meta/shadow-dom/slots-fallback.html.ini
@@ -1,3 +1,0 @@
-[slots-fallback.html]
-  [Slots fallback: Mutation.  Remove a slot which is a fallback content of another slot.]
-    expected: FAIL


### PR DESCRIPTION
We never cleared the containing shadowRoot when unbinding
a node, which meant that slots wouldn't update their
slottables.