### PR TITLE
servoshell: Support `WebDriverCommandMsg::InputEvent` for egl

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -487,7 +487,7 @@ impl App {
                         };
 
                         running_state.handle_webdriver_input_event(
-                            webview_id,
+                            webview.clone(),
                             input_event,
                             response_sender,
                         );

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -13,16 +13,15 @@ use std::{env, fs};
 
 use ::servo::ServoBuilder;
 use crossbeam_channel::unbounded;
-use log::{info, trace, warn};
+use log::{error, info, trace, warn};
 use net::protocols::ProtocolRegistry;
 use servo::config::opts::Opts;
 use servo::config::prefs::Preferences;
 use servo::servo_url::ServoUrl;
 use servo::user_content_manager::{UserContentManager, UserScript};
-use servo::webrender_api::units::DeviceVector2D;
 use servo::{
-    EventLoopWaker, InputEvent, ScreenshotCaptureError, Scroll, WebDriverCommandMsg,
-    WebDriverScriptCommand, WebDriverUserPromptAction, WheelEvent,
+    EventLoopWaker, ScreenshotCaptureError, WebDriverCommandMsg, WebDriverScriptCommand,
+    WebDriverUserPromptAction,
 };
 use url::Url;
 use winit::application::ApplicationHandler;
@@ -474,28 +473,16 @@ impl App {
                 },
                 WebDriverCommandMsg::InputEvent(webview_id, input_event, response_sender) => {
                     if let Some(webview) = running_state.webview_by_id(webview_id) {
-                        // TODO: Scroll events triggered by wheel events should happen as
-                        // a default event action in the compositor.
-                        let scroll_event = match &input_event {
-                            InputEvent::Wheel(WheelEvent { delta, point }) => {
-                                let scroll = Scroll::Delta(
-                                    DeviceVector2D::new(-delta.x as f32, -delta.y as f32).into(),
-                                );
-                                Some((scroll, *point))
-                            },
-                            _ => None,
-                        };
-
                         running_state.handle_webdriver_input_event(
-                            webview.clone(),
+                            webview,
                             input_event,
                             response_sender,
                         );
-
-                        if let Some((scroll, scroll_point)) = scroll_event {
-                            webview.notify_scroll_event(scroll, scroll_point);
-                        }
-                    }
+                    } else {
+                        error!(
+                            "Could not find WebView ({webview_id:?}) for WebDriver event: {input_event:?}"
+                        );
+                    };
                 },
                 WebDriverCommandMsg::ScriptCommand(_, ref webdriver_script_command) => {
                     self.handle_webdriver_script_command(webdriver_script_command, running_state);

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -8,7 +8,7 @@ use std::collections::hash_map::Entry;
 use std::mem;
 use std::rc::Rc;
 
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam_channel::Receiver;
 use image::{DynamicImage, ImageFormat};
 use log::{error, info};
 use servo::base::generic_channel::GenericSender;
@@ -18,7 +18,7 @@ use servo::ipc_channel::ipc::IpcSender;
 use servo::webrender_api::units::{DeviceIntPoint, DeviceIntSize};
 use servo::{
     AllowOrDenyRequest, AuthenticationRequest, EmbedderControl, EmbedderControlId,
-    GamepadHapticEffectType, InputEvent, InputEventId, InputEventResult, JSValue, LoadStatus,
+    GamepadHapticEffectType, InputEventId, InputEventResult, JSValue, LoadStatus,
     PermissionRequest, Servo, ServoDelegate, ServoError, SimpleDialog, TraversalId,
     WebDriverCommandMsg, WebDriverLoadStatus, WebDriverUserPrompt, WebView, WebViewBuilder,
     WebViewDelegate,
@@ -528,27 +528,6 @@ impl RunningAppState {
                 error!("Failed to save screenshot: {error}.");
             }
         });
-    }
-
-    pub(crate) fn handle_webdriver_input_event(
-        &self,
-        webview_id: WebViewId,
-        input_event: InputEvent,
-        response_sender: Option<Sender<()>>,
-    ) {
-        let Some(webview) = self.webview_by_id(webview_id) else {
-            error!("Could not find WebView ({webview_id:?}) for WebDriver event: {input_event:?}");
-            return;
-        };
-
-        let event_id = webview.notify_input_event(input_event);
-
-        if let Some(response_sender) = response_sender {
-            self.base()
-                .pending_webdriver_events
-                .borrow_mut()
-                .insert(event_id, response_sender);
-        }
     }
 }
 

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -25,7 +25,7 @@ use servo::{
     NavigationRequest, PermissionRequest, RefreshDriver, RenderingContext, ScreenGeometry, Scroll,
     Servo, ServoDelegate, ServoError, TouchEvent, TouchEventType, TouchId, TraversalId,
     WebDriverCommandMsg, WebDriverLoadStatus, WebDriverScriptCommand, WebView, WebViewBuilder,
-    WebViewDelegate, WheelEvent, WindowRenderingContext,
+    WebViewDelegate, WindowRenderingContext,
 };
 use url::Url;
 
@@ -632,7 +632,7 @@ impl RunningAppState {
     }
 
     /// WebDriver message handling methods
-    pub fn webview_by_id(&self, id: WebViewId) -> Option<WebView> {
+    fn webview_by_id(&self, id: WebViewId) -> Option<WebView> {
         self.inner().webviews.get(&id).cloned()
     }
 
@@ -772,8 +772,8 @@ impl RunningAppState {
                         let _ = response_sender.send(self.rendering_context.size2d());
                     },
                     WebDriverCommandMsg::InputEvent(webview_id, input_event, response_sender) => {
-                        if let Some(webview) = running_state.webview_by_id(webview_id) {
-                            running_state.handle_webdriver_input_event(
+                        if let Some(webview) = self.webview_by_id(webview_id) {
+                            self.handle_webdriver_input_event(
                                 webview,
                                 input_event,
                                 response_sender,

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -5,28 +5,27 @@ use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use crossbeam_channel::Receiver;
+use crossbeam_channel::{Receiver, Sender};
 use dpi::PhysicalSize;
-use euclid::{Point2D, Rect, Scale, Size2D, Vector2D};
+use euclid::{Point2D, Rect, Scale, Size2D};
 use image::{DynamicImage, ImageFormat};
 use keyboard_types::{CompositionEvent, CompositionState, Key, KeyState, NamedKey};
 use log::{debug, error, info, warn};
 use raw_window_handle::{RawWindowHandle, WindowHandle};
 use servo::base::generic_channel::GenericSender;
 use servo::base::id::WebViewId;
-use servo::ipc_channel::ipc::IpcSender;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::units::{
     DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint, DeviceVector2D,
 };
 use servo::{
     AllowOrDenyRequest, ContextMenuResult, EmbedderControl, EmbedderControlId, ImeEvent,
-    InputEvent, KeyboardEvent, LoadStatus, MediaSessionActionType, MediaSessionEvent, MouseButton,
-    MouseButtonAction, MouseButtonEvent, MouseMoveEvent, NavigationRequest, PermissionRequest,
-    RefreshDriver, RenderingContext, ScreenGeometry, Scroll, Servo, ServoDelegate, ServoError,
-    SimpleDialog, TouchEvent, TouchEventType, TouchId, TraversalId, WebDriverCommandMsg,
-    WebDriverJSResult, WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView,
-    WebViewBuilder, WebViewDelegate, WindowRenderingContext,
+    InputEvent, InputEventId, InputEventResult, KeyboardEvent, LoadStatus, MediaSessionActionType,
+    MediaSessionEvent, MouseButton, MouseButtonAction, MouseButtonEvent, MouseMoveEvent,
+    NavigationRequest, PermissionRequest, RefreshDriver, RenderingContext, ScreenGeometry, Scroll,
+    Servo, ServoDelegate, ServoError, TouchEvent, TouchEventType, TouchId, TraversalId,
+    WebDriverCommandMsg, WebDriverLoadStatus, WebDriverScriptCommand, WebView, WebViewBuilder,
+    WebViewDelegate, WheelEvent, WindowRenderingContext,
 };
 use url::Url;
 
@@ -264,6 +263,22 @@ impl WebViewDelegate for RunningAppState {
 
     fn notify_new_frame_ready(&self, _webview: WebView) {
         self.inner_mut().need_present = true;
+    }
+
+    fn notify_input_event_handled(
+        &self,
+        _webview: WebView,
+        id: InputEventId,
+        _result: InputEventResult,
+    ) {
+        if let Some(response_sender) = self
+            .base()
+            .pending_webdriver_events
+            .borrow_mut()
+            .remove(&id)
+        {
+            let _ = response_sender.send(());
+        }
     }
 
     fn request_navigation(&self, _webview: WebView, navigation_request: NavigationRequest) {
@@ -756,11 +771,58 @@ impl RunningAppState {
                         info!("Handling GetViewportSize for webview {}", webview_id);
                         let _ = response_sender.send(self.rendering_context.size2d());
                     },
+                    WebDriverCommandMsg::InputEvent(webview_id, input_event, response_sender) => {
+                        if let Some(webview) = self.webview_by_id(webview_id) {
+                            // TODO: Scroll events triggered by wheel events should happen as
+                            // a default event action in the compositor.
+                            let scroll_event = match &input_event {
+                                InputEvent::Wheel(WheelEvent { delta, point }) => {
+                                    let scroll = Scroll::Delta(
+                                        DeviceVector2D::new(-delta.x as f32, -delta.y as f32)
+                                            .into(),
+                                    );
+                                    Some((scroll, *point))
+                                },
+                                _ => None,
+                            };
+
+                            self.handle_webdriver_input_event(
+                                webview_id,
+                                input_event,
+                                response_sender,
+                            );
+
+                            if let Some((scroll, scroll_point)) = scroll_event {
+                                webview.notify_scroll_event(scroll, scroll_point);
+                            }
+                        }
+                    },
                     _ => {
                         info!("Received WebDriver command: {:?}", msg);
                     },
                 }
             }
+        }
+    }
+
+    fn handle_webdriver_input_event(
+        &self,
+        webview_id: WebViewId,
+        input_event: InputEvent,
+        response_sender: Option<Sender<()>>,
+    ) {
+        let Some(webview) = self.webview_by_id(webview_id) else {
+            error!("Could not find WebView ({webview_id:?}) for WebDriver event: {input_event:?}");
+            return;
+        };
+
+        let event_id = webview.notify_input_event(input_event);
+
+        if let Some(response_sender) = response_sender {
+            self.base()
+                .pending_webdriver_events
+                .borrow_mut()
+                .insert(event_id, response_sender);
         }
     }
 

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -5,7 +5,7 @@ use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam_channel::Receiver;
 use dpi::PhysicalSize;
 use euclid::{Point2D, Rect, Scale, Size2D};
 use image::{DynamicImage, ImageFormat};
@@ -787,7 +787,7 @@ impl RunningAppState {
                             };
 
                             self.handle_webdriver_input_event(
-                                webview_id,
+                                webview.clone(),
                                 input_event,
                                 response_sender,
                             );
@@ -802,27 +802,6 @@ impl RunningAppState {
                     },
                 }
             }
-        }
-    }
-
-    fn handle_webdriver_input_event(
-        &self,
-        webview_id: WebViewId,
-        input_event: InputEvent,
-        response_sender: Option<Sender<()>>,
-    ) {
-        let Some(webview) = self.webview_by_id(webview_id) else {
-            error!("Could not find WebView ({webview_id:?}) for WebDriver event: {input_event:?}");
-            return;
-        };
-
-        let event_id = webview.notify_input_event(input_event);
-
-        if let Some(response_sender) = response_sender {
-            self.base()
-                .pending_webdriver_events
-                .borrow_mut()
-                .insert(event_id, response_sender);
         }
     }
 

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -5,20 +5,28 @@
 //! Shared state and methods for desktop and EGL implementations.
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 
+use crossbeam_channel::Sender;
 use servo::base::generic_channel::GenericSender;
 use servo::base::id::WebViewId;
 use servo::ipc_channel::ipc::IpcSender;
-use servo::{TraversalId, WebDriverJSResult, WebDriverLoadStatus, WebDriverSenders};
+use servo::{InputEventId, TraversalId, WebDriverJSResult, WebDriverLoadStatus, WebDriverSenders};
 
 pub struct RunningAppStateBase {
     pub(crate) webdriver_senders: RefCell<WebDriverSenders>,
+
+    /// A [`HashMap`] of pending WebDriver events. It is the WebDriver embedder's responsibility
+    /// to inform the WebDriver server when the event has been fully handled. This map is used
+    /// to report back to WebDriver when that happens.
+    pub(crate) pending_webdriver_events: RefCell<HashMap<InputEventId, Sender<()>>>,
 }
 
 impl RunningAppStateBase {
     pub fn new() -> Self {
         Self {
             webdriver_senders: RefCell::default(),
+            pending_webdriver_events: Default::default(),
         }
     }
 }

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -11,7 +11,10 @@ use crossbeam_channel::Sender;
 use servo::base::generic_channel::GenericSender;
 use servo::base::id::WebViewId;
 use servo::ipc_channel::ipc::IpcSender;
-use servo::{InputEventId, TraversalId, WebDriverJSResult, WebDriverLoadStatus, WebDriverSenders};
+use servo::{
+    InputEvent, InputEventId, TraversalId, WebDriverJSResult, WebDriverLoadStatus,
+    WebDriverSenders, WebView,
+};
 
 pub struct RunningAppStateBase {
     pub(crate) webdriver_senders: RefCell<WebDriverSenders>,
@@ -74,5 +77,20 @@ pub trait RunningAppStateTrait {
             .webdriver_senders
             .borrow_mut()
             .script_evaluation_interrupt_sender = sender;
+    }
+
+    fn handle_webdriver_input_event(
+        &self,
+        webview: WebView,
+        input_event: InputEvent,
+        response_sender: Option<Sender<()>>,
+    ) {
+        let event_id = webview.notify_input_event(input_event);
+        if let Some(response_sender) = response_sender {
+            self.base()
+                .pending_webdriver_events
+                .borrow_mut()
+                .insert(event_id, response_sender);
+        }
     }
 }

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -11,9 +11,10 @@ use crossbeam_channel::Sender;
 use servo::base::generic_channel::GenericSender;
 use servo::base::id::WebViewId;
 use servo::ipc_channel::ipc::IpcSender;
+use servo::webrender_api::units::DeviceVector2D;
 use servo::{
-    InputEvent, InputEventId, TraversalId, WebDriverJSResult, WebDriverLoadStatus,
-    WebDriverSenders, WebView,
+    InputEvent, InputEventId, Scroll, TraversalId, WebDriverJSResult, WebDriverLoadStatus,
+    WebDriverSenders, WebView, WheelEvent,
 };
 
 pub struct RunningAppStateBase {
@@ -85,12 +86,27 @@ pub trait RunningAppStateTrait {
         input_event: InputEvent,
         response_sender: Option<Sender<()>>,
     ) {
+        // TODO: Scroll events triggered by wheel events should happen as
+        // a default event action in the compositor.
+        let scroll_event = match &input_event {
+            InputEvent::Wheel(WheelEvent { delta, point }) => {
+                let scroll =
+                    Scroll::Delta(DeviceVector2D::new(-delta.x as f32, -delta.y as f32).into());
+                Some((scroll, *point))
+            },
+            _ => None,
+        };
+
         let event_id = webview.notify_input_event(input_event);
         if let Some(response_sender) = response_sender {
             self.base()
                 .pending_webdriver_events
                 .borrow_mut()
                 .insert(event_id, response_sender);
+        }
+
+        if let Some((scroll, scroll_point)) = scroll_event {
+            webview.notify_scroll_event(scroll, scroll_point);
         }
     }
 }


### PR DESCRIPTION
- Support `WebDriverCommandMsg::InputEvent` for egl
- Move `pending_webdriver_events` and related handlers to `RunningAppStateBase`

Testing: Manually tested on Ohos device. Element click now scrolls into view + click.
Fixes: Part of #40279
