### PR TITLE
compositing: Stop down render backend before shutting down WebRender

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -267,6 +267,7 @@ impl PipelineDetails {
 
 impl Drop for ServoRenderer {
     fn drop(&mut self) {
+        self.webrender_api.stop_render_backend();
         self.webrender_api.shut_down(true);
     }
 }


### PR DESCRIPTION
This is a tentative fix for #40173. In this change we ensure to stop the
render backend before shutting down the WebRender API. Since I cannot
reproduce this problem locally, this is just an attempt to fix the
issue.

Testing: This should fix crashes observed with the unit tests.
Fixes: #40173.
