### PR TITLE
tests: Mark iframe-same-origin.html.ini as passing.

### DIFF
--- a/tests/wpt/meta/resize-observer/iframe-same-origin.html.ini
+++ b/tests/wpt/meta/resize-observer/iframe-same-origin.html.ini
@@ -1,2 +1,0 @@
-[iframe-same-origin.html]
-  expected: [PASS, FAIL]


### PR DESCRIPTION
I can't make this test fail locally, even under heavy load. It's entirely possible that it's been fixed by the various pieces of work we've done to integrate ResizeObserver into the event loop and improve the accuracy of the size calculations. If it starts failing intermittently again, we can file an issue to track it, which will give us much better insight into how often it fails.