### PR TITLE
ci: Extract fast checkout steps into composite action

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -96,7 +96,7 @@ jobs:
     name: Bencher (${{ inputs.target }}) [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@main
+      - uses: servo/ci-runners/actions/checkout@59aba6fdaa43f0336329918e18b9f6fd1996b487
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-${{ inputs.target }}

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -96,7 +96,7 @@ jobs:
     name: Bencher (${{ inputs.target }}) [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@59aba6fdaa43f0336329918e18b9f6fd1996b487
+      - uses: servo/ci-runners/actions/checkout@78f4b65e1be542d0e9d84c65a0fcc35529e7b29f
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-${{ inputs.target }}

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -96,26 +96,7 @@ jobs:
     name: Bencher (${{ inputs.target }}) [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: actions/checkout@v4
-        if: ${{ runner.environment != 'self-hosted' && github.event_name != 'pull_request_target' }}
-      # This is necessary to checkout the pull request if this run was triggered via a
-      # `pull_request_target` event.
-      - uses: actions/checkout@v4
-        if: ${{ runner.environment != 'self-hosted' && github.event_name == 'pull_request_target' }}
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      # Faster checkout for self-hosted runner that uses prebaked repo.
-      - if: ${{ runner.environment == 'self-hosted' && github.event_name != 'pull_request_target' }}
-        run: git fetch --depth=1 origin $GITHUB_SHA
-      - if: ${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request_target' }}
-        run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
-      - if: ${{ runner.environment == 'self-hosted' }}
-        # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
-        # trees, in case the runner image was baked with a dirty working tree.
-        run: |
-          git switch --detach
-          git reset --hard FETCH_HEAD
-
+      - uses: servo/actions/fast-checkout@fast-checkout
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-${{ inputs.target }}

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -96,7 +96,7 @@ jobs:
     name: Bencher (${{ inputs.target }}) [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@78f4b65e1be542d0e9d84c65a0fcc35529e7b29f
+      - uses: servo/ci-runners/actions/checkout@0b9edd49381b22c14e5b123f21377269864ddf54
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-${{ inputs.target }}

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -96,7 +96,7 @@ jobs:
     name: Bencher (${{ inputs.target }}) [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/actions/fast-checkout@fast-checkout
+      - uses: servo/ci-runners/actions/checkout@main
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-${{ inputs.target }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,7 @@ jobs:
     name: Lint [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@59aba6fdaa43f0336329918e18b9f6fd1996b487
+      - uses: servo/ci-runners/actions/checkout@78f4b65e1be542d0e9d84c65a0fcc35529e7b29f
         with:
           fetch-depth: 2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,28 +61,9 @@ jobs:
     name: Lint [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: actions/checkout@v4
-        if: ${{ runner.environment != 'self-hosted' && github.event_name != 'pull_request_target' }}
+      - uses: servo/actions/fast-checkout@fast-checkout
         with:
-          fetch-depth: 2 # This is necessary for `test-tidy`.
-      # This is necessary to checkout the pull request if this run was triggered via a
-      # `pull_request_target` event.
-      - uses: actions/checkout@v4
-        if: ${{ runner.environment != 'self-hosted' && github.event_name == 'pull_request_target' }}
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 2 # This is necessary for `test-tidy`.
-      # Faster checkout for self-hosted runner that uses prebaked repo.
-      - if: ${{ runner.environment == 'self-hosted' && github.event_name != 'pull_request_target' }}
-        run: git fetch --depth=2 origin $GITHUB_SHA  # The depth is necessary for `test-tidy`.
-      - if: ${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request_target' }}
-        run: git fetch --depth=2 origin ${{ github.event.pull_request.head.sha }}  # The depth is necessary for `test-tidy`.
-      - if: ${{ runner.environment == 'self-hosted' }}
-        # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
-        # trees, in case the runner image was baked with a dirty working tree.
-        run: |
-          git switch --detach
-          git reset --hard FETCH_HEAD
+          fetch-depth: 2
 
       - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,7 @@ jobs:
     name: Lint [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/actions/fast-checkout@fast-checkout
+      - uses: servo/ci-runners/actions/checkout@main
         with:
           fetch-depth: 2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,7 @@ jobs:
     name: Lint [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@main
+      - uses: servo/ci-runners/actions/checkout@59aba6fdaa43f0336329918e18b9f6fd1996b487
         with:
           fetch-depth: 2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,7 @@ jobs:
     name: Lint [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@78f4b65e1be542d0e9d84c65a0fcc35529e7b29f
+      - uses: servo/ci-runners/actions/checkout@0b9edd49381b22c14e5b123f21377269864ddf54
         with:
           fetch-depth: 2
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -152,7 +152,7 @@ jobs:
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@78f4b65e1be542d0e9d84c65a0fcc35529e7b29f
+      - uses: servo/ci-runners/actions/checkout@0b9edd49381b22c14e5b123f21377269864ddf54
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}
@@ -343,7 +343,7 @@ jobs:
     runs-on: ${{ needs.runner-select-coverage.outputs.selected-runner-label }}
     continue-on-error: true
     steps:
-      - uses: servo/ci-runners/actions/checkout@78f4b65e1be542d0e9d84c65a0fcc35529e7b29f
+      - uses: servo/ci-runners/actions/checkout@0b9edd49381b22c14e5b123f21377269864ddf54
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -152,7 +152,7 @@ jobs:
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@main
+      - uses: servo/ci-runners/actions/checkout@59aba6fdaa43f0336329918e18b9f6fd1996b487
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}
@@ -343,7 +343,7 @@ jobs:
     runs-on: ${{ needs.runner-select-coverage.outputs.selected-runner-label }}
     continue-on-error: true
     steps:
-      - uses: servo/ci-runners/actions/checkout@main
+      - uses: servo/ci-runners/actions/checkout@59aba6fdaa43f0336329918e18b9f6fd1996b487
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -152,7 +152,7 @@ jobs:
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/actions/fast-checkout@fast-checkout
+      - uses: servo/ci-runners/actions/checkout@main
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}
@@ -343,7 +343,7 @@ jobs:
     runs-on: ${{ needs.runner-select-coverage.outputs.selected-runner-label }}
     continue-on-error: true
     steps:
-      - uses: servo/actions/fast-checkout@fast-checkout
+      - uses: servo/ci-runners/actions/checkout@main
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -152,26 +152,7 @@ jobs:
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: actions/checkout@v4
-        if: ${{ runner.environment != 'self-hosted' && github.event_name != 'pull_request_target' }}
-      # This is necessary to checkout the pull request if this run was triggered via a
-      # `pull_request_target` event.
-      - uses: actions/checkout@v4
-        if: ${{ runner.environment != 'self-hosted' && github.event_name == 'pull_request_target' }}
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      # Faster checkout for self-hosted runner that uses prebaked repo.
-      - if: ${{ runner.environment == 'self-hosted' && github.event_name != 'pull_request_target' }}
-        run: git fetch --depth=1 origin $GITHUB_SHA
-      - if: ${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request_target' }}
-        run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
-      - if: ${{ runner.environment == 'self-hosted' }}
-        # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
-        # trees, in case the runner image was baked with a dirty working tree.
-        run: |
-          git switch --detach
-          git reset --hard FETCH_HEAD
+      - uses: servo/actions/fast-checkout@fast-checkout
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}
@@ -362,25 +343,7 @@ jobs:
     runs-on: ${{ needs.runner-select-coverage.outputs.selected-runner-label }}
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-        if: ${{ runner.environment != 'self-hosted' && github.event_name != 'pull_request_target' }}
-      # This is necessary to checkout the pull request if this run was triggered via a
-      # `pull_request_target` event.
-      - uses: actions/checkout@v4
-        if: ${{ runner.environment != 'self-hosted' && github.event_name == 'pull_request_target' }}
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      # Faster checkout for self-hosted runner that uses prebaked repo.
-      - if: ${{ runner.environment == 'self-hosted' && github.event_name != 'pull_request_target' }}
-        run: git fetch --depth=1 origin $GITHUB_SHA
-      - if: ${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request_target' }}
-        run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
-      - if: ${{ runner.environment == 'self-hosted' }}
-        # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
-        # trees, in case the runner image was baked with a dirty working tree.
-        run: |
-          git switch --detach
-          git reset --hard FETCH_HEAD
+      - uses: servo/actions/fast-checkout@fast-checkout
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -152,7 +152,7 @@ jobs:
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@59aba6fdaa43f0336329918e18b9f6fd1996b487
+      - uses: servo/ci-runners/actions/checkout@78f4b65e1be542d0e9d84c65a0fcc35529e7b29f
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}
@@ -343,7 +343,7 @@ jobs:
     runs-on: ${{ needs.runner-select-coverage.outputs.selected-runner-label }}
     continue-on-error: true
     steps:
-      - uses: servo/ci-runners/actions/checkout@59aba6fdaa43f0336329918e18b9f6fd1996b487
+      - uses: servo/ci-runners/actions/checkout@78f4b65e1be542d0e9d84c65a0fcc35529e7b29f
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -138,25 +138,7 @@ jobs:
       - name: Kill XProtectBehaviorService
         run: |
           echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
-      - uses: actions/checkout@v4
-        if: runner.environment != 'self-hosted' && github.event_name != 'pull_request_target'
-      # This is necessary to checkout the pull request if this run was triggered via a
-      # `pull_request_target` event.
-      - uses: actions/checkout@v4
-        if: runner.environment != 'self-hosted' && github.event_name == 'pull_request_target'
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      # Faster checkout for self-hosted runner that uses prebaked repo.
-      - if: ${{ runner.environment == 'self-hosted' && github.event_name != 'pull_request_target' }}
-        run: git fetch --depth=1 origin $GITHUB_SHA
-      - if: ${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request_target' }}
-        run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
-      - if: ${{ runner.environment == 'self-hosted' }}
-        # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
-        # trees, in case the runner image was baked with a dirty working tree.
-        run: |
-          git switch --detach
-          git reset --hard FETCH_HEAD
+      - uses: servo/actions/fast-checkout@fast-checkout
 
       - if: runner.environment != 'self-hosted'
         name: Setup Python

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Kill XProtectBehaviorService
         run: |
           echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
-      - uses: servo/ci-runners/actions/checkout@78f4b65e1be542d0e9d84c65a0fcc35529e7b29f
+      - uses: servo/ci-runners/actions/checkout@0b9edd49381b22c14e5b123f21377269864ddf54
 
       - if: runner.environment != 'self-hosted'
         name: Setup Python

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Kill XProtectBehaviorService
         run: |
           echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
-      - uses: servo/ci-runners/actions/checkout@59aba6fdaa43f0336329918e18b9f6fd1996b487
+      - uses: servo/ci-runners/actions/checkout@78f4b65e1be542d0e9d84c65a0fcc35529e7b29f
 
       - if: runner.environment != 'self-hosted'
         name: Setup Python

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Kill XProtectBehaviorService
         run: |
           echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
-      - uses: servo/ci-runners/actions/checkout@main
+      - uses: servo/ci-runners/actions/checkout@59aba6fdaa43f0336329918e18b9f6fd1996b487
 
       - if: runner.environment != 'self-hosted'
         name: Setup Python

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Kill XProtectBehaviorService
         run: |
           echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
-      - uses: servo/actions/fast-checkout@fast-checkout
+      - uses: servo/ci-runners/actions/checkout@main
 
       - if: runner.environment != 'self-hosted'
         name: Setup Python

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -122,7 +122,7 @@ jobs:
     name: Windows Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@main
+      - uses: servo/ci-runners/actions/checkout@59aba6fdaa43f0336329918e18b9f6fd1996b487
 
       - name: ccache
         # FIXME: “Error: Restoring cache failed: Error: Unable to locate executable file: sh.”

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -122,7 +122,7 @@ jobs:
     name: Windows Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@59aba6fdaa43f0336329918e18b9f6fd1996b487
+      - uses: servo/ci-runners/actions/checkout@78f4b65e1be542d0e9d84c65a0fcc35529e7b29f
 
       - name: ccache
         # FIXME: “Error: Restoring cache failed: Error: Unable to locate executable file: sh.”

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -122,7 +122,7 @@ jobs:
     name: Windows Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/actions/fast-checkout@fast-checkout
+      - uses: servo/ci-runners/actions/checkout@main
 
       - name: ccache
         # FIXME: “Error: Restoring cache failed: Error: Unable to locate executable file: sh.”

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -122,7 +122,7 @@ jobs:
     name: Windows Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@78f4b65e1be542d0e9d84c65a0fcc35529e7b29f
+      - uses: servo/ci-runners/actions/checkout@0b9edd49381b22c14e5b123f21377269864ddf54
 
       - name: ccache
         # FIXME: “Error: Restoring cache failed: Error: Unable to locate executable file: sh.”

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -122,25 +122,7 @@ jobs:
     name: Windows Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - if: ${{ runner.environment != 'self-hosted' && github.event_name != 'pull_request_target' }}
-        uses: actions/checkout@v4
-      - if: ${{ runner.environment != 'self-hosted' && github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 1
-
-      # Faster checkout for self-hosted runner that uses prebaked repo.
-      - if: ${{ runner.environment == 'self-hosted' && github.event_name != 'pull_request_target' }}
-        run: git fetch --depth=1 origin $env:GITHUB_SHA
-      - if: ${{ runner.environment == 'self-hosted' && github.event_name == 'pull_request_target' }}
-        run: git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
-      - if: ${{ runner.environment == 'self-hosted' }}
-        # Same as `git switch --detach FETCH_HEAD`, but fixes up dirty working
-        # trees, in case the runner image was baked with a dirty working tree.
-        run: |
-          git switch --detach
-          git reset --hard FETCH_HEAD
+      - uses: servo/actions/fast-checkout@fast-checkout
 
       - name: ccache
         # FIXME: “Error: Restoring cache failed: Error: Unable to locate executable file: sh.”


### PR DESCRIPTION
this patch extracts the “faster checkout” steps we use for jobs that may run on self-hosted runners into a composite action. the action is stored in [servo/ci-runners](https://github.com/servo/ci-runners), to avoid an extra checkout step, and the action calls are locked to a commit, to avoid problems when making breaking changes.

while [servo/actions](https://github.com/servo/actions) is a reasonable place to store this action, i’m planning to document our self-hosted CI system and potentially make it usable by other projects, and this action is effectively part of that system. that said, actions in that repo will undergo [review](https://github.com/servo/ci-runners/commit/00deefd2be1ce9f8bb065157f42b37cba04780da) as if they were in this repo.

Testing:
- self-hosted: [windows](https://github.com/servo/servo/actions/runs/19125076579/job/54653625055#step:2:25), [lint](https://github.com/servo/servo/actions/runs/19125076579/job/54653630737#step:2:21)
- GitHub-hosted: [windows](https://github.com/delan/servo/actions/runs/19125003933/job/54653410264#step:2:25), [lint](https://github.com/delan/servo/actions/runs/19125003933/job/54653410010#step:2:21)