### PR TITLE
libservo: Expose `WebViewPoint` / `WebViewRect` and use them for the API

### DIFF
--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -13,7 +13,7 @@ use servo::{
 use tracing::warn;
 use url::Url;
 use webrender_api::ScrollLocation;
-use webrender_api::units::{DeviceIntPoint, DevicePixel, LayoutVector2D};
+use webrender_api::units::{DevicePixel, DevicePoint, LayoutVector2D};
 use winit::application::ApplicationHandler;
 use winit::dpi::PhysicalSize;
 use winit::event::{MouseScrollDelta, WindowEvent};
@@ -162,7 +162,7 @@ impl ApplicationHandler<WakerEvent> for App {
                         };
                         webview.notify_scroll_event(
                             ScrollLocation::Delta(moved_by),
-                            DeviceIntPoint::new(10, 10),
+                            DevicePoint::new(10.0, 10.0).into(),
                         );
                     }
                 }

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -22,6 +22,7 @@ use webrender_api::units::{DeviceIntSize, DevicePoint};
 use crate::common::{ServoTest, WebViewDelegateImpl, evaluate_javascript};
 
 fn click_at_point(webview: &WebView, point: DevicePoint) {
+    let point = point.into();
     webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point)));
     webview.notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
         MouseButtonAction::Down,
@@ -197,9 +198,9 @@ fn test_cursor_change() {
     let captured_delegate = delegate.clone();
     servo_test.spin(move || !captured_delegate.new_frame_ready.get());
 
-    webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(Point2D::new(
-        10., 10.,
-    ))));
+    webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(
+        DevicePoint::new(10., 10.).into(),
+    )));
 
     let captured_delegate = delegate.clone();
     servo_test.spin(move || !captured_delegate.cursor_changed.get());

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -15,7 +15,7 @@ use dpi::PhysicalSize;
 use embedder_traits::{
     Cursor, Image, InputEvent, InputEventAndId, InputEventId, JSValue, JavaScriptEvaluationError,
     LoadStatus, MediaSessionActionType, ScreenGeometry, ScreenshotCaptureError, Theme, TraversalId,
-    ViewportDetails,
+    ViewportDetails, WebViewPoint, WebViewRect,
 };
 use euclid::{Point2D, Scale, Size2D};
 use image::RgbaImage;
@@ -23,7 +23,7 @@ use servo_geometry::DeviceIndependentPixel;
 use style_traits::CSSPixel;
 use url::Url;
 use webrender_api::ScrollLocation;
-use webrender_api::units::{DeviceIntPoint, DevicePixel, DevicePoint, DeviceRect};
+use webrender_api::units::{DevicePixel, DevicePoint, DeviceRect};
 
 use crate::clipboard_delegate::{ClipboardDelegate, DefaultClipboardDelegate};
 use crate::javascript_evaluator::JavaScriptEvaluator;
@@ -470,7 +470,7 @@ impl WebView {
 
     /// Ask the [`WebView`] to scroll web content. Note that positive scroll offsets reveal more
     /// content on the bottom and right of the page.
-    pub fn notify_scroll_event(&self, location: ScrollLocation, point: DeviceIntPoint) {
+    pub fn notify_scroll_event(&self, location: ScrollLocation, point: WebViewPoint) {
         self.inner()
             .compositor
             .borrow_mut()
@@ -634,7 +634,7 @@ impl WebView {
     /// operation.
     pub fn take_screenshot(
         &self,
-        rect: Option<DeviceRect>,
+        rect: Option<WebViewRect>,
         callback: impl FnOnce(Result<RgbaImage, ScreenshotCaptureError>) + 'static,
     ) {
         self.inner()

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -9,7 +9,8 @@ use keyboard_types::{Code, CompositionEvent, Key, KeyState, Location, Modifiers}
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use webrender_api::ExternalScrollId;
-use webrender_api::units::DevicePoint;
+
+use crate::WebViewPoint;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct InputEventId(usize);
@@ -75,7 +76,7 @@ pub enum EditingActionEvent {
 }
 
 impl InputEvent {
-    pub fn point(&self) -> Option<DevicePoint> {
+    pub fn point(&self) -> Option<WebViewPoint> {
         match self {
             InputEvent::EditingAction(..) => None,
             InputEvent::Gamepad(..) => None,
@@ -136,11 +137,11 @@ impl KeyboardEvent {
 pub struct MouseButtonEvent {
     pub action: MouseButtonAction,
     pub button: MouseButton,
-    pub point: DevicePoint,
+    pub point: WebViewPoint,
 }
 
 impl MouseButtonEvent {
-    pub fn new(action: MouseButtonAction, button: MouseButton, point: DevicePoint) -> Self {
+    pub fn new(action: MouseButtonAction, button: MouseButton, point: WebViewPoint) -> Self {
         Self {
             action,
             button,
@@ -197,11 +198,11 @@ pub enum MouseButtonAction {
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct MouseMoveEvent {
-    pub point: DevicePoint,
+    pub point: WebViewPoint,
 }
 
 impl MouseMoveEvent {
-    pub fn new(point: DevicePoint) -> Self {
+    pub fn new(point: WebViewPoint) -> Self {
         Self { point }
     }
 }
@@ -234,13 +235,13 @@ pub struct TouchId(pub i32);
 pub struct TouchEvent {
     pub event_type: TouchEventType,
     pub id: TouchId,
-    pub point: DevicePoint,
+    pub point: WebViewPoint,
     /// cancelable default value is true, once the first move has been processed by script disable it.
     cancelable: bool,
 }
 
 impl TouchEvent {
-    pub fn new(event_type: TouchEventType, id: TouchId, point: DevicePoint) -> Self {
+    pub fn new(event_type: TouchEventType, id: TouchId, point: WebViewPoint) -> Self {
         TouchEvent {
             event_type,
             id,
@@ -287,11 +288,11 @@ pub struct WheelDelta {
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct WheelEvent {
     pub delta: WheelDelta,
-    pub point: DevicePoint,
+    pub point: WebViewPoint,
 }
 
 impl WheelEvent {
-    pub fn new(delta: WheelDelta, point: DevicePoint) -> Self {
+    pub fn new(delta: WheelDelta, point: WebViewPoint) -> Self {
         WheelEvent { delta, point }
     }
 }

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -10,8 +10,9 @@ use base::id::BrowsingContextId;
 use crossbeam_channel::Select;
 use embedder_traits::{
     InputEvent, KeyboardEvent, MouseButtonAction, MouseButtonEvent, MouseMoveEvent,
-    WebDriverCommandMsg, WebDriverScriptCommand, WheelDelta, WheelEvent, WheelMode,
+    WebDriverCommandMsg, WebDriverScriptCommand, WebViewPoint, WheelDelta, WheelEvent, WheelMode,
 };
+use euclid::Point2D;
 use ipc_channel::ipc;
 use keyboard_types::webdriver::KeyInputState;
 use log::info;
@@ -24,7 +25,6 @@ use webdriver::actions::{
 };
 use webdriver::command::ActionsParameters;
 use webdriver::error::{ErrorStatus, WebDriverError};
-use webrender_api::units::DevicePoint;
 
 use crate::{Handler, VerifyBrowsingContextIsOpen, WebElement, wait_for_ipc_response};
 
@@ -369,7 +369,7 @@ impl Handler {
         self.send_blocking_input_event_to_embedder(InputEvent::MouseButton(MouseButtonEvent::new(
             MouseButtonAction::Down,
             action.button.into(),
-            DevicePoint::new(x as f32, y as f32),
+            WebViewPoint::Page(Point2D::new(x as f32, y as f32)),
         )));
 
         // Step 17. Return success with data null.
@@ -405,7 +405,7 @@ impl Handler {
         self.send_blocking_input_event_to_embedder(InputEvent::MouseButton(MouseButtonEvent::new(
             MouseButtonAction::Up,
             action.button.into(),
-            DevicePoint::new(x as f32, y as f32),
+            WebViewPoint::Page(Point2D::new(x as f32, y as f32)),
         )));
 
         // Step 8. Return success with data null.
@@ -522,9 +522,8 @@ impl Handler {
             if x != current_x || y != current_y || last {
                 // Step 7.1. Let buttons be equal to input state's buttons property.
                 // Step 7.2. Perform implementation-specific action dispatch steps
-                let input_event = InputEvent::MouseMove(MouseMoveEvent::new(DevicePoint::new(
-                    x as f32, y as f32,
-                )));
+                let point = WebViewPoint::Page(Point2D::new(x as f32, y as f32));
+                let input_event = InputEvent::MouseMove(MouseMoveEvent::new(point));
                 if last {
                     self.send_blocking_input_event_to_embedder(input_event);
                 } else {
@@ -690,7 +689,7 @@ impl Handler {
                     z: 0.0,
                     mode: WheelMode::DeltaPixel,
                 };
-                let point = DevicePoint::new(x as f32, y as f32);
+                let point = WebViewPoint::Page(Point2D::new(x as f32, y as f32));
                 let input_event = InputEvent::Wheel(WheelEvent::new(delta, point));
                 if last {
                     self.send_blocking_input_event_to_embedder(input_event);

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -482,7 +482,7 @@ impl App {
                                     -delta.x as f32,
                                     -delta.y as f32,
                                 ));
-                                Some((scroll_location, point.to_i32()))
+                                Some((scroll_location, *point))
                             },
                             _ => None,
                         };
@@ -557,8 +557,7 @@ impl App {
                         }
                         continue;
                     };
-                    let rect =
-                        rect.map(|rect| rect.to_box2d() * webview.device_pixels_per_css_pixel());
+                    let rect = rect.map(|rect| rect.to_box2d().into());
                     webview.take_screenshot(rect, move |result| {
                         if let Err(error) = result_sender.send(result) {
                             warn!("Failed to send response to TakeScreenshot: {error}");

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -21,7 +21,9 @@ use servo::servo_geometry::{
     DeviceIndependentIntRect, DeviceIndependentPixel, convert_rect_to_css_pixel,
 };
 use servo::webrender_api::ScrollLocation;
-use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel};
+use servo::webrender_api::units::{
+    DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint,
+};
 use servo::{
     Cursor, ImeEvent, InputEvent, InputEventId, InputEventResult, InputMethodControl, Key,
     KeyState, KeyboardEvent, Modifiers, MouseButton as ServoMouseButton, MouseButtonAction,
@@ -260,7 +262,7 @@ impl Window {
         webview.notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
             action,
             mouse_button,
-            point,
+            point.into(),
         )));
     }
 
@@ -291,7 +293,7 @@ impl Window {
             return;
         }
 
-        webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point)));
+        webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point.into())));
     }
 
     /// Handle key events before sending them to Servo.
@@ -684,15 +686,15 @@ impl WindowPortsMethods for Window {
                 }
 
                 // Send events
-                webview.notify_input_event(InputEvent::Wheel(WheelEvent::new(delta, point)));
+                webview.notify_input_event(InputEvent::Wheel(WheelEvent::new(delta, point.into())));
                 let scroll_location = ScrollLocation::Delta(-Vector2D::new(dx as f32, dy as f32));
-                webview.notify_scroll_event(scroll_location, point.to_i32());
+                webview.notify_scroll_event(scroll_location, point.into());
             },
             WindowEvent::Touch(touch) => {
                 webview.notify_input_event(InputEvent::Touch(TouchEvent::new(
                     winit_phase_to_touch_event_type(touch.phase),
                     TouchId(touch.id as i32),
-                    Point2D::new(touch.location.x as f32, touch.location.y as f32),
+                    DevicePoint::new(touch.location.x as f32, touch.location.y as f32).into(),
                 )));
             },
             WindowEvent::PinchGesture { delta, .. } => {
@@ -992,7 +994,7 @@ impl TouchEventSimulator {
         webview: &WebView,
         button: MouseButton,
         action: ElementState,
-        point: Point2D<f32, DevicePixel>,
+        point: DevicePoint,
     ) -> bool {
         if button != MouseButton::Left {
             return false;
@@ -1002,14 +1004,14 @@ impl TouchEventSimulator {
             webview.notify_input_event(InputEvent::Touch(TouchEvent::new(
                 TouchEventType::Down,
                 TouchId(0),
-                point,
+                point.into(),
             )));
             self.left_mouse_button_down.set(true);
         } else if action == ElementState::Released {
             webview.notify_input_event(InputEvent::Touch(TouchEvent::new(
                 TouchEventType::Up,
                 TouchId(0),
-                point,
+                point.into(),
             )));
             self.left_mouse_button_down.set(false);
         }
@@ -1029,7 +1031,7 @@ impl TouchEventSimulator {
         webview.notify_input_event(InputEvent::Touch(TouchEvent::new(
             TouchEventType::Move,
             TouchId(0),
-            point,
+            point.into(),
         )));
         true
     }

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -270,7 +270,9 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_scroll<'local>(
     y: jint,
 ) {
     debug!("scroll");
-    call(&mut env, |s| s.scroll(dx as f32, dy as f32, x, y));
+    call(&mut env, |s| {
+        s.scroll(dx as f32, dy as f32, x as f32, y as f32)
+    });
 }
 
 enum KeyCode {

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -618,11 +618,11 @@ impl RunningAppState {
     /// Scroll.
     /// x/y are scroll coordinates.
     /// dx/dy are scroll deltas.
-    pub fn scroll(&self, dx: f32, dy: f32, x: i32, y: i32) {
-        let delta = Vector2D::new(dx, dy);
-        let scroll_location = ScrollLocation::Delta(delta);
+    pub fn scroll(&self, dx: f32, dy: f32, x: f32, y: f32) {
+        let scroll_location = ScrollLocation::Delta(Vector2D::new(dx, dy));
+        let point = DevicePoint::new(x, y).into();
         self.active_webview()
-            .notify_scroll_event(scroll_location, Point2D::new(x, y));
+            .notify_scroll_event(scroll_location, point);
         self.perform_updates();
     }
 
@@ -797,7 +797,7 @@ impl RunningAppState {
             .notify_input_event(InputEvent::Touch(TouchEvent::new(
                 TouchEventType::Down,
                 TouchId(pointer_id),
-                Point2D::new(x, y),
+                DevicePoint::new(x, y).into(),
             )));
         self.perform_updates();
     }
@@ -808,7 +808,7 @@ impl RunningAppState {
             .notify_input_event(InputEvent::Touch(TouchEvent::new(
                 TouchEventType::Move,
                 TouchId(pointer_id),
-                Point2D::new(x, y),
+                DevicePoint::new(x, y).into(),
             )));
         self.perform_updates();
     }
@@ -819,7 +819,7 @@ impl RunningAppState {
             .notify_input_event(InputEvent::Touch(TouchEvent::new(
                 TouchEventType::Up,
                 TouchId(pointer_id),
-                Point2D::new(x, y),
+                DevicePoint::new(x, y).into(),
             )));
         self.perform_updates();
     }
@@ -830,7 +830,7 @@ impl RunningAppState {
             .notify_input_event(InputEvent::Touch(TouchEvent::new(
                 TouchEventType::Cancel,
                 TouchId(pointer_id),
-                Point2D::new(x, y),
+                DevicePoint::new(x, y).into(),
             )));
         self.perform_updates();
     }
@@ -838,9 +838,9 @@ impl RunningAppState {
     /// Register a mouse movement.
     pub fn mouse_move(&self, x: f32, y: f32) {
         self.active_webview()
-            .notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(Point2D::new(
-                x, y,
-            ))));
+            .notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(
+                DevicePoint::new(x, y).into(),
+            )));
         self.perform_updates();
     }
 
@@ -850,7 +850,7 @@ impl RunningAppState {
             .notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
                 MouseButtonAction::Down,
                 button,
-                Point2D::new(x, y),
+                DevicePoint::new(x, y).into(),
             )));
         self.perform_updates();
     }
@@ -861,7 +861,7 @@ impl RunningAppState {
             .notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
                 MouseButtonAction::Up,
                 button,
-                Point2D::new(x, y),
+                DevicePoint::new(x, y).into(),
             )));
         self.perform_updates();
     }


### PR DESCRIPTION
This change exposes two new data types in the API, which allow embedders
to supply coordinates in either page pixels or device pixels. In
particular, WebDriver wants to give coordiantes to the API in page
pixels. This prevents the embedder from having to do these conversions
and makes it harder to misuse the API.

Testing: This should fix WebDriver conformance tests that are run in headed mode.
Fixes: #40152
