### PR TITLE
libservo: Use the embedder control API for simple dialogs

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -972,6 +972,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         let (sender, receiver) =
             ProfiledGenericChannel::channel(self.global().time_profiler_chan().clone()).unwrap();
         let dialog = SimpleDialog::Alert {
+            id: self.Document().embedder_controls().next_control_id(),
             message: message.to_string(),
             response_sender: sender,
         };
@@ -1004,6 +1005,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         let (sender, receiver) =
             ProfiledGenericChannel::channel(self.global().time_profiler_chan().clone()).unwrap();
         let dialog = SimpleDialog::Confirm {
+            id: self.Document().embedder_controls().next_control_id(),
             message: message.to_string(),
             response_sender: sender,
         };
@@ -1054,6 +1056,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         let (sender, receiver) =
             ProfiledGenericChannel::channel(self.global().time_profiler_chan().clone()).unwrap();
         let dialog = SimpleDialog::Prompt {
+            id: self.Document().embedder_controls().next_control_id(),
             message: message.to_string(),
             default: default.to_string(),
             response_sender: sender,

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -519,11 +519,12 @@ impl Servo {
                         .request_resize_to(webview, size.max(MINIMUM_WEBVIEW_SIZE));
                 }
             },
-            EmbedderMsg::ShowSimpleDialog(webview_id, prompt_definition) => {
+            EmbedderMsg::ShowSimpleDialog(webview_id, simple_dialog) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview
-                        .delegate()
-                        .show_simple_dialog(webview, prompt_definition);
+                    webview.delegate().show_embedder_control(
+                        webview,
+                        EmbedderControl::SimpleDialog(simple_dialog),
+                    );
                 }
             },
             EmbedderMsg::ShowContextMenu(webview_id, ipc_sender, title, items) => {

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -13,7 +13,7 @@ use euclid::{Point2D, Size2D};
 use servo::{
     Cursor, EmbedderControl, InputEvent, InputMethodType, JSValue, JavaScriptEvaluationError,
     LoadStatus, MouseButton, MouseButtonAction, MouseButtonEvent, MouseLeftViewportEvent,
-    MouseMoveEvent, Servo, Theme, WebView, WebViewBuilder, WebViewDelegate,
+    MouseMoveEvent, Servo, SimpleDialog, Theme, WebView, WebViewBuilder, WebViewDelegate,
 };
 use servo_config::prefs::Preferences;
 use url::Url;
@@ -463,4 +463,83 @@ fn test_show_and_hide_ime() {
     // The form control should be hidden when the field no longer has focus.
     let captured_delegate = delegate.clone();
     servo_test.spin(move || captured_delegate.number_of_controls_hidden.get() != 1);
+}
+
+#[test]
+fn test_alert_dialog() {
+    test_simple_dialog("window.alert('Alert');", |dialog| {
+        let SimpleDialog::Alert { .. } = dialog else {
+            unreachable!("Expected dialog to be a SimpleDialog::Alert");
+        };
+        assert_eq!(dialog.message(), "Alert");
+    });
+}
+
+#[test]
+fn test_prompt_dialog() {
+    test_simple_dialog("window.prompt('Prompt');", |dialog| {
+        let SimpleDialog::Prompt { .. } = dialog else {
+            unreachable!("Expected dialog to be a SimpleDialog::Prompt");
+        };
+        assert_eq!(dialog.message(), "Prompt");
+    });
+}
+
+#[test]
+fn test_confirm_dialog() {
+    test_simple_dialog("window.confirm('Confirm');", |dialog| {
+        let SimpleDialog::Confirm { .. } = dialog else {
+            unreachable!("Expected dialog to be a SimpleDialog::Confirm");
+        };
+        assert_eq!(dialog.message(), "Confirm");
+    });
+}
+
+// A helper function to share code among the dialog tests.
+//
+// `prompt` must be a string that can be used in the `onclick` attribute and therefore must
+// be escaped correctly. Use single quotes instead of double quotes for string literals.
+fn test_simple_dialog(prompt: &str, validate: impl Fn(&SimpleDialog)) {
+    let make_test_html = |prompt: &str| {
+        let html = format!(
+            "data:text/html,<!DOCTYPE html>\
+            <input type=\"button\" value=\"click\" style=\"width: 200px; height: 200px;\"\
+            onclick=\"{}\">",
+            prompt
+        );
+        Url::parse(&html).unwrap()
+    };
+
+    let servo_test = ServoTest::new();
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo())
+        .delegate(delegate.clone())
+        .url(make_test_html(prompt))
+        .build();
+
+    webview.focus();
+    webview.show(true);
+    webview.move_resize(servo_test.rendering_context.size2d().to_f32().into());
+
+    let load_webview = webview.clone();
+    servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+
+    // Wait for at least one frame after the load completes.
+    delegate.reset();
+    let captured_delegate = delegate.clone();
+    servo_test.spin(move || !captured_delegate.new_frame_ready.get());
+
+    // The dialog should NOT be shown.
+    assert!(delegate.active_dialog.borrow().is_none());
+
+    click_at_point(&webview, Point2D::new(100., 100.));
+    let captured_delegate = delegate.clone();
+    servo_test.spin(move || captured_delegate.active_dialog.borrow().is_none());
+
+    let active_dialog = delegate.active_dialog.borrow();
+    validate(
+        active_dialog
+            .as_ref()
+            .expect("the spin call above ensures this is not None"),
+    );
 }

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -160,18 +160,21 @@ pub enum SimpleDialog {
     /// [`alert()`](https://html.spec.whatwg.org/multipage/#dom-alert).
     /// TODO: Include details about the document origin.
     Alert {
+        id: EmbedderControlId,
         message: String,
         response_sender: GenericSender<AlertResponse>,
     },
     /// [`confirm()`](https://html.spec.whatwg.org/multipage/#dom-confirm).
     /// TODO: Include details about the document origin.
     Confirm {
+        id: EmbedderControlId,
         message: String,
         response_sender: GenericSender<ConfirmResponse>,
     },
     /// [`prompt()`](https://html.spec.whatwg.org/multipage/#dom-prompt).
     /// TODO: Include details about the document origin.
     Prompt {
+        id: EmbedderControlId,
         message: String,
         default: String,
         response_sender: GenericSender<PromptResponse>,
@@ -235,6 +238,14 @@ impl SimpleDialog {
             } => {
                 let _ = response_sender.send(PromptResponse::Ok(default.clone()));
             },
+        }
+    }
+
+    pub fn id(&self) -> EmbedderControlId {
+        match self {
+            SimpleDialog::Alert { id, .. } |
+            SimpleDialog::Confirm { id, .. } |
+            SimpleDialog::Prompt { id, .. } => *id,
         }
     }
 }

--- a/ports/servoshell/desktop/dialog.rs
+++ b/ports/servoshell/desktop/dialog.rs
@@ -230,6 +230,7 @@ impl Dialog {
             Dialog::SimpleDialog(SimpleDialog::Alert {
                 message,
                 response_sender,
+                ..
             }) => {
                 let mut is_open = true;
                 let modal = Modal::new("Alert".into());
@@ -255,6 +256,7 @@ impl Dialog {
             Dialog::SimpleDialog(SimpleDialog::Confirm {
                 message,
                 response_sender,
+                ..
             }) => {
                 let mut is_open = true;
                 let modal = Modal::new("Confirm".into());
@@ -290,6 +292,7 @@ impl Dialog {
                 // The `default` field gets reused as the input buffer.
                 default: input,
                 response_sender,
+                ..
             }) => {
                 let mut is_open = true;
                 Modal::new("Prompt".into()).show(ctx, |ui| {

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -556,6 +556,7 @@ impl HostTrait for HostCallbacks {
             SimpleDialog::Alert {
                 message,
                 response_sender,
+                ..
             } => {
                 debug!("SimpleDialog::Alert");
                 // TODO: Indicate that this message is untrusted, and what origin it came from.
@@ -565,6 +566,7 @@ impl HostTrait for HostCallbacks {
             SimpleDialog::Confirm {
                 message,
                 response_sender,
+                ..
             } => {
                 warn!("Confirm dialog not implemented. Cancelled. {}", message);
                 response_sender.send(Default::default())

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -312,13 +312,7 @@ impl WebViewDelegate for RunningAppState {
         }
     }
 
-    fn show_simple_dialog(&self, webview: WebView, dialog: SimpleDialog) {
-        self.callbacks
-            .host_callbacks
-            .show_simple_dialog(webview, dialog);
-    }
-
-    fn show_embedder_control(&self, _webview: WebView, embedder_control: EmbedderControl) {
+    fn show_embedder_control(&self, webview: WebView, embedder_control: EmbedderControl) {
         let control_id = embedder_control.id();
         match embedder_control {
             EmbedderControl::InputMethod(input_method_control) => {
@@ -327,6 +321,10 @@ impl WebViewDelegate for RunningAppState {
                     .host_callbacks
                     .on_ime_show(input_method_control);
             },
+            EmbedderControl::SimpleDialog(simple_dialog) => self
+                .callbacks
+                .host_callbacks
+                .show_simple_dialog(webview, simple_dialog),
             _ => {},
         }
     }

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -900,6 +900,7 @@ impl HostTrait for HostCallbacks {
             SimpleDialog::Alert {
                 message,
                 response_sender,
+                ..
             } => {
                 debug!("SimpleDialog::Alert");
 
@@ -920,6 +921,7 @@ impl HostTrait for HostCallbacks {
             SimpleDialog::Confirm {
                 message,
                 response_sender,
+                ..
             } => {
                 warn!("Confirm dialog not implemented. Cancelled. {}", message);
                 response_sender.send(Default::default())


### PR DESCRIPTION
This is part of a series of changes to unify the different APIs we have currently for requesting the embedder to display UI elements.

This patch doesn't change how the script requests the dialogs to be displayed, it only switches the webview delegate method that gets invoked in response to the request from script. The change also adds an `EmbedderControlId` field to the simple dialogs, but these are not currently used. They exist only to satify the calls to `id()` method of the `EmbedderControl` enum.

Testing: Added new unit tests to validate that the dialogs are displayed.
