### PR TITLE
Edit accesskit Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
   groups:
     accesskit-related:
       patterns:
-        - "accesskit_*"
+        - "accesskit*"
     egui-related:
       patterns:
         - "ecolor"


### PR DESCRIPTION
Edit the accesskit Dependabot group to remove the underscore as the main accesskit crate doesn't have one in its name.

Testing: No tests for dependabot.yml edit.