### PR TITLE
script: Use new inserted node when performing slot checks

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2557,8 +2557,8 @@ impl Node {
             if let Some(shadow_root) = parent.downcast::<Element>().and_then(Element::shadow_root) {
                 if shadow_root.SlotAssignment() == SlotAssignmentMode::Named {
                     let cx = GlobalScope::get_cx();
-                    if node.is::<Element>() || node.is::<Text>() {
-                        rooted!(in(*cx) let slottable = Slottable(Dom::from_ref(node)));
+                    if kid.is::<Element>() || kid.is::<Text>() {
+                        rooted!(in(*cx) let slottable = Slottable(Dom::from_ref(kid)));
                         slottable.assign_a_slot();
                     }
                 }

--- a/tests/wpt/meta/shadow-dom/slotchange-event.html.ini
+++ b/tests/wpt/meta/shadow-dom/slotchange-event.html.ini
@@ -1,16 +1,4 @@
 [slotchange-event.html]
-  [slotchange event must fire on a slot element inside an open shadow root  in a document when innerHTML modifies the children of the shadow host]
-    expected: FAIL
-
-  [slotchange event must fire on a slot element inside a closed shadow root  in a document when innerHTML modifies the children of the shadow host]
-    expected: FAIL
-
-  [slotchange event must fire on a slot element inside an open shadow root  not in a document when innerHTML modifies the children of the shadow host]
-    expected: FAIL
-
-  [slotchange event must fire on a slot element inside a closed shadow root  not in a document when innerHTML modifies the children of the shadow host]
-    expected: FAIL
-
   [slotchange event must fire on a slot element inside an open shadow root  in a document when nested slots's contents change]
     expected: FAIL
 


### PR DESCRIPTION
https://github.com/servo/servo/blob/main/components/script/dom/node.rs#L2560
The node in this line should be kid.
Step 7.4 If parent is a shadow host whose shadow root’s slot assignment is "named" and node is a slottable, then assign a slot for node.
The node here should be the node of "for each" rather than the node of the insert parameter.

Fixes: https://github.com/servo/servo/issues/40250