### PR TITLE
script: Rephrase default error message for Error::Namespace

### DIFF
--- a/components/script/dom/domexception.rs
+++ b/components/script/dom/domexception.rs
@@ -122,7 +122,7 @@ impl DOMException {
             DOMErrorName::InvalidStateError => "The object is in an invalid state.",
             DOMErrorName::SyntaxError => "The string did not match the expected pattern.",
             DOMErrorName::InvalidModificationError => "The object can not be modified in this way.",
-            DOMErrorName::NamespaceError => "The operation is not allowed by Namespaces in XML.",
+            DOMErrorName::NamespaceError => "The operation is incorrect with regard to namespaces.",
             DOMErrorName::InvalidAccessError => {
                 "The object does not support the operation or argument."
             },


### PR DESCRIPTION
The current message mentions XML namespaces, which doesn't always make sense because namespace errors are not necessarily related to xml. 

Firefox uses
> An attempt was made to create or change an object in a way which is incorrect with regard to namespaces

which is phrased much more defensively.

I've used
> The operation is incorrect with regard to namespaces.

here because that matches the style of other existing messages better.
