### PR TITLE
ImageCache: Replace IpcSharedMemory with the Image Cache owning the bytes.

### DIFF
--- a/components/pixels/snapshot.rs
+++ b/components/pixels/snapshot.rs
@@ -199,7 +199,7 @@ impl Snapshot {
         size: Size2D<u32>,
         format: SnapshotPixelFormat,
         alpha_mode: SnapshotAlphaMode,
-        data: Arc<IpcSharedMemory>,
+        data: Vec<u8>,
         byte_range_bounds: impl RangeBounds<usize>,
     ) -> Self {
         let range_start = match byte_range_bounds.start_bound() {
@@ -214,7 +214,7 @@ impl Snapshot {
         };
         Self {
             size,
-            data: SnapshotData::SharedMemory(data, range_start..range_end),
+            data: SnapshotData::Owned(data[range_start..range_end].to_vec()),
             format,
             alpha_mode,
         }

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -24,7 +24,7 @@ use fonts::{
     ByteIndex, FontBaseline, FontContext, FontGroup, FontIdentifier, FontMetrics, FontRef,
     LAST_RESORT_GLYPH_ADVANCE, ShapingFlags, ShapingOptions,
 };
-use ipc_channel::ipc;
+use ipc_channel::ipc::{self};
 use net_traits::image_cache::{ImageCache, ImageResponse};
 use net_traits::request::CorsSettings;
 use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
@@ -418,7 +418,8 @@ impl CanvasState {
             },
         };
 
-        Some(raster_image.as_snapshot())
+        let byte_store = self.image_cache.byte_store();
+        Some(raster_image.as_snapshot(&byte_store.reader()))
     }
 
     fn request_image_from_cache(

--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -538,14 +538,16 @@ impl ImageBitmap {
                 // (e.g., a vector graphic with no natural size), then queue
                 // a global task, using the bitmap task source, to reject promise
                 // with an "InvalidStateError" DOMException and abort these steps.
-                let Some(raster_image) = pixels::load_from_memory(&bytes, CorsStatus::Safe) else {
+
+                let image_cache = global_scope.image_cache();
+                let Some(img) = image_cache.load_from_memory(&bytes, CorsStatus::Safe) else {
                     reject_promise_on_bitmap_task_source(&p);
                     return p;
                 };
 
                 // Step 6.4. Set imageBitmap's bitmap data to imageData, cropped
                 // to the source rectangle with formatting.
-                let snapshot = raster_image.as_snapshot();
+                let snapshot = img.as_snapshot(&image_cache.byte_store().reader());
                 let Some(bitmap_data) =
                     ImageBitmap::crop_and_transform_bitmap_data(snapshot, sx, sy, sw, sh, options)
                 else {

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -218,7 +218,8 @@ impl HTMLImageElement {
             warn!("Vector image is not supported as raster image source");
             return None;
         };
-        Some(raster_image.as_snapshot())
+        let byte_store = self.owner_window().image_cache().byte_store();
+        Some(raster_image.as_snapshot(&byte_store.reader()))
     }
 }
 

--- a/components/script/image_animation.rs
+++ b/components/script/image_animation.rs
@@ -67,8 +67,10 @@ impl ImageAnimationManager {
                 }
 
                 let image = &state.image;
-                let (descriptor, ipc_shared_memory) =
-                    image.webrender_image_descriptor_and_data_for_frame(state.active_frame);
+                let reader = window.image_cache().byte_store();
+                let reader = reader.reader();
+                let (descriptor, ipc_shared_memory) = image
+                    .webrender_image_descriptor_and_data_for_frame(state.active_frame, &reader);
 
                 Some(ImageUpdate::UpdateImage(
                     image.id.unwrap(),

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -813,7 +813,6 @@ mod test {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use ipc_channel::ipc::IpcSharedMemory;
     use pixels::{CorsStatus, ImageFrame, ImageMetadata, PixelFormat, RasterImage};
 
     use crate::ImageAnimationState;
@@ -835,7 +834,7 @@ mod test {
             },
             format: PixelFormat::BGRA8,
             id: None,
-            bytes: Arc::new(IpcSharedMemory::from_byte(1, 1)),
+            index: pixels::ImageByteStorageIndex::mock_for_testing(),
             frames: image_frames,
             cors_status: CorsStatus::Unsafe,
             is_opaque: false,

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -10,7 +10,7 @@ use ipc_channel::ipc::IpcSender;
 use log::debug;
 use malloc_size_of::MallocSizeOfOps;
 use malloc_size_of_derive::MallocSizeOf;
-use pixels::{CorsStatus, ImageMetadata, RasterImage};
+use pixels::{CorsStatus, ImageByteStorage, ImageMetadata, RasterImage};
 use profile_traits::mem::Report;
 use serde::{Deserialize, Serialize};
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -240,4 +240,10 @@ pub trait ImageCache: Sync + Send {
 
     /// Fills the image cache with a batch of keys.
     fn fill_key_cache_with_batch_of_keys(&self, image_keys: Vec<ImageKey>);
+
+    /// Get a reference to the ImageByteStore.
+    fn byte_store(&self) -> Arc<ImageByteStorage>;
+
+    /// Load an image from memory, storing it in the cache.
+    fn load_from_memory(&self, buffer: &[u8], cors_status: CorsStatus) -> Option<RasterImage>;
 }


### PR DESCRIPTION
This replaces the RasterImage::bytes which was IpcSharedMemory to the ImageCache having ImageByteStorage which is a RwLock<Vec<Vec<u8>>>.
The RasterImage now only owns the opaque type ImageByteStorageIndex and queries the ImageCache via various methods to get the bytes when needed.
We also give appropriate Reader and Writer structs to encapsulate the handling.

This introduces some more locking but I think the tradeoff is worth it.

Testing: Websites still work and WPT should find out everything else.
Fixes: We currently have one File descriptor per image which means we easily exhaust them.
