### PR TITLE
Script: Use the correct constructor for DOMString to be lazy

### DIFF
--- a/components/script_bindings/conversions.rs
+++ b/components/script_bindings/conversions.rs
@@ -107,14 +107,9 @@ impl FromJSValConvertible for DOMString {
         if null_behavior == StringificationBehavior::Empty && value.get().is_null() {
             Ok(ConversionResult::Success(DOMString::new()))
         } else {
-            match ptr::NonNull::new(ToString(cx, value)) {
-                Some(jsstr) => Ok(ConversionResult::Success(DOMString::from_string(
-                    jsstr_to_string(cx, jsstr),
-                ))),
-                None => {
-                    debug!("ToString failed");
-                    Err(())
-                },
+            match DOMString::from_js_string(unsafe { SafeJSContext::from_ptr(cx) }, value) {
+                Ok(domstring) => Ok(ConversionResult::Success(domstring)),
+                Err(_) => Err(()),
             }
         }
     }


### PR DESCRIPTION
Somewhere in the transition to SafeJSContext, I did not merge correctly and used the DOMString::from_String method instead of the
DOMString::from_js_string method, hence, defeating the lazyness.
This fixes this.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Compiling and the function was enabled on a local branch earlier.
