### PR TITLE
 libservo: Have wheel events trigger scroll in Servo

### DIFF
--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -21,11 +21,6 @@ use super::app_state::RunningAppState;
 pub(crate) const LINE_HEIGHT: f32 = 76.0;
 pub(crate) const LINE_WIDTH: f32 = 76.0;
 
-// MouseScrollDelta::PixelDelta is default for MacOS, which is high precision and very slow
-// in winit. Therefore we use a factor of 4.0 to make it more usable.
-// See https://github.com/servo/servo/pull/34063#discussion_r2197729507
-pub(crate) const PIXEL_DELTA_FACTOR: f64 = 4.0;
-
 /// <https://github.com/web-platform-tests/wpt/blob/9320b1f724632c52929a3fdb11bdaf65eafc7611/webdriver/tests/classic/set_window_rect/set.py#L287-L290>
 /// "A window size of 10x10px shouldn't be supported by any browser."
 pub(crate) const MIN_WINDOW_INNER_SIZE: DeviceIntSize = DeviceIntSize::new(100, 100);

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -11,10 +11,9 @@ use crossbeam_channel::Sender;
 use servo::base::generic_channel::GenericSender;
 use servo::base::id::WebViewId;
 use servo::ipc_channel::ipc::IpcSender;
-use servo::webrender_api::units::DeviceVector2D;
 use servo::{
-    InputEvent, InputEventId, Scroll, TraversalId, WebDriverJSResult, WebDriverLoadStatus,
-    WebDriverSenders, WebView, WheelEvent,
+    InputEvent, InputEventId, TraversalId, WebDriverJSResult, WebDriverLoadStatus,
+    WebDriverSenders, WebView,
 };
 
 pub struct RunningAppStateBase {
@@ -86,27 +85,12 @@ pub trait RunningAppStateTrait {
         input_event: InputEvent,
         response_sender: Option<Sender<()>>,
     ) {
-        // TODO: Scroll events triggered by wheel events should happen as
-        // a default event action in the compositor.
-        let scroll_event = match &input_event {
-            InputEvent::Wheel(WheelEvent { delta, point }) => {
-                let scroll =
-                    Scroll::Delta(DeviceVector2D::new(-delta.x as f32, -delta.y as f32).into());
-                Some((scroll, *point))
-            },
-            _ => None,
-        };
-
         let event_id = webview.notify_input_event(input_event);
         if let Some(response_sender) = response_sender {
             self.base()
                 .pending_webdriver_events
                 .borrow_mut()
                 .insert(event_id, response_sender);
-        }
-
-        if let Some((scroll, scroll_point)) = scroll_event {
-            webview.notify_scroll_event(scroll, scroll_point);
         }
     }
 }


### PR DESCRIPTION
Instead of forcing embedders to implement scrolling when wheel events
happen, have Servo take care of this. This means that scrolling happens
consistently with wheel events across all embedders.

Testing: This is tested by the WebDriver conformance suite.
