### PR TITLE
script: Do not store an initial content size in new ResizeObservers.

### DIFF
--- a/tests/wpt/meta/resize-observer/notify.html.ini
+++ b/tests/wpt/meta/resize-observer/notify.html.ini
@@ -8,9 +8,3 @@
 
   [test6: inline element notifies once with 0x0.]
     expected: FAIL
-
-  [test11: display:none element should be notified]
-    expected: FAIL
-
-  [test12: element sized 0x0 should be notified]
-    expected: FAIL

--- a/tests/wpt/meta/resize-observer/observe.html.ini
+++ b/tests/wpt/meta/resize-observer/observe.html.ini
@@ -20,8 +20,5 @@
   [test14: observe the same target but using a different box should override the previous one]
     expected: FAIL
 
-  [test16: observations fire once with 0x0 size for non-replaced inline elements]
-    expected: FAIL
-
   [test17: Box sizing snd Resize Observer notifications]
     expected: FAIL

--- a/tests/wpt/meta/resize-observer/svg-with-css-box-001.html.ini
+++ b/tests/wpt/meta/resize-observer/svg-with-css-box-001.html.ini
@@ -1,10 +1,3 @@
 [svg-with-css-box-001.html]
-  expected: TIMEOUT
   [test0: observe `foreignObject` SVG in HTML document]
     expected: FAIL
-
-  [test1: observe inline SVG in HTML]
-    expected: FAIL
-
-  [guard]
-    expected: NOTRUN


### PR DESCRIPTION
ResizeObservers are supposed to have an initial 0x0 notification for targets that don't have a CSS layout box, but our default values were interfering with that.

Testing: New passing tests.
Fixes: part of #31182
