### PR TITLE
wpt: Enable WebDriver by default when running WPT

### DIFF
--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -55,7 +55,7 @@ def run_tests(default_binary_path: str, **kwargs: Any) -> int:
     # makes CI logs unreadable.
     github_context = os.environ.pop("GITHUB_CONTEXT", None)
 
-    set_if_none(kwargs, "product", "servo")
+    set_if_none(kwargs, "product", "servodriver")
     set_if_none(kwargs, "config", os.path.join(WPT_PATH, "config.ini"))
     set_if_none(kwargs, "include_manifest", os.path.join(WPT_PATH, "include.ini"))
     set_if_none(kwargs, "manifest_update", False)

--- a/tests/wpt/meta/clipboard-apis/detached-iframe/writeText-readText-on-detached-iframe.https.html.ini
+++ b/tests/wpt/meta/clipboard-apis/detached-iframe/writeText-readText-on-detached-iframe.https.html.ini
@@ -1,4 +1,4 @@
 [writeText-readText-on-detached-iframe.https.html]
-  expected: TIMEOUT
+  expected: OK
   [Verify readText and writeText fails on detached iframe]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/clipboard-apis/text-write-read/async-writeText-readText.https.html.ini
+++ b/tests/wpt/meta/clipboard-apis/text-write-read/async-writeText-readText.https.html.ini
@@ -1,0 +1,6 @@
+[async-writeText-readText.https.html]
+  [Verify write and read clipboard given text: Clipboard write text -> read text test]
+    expected: FAIL
+
+  [Verify write and read clipboard given text: non-Latin1 text encoding test データ]
+    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/inheritance/blob-url-in-child-frame-self-navigate-inherits.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/blob-url-in-child-frame-self-navigate-inherits.sub.html.ini
@@ -1,3 +1,4 @@
 [blob-url-in-child-frame-self-navigate-inherits.sub.html]
+  expected: ERROR
   [Violation report status OK.]
     expected: FAIL

--- a/tests/wpt/meta/content-security-policy/inheritance/blob-url-in-main-window-self-navigate-inherits.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/blob-url-in-main-window-self-navigate-inherits.sub.html.ini
@@ -1,3 +1,4 @@
 [blob-url-in-main-window-self-navigate-inherits.sub.html]
+  expected: CRASH
   [Violation report status OK.]
     expected: FAIL

--- a/tests/wpt/meta/content-security-policy/inheritance/unsandboxed-blob-scheme.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/unsandboxed-blob-scheme.html.ini
@@ -1,3 +1,4 @@
 [unsandboxed-blob-scheme.html]
+  expected: ERROR
   [Violation report status OK.]
     expected: FAIL

--- a/tests/wpt/meta/content-security-policy/inheritance/unsandboxed-data-scheme.html.ini
+++ b/tests/wpt/meta/content-security-policy/inheritance/unsandboxed-data-scheme.html.ini
@@ -1,3 +1,4 @@
 [unsandboxed-data-scheme.html]
+  expected: ERROR
   [Violation report status OK.]
     expected: FAIL

--- a/tests/wpt/meta/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html.ini
+++ b/tests/wpt/meta/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html.ini
@@ -1,2 +1,3 @@
 [partitioned-cookies.tentative.https.html]
-  expected: ERROR
+  [Partitioned cookies are not accessible on a different top-level site via HTTP]
+    expected: FAIL

--- a/tests/wpt/meta/cookies/path/match.html.ini
+++ b/tests/wpt/meta/cookies/path/match.html.ini
@@ -1,2 +1,0 @@
-[match.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/cookies/value/value-ctl.html.ini
+++ b/tests/wpt/meta/cookies/value/value-ctl.html.ini
@@ -1,4 +1,5 @@
 [value-ctl.html]
+  expected: OK
   [Cookie with %x0 in value is truncated.]
     expected: FAIL
 

--- a/tests/wpt/meta/cookiestore/cookieListItem_attributes.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieListItem_attributes.https.window.js.ini
@@ -1,7 +1,4 @@
 [cookieListItem_attributes.https.window.html]
-  [CookieListItem - cookieStore.set defaults with positional name and value]
-    expected: FAIL
-
   [CookieListItem - cookieStore.set defaults with name and value in options]
     expected: FAIL
 
@@ -11,13 +8,7 @@
   [CookieListItem - cookieStore.set with expires set to a Date 10 years in the future]
     expected: FAIL
 
-  [CookieListItem - cookieStore.set with domain set to the current hostname]
-    expected: FAIL
-
   [CookieListItem - cookieStore.set with path set to the current directory]
-    expected: FAIL
-
-  [CookieListItem - cookieStore.set does not add / to path if it does not end with /]
     expected: FAIL
 
   [CookieListItem - cookieStore.set with sameSite set to strict]

--- a/tests/wpt/meta/cookiestore/cookieStore_set_path.https.window.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_set_path.https.window.js.ini
@@ -1,6 +1,3 @@
 [cookieStore_set_path.https.window.html]
-  [CookieListItem - cookieStore.set with empty string path defaults to current URL]
-    expected: FAIL
-
   [CookieListItem - cookieStore.set with empty string path defaults to current URL with __host- prefix]
     expected: FAIL

--- a/tests/wpt/meta/css/css-animations/crashtests/replace-keyframes-animating-filter-001.html.ini
+++ b/tests/wpt/meta/css/css-animations/crashtests/replace-keyframes-animating-filter-001.html.ini
@@ -1,2 +1,0 @@
-[replace-keyframes-animating-filter-001.html]
-    expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/background-attachment-fixed-block-002.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-attachment-fixed-block-002.html.ini
@@ -1,2 +1,0 @@
-[background-attachment-fixed-block-002.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/background-attachment-fixed-inline-002.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-attachment-fixed-inline-002.html.ini
@@ -1,2 +1,0 @@
-[background-attachment-fixed-inline-002.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/background-attachment-local-block-002.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-attachment-local-block-002.html.ini
@@ -1,2 +1,0 @@
-[background-attachment-local-block-002.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/background-attachment-local-inline-002.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-attachment-local-inline-002.html.ini
@@ -1,2 +1,0 @@
-[background-attachment-local-inline-002.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-backgrounds/background-size-041.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size-041.html.ini
@@ -1,2 +1,0 @@
-[background-size-041.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-backgrounds/background-size-042.html.ini
+++ b/tests/wpt/meta/css/css-backgrounds/background-size-042.html.ini
@@ -1,2 +1,0 @@
-[background-size-042.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-conditional/at-media-dynamic-001.html.ini
+++ b/tests/wpt/meta/css/css-conditional/at-media-dynamic-001.html.ini
@@ -1,2 +1,0 @@
-[at-media-dynamic-001.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-flexbox/flexbox-align-self-horiz-004.xhtml.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexbox-align-self-horiz-004.xhtml.ini
@@ -1,2 +1,0 @@
-[flexbox-align-self-horiz-004.xhtml]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-lists/marker-dynamic-content-change.html.ini
+++ b/tests/wpt/meta/css/css-lists/marker-dynamic-content-change.html.ini
@@ -1,2 +1,0 @@
-[marker-dynamic-content-change.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-overflow/root-scroll-button-activation.html.ini
+++ b/tests/wpt/meta/css/css-overflow/root-scroll-button-activation.html.ini
@@ -1,3 +1,4 @@
 [root-scroll-button-activation.html]
+  expected: TIMEOUT
   [CSS Overflow: ::scroll-button on root element activation]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/css/css-overflow/scrollbar-gutter-dynamic-004.html.ini
+++ b/tests/wpt/meta/css/css-overflow/scrollbar-gutter-dynamic-004.html.ini
@@ -1,2 +1,0 @@
-[scrollbar-gutter-dynamic-004.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-sizing/animation/width-interpolation.html.ini
+++ b/tests/wpt/meta/css/css-sizing/animation/width-interpolation.html.ini
@@ -256,3 +256,15 @@
 
   [Web Animations: property <width> from neutral to [min-content\] at (1.5) should be [min-content\]]
     expected: FAIL
+
+  [Web Animations: property <width> from [1em\] to [10vw\] at (0.3) should be [35.20px\]]
+    expected: FAIL
+
+  [Web Animations: property <width> from [1em\] to [10vw\] at (0.6) should be [54.40px\]]
+    expected: FAIL
+
+  [Web Animations: property <width> from [1em\] to [10vw\] at (1) should be [80.00px\]]
+    expected: FAIL
+
+  [Web Animations: property <width> from [1em\] to [10vw\] at (1.5) should be [112.00px\]]
+    expected: FAIL

--- a/tests/wpt/meta/css/css-syntax/charset/page-utf16-css-bomless-utf16.html.ini
+++ b/tests/wpt/meta/css/css-syntax/charset/page-utf16-css-bomless-utf16.html.ini
@@ -1,2 +1,2 @@
 [page-utf16-css-bomless-utf16.html]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/css/css-syntax/charset/page-utf16-css-bomless-utf16be.html.ini
+++ b/tests/wpt/meta/css/css-syntax/charset/page-utf16-css-bomless-utf16be.html.ini
@@ -1,2 +1,2 @@
 [page-utf16-css-bomless-utf16be.html]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/css/css-syntax/charset/page-utf16-css-no-decl-ascii-only.html.ini
+++ b/tests/wpt/meta/css/css-syntax/charset/page-utf16-css-no-decl-ascii-only.html.ini
@@ -1,2 +1,2 @@
 [page-utf16-css-no-decl-ascii-only.html]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/css/css-syntax/charset/page-utf16-css-no-decl.html.ini
+++ b/tests/wpt/meta/css/css-syntax/charset/page-utf16-css-no-decl.html.ini
@@ -1,2 +1,2 @@
 [page-utf16-css-no-decl.html]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/css/css-transforms/transform-3d-scales-different-x-y-dynamic-001.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform-3d-scales-different-x-y-dynamic-001.html.ini
@@ -1,2 +1,0 @@
-[transform-3d-scales-different-x-y-dynamic-001.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-transforms/transform-3d-scales-different-x-y-dynamic-002.html.ini
+++ b/tests/wpt/meta/css/css-transforms/transform-3d-scales-different-x-y-dynamic-002.html.ini
@@ -1,2 +1,0 @@
-[transform-3d-scales-different-x-y-dynamic-002.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-ui/outline-auto-dynamic-change.html.ini
+++ b/tests/wpt/meta/css/css-ui/outline-auto-dynamic-change.html.ini
@@ -1,2 +1,0 @@
-[outline-auto-dynamic-change.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/css-ui/pointer-events-no-scrollbars-002.html.ini
+++ b/tests/wpt/meta/css/css-ui/pointer-events-no-scrollbars-002.html.ini
@@ -1,2 +1,0 @@
-[pointer-events-no-scrollbars-002.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/filter-effects/backdrop-filter-root-toggle-crash.html.ini
+++ b/tests/wpt/meta/css/filter-effects/backdrop-filter-root-toggle-crash.html.ini
@@ -1,2 +1,0 @@
-[backdrop-filter-root-toggle-crash.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/css/filter-effects/parsing/flood-opacity-computed.svg.ini
+++ b/tests/wpt/meta/css/filter-effects/parsing/flood-opacity-computed.svg.ini
@@ -1,2 +1,2 @@
 [flood-opacity-computed.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/css/filter-effects/parsing/flood-opacity-invalid.svg.ini
+++ b/tests/wpt/meta/css/filter-effects/parsing/flood-opacity-invalid.svg.ini
@@ -1,2 +1,2 @@
 [flood-opacity-invalid.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/css/filter-effects/parsing/flood-opacity-valid.svg.ini
+++ b/tests/wpt/meta/css/filter-effects/parsing/flood-opacity-valid.svg.ini
@@ -1,2 +1,2 @@
 [flood-opacity-valid.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/css/selectors/focus-visible-018-2.html.ini
+++ b/tests/wpt/meta/css/selectors/focus-visible-018-2.html.ini
@@ -1,5 +1,5 @@
 [focus-visible-018-2.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Mouse focus does not show a focus ring by default in element TABLE]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/css/selectors/has-display-none-checked.html.ini
+++ b/tests/wpt/meta/css/selectors/has-display-none-checked.html.ini
@@ -1,2 +1,2 @@
 [has-display-none-checked.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/custom-elements/Document-createElement-svg.svg.ini
+++ b/tests/wpt/meta/custom-elements/Document-createElement-svg.svg.ini
@@ -1,2 +1,2 @@
 [Document-createElement-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/custom-elements/parser/parser-uses-create-an-element-for-a-token-svg.svg.ini
+++ b/tests/wpt/meta/custom-elements/parser/parser-uses-create-an-element-for-a-token-svg.svg.ini
@@ -1,2 +1,2 @@
 [parser-uses-create-an-element-for-a-token-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/custom-elements/state/state-css-selector.html.ini
+++ b/tests/wpt/meta/custom-elements/state/state-css-selector.html.ini
@@ -1,4 +1,5 @@
 [state-css-selector.html]
+  expected: CRASH
   [state selector influences siblings when state is applied]
     expected: FAIL
 

--- a/tests/wpt/meta/custom-elements/state/state-pseudo-class.html.ini
+++ b/tests/wpt/meta/custom-elements/state/state-pseudo-class.html.ini
@@ -1,3 +1,4 @@
 [state-pseudo-class.html]
+  expected: CRASH
   [:state(foo) and other pseudo classes]
     expected: FAIL

--- a/tests/wpt/meta/dom/nodes/Document-constructor-svg.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Document-constructor-svg.svg.ini
@@ -1,2 +1,2 @@
 [Document-constructor-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Document-constructor-xml.xml.ini
+++ b/tests/wpt/meta/dom/nodes/Document-constructor-xml.xml.ini
@@ -1,2 +1,0 @@
-[Document-constructor-xml.xml]
-  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Element-childElement-null-svg.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Element-childElement-null-svg.svg.ini
@@ -1,2 +1,2 @@
 [Element-childElement-null-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Element-childElementCount-dynamic-add-svg.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Element-childElementCount-dynamic-add-svg.svg.ini
@@ -1,2 +1,2 @@
 [Element-childElementCount-dynamic-add-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Element-childElementCount-dynamic-remove-svg.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Element-childElementCount-dynamic-remove-svg.svg.ini
@@ -1,2 +1,2 @@
 [Element-childElementCount-dynamic-remove-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Element-childElementCount-nochild-svg.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Element-childElementCount-nochild-svg.svg.ini
@@ -1,2 +1,2 @@
 [Element-childElementCount-nochild-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Element-childElementCount-svg.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Element-childElementCount-svg.svg.ini
@@ -1,2 +1,2 @@
 [Element-childElementCount-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Element-firstElementChild-entity.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Element-firstElementChild-entity.svg.ini
@@ -1,2 +1,2 @@
 [Element-firstElementChild-entity.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Element-firstElementChild-namespace-svg.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Element-firstElementChild-namespace-svg.svg.ini
@@ -1,2 +1,2 @@
 [Element-firstElementChild-namespace-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Element-firstElementChild-svg.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Element-firstElementChild-svg.svg.ini
@@ -1,2 +1,2 @@
 [Element-firstElementChild-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Element-lastElementChild-svg.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Element-lastElementChild-svg.svg.ini
@@ -1,2 +1,2 @@
 [Element-lastElementChild-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Element-nextElementSibling-svg.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Element-nextElementSibling-svg.svg.ini
@@ -1,2 +1,2 @@
 [Element-nextElementSibling-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Element-previousElementSibling-svg.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Element-previousElementSibling-svg.svg.ini
@@ -1,2 +1,2 @@
 [Element-previousElementSibling-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Element-siblingElement-null-svg.svg.ini
+++ b/tests/wpt/meta/dom/nodes/Element-siblingElement-null-svg.svg.ini
@@ -1,2 +1,2 @@
 [Element-siblingElement-null-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/Node-contains-xml.xml.ini
+++ b/tests/wpt/meta/dom/nodes/Node-contains-xml.xml.ini
@@ -1,2 +1,0 @@
-[Node-contains-xml.xml]
-  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/getElementsByClassName-10.xml.ini
+++ b/tests/wpt/meta/dom/nodes/getElementsByClassName-10.xml.ini
@@ -1,2 +1,0 @@
-[getElementsByClassName-10.xml]
-  expected: ERROR

--- a/tests/wpt/meta/dom/nodes/getElementsByClassName-11.xml.ini
+++ b/tests/wpt/meta/dom/nodes/getElementsByClassName-11.xml.ini
@@ -1,2 +1,0 @@
-[getElementsByClassName-11.xml]
-  expected: ERROR

--- a/tests/wpt/meta/fetch/corb/response_block.tentative.https.html.ini
+++ b/tests/wpt/meta/fetch/corb/response_block.tentative.https.html.ini
@@ -1,4 +1,5 @@
 [response_block.tentative.https.html]
+  expected: ERROR
   [ORB: Expect error response from <script> fetch.]
     expected: FAIL
 

--- a/tests/wpt/meta/fetch/local-network-access/iframe.tentative.https.window.js.ini
+++ b/tests/wpt/meta/fetch/local-network-access/iframe.tentative.https.window.js.ini
@@ -1,11 +1,5 @@
 [iframe.tentative.https.window.html?include=from-public]
-  [public to loopback: permission denied.]
-    expected: FAIL
-
   [public to loopback: success.]
-    expected: FAIL
-
-  [public to local: permission denied.]
     expected: FAIL
 
   [public to local: success.]
@@ -38,16 +32,10 @@
 
 
 [iframe.tentative.https.window.html?include=from-treat-as-public]
-  [treat-as-public-address to loopback: permission denied.]
-    expected: FAIL
-
   [treat-as-public-address to loopback: success.]
     expected: FAIL
 
   [treat-as-public-address to local (same-origin): no permission required.]
-    expected: FAIL
-
-  [treat-as-public-address to local: permission denied.]
     expected: FAIL
 
   [treat-as-public-address to local: success.]

--- a/tests/wpt/meta/fetch/metadata/window-open.https.sub.html.ini
+++ b/tests/wpt/meta/fetch/metadata/window-open.https.sub.html.ini
@@ -1,5 +1,5 @@
 [window-open.https.sub.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Same-origin window, user-activated]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/focus/focus-event-after-switching-iframes.sub.html.ini
+++ b/tests/wpt/meta/focus/focus-event-after-switching-iframes.sub.html.ini
@@ -1,2 +1,2 @@
 [focus-event-after-switching-iframes.sub.html]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-cross-origin-redirect.sub.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-with-cross-origin-redirect.sub.html.ini
@@ -1,2 +1,4 @@
 [pageswap-push-with-cross-origin-redirect.sub.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [pageswap on navigation with same-origin redirect]
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html.ini
@@ -1,2 +1,4 @@
 [pageswap-replace-with-cross-origin-redirect.sub.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [pageswap on navigation with same-origin redirect]
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-cross-origin-redirect-no-bfcache.https.sub.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-cross-origin-redirect-no-bfcache.https.sub.html.ini
@@ -1,2 +1,4 @@
 [pageswap-traverse-navigation-cross-origin-redirect-no-bfcache.https.sub.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [pageswap on traverse navigation from script]
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-no-bfcache.https.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-traverse-navigation-no-bfcache.https.html.ini
@@ -1,2 +1,4 @@
 [pageswap-traverse-navigation-no-bfcache.https.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [pageswap on traverse navigation from script]
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/abort-document-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/abort-document-load.html.ini
@@ -1,5 +1,4 @@
 [abort-document-load.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Aborting a Document load]
     expected: FAIL
-

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-pushState-replaceState.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/initial-empty-document/window-open-204-pushState-replaceState.html.ini
@@ -1,7 +1,6 @@
 [window-open-204-pushState-replaceState.html]
-  expected: TIMEOUT
   [history.pushState]
-    expected: TIMEOUT
+    expected: FAIL
 
   [history.replaceState]
-    expected: NOTRUN
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-user-click-during-load.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-user-click-during-load.html.ini
@@ -1,4 +1,4 @@
 [a-user-click-during-load.html]
-  expected: ERROR
+  expected: TIMEOUT
   [User click on <a> during the load event must NOT replace]
     expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-user-click-during-pageshow.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-user-click-during-pageshow.html.ini
@@ -1,4 +1,4 @@
 [a-user-click-during-pageshow.html]
-  expected: ERROR
+  expected: TIMEOUT
   [User click on <a> during the pageshow event must NOT replace]
     expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-user-click.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/a-user-click.html.ini
@@ -1,4 +1,3 @@
 [a-user-click.html]
-  expected: ERROR
   [User click on <a> before the load event must NOT replace]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-assign-user-click.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-assign-user-click.html.ini
@@ -1,4 +1,3 @@
 [location-assign-user-click.html]
-  expected: ERROR
   [NO replace before load, triggered by location.assign()]
     expected: FAIL

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-user-click.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-user-click.html.ini
@@ -1,5 +1,4 @@
 [location-setter-user-click.html]
-  expected: ERROR
   [href]
     expected: FAIL
 

--- a/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-user-mouseup.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-user-mouseup.html.ini
@@ -1,5 +1,4 @@
 [location-setter-user-mouseup.html]
-  expected: ERROR
   [href]
     expected: FAIL
 

--- a/tests/wpt/meta/html/browsers/browsing-the-web/unloading-documents/prompt-and-unload-script-closeable.html.ini
+++ b/tests/wpt/meta/html/browsers/browsing-the-web/unloading-documents/prompt-and-unload-script-closeable.html.ini
@@ -1,3 +1,5 @@
 [prompt-and-unload-script-closeable.html]
   bug: https://github.com/servo/servo/issues/34751
-  expected: CRASH
+  expected: TIMEOUT
+  [beforeunload and unload events fire after window.close() in script-closeable browsing context]
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/regression-1399759.https.sub.html.ini
+++ b/tests/wpt/meta/html/browsers/origin/origin-keyed-agent-clusters/regression-1399759.https.sub.html.ini
@@ -1,5 +1,8 @@
 [regression-1399759.https.sub.html?pipe=header(Origin-Agent-Cluster,%3F0)]
-  expected: ERROR
+  [Check that about:srcdoc navigation does not follow about:blank rules.]
+    expected: FAIL
+
 
 [regression-1399759.https.sub.html?pipe=header(Origin-Agent-Cluster,%3F1)]
-  expected: ERROR
+  [Check that about:srcdoc navigation does not follow about:blank rules.]
+    expected: FAIL

--- a/tests/wpt/meta/html/browsers/the-window-object/security-window/window-security.https.html.ini
+++ b/tests/wpt/meta/html/browsers/the-window-object/security-window/window-security.https.html.ini
@@ -1,4 +1,5 @@
 [window-security.https.html]
+  expected: ERROR
   [A SecurityError exception must be thrown when window.devicePixelRatio is accessed from a different origin.]
     expected: FAIL
 

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-auto-dynamic-simple-dataChange.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-auto-dynamic-simple-dataChange.html.ini
@@ -1,2 +1,0 @@
-[dir-auto-dynamic-simple-dataChange.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-auto-dynamic-simple-replace.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-auto-dynamic-simple-replace.html.ini
@@ -1,2 +1,0 @@
-[dir-auto-dynamic-simple-replace.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/dom/elements/global-attributes/dir-auto-dynamic-simple-textContent.html.ini
+++ b/tests/wpt/meta/html/dom/elements/global-attributes/dir-auto-dynamic-simple-textContent.html.ini
@@ -1,2 +1,0 @@
-[dir-auto-dynamic-simple-textContent.html]
-  expected: TIMEOUT

--- a/tests/wpt/meta/html/editing/editing-0/making-entire-documents-editable-the-designmode-idl-attribute/user-interaction-editing-designMode-svg.svg.ini
+++ b/tests/wpt/meta/html/editing/editing-0/making-entire-documents-editable-the-designmode-idl-attribute/user-interaction-editing-designMode-svg.svg.ini
@@ -1,2 +1,2 @@
 [user-interaction-editing-designMode-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/html/editing/editing-0/making-entire-documents-editable-the-designmode-idl-attribute/user-interaction-editing-designMode-xml.xml.ini
+++ b/tests/wpt/meta/html/editing/editing-0/making-entire-documents-editable-the-designmode-idl-attribute/user-interaction-editing-designMode-xml.xml.ini
@@ -1,2 +1,9 @@
 [user-interaction-editing-designMode-xml.xml]
-  expected: ERROR
+  [initial designMode attribute]
+    expected: FAIL
+
+  [set designMode = "on"]
+    expected: FAIL
+
+  [set designMode = "off"]
+    expected: FAIL

--- a/tests/wpt/meta/html/select/options-length-too-large.html.ini
+++ b/tests/wpt/meta/html/select/options-length-too-large.html.ini
@@ -1,2 +1,2 @@
 [options-length-too-large.html]
-  expected: TIMEOUT
+  expected: CRASH

--- a/tests/wpt/meta/html/semantics/document-metadata/the-style-element/style_type_svg.svg.ini
+++ b/tests/wpt/meta/html/semantics/document-metadata/the-style-element/style_type_svg.svg.ini
@@ -1,2 +1,2 @@
 [style_type_svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/src_object_blob.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/src_object_blob.html.ini
@@ -1,4 +1,0 @@
-[src_object_blob.html]
-  expected: TIMEOUT
-  [HTMLMediaElement.srcObject blob]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/constraints/infinite_backtracking.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/constraints/infinite_backtracking.tentative.html.ini
@@ -1,2 +1,2 @@
 [infinite_backtracking.tentative.html]
-  expected: TIMEOUT
+  expected: CRASH

--- a/tests/wpt/meta/html/semantics/forms/constraints/reportValidity-crash.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/constraints/reportValidity-crash.html.ini
@@ -1,0 +1,2 @@
+[reportValidity-crash.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/forms/the-input-element/show-picker-does-not-focus.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-input-element/show-picker-does-not-focus.html.ini
@@ -1,0 +1,66 @@
+[show-picker-does-not-focus.html]
+  [input[type=button\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=checkbox\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=color\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=date\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=datetime-local\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=email\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=file\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=hidden\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=image\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=month\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=number\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=password\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=radio\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=range\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=reset\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=search\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=submit\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=tel\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=text\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=time\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=url\].showPicker() does not focus the element]
+    expected: FAIL
+
+  [input[type=week\].showPicker() does not focus the element]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-option-element/dynamic-content-change-rendering.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-option-element/dynamic-content-change-rendering.html.ini
@@ -1,2 +1,2 @@
 [dynamic-content-change-rendering.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-select-element/reset-algorithm-rendering.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-select-element/reset-algorithm-rendering.html.ini
@@ -1,2 +1,2 @@
 [reset-algorithm-rendering.html]
-  expected: TIMEOUT
+  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-textarea-element/selection-after-whitespace-change.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-textarea-element/selection-after-whitespace-change.html.ini
@@ -1,3 +1,0 @@
-[selection-after-whitespace-change.html]
-  [Changing white-space should not change selection]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/interactive-elements/the-details-element/details-toggle-source.html.ini
+++ b/tests/wpt/meta/html/semantics/interactive-elements/the-details-element/details-toggle-source.html.ini
@@ -1,9 +1,3 @@
 [details-toggle-source.html]
-  [ToggleEvent.source on <details> elements: details.open.]
-    expected: FAIL
-
-  [ToggleEvent.source on <details> elements: click summary.]
-    expected: FAIL
-
   [ToggleEvent.source on <details> elements: click details.]
     expected: FAIL

--- a/tests/wpt/meta/html/semantics/links/links-created-by-a-and-area-elements/target_blank_implicit_noopener_base.html.ini
+++ b/tests/wpt/meta/html/semantics/links/links-created-by-a-and-area-elements/target_blank_implicit_noopener_base.html.ini
@@ -1,2 +1,2 @@
 [target_blank_implicit_noopener_base.html]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/menu/tentative/menuitem-activate.html.ini
+++ b/tests/wpt/meta/html/semantics/menu/tentative/menuitem-activate.html.ini
@@ -7,3 +7,9 @@
 
   [Menulist inside a popover works correctly; does not get accidentally dismissed by opening submenus]
     expected: FAIL
+
+  [A mousedown-drag-mouseup gesture on a normal menuitem picks the item]
+    expected: FAIL
+
+  [A mousedown-drag-mouseup gesture on a submenu item leaves both menus open]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/popovers/popover-focus-5.html.ini
+++ b/tests/wpt/meta/html/semantics/popovers/popover-focus-5.html.ini
@@ -59,6 +59,7 @@
 
 
 [popover-focus-5.html?imperative]
+  expected: ERROR
   [Focusing elements inside a popover with form controls inside, using imperative]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/popovers/popover-self-invoke.html.ini
+++ b/tests/wpt/meta/html/semantics/popovers/popover-self-invoke.html.ini
@@ -1,0 +1,9 @@
+[popover-self-invoke.html]
+  [mouse on a popover button that is its own target should open it.]
+    expected: FAIL
+
+  [touch on a popover button that is its own target should open it.]
+    expected: FAIL
+
+  [click on a popover button that is its own target should open it.]
+    expected: FAIL

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/script-type-and-language-js-svg.svg.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/script-type-and-language-js-svg.svg.ini
@@ -1,2 +1,2 @@
 [script-type-and-language-js-svg.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html.ini
+++ b/tests/wpt/meta/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html.ini
@@ -1,0 +1,13 @@
+[invalid-element-types.html?command=--custom-event&half=second]
+  [command/commandfor on <select> with command=--custom-event should not function]
+    expected: FAIL
+
+
+[invalid-element-types.html?command=show-popover&half=second]
+  [command/commandfor on <select> with command=show-popover should not function]
+    expected: FAIL
+
+
+[invalid-element-types.html?command=show-modal&half=second]
+  [command/commandfor on <select> with command=show-modal should not function]
+    expected: FAIL

--- a/tests/wpt/meta/html/syntax/charset/without-inheritance.html.ini
+++ b/tests/wpt/meta/html/syntax/charset/without-inheritance.html.ini
@@ -1,2 +1,2 @@
 [without-inheritance.html]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/html/syntax/parsing-html-fragments/the-input-byte-stream-003.html.ini
+++ b/tests/wpt/meta/html/syntax/parsing-html-fragments/the-input-byte-stream-003.html.ini
@@ -1,2 +1,2 @@
 [the-input-byte-stream-003.html]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/html/syntax/parsing-html-fragments/the-input-byte-stream-004.html.ini
+++ b/tests/wpt/meta/html/syntax/parsing-html-fragments/the-input-byte-stream-004.html.ini
@@ -1,2 +1,2 @@
 [the-input-byte-stream-004.html]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/html/webappapis/user-prompts/cannot-show-simple-dialogs/confirm-different-origin-frame.sub.html.ini
+++ b/tests/wpt/meta/html/webappapis/user-prompts/cannot-show-simple-dialogs/confirm-different-origin-frame.sub.html.ini
@@ -1,0 +1,2 @@
+[confirm-different-origin-frame.sub.html]
+  expected: ERROR

--- a/tests/wpt/meta/html/webappapis/user-prompts/cannot-show-simple-dialogs/prompt-different-origin-frame.sub.html.ini
+++ b/tests/wpt/meta/html/webappapis/user-prompts/cannot-show-simple-dialogs/prompt-different-origin-frame.sub.html.ini
@@ -1,0 +1,2 @@
+[prompt-different-origin-frame.sub.html]
+  expected: ERROR

--- a/tests/wpt/meta/intersection-observer/v2/blur-filter.html.ini
+++ b/tests/wpt/meta/intersection-observer/v2/blur-filter.html.ini
@@ -1,6 +1,3 @@
 [blur-filter.html]
-  [First rAF.]
-    expected: FAIL
-
   [occluder.style.opacity = 0]
     expected: FAIL

--- a/tests/wpt/meta/intersection-observer/v2/drop-shadow-filter-vertical-rl.html.ini
+++ b/tests/wpt/meta/intersection-observer/v2/drop-shadow-filter-vertical-rl.html.ini
@@ -1,6 +1,3 @@
 [drop-shadow-filter-vertical-rl.html]
-  [First rAF.]
-    expected: FAIL
-
   [occluder.style.opacity = 0]
     expected: FAIL

--- a/tests/wpt/meta/intersection-observer/v2/iframe-target.html.ini
+++ b/tests/wpt/meta/intersection-observer/v2/iframe-target.html.ini
@@ -1,3 +1,0 @@
-[iframe-target.html]
-  [First rAF.]
-    expected: FAIL

--- a/tests/wpt/meta/intersection-observer/v2/simple-effects.html.ini
+++ b/tests/wpt/meta/intersection-observer/v2/simple-effects.html.ini
@@ -1,7 +1,4 @@
 [simple-effects.html]
-  [First rAF.]
-    expected: FAIL
-
   [effects.style.opacity = 0.99]
     expected: FAIL
 

--- a/tests/wpt/meta/intersection-observer/v2/simple-occlusion.html.ini
+++ b/tests/wpt/meta/intersection-observer/v2/simple-occlusion.html.ini
@@ -1,7 +1,4 @@
 [simple-occlusion.html]
-  [First rAF.]
-    expected: FAIL
-
   [occluder.style.marginTop = '-10px']
     expected: FAIL
 

--- a/tests/wpt/meta/mimesniff/media/media-sniff.window.js.ini
+++ b/tests/wpt/meta/mimesniff/media/media-sniff.window.js.ini
@@ -1,3 +1,3 @@
 [media-sniff.window.html]
   bug: https://github.com/servo/servo/issues/36626
-  expected: TIMEOUT
+  expected: CRASH

--- a/tests/wpt/meta/performance-timeline/not-restored-reasons/abort-block-bfcache.window.js.ini
+++ b/tests/wpt/meta/performance-timeline/not-restored-reasons/abort-block-bfcache.window.js.ini
@@ -1,3 +1,4 @@
 [abort-block-bfcache.window.html]
+  expected: TIMEOUT
   [aborting a parser should block bfcache.]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_lostpointercapture_for_disconnected_shadow_host.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_lostpointercapture_for_disconnected_shadow_host.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_lostpointercapture_for_disconnected_shadow_host.html]
-  expected: ERROR
+  expected: CRASH
   [lostpointercapture is dispatched on the document when shadow host is removed]
     expected: TIMEOUT

--- a/tests/wpt/meta/resize-observer/svg-with-css-box-002.svg.ini
+++ b/tests/wpt/meta/resize-observer/svg-with-css-box-002.svg.ini
@@ -1,2 +1,2 @@
 [svg-with-css-box-002.svg]
-  expected: TIMEOUT
+  expected: ERROR

--- a/tests/wpt/meta/service-workers/service-worker/claim-with-redirect.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/claim-with-redirect.https.html.ini
@@ -1,2 +1,3 @@
 [claim-with-redirect.https.html]
-  expected: ERROR
+  [Claim works after redirection to another origin]
+    expected: FAIL

--- a/tests/wpt/meta/service-workers/service-worker/navigation-preload/samesite-iframe.https.html.ini
+++ b/tests/wpt/meta/service-workers/service-worker/navigation-preload/samesite-iframe.https.html.ini
@@ -1,2 +1,4 @@
 [samesite-iframe.https.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [Navigation Preload for same site iframe]
+    expected: TIMEOUT

--- a/tests/wpt/meta/workers/same-site-cookies/third-party.default.tentative.sub.https.window.js.ini
+++ b/tests/wpt/meta/workers/same-site-cookies/third-party.default.tentative.sub.https.window.js.ini
@@ -1,4 +1,3 @@
 [third-party.default.tentative.sub.https.window.html]
-  expected: ERROR
   [Check SharedWorker sameSiteCookies option default for third-party]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/workers/same-site-cookies/third-party.none.tentative.sub.https.window.js.ini
+++ b/tests/wpt/meta/workers/same-site-cookies/third-party.none.tentative.sub.https.window.js.ini
@@ -1,4 +1,3 @@
 [third-party.none.tentative.sub.https.window.html]
-  expected: ERROR
   [Check SharedWorker sameSiteCookies option none for third-party]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/mozilla/meta/css/animations/pseudo-element-transition-continues-on-box-tree-re-construction.html.ini
+++ b/tests/wpt/mozilla/meta/css/animations/pseudo-element-transition-continues-on-box-tree-re-construction.html.ini
@@ -1,0 +1,3 @@
+[pseudo-element-transition-continues-on-box-tree-re-construction.html]
+  [::before width transition continues while pointer moves]
+    expected: FAIL

--- a/tests/wpt/mozilla/meta/css/pixel_snapping_border_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/pixel_snapping_border_a.html.ini
@@ -1,0 +1,2 @@
+[pixel_snapping_border_a.html]
+  expected: ERROR

--- a/tests/wpt/mozilla/meta/css/pixel_snapping_position_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/pixel_snapping_position_a.html.ini
@@ -1,0 +1,2 @@
+[pixel_snapping_position_a.html]
+  expected: ERROR

--- a/tests/wpt/mozilla/meta/css/viewport_percentage_vmin_vmax_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/viewport_percentage_vmin_vmax_a.html.ini
@@ -1,0 +1,2 @@
+[viewport_percentage_vmin_vmax_a.html]
+  expected: ERROR

--- a/tests/wpt/mozilla/meta/css/viewport_percentage_vmin_vmax_b.html.ini
+++ b/tests/wpt/mozilla/meta/css/viewport_percentage_vmin_vmax_b.html.ini
@@ -1,0 +1,2 @@
+[viewport_percentage_vmin_vmax_b.html]
+  expected: ERROR

--- a/tests/wpt/mozilla/meta/css/viewport_percentage_vw_vh_a.html.ini
+++ b/tests/wpt/mozilla/meta/css/viewport_percentage_vw_vh_a.html.ini
@@ -1,0 +1,2 @@
+[viewport_percentage_vw_vh_a.html]
+  expected: ERROR

--- a/tests/wpt/mozilla/meta/css/viewport_percentage_vw_vh_b.html.ini
+++ b/tests/wpt/mozilla/meta/css/viewport_percentage_vw_vh_b.html.ini
@@ -1,0 +1,2 @@
+[viewport_percentage_vw_vh_b.html]
+  expected: ERROR


### PR DESCRIPTION
This change switches the default test runner for WPT to be WebDriver,
enabling testdriver tests by default. In addition, it update results to
reflect the ones that you would expect when running with WebDriver.
While there are some failures that require more investigation, in
general the differences in results are fairly explicable.

Testing: This change modifies the way that tests are run and is thus
tested by all WPT-like tests.
Fixes: #34683
