### PR TITLE
libservo: Allow passing device or page pixels as scroll delta

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -29,7 +29,7 @@ use crossbeam_channel::Sender;
 use dpi::PhysicalSize;
 use embedder_traits::{
     CompositorHitTestResult, InputEventAndId, InputEventId, InputEventResult,
-    ScreenshotCaptureError, ShutdownState, ViewportDetails, WebViewPoint, WebViewRect,
+    ScreenshotCaptureError, Scroll, ShutdownState, ViewportDetails, WebViewPoint, WebViewRect,
 };
 use euclid::{Point2D, Scale, Size2D};
 use gleam::gl::RENDERER;
@@ -58,8 +58,8 @@ use webrender_api::{
     self, BuiltDisplayList, ColorF, DirtyRect, DisplayListPayload, DocumentId,
     Epoch as WebRenderEpoch, ExternalScrollId, FontInstanceFlags, FontInstanceKey,
     FontInstanceOptions, FontKey, FontVariation, ImageKey, PipelineId as WebRenderPipelineId,
-    PropertyBinding, ReferenceFrameKind, RenderReasons, SampledScrollOffset, ScrollLocation,
-    SpaceAndClipInfo, SpatialId, SpatialTreeItemKey, TransformStyle,
+    PropertyBinding, ReferenceFrameKind, RenderReasons, SampledScrollOffset, SpaceAndClipInfo,
+    SpatialId, SpatialTreeItemKey, TransformStyle,
 };
 
 use crate::InitialCompositorState;
@@ -1754,11 +1754,11 @@ impl IOCompositor {
     pub fn notify_scroll_event(
         &mut self,
         webview_id: WebViewId,
-        scroll_location: ScrollLocation,
+        scroll: Scroll,
         point: WebViewPoint,
     ) {
         if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
-            webview_renderer.notify_scroll_event(scroll_location, point);
+            webview_renderer.notify_scroll_event(scroll, point);
         }
     }
 

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -5,13 +5,12 @@
 use std::cell::RefCell;
 
 use base::id::WebViewId;
-use embedder_traits::{CompositorHitTestResult, InputEventId, TouchEventType, TouchId};
+use embedder_traits::{CompositorHitTestResult, InputEventId, Scroll, TouchEventType, TouchId};
 use euclid::{Point2D, Scale, Vector2D};
 use log::{debug, error, warn};
 use rustc_hash::FxHashMap;
 use style_traits::CSSPixel;
-use webrender_api::ScrollLocation;
-use webrender_api::units::{DevicePixel, DevicePoint, LayoutVector2D};
+use webrender_api::units::{DevicePixel, DevicePoint, DeviceVector2D};
 
 use self::TouchSequenceState::*;
 use crate::IOCompositor;
@@ -198,7 +197,7 @@ pub(crate) enum TouchSequenceState {
 }
 
 pub(crate) struct FlingAction {
-    pub delta: LayoutVector2D,
+    pub delta: DeviceVector2D,
     pub cursor: DevicePoint,
 }
 
@@ -387,7 +386,7 @@ impl TouchHandler {
             *velocity *= FLING_SCALING_FACTOR;
             debug_assert!(velocity.length() <= FLING_MAX_SCREEN_PX);
             Some(FlingAction {
-                delta: LayoutVector2D::new(velocity.x, velocity.y),
+                delta: DeviceVector2D::new(velocity.x, velocity.y),
                 cursor: *cursor,
             })
         }
@@ -428,7 +427,7 @@ impl TouchHandler {
 
                     // Scroll offsets are opposite to the direction of finger motion.
                     Some(ScrollZoomEvent::Scroll(ScrollEvent {
-                        scroll_location: ScrollLocation::Delta(-delta.cast_unit()),
+                        scroll: Scroll::Delta((-delta).into()),
                         point,
                         event_count: 1,
                     }))
@@ -445,7 +444,7 @@ impl TouchHandler {
 
                     // Scroll offsets are opposite to the direction of finger motion.
                     Some(ScrollZoomEvent::Scroll(ScrollEvent {
-                        scroll_location: ScrollLocation::Delta(-delta.cast_unit()),
+                        scroll: Scroll::Delta((-delta).into()),
                         point,
                         event_count: 1,
                     }))

--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -8,11 +8,10 @@ use std::rc::Rc;
 
 use euclid::{Scale, Size2D};
 use servo::{
-    RenderingContext, Servo, ServoBuilder, WebView, WebViewBuilder, WindowRenderingContext,
+    RenderingContext, Scroll, Servo, ServoBuilder, WebView, WebViewBuilder, WindowRenderingContext,
 };
 use tracing::warn;
 use url::Url;
-use webrender_api::ScrollLocation;
 use webrender_api::units::{DevicePixel, DevicePoint, LayoutVector2D};
 use winit::application::ApplicationHandler;
 use winit::dpi::PhysicalSize;
@@ -161,7 +160,7 @@ impl ApplicationHandler<WakerEvent> for App {
                             },
                         };
                         webview.notify_scroll_event(
-                            ScrollLocation::Delta(moved_by),
+                            Scroll::Delta(moved_by.into()),
                             DevicePoint::new(10.0, 10.0).into(),
                         );
                     }

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -14,15 +14,14 @@ use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use dpi::PhysicalSize;
 use embedder_traits::{
     Cursor, Image, InputEvent, InputEventAndId, InputEventId, JSValue, JavaScriptEvaluationError,
-    LoadStatus, MediaSessionActionType, ScreenGeometry, ScreenshotCaptureError, Theme, TraversalId,
-    ViewportDetails, WebViewPoint, WebViewRect,
+    LoadStatus, MediaSessionActionType, ScreenGeometry, ScreenshotCaptureError, Scroll, Theme,
+    TraversalId, ViewportDetails, WebViewPoint, WebViewRect,
 };
 use euclid::{Point2D, Scale, Size2D};
 use image::RgbaImage;
 use servo_geometry::DeviceIndependentPixel;
 use style_traits::CSSPixel;
 use url::Url;
-use webrender_api::ScrollLocation;
 use webrender_api::units::{DevicePixel, DevicePoint, DeviceRect};
 
 use crate::clipboard_delegate::{ClipboardDelegate, DefaultClipboardDelegate};
@@ -470,11 +469,11 @@ impl WebView {
 
     /// Ask the [`WebView`] to scroll web content. Note that positive scroll offsets reveal more
     /// content on the bottom and right of the page.
-    pub fn notify_scroll_event(&self, location: ScrollLocation, point: WebViewPoint) {
+    pub fn notify_scroll_event(&self, scroll: Scroll, point: WebViewPoint) {
         self.inner()
             .compositor
             .borrow_mut()
-            .notify_scroll_event(self.id(), location, point);
+            .notify_scroll_event(self.id(), scroll, point);
     }
 
     pub fn notify_input_event(&self, event: InputEvent) -> InputEventId {

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -13,16 +13,15 @@ use std::{env, fs};
 
 use ::servo::ServoBuilder;
 use crossbeam_channel::unbounded;
-use euclid::Vector2D;
 use log::{info, trace, warn};
 use net::protocols::ProtocolRegistry;
 use servo::config::opts::Opts;
 use servo::config::prefs::Preferences;
 use servo::servo_url::ServoUrl;
 use servo::user_content_manager::{UserContentManager, UserScript};
-use servo::webrender_api::ScrollLocation;
+use servo::webrender_api::units::DeviceVector2D;
 use servo::{
-    EventLoopWaker, InputEvent, ScreenshotCaptureError, WebDriverCommandMsg,
+    EventLoopWaker, InputEvent, ScreenshotCaptureError, Scroll, WebDriverCommandMsg,
     WebDriverScriptCommand, WebDriverUserPromptAction, WheelEvent,
 };
 use url::Url;
@@ -478,11 +477,10 @@ impl App {
                         // a default event action in the compositor.
                         let scroll_event = match &input_event {
                             InputEvent::Wheel(WheelEvent { delta, point }) => {
-                                let scroll_location = ScrollLocation::Delta(Vector2D::new(
-                                    -delta.x as f32,
-                                    -delta.y as f32,
-                                ));
-                                Some((scroll_location, *point))
+                                let scroll = Scroll::Delta(
+                                    DeviceVector2D::new(-delta.x as f32, -delta.y as f32).into(),
+                                );
+                                Some((scroll, *point))
                             },
                             _ => None,
                         };
@@ -493,8 +491,8 @@ impl App {
                             response_sender,
                         );
 
-                        if let Some((scroll_location, scroll_point)) = scroll_event {
-                            webview.notify_scroll_event(scroll_location, scroll_point);
+                        if let Some((scroll, scroll_point)) = scroll_event {
+                            webview.notify_scroll_event(scroll, scroll_point);
                         }
                     }
                 },

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -13,22 +13,21 @@ use std::env;
 use std::rc::Rc;
 use std::time::Duration;
 
-use euclid::{Angle, Length, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vector2D, Vector3D};
+use euclid::{Angle, Length, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vector3D};
 use keyboard_types::ShortcutMatcher;
 use log::debug;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
 use servo::servo_geometry::{
     DeviceIndependentIntRect, DeviceIndependentPixel, convert_rect_to_css_pixel,
 };
-use servo::webrender_api::ScrollLocation;
 use servo::webrender_api::units::{
-    DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint,
+    DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint, DeviceVector2D,
 };
 use servo::{
     Cursor, ImeEvent, InputEvent, InputEventId, InputEventResult, InputMethodControl, Key,
     KeyState, KeyboardEvent, Modifiers, MouseButton as ServoMouseButton, MouseButtonAction,
     MouseButtonEvent, MouseLeftViewportEvent, MouseMoveEvent, NamedKey, OffscreenRenderingContext,
-    RenderingContext, ScreenGeometry, Theme, TouchEvent, TouchEventType, TouchId,
+    RenderingContext, ScreenGeometry, Scroll, Theme, TouchEvent, TouchEventType, TouchId,
     WebRenderDebugOption, WebView, WheelDelta, WheelEvent, WheelMode, WindowRenderingContext,
 };
 use url::Url;
@@ -687,8 +686,8 @@ impl WindowPortsMethods for Window {
 
                 // Send events
                 webview.notify_input_event(InputEvent::Wheel(WheelEvent::new(delta, point.into())));
-                let scroll_location = ScrollLocation::Delta(-Vector2D::new(dx as f32, dy as f32));
-                webview.notify_scroll_event(scroll_location, point.into());
+                let scroll = Scroll::Delta((-DeviceVector2D::new(dx as f32, dy as f32)).into());
+                webview.notify_scroll_event(scroll, point.into());
             },
             WindowEvent::Touch(touch) => {
                 webview.notify_input_event(InputEvent::Touch(TouchEvent::new(

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -16,13 +16,14 @@ use servo::base::generic_channel::GenericSender;
 use servo::base::id::WebViewId;
 use servo::ipc_channel::ipc::IpcSender;
 use servo::servo_geometry::DeviceIndependentPixel;
-use servo::webrender_api::ScrollLocation;
-use servo::webrender_api::units::{DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint};
+use servo::webrender_api::units::{
+    DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint, DeviceVector2D,
+};
 use servo::{
     AllowOrDenyRequest, ContextMenuResult, EmbedderControl, EmbedderControlId, ImeEvent,
     InputEvent, KeyboardEvent, LoadStatus, MediaSessionActionType, MediaSessionEvent, MouseButton,
     MouseButtonAction, MouseButtonEvent, MouseMoveEvent, NavigationRequest, PermissionRequest,
-    RefreshDriver, RenderingContext, ScreenGeometry, Servo, ServoDelegate, ServoError,
+    RefreshDriver, RenderingContext, ScreenGeometry, Scroll, Servo, ServoDelegate, ServoError,
     SimpleDialog, TouchEvent, TouchEventType, TouchId, TraversalId, WebDriverCommandMsg,
     WebDriverJSResult, WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView,
     WebViewBuilder, WebViewDelegate, WindowRenderingContext,
@@ -617,10 +618,9 @@ impl RunningAppState {
     /// x/y are scroll coordinates.
     /// dx/dy are scroll deltas.
     pub fn scroll(&self, dx: f32, dy: f32, x: f32, y: f32) {
-        let scroll_location = ScrollLocation::Delta(Vector2D::new(dx, dy));
+        let scroll = Scroll::Delta(DeviceVector2D::new(dx, dy).into());
         let point = DevicePoint::new(x, y).into();
-        self.active_webview()
-            .notify_scroll_event(scroll_location, point);
+        self.active_webview().notify_scroll_event(scroll, point);
         self.perform_updates();
     }
 


### PR DESCRIPTION
This change allows the embedder to pass scroll deltas in either page pixels or device pixels. In addition, it makes it so that device pixels are never stored in LayoutVector2D when processing scroll events, which was very confusing.


Testing: Current tests should cover these changes