### PR TITLE
script: Report target padding and desired sizes for ResizeObserver notifications

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -26,8 +26,8 @@ use fonts_traits::StylesheetWebFontLoadFinishedCallback;
 use layout_api::wrapper_traits::LayoutNode;
 use layout_api::{
     BoxAreaType, IFrameSizes, Layout, LayoutConfig, LayoutDamage, LayoutFactory,
-    OffsetParentResponse, PropertyRegistration, QueryMsg, ReflowGoal, ReflowPhasesRun,
-    ReflowRequest, ReflowRequestRestyle, ReflowResult, RegisterPropertyError,
+    OffsetParentResponse, PhysicalSides, PropertyRegistration, QueryMsg, ReflowGoal,
+    ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle, ReflowResult, RegisterPropertyError,
     ScrollContainerQueryFlags, ScrollContainerResponse, TrustedNodeAddress,
 };
 use log::{debug, error, warn};
@@ -91,8 +91,8 @@ use crate::display_list::{DisplayListBuilder, HitTest, StackingContextTree};
 use crate::query::{
     get_the_text_steps, process_box_area_request, process_box_areas_request,
     process_client_rect_request, process_node_scroll_area_request, process_offset_parent_query,
-    process_padding_top_and_left_request, process_resolved_font_style_query,
-    process_resolved_style_request, process_scroll_container_query, process_text_index_request,
+    process_padding_request, process_resolved_font_style_query, process_resolved_style_request,
+    process_scroll_container_query, process_text_index_request,
 };
 use crate::traversal::{RecalcStyle, compute_damage_and_repair_style};
 use crate::{BoxTree, FragmentTree};
@@ -257,7 +257,7 @@ impl Layout for LayoutThread {
 
     /// Return the resolved values of this node's top and left padding rect.
     #[servo_tracing::instrument(skip_all)]
-    fn query_padding_top_and_left(&self, node: TrustedNodeAddress) -> Option<(Au, Au)> {
+    fn query_padding(&self, node: TrustedNodeAddress) -> Option<PhysicalSides> {
         // If we have not built a fragment tree yet, there is no way we have layout information for
         // this query, which can be run without forcing a layout (for IntersectionObserver).
         if self.fragment_tree.borrow().is_none() {
@@ -265,7 +265,7 @@ impl Layout for LayoutThread {
         }
 
         let node = unsafe { ServoLayoutNode::new(&node) };
-        process_padding_top_and_left_request(node.to_threadsafe())
+        process_padding_request(node.to_threadsafe())
     }
 
     /// Return the union of this node's areas in the coordinate space of the Document. This is used
@@ -1635,7 +1635,7 @@ impl ReflowPhases {
                 QueryMsg::ClientRectQuery |
                 QueryMsg::ElementInnerOuterTextQuery |
                 QueryMsg::InnerWindowDimensionsQuery |
-                QueryMsg::PaddingTopAndLeftQuery |
+                QueryMsg::PaddingQuery |
                 QueryMsg::ResolvedFontStyleQuery |
                 QueryMsg::ScrollParentQuery |
                 QueryMsg::StyleQuery |

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -255,7 +255,7 @@ impl Layout for LayoutThread {
             .remove_all_web_fonts_from_stylesheet(&stylesheet);
     }
 
-    /// Return the resolved values of this node's top and left padding rect.
+    /// Return the resolved values of this node's padding rect.
     #[servo_tracing::instrument(skip_all)]
     fn query_padding(&self, node: TrustedNodeAddress) -> Option<PhysicalSides> {
         // If we have not built a fragment tree yet, there is no way we have layout information for

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -91,8 +91,8 @@ use crate::display_list::{DisplayListBuilder, HitTest, StackingContextTree};
 use crate::query::{
     get_the_text_steps, process_box_area_request, process_box_areas_request,
     process_client_rect_request, process_node_scroll_area_request, process_offset_parent_query,
-    process_resolved_font_style_query, process_resolved_style_request,
-    process_scroll_container_query, process_text_index_request,
+    process_padding_top_and_left_request, process_resolved_font_style_query,
+    process_resolved_style_request, process_scroll_container_query, process_text_index_request,
 };
 use crate::traversal::{RecalcStyle, compute_damage_and_repair_style};
 use crate::{BoxTree, FragmentTree};
@@ -253,6 +253,19 @@ impl Layout for LayoutThread {
         self.stylist.remove_stylesheet(stylesheet.clone(), &guard);
         self.font_context
             .remove_all_web_fonts_from_stylesheet(&stylesheet);
+    }
+
+    /// Return the resolved values of this node's top and left padding rect.
+    #[servo_tracing::instrument(skip_all)]
+    fn query_padding_top_and_left(&self, node: TrustedNodeAddress) -> Option<(Au, Au)> {
+        // If we have not built a fragment tree yet, there is no way we have layout information for
+        // this query, which can be run without forcing a layout (for IntersectionObserver).
+        if self.fragment_tree.borrow().is_none() {
+            return None;
+        }
+
+        let node = unsafe { ServoLayoutNode::new(&node) };
+        process_padding_top_and_left_request(node.to_threadsafe())
     }
 
     /// Return the union of this node's areas in the coordinate space of the Document. This is used
@@ -1622,6 +1635,7 @@ impl ReflowPhases {
                 QueryMsg::ClientRectQuery |
                 QueryMsg::ElementInnerOuterTextQuery |
                 QueryMsg::InnerWindowDimensionsQuery |
+                QueryMsg::PaddingTopAndLeftQuery |
                 QueryMsg::ResolvedFontStyleQuery |
                 QueryMsg::ScrollParentQuery |
                 QueryMsg::StyleQuery |

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -73,9 +73,7 @@ pub(crate) fn process_padding_top_and_left_request(
     node: ServoThreadSafeLayoutNode<'_>,
 ) -> Option<(Au, Au)> {
     let fragments = node.fragments_for_pseudo(None);
-    let Some(fragment) = fragments.first() else {
-        return None;
-    };
+    let fragment = fragments.first()?;
     match fragment {
         Fragment::Box(box_fragment) | Fragment::Float(box_fragment) => {
             let padding = box_fragment.borrow().padding;

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -968,6 +968,10 @@ impl Node {
         TrustedNodeAddress(self as *const Node as *const libc::c_void)
     }
 
+    pub(crate) fn padding_top_and_left(&self) -> Option<(Au, Au)> {
+        self.owner_window().padding_top_and_left_query(self)
+    }
+
     pub(crate) fn content_box(&self) -> Option<Rect<Au>> {
         self.owner_window()
             .box_area_query(self, BoxAreaType::Content)

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -27,7 +27,7 @@ use js::rust::HandleObject;
 use keyboard_types::Modifiers;
 use layout_api::{
     BoxAreaType, GenericLayoutData, HTMLCanvasData, HTMLMediaData, LayoutElementType,
-    LayoutNodeType, QueryMsg, SVGElementData, StyleData, TrustedNodeAddress,
+    LayoutNodeType, PhysicalSides, QueryMsg, SVGElementData, StyleData, TrustedNodeAddress,
 };
 use libc::{self, c_void, uintptr_t};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
@@ -968,8 +968,8 @@ impl Node {
         TrustedNodeAddress(self as *const Node as *const libc::c_void)
     }
 
-    pub(crate) fn padding_top_and_left(&self) -> Option<(Au, Au)> {
-        self.owner_window().padding_top_and_left_query(self)
+    pub(crate) fn padding(&self) -> Option<PhysicalSides> {
+        self.owner_window().padding_query_without_reflow(self)
     }
 
     pub(crate) fn content_box(&self) -> Option<Rect<Au>> {

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -192,8 +192,7 @@ fn create_and_populate_a_resizeobserverentry(
         ResizeObserverBoxOptions::Border_box => border_box_size,
         ResizeObserverBoxOptions::Device_pixel_content_box => device_pixel_content_box,
     };
-    let last_reported_size =
-        ResizeObserverSizeImpl::new(last_size.width(), last_size.height());
+    let last_reported_size = ResizeObserverSizeImpl::new(last_size.width(), last_size.height());
     if observation.last_reported_sizes.is_empty() {
         observation.last_reported_sizes.push(last_reported_size);
     } else {

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -4,9 +4,12 @@
 
 use std::rc::Rc;
 
+use app_units::Au;
 use dom_struct::dom_struct;
 use euclid::Size2D;
 use euclid::default::Rect;
+use euclid::num::Zero;
+use html5ever::ns;
 use js::rust::HandleObject;
 
 use crate::dom::bindings::callback::ExceptionHandling;
@@ -171,13 +174,12 @@ fn create_and_populate_a_resizeobserverentry(
     observation: &mut ResizeObservation,
     can_gc: CanGc,
 ) -> DomRoot<ResizeObserverEntry> {
+    // Step 3. Set this.borderBoxSize slot to result of calculating box size given target and observedBox of "border-box".
     let border_box_size = calculate_box_size(target, &ResizeObserverBoxOptions::Border_box);
+    // Step 4. Set this.contentBoxSize slot to result of calculating box size given target and observedBox of "content-box".
     let content_box_size = calculate_box_size(target, &ResizeObserverBoxOptions::Content_box);
-    let (padding_top, padding_left) = target
-        .upcast::<Node>()
-        .padding_top_and_left()
-        .unwrap_or_default();
 
+    // Step 5. Set this.devicePixelContentBoxSize slot to result of calculating box size given target and observedBox of "device-pixel-content-box".
     let device_pixel_content_box =
         calculate_box_size(target, &ResizeObserverBoxOptions::Device_pixel_content_box);
 
@@ -198,6 +200,22 @@ fn create_and_populate_a_resizeobserverentry(
         observation.last_reported_sizes[0] = last_reported_size;
     }
 
+    // Step 7. If target is not an SVG element or target is an SVG element with an associated CSS layout box do these steps:
+    let use_padding = *target.namespace() != ns!(svg) || target.has_css_layout_box();
+    let (padding_top, padding_left) = if use_padding {
+        // Step 7.1. Set this.contentRect.top to target.padding top.
+        // Step 7.2. Set this.contentRect.left to target.padding left.
+        target
+            .upcast::<Node>()
+            .padding_top_and_left()
+            .unwrap_or_default()
+    } else {
+        // Step 8. If target is an SVG element without an associated CSS layout box do these steps:
+        // Step 8.1. Set this.contentRect.top and this.contentRect.left to 0.
+        (Au::zero(), Au::zero())
+    };
+
+    // Step 6. Set this.contentRect to logical this.contentBoxSize given target and observedBox of "content-box".
     let content_rect = DOMRectReadOnly::new(
         window.upcast(),
         None,
@@ -227,6 +245,8 @@ fn create_and_populate_a_resizeobserverentry(
         can_gc,
     );
 
+    // Step 1. Let this be a new ResizeObserverEntry.
+    // Step 2. Set this.target slot to target.
     ResizeObserverEntry::new(
         window,
         target,

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -205,10 +205,8 @@ fn create_and_populate_a_resizeobserverentry(
     let (padding_top, padding_left) = if use_padding {
         // Step 7.1. Set this.contentRect.top to target.padding top.
         // Step 7.2. Set this.contentRect.left to target.padding left.
-        target
-            .upcast::<Node>()
-            .padding_top_and_left()
-            .unwrap_or_default()
+        let padding = target.upcast::<Node>().padding().unwrap_or_default();
+        (padding.top, padding.left)
     } else {
         // Step 8. If target is an SVG element without an associated CSS layout box do these steps:
         // Step 8.1. Set this.contentRect.top and this.contentRect.left to 0.

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -173,6 +173,11 @@ fn create_and_populate_a_resizeobserverentry(
 ) -> DomRoot<ResizeObserverEntry> {
     let border_box_size = calculate_box_size(target, &ResizeObserverBoxOptions::Border_box);
     let content_box_size = calculate_box_size(target, &ResizeObserverBoxOptions::Content_box);
+    let (padding_top, padding_left) = target
+        .upcast::<Node>()
+        .padding_top_and_left()
+        .unwrap_or_default();
+
     let device_pixel_content_box =
         calculate_box_size(target, &ResizeObserverBoxOptions::Device_pixel_content_box);
 
@@ -191,8 +196,8 @@ fn create_and_populate_a_resizeobserverentry(
     let content_rect = DOMRectReadOnly::new(
         window.upcast(),
         None,
-        content_box_size.origin.x,
-        content_box_size.origin.y,
+        padding_left.to_f64_px(),
+        padding_top.to_f64_px(),
         content_box_size.width(),
         content_box_size.height(),
         can_gc,

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -185,8 +185,13 @@ fn create_and_populate_a_resizeobserverentry(
     // initialized with one reported size (zero).
     // The spec plans to store multiple reported sizes,
     // but for now there can be only one.
+    let last_size = match observation.observed_box {
+        ResizeObserverBoxOptions::Content_box => content_box_size,
+        ResizeObserverBoxOptions::Border_box => border_box_size,
+        ResizeObserverBoxOptions::Device_pixel_content_box => device_pixel_content_box,
+    };
     let last_reported_size =
-        ResizeObserverSizeImpl::new(content_box_size.width(), content_box_size.height());
+        ResizeObserverSizeImpl::new(last_size.width(), last_size.height());
     if observation.last_reported_sizes.is_empty() {
         observation.last_reported_sizes.push(last_reported_size);
     } else {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -57,9 +57,9 @@ use js::rust::{
 };
 use layout_api::{
     BoxAreaType, ElementsFromPointFlags, ElementsFromPointResult, FragmentType, Layout,
-    LayoutImageDestination, PendingImage, PendingImageState, PendingRasterizationImage, QueryMsg,
-    ReflowGoal, ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle, RestyleReason,
-    ScrollContainerQueryFlags, ScrollContainerResponse, TrustedNodeAddress,
+    LayoutImageDestination, PendingImage, PendingImageState, PendingRasterizationImage,
+    PhysicalSides, QueryMsg, ReflowGoal, ReflowPhasesRun, ReflowRequest, ReflowRequestRestyle,
+    RestyleReason, ScrollContainerQueryFlags, ScrollContainerResponse, TrustedNodeAddress,
     combine_id_with_fragment_type,
 };
 use malloc_size_of::MallocSizeOf;
@@ -2631,21 +2631,13 @@ impl Window {
         )
     }
 
-    /// Do the same kind of query as `Self::padding_top_and_left_query`, but do not force a reflow.
-    /// This is used for things like `IntersectionObserver` which should observe the value
+    /// Query the used padding values for the given node, but do not force a reflow.
+    /// This is used for things like `ResizeObserver` which should observe the value
     /// from the most recent reflow, but do not need it to reflect the current state of
     /// the DOM / style.
-    pub(crate) fn padding_top_and_left_query_without_reflow(
-        &self,
-        node: &Node,
-    ) -> Option<(Au, Au)> {
+    pub(crate) fn padding_query_without_reflow(&self, node: &Node) -> Option<PhysicalSides> {
         let layout = self.layout.borrow();
-        layout.query_padding_top_and_left(node.to_trusted_node_address())
-    }
-
-    pub(crate) fn padding_top_and_left_query(&self, node: &Node) -> Option<(Au, Au)> {
-        self.layout_reflow(QueryMsg::PaddingTopAndLeftQuery);
-        self.padding_top_and_left_query_without_reflow(node)
+        layout.query_padding(node.to_trusted_node_address())
     }
 
     /// Do the same kind of query as `Self::box_area_query`, but do not force a reflow.

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2631,6 +2631,23 @@ impl Window {
         )
     }
 
+    /// Do the same kind of query as `Self::padding_top_and_left_query`, but do not force a reflow.
+    /// This is used for things like `IntersectionObserver` which should observe the value
+    /// from the most recent reflow, but do not need it to reflect the current state of
+    /// the DOM / style.
+    pub(crate) fn padding_top_and_left_query_without_reflow(
+        &self,
+        node: &Node,
+    ) -> Option<(Au, Au)> {
+        let layout = self.layout.borrow();
+        layout.query_padding_top_and_left(node.to_trusted_node_address())
+    }
+
+    pub(crate) fn padding_top_and_left_query(&self, node: &Node) -> Option<(Au, Au)> {
+        self.layout_reflow(QueryMsg::PaddingTopAndLeftQuery);
+        self.padding_top_and_left_query_without_reflow(node)
+    }
+
     /// Do the same kind of query as `Self::box_area_query`, but do not force a reflow.
     /// This is used for things like `IntersectionObserver` which should observe the value
     /// from the most recent reflow, but do not need it to reflect the current state of

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -298,6 +298,7 @@ pub trait Layout {
     /// Marks that this layout needs to produce a new display list for rendering updates.
     fn set_needs_new_display_list(&self);
 
+    fn query_padding_top_and_left(&self, node: TrustedNodeAddress) -> Option<(Au, Au)>;
     fn query_box_area(&self, node: TrustedNodeAddress, area: BoxAreaType) -> Option<Rect<Au>>;
     fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> Vec<Rect<Au>>;
     fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32>;
@@ -431,6 +432,7 @@ pub enum QueryMsg {
     ScrollingAreaOrOffsetQuery,
     StyleQuery,
     TextIndexQuery,
+    PaddingTopAndLeftQuery,
 }
 
 /// The goal of a reflow request.

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -298,7 +298,7 @@ pub trait Layout {
     /// Marks that this layout needs to produce a new display list for rendering updates.
     fn set_needs_new_display_list(&self);
 
-    fn query_padding_top_and_left(&self, node: TrustedNodeAddress) -> Option<(Au, Au)>;
+    fn query_padding(&self, node: TrustedNodeAddress) -> Option<PhysicalSides>;
     fn query_box_area(&self, node: TrustedNodeAddress, area: BoxAreaType) -> Option<Rect<Au>>;
     fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> Vec<Rect<Au>>;
     fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32>;
@@ -359,6 +359,14 @@ pub enum BoxAreaType {
     Content,
     Padding,
     Border,
+}
+
+#[derive(Default)]
+pub struct PhysicalSides {
+    pub left: Au,
+    pub top: Au,
+    pub right: Au,
+    pub bottom: Au,
 }
 
 #[derive(Clone, Default)]
@@ -432,7 +440,7 @@ pub enum QueryMsg {
     ScrollingAreaOrOffsetQuery,
     StyleQuery,
     TextIndexQuery,
-    PaddingTopAndLeftQuery,
+    PaddingQuery,
 }
 
 /// The goal of a reflow request.

--- a/tests/wpt/meta/resize-observer/notify.html.ini
+++ b/tests/wpt/meta/resize-observer/notify.html.ini
@@ -1,8 +1,5 @@
 [notify.html]
   expected: ERROR
-  [test3: dimensions match]
-    expected: FAIL
-
   [test4: transform do not cause notifications]
     expected: FAIL
 

--- a/tests/wpt/meta/resize-observer/observe.html.ini
+++ b/tests/wpt/meta/resize-observer/observe.html.ini
@@ -1,13 +1,4 @@
 [observe.html]
-  [test8: simple content-box observation]
-    expected: [PASS, FAIL]
-
-  [test9: simple content-box observation but keep border-box size unchanged]
-    expected: [PASS, FAIL]
-
-  [test10: simple border-box observation]
-    expected: [PASS, FAIL]
-
   [test11: simple observation with vertical writing mode]
     expected: FAIL
 
@@ -15,9 +6,6 @@
     expected: FAIL
 
   [test13: an observation is fired after the change of writing mode when box's specified size comes from physical size properties.]
-    expected: FAIL
-
-  [test14: observe the same target but using a different box should override the previous one]
     expected: FAIL
 
   [test17: Box sizing snd Resize Observer notifications]

--- a/tests/wpt/meta/resize-observer/observe.html.ini
+++ b/tests/wpt/meta/resize-observer/observe.html.ini
@@ -7,6 +7,3 @@
 
   [test13: an observation is fired after the change of writing mode when box's specified size comes from physical size properties.]
     expected: FAIL
-
-  [test17: Box sizing snd Resize Observer notifications]
-    expected: FAIL


### PR DESCRIPTION
We were not following the specification for computing the values of the content rect. Additionally, any non-content-box observer would get confused because we never stored the correct size, leading to infinite notifications when the latest size didn't match the last observed size.

Testing: Various tests now pass.
Fixes: #32549
Fixes: #40107