### PR TITLE
rename `WorkerGlobalScope.get_worker_id` to `WorkerGlobalScope.worker_id`

### DIFF
--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -92,7 +92,7 @@ impl Console {
         if let Some(chan) = global.devtools_chan() {
             let worker_id = global
                 .downcast::<WorkerGlobalScope>()
-                .map(|worker| worker.get_worker_id());
+                .map(|worker| worker.worker_id());
             let devtools_message =
                 ScriptToDevtoolsControlMsg::ConsoleAPI(global.pipeline_id(), message, worker_id);
             chan.send(devtools_message).unwrap();

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -452,7 +452,7 @@ impl WorkerGlobalScope {
         self.worker_name.clone()
     }
 
-    pub(crate) fn get_worker_id(&self) -> WorkerId {
+    pub(crate) fn worker_id(&self) -> WorkerId {
         self.worker_id
     }
 


### PR DESCRIPTION
rename `WorkerGlobalScope.get_worker_id` to `WorkerGlobalScope.worker_id`

Testing: This is a simple rename. No testing is necessary, since compiler will complain if something is wrong.

Context: In https://github.com/servo/servo/pull/40156#discussion_r2462627713 I received feedback to use Rust getter name [convention](https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter) and avoid adding `get_` methods. I initially chose `get_worker_name()` to match existing `get_worker_id()` below it. Overall I think it does make sense to rename `get_worker_id()` to `worker_id()`.

`WorkerGlobalScope` has 2 more methods that start with `get_`: `get_cx(&self) -> JSContext` and `get_url`. `get_url` has a corresponding `set_url` as well in the same file. I am not sure if folks prefer to have those renamed as well or not, so I left those out of this PR, and instead started a discussion in a separate [issue](https://github.com/servo/servo/issues/40192) to figure out a consistent policy on Rust getter name convention in Servo codebase.
