### PR TITLE
CI: Remove timeout from bootstrap dependencies step

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Change Mirror Priorities
         uses: ./.github/actions/apt-mirrors
       - name: Bootstrap dependencies
-        timeout-minutes: 10
         run: |
           sudo apt update
           sudo apt install -qy --no-install-recommends mesa-vulkan-drivers fonts-noto-cjk


### PR DESCRIPTION
Sometimes things are just slow.
