### PR TITLE
indexeddb: Rework transaction system

### DIFF
--- a/components/script/dom/domstringlist.rs
+++ b/components/script/dom/domstringlist.rs
@@ -36,6 +36,10 @@ impl DOMStringList {
             can_gc,
         )
     }
+
+    pub(crate) fn strings(&self) -> &Vec<DOMString> {
+        &self.strings
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/#domstringlist


### PR DESCRIPTION
Stores state of transactions and shares it. Allows transactions to be scheduled using a channel directly, instead of a channel + a `VecDeque`, leading to performance improvements in the indexeddb thread, since it now doesn't care for async operations at all.

Testing: Refactor, covered by WPT
Known issues: No transaction scheduling