### PR TITLE
Media: Change of Volume of video tag should passed to player

### DIFF
--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3006,7 +3006,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
         if *value != self.volume.get() {
             self.volume.set(*value);
-            if let Some(player) = &*self.player.borrow_mut() {
+            if let Some(player) = self.player.borrow().as_ref() {
                 let _ = player.lock().unwrap().set_volume(*value);
             }
             self.owner_global()

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3006,7 +3006,9 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
 
         if *value != self.volume.get() {
             self.volume.set(*value);
-
+            if let Some(player) = &*self.player.borrow_mut() {
+                let _ = player.lock().unwrap().set_volume(*value);
+            }
             self.owner_global()
                 .task_manager()
                 .media_element_task_source()


### PR DESCRIPTION
When changing the 'volume' attribute of media element, should also call `set_volume()` api of underlying player if it is valid value.

Testing: No Test is required, as this should not affect any WPT Test
Fixes: N/A
