### PR TITLE
layout: Show pointer cursor for submit input with text value

### DIFF
--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -156,6 +156,10 @@ input:not([type=radio i]):not([type=checkbox i]):not([type=reset i]):not([type=b
   white-space: pre;
 }
 
+input:is([type=submit i], [type=reset i], [type=button i], [type=checkbox i], [type=radio i]) {
+  cursor: default;
+}
+
 textarea {
   cursor: text;
   overflow: auto;


### PR DESCRIPTION
layout: Show pointer cursor for submit input with text value

Before:
<img width="976" height="261" alt="Screenshot 2025-10-26 at 8 51 39 PM" src="https://github.com/user-attachments/assets/1ee76a03-3817-4053-b6b0-d689ce1eac92" />


After:
<img width="985" height="253" alt="Screenshot 2025-10-26 at 8 54 19 PM" src="https://github.com/user-attachments/assets/06459bc7-94ed-4910-8e1d-c87dccb3880c" />


Testing: tested manually, as [suggested](https://github.com/servo/servo/issues/9084#issuecomment-3257188850) by @jdm.
Fixes: https://github.com/servo/servo/issues/9084
