### PR TITLE
compositing: Split out `Painter` from `IOCompositor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,6 +1493,7 @@ dependencies = [
  "servo_config",
  "servo_geometry",
  "servo_malloc_size_of",
+ "smallvec",
  "stylo_traits",
  "surfman",
  "timers",

--- a/components/compositing/Cargo.toml
+++ b/components/compositing/Cargo.toml
@@ -47,6 +47,7 @@ servo-tracing = { workspace = true }
 servo_allocator = { path = "../allocator" }
 servo_config = { path = "../config" }
 servo_geometry = { path = "../geometry" }
+smallvec = { workspace = true }
 stylo_traits = { workspace = true }
 timers = { path = "../timers" }
 tracing = { workspace = true, optional = true }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -2,88 +2,56 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::cell::{Cell, Ref, RefCell};
-use std::collections::hash_map::Entry;
+use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::env;
 use std::fs::create_dir_all;
-use std::iter::once;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use base::Epoch;
-use base::cross_process_instant::CrossProcessInstant;
-use base::generic_channel::{GenericSender, RoutedReceiver};
-use base::id::{PipelineId, RenderingGroupId, WebViewId};
+use base::generic_channel::RoutedReceiver;
+use base::id::WebViewId;
 use bitflags::bitflags;
-use canvas_traits::webgl::{GlType, WebGLThreads};
-use compositing_traits::display_list::{CompositorDisplayListInfo, ScrollTree, ScrollType};
-use compositing_traits::rendering_context::RenderingContext;
-use compositing_traits::{
-    CompositionPipeline, CompositorMsg, ImageUpdate, PipelineExitSource, SendableFrameTree,
-    WebRenderExternalImageHandlers, WebRenderExternalImageRegistry, WebRenderImageHandlerType,
-    WebViewTrait,
-};
-use constellation_traits::{EmbedderToConstellationMessage, PaintMetricEvent};
+use canvas_traits::webgl::WebGLThreads;
+use compositing_traits::{CompositorMsg, WebRenderExternalImageRegistry, WebViewTrait};
+use constellation_traits::EmbedderToConstellationMessage;
 use crossbeam_channel::Sender;
 use dpi::PhysicalSize;
 use embedder_traits::{
-    CompositorHitTestResult, InputEventAndId, InputEventId, InputEventResult,
-    ScreenshotCaptureError, Scroll, ShutdownState, ViewportDetails, WebViewPoint, WebViewRect,
+    InputEventAndId, InputEventId, InputEventResult, ScreenshotCaptureError, Scroll, ShutdownState,
+    ViewportDetails, WebViewPoint, WebViewRect,
 };
-use euclid::{Point2D, Scale, Size2D};
-use gleam::gl::RENDERER;
+use euclid::{Scale, Size2D};
 use image::RgbaImage;
-use ipc_channel::ipc::{self, IpcSharedMemory};
-use log::{debug, info, trace, warn};
-use media::WindowGLContext;
+use ipc_channel::ipc::{self};
+use log::debug;
 use profile_traits::mem::{
     ProcessReports, ProfilerRegistration, Report, ReportKind, perform_memory_report,
 };
-use profile_traits::time::{self as profile_time, ProfilerCategory};
-use profile_traits::{path, time_profile};
-use rustc_hash::{FxHashMap, FxHashSet};
-use servo_config::pref;
+use profile_traits::path;
+use profile_traits::time::{self as profile_time};
 use servo_geometry::DeviceIndependentPixel;
 use style_traits::CSSPixel;
-use webgl::WebGLComm;
-use webrender::{
-    CaptureBits, ONE_TIME_USAGE_HINT, RenderApi, ShaderPrecacheFlags, Transaction, UploadMethod,
-};
-use webrender_api::units::{
-    DeviceIntRect, DevicePixel, DevicePoint, DeviceRect, LayoutPoint, LayoutRect, LayoutSize,
-    LayoutTransform, WorldPoint,
-};
-use webrender_api::{
-    self, BuiltDisplayList, ColorF, DirtyRect, DisplayListPayload, DocumentId,
-    Epoch as WebRenderEpoch, ExternalScrollId, FontInstanceFlags, FontInstanceKey,
-    FontInstanceOptions, FontKey, FontVariation, ImageKey, PipelineId as WebRenderPipelineId,
-    PropertyBinding, ReferenceFrameKind, RenderReasons, SampledScrollOffset, SpaceAndClipInfo,
-    SpatialId, SpatialTreeItemKey, TransformStyle,
-};
+use webrender::{CaptureBits, MemoryReport};
+use webrender_api::units::{DevicePixel, DevicePoint, DeviceRect};
 
 use crate::InitialCompositorState;
-use crate::refresh_driver::{AnimationRefreshDriverObserver, BaseRefreshDriver};
-use crate::render_notifier::RenderNotifier;
-use crate::screenshot::ScreenshotTaker;
-use crate::webview_manager::WebViewManager;
-use crate::webview_renderer::{PinchZoomResult, ScrollResult, UnknownWebView, WebViewRenderer};
+use crate::painter::Painter;
+use crate::webview_renderer::UnknownWebView;
 
 /// An option to control what kind of WebRender debugging is enabled while Servo is running.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub enum WebRenderDebugOption {
     Profiler,
     TextureCacheDebug,
     RenderTargetDebug,
 }
 
-/// Data that is shared by all WebView renderers.
-pub struct ServoRenderer {
-    /// The [`BaseRefreshDriver`] which manages the painting of `WebView`s during animations.
-    pub(crate) refresh_driver: Rc<BaseRefreshDriver>,
-
-    /// A [`RefreshDriverObserver`] for WebView content animations.
-    animation_refresh_driver_observer: Rc<AnimationRefreshDriverObserver>,
+/// NB: Never block on the constellation, because sometimes the constellation blocks on us.
+pub struct IOCompositor {
+    /// All of the [`Painters`] for this [`IOCompositor`]. Each [`Painter`] handles painting to
+    /// a single [`RenderingContext`].
+    painters: Vec<Rc<RefCell<Painter>>>,
 
     /// Tracks whether we are in the process of shutting down, or have shut down and should close
     /// the compositor. This is shared with the `Servo` instance.
@@ -97,62 +65,6 @@ pub struct ServoRenderer {
 
     /// The channel on which messages can be sent to the time profiler.
     time_profiler_chan: profile_time::ProfilerChan,
-
-    /// The WebRender [`RenderApi`] interface used to communicate with WebRender.
-    pub(crate) webrender_api: RenderApi,
-
-    /// The active webrender document.
-    pub(crate) webrender_document: DocumentId,
-
-    /// The GL bindings for webrender
-    webrender_gl: Rc<dyn gleam::gl::Gl>,
-
-    /// The last position in the rendered view that the mouse moved over. This becomes `None`
-    /// when the mouse leaves the rendered view.
-    pub(crate) last_mouse_move_position: Option<DevicePoint>,
-
-    /// A [`FrameRequestDelayer`] which is used to wait for canvas image updates to
-    /// arrive before requesting a new frame, as these happen asynchronously with
-    /// `ScriptThread` display list construction.
-    frame_delayer: FrameDelayer,
-
-    /// The WebRender image registry from this renderer.
-    webrender_external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
-
-    #[cfg(feature = "webxr")]
-    /// Some XR devices want to run on the main thread.
-    webxr_main_thread: webxr::MainThreadRegistry,
-
-    /// The [`WebGLThreads`] for this renderer.
-    webgl_threads: WebGLThreads,
-
-    #[cfg(feature = "webgpu")]
-    /// The WebGPU image map for this renderer.
-    webgpu_image_map: webgpu::canvas_context::WGPUImageMap,
-}
-
-/// NB: Never block on the constellation, because sometimes the constellation blocks on us.
-pub struct IOCompositor {
-    /// Data that is shared by all WebView renderers.
-    global: Rc<RefCell<ServoRenderer>>,
-
-    /// Our [`WebViewRenderer`]s, one for every `WebView`.
-    webview_renderers: WebViewManager<WebViewRenderer>,
-
-    /// Tracks whether or not the view needs to be repainted.
-    needs_repaint: Cell<RepaintReason>,
-
-    /// The webrender renderer.
-    webrender: Option<webrender::Renderer>,
-
-    /// The [`RenderingContext`] instance that webrender targets, which is the viewport.
-    rendering_context: Rc<dyn RenderingContext>,
-
-    /// The number of frames pending to receive from WebRender.
-    pending_frames: Cell<usize>,
-
-    /// A [`ScreenshotTaker`] responsible for handling all screenshot requests.
-    screenshot_taker: ScreenshotTaker,
 
     /// A handle to the memory profiler which will automatically unregister
     /// when it's dropped.
@@ -176,342 +88,72 @@ bitflags! {
     }
 }
 
-/// The paint status of a particular pipeline in the Servo renderer. This is used to trigger metrics
-/// in script (via the constellation) when display lists are received.
-///
-/// See <https://w3c.github.io/paint-timing/#first-contentful-paint>.
-#[derive(PartialEq)]
-pub(crate) enum PaintMetricState {
-    /// The renderer is still waiting to process a display list which triggers this metric.
-    Waiting,
-    /// The renderer has processed the display list which will trigger this event, marked the Servo
-    /// instance ready to paint, and is waiting for the given epoch to actually be rendered.
-    Seen(WebRenderEpoch, bool /* first_reflow */),
-    /// The metric has been sent to the constellation and no more work needs to be done.
-    Sent,
-}
-
-pub(crate) struct PipelineDetails {
-    /// The pipeline associated with this PipelineDetails object.
-    pub pipeline: Option<CompositionPipeline>,
-
-    /// The id of the parent pipeline, if any.
-    pub parent_pipeline_id: Option<PipelineId>,
-
-    /// Whether animations are running
-    pub animations_running: bool,
-
-    /// Whether there are animation callbacks
-    pub animation_callbacks_running: bool,
-
-    /// Whether to use less resources by stopping animations.
-    pub throttled: bool,
-
-    /// The compositor-side [ScrollTree]. This is used to allow finding and scrolling
-    /// nodes in the compositor before forwarding new offsets to WebRender.
-    pub scroll_tree: ScrollTree,
-
-    /// The paint metric status of the first paint.
-    pub first_paint_metric: PaintMetricState,
-
-    /// The paint metric status of the first contentful paint.
-    pub first_contentful_paint_metric: PaintMetricState,
-
-    /// The CSS pixel to device pixel scale of the viewport of this pipeline, including
-    /// page zoom, but not including any pinch zoom amount. This is used to detect
-    /// situations where the current display list is for an old scale.
-    pub viewport_scale: Option<Scale<f32, CSSPixel, DevicePixel>>,
-
-    /// Which parts of Servo have reported that this `Pipeline` has exited. Only when all
-    /// have done so will it be discarded.
-    pub exited: PipelineExitSource,
-
-    /// The [`Epoch`] of the latest display list received for this `Pipeline` or `None` if no
-    /// display list has been received.
-    pub display_list_epoch: Option<Epoch>,
-}
-
-impl PipelineDetails {
-    pub(crate) fn animation_callbacks_running(&self) -> bool {
-        self.animation_callbacks_running
-    }
-
-    pub(crate) fn animating(&self) -> bool {
-        !self.throttled && (self.animation_callbacks_running || self.animations_running)
-    }
-}
-
-impl PipelineDetails {
-    pub(crate) fn new() -> PipelineDetails {
-        PipelineDetails {
-            pipeline: None,
-            parent_pipeline_id: None,
-            viewport_scale: None,
-            animations_running: false,
-            animation_callbacks_running: false,
-            throttled: false,
-            scroll_tree: ScrollTree::default(),
-            first_paint_metric: PaintMetricState::Waiting,
-            first_contentful_paint_metric: PaintMetricState::Waiting,
-            exited: PipelineExitSource::empty(),
-            display_list_epoch: None,
-        }
-    }
-
-    fn install_new_scroll_tree(&mut self, new_scroll_tree: ScrollTree) {
-        let old_scroll_offsets = self.scroll_tree.scroll_offsets();
-        self.scroll_tree = new_scroll_tree;
-        self.scroll_tree.set_all_scroll_offsets(&old_scroll_offsets);
-    }
-}
-
-impl Drop for ServoRenderer {
-    fn drop(&mut self) {
-        self.webrender_api.stop_render_backend();
-        self.webrender_api.shut_down(true);
-    }
-}
-
-impl ServoRenderer {
-    pub fn shutdown_state(&self) -> ShutdownState {
-        self.shutdown_state.get()
-    }
-
-    pub(crate) fn hit_test_at_point(&self, point: DevicePoint) -> Vec<CompositorHitTestResult> {
-        // DevicePoint and WorldPoint are the same for us.
-        let world_point = WorldPoint::from_untyped(point.to_untyped());
-        let results = self
-            .webrender_api
-            .hit_test(self.webrender_document, world_point);
-
-        results
-            .items
-            .iter()
-            .map(|item| {
-                let pipeline_id = item.pipeline.into();
-                let external_scroll_id = ExternalScrollId(item.tag.0, item.pipeline);
-                CompositorHitTestResult {
-                    pipeline_id,
-                    point_in_viewport: Point2D::from_untyped(item.point_in_viewport.to_untyped()),
-                    external_scroll_id,
-                }
-            })
-            .collect()
-    }
-
-    pub(crate) fn send_transaction(&mut self, transaction: Transaction) {
-        self.webrender_api
-            .send_transaction(self.webrender_document, transaction);
-    }
-}
-
 impl IOCompositor {
-    pub fn new(state: InitialCompositorState) -> Self {
-        let rendering_context = state.rendering_context;
-        let webrender_gl = rendering_context.gleam_gl_api();
-
-        // Make sure the gl context is made current.
-        if let Err(err) = rendering_context.make_current() {
-            warn!("Failed to make the rendering context current: {:?}", err);
-        }
-        debug_assert_eq!(webrender_gl.get_error(), gleam::gl::NO_ERROR,);
-
-        // Create the webgl thread
-        let gl_type = match webrender_gl.get_type() {
-            gleam::gl::GlType::Gl => GlType::Gl,
-            gleam::gl::GlType::Gles => GlType::Gles,
-        };
-
-        let (external_image_handlers, webrender_external_images) =
-            WebRenderExternalImageHandlers::new();
-        let mut external_image_handlers = Box::new(external_image_handlers);
-
-        let WebGLComm {
-            webgl_threads,
-            #[cfg(feature = "webxr")]
-            webxr_layer_grand_manager,
-            image_handler,
-        } = WebGLComm::new(
-            rendering_context.clone(),
-            state.compositor_proxy.cross_process_compositor_api.clone(),
-            webrender_external_images.clone(),
-            gl_type,
-        );
-
-        // Set webrender external image handler for WebGL textures
-        external_image_handlers.set_handler(image_handler, WebRenderImageHandlerType::WebGl);
-
-        // Create the WebXR main thread
-        #[cfg(feature = "webxr")]
-        let mut webxr_main_thread = webxr::MainThreadRegistry::new(
-            state.event_loop_waker.clone(),
-            webxr_layer_grand_manager,
-        )
-        .expect("Failed to create WebXR device registry");
-        #[cfg(feature = "webxr")]
-        if pref!(dom_webxr_enabled) {
-            state.webxr_registry.register(&mut webxr_main_thread);
-        }
-
-        #[cfg(feature = "webgpu")]
-        let webgpu_image_map = {
-            let webgpu_image_handler = webgpu::WGPUExternalImages::default();
-            let webgpu_image_map = webgpu_image_handler.images.clone();
-            external_image_handlers.set_handler(
-                Box::new(webgpu_image_handler),
-                WebRenderImageHandlerType::WebGpu,
-            );
-            webgpu_image_map
-        };
-
-        WindowGLContext::initialize_image_handler(
-            &mut external_image_handlers,
-            webrender_external_images.clone(),
-        );
-
+    pub fn new(state: InitialCompositorState) -> Rc<RefCell<Self>> {
         let registration = state.mem_profiler_chan.prepare_memory_reporting(
             "compositor".into(),
             state.compositor_proxy.clone(),
             CompositorMsg::CollectMemoryReport,
         );
 
-        let refresh_driver = Rc::new(BaseRefreshDriver::new(
+        let compositor = Rc::new(RefCell::new(IOCompositor {
+            painters: Default::default(),
+            shutdown_state: state.shutdown_state,
+            compositor_receiver: state.receiver,
+            embedder_to_constellation_sender: state.embedder_to_constellation_sender.clone(),
+            time_profiler_chan: state.time_profiler_chan,
+            _mem_profiler_registration: registration,
+        }));
+
+        let painter = Painter::new(
+            state.rendering_context,
+            state.compositor_proxy,
             state.event_loop_waker,
             state.refresh_driver,
-        ));
-        let animation_refresh_driver_observer = Rc::new(AnimationRefreshDriverObserver::new(
-            state.embedder_to_constellation_sender.clone(),
-        ));
-
-        rendering_context.prepare_for_rendering();
-        let clear_color = servo_config::pref!(shell_background_color_rgba);
-        let clear_color = ColorF::new(
-            clear_color[0] as f32,
-            clear_color[1] as f32,
-            clear_color[2] as f32,
-            clear_color[3] as f32,
+            state.shaders_path,
+            compositor.borrow().embedder_to_constellation_sender.clone(),
+            #[cfg(feature = "webxr")]
+            state.webxr_registry,
         );
 
-        // Use same texture upload method as Gecko with ANGLE:
-        // https://searchfox.org/mozilla-central/source/gfx/webrender_bindings/src/bindings.rs#1215-1219
-        let upload_method = if webrender_gl.get_string(RENDERER).starts_with("ANGLE") {
-            UploadMethod::Immediate
-        } else {
-            UploadMethod::PixelBuffer(ONE_TIME_USAGE_HINT)
-        };
-        let worker_threads = std::thread::available_parallelism()
-            .map(|i| i.get())
-            .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
-            .min(pref!(threadpools_webrender_workers_max).max(1) as usize);
-        let workers = Some(Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(worker_threads)
-                .thread_name(|idx| format!("WRWorker#{}", idx))
-                .build()
-                .expect("Unable to initialize WebRender worker pool."),
-        ));
+        compositor
+            .borrow_mut()
+            .painters
+            .push(Rc::new(RefCell::new(painter)));
 
-        let (mut webrender, webrender_api_sender) = webrender::create_webrender_instance(
-            webrender_gl.clone(),
-            Box::new(RenderNotifier::new(state.compositor_proxy.clone())),
-            webrender::WebRenderOptions {
-                // We force the use of optimized shaders here because rendering is broken
-                // on Android emulators with unoptimized shaders. This is due to a known
-                // issue in the emulator's OpenGL emulation layer.
-                // See: https://github.com/servo/servo/issues/31726
-                use_optimized_shaders: true,
-                resource_override_path: state.shaders_path,
-                debug_flags: webrender::DebugFlags::empty(),
-                precache_flags: if pref!(gfx_precache_shaders) {
-                    ShaderPrecacheFlags::FULL_COMPILE
-                } else {
-                    ShaderPrecacheFlags::empty()
-                },
-                enable_aa: pref!(gfx_text_antialiasing_enabled),
-                enable_subpixel_aa: pref!(gfx_subpixel_text_antialiasing_enabled),
-                allow_texture_swizzling: pref!(gfx_texture_swizzling_enabled),
-                clear_color,
-                upload_method,
-                workers,
-                size_of_op: Some(servo_allocator::usable_size),
-                ..Default::default()
-            },
-            None,
-        )
-        .expect("Unable to initialize WebRender.");
-
-        webrender.set_external_image_handler(external_image_handlers);
-
-        let webrender_api = webrender_api_sender.create_api();
-        let webrender_document = webrender_api.add_document(rendering_context.size2d().to_i32());
-
-        let compositor = IOCompositor {
-            global: Rc::new(RefCell::new(ServoRenderer {
-                refresh_driver,
-                animation_refresh_driver_observer,
-                shutdown_state: state.shutdown_state,
-                compositor_receiver: state.receiver,
-                embedder_to_constellation_sender: state.embedder_to_constellation_sender,
-                time_profiler_chan: state.time_profiler_chan,
-                webrender_api,
-                webrender_document,
-                webrender_gl,
-                last_mouse_move_position: None,
-                frame_delayer: Default::default(),
-                webrender_external_images,
-                webgl_threads,
-                #[cfg(feature = "webxr")]
-                webxr_main_thread,
-                #[cfg(feature = "webgpu")]
-                webgpu_image_map,
-            })),
-            webview_renderers: WebViewManager::default(),
-            needs_repaint: Cell::default(),
-            webrender: Some(webrender),
-            rendering_context,
-            pending_frames: Default::default(),
-            screenshot_taker: Default::default(),
-            _mem_profiler_registration: registration,
-        };
-
-        {
-            let gl = &compositor.global.borrow().webrender_gl;
-            info!("Running on {}", gl.get_string(gleam::gl::RENDERER));
-            info!("OpenGL Version {}", gl.get_string(gleam::gl::VERSION));
-        }
-        compositor.assert_gl_framebuffer_complete();
         compositor
     }
 
-    pub fn deinit(&mut self) {
-        if let Err(err) = self.rendering_context.make_current() {
-            warn!("Failed to make the rendering context current: {:?}", err);
-        }
-        if let Some(webrender) = self.webrender.take() {
-            webrender.deinit();
-        }
+    pub(crate) fn painter<'a>(&'a self) -> Ref<'a, Painter> {
+        self.painters[0].borrow()
     }
 
-    pub(crate) fn rendering_context(&self) -> &dyn RenderingContext {
-        &*self.rendering_context
+    pub(crate) fn painter_mut<'a>(&'a self) -> RefMut<'a, Painter> {
+        self.painters[0].borrow_mut()
+    }
+
+    pub fn deinit(&mut self) {
+        for painter in &self.painters {
+            painter.borrow_mut().deinit();
+        }
     }
 
     pub fn rendering_context_size(&self) -> Size2D<u32, DevicePixel> {
-        self.rendering_context.size2d()
+        self.painter().rendering_context.size2d()
     }
 
     pub fn webgl_threads(&self) -> WebGLThreads {
-        self.global.borrow().webgl_threads.clone()
+        self.painter().webgl_threads.clone()
     }
 
     pub fn webrender_external_images(&self) -> Arc<Mutex<WebRenderExternalImageRegistry>> {
-        self.global.borrow().webrender_external_images.clone()
+        self.painter().webrender_external_images.clone()
     }
 
     pub fn webxr_running(&self) -> bool {
         #[cfg(feature = "webxr")]
         {
-            self.global.borrow().webxr_main_thread.running()
+            self.painter().webxr_main_thread.running()
         }
         #[cfg(not(feature = "webxr"))]
         {
@@ -521,66 +163,36 @@ impl IOCompositor {
 
     #[cfg(feature = "webxr")]
     pub fn webxr_main_thread_registry(&self) -> webxr_api::Registry {
-        self.global.borrow().webxr_main_thread.registry()
+        self.painter().webxr_main_thread.registry()
     }
 
     #[cfg(feature = "webgpu")]
     pub fn webgpu_image_map(&self) -> webgpu::canvas_context::WGPUImageMap {
-        self.global.borrow().webgpu_image_map.clone()
-    }
-
-    pub(crate) fn webview_renderer(&self, webview_id: WebViewId) -> Option<&WebViewRenderer> {
-        self.webview_renderers.get(webview_id)
-    }
-
-    pub(crate) fn webview_renderer_mut(
-        &mut self,
-        webview_id: WebViewId,
-    ) -> Option<&mut WebViewRenderer> {
-        self.webview_renderers.get_mut(webview_id)
+        self.painter().webgpu_image_map.clone()
     }
 
     pub(crate) fn set_needs_repaint(&self, reason: RepaintReason) {
-        let mut needs_repaint = self.needs_repaint.get();
-        needs_repaint.insert(reason);
-        self.needs_repaint.set(needs_repaint);
+        self.painter().set_needs_repaint(reason);
     }
 
     pub fn needs_repaint(&self) -> bool {
-        let repaint_reason = self.needs_repaint.get();
-        if repaint_reason.is_empty() {
-            return false;
-        }
-
-        !self
-            .global
-            .borrow()
-            .refresh_driver
-            .wait_to_paint(repaint_reason)
+        self.painter().needs_repaint()
     }
 
-    pub fn finish_shutting_down(&mut self) {
+    pub fn finish_shutting_down(&self) {
         // Drain compositor port, sometimes messages contain channels that are blocking
         // another thread from finishing (i.e. SetFrameTree).
-        while self
-            .global
-            .borrow_mut()
-            .compositor_receiver
-            .try_recv()
-            .is_ok()
-        {}
+        while self.compositor_receiver.try_recv().is_ok() {}
 
         // Tell the profiler, memory profiler, and scrolling timer to shut down.
         if let Ok((sender, receiver)) = ipc::channel() {
-            self.global
-                .borrow()
-                .time_profiler_chan
+            self.time_profiler_chan
                 .send(profile_time::ProfilerMsg::Exit(sender));
             let _ = receiver.recv();
         }
     }
 
-    fn handle_browser_message(&mut self, msg: CompositorMsg) {
+    fn handle_browser_message(&self, msg: CompositorMsg) {
         trace_msg_from_constellation!(msg, "{msg:?}");
 
         match self.shutdown_state() {
@@ -597,373 +209,105 @@ impl IOCompositor {
 
         match msg {
             CompositorMsg::CollectMemoryReport(sender) => {
-                let ops =
-                    wr_malloc_size_of::MallocSizeOfOps::new(servo_allocator::usable_size, None);
-                let report = self.global.borrow().webrender_api.report_memory(ops);
-                let mut reports = vec![
-                    Report {
-                        path: path!["webrender", "fonts"],
-                        kind: ReportKind::ExplicitJemallocHeapSize,
-                        size: report.fonts,
-                    },
-                    Report {
-                        path: path!["webrender", "images"],
-                        kind: ReportKind::ExplicitJemallocHeapSize,
-                        size: report.images,
-                    },
-                    Report {
-                        path: path!["webrender", "display-list"],
-                        kind: ReportKind::ExplicitJemallocHeapSize,
-                        size: report.display_list,
-                    },
-                ];
-
-                perform_memory_report(|ops| {
-                    reports.push(Report {
-                        path: path!["compositor", "scroll-tree"],
-                        kind: ReportKind::ExplicitJemallocHeapSize,
-                        size: self.webview_renderers.scroll_trees_memory_usage(ops),
-                    });
-                });
-
-                sender.send(ProcessReports::new(reports));
+                self.collect_memory_report(sender);
             },
-
             CompositorMsg::ChangeRunningAnimationsState(
                 webview_id,
                 pipeline_id,
                 animation_state,
             ) => {
-                let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
-                    return;
-                };
-
-                if webview_renderer
-                    .change_pipeline_running_animations_state(pipeline_id, animation_state)
-                {
-                    let global = self.global.borrow();
-                    if global
-                        .animation_refresh_driver_observer
-                        .notify_animation_state_changed(webview_renderer)
-                    {
-                        global
-                            .refresh_driver
-                            .add_observer(global.animation_refresh_driver_observer.clone());
-                    }
-                }
-            },
-
-            CompositorMsg::CreateOrUpdateWebView(frame_tree) => {
-                self.set_frame_tree_for_webview(&frame_tree);
-            },
-
-            CompositorMsg::RemoveWebView(webview_id) => {
-                self.remove_webview(webview_id);
-            },
-
-            CompositorMsg::SetThrottled(webview_id, pipeline_id, throttled) => {
-                let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
-                    return;
-                };
-
-                if webview_renderer.set_throttled(pipeline_id, throttled) {
-                    let global = self.global.borrow();
-                    if global
-                        .animation_refresh_driver_observer
-                        .notify_animation_state_changed(webview_renderer)
-                    {
-                        global
-                            .refresh_driver
-                            .add_observer(global.animation_refresh_driver_observer.clone());
-                    }
-                }
-            },
-
-            CompositorMsg::PipelineExited(webview_id, pipeline_id, pipeline_exit_source) => {
-                debug!(
-                    "Compositor got pipeline exited: {:?} {:?}",
-                    webview_id, pipeline_id
+                self.painter_mut().change_running_animations_state(
+                    webview_id,
+                    pipeline_id,
+                    animation_state,
                 );
-                if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-                    webview_renderer.pipeline_exited(pipeline_id, pipeline_exit_source);
-                }
             },
-
+            CompositorMsg::CreateOrUpdateWebView(frame_tree) => {
+                self.painter_mut().set_frame_tree_for_webview(&frame_tree);
+            },
+            CompositorMsg::RemoveWebView(webview_id) => {
+                self.painter_mut().remove_webview(webview_id);
+            },
+            CompositorMsg::SetThrottled(webview_id, pipeline_id, throttled) => {
+                self.painter_mut()
+                    .set_throttled(webview_id, pipeline_id, throttled);
+            },
+            CompositorMsg::PipelineExited(webview_id, pipeline_id, pipeline_exit_source) => {
+                self.painter_mut().notify_pipeline_exited(
+                    webview_id,
+                    pipeline_id,
+                    pipeline_exit_source,
+                );
+            },
             CompositorMsg::NewWebRenderFrameReady(..) => {
                 unreachable!("New WebRender frames should be handled in the caller.");
             },
-
             CompositorMsg::SendInitialTransaction(webview_id, pipeline_id) => {
-                let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
-                    return warn!("Could not find WebView for incoming display list");
-                };
-
-                let starting_epoch = Epoch(0);
-                let details = webview_renderer.ensure_pipeline_details(pipeline_id.into());
-                details.display_list_epoch = Some(starting_epoch);
-
-                let mut txn = Transaction::new();
-                txn.set_display_list(starting_epoch.into(), (pipeline_id, Default::default()));
-                self.generate_frame(&mut txn, RenderReasons::SCENE);
-                self.global.borrow_mut().send_transaction(txn);
+                self.painter_mut()
+                    .send_initial_pipeline_transaction(webview_id, pipeline_id);
             },
-
             CompositorMsg::ScrollNodeByDelta(
                 webview_id,
                 pipeline_id,
                 offset,
                 external_scroll_id,
             ) => {
-                let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
-                    return;
-                };
-
-                let pipeline_id = pipeline_id.into();
-                let Some(pipeline_details) = webview_renderer.pipelines.get_mut(&pipeline_id)
-                else {
-                    return;
-                };
-
-                let Some(offset) = pipeline_details
-                    .scroll_tree
-                    .set_scroll_offset_for_node_with_external_scroll_id(
-                        external_scroll_id,
-                        offset,
-                        ScrollType::Script,
-                    )
-                else {
-                    // The renderer should be fully up-to-date with script at this point and script
-                    // should never try to scroll to an invalid location.
-                    warn!("Could not scroll node with id: {external_scroll_id:?}");
-                    return;
-                };
-
-                let mut txn = Transaction::new();
-                txn.set_scroll_offsets(
+                self.painter_mut().scroll_node_by_delta(
+                    webview_id,
+                    pipeline_id,
+                    offset,
                     external_scroll_id,
-                    vec![SampledScrollOffset {
-                        offset,
-                        generation: 0,
-                    }],
                 );
-                self.generate_frame(&mut txn, RenderReasons::APZ);
-                self.global.borrow_mut().send_transaction(txn);
             },
-
             CompositorMsg::ScrollViewportByDelta(webview_id, delta) => {
-                let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
-                    return;
-                };
-                let (pinch_zoom_result, scroll_results) =
-                    webview_renderer.scroll_viewport_by_delta(delta);
-                self.send_zoom_and_scroll_offset_updates(
-                    pinch_zoom_result == PinchZoomResult::DidPinchZoom,
-                    scroll_results,
-                );
+                self.painter_mut()
+                    .scroll_viewport_by_delta(webview_id, delta);
             },
-
             CompositorMsg::UpdateEpoch {
                 webview_id,
                 pipeline_id,
                 epoch,
             } => {
-                let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
-                    return warn!("Could not find WebView for Epoch update.");
-                };
-                webview_renderer
-                    .ensure_pipeline_details(pipeline_id)
-                    .display_list_epoch = Some(Epoch(epoch.0));
+                self.painter_mut()
+                    .update_epoch(webview_id, pipeline_id, epoch);
             },
-
             CompositorMsg::SendDisplayList {
                 webview_id,
                 display_list_descriptor,
                 display_list_receiver,
             } => {
-                // This must match the order from the sender, currently in `shared/script/lib.rs`.
-                let display_list_info = match display_list_receiver.recv() {
-                    Ok(display_list_info) => display_list_info,
-                    Err(error) => {
-                        return warn!("Could not receive display list info: {error}");
-                    },
-                };
-                let display_list_info: CompositorDisplayListInfo =
-                    match bincode::deserialize(&display_list_info) {
-                        Ok(display_list_info) => display_list_info,
-                        Err(error) => {
-                            return warn!("Could not deserialize display list info: {error}");
-                        },
-                    };
-                let items_data = match display_list_receiver.recv() {
-                    Ok(display_list_data) => display_list_data,
-                    Err(error) => {
-                        return warn!(
-                            "Could not receive WebRender display list items data: {error}"
-                        );
-                    },
-                };
-                let cache_data = match display_list_receiver.recv() {
-                    Ok(display_list_data) => display_list_data,
-                    Err(error) => {
-                        return warn!(
-                            "Could not receive WebRender display list cache data: {error}"
-                        );
-                    },
-                };
-                let spatial_tree = match display_list_receiver.recv() {
-                    Ok(display_list_data) => display_list_data,
-                    Err(error) => {
-                        return warn!(
-                            "Could not receive WebRender display list spatial tree: {error}."
-                        );
-                    },
-                };
-                let built_display_list = BuiltDisplayList::from_data(
-                    DisplayListPayload {
-                        items_data,
-                        cache_data,
-                        spatial_tree,
-                    },
+                self.painter_mut().handle_new_display_list(
+                    webview_id,
                     display_list_descriptor,
+                    display_list_receiver,
                 );
-
-                #[cfg(feature = "tracing")]
-                let _span = tracing::trace_span!(
-                    "ScriptToCompositorMsg::BuiltDisplayList",
-                    servo_profiling = true,
-                )
-                .entered();
-
-                let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
-                    return warn!("Could not find WebView for incoming display list");
-                };
-
-                let old_scale = webview_renderer.device_pixels_per_page_pixel();
-
-                let pipeline_id = display_list_info.pipeline_id;
-                let details = webview_renderer.ensure_pipeline_details(pipeline_id.into());
-                details.install_new_scroll_tree(display_list_info.scroll_tree);
-                details.viewport_scale =
-                    Some(display_list_info.viewport_details.hidpi_scale_factor);
-
-                let epoch = display_list_info.epoch.into();
-                let first_reflow = display_list_info.first_reflow;
-                if details.first_paint_metric == PaintMetricState::Waiting {
-                    details.first_paint_metric = PaintMetricState::Seen(epoch, first_reflow);
-                }
-                if details.first_contentful_paint_metric == PaintMetricState::Waiting &&
-                    display_list_info.is_contentful
-                {
-                    details.first_contentful_paint_metric =
-                        PaintMetricState::Seen(epoch, first_reflow);
-                }
-
-                let mut transaction = Transaction::new();
-                let is_root_pipeline =
-                    Some(pipeline_id.into()) == webview_renderer.root_pipeline_id;
-                if is_root_pipeline && old_scale != webview_renderer.device_pixels_per_page_pixel()
-                {
-                    self.send_root_pipeline_display_list_in_transaction(&mut transaction);
-                }
-
-                transaction.set_display_list(epoch, (pipeline_id, built_display_list));
-                self.update_transaction_with_all_scroll_offsets(&mut transaction);
-                self.global.borrow_mut().send_transaction(transaction);
             },
-
             CompositorMsg::GenerateFrame => {
-                let mut global = self.global.borrow_mut();
-                global.frame_delayer.set_pending_frame(true);
-
-                if !global.frame_delayer.needs_new_frame() {
-                    return;
-                }
-
-                let mut transaction = Transaction::new();
-                self.generate_frame(&mut transaction, RenderReasons::SCENE);
-                global.send_transaction(transaction);
-
-                let waiting_pipelines = global.frame_delayer.take_waiting_pipelines();
-                let _ = global.embedder_to_constellation_sender.send(
-                    EmbedderToConstellationMessage::NoLongerWaitingOnAsynchronousImageUpdates(
-                        waiting_pipelines,
-                    ),
-                );
-                global.frame_delayer.set_pending_frame(false);
-                self.screenshot_taker
-                    .prepare_screenshot_requests_for_render(self)
+                self.painter_mut().generate_frame_for_script();
             },
-
             CompositorMsg::GenerateImageKey(sender) => {
-                let _ = sender.send(self.global.borrow().webrender_api.generate_image_key());
+                let _ = sender.send(self.painter().generate_image_key());
             },
-
             CompositorMsg::GenerateImageKeysForPipeline(pipeline_id) => {
-                let image_keys = (0..pref!(image_key_batch_size))
-                    .map(|_| self.global.borrow().webrender_api.generate_image_key())
-                    .collect();
-                if let Err(error) = self.global.borrow().embedder_to_constellation_sender.send(
+                let _ = self.embedder_to_constellation_sender.send(
                     EmbedderToConstellationMessage::SendImageKeysForPipeline(
                         pipeline_id,
-                        image_keys,
+                        self.painter().generate_image_keys(),
                     ),
-                ) {
-                    warn!("Sending Image Keys to Constellation failed with({error:?}).");
-                }
+                );
             },
             CompositorMsg::UpdateImages(updates) => {
-                let mut global = self.global.borrow_mut();
-                let mut txn = Transaction::new();
-                for update in updates {
-                    match update {
-                        ImageUpdate::AddImage(key, desc, data) => {
-                            txn.add_image(key, desc, data.into(), None)
-                        },
-                        ImageUpdate::DeleteImage(key) => {
-                            txn.delete_image(key);
-                            global.frame_delayer.delete_image(key);
-                        },
-                        ImageUpdate::UpdateImage(key, desc, data, epoch) => {
-                            if let Some(epoch) = epoch {
-                                global.frame_delayer.update_image(key, epoch);
-                            }
-                            txn.update_image(key, desc, data.into(), &DirtyRect::All)
-                        },
-                    }
-                }
-
-                if global.frame_delayer.needs_new_frame() {
-                    global.frame_delayer.set_pending_frame(false);
-                    self.generate_frame(&mut txn, RenderReasons::SCENE);
-                    let waiting_pipelines = global.frame_delayer.take_waiting_pipelines();
-                    let _ = global.embedder_to_constellation_sender.send(
-                        EmbedderToConstellationMessage::NoLongerWaitingOnAsynchronousImageUpdates(
-                            waiting_pipelines,
-                        ),
-                    );
-                    self.screenshot_taker
-                        .prepare_screenshot_requests_for_render(self);
-                }
-
-                global.send_transaction(txn);
+                self.painter_mut().update_images(updates);
             },
-
             CompositorMsg::DelayNewFrameForCanvas(pipeline_id, canvas_epoch, image_keys) => self
-                .global
-                .borrow_mut()
-                .frame_delayer
-                .add_delay(pipeline_id, canvas_epoch, image_keys),
-
+                .painter_mut()
+                .delay_new_frames_for_canvas(pipeline_id, canvas_epoch, image_keys),
             CompositorMsg::AddFont(font_key, data, index) => {
-                self.add_font(font_key, index, data);
+                self.painter_mut().add_font(font_key, data, index);
             },
-
             CompositorMsg::AddSystemFont(font_key, native_handle) => {
-                let mut transaction = Transaction::new();
-                transaction.add_native_font(font_key, native_handle);
-                self.global.borrow_mut().send_transaction(transaction);
+                self.painter_mut().add_system_font(font_key, native_handle);
             },
-
             CompositorMsg::AddFontInstance(
                 font_instance_key,
                 font_key,
@@ -971,48 +315,75 @@ impl IOCompositor {
                 flags,
                 variations,
             ) => {
-                self.add_font_instance(font_instance_key, font_key, size, flags, variations);
+                self.painter_mut().add_font_instance(
+                    font_instance_key,
+                    font_key,
+                    size,
+                    flags,
+                    variations,
+                );
             },
-
             CompositorMsg::RemoveFonts(keys, instance_keys) => {
-                let mut transaction = Transaction::new();
-
-                for instance in instance_keys.into_iter() {
-                    transaction.delete_font_instance(instance);
-                }
-                for key in keys.into_iter() {
-                    transaction.delete_font(key);
-                }
-
-                self.global.borrow_mut().send_transaction(transaction);
+                self.painter_mut().remove_fonts(keys, instance_keys);
             },
-
             CompositorMsg::GenerateFontKeys(
                 number_of_font_keys,
                 number_of_font_instance_keys,
                 result_sender,
-                rendering_group_id,
+                _rendering_group_id,
             ) => {
-                self.handle_generate_font_keys(
-                    number_of_font_keys,
-                    number_of_font_instance_keys,
-                    result_sender,
-                    rendering_group_id,
+                let _ = result_sender.send(
+                    self.painter_mut()
+                        .generate_font_keys(number_of_font_keys, number_of_font_instance_keys),
                 );
             },
             CompositorMsg::Viewport(webview_id, viewport_description) => {
-                if let Some(webview) = self.webview_renderers.get_mut(webview_id) {
-                    webview.set_viewport_description(viewport_description);
-                }
+                self.painter_mut()
+                    .set_viewport_description(webview_id, viewport_description);
             },
             CompositorMsg::ScreenshotReadinessReponse(webview_id, pipelines_and_epochs) => {
-                self.screenshot_taker.handle_screenshot_readiness_reply(
-                    webview_id,
-                    pipelines_and_epochs,
-                    self,
-                );
+                self.painter()
+                    .handle_screenshot_readiness_reply(webview_id, pipelines_and_epochs);
             },
         }
+    }
+
+    fn collect_memory_report(&self, sender: profile_traits::mem::ReportsChan) {
+        let mut memory_report = MemoryReport::default();
+        for painter in &self.painters {
+            memory_report += painter.borrow().report_memory();
+        }
+
+        let mut reports = vec![
+            Report {
+                path: path!["webrender", "fonts"],
+                kind: ReportKind::ExplicitJemallocHeapSize,
+                size: memory_report.fonts,
+            },
+            Report {
+                path: path!["webrender", "images"],
+                kind: ReportKind::ExplicitJemallocHeapSize,
+                size: memory_report.images,
+            },
+            Report {
+                path: path!["webrender", "display-list"],
+                kind: ReportKind::ExplicitJemallocHeapSize,
+                size: memory_report.display_list,
+            },
+        ];
+
+        perform_memory_report(|ops| {
+            reports.push(Report {
+                path: path!["compositor", "scroll-tree"],
+                kind: ReportKind::ExplicitJemallocHeapSize,
+                size: self
+                    .painter()
+                    .webview_renderers
+                    .scroll_trees_memory_usage(ops),
+            });
+        });
+
+        sender.send(ProcessReports::new(reports));
     }
 
     /// Handle messages sent to the compositor during the shutdown process. In general,
@@ -1024,31 +395,27 @@ impl IOCompositor {
     /// When that involves generating WebRender ids, our approach here is to simply
     /// generate them, but assume they will never be used, since once shutting down the
     /// compositor no longer does any WebRender frame generation.
-    fn handle_browser_message_while_shutting_down(&mut self, msg: CompositorMsg) {
+    fn handle_browser_message_while_shutting_down(&self, msg: CompositorMsg) {
         match msg {
             CompositorMsg::PipelineExited(webview_id, pipeline_id, pipeline_exit_source) => {
-                debug!(
-                    "Compositor got pipeline exited: {:?} {:?}",
-                    webview_id, pipeline_id
+                self.painter_mut().notify_pipeline_exited(
+                    webview_id,
+                    pipeline_id,
+                    pipeline_exit_source,
                 );
-                if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-                    webview_renderer.pipeline_exited(pipeline_id, pipeline_exit_source);
-                }
             },
             CompositorMsg::GenerateImageKey(sender) => {
-                let _ = sender.send(self.global.borrow().webrender_api.generate_image_key());
+                let _ = sender.send(self.painter().webrender_api.generate_image_key());
             },
             CompositorMsg::GenerateFontKeys(
                 number_of_font_keys,
                 number_of_font_instance_keys,
                 result_sender,
-                rendering_group_id,
+                _rendering_group_id,
             ) => {
-                self.handle_generate_font_keys(
-                    number_of_font_keys,
-                    number_of_font_instance_keys,
-                    result_sender,
-                    rendering_group_id,
+                let _ = result_sender.send(
+                    self.painter_mut()
+                        .generate_font_keys(number_of_font_keys, number_of_font_instance_keys),
                 );
             },
             _ => {
@@ -1057,515 +424,76 @@ impl IOCompositor {
         }
     }
 
-    /// Generate the font keys and send them to the `result_sender`.
-    /// Currently `RenderingGroupId` is not used.
-    fn handle_generate_font_keys(
-        &self,
-        number_of_font_keys: usize,
-        number_of_font_instance_keys: usize,
-        result_sender: GenericSender<(Vec<FontKey>, Vec<FontInstanceKey>)>,
-        _rendering_group_id: RenderingGroupId,
-    ) {
-        let font_keys = (0..number_of_font_keys)
-            .map(|_| self.global.borrow().webrender_api.generate_font_key())
-            .collect();
-        let font_instance_keys = (0..number_of_font_instance_keys)
-            .map(|_| {
-                self.global
-                    .borrow()
-                    .webrender_api
-                    .generate_font_instance_key()
-            })
-            .collect();
-        let _ = result_sender.send((font_keys, font_instance_keys));
-    }
-
-    /// Queue a new frame in the transaction and increase the pending frames count.
-    pub(crate) fn generate_frame(&self, transaction: &mut Transaction, reason: RenderReasons) {
-        transaction.generate_frame(0, true /* present */, false /* tracked */, reason);
-        self.pending_frames.set(self.pending_frames.get() + 1);
-    }
-
-    /// Set the root pipeline for our WebRender scene to a display list that consists of an iframe
-    /// for each visible top-level browsing context, applying a transformation on the root for
-    /// pinch zoom, page zoom, and HiDPI scaling.
-    fn send_root_pipeline_display_list(&mut self) {
-        let mut transaction = Transaction::new();
-        self.send_root_pipeline_display_list_in_transaction(&mut transaction);
-        self.generate_frame(&mut transaction, RenderReasons::SCENE);
-        self.global.borrow_mut().send_transaction(transaction);
-    }
-
-    /// Set the root pipeline for our WebRender scene to a display list that consists of an iframe
-    /// for each visible top-level browsing context, applying a transformation on the root for
-    /// pinch zoom, page zoom, and HiDPI scaling.
-    pub(crate) fn send_root_pipeline_display_list_in_transaction(
-        &self,
-        transaction: &mut Transaction,
-    ) {
-        // Every display list needs a pipeline, but we'd like to choose one that is unlikely
-        // to conflict with our content pipelines, which start at (1, 1). (0, 0) is WebRender's
-        // dummy pipeline, so we choose (0, 1).
-        let root_pipeline = WebRenderPipelineId(0, 1);
-        transaction.set_root_pipeline(root_pipeline);
-
-        let mut builder = webrender_api::DisplayListBuilder::new(root_pipeline);
-        builder.begin();
-
-        let root_reference_frame = SpatialId::root_reference_frame(root_pipeline);
-
-        let viewport_size = self.rendering_context.size2d().to_f32().to_untyped();
-        let viewport_rect = LayoutRect::from_origin_and_size(
-            LayoutPoint::zero(),
-            LayoutSize::from_untyped(viewport_size),
-        );
-
-        let root_clip_id = builder.define_clip_rect(root_reference_frame, viewport_rect);
-        let clip_chain_id = builder.define_clip_chain(None, [root_clip_id]);
-        for (_, webview_renderer) in self.webview_renderers.painting_order() {
-            let Some(pipeline_id) = webview_renderer.root_pipeline_id else {
-                continue;
-            };
-
-            let pinch_zoom_transform = webview_renderer.pinch_zoom().transform().to_untyped();
-            let device_pixels_per_page_pixel_not_including_pinch_zoom = webview_renderer
-                .device_pixels_per_page_pixel_not_including_pinch_zoom()
-                .get();
-
-            let transform = LayoutTransform::scale(
-                device_pixels_per_page_pixel_not_including_pinch_zoom,
-                device_pixels_per_page_pixel_not_including_pinch_zoom,
-                1.0,
-            )
-            .then(&LayoutTransform::from_untyped(
-                &pinch_zoom_transform.to_3d(),
-            ));
-
-            let webview_reference_frame = builder.push_reference_frame(
-                LayoutPoint::zero(),
-                root_reference_frame,
-                TransformStyle::Flat,
-                PropertyBinding::Value(transform),
-                ReferenceFrameKind::Transform {
-                    is_2d_scale_translation: true,
-                    should_snap: true,
-                    paired_with_perspective: false,
-                },
-                SpatialTreeItemKey::new(0, 0),
-            );
-
-            let scaled_webview_rect = webview_renderer.rect /
-                webview_renderer.device_pixels_per_page_pixel_not_including_pinch_zoom();
-            builder.push_iframe(
-                LayoutRect::from_untyped(&scaled_webview_rect.to_untyped()),
-                LayoutRect::from_untyped(&scaled_webview_rect.to_untyped()),
-                &SpaceAndClipInfo {
-                    spatial_id: webview_reference_frame,
-                    clip_chain_id,
-                },
-                pipeline_id.into(),
-                true,
-            );
-        }
-
-        let built_display_list = builder.end();
-
-        // NB: We are always passing 0 as the epoch here, but this doesn't seem to
-        // be an issue. WebRender will still update the scene and generate a new
-        // frame even though the epoch hasn't changed.
-        transaction.set_display_list(WebRenderEpoch(0), built_display_list);
-        self.update_transaction_with_all_scroll_offsets(transaction);
-    }
-
-    /// Update the given transaction with the scroll offsets of all active scroll nodes in
-    /// the WebRender scene. This is necessary because WebRender does not preserve scroll
-    /// offsets between scroll tree modifications. If a display list could potentially
-    /// modify a scroll tree branch, WebRender needs to have scroll offsets for that
-    /// branch.
-    ///
-    /// TODO(mrobinson): Could we only send offsets for the branch being modified
-    /// and not the entire scene?
-    fn update_transaction_with_all_scroll_offsets(&self, transaction: &mut Transaction) {
-        for webview_renderer in self.webview_renderers.iter() {
-            for details in webview_renderer.pipelines.values() {
-                for node in details.scroll_tree.nodes.iter() {
-                    let (Some(offset), Some(external_id)) = (node.offset(), node.external_id())
-                    else {
-                        continue;
-                    };
-
-                    transaction.set_scroll_offsets(
-                        external_id,
-                        vec![SampledScrollOffset {
-                            offset,
-                            generation: 0,
-                        }],
-                    );
-                }
-            }
-        }
-    }
-
-    pub fn add_webview(
-        &mut self,
-        webview: Box<dyn WebViewTrait>,
-        viewport_details: ViewportDetails,
-    ) {
-        self.webview_renderers
-            .entry(webview.id())
-            .or_insert(WebViewRenderer::new(
-                self.global.clone(),
-                webview,
-                viewport_details,
-            ));
-    }
-
-    fn set_frame_tree_for_webview(&mut self, frame_tree: &SendableFrameTree) {
-        debug!("{}: Setting frame tree for webview", frame_tree.pipeline.id);
-
-        let webview_id = frame_tree.pipeline.webview_id;
-        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
-            warn!(
-                "Attempted to set frame tree on unknown WebView (perhaps closed?): {webview_id:?}"
-            );
-            return;
-        };
-
-        webview_renderer.set_frame_tree(frame_tree);
-        self.send_root_pipeline_display_list();
-    }
-
-    fn remove_webview(&mut self, webview_id: WebViewId) {
-        debug!("{}: Removing", webview_id);
-        if self.webview_renderers.remove(webview_id).is_err() {
-            warn!("{webview_id}: Removing unknown webview");
-            return;
-        };
-
-        self.send_root_pipeline_display_list();
+    pub fn add_webview(&self, webview: Box<dyn WebViewTrait>, viewport_details: ViewportDetails) {
+        self.painter_mut().add_webview(webview, viewport_details);
     }
 
     pub fn show_webview(
-        &mut self,
+        &self,
         webview_id: WebViewId,
         hide_others: bool,
     ) -> Result<(), UnknownWebView> {
-        debug!("{webview_id}: Showing webview; hide_others={hide_others}");
-        let painting_order_changed = if hide_others {
-            let result = self
-                .webview_renderers
-                .painting_order()
-                .map(|(&id, _)| id)
-                .ne(once(webview_id));
-            self.webview_renderers.hide_all();
-            self.webview_renderers.show(webview_id)?;
-            result
-        } else {
-            self.webview_renderers.show(webview_id)?
-        };
-        if painting_order_changed {
-            self.send_root_pipeline_display_list();
-        }
-        Ok(())
+        self.painter_mut().show_webview(webview_id, hide_others)
     }
 
-    pub fn hide_webview(&mut self, webview_id: WebViewId) -> Result<(), UnknownWebView> {
-        debug!("{webview_id}: Hiding webview");
-        if self.webview_renderers.hide(webview_id)? {
-            self.send_root_pipeline_display_list();
-        }
-        Ok(())
+    pub fn hide_webview(&self, webview_id: WebViewId) -> Result<(), UnknownWebView> {
+        self.painter_mut().hide_webview(webview_id)
     }
 
     pub fn raise_webview_to_top(
-        &mut self,
+        &self,
         webview_id: WebViewId,
         hide_others: bool,
     ) -> Result<(), UnknownWebView> {
-        debug!("{webview_id}: Raising webview to top; hide_others={hide_others}");
-        let painting_order_changed = if hide_others {
-            let result = self
-                .webview_renderers
-                .painting_order()
-                .map(|(&id, _)| id)
-                .ne(once(webview_id));
-            self.webview_renderers.hide_all();
-            self.webview_renderers.raise_to_top(webview_id)?;
-            result
-        } else {
-            self.webview_renderers.raise_to_top(webview_id)?
-        };
-        if painting_order_changed {
-            self.send_root_pipeline_display_list();
-        }
-        Ok(())
+        self.painter_mut()
+            .raise_webview_to_top(webview_id, hide_others)
     }
 
-    pub fn move_resize_webview(&mut self, webview_id: WebViewId, rect: DeviceRect) {
-        if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
+    pub fn move_resize_webview(&self, webview_id: WebViewId, rect: DeviceRect) {
+        if self.shutdown_state() != ShutdownState::NotShuttingDown {
             return;
         }
-        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
-            return;
-        };
-        if !webview_renderer.set_rect(rect) {
-            return;
-        }
-
-        self.send_root_pipeline_display_list();
-        self.set_needs_repaint(RepaintReason::Resize);
+        self.painter_mut().move_resize_webview(webview_id, rect);
     }
 
     pub fn set_hidpi_scale_factor(
-        &mut self,
+        &self,
         webview_id: WebViewId,
         new_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
     ) {
-        if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
+        if self.shutdown_state() != ShutdownState::NotShuttingDown {
             return;
         }
-        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
-            return;
-        };
-        if !webview_renderer.set_hidpi_scale_factor(new_scale_factor) {
-            return;
-        }
-
-        self.send_root_pipeline_display_list();
-        self.set_needs_repaint(RepaintReason::Resize);
+        self.painter_mut()
+            .set_hidpi_scale_factor(webview_id, new_scale_factor);
     }
 
-    pub fn resize_rendering_context(&mut self, new_size: PhysicalSize<u32>) {
-        if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
+    pub fn resize_rendering_context(&self, new_size: PhysicalSize<u32>) {
+        if self.shutdown_state() != ShutdownState::NotShuttingDown {
             return;
         }
-        if self.rendering_context.size() == new_size {
+        self.painter_mut().resize_rendering_context(new_size);
+    }
+
+    pub fn set_page_zoom(&self, webview_id: WebViewId, new_zoom: f32) {
+        if self.shutdown_state() != ShutdownState::NotShuttingDown {
             return;
         }
-
-        self.rendering_context.resize(new_size);
-
-        let mut transaction = Transaction::new();
-        let output_region = DeviceIntRect::new(
-            Point2D::zero(),
-            Point2D::new(new_size.width as i32, new_size.height as i32),
-        );
-        transaction.set_document_view(output_region);
-        self.global.borrow_mut().send_transaction(transaction);
-
-        self.send_root_pipeline_display_list();
-        self.set_needs_repaint(RepaintReason::Resize);
+        self.painter_mut().set_page_zoom(webview_id, new_zoom);
     }
 
-    pub fn set_page_zoom(&mut self, webview_id: WebViewId, new_zoom: f32) {
-        if self.global.borrow().shutdown_state() != ShutdownState::NotShuttingDown {
-            return;
-        }
-
-        if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-            webview_renderer.set_page_zoom(Scale::new(new_zoom));
-        }
-    }
-
-    pub fn page_zoom(&mut self, webview_id: WebViewId) -> f32 {
-        self.webview_renderers
-            .get(webview_id)
-            .map(|webview_renderer| webview_renderer.page_zoom.get())
-            .unwrap_or_default()
-    }
-
-    /// Returns true if any animation callbacks (ie `requestAnimationFrame`) are waiting for a response.
-    fn animation_callbacks_running(&self) -> bool {
-        self.webview_renderers
-            .iter()
-            .any(WebViewRenderer::animation_callbacks_running)
-    }
-
-    pub(crate) fn animating_webviews(&self) -> Vec<WebViewId> {
-        self.webview_renderers
-            .iter()
-            .filter_map(|webview_renderer| {
-                if webview_renderer.animating() {
-                    Some(webview_renderer.id)
-                } else {
-                    None
-                }
-            })
-            .collect()
+    pub fn page_zoom(&self, webview_id: WebViewId) -> f32 {
+        self.painter().page_zoom(webview_id)
     }
 
     /// Render the WebRender scene to the active `RenderingContext`.
-    pub fn render(&mut self) {
-        let refresh_driver = &self.global.borrow().refresh_driver.clone();
-        refresh_driver.notify_will_paint(self);
-
-        self.render_inner();
-
-        // We've painted the default target, which means that from the embedder's perspective,
-        // the scene no longer needs to be repainted.
-        self.needs_repaint.set(RepaintReason::empty());
-    }
-
-    #[servo_tracing::instrument(skip_all)]
-    fn render_inner(&mut self) {
-        if let Err(err) = self.rendering_context.make_current() {
-            warn!("Failed to make the rendering context current: {:?}", err);
-        }
-        self.assert_no_gl_error();
-
-        if let Some(webrender) = self.webrender.as_mut() {
-            webrender.update();
-        }
-
-        self.rendering_context.prepare_for_rendering();
-
-        let time_profiler_chan = self.global.borrow().time_profiler_chan.clone();
-        time_profile!(
-            ProfilerCategory::Compositing,
-            None,
-            time_profiler_chan,
-            || {
-                trace!("Compositing");
-
-                // Paint the scene.
-                // TODO(gw): Take notice of any errors the renderer returns!
-                self.clear_background();
-                if let Some(webrender) = self.webrender.as_mut() {
-                    let size = self.rendering_context.size2d().to_i32();
-                    webrender.render(size, 0 /* buffer_age */).ok();
-                }
-            },
-        );
-
-        self.send_pending_paint_metrics_messages_after_composite();
-        self.screenshot_taker.maybe_take_screenshots(self);
-    }
-
-    /// Send all pending paint metrics messages after a composite operation, which may advance
-    /// the epoch for pipelines in the WebRender scene.
-    ///
-    /// If there are pending paint metrics, we check if any of the painted epochs is one
-    /// of the ones that the paint metrics recorder is expecting. In that case, we get the
-    /// current time, inform the constellation about it and remove the pending metric from
-    /// the list.
-    fn send_pending_paint_metrics_messages_after_composite(&mut self) {
-        let paint_time = CrossProcessInstant::now();
-        let document_id = self.webrender_document();
-        for webview_renderer in self.webview_renderers.iter_mut() {
-            for (pipeline_id, pipeline) in webview_renderer.pipelines.iter_mut() {
-                let Some(current_epoch) = self
-                    .webrender
-                    .as_ref()
-                    .and_then(|wr| wr.current_epoch(document_id, pipeline_id.into()))
-                else {
-                    continue;
-                };
-
-                match pipeline.first_paint_metric {
-                    // We need to check whether the current epoch is later, because
-                    // CrossProcessCompositorMessage::SendInitialTransaction sends an
-                    // empty display list to WebRender which can happen before we receive
-                    // the first "real" display list.
-                    PaintMetricState::Seen(epoch, first_reflow) if epoch <= current_epoch => {
-                        assert!(epoch <= current_epoch);
-                        #[cfg(feature = "tracing")]
-                        tracing::info!(
-                            name: "FirstPaint",
-                            servo_profiling = true,
-                            epoch = ?epoch,
-                            paint_time = ?paint_time,
-                            pipeline_id = ?pipeline_id,
-                        );
-                        if let Err(error) =
-                            self.global.borrow().embedder_to_constellation_sender.send(
-                                EmbedderToConstellationMessage::PaintMetric(
-                                    *pipeline_id,
-                                    PaintMetricEvent::FirstPaint(paint_time, first_reflow),
-                                ),
-                            )
-                        {
-                            warn!(
-                                "Sending paint metric event to constellation failed ({error:?})."
-                            );
-                        }
-                        pipeline.first_paint_metric = PaintMetricState::Sent;
-                    },
-                    _ => {},
-                }
-
-                match pipeline.first_contentful_paint_metric {
-                    PaintMetricState::Seen(epoch, first_reflow) if epoch <= current_epoch => {
-                        #[cfg(feature = "tracing")]
-                        tracing::info!(
-                            name: "FirstContentfulPaint",
-                            servo_profiling = true,
-                            epoch = ?epoch,
-                            paint_time = ?paint_time,
-                            pipeline_id = ?pipeline_id,
-                        );
-                        if let Err(error) = self
-                            .global
-                            .borrow()
-                            .embedder_to_constellation_sender
-                            .send(EmbedderToConstellationMessage::PaintMetric(
-                                *pipeline_id,
-                                PaintMetricEvent::FirstContentfulPaint(paint_time, first_reflow),
-                            ))
-                        {
-                            warn!(
-                                "Sending paint metric event to constellation failed ({error:?})."
-                            );
-                        }
-                        pipeline.first_contentful_paint_metric = PaintMetricState::Sent;
-                    },
-                    _ => {},
-                }
-            }
-        }
-    }
-
-    fn clear_background(&self) {
-        let gl = &self.global.borrow().webrender_gl;
-        self.assert_gl_framebuffer_complete();
-
-        // Always clear the entire RenderingContext, regardless of how many WebViews there are
-        // or where they are positioned. This is so WebView actually clears even before the
-        // first WebView is ready.
-        let color = servo_config::pref!(shell_background_color_rgba);
-        gl.clear_color(
-            color[0] as f32,
-            color[1] as f32,
-            color[2] as f32,
-            color[3] as f32,
-        );
-        gl.clear(gleam::gl::COLOR_BUFFER_BIT);
-    }
-
-    #[track_caller]
-    fn assert_no_gl_error(&self) {
-        debug_assert_eq!(
-            self.global.borrow().webrender_gl.get_error(),
-            gleam::gl::NO_ERROR
-        );
-    }
-
-    #[track_caller]
-    fn assert_gl_framebuffer_complete(&self) {
-        debug_assert_eq!(
-            (
-                self.global.borrow().webrender_gl.get_error(),
-                self.global
-                    .borrow()
-                    .webrender_gl
-                    .check_frame_buffer_status(gleam::gl::FRAMEBUFFER)
-            ),
-            (gleam::gl::NO_ERROR, gleam::gl::FRAMEBUFFER_COMPLETE)
-        );
+    pub fn render(&self) {
+        self.painter_mut().render(&self.time_profiler_chan);
     }
 
     /// Get the message receiver for this [`IOCompositor`].
-    pub fn receiver(&self) -> Ref<'_, RoutedReceiver<CompositorMsg>> {
-        Ref::map(self.global.borrow(), |global| &global.compositor_receiver)
+    pub fn receiver(&self) -> &RoutedReceiver<CompositorMsg> {
+        &self.compositor_receiver
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -1579,7 +507,7 @@ impl IOCompositor {
 
         messages.retain(|message| match message {
             CompositorMsg::NewWebRenderFrameReady(_, need_repaint) => {
-                self.pending_frames.set(self.pending_frames.get() - 1);
+                self.painter().decrement_pending_frames();
                 repaint_needed |= need_repaint;
                 saw_webrender_frame_ready = true;
 
@@ -1590,7 +518,7 @@ impl IOCompositor {
 
         for message in messages {
             self.handle_browser_message(message);
-            if self.global.borrow().shutdown_state() == ShutdownState::FinishedShuttingDown {
+            if self.shutdown_state() == ShutdownState::FinishedShuttingDown {
                 return;
             }
         }
@@ -1601,86 +529,25 @@ impl IOCompositor {
     }
 
     #[servo_tracing::instrument(skip_all)]
-    pub fn perform_updates(&mut self) -> bool {
-        if self.global.borrow().shutdown_state() == ShutdownState::FinishedShuttingDown {
+    pub fn perform_updates(&self) -> bool {
+        if self.shutdown_state() == ShutdownState::FinishedShuttingDown {
             return false;
         }
 
-        #[cfg(feature = "webxr")]
-        // Run the WebXR main thread
-        self.global.borrow_mut().webxr_main_thread.run_one_frame();
-
-        // The WebXR thread may make a different context current
-        if let Err(err) = self.rendering_context.make_current() {
-            warn!("Failed to make the rendering context current: {:?}", err);
+        for painter in &self.painters {
+            painter.borrow_mut().perform_updates();
         }
 
-        let mut need_zoom = false;
-        let scroll_offset_updates: Vec<_> = self
-            .webview_renderers
-            .iter_mut()
-            .filter_map(|webview_renderer| {
-                let (zoom, scroll_result) =
-                    webview_renderer.process_pending_scroll_and_pinch_zoom_events();
-                need_zoom = need_zoom || (zoom == PinchZoomResult::DidPinchZoom);
-                scroll_result
-            })
-            .collect();
-        self.send_zoom_and_scroll_offset_updates(need_zoom, scroll_offset_updates);
-
-        self.global.borrow().shutdown_state() != ShutdownState::FinishedShuttingDown
+        self.shutdown_state() != ShutdownState::FinishedShuttingDown
     }
 
-    pub(crate) fn send_zoom_and_scroll_offset_updates(
-        &self,
-        need_zoom: bool,
-        scroll_offset_updates: Vec<ScrollResult>,
-    ) {
-        if !need_zoom && scroll_offset_updates.is_empty() {
-            return;
+    pub fn toggle_webrender_debug(&self, option: WebRenderDebugOption) {
+        for painter in &self.painters {
+            painter.borrow_mut().toggle_webrender_debug(option);
         }
-
-        let mut transaction = Transaction::new();
-        if need_zoom {
-            self.send_root_pipeline_display_list_in_transaction(&mut transaction);
-        }
-        for update in scroll_offset_updates {
-            transaction.set_scroll_offsets(
-                update.external_scroll_id,
-                vec![SampledScrollOffset {
-                    offset: update.offset,
-                    generation: 0,
-                }],
-            );
-        }
-
-        self.generate_frame(&mut transaction, RenderReasons::APZ);
-        self.global.borrow_mut().send_transaction(transaction);
     }
 
-    pub fn toggle_webrender_debug(&mut self, option: WebRenderDebugOption) {
-        let Some(webrender) = self.webrender.as_mut() else {
-            return;
-        };
-        let mut flags = webrender.get_debug_flags();
-        let flag = match option {
-            WebRenderDebugOption::Profiler => {
-                webrender::DebugFlags::PROFILER_DBG |
-                    webrender::DebugFlags::GPU_TIME_QUERIES |
-                    webrender::DebugFlags::GPU_SAMPLE_QUERIES
-            },
-            WebRenderDebugOption::TextureCacheDebug => webrender::DebugFlags::TEXTURE_CACHE_DBG,
-            WebRenderDebugOption::RenderTargetDebug => webrender::DebugFlags::RENDER_TARGET_DBG,
-        };
-        flags.toggle(flag);
-        webrender.set_debug_flags(flags);
-
-        let mut txn = Transaction::new();
-        self.generate_frame(&mut txn, RenderReasons::TESTING);
-        self.global.borrow_mut().send_transaction(txn);
-    }
-
-    pub fn capture_webrender(&mut self) {
+    pub fn capture_webrender(&self) {
         let capture_id = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -1701,122 +568,52 @@ impl IOCompositor {
         };
 
         println!("Saving WebRender capture to {capture_path:?}");
-        self.global
-            .borrow()
+        self.painter()
             .webrender_api
             .save_capture(capture_path.clone(), CaptureBits::all());
     }
 
-    fn add_font_instance(
-        &mut self,
-        instance_key: FontInstanceKey,
-        font_key: FontKey,
-        size: f32,
-        flags: FontInstanceFlags,
-        variations: Vec<FontVariation>,
-    ) {
-        let variations = if pref!(layout_variable_fonts_enabled) {
-            variations
-        } else {
-            vec![]
-        };
-
-        let mut transaction = Transaction::new();
-
-        let font_instance_options = FontInstanceOptions {
-            flags,
-            ..Default::default()
-        };
-        transaction.add_font_instance(
-            instance_key,
-            font_key,
-            size,
-            Some(font_instance_options),
-            None,
-            variations,
-        );
-
-        self.global.borrow_mut().send_transaction(transaction);
-    }
-
-    fn add_font(&mut self, font_key: FontKey, index: u32, data: Arc<IpcSharedMemory>) {
-        let mut transaction = Transaction::new();
-        transaction.add_raw_font(font_key, (**data).into(), index);
-        self.global.borrow_mut().send_transaction(transaction);
-    }
-
-    pub fn notify_input_event(&mut self, webview_id: WebViewId, event: InputEventAndId) {
-        if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-            webview_renderer.notify_input_event(event);
+    pub fn notify_input_event(&self, webview_id: WebViewId, event: InputEventAndId) {
+        if self.shutdown_state() != ShutdownState::NotShuttingDown {
+            return;
         }
+        self.painter_mut().notify_input_event(webview_id, event);
     }
 
-    pub fn notify_scroll_event(
-        &mut self,
-        webview_id: WebViewId,
-        scroll: Scroll,
-        point: WebViewPoint,
-    ) {
-        if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-            webview_renderer.notify_scroll_event(scroll, point);
+    pub fn notify_scroll_event(&self, webview_id: WebViewId, scroll: Scroll, point: WebViewPoint) {
+        if self.shutdown_state() != ShutdownState::NotShuttingDown {
+            return;
         }
+        self.painter_mut()
+            .notify_scroll_event(webview_id, scroll, point);
     }
 
-    pub fn pinch_zoom(
-        &mut self,
-        webview_id: WebViewId,
-        pinch_zoom_delta: f32,
-        center: DevicePoint,
-    ) {
-        if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-            webview_renderer.adjust_pinch_zoom(pinch_zoom_delta, center);
+    pub fn pinch_zoom(&self, webview_id: WebViewId, pinch_zoom_delta: f32, center: DevicePoint) {
+        if self.shutdown_state() != ShutdownState::NotShuttingDown {
+            return;
         }
+        self.painter_mut()
+            .pinch_zoom(webview_id, pinch_zoom_delta, center);
     }
 
     pub fn device_pixels_per_page_pixel(
         &self,
         webview_id: WebViewId,
     ) -> Scale<f32, CSSPixel, DevicePixel> {
-        self.webview_renderers
-            .get(webview_id)
-            .map(WebViewRenderer::device_pixels_per_page_pixel)
-            .unwrap_or_default()
+        self.painter_mut().device_pixels_per_page_pixel(webview_id)
     }
 
-    fn webrender_document(&self) -> DocumentId {
-        self.global.borrow().webrender_document
-    }
-
-    fn shutdown_state(&self) -> ShutdownState {
-        self.global.borrow().shutdown_state()
-    }
-
-    fn refresh_cursor(&self) {
-        let global = self.global.borrow();
-        let Some(last_mouse_move_position) = global.last_mouse_move_position else {
-            return;
-        };
-
-        let Some(hit_test_result) = global
-            .hit_test_at_point(last_mouse_move_position)
-            .first()
-            .cloned()
-        else {
-            return;
-        };
-
-        if let Err(error) = global.embedder_to_constellation_sender.send(
-            EmbedderToConstellationMessage::RefreshCursor(hit_test_result.pipeline_id),
-        ) {
-            warn!("Sending event to constellation failed ({:?}).", error);
-        }
+    pub(crate) fn shutdown_state(&self) -> ShutdownState {
+        self.shutdown_state.get()
     }
 
     fn handle_new_webrender_frame_ready(&mut self, repaint_needed: bool) {
+        let painter = self.painter();
         if repaint_needed {
-            self.refresh_cursor();
+            painter.refresh_cursor()
         }
-        if repaint_needed || self.animation_callbacks_running() {
+
+        if repaint_needed || painter.animation_callbacks_running() {
             self.set_needs_repaint(RepaintReason::NewWebRenderFrame);
         }
 
@@ -1824,16 +621,10 @@ impl IOCompositor {
         // is the last frame that was pending. In that case, trigger a manual repaint so
         // that the screenshot can be taken at the end of the repaint procedure.
         if !repaint_needed {
-            self.screenshot_taker
-                .maybe_trigger_paint_for_screenshot(self);
+            painter
+                .screenshot_taker
+                .maybe_trigger_paint_for_screenshot(&painter);
         }
-    }
-
-    /// Whether or not the renderer is waiting on a frame, either because it has been sent
-    /// to WebRender and is not ready yet or because the [`FrameDelayer`] is delaying a frame
-    /// waiting for asynchronous (canvas) image updates to complete.
-    pub(crate) fn has_pending_frames(&self) -> bool {
-        self.pending_frames.get() != 0 || self.global.borrow().frame_delayer.pending_frame
     }
 
     pub fn request_screenshot(
@@ -1842,102 +633,17 @@ impl IOCompositor {
         rect: Option<WebViewRect>,
         callback: Box<dyn FnOnce(Result<RgbaImage, ScreenshotCaptureError>) + 'static>,
     ) {
-        let Some(webview) = self.webview_renderers.get(webview_id) else {
-            return;
-        };
-
-        let rect = rect.map(|rect| rect.as_device_rect(webview.device_pixels_per_page_pixel()));
-        self.screenshot_taker
+        self.painter()
             .request_screenshot(webview_id, rect, callback);
-        let _ = self.global.borrow().embedder_to_constellation_sender.send(
-            EmbedderToConstellationMessage::RequestScreenshotReadiness(webview_id),
-        );
     }
 
     pub fn notify_input_event_handled(
-        &mut self,
+        &self,
         webview_id: WebViewId,
         input_event_id: InputEventId,
         result: InputEventResult,
     ) {
-        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
-            warn!("Handled input event for unknown webview: {webview_id}");
-            return;
-        };
-        webview_renderer.notify_input_event_handled(input_event_id, result);
-    }
-}
-
-/// A struct that is reponsible for delaying frame requests until all new canvas images
-/// for a particular "update the rendering" call in the `ScriptThread` have been
-/// sent to WebRender.
-///
-/// These images may be updated in WebRender asynchronously in the canvas task. A frame
-/// is then requested if:
-///
-///  - The renderer has received a GenerateFrame message from a `ScriptThread`.
-///  - All pending image updates have finished and have been noted in the [`FrameDelayer`].
-#[derive(Default)]
-struct FrameDelayer {
-    /// The latest [`Epoch`] of canvas images that have been sent to WebRender. Note
-    /// that this only records the `Epoch`s for canvases and only ones that are involved
-    /// in "update the rendering".
-    image_epochs: FxHashMap<ImageKey, Epoch>,
-    /// A map of all pending canvas images
-    pending_canvas_images: FxHashMap<ImageKey, Epoch>,
-    /// Whether or not we have a pending frame.
-    pending_frame: bool,
-    /// A list of pipelines that should be notified when we are no longer waiting for
-    /// canvas images.
-    waiting_pipelines: FxHashSet<PipelineId>,
-}
-
-impl FrameDelayer {
-    fn delete_image(&mut self, image_key: ImageKey) {
-        self.image_epochs.remove(&image_key);
-        self.pending_canvas_images.remove(&image_key);
-    }
-
-    fn update_image(&mut self, image_key: ImageKey, epoch: Epoch) {
-        self.image_epochs.insert(image_key, epoch);
-        let Entry::Occupied(entry) = self.pending_canvas_images.entry(image_key) else {
-            return;
-        };
-        if *entry.get() <= epoch {
-            entry.remove();
-        }
-    }
-
-    fn add_delay(
-        &mut self,
-        pipeline_id: PipelineId,
-        canvas_epoch: Epoch,
-        image_keys: Vec<ImageKey>,
-    ) {
-        for image_key in image_keys.into_iter() {
-            // If we've already seen the necessary epoch for this image, do not
-            // start waiting for it.
-            if self
-                .image_epochs
-                .get(&image_key)
-                .is_some_and(|epoch_seen| *epoch_seen >= canvas_epoch)
-            {
-                continue;
-            }
-            self.pending_canvas_images.insert(image_key, canvas_epoch);
-        }
-        self.waiting_pipelines.insert(pipeline_id);
-    }
-
-    fn needs_new_frame(&self) -> bool {
-        self.pending_frame && self.pending_canvas_images.is_empty()
-    }
-
-    fn set_pending_frame(&mut self, value: bool) {
-        self.pending_frame = value;
-    }
-
-    fn take_waiting_pipelines(&mut self) -> Vec<PipelineId> {
-        self.waiting_pipelines.drain().collect()
+        self.painter_mut()
+            .notify_input_event_handled(webview_id, input_event_id, result);
     }
 }

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -24,7 +24,9 @@ pub use crate::compositor::{IOCompositor, WebRenderDebugOption};
 mod tracing;
 
 mod compositor;
+mod painter;
 mod pinch_zoom;
+mod pipeline_details;
 mod refresh_driver;
 mod render_notifier;
 mod screenshot;

--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -1,0 +1,1520 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::Cell;
+use std::collections::hash_map::Entry;
+use std::iter::once;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+use base::Epoch;
+use base::cross_process_instant::CrossProcessInstant;
+use base::id::{PipelineId, WebViewId};
+use canvas_traits::webgl::{GlType, WebGLThreads};
+use compositing_traits::display_list::{CompositorDisplayListInfo, ScrollType};
+use compositing_traits::rendering_context::RenderingContext;
+use compositing_traits::viewport_description::ViewportDescription;
+use compositing_traits::{
+    CompositorProxy, ImageUpdate, PipelineExitSource, SendableFrameTree,
+    WebRenderExternalImageHandlers, WebRenderExternalImageRegistry, WebRenderImageHandlerType,
+    WebViewTrait,
+};
+use constellation_traits::{EmbedderToConstellationMessage, PaintMetricEvent};
+use crossbeam_channel::Sender;
+use dpi::PhysicalSize;
+use embedder_traits::{
+    CompositorHitTestResult, EventLoopWaker, InputEvent, InputEventAndId, InputEventId,
+    InputEventResult, RefreshDriver, ScreenshotCaptureError, Scroll, ViewportDetails, WebViewPoint,
+    WebViewRect,
+};
+use euclid::{Point2D, Scale};
+use gleam::gl::RENDERER;
+use image::RgbaImage;
+use ipc_channel::ipc::{IpcBytesReceiver, IpcSharedMemory};
+use log::{debug, info, warn};
+use media::WindowGLContext;
+use profile_traits::time::{ProfilerCategory, ProfilerChan};
+use profile_traits::time_profile;
+use rustc_hash::{FxHashMap, FxHashSet};
+use servo_config::pref;
+use servo_geometry::DeviceIndependentPixel;
+use smallvec::SmallVec;
+use style_traits::CSSPixel;
+use webgl::WebGLComm;
+use webrender::{
+    MemoryReport, ONE_TIME_USAGE_HINT, RenderApi, ShaderPrecacheFlags, Transaction, UploadMethod,
+};
+use webrender_api::units::{
+    DeviceIntRect, DevicePixel, DevicePoint, DeviceRect, LayoutPoint, LayoutRect, LayoutSize,
+    LayoutTransform, LayoutVector2D, WorldPoint,
+};
+use webrender_api::{
+    self, BuiltDisplayList, BuiltDisplayListDescriptor, ColorF, DirtyRect, DisplayListPayload,
+    DocumentId, Epoch as WebRenderEpoch, ExternalScrollId, FontInstanceFlags, FontInstanceKey,
+    FontInstanceOptions, FontKey, FontVariation, ImageKey, NativeFontHandle,
+    PipelineId as WebRenderPipelineId, PropertyBinding, ReferenceFrameKind, RenderReasons,
+    SampledScrollOffset, SpaceAndClipInfo, SpatialId, SpatialTreeItemKey, TransformStyle,
+};
+use wr_malloc_size_of::MallocSizeOfOps;
+
+use crate::compositor::{RepaintReason, WebRenderDebugOption};
+use crate::refresh_driver::{AnimationRefreshDriverObserver, BaseRefreshDriver};
+use crate::render_notifier::RenderNotifier;
+use crate::screenshot::ScreenshotTaker;
+use crate::webview_manager::WebViewManager;
+use crate::webview_renderer::{PinchZoomResult, ScrollResult, UnknownWebView, WebViewRenderer};
+
+/// A [`Painter`] is responsible for all of the painting to a particular [`RenderingContext`].
+/// This holds all of the WebRender specific data structures and state necessary for painting
+/// and handling events that happen to `WebView`s that use a particular [`RenderingContext`].
+/// Notable is that a [`Painter`] might be responsible for painting more than a single
+/// [`WebView`] as long as they share the same [`RenderingContext`].
+///
+/// Each [`Painter`] also has its own [`RefreshDriver`] as well, which may be shared with
+/// other [`Painter`]s. It's up to the embedder to decide which [`RefreshDriver`]s are associated
+/// with a particular [`RenderingContext`].
+pub(crate) struct Painter {
+    /// The [`RenderingContext`] instance that webrender targets, which is the viewport.
+    pub(crate) rendering_context: Rc<dyn RenderingContext>,
+
+    /// Our [`WebViewRenderer`]s, one for every `WebView`.
+    pub(crate) webview_renderers: WebViewManager<WebViewRenderer>,
+
+    /// Tracks whether or not the view needs to be repainted.
+    pub(crate) needs_repaint: Cell<RepaintReason>,
+
+    /// The number of frames pending to receive from WebRender.
+    pub(crate) pending_frames: Cell<usize>,
+
+    /// The [`BaseRefreshDriver`] which manages the painting of `WebView`s during animations.
+    refresh_driver: Rc<BaseRefreshDriver>,
+
+    /// A [`RefreshDriverObserver`] for WebView content animations.
+    animation_refresh_driver_observer: Rc<AnimationRefreshDriverObserver>,
+
+    /// The WebRender [`RenderApi`] interface used to communicate with WebRender.
+    pub(crate) webrender_api: RenderApi,
+
+    /// The active webrender document.
+    pub(crate) webrender_document: DocumentId,
+
+    /// The webrender renderer.
+    pub(crate) webrender: Option<webrender::Renderer>,
+
+    /// The GL bindings for webrender
+    webrender_gl: Rc<dyn gleam::gl::Gl>,
+
+    /// The last position in the rendered view that the mouse moved over. This becomes `None`
+    /// when the mouse leaves the rendered view.
+    pub(crate) last_mouse_move_position: Option<DevicePoint>,
+
+    /// A [`ScreenshotTaker`] responsible for handling all screenshot requests.
+    pub(crate) screenshot_taker: ScreenshotTaker,
+
+    /// A [`FrameRequestDelayer`] which is used to wait for canvas image updates to
+    /// arrive before requesting a new frame, as these happen asynchronously with
+    /// `ScriptThread` display list construction.
+    pub(crate) frame_delayer: FrameDelayer,
+
+    /// The WebRender image registry from this renderer.
+    pub(crate) webrender_external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
+
+    #[cfg(feature = "webxr")]
+    /// Some XR devices want to run on the main thread.
+    pub(crate) webxr_main_thread: webxr::MainThreadRegistry,
+
+    /// The [`WebGLThreads`] for this renderer.
+    pub(crate) webgl_threads: WebGLThreads,
+
+    #[cfg(feature = "webgpu")]
+    /// The WebGPU image map for this renderer.
+    pub(crate) webgpu_image_map: webgpu::canvas_context::WGPUImageMap,
+
+    /// The channel on which messages can be sent to the constellation.
+    embedder_to_constellation_sender: Sender<EmbedderToConstellationMessage>,
+}
+
+impl Drop for Painter {
+    fn drop(&mut self) {
+        self.webrender_api.stop_render_backend();
+        self.webrender_api.shut_down(true);
+    }
+}
+
+impl Painter {
+    pub(crate) fn new(
+        rendering_context: Rc<dyn RenderingContext>,
+        compositor_proxy: CompositorProxy,
+        event_loop_waker: Box<dyn EventLoopWaker>,
+        refresh_driver: Option<Rc<dyn RefreshDriver>>,
+        shader_path: Option<PathBuf>,
+        embedder_to_constellation_sender: Sender<EmbedderToConstellationMessage>,
+        #[cfg(feature = "webxr")] webxr_registry: Box<dyn webxr::WebXrRegistry>,
+    ) -> Self {
+        let webrender_gl = rendering_context.gleam_gl_api();
+
+        // Make sure the gl context is made current.
+        if let Err(err) = rendering_context.make_current() {
+            warn!("Failed to make the rendering context current: {:?}", err);
+        }
+        debug_assert_eq!(webrender_gl.get_error(), gleam::gl::NO_ERROR,);
+
+        // Create the webgl thread
+        let gl_type = match webrender_gl.get_type() {
+            gleam::gl::GlType::Gl => GlType::Gl,
+            gleam::gl::GlType::Gles => GlType::Gles,
+        };
+
+        let (external_image_handlers, webrender_external_images) =
+            WebRenderExternalImageHandlers::new();
+        let mut external_image_handlers = Box::new(external_image_handlers);
+
+        let WebGLComm {
+            webgl_threads,
+            #[cfg(feature = "webxr")]
+            webxr_layer_grand_manager,
+            image_handler,
+        } = WebGLComm::new(
+            rendering_context.clone(),
+            compositor_proxy.cross_process_compositor_api.clone(),
+            webrender_external_images.clone(),
+            gl_type,
+        );
+
+        // Set webrender external image handler for WebGL textures
+        external_image_handlers.set_handler(image_handler, WebRenderImageHandlerType::WebGl);
+
+        // Create the WebXR main thread
+        #[cfg(feature = "webxr")]
+        let mut webxr_main_thread =
+            webxr::MainThreadRegistry::new(event_loop_waker.clone(), webxr_layer_grand_manager)
+                .expect("Failed to create WebXR device registry");
+        #[cfg(feature = "webxr")]
+        if pref!(dom_webxr_enabled) {
+            webxr_registry.register(&mut webxr_main_thread);
+        }
+
+        #[cfg(feature = "webgpu")]
+        let webgpu_image_map = {
+            let webgpu_image_handler = webgpu::WGPUExternalImages::default();
+            let webgpu_image_map = webgpu_image_handler.images.clone();
+            external_image_handlers.set_handler(
+                Box::new(webgpu_image_handler),
+                WebRenderImageHandlerType::WebGpu,
+            );
+            webgpu_image_map
+        };
+
+        WindowGLContext::initialize_image_handler(
+            &mut external_image_handlers,
+            webrender_external_images.clone(),
+        );
+
+        let refresh_driver = Rc::new(BaseRefreshDriver::new(event_loop_waker, refresh_driver));
+        let animation_refresh_driver_observer = Rc::new(AnimationRefreshDriverObserver::new(
+            embedder_to_constellation_sender.clone(),
+        ));
+
+        rendering_context.prepare_for_rendering();
+        let clear_color = servo_config::pref!(shell_background_color_rgba);
+        let clear_color = ColorF::new(
+            clear_color[0] as f32,
+            clear_color[1] as f32,
+            clear_color[2] as f32,
+            clear_color[3] as f32,
+        );
+
+        // Use same texture upload method as Gecko with ANGLE:
+        // https://searchfox.org/mozilla-central/source/gfx/webrender_bindings/src/bindings.rs#1215-1219
+        let upload_method = if webrender_gl.get_string(RENDERER).starts_with("ANGLE") {
+            UploadMethod::Immediate
+        } else {
+            UploadMethod::PixelBuffer(ONE_TIME_USAGE_HINT)
+        };
+        let worker_threads = std::thread::available_parallelism()
+            .map(|i| i.get())
+            .unwrap_or(pref!(threadpools_fallback_worker_num) as usize)
+            .min(pref!(threadpools_webrender_workers_max).max(1) as usize);
+        let workers = Some(Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(worker_threads)
+                .thread_name(|idx| format!("WRWorker#{}", idx))
+                .build()
+                .expect("Unable to initialize WebRender worker pool."),
+        ));
+
+        let (mut webrender, webrender_api_sender) = webrender::create_webrender_instance(
+            webrender_gl.clone(),
+            Box::new(RenderNotifier::new(compositor_proxy)),
+            webrender::WebRenderOptions {
+                // We force the use of optimized shaders here because rendering is broken
+                // on Android emulators with unoptimized shaders. This is due to a known
+                // issue in the emulator's OpenGL emulation layer.
+                // See: https://github.com/servo/servo/issues/31726
+                use_optimized_shaders: true,
+                resource_override_path: shader_path,
+                debug_flags: webrender::DebugFlags::empty(),
+                precache_flags: if pref!(gfx_precache_shaders) {
+                    ShaderPrecacheFlags::FULL_COMPILE
+                } else {
+                    ShaderPrecacheFlags::empty()
+                },
+                enable_aa: pref!(gfx_text_antialiasing_enabled),
+                enable_subpixel_aa: pref!(gfx_subpixel_text_antialiasing_enabled),
+                allow_texture_swizzling: pref!(gfx_texture_swizzling_enabled),
+                clear_color,
+                upload_method,
+                workers,
+                size_of_op: Some(servo_allocator::usable_size),
+                ..Default::default()
+            },
+            None,
+        )
+        .expect("Unable to initialize WebRender.");
+
+        webrender.set_external_image_handler(external_image_handlers);
+
+        let webrender_api = webrender_api_sender.create_api();
+        let webrender_document = webrender_api.add_document(rendering_context.size2d().to_i32());
+
+        let gl_renderer = webrender_gl.get_string(gleam::gl::RENDERER);
+        let gl_version = webrender_gl.get_string(gleam::gl::VERSION);
+        info!("Running on {gl_renderer} with OpenGL version {gl_version}");
+
+        let painter = Painter {
+            embedder_to_constellation_sender,
+            webview_renderers: Default::default(),
+            rendering_context,
+            needs_repaint: Cell::default(),
+            pending_frames: Default::default(),
+            screenshot_taker: Default::default(),
+            refresh_driver,
+            animation_refresh_driver_observer,
+            webrender: Some(webrender),
+            webrender_api,
+            webrender_document,
+            webrender_gl,
+            last_mouse_move_position: None,
+            frame_delayer: Default::default(),
+            webrender_external_images,
+            webgl_threads,
+            #[cfg(feature = "webxr")]
+            webxr_main_thread,
+            #[cfg(feature = "webgpu")]
+            webgpu_image_map,
+        };
+        painter.assert_gl_framebuffer_complete();
+        painter
+    }
+
+    pub(crate) fn perform_updates(&mut self) {
+        #[cfg(feature = "webxr")]
+        // Run the WebXR main thread
+        self.webxr_main_thread.run_one_frame();
+
+        // The WebXR thread may make a different context current
+        if let Err(err) = self.rendering_context.make_current() {
+            warn!("Failed to make the rendering context current: {:?}", err);
+        }
+
+        let mut need_zoom = false;
+        let scroll_offset_updates: Vec<_> = self
+            .webview_renderers
+            .iter_mut()
+            .filter_map(|webview_renderer| {
+                let (zoom, scroll_result) = webview_renderer
+                    .process_pending_scroll_and_pinch_zoom_events(&self.webrender_api);
+                need_zoom = need_zoom || (zoom == PinchZoomResult::DidPinchZoom);
+                scroll_result
+            })
+            .collect();
+
+        self.send_zoom_and_scroll_offset_updates(need_zoom, scroll_offset_updates);
+    }
+
+    pub(crate) fn deinit(&mut self) {
+        if let Err(error) = self.rendering_context.make_current() {
+            warn!("Failed to make the rendering context current: {error:?}");
+        }
+        if let Some(webrender) = self.webrender.take() {
+            webrender.deinit();
+        }
+    }
+
+    #[track_caller]
+    fn assert_no_gl_error(&self) {
+        debug_assert_eq!(self.webrender_gl.get_error(), gleam::gl::NO_ERROR);
+    }
+
+    #[track_caller]
+    fn assert_gl_framebuffer_complete(&self) {
+        debug_assert_eq!(
+            (
+                self.webrender_gl.get_error(),
+                self.webrender_gl
+                    .check_frame_buffer_status(gleam::gl::FRAMEBUFFER)
+            ),
+            (gleam::gl::NO_ERROR, gleam::gl::FRAMEBUFFER_COMPLETE)
+        );
+    }
+
+    pub(crate) fn webview_renderer(&self, webview_id: WebViewId) -> Option<&WebViewRenderer> {
+        self.webview_renderers.get(webview_id)
+    }
+
+    pub(crate) fn webview_renderer_mut(
+        &mut self,
+        webview_id: WebViewId,
+    ) -> Option<&mut WebViewRenderer> {
+        self.webview_renderers.get_mut(webview_id)
+    }
+
+    /// Whether or not the renderer is waiting on a frame, either because it has been sent
+    /// to WebRender and is not ready yet or because the [`FrameDelayer`] is delaying a frame
+    /// waiting for asynchronous (canvas) image updates to complete.
+    pub(crate) fn has_pending_frames(&self) -> bool {
+        self.pending_frames.get() != 0 || self.frame_delayer.pending_frame
+    }
+
+    pub(crate) fn set_needs_repaint(&self, reason: RepaintReason) {
+        let mut needs_repaint = self.needs_repaint.get();
+        needs_repaint.insert(reason);
+        self.needs_repaint.set(needs_repaint);
+    }
+
+    pub(crate) fn needs_repaint(&self) -> bool {
+        let repaint_reason = self.needs_repaint.get();
+        if repaint_reason.is_empty() {
+            return false;
+        }
+
+        !self.refresh_driver.wait_to_paint(repaint_reason)
+    }
+
+    /// Returns true if any animation callbacks (ie `requestAnimationFrame`) are waiting for a response.
+    pub(crate) fn animation_callbacks_running(&self) -> bool {
+        self.webview_renderers
+            .iter()
+            .any(WebViewRenderer::animation_callbacks_running)
+    }
+
+    pub(crate) fn animating_webviews(&self) -> Vec<WebViewId> {
+        self.webview_renderers
+            .iter()
+            .filter_map(|webview_renderer| {
+                if webview_renderer.animating() {
+                    Some(webview_renderer.id)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn send_to_constellation(&self, message: EmbedderToConstellationMessage) {
+        if let Err(error) = self.embedder_to_constellation_sender.send(message) {
+            warn!("Could not send message to constellation ({error:?})");
+        }
+    }
+
+    #[servo_tracing::instrument(skip_all)]
+    pub(crate) fn render(&mut self, time_profiler_channel: &ProfilerChan) {
+        let refresh_driver = &self.refresh_driver.clone();
+        refresh_driver.notify_will_paint(self);
+
+        if let Err(err) = self.rendering_context.make_current() {
+            warn!("Failed to make the rendering context current: {:?}", err);
+        }
+        self.assert_no_gl_error();
+
+        self.rendering_context.prepare_for_rendering();
+
+        time_profile!(
+            ProfilerCategory::Compositing,
+            None,
+            time_profiler_channel.clone(),
+            || {
+                if let Some(webrender) = self.webrender.as_mut() {
+                    webrender.update();
+                }
+
+                // Paint the scene.
+                // TODO(gw): Take notice of any errors the renderer returns!
+                self.clear_background();
+                if let Some(webrender) = self.webrender.as_mut() {
+                    let size = self.rendering_context.size2d().to_i32();
+                    webrender.render(size, 0 /* buffer_age */).ok();
+                }
+            }
+        );
+
+        // We've painted the default target, which means that from the embedder's perspective,
+        // the scene no longer needs to be repainted.
+        self.needs_repaint.set(RepaintReason::empty());
+
+        self.screenshot_taker.maybe_take_screenshots(self);
+        self.send_pending_paint_metrics_messages_after_composite();
+    }
+
+    fn clear_background(&self) {
+        self.assert_gl_framebuffer_complete();
+
+        // Always clear the entire RenderingContext, regardless of how many WebViews there are
+        // or where they are positioned. This is so WebView actually clears even before the
+        // first WebView is ready.
+        let color = servo_config::pref!(shell_background_color_rgba);
+        self.webrender_gl.clear_color(
+            color[0] as f32,
+            color[1] as f32,
+            color[2] as f32,
+            color[3] as f32,
+        );
+        self.webrender_gl.clear(gleam::gl::COLOR_BUFFER_BIT);
+    }
+
+    /// Send all pending paint metrics messages after a composite operation, which may advance
+    /// the epoch for pipelines in the WebRender scene.
+    ///
+    /// If there are pending paint metrics, we check if any of the painted epochs is one
+    /// of the ones that the paint metrics recorder is expecting. In that case, we get the
+    /// current time, inform the constellation about it and remove the pending metric from
+    /// the list.
+    fn send_pending_paint_metrics_messages_after_composite(&mut self) {
+        let paint_time = CrossProcessInstant::now();
+        for webview_renderer in self.webview_renderers.iter() {
+            for (pipeline_id, pipeline) in webview_renderer.pipelines.iter() {
+                let Some(current_epoch) = self
+                    .webrender
+                    .as_ref()
+                    .and_then(|wr| wr.current_epoch(self.webrender_document, pipeline_id.into()))
+                else {
+                    continue;
+                };
+
+                match pipeline.first_paint_metric.get() {
+                    // We need to check whether the current epoch is later, because
+                    // CrossProcessCompositorMessage::SendInitialTransaction sends an
+                    // empty display list to WebRender which can happen before we receive
+                    // the first "real" display list.
+                    PaintMetricState::Seen(epoch, first_reflow) if epoch <= current_epoch => {
+                        assert!(epoch <= current_epoch);
+                        #[cfg(feature = "tracing")]
+                        tracing::info!(
+                            name: "FirstPaint",
+                            servo_profiling = true,
+                            epoch = ?epoch,
+                            paint_time = ?paint_time,
+                            pipeline_id = ?pipeline_id,
+                        );
+
+                        self.send_to_constellation(EmbedderToConstellationMessage::PaintMetric(
+                            *pipeline_id,
+                            PaintMetricEvent::FirstPaint(paint_time, first_reflow),
+                        ));
+
+                        pipeline.first_paint_metric.set(PaintMetricState::Sent);
+                    },
+                    _ => {},
+                }
+
+                match pipeline.first_contentful_paint_metric.get() {
+                    PaintMetricState::Seen(epoch, first_reflow) if epoch <= current_epoch => {
+                        #[cfg(feature = "tracing")]
+                        tracing::info!(
+                            name: "FirstContentfulPaint",
+                            servo_profiling = true,
+                            epoch = ?epoch,
+                            paint_time = ?paint_time,
+                            pipeline_id = ?pipeline_id,
+                        );
+                        self.send_to_constellation(EmbedderToConstellationMessage::PaintMetric(
+                            *pipeline_id,
+                            PaintMetricEvent::FirstContentfulPaint(paint_time, first_reflow),
+                        ));
+                        pipeline
+                            .first_contentful_paint_metric
+                            .set(PaintMetricState::Sent);
+                    },
+                    _ => {},
+                }
+            }
+        }
+    }
+
+    /// Queue a new frame in the transaction and increase the pending frames count.
+    pub(crate) fn generate_frame(&self, transaction: &mut Transaction, reason: RenderReasons) {
+        transaction.generate_frame(0, true /* present */, false /* tracked */, reason);
+        self.pending_frames.set(self.pending_frames.get() + 1);
+    }
+
+    pub(crate) fn hit_test_at_point_with_api_and_document(
+        webrender_api: &RenderApi,
+        webrender_document: DocumentId,
+        point: DevicePoint,
+    ) -> Vec<CompositorHitTestResult> {
+        // DevicePoint and WorldPoint are the same for us.
+        let world_point = WorldPoint::from_untyped(point.to_untyped());
+        let results = webrender_api.hit_test(webrender_document, world_point);
+
+        results
+            .items
+            .iter()
+            .map(|item| {
+                let pipeline_id = item.pipeline.into();
+                let external_scroll_id = ExternalScrollId(item.tag.0, item.pipeline);
+                CompositorHitTestResult {
+                    pipeline_id,
+                    point_in_viewport: Point2D::from_untyped(item.point_in_viewport.to_untyped()),
+                    external_scroll_id,
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn send_transaction(&mut self, transaction: Transaction) {
+        self.webrender_api
+            .send_transaction(self.webrender_document, transaction);
+    }
+
+    /// Set the root pipeline for our WebRender scene to a display list that consists of an iframe
+    /// for each visible top-level browsing context, applying a transformation on the root for
+    /// pinch zoom, page zoom, and HiDPI scaling.
+    fn send_root_pipeline_display_list_in_transaction(&self, transaction: &mut Transaction) {
+        // Every display list needs a pipeline, but we'd like to choose one that is unlikely
+        // to conflict with our content pipelines, which start at (1, 1). (0, 0) is WebRender's
+        // dummy pipeline, so we choose (0, 1).
+        let root_pipeline = WebRenderPipelineId(0, 1);
+        transaction.set_root_pipeline(root_pipeline);
+
+        let mut builder = webrender_api::DisplayListBuilder::new(root_pipeline);
+        builder.begin();
+
+        let root_reference_frame = SpatialId::root_reference_frame(root_pipeline);
+
+        let viewport_size = self.rendering_context.size2d().to_f32().to_untyped();
+        let viewport_rect = LayoutRect::from_origin_and_size(
+            LayoutPoint::zero(),
+            LayoutSize::from_untyped(viewport_size),
+        );
+
+        let root_clip_id = builder.define_clip_rect(root_reference_frame, viewport_rect);
+        let clip_chain_id = builder.define_clip_chain(None, [root_clip_id]);
+        for (_, webview_renderer) in self.webview_renderers.painting_order() {
+            let Some(pipeline_id) = webview_renderer.root_pipeline_id else {
+                continue;
+            };
+
+            let pinch_zoom_transform = webview_renderer.pinch_zoom().transform().to_untyped();
+            let device_pixels_per_page_pixel_not_including_pinch_zoom = webview_renderer
+                .device_pixels_per_page_pixel_not_including_pinch_zoom()
+                .get();
+
+            let transform = LayoutTransform::scale(
+                device_pixels_per_page_pixel_not_including_pinch_zoom,
+                device_pixels_per_page_pixel_not_including_pinch_zoom,
+                1.0,
+            )
+            .then(&LayoutTransform::from_untyped(
+                &pinch_zoom_transform.to_3d(),
+            ));
+
+            let webview_reference_frame = builder.push_reference_frame(
+                LayoutPoint::zero(),
+                root_reference_frame,
+                TransformStyle::Flat,
+                PropertyBinding::Value(transform),
+                ReferenceFrameKind::Transform {
+                    is_2d_scale_translation: true,
+                    should_snap: true,
+                    paired_with_perspective: false,
+                },
+                SpatialTreeItemKey::new(0, 0),
+            );
+
+            let scaled_webview_rect = webview_renderer.rect /
+                webview_renderer.device_pixels_per_page_pixel_not_including_pinch_zoom();
+            builder.push_iframe(
+                LayoutRect::from_untyped(&scaled_webview_rect.to_untyped()),
+                LayoutRect::from_untyped(&scaled_webview_rect.to_untyped()),
+                &SpaceAndClipInfo {
+                    spatial_id: webview_reference_frame,
+                    clip_chain_id,
+                },
+                pipeline_id.into(),
+                true,
+            );
+        }
+
+        let built_display_list = builder.end();
+
+        // NB: We are always passing 0 as the epoch here, but this doesn't seem to
+        // be an issue. WebRender will still update the scene and generate a new
+        // frame even though the epoch hasn't changed.
+        transaction.set_display_list(WebRenderEpoch(0), built_display_list);
+        self.update_transaction_with_all_scroll_offsets(transaction);
+    }
+
+    /// Set the root pipeline for our WebRender scene to a display list that consists of an iframe
+    /// for each visible top-level browsing context, applying a transformation on the root for
+    /// pinch zoom, page zoom, and HiDPI scaling.
+    fn send_root_pipeline_display_list(&mut self) {
+        let mut transaction = Transaction::new();
+        self.send_root_pipeline_display_list_in_transaction(&mut transaction);
+        self.generate_frame(&mut transaction, RenderReasons::SCENE);
+        self.send_transaction(transaction);
+    }
+
+    /// Update the given transaction with the scroll offsets of all active scroll nodes in
+    /// the WebRender scene. This is necessary because WebRender does not preserve scroll
+    /// offsets between scroll tree modifications. If a display list could potentially
+    /// modify a scroll tree branch, WebRender needs to have scroll offsets for that
+    /// branch.
+    ///
+    /// TODO(mrobinson): Could we only send offsets for the branch being modified
+    /// and not the entire scene?
+    fn update_transaction_with_all_scroll_offsets(&self, transaction: &mut Transaction) {
+        for webview_renderer in self.webview_renderers.iter() {
+            for details in webview_renderer.pipelines.values() {
+                for node in details.scroll_tree.nodes.iter() {
+                    let (Some(offset), Some(external_id)) = (node.offset(), node.external_id())
+                    else {
+                        continue;
+                    };
+
+                    transaction.set_scroll_offsets(
+                        external_id,
+                        vec![SampledScrollOffset {
+                            offset,
+                            generation: 0,
+                        }],
+                    );
+                }
+            }
+        }
+    }
+
+    fn send_zoom_and_scroll_offset_updates(
+        &mut self,
+        need_zoom: bool,
+        scroll_offset_updates: Vec<ScrollResult>,
+    ) {
+        if !need_zoom && scroll_offset_updates.is_empty() {
+            return;
+        }
+
+        let mut transaction = Transaction::new();
+        if need_zoom {
+            self.send_root_pipeline_display_list_in_transaction(&mut transaction);
+        }
+        for update in scroll_offset_updates {
+            transaction.set_scroll_offsets(
+                update.external_scroll_id,
+                vec![SampledScrollOffset {
+                    offset: update.offset,
+                    generation: 0,
+                }],
+            );
+        }
+
+        self.generate_frame(&mut transaction, RenderReasons::APZ);
+        self.send_transaction(transaction);
+    }
+
+    pub(crate) fn toggle_webrender_debug(&mut self, option: WebRenderDebugOption) {
+        let Some(webrender) = self.webrender.as_mut() else {
+            return;
+        };
+        let mut flags = webrender.get_debug_flags();
+        let flag = match option {
+            WebRenderDebugOption::Profiler => {
+                webrender::DebugFlags::PROFILER_DBG |
+                    webrender::DebugFlags::GPU_TIME_QUERIES |
+                    webrender::DebugFlags::GPU_SAMPLE_QUERIES
+            },
+            WebRenderDebugOption::TextureCacheDebug => webrender::DebugFlags::TEXTURE_CACHE_DBG,
+            WebRenderDebugOption::RenderTargetDebug => webrender::DebugFlags::RENDER_TARGET_DBG,
+        };
+        flags.toggle(flag);
+        webrender.set_debug_flags(flags);
+
+        let mut txn = Transaction::new();
+        self.generate_frame(&mut txn, RenderReasons::TESTING);
+        self.send_transaction(txn);
+    }
+
+    pub(crate) fn decrement_pending_frames(&self) {
+        self.pending_frames.set(self.pending_frames.get() - 1);
+    }
+
+    pub(crate) fn report_memory(&self) -> MemoryReport {
+        self.webrender_api
+            .report_memory(MallocSizeOfOps::new(servo_allocator::usable_size, None))
+    }
+
+    pub(crate) fn change_running_animations_state(
+        &mut self,
+        webview_id: WebViewId,
+        pipeline_id: PipelineId,
+        animation_state: embedder_traits::AnimationState,
+    ) {
+        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
+            return;
+        };
+        if !webview_renderer.change_pipeline_running_animations_state(pipeline_id, animation_state)
+        {
+            return;
+        }
+        if !self
+            .animation_refresh_driver_observer
+            .notify_animation_state_changed(webview_renderer)
+        {
+            return;
+        }
+
+        self.refresh_driver
+            .add_observer(self.animation_refresh_driver_observer.clone());
+    }
+
+    pub(crate) fn set_frame_tree_for_webview(&mut self, frame_tree: &SendableFrameTree) {
+        debug!("{}: Setting frame tree for webview", frame_tree.pipeline.id);
+
+        let webview_id = frame_tree.pipeline.webview_id;
+        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
+            warn!(
+                "Attempted to set frame tree on unknown WebView (perhaps closed?): {webview_id:?}"
+            );
+            return;
+        };
+
+        webview_renderer.set_frame_tree(frame_tree);
+        self.send_root_pipeline_display_list();
+    }
+
+    pub(crate) fn remove_webview(&mut self, webview_id: WebViewId) {
+        debug!("{webview_id}: Removing");
+        if self.webview_renderers.remove(webview_id).is_err() {
+            warn!("{webview_id}: Removing unknown webview");
+            return;
+        };
+
+        self.send_root_pipeline_display_list();
+    }
+
+    pub(crate) fn set_throttled(
+        &mut self,
+        webview_id: WebViewId,
+        pipeline_id: PipelineId,
+        throttled: bool,
+    ) {
+        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
+            return;
+        };
+        if !webview_renderer.set_throttled(pipeline_id, throttled) {
+            return;
+        }
+
+        if self
+            .animation_refresh_driver_observer
+            .notify_animation_state_changed(webview_renderer)
+        {
+            self.refresh_driver
+                .add_observer(self.animation_refresh_driver_observer.clone());
+        }
+    }
+
+    pub(crate) fn notify_pipeline_exited(
+        &mut self,
+        webview_id: WebViewId,
+        pipeline_id: PipelineId,
+        pipeline_exit_source: PipelineExitSource,
+    ) {
+        debug!("Compositor got pipeline exited: {webview_id:?} {pipeline_id:?}",);
+        if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
+            webview_renderer.pipeline_exited(pipeline_id, pipeline_exit_source);
+        }
+    }
+
+    pub(crate) fn send_initial_pipeline_transaction(
+        &mut self,
+        webview_id: WebViewId,
+        pipeline_id: WebRenderPipelineId,
+    ) {
+        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
+            return warn!("Could not find WebView for incoming display list");
+        };
+
+        let starting_epoch = Epoch(0);
+        let details = webview_renderer.ensure_pipeline_details(pipeline_id.into());
+        details.display_list_epoch = Some(starting_epoch);
+
+        let mut txn = Transaction::new();
+        txn.set_display_list(starting_epoch.into(), (pipeline_id, Default::default()));
+
+        self.generate_frame(&mut txn, RenderReasons::SCENE);
+        self.send_transaction(txn);
+    }
+
+    pub(crate) fn scroll_node_by_delta(
+        &mut self,
+        webview_id: WebViewId,
+        pipeline_id: WebRenderPipelineId,
+        offset: LayoutVector2D,
+        external_scroll_id: webrender_api::ExternalScrollId,
+    ) {
+        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
+            return;
+        };
+
+        let pipeline_id = pipeline_id.into();
+        let Some(pipeline_details) = webview_renderer.pipelines.get_mut(&pipeline_id) else {
+            return;
+        };
+
+        let Some(offset) = pipeline_details
+            .scroll_tree
+            .set_scroll_offset_for_node_with_external_scroll_id(
+                external_scroll_id,
+                offset,
+                ScrollType::Script,
+            )
+        else {
+            // The renderer should be fully up-to-date with script at this point and script
+            // should never try to scroll to an invalid location.
+            warn!("Could not scroll node with id: {external_scroll_id:?}");
+            return;
+        };
+
+        let mut transaction = Transaction::new();
+        transaction.set_scroll_offsets(
+            external_scroll_id,
+            vec![SampledScrollOffset {
+                offset,
+                generation: 0,
+            }],
+        );
+
+        self.generate_frame(&mut transaction, RenderReasons::APZ);
+        self.send_transaction(transaction);
+    }
+
+    pub(crate) fn scroll_viewport_by_delta(
+        &mut self,
+        webview_id: WebViewId,
+        delta: LayoutVector2D,
+    ) {
+        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
+            return;
+        };
+        let (pinch_zoom_result, scroll_results) = webview_renderer.scroll_viewport_by_delta(delta);
+        self.send_zoom_and_scroll_offset_updates(
+            pinch_zoom_result == PinchZoomResult::DidPinchZoom,
+            scroll_results,
+        );
+    }
+
+    pub(crate) fn update_epoch(
+        &mut self,
+        webview_id: WebViewId,
+        pipeline_id: PipelineId,
+        epoch: Epoch,
+    ) {
+        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
+            return warn!("Could not find WebView for Epoch update.");
+        };
+        webview_renderer
+            .ensure_pipeline_details(pipeline_id)
+            .display_list_epoch = Some(Epoch(epoch.0));
+    }
+
+    pub(crate) fn handle_new_display_list(
+        &mut self,
+        webview_id: WebViewId,
+        display_list_descriptor: BuiltDisplayListDescriptor,
+        display_list_receiver: IpcBytesReceiver,
+    ) {
+        // This must match the order from the sender, currently in `shared/script/lib.rs`.
+        let display_list_info = match display_list_receiver.recv() {
+            Ok(display_list_info) => display_list_info,
+            Err(error) => {
+                return warn!("Could not receive display list info: {error}");
+            },
+        };
+        let display_list_info: CompositorDisplayListInfo =
+            match bincode::deserialize(&display_list_info) {
+                Ok(display_list_info) => display_list_info,
+                Err(error) => {
+                    return warn!("Could not deserialize display list info: {error}");
+                },
+            };
+        let items_data = match display_list_receiver.recv() {
+            Ok(display_list_data) => display_list_data,
+            Err(error) => {
+                return warn!("Could not receive WebRender display list items data: {error}");
+            },
+        };
+        let cache_data = match display_list_receiver.recv() {
+            Ok(display_list_data) => display_list_data,
+            Err(error) => {
+                return warn!("Could not receive WebRender display list cache data: {error}");
+            },
+        };
+        let spatial_tree = match display_list_receiver.recv() {
+            Ok(display_list_data) => display_list_data,
+            Err(error) => {
+                return warn!("Could not receive WebRender display list spatial tree: {error}.");
+            },
+        };
+        let built_display_list = BuiltDisplayList::from_data(
+            DisplayListPayload {
+                items_data,
+                cache_data,
+                spatial_tree,
+            },
+            display_list_descriptor,
+        );
+        #[cfg(feature = "tracing")]
+        let _span = tracing::trace_span!(
+            "ScriptToCompositorMsg::BuiltDisplayList",
+            servo_profiling = true,
+        )
+        .entered();
+        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
+            return warn!("Could not find WebView for incoming display list");
+        };
+
+        let old_scale = webview_renderer.device_pixels_per_page_pixel();
+        let pipeline_id = display_list_info.pipeline_id;
+        let details = webview_renderer.ensure_pipeline_details(pipeline_id.into());
+
+        details.install_new_scroll_tree(display_list_info.scroll_tree);
+        details.viewport_scale = Some(display_list_info.viewport_details.hidpi_scale_factor);
+
+        let epoch = display_list_info.epoch.into();
+        let first_reflow = display_list_info.first_reflow;
+        if details.first_paint_metric.get() == PaintMetricState::Waiting {
+            details
+                .first_paint_metric
+                .set(PaintMetricState::Seen(epoch, first_reflow));
+        }
+
+        if details.first_contentful_paint_metric.get() == PaintMetricState::Waiting &&
+            display_list_info.is_contentful
+        {
+            details
+                .first_contentful_paint_metric
+                .set(PaintMetricState::Seen(epoch, first_reflow));
+        }
+
+        let mut transaction = Transaction::new();
+        let is_root_pipeline = Some(pipeline_id.into()) == webview_renderer.root_pipeline_id;
+        if is_root_pipeline && old_scale != webview_renderer.device_pixels_per_page_pixel() {
+            self.send_root_pipeline_display_list_in_transaction(&mut transaction);
+        }
+
+        transaction.set_display_list(epoch, (pipeline_id, built_display_list));
+
+        self.update_transaction_with_all_scroll_offsets(&mut transaction);
+        self.send_transaction(transaction);
+    }
+
+    pub(crate) fn generate_frame_for_script(&mut self) {
+        self.frame_delayer.set_pending_frame(true);
+
+        if !self.frame_delayer.needs_new_frame() {
+            return;
+        }
+
+        let mut transaction = Transaction::new();
+        self.generate_frame(&mut transaction, RenderReasons::SCENE);
+        self.send_transaction(transaction);
+
+        let waiting_pipelines = self.frame_delayer.take_waiting_pipelines();
+
+        self.send_to_constellation(
+            EmbedderToConstellationMessage::NoLongerWaitingOnAsynchronousImageUpdates(
+                waiting_pipelines,
+            ),
+        );
+
+        self.frame_delayer.set_pending_frame(false);
+        self.screenshot_taker
+            .prepare_screenshot_requests_for_render(self)
+    }
+
+    pub(crate) fn generate_image_key(&self) -> ImageKey {
+        self.webrender_api.generate_image_key()
+    }
+
+    pub(crate) fn generate_image_keys(&self) -> Vec<ImageKey> {
+        (0..pref!(image_key_batch_size))
+            .map(|_| self.webrender_api.generate_image_key())
+            .collect()
+    }
+
+    pub(crate) fn update_images(&mut self, updates: SmallVec<[ImageUpdate; 1]>) {
+        let mut txn = Transaction::new();
+        for update in updates {
+            match update {
+                ImageUpdate::AddImage(key, desc, data) => {
+                    txn.add_image(key, desc, data.into(), None)
+                },
+                ImageUpdate::DeleteImage(key) => {
+                    txn.delete_image(key);
+                    self.frame_delayer.delete_image(key);
+                },
+                ImageUpdate::UpdateImage(key, desc, data, epoch) => {
+                    if let Some(epoch) = epoch {
+                        self.frame_delayer.update_image(key, epoch);
+                    }
+                    txn.update_image(key, desc, data.into(), &DirtyRect::All)
+                },
+            }
+        }
+
+        if self.frame_delayer.needs_new_frame() {
+            self.frame_delayer.set_pending_frame(false);
+            self.generate_frame(&mut txn, RenderReasons::SCENE);
+            let waiting_pipelines = self.frame_delayer.take_waiting_pipelines();
+
+            self.send_to_constellation(
+                EmbedderToConstellationMessage::NoLongerWaitingOnAsynchronousImageUpdates(
+                    waiting_pipelines,
+                ),
+            );
+
+            self.screenshot_taker
+                .prepare_screenshot_requests_for_render(&*self);
+        }
+
+        self.send_transaction(txn);
+    }
+
+    pub(crate) fn delay_new_frames_for_canvas(
+        &mut self,
+        pipeline_id: PipelineId,
+        canvas_epoch: Epoch,
+        image_keys: Vec<ImageKey>,
+    ) {
+        self.frame_delayer
+            .add_delay(pipeline_id, canvas_epoch, image_keys);
+    }
+
+    pub(crate) fn add_font(&mut self, font_key: FontKey, data: Arc<IpcSharedMemory>, index: u32) {
+        let mut transaction = Transaction::new();
+        transaction.add_raw_font(font_key, (**data).into(), index);
+        self.send_transaction(transaction);
+    }
+
+    pub(crate) fn add_system_font(&mut self, font_key: FontKey, native_handle: NativeFontHandle) {
+        let mut transaction = Transaction::new();
+        transaction.add_native_font(font_key, native_handle);
+        self.send_transaction(transaction);
+    }
+
+    pub(crate) fn add_font_instance(
+        &mut self,
+        instance_key: FontInstanceKey,
+        font_key: FontKey,
+        size: f32,
+        flags: FontInstanceFlags,
+        variations: Vec<FontVariation>,
+    ) {
+        let variations = if pref!(layout_variable_fonts_enabled) {
+            variations
+        } else {
+            vec![]
+        };
+
+        let mut transaction = Transaction::new();
+
+        let font_instance_options = FontInstanceOptions {
+            flags,
+            ..Default::default()
+        };
+        transaction.add_font_instance(
+            instance_key,
+            font_key,
+            size,
+            Some(font_instance_options),
+            None,
+            variations,
+        );
+
+        self.send_transaction(transaction);
+    }
+
+    pub(crate) fn remove_fonts(&mut self, keys: Vec<FontKey>, instance_keys: Vec<FontInstanceKey>) {
+        let mut transaction = Transaction::new();
+
+        for instance in instance_keys.into_iter() {
+            transaction.delete_font_instance(instance);
+        }
+        for key in keys.into_iter() {
+            transaction.delete_font(key);
+        }
+
+        self.send_transaction(transaction);
+    }
+
+    /// Generate the font keys and send them to the `result_sender`.
+    /// Currently `RenderingGroupId` is not used.
+    pub(crate) fn generate_font_keys(
+        &self,
+        number_of_font_keys: usize,
+        number_of_font_instance_keys: usize,
+    ) -> (Vec<FontKey>, Vec<FontInstanceKey>) {
+        let font_keys = (0..number_of_font_keys)
+            .map(|_| self.webrender_api.generate_font_key())
+            .collect();
+        let font_instance_keys = (0..number_of_font_instance_keys)
+            .map(|_| self.webrender_api.generate_font_instance_key())
+            .collect();
+        (font_keys, font_instance_keys)
+    }
+
+    pub(crate) fn set_viewport_description(
+        &mut self,
+        webview_id: WebViewId,
+        viewport_description: ViewportDescription,
+    ) {
+        if let Some(webview) = self.webview_renderers.get_mut(webview_id) {
+            webview.set_viewport_description(viewport_description);
+        }
+    }
+
+    pub(crate) fn handle_screenshot_readiness_reply(
+        &self,
+        webview_id: WebViewId,
+        expected_epochs: FxHashMap<PipelineId, Epoch>,
+    ) {
+        self.screenshot_taker
+            .handle_screenshot_readiness_reply(webview_id, expected_epochs, self);
+    }
+
+    pub(crate) fn add_webview(
+        &mut self,
+        webview: Box<dyn WebViewTrait>,
+        viewport_details: ViewportDetails,
+    ) {
+        self.webview_renderers
+            .entry(webview.id())
+            .or_insert(WebViewRenderer::new(
+                webview,
+                viewport_details,
+                self.embedder_to_constellation_sender.clone(),
+                self.refresh_driver.clone(),
+                self.webrender_document,
+            ));
+    }
+
+    pub(crate) fn show_webview(
+        &mut self,
+        webview_id: WebViewId,
+        hide_others: bool,
+    ) -> Result<(), UnknownWebView> {
+        debug!("{webview_id}: Showing webview; hide_others={hide_others}");
+        let painting_order_changed = if hide_others {
+            let result = self
+                .webview_renderers
+                .painting_order()
+                .map(|(&id, _)| id)
+                .ne(once(webview_id));
+            self.webview_renderers.hide_all();
+            self.webview_renderers.show(webview_id)?;
+            result
+        } else {
+            self.webview_renderers.show(webview_id)?
+        };
+        if painting_order_changed {
+            self.send_root_pipeline_display_list();
+        }
+        Ok(())
+    }
+
+    pub(crate) fn hide_webview(&mut self, webview_id: WebViewId) -> Result<(), UnknownWebView> {
+        debug!("{webview_id}: Hiding webview");
+        if self.webview_renderers.hide(webview_id)? {
+            self.send_root_pipeline_display_list();
+        }
+        Ok(())
+    }
+
+    pub(crate) fn raise_webview_to_top(
+        &mut self,
+        webview_id: WebViewId,
+        hide_others: bool,
+    ) -> Result<(), UnknownWebView> {
+        debug!("{webview_id}: Raising webview to top; hide_others={hide_others}");
+        let painting_order_changed = if hide_others {
+            let result = self
+                .webview_renderers
+                .painting_order()
+                .map(|(&id, _)| id)
+                .ne(once(webview_id));
+            self.webview_renderers.hide_all();
+            self.webview_renderers.raise_to_top(webview_id)?;
+            result
+        } else {
+            self.webview_renderers.raise_to_top(webview_id)?
+        };
+        if painting_order_changed {
+            self.send_root_pipeline_display_list();
+        }
+        Ok(())
+    }
+
+    pub(crate) fn move_resize_webview(&mut self, webview_id: WebViewId, rect: DeviceRect) {
+        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
+            return;
+        };
+        if !webview_renderer.set_rect(rect) {
+            return;
+        }
+
+        self.send_root_pipeline_display_list();
+        self.set_needs_repaint(RepaintReason::Resize);
+    }
+
+    pub(crate) fn set_hidpi_scale_factor(
+        &mut self,
+        webview_id: WebViewId,
+        new_scale_factor: Scale<f32, DeviceIndependentPixel, DevicePixel>,
+    ) {
+        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
+            return;
+        };
+        if !webview_renderer.set_hidpi_scale_factor(new_scale_factor) {
+            return;
+        }
+
+        self.send_root_pipeline_display_list();
+        self.set_needs_repaint(RepaintReason::Resize);
+    }
+
+    pub(crate) fn resize_rendering_context(&mut self, new_size: PhysicalSize<u32>) {
+        if self.rendering_context.size() == new_size {
+            return;
+        }
+
+        self.rendering_context.resize(new_size);
+
+        let mut transaction = Transaction::new();
+        let output_region = DeviceIntRect::new(
+            Point2D::zero(),
+            Point2D::new(new_size.width as i32, new_size.height as i32),
+        );
+        transaction.set_document_view(output_region);
+        self.send_transaction(transaction);
+
+        self.send_root_pipeline_display_list();
+        self.set_needs_repaint(RepaintReason::Resize);
+    }
+
+    pub(crate) fn set_page_zoom(&mut self, webview_id: WebViewId, new_zoom: f32) {
+        if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
+            webview_renderer.set_page_zoom(Scale::new(new_zoom));
+        }
+    }
+
+    pub(crate) fn page_zoom(&self, webview_id: WebViewId) -> f32 {
+        self.webview_renderers
+            .get(webview_id)
+            .map(|webview_renderer| webview_renderer.page_zoom.get())
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn notify_input_event(&mut self, webview_id: WebViewId, event: InputEventAndId) {
+        if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
+            match &event.event {
+                InputEvent::MouseMove(event) => {
+                    let event_point = event
+                        .point
+                        .as_device_point(webview_renderer.device_pixels_per_page_pixel());
+                    self.last_mouse_move_position = Some(event_point);
+                },
+                InputEvent::MouseLeftViewport(_) => {
+                    self.last_mouse_move_position = None;
+                },
+                _ => {},
+            }
+
+            webview_renderer.notify_input_event(&self.webrender_api, event);
+        }
+    }
+
+    pub(crate) fn notify_scroll_event(
+        &mut self,
+        webview_id: WebViewId,
+        scroll: Scroll,
+        point: WebViewPoint,
+    ) {
+        if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
+            webview_renderer.notify_scroll_event(scroll, point);
+        }
+    }
+
+    pub(crate) fn pinch_zoom(
+        &mut self,
+        webview_id: WebViewId,
+        pinch_zoom_delta: f32,
+        center: DevicePoint,
+    ) {
+        if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
+            webview_renderer.adjust_pinch_zoom(pinch_zoom_delta, center);
+        }
+    }
+
+    pub(crate) fn device_pixels_per_page_pixel(
+        &self,
+        webview_id: WebViewId,
+    ) -> Scale<f32, CSSPixel, DevicePixel> {
+        self.webview_renderers
+            .get(webview_id)
+            .map(WebViewRenderer::device_pixels_per_page_pixel)
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn request_screenshot(
+        &self,
+        webview_id: WebViewId,
+        rect: Option<WebViewRect>,
+        callback: Box<dyn FnOnce(Result<RgbaImage, ScreenshotCaptureError>) + 'static>,
+    ) {
+        let Some(webview) = self.webview_renderers.get(webview_id) else {
+            return;
+        };
+
+        let rect = rect.map(|rect| rect.as_device_rect(webview.device_pixels_per_page_pixel()));
+        self.screenshot_taker
+            .request_screenshot(webview_id, rect, callback);
+        self.send_to_constellation(EmbedderToConstellationMessage::RequestScreenshotReadiness(
+            webview_id,
+        ));
+    }
+
+    pub(crate) fn notify_input_event_handled(
+        &mut self,
+        webview_id: WebViewId,
+        input_event_id: InputEventId,
+        result: InputEventResult,
+    ) {
+        let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) else {
+            warn!("Handled input event for unknown webview: {webview_id}");
+            return;
+        };
+        webview_renderer.notify_input_event_handled(&self.webrender_api, input_event_id, result);
+    }
+
+    pub(crate) fn refresh_cursor(&self) {
+        let Some(last_mouse_move_position) = self.last_mouse_move_position else {
+            return;
+        };
+
+        let Some(hit_test_result) = Self::hit_test_at_point_with_api_and_document(
+            &self.webrender_api,
+            self.webrender_document,
+            last_mouse_move_position,
+        )
+        .first()
+        .cloned() else {
+            return;
+        };
+
+        if let Err(error) = self.embedder_to_constellation_sender.send(
+            EmbedderToConstellationMessage::RefreshCursor(hit_test_result.pipeline_id),
+        ) {
+            warn!("Sending event to constellation failed ({:?}).", error);
+        }
+    }
+}
+
+/// A struct that is reponsible for delaying frame requests until all new canvas images
+/// for a particular "update the rendering" call in the `ScriptThread` have been
+/// sent to WebRender.
+///
+/// These images may be updated in WebRender asynchronously in the canvas task. A frame
+/// is then requested if:
+///
+///  - The renderer has received a GenerateFrame message from a `ScriptThread`.
+///  - All pending image updates have finished and have been noted in the [`FrameDelayer`].
+#[derive(Default)]
+pub(crate) struct FrameDelayer {
+    /// The latest [`Epoch`] of canvas images that have been sent to WebRender. Note
+    /// that this only records the `Epoch`s for canvases and only ones that are involved
+    /// in "update the rendering".
+    image_epochs: FxHashMap<ImageKey, Epoch>,
+    /// A map of all pending canvas images
+    pending_canvas_images: FxHashMap<ImageKey, Epoch>,
+    /// Whether or not we have a pending frame.
+    pub(crate) pending_frame: bool,
+    /// A list of pipelines that should be notified when we are no longer waiting for
+    /// canvas images.
+    waiting_pipelines: FxHashSet<PipelineId>,
+}
+
+impl FrameDelayer {
+    pub(crate) fn delete_image(&mut self, image_key: ImageKey) {
+        self.image_epochs.remove(&image_key);
+        self.pending_canvas_images.remove(&image_key);
+    }
+
+    pub(crate) fn update_image(&mut self, image_key: ImageKey, epoch: Epoch) {
+        self.image_epochs.insert(image_key, epoch);
+        let Entry::Occupied(entry) = self.pending_canvas_images.entry(image_key) else {
+            return;
+        };
+        if *entry.get() <= epoch {
+            entry.remove();
+        }
+    }
+
+    pub(crate) fn add_delay(
+        &mut self,
+        pipeline_id: PipelineId,
+        canvas_epoch: Epoch,
+        image_keys: Vec<ImageKey>,
+    ) {
+        for image_key in image_keys.into_iter() {
+            // If we've already seen the necessary epoch for this image, do not
+            // start waiting for it.
+            if self
+                .image_epochs
+                .get(&image_key)
+                .is_some_and(|epoch_seen| *epoch_seen >= canvas_epoch)
+            {
+                continue;
+            }
+            self.pending_canvas_images.insert(image_key, canvas_epoch);
+        }
+        self.waiting_pipelines.insert(pipeline_id);
+    }
+
+    pub(crate) fn needs_new_frame(&self) -> bool {
+        self.pending_frame && self.pending_canvas_images.is_empty()
+    }
+
+    pub(crate) fn set_pending_frame(&mut self, value: bool) {
+        self.pending_frame = value;
+    }
+
+    pub(crate) fn take_waiting_pipelines(&mut self) -> Vec<PipelineId> {
+        self.waiting_pipelines.drain().collect()
+    }
+}
+
+/// The paint status of a particular pipeline in a [`Painter`]. This is used to trigger metrics
+/// in script (via the constellation) when display lists are received.
+///
+/// See <https://w3c.github.io/paint-timing/#first-contentful-paint>.
+#[derive(Clone, Copy, PartialEq)]
+pub(crate) enum PaintMetricState {
+    /// The painter is still waiting to process a display list which triggers this metric.
+    Waiting,
+    /// The painter has processed the display list which will trigger this event, marked the Servo
+    /// instance ready to paint, and is waiting for the given epoch to actually be rendered.
+    Seen(WebRenderEpoch, bool /* first_reflow */),
+    /// The metric has been sent to the constellation and no more work needs to be done.
+    Sent,
+}

--- a/components/compositing/pipeline_details.rs
+++ b/components/compositing/pipeline_details.rs
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::Cell;
+
+use base::Epoch;
+use base::id::PipelineId;
+use compositing_traits::display_list::ScrollTree;
+use compositing_traits::{CompositionPipeline, PipelineExitSource};
+use euclid::Scale;
+use style_traits::CSSPixel;
+use webrender_api::units::DevicePixel;
+
+use crate::painter::PaintMetricState;
+
+pub(crate) struct PipelineDetails {
+    /// The pipeline associated with this PipelineDetails object.
+    pub pipeline: Option<CompositionPipeline>,
+
+    /// The id of the parent pipeline, if any.
+    pub parent_pipeline_id: Option<PipelineId>,
+
+    /// Whether animations are running
+    pub animations_running: bool,
+
+    /// Whether there are animation callbacks
+    pub animation_callbacks_running: bool,
+
+    /// Whether to use less resources by stopping animations.
+    pub throttled: bool,
+
+    /// The compositor-side [ScrollTree]. This is used to allow finding and scrolling
+    /// nodes in the compositor before forwarding new offsets to WebRender.
+    pub scroll_tree: ScrollTree,
+
+    /// The paint metric status of the first paint.
+    pub first_paint_metric: Cell<PaintMetricState>,
+
+    /// The paint metric status of the first contentful paint.
+    pub first_contentful_paint_metric: Cell<PaintMetricState>,
+
+    /// The CSS pixel to device pixel scale of the viewport of this pipeline, including
+    /// page zoom, but not including any pinch zoom amount. This is used to detect
+    /// situations where the current display list is for an old scale.
+    pub viewport_scale: Option<Scale<f32, CSSPixel, DevicePixel>>,
+
+    /// Which parts of Servo have reported that this `Pipeline` has exited. Only when all
+    /// have done so will it be discarded.
+    pub exited: PipelineExitSource,
+
+    /// The [`Epoch`] of the latest display list received for this `Pipeline` or `None` if no
+    /// display list has been received.
+    pub display_list_epoch: Option<Epoch>,
+}
+
+impl PipelineDetails {
+    pub(crate) fn animation_callbacks_running(&self) -> bool {
+        self.animation_callbacks_running
+    }
+
+    pub(crate) fn animating(&self) -> bool {
+        !self.throttled && (self.animation_callbacks_running || self.animations_running)
+    }
+}
+
+impl PipelineDetails {
+    pub(crate) fn new() -> PipelineDetails {
+        PipelineDetails {
+            pipeline: None,
+            parent_pipeline_id: None,
+            viewport_scale: None,
+            animations_running: false,
+            animation_callbacks_running: false,
+            throttled: false,
+            scroll_tree: ScrollTree::default(),
+            first_paint_metric: Cell::new(PaintMetricState::Waiting),
+            first_contentful_paint_metric: Cell::new(PaintMetricState::Waiting),
+            exited: PipelineExitSource::empty(),
+            display_list_epoch: None,
+        }
+    }
+
+    pub(crate) fn install_new_scroll_tree(&mut self, new_scroll_tree: ScrollTree) {
+        let old_scroll_offsets = self.scroll_tree.scroll_offsets();
+        self.scroll_tree = new_scroll_tree;
+        self.scroll_tree.set_all_scroll_offsets(&old_scroll_offsets);
+    }
+}

--- a/components/compositing/screenshot.rs
+++ b/components/compositing/screenshot.rs
@@ -13,8 +13,8 @@ use image::RgbaImage;
 use rustc_hash::FxHashMap;
 use webrender_api::units::{DeviceIntRect, DeviceRect};
 
-use crate::IOCompositor;
 use crate::compositor::RepaintReason;
+use crate::painter::Painter;
 
 pub(crate) struct ScreenshotRequest {
     webview_id: WebViewId,
@@ -81,7 +81,7 @@ impl ScreenshotTaker {
         &self,
         webview_id: WebViewId,
         expected_epochs: FxHashMap<PipelineId, Epoch>,
-        renderer: &IOCompositor,
+        renderer: &Painter,
     ) {
         let expected_epochs = Rc::new(expected_epochs);
 
@@ -101,7 +101,7 @@ impl ScreenshotTaker {
         self.prepare_screenshot_requests_for_render(renderer);
     }
 
-    pub(crate) fn prepare_screenshot_requests_for_render(&self, renderer: &IOCompositor) {
+    pub(crate) fn prepare_screenshot_requests_for_render(&self, renderer: &Painter) {
         let mut any_became_ready = false;
 
         for screenshot_request in self.requests.borrow_mut().iter_mut() {
@@ -135,7 +135,7 @@ impl ScreenshotTaker {
         }
     }
 
-    pub(crate) fn maybe_trigger_paint_for_screenshot(&self, renderer: &IOCompositor) {
+    pub(crate) fn maybe_trigger_paint_for_screenshot(&self, renderer: &Painter) {
         if renderer.has_pending_frames() {
             return;
         }
@@ -150,7 +150,7 @@ impl ScreenshotTaker {
         }
     }
 
-    pub(crate) fn maybe_take_screenshots(&self, renderer: &IOCompositor) {
+    pub(crate) fn maybe_take_screenshots(&self, renderer: &Painter) {
         if renderer.has_pending_frames() {
             return;
         }
@@ -197,7 +197,7 @@ impl ScreenshotTaker {
                     DeviceIntRect::from_origin_and_size(Point2D::new(x, y), Size2D::new(w, h))
                 });
                 let result = renderer
-                    .rendering_context()
+                    .rendering_context
                     .read_to_image(rect)
                     .ok_or(ScreenshotCaptureError::CouldNotReadImage);
                 callback(result);

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -13,7 +13,7 @@ use style_traits::CSSPixel;
 use webrender_api::units::{DevicePixel, DevicePoint, DeviceVector2D};
 
 use self::TouchSequenceState::*;
-use crate::IOCompositor;
+use crate::painter::Painter;
 use crate::refresh_driver::RefreshDriverObserver;
 use crate::webview_renderer::{ScrollEvent, ScrollZoomEvent, WebViewRenderer};
 
@@ -649,7 +649,7 @@ pub(crate) struct FlingRefreshDriverObserver {
 }
 
 impl RefreshDriverObserver for FlingRefreshDriverObserver {
-    fn frame_started(&self, compositor: &mut IOCompositor) -> bool {
+    fn frame_started(&self, compositor: &mut Painter) -> bool {
         compositor
             .webview_renderer_mut(self.webview_id)
             .is_some_and(WebViewRenderer::update_touch_handling_at_new_frame_start)

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -295,7 +295,7 @@ impl Servo {
 
         create_constellation(
             embedder_to_constellation_receiver,
-            &compositor,
+            &compositor.borrow(),
             opts.config_dir.clone(),
             embedder_proxy,
             compositor_proxy.clone(),
@@ -312,7 +312,7 @@ impl Servo {
 
         Self {
             delegate: RefCell::new(Rc::new(DefaultServoDelegate)),
-            compositor: Rc::new(RefCell::new(compositor)),
+            compositor,
             javascript_evaluator: Rc::new(RefCell::new(JavaScriptEvaluator::new(
                 constellation_proxy.clone(),
             ))),

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -144,10 +144,7 @@ impl WebView {
             weak_handle: webview.weak_handle(),
             id,
         });
-        servo
-            .compositor
-            .borrow_mut()
-            .add_webview(wv, viewport_details);
+        servo.compositor.borrow().add_webview(wv, viewport_details);
 
         servo
             .webviews
@@ -352,7 +349,7 @@ impl WebView {
         self.inner_mut().rect = rect;
         self.inner()
             .compositor
-            .borrow_mut()
+            .borrow()
             .move_resize_webview(self.id(), rect);
     }
 
@@ -367,7 +364,7 @@ impl WebView {
 
         self.inner()
             .compositor
-            .borrow_mut()
+            .borrow()
             .resize_rendering_context(new_size);
     }
 
@@ -386,14 +383,14 @@ impl WebView {
         self.inner_mut().hidpi_scale_factor = new_scale_factor;
         self.inner()
             .compositor
-            .borrow_mut()
+            .borrow()
             .set_hidpi_scale_factor(self.id(), new_scale_factor);
     }
 
     pub fn show(&self, hide_others: bool) {
         self.inner()
             .compositor
-            .borrow_mut()
+            .borrow()
             .show_webview(self.id(), hide_others)
             .expect("BUG: invalid WebView instance");
     }
@@ -401,7 +398,7 @@ impl WebView {
     pub fn hide(&self) {
         self.inner()
             .compositor
-            .borrow_mut()
+            .borrow()
             .hide_webview(self.id())
             .expect("BUG: invalid WebView instance");
     }
@@ -409,7 +406,7 @@ impl WebView {
     pub fn raise_to_top(&self, hide_others: bool) {
         self.inner()
             .compositor
-            .borrow_mut()
+            .borrow()
             .raise_webview_to_top(self.id(), hide_others)
             .expect("BUG: invalid WebView instance");
     }
@@ -472,7 +469,7 @@ impl WebView {
     pub fn notify_scroll_event(&self, scroll: Scroll, point: WebViewPoint) {
         self.inner()
             .compositor
-            .borrow_mut()
+            .borrow()
             .notify_scroll_event(self.id(), scroll, point);
     }
 
@@ -484,7 +481,7 @@ impl WebView {
         if event.event.point().is_some() {
             self.inner()
                 .compositor
-                .borrow_mut()
+                .borrow()
                 .notify_input_event(self.id(), event);
         } else {
             self.inner().constellation_proxy.send(
@@ -519,13 +516,13 @@ impl WebView {
     pub fn set_page_zoom(&self, new_zoom: f32) {
         self.inner()
             .compositor
-            .borrow_mut()
+            .borrow()
             .set_page_zoom(self.id(), new_zoom);
     }
 
     /// Get the page zoom of the [`WebView`].
     pub fn page_zoom(&self) -> f32 {
-        self.inner().compositor.borrow_mut().page_zoom(self.id())
+        self.inner().compositor.borrow().page_zoom(self.id())
     }
 
     /// Adjust the pinch zoom on this [`WebView`] multiplying the current pinch zoom
@@ -540,7 +537,7 @@ impl WebView {
     pub fn pinch_zoom(&self, pinch_zoom_delta: f32, center: DevicePoint) {
         self.inner()
             .compositor
-            .borrow_mut()
+            .borrow()
             .pinch_zoom(self.id(), pinch_zoom_delta, center);
     }
 
@@ -569,12 +566,12 @@ impl WebView {
     pub fn toggle_webrender_debugging(&self, debugging: WebRenderDebugOption) {
         self.inner()
             .compositor
-            .borrow_mut()
+            .borrow()
             .toggle_webrender_debug(debugging);
     }
 
     pub fn capture_webrender(&self) {
-        self.inner().compositor.borrow_mut().capture_webrender();
+        self.inner().compositor.borrow().capture_webrender();
     }
 
     pub fn toggle_sampling_profiler(&self, rate: Duration, max_duration: Duration) {
@@ -597,7 +594,7 @@ impl WebView {
 
     /// Paint the contents of this [`WebView`] into its `RenderingContext`.
     pub fn paint(&self) {
-        self.inner().compositor.borrow_mut().render();
+        self.inner().compositor.borrow().render();
     }
 
     /// Evaluate the specified string of JavaScript code. Once execution is complete or an error


### PR DESCRIPTION
This change splits `IOCompositor` into two structs: `IOCompositor` and
`Painter`. The idea is that `Painter` will be per-`RenderingContext`.
Currently there is only one, but when there is more than one there will
be one `Painter` per-`RenderingContext`. Therefore, everything that we
suspect will be managed this way is moved to `Painter`.

In addition, to avoid the risk of double-borrows, `WebViewRender` no
longer keeps a reference to any of the containing structs. Instead
necessary things are passed down when necessary or stored internally.

Testing: This should not change behavior and is thus covered by existing
tests.
Fixes: This is part of #40261.
