### PR TITLE
wpt: avoid checking if worker is instanceof SharedWorker in abrupt-completion.html

### DIFF
--- a/tests/wpt/meta/workers/abrupt-completion.html.ini
+++ b/tests/wpt/meta/workers/abrupt-completion.html.ini
@@ -1,6 +1,3 @@
 [abrupt-completion.html]
-  [DedicatedWorker should correctly handle abrupt completion]
-    expected: FAIL
-
   [SharedWorker should correctly handle abrupt completion]
     expected: FAIL

--- a/tests/wpt/tests/workers/abrupt-completion.html
+++ b/tests/wpt/tests/workers/abrupt-completion.html
@@ -34,10 +34,10 @@ async function testWorker(worker) {
       resolve();
     };
 
-    if (worker instanceof SharedWorker) {
-      worker.port.postMessage("", [channel.port2]);
-    } else {
+    if ('onmessage' in worker) { // dedicated worker
       worker.postMessage("", [channel.port2]);
+    } else { // shared worker
+      worker.port.postMessage("", [channel.port2]);
     }
   });
 }


### PR DESCRIPTION
Since we don't implement SharedWorker this tests ended up failing also for the dedicate worker case, with this patch we resort to checking the existence of the onmessage property, making sure that we actually pass this test.

Testing: a new test pass for worker
