### PR TITLE
wpt: Skip Bluetooh WebDriver BiDi tests

### DIFF
--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -7,6 +7,8 @@ skip: true
   skip: false
 [bluetooth]
   skip: false
+  [bidi]
+    skip: true
 [clipboard-apis]
   skip: false
 [compression]


### PR DESCRIPTION
We do not support WebDriver BiDi, so it doesn't make sense to run these
tests.

Testing: This change adjusts which tests are run.
