### PR TITLE
fonts: Add WebFontDocumentContext for CSS Fonts 4 font fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,6 +2816,7 @@ dependencies = [
  "bitflags 2.10.0",
  "byteorder",
  "compositing_traits",
+ "content-security-policy",
  "core-foundation 0.9.4",
  "core-graphics",
  "core-text",

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -21,6 +21,7 @@ app_units = { workspace = true }
 base = { workspace = true }
 bitflags = { workspace = true }
 compositing_traits = { workspace = true }
+content-security-policy = { workspace = true }
 euclid = { workspace = true }
 fonts_traits = { workspace = true }
 fontsan = { git = "https://github.com/servo/fontsan" }

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -109,6 +109,7 @@ pub struct FontContext {
     have_removed_web_fonts: AtomicBool,
 }
 
+/// Document-specific data required to fetch a web font.
 #[derive(Clone, Debug)]
 pub struct WebFontDocumentContext {
     pub policy_container: PolicyContainer,

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -28,7 +28,7 @@ use parking_lot::{Mutex, RwLock};
 use rustc_hash::FxHashSet;
 use servo_arc::Arc as ServoArc;
 use servo_config::pref;
-use servo_url::{ImmutableOrigin, ServoUrl};
+use servo_url::ServoUrl;
 use style::Atom;
 use style::computed_values::font_variant_caps::T as FontVariantCaps;
 use style::font_face::{

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -877,6 +877,7 @@ impl RemoteWebFontDownloader {
             url.clone().into(),
             Referrer::ReferrerUrl(document_context.document_url.clone()),
         )
+        .origin(document_context.document_url.origin())
         .destination(Destination::Font)
         .mode(RequestMode::CorsMode)
         .credentials_mode(CredentialsMode::CredentialsSameOrigin)

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -20,7 +20,7 @@ pub use font::{
     FontBaseline, FontGroup, FontMetrics, FontRef, LAST_RESORT_GLYPH_ADVANCE, ShapingFlags,
     ShapingOptions,
 };
-pub use font_context::{FontContext, FontContextWebFontMethods};
+pub use font_context::{FontContext, FontContextWebFontMethods, WebFontDocumentContext};
 pub use font_store::FontTemplates;
 pub use fonts_traits::*;
 pub(crate) use glyph::*;

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -20,7 +20,9 @@ pub use font::{
     FontBaseline, FontGroup, FontMetrics, FontRef, LAST_RESORT_GLYPH_ADVANCE, ShapingFlags,
     ShapingOptions,
 };
-pub use font_context::{FontContext, FontContextWebFontMethods, WebFontDocumentContext};
+pub use font_context::{
+    CspViolationHandler, FontContext, FontContextWebFontMethods, WebFontDocumentContext,
+};
 pub use font_store::FontTemplates;
 pub use fonts_traits::*;
 pub(crate) use glyph::*;

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -263,7 +263,7 @@ impl Layout for LayoutThread {
 
     fn load_web_fonts_from_stylesheet(
         &self,
-        stylesheet: ServoArc<Stylesheet>,
+        stylesheet: &ServoArc<Stylesheet>,
         document_context: &WebFontDocumentContext,
     ) {
         let guard = stylesheet.shared_lock.read();

--- a/components/script/dom/bindings/refcounted.rs
+++ b/components/script/dom/bindings/refcounted.rs
@@ -176,6 +176,12 @@ pub(crate) struct Trusted<T: DomObject> {
     phantom: PhantomData<T>,
 }
 
+impl<T: DomObject> std::fmt::Debug for Trusted<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.write_str("...")
+    }
+}
+
 unsafe impl<T: DomObject> Send for Trusted<T> {}
 
 impl<T: DomObject> Trusted<T> {

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -539,7 +539,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
         .expect("Parsing shouldn't fail as descriptors are valid by construction");
 
         // Construct a WebFontDocumentContext object for the current document.
-        let document_context = global.as_window().new_document_context();
+        let document_context = global.as_window().web_font_context();
 
         // Step 4. Using the value of font face’s [[Urls]] slot, attempt to load a font as defined
         // in [CSS-FONTS-3], as if it was the value of a @font-face rule’s src descriptor.

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -7,7 +7,10 @@ use std::rc::Rc;
 
 use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
-use fonts::{FontContext, FontContextWebFontMethods, FontTemplate, LowercaseFontFamilyName};
+use fonts::{
+    FontContext, FontContextWebFontMethods, FontTemplate, LowercaseFontFamilyName,
+    WebFontDocumentContext,
+};
 use js::rust::HandleObject;
 use style::error_reporting::ParseErrorReporter;
 use style::font_face::SourceList;
@@ -538,6 +541,14 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
         )
         .expect("Parsing shouldn't fail as descriptors are valid by construction");
 
+        //Construct a WebFontDocumentContext object for the current document.
+        let document_context = WebFontDocumentContext {
+            policy_container: global.policy_container(),
+            document_url: global.api_base_url(),
+            has_trustworthy_ancestor_origin: global.has_trustworthy_ancestor_origin(),
+            insecure_requests_policy: global.insecure_requests_policy(),
+        };
+
         // Step 4. Using the value of font face’s [[Urls]] slot, attempt to load a font as defined
         // in [CSS-FONTS-3], as if it was the value of a @font-face rule’s src descriptor.
         // TODO: FontFaceSet is not supported on Workers yet. The `as_window` call below should be
@@ -547,6 +558,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
             sources,
             (&parsed_font_face_rule).into(),
             finished_callback,
+            &document_context,
         );
 
         // Step 3. Set font face’s status attribute to "loading", return font face’s

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -7,10 +7,7 @@ use std::rc::Rc;
 
 use cssparser::{Parser, ParserInput};
 use dom_struct::dom_struct;
-use fonts::{
-    FontContext, FontContextWebFontMethods, FontTemplate, LowercaseFontFamilyName,
-    WebFontDocumentContext,
-};
+use fonts::{FontContext, FontContextWebFontMethods, FontTemplate, LowercaseFontFamilyName};
 use js::rust::HandleObject;
 use style::error_reporting::ParseErrorReporter;
 use style::font_face::SourceList;
@@ -541,13 +538,8 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
         )
         .expect("Parsing shouldn't fail as descriptors are valid by construction");
 
-        //Construct a WebFontDocumentContext object for the current document.
-        let document_context = WebFontDocumentContext {
-            policy_container: global.policy_container(),
-            document_url: global.api_base_url(),
-            has_trustworthy_ancestor_origin: global.has_trustworthy_ancestor_origin(),
-            insecure_requests_policy: global.insecure_requests_policy(),
-        };
+        // Construct a WebFontDocumentContext object for the current document.
+        let document_context = global.as_window().new_document_context();
 
         // Step 4. Using the value of font face’s [[Urls]] slot, attempt to load a font as defined
         // in [CSS-FONTS-3], as if it was the value of a @font-face rule’s src descriptor.

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4196,8 +4196,7 @@ impl Document {
             .cloned();
 
         if self.has_browsing_context() {
-            // Construct WebFontDocumentContext for font fetching
-            let document_context = self.window.new_document_context();
+            let document_context = self.window.web_font_context();
 
             self.window.layout_mut().add_stylesheet(
                 sheet.clone(),
@@ -4236,7 +4235,7 @@ impl Document {
             self.window.layout_mut().add_stylesheet(
                 sheet.clone(),
                 insertion_point.as_ref().map(|s| s.sheet.clone()),
-                &self.window.new_document_context(),
+                &self.window.web_font_context(),
             );
         }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4197,15 +4197,7 @@ impl Document {
 
         if self.has_browsing_context() {
             // Construct WebFontDocumentContext for font fetching
-            let document_context = WebFontDocumentContext {
-                policy_container: self.window.global().policy_container(),
-                document_url: self.window.global().api_base_url(),
-                has_trustworthy_ancestor_origin: self
-                    .window
-                    .global()
-                    .has_trustworthy_ancestor_origin(),
-                insecure_requests_policy: self.window.global().insecure_requests_policy(),
-            };
+            let document_context = self.window.new_document_context();
 
             self.window.layout_mut().add_stylesheet(
                 sheet.clone(),
@@ -4244,6 +4236,7 @@ impl Document {
             self.window.layout_mut().add_stylesheet(
                 sheet.clone(),
                 insertion_point.as_ref().map(|s| s.sheet.clone()),
+                &self.window.new_document_context(),
             );
         }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -843,6 +843,15 @@ impl Window {
     pub(crate) fn perform_a_microtask_checkpoint(&self, can_gc: CanGc) {
         with_script_thread(|script_thread| script_thread.perform_a_microtask_checkpoint(can_gc));
     }
+
+    pub fn new_document_context(&self) -> WebFontDocumentContext {
+        WebFontDocumentContext {
+            policy_container: self.global().policy_container(),
+            document_url: self.global().api_base_url(),
+            has_trustworthy_ancestor_origin: self.global().has_trustworthy_ancestor_origin(),
+            insecure_requests_policy: self.global().insecure_requests_policy(),
+        }
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/#atob
@@ -2452,13 +2461,9 @@ impl Window {
         };
 
         //Construct a new document context for the reflow.
-        let document_context = WebFontDocumentContext {
-            policy_container: self.global().policy_container(),
-            document_url: self.global().api_base_url(),
-            has_trustworthy_ancestor_origin: self.global().has_trustworthy_ancestor_origin(),
-            insecure_requests_policy: self.global().insecure_requests_policy(),
-        };
+        let document_context = self.new_document_context();
 
+        // Send new document and relevant styles to layout.
         let reflow = ReflowRequest {
             document: document.upcast::<Node>().to_trusted_node_address(),
             epoch: document.current_rendering_epoch(),

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -30,6 +30,7 @@ use constellation_traits::{
     ScriptToConstellationChan, ScriptToConstellationMessage, StructuredSerializedData,
     WindowSizeType,
 };
+use content_security_policy::Violation;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use crossbeam_channel::{Sender, unbounded};
 use cssparser::SourceLocation;
@@ -43,7 +44,7 @@ use embedder_traits::{
 };
 use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect};
 use euclid::{Point2D, Scale, Size2D, Vector2D};
-use fonts::{FontContext, WebFontDocumentContext};
+use fonts::{CspViolationHandler, FontContext, WebFontDocumentContext};
 use ipc_channel::ipc::IpcSender;
 use js::glue::DumpJSStack;
 use js::jsapi::{
@@ -138,6 +139,7 @@ use crate::dom::bindings::weakref::DOMTracker;
 use crate::dom::bluetooth::BluetoothExtraPermissionData;
 use crate::dom::cookiestore::CookieStore;
 use crate::dom::crypto::Crypto;
+use crate::dom::csp::GlobalCspReporting;
 use crate::dom::css::cssstyledeclaration::{
     CSSModificationAccess, CSSStyleDeclaration, CSSStyleOwner,
 };
@@ -187,6 +189,7 @@ use crate::realms::{InRealm, enter_realm};
 use crate::script_runtime::{CanGc, JSContext, Runtime};
 use crate::script_thread::{ScriptThread, with_script_thread};
 use crate::script_window_proxies::ScriptWindowProxies;
+use crate::task_source::SendableTaskSource;
 use crate::timers::{IsInterval, TimerCallback};
 use crate::unminify::unminified_path;
 use crate::webdriver_handlers::{find_node_by_unique_id_in_document, jsval_to_webdriver};
@@ -851,7 +854,36 @@ impl Window {
             document_url: global.api_base_url(),
             has_trustworthy_ancestor_origin: global.has_trustworthy_ancestor_origin(),
             insecure_requests_policy: global.insecure_requests_policy(),
+            csp_handler: Box::new(FontCspHandler {
+                global: Trusted::new(global),
+                task_source: global
+                    .task_manager()
+                    .dom_manipulation_task_source()
+                    .to_sendable(),
+            }),
         }
+    }
+}
+
+#[derive(Debug)]
+struct FontCspHandler {
+    global: Trusted<GlobalScope>,
+    task_source: SendableTaskSource,
+}
+
+impl CspViolationHandler for FontCspHandler {
+    fn process_violations(&self, violations: Vec<Violation>) {
+        let global = self.global.clone();
+        self.task_source.queue(task!(csp_violation: move || {
+            global.root().report_csp_violations(violations, None, None);
+        }));
+    }
+
+    fn clone(&self) -> Box<dyn CspViolationHandler> {
+        Box::new(Self {
+            global: self.global.clone(),
+            task_source: self.task_source.clone(),
+        })
     }
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -845,13 +845,12 @@ impl Window {
     }
 
     pub(crate) fn web_font_context(&self) -> WebFontDocumentContext {
+        let global = self.as_global_scope();
         WebFontDocumentContext {
-            policy_container: self.as_global_scope().policy_container(),
-            document_url: self.as_global_scope().api_base_url(),
-            has_trustworthy_ancestor_origin: self
-                .as_global_scope()
-                .has_trustworthy_ancestor_origin(),
-            insecure_requests_policy: self.as_global_scope().insecure_requests_policy(),
+            policy_container: global.policy_container(),
+            document_url: global.api_base_url(),
+            has_trustworthy_ancestor_origin: global.has_trustworthy_ancestor_origin(),
+            insecure_requests_policy: global.insecure_requests_policy(),
         }
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -844,12 +844,14 @@ impl Window {
         with_script_thread(|script_thread| script_thread.perform_a_microtask_checkpoint(can_gc));
     }
 
-    pub fn new_document_context(&self) -> WebFontDocumentContext {
+    pub(crate) fn web_font_context(&self) -> WebFontDocumentContext {
         WebFontDocumentContext {
-            policy_container: self.global().policy_container(),
-            document_url: self.global().api_base_url(),
-            has_trustworthy_ancestor_origin: self.global().has_trustworthy_ancestor_origin(),
-            insecure_requests_policy: self.global().insecure_requests_policy(),
+            policy_container: self.as_global_scope().policy_container(),
+            document_url: self.as_global_scope().api_base_url(),
+            has_trustworthy_ancestor_origin: self
+                .as_global_scope()
+                .has_trustworthy_ancestor_origin(),
+            insecure_requests_policy: self.as_global_scope().insecure_requests_policy(),
         }
     }
 }
@@ -2460,8 +2462,7 @@ impl Window {
             None
         };
 
-        //Construct a new document context for the reflow.
-        let document_context = self.new_document_context();
+        let document_context = self.web_font_context();
 
         // Send new document and relevant styles to layout.
         let reflow = ReflowRequest {

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -8,8 +8,6 @@ use base::id::PipelineId;
 use crossbeam_channel::Sender;
 use cssparser::SourceLocation;
 use encoding_rs::UTF_8;
-use fonts::WebFontDocumentContext;
-use mime::{self, Mime};
 use net_traits::mime_classifier::MimeClassifier;
 use net_traits::request::{CorsSettings, Destination, RequestId};
 use net_traits::{
@@ -257,7 +255,7 @@ impl StylesheetContext {
                 StylesheetContextSource::Import { import_rule } => {
                     // Construct a new WebFontDocumentContext for the stylesheet
                     let window = element.owner_window();
-                    let document_context = window.new_document_context();
+                    let document_context = window.web_font_context();
 
                     // Layout knows about this stylesheet, because Stylo added it to the Stylist,
                     // but Layout doesn't know about any new web fonts that it contains.
@@ -347,100 +345,6 @@ impl FetchResponseListener for StylesheetContext {
         self.unminify_css(metadata.final_url.clone());
         if !is_css {
             self.data.clear();
-=======
-            // From <https://html.spec.whatwg.org/multipage/#link-type-stylesheet>:
-            // > Quirk: If the document has been set to quirks mode, has the same origin as
-            // > the URL of the external resource, and the Content-Type metadata of the
-            // > external resource is not a supported style sheet type, the user agent must
-            // > instead assume it to be text/css.
-            if document.quirks_mode() == QuirksMode::Quirks &&
-                document.url().origin() == self.url.origin()
-            {
-                is_css = true;
-            }
-
-            let data = if is_css {
-                let data = std::mem::take(&mut self.data);
-                self.unminify_css(data, metadata.final_url.clone())
-            } else {
-                vec![]
-            };
-
-            // TODO: Get the actual value. http://dev.w3.org/csswg/css-syntax/#environment-encoding
-            let environment_encoding = UTF_8;
-            let protocol_encoding_label = metadata.charset.as_deref();
-            let final_url = metadata.final_url;
-
-            let win = element.owner_window();
-
-            let loader = ElementStylesheetLoader::new(&element);
-            let shared_lock = document.style_shared_lock();
-            let stylesheet = |media| {
-                #[cfg(feature = "tracing")]
-                let _span =
-                    tracing::trace_span!("ParseStylesheet", servo_profiling = true).entered();
-                Arc::new(Stylesheet::from_bytes(
-                    &data,
-                    UrlExtraData(final_url.get_arc()),
-                    protocol_encoding_label,
-                    Some(environment_encoding),
-                    Origin::Author,
-                    media,
-                    shared_lock.clone(),
-                    Some(&loader),
-                    win.css_error_reporter(),
-                    document.quirks_mode(),
-                ))
-            };
-            match &self.source {
-                StylesheetContextSource::LinkElement { media } => {
-                    let link = element.downcast::<HTMLLinkElement>().unwrap();
-                    // We must first check whether the generations of the context and the element match up,
-                    // else we risk applying the wrong stylesheet when responses come out-of-order.
-                    let is_stylesheet_load_applicable = self
-                        .request_generation_id
-                        .is_none_or(|generation| generation == link.get_request_generation_id());
-                    if is_stylesheet_load_applicable {
-                        let stylesheet = stylesheet(media.clone());
-                        if link.is_effectively_disabled() {
-                            stylesheet.set_disabled(true);
-                        }
-                        link.set_stylesheet(stylesheet);
-                    }
-                },
-                StylesheetContextSource::Import { import_rule, media } => {
-                    let stylesheet = stylesheet(media.clone());
-
-                    let document_context = win.web_font_context();
-
-                    // Layout knows about this stylesheet, because Stylo added it to the Stylist,
-                    // but Layout doesn't know about any new web fonts that it contains.
-                    document.load_web_fonts_from_stylesheet(&stylesheet, &document_context);
-
-                    let mut guard = shared_lock.write();
-                    import_rule.write_with(&mut guard).stylesheet = ImportSheet::Sheet(stylesheet);
-                },
-            }
-
-            if let Some(ref shadow_root) = self.shadow_root {
-                shadow_root.root().invalidate_stylesheets();
-            } else {
-                document.invalidate_stylesheets();
-            }
-
-            // FIXME: Revisit once consensus is reached at:
-            // https://github.com/whatwg/html/issues/1142
-            successful = metadata.status == http::StatusCode::OK;
-        }
-
-        let owner = element
-            .upcast::<Element>()
-            .as_stylesheet_owner()
-            .expect("Stylesheet not loaded by <style> or <link> element!");
-        owner.set_origin_clean(self.origin_clean);
-        if owner.parser_inserted() {
-            document.decrement_script_blocking_stylesheet_count();
->>>>>>> 8f6719e1036 (Add Helper method for creating new WebFontDocumentContext)
         }
 
         // From <https://html.spec.whatwg.org/multipage/#link-type-stylesheet>:

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -411,8 +411,7 @@ impl FetchResponseListener for StylesheetContext {
                 StylesheetContextSource::Import { import_rule, media } => {
                     let stylesheet = stylesheet(media.clone());
 
-                    // Construct a new WebFontDocumentContext for the stylesheet
-                    let document_context = win.new_document_context();
+                    let document_context = win.web_font_context();
 
                     // Layout knows about this stylesheet, because Stylo added it to the Stylist,
                     // but Layout doesn't know about any new web fonts that it contains.

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -8,7 +8,12 @@ use base::id::PipelineId;
 use crossbeam_channel::Sender;
 use cssparser::SourceLocation;
 use encoding_rs::UTF_8;
+<<<<<<< HEAD
 use net_traits::mime_classifier::MimeClassifier;
+=======
+use fonts::WebFontDocumentContext;
+use mime::{self, Mime};
+>>>>>>> 6b708ce6752 (Add WebFontDocumentContext for CSS Fonts 4 font fetching)
 use net_traits::request::{CorsSettings, Destination, RequestId};
 use net_traits::{
     FetchMetadata, FilteredMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming,
@@ -253,9 +258,19 @@ impl StylesheetContext {
                     link.set_stylesheet(stylesheet);
                 },
                 StylesheetContextSource::Import { import_rule } => {
+                    // Construct a new WebFontDocumentContext for the stylesheet
+                    let global = element.global();
+                    let document_context = WebFontDocumentContext {
+                        policy_container: global.policy_container(),
+                        document_url: global.api_base_url(),
+                        has_trustworthy_ancestor_origin: global
+                            .has_trustworthy_ancestor_origin(),
+                        insecure_requests_policy: global.insecure_requests_policy(),
+                    };
+
                     // Layout knows about this stylesheet, because Stylo added it to the Stylist,
                     // but Layout doesn't know about any new web fonts that it contains.
-                    document.load_web_fonts_from_stylesheet(&stylesheet);
+                    document.load_web_fonts_from_stylesheet(&stylesheet, &document_context);
 
                     let mut guard = document.style_shared_lock().write();
                     import_rule.write_with(&mut guard).stylesheet = ImportSheet::Sheet(stylesheet);

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -28,7 +28,7 @@ use compositing_traits::CrossProcessCompositorApi;
 use embedder_traits::{Cursor, Theme, UntrustedNodeAddress, ViewportDetails};
 use euclid::Point2D;
 use euclid::default::{Point2D as UntypedPoint2D, Rect};
-use fonts::FontContext;
+use fonts::{FontContext, WebFontDocumentContext};
 pub use layout_damage::LayoutDamage;
 use libc::c_void;
 use malloc_size_of::{MallocSizeOf as MallocSizeOfTrait, MallocSizeOfOps, malloc_size_of_is_0};
@@ -253,7 +253,11 @@ pub trait Layout {
 
     /// Load all fonts from the given stylesheet, returning the number of fonts that
     /// need to be loaded.
-    fn load_web_fonts_from_stylesheet(&self, stylesheet: &ServoArc<Stylesheet>);
+    fn load_web_fonts_from_stylesheet(
+        &self,
+        stylesheet: &ServoArc<Stylesheet>,
+        font_context: &WebFontDocumentContext,
+    );
 
     /// Add a stylesheet to this Layout. This will add it to the Layout's `Stylist` as well as
     /// loading all web fonts defined in the stylesheet. The second stylesheet is the insertion
@@ -262,6 +266,7 @@ pub trait Layout {
         &mut self,
         stylesheet: ServoArc<Stylesheet>,
         before_stylsheet: Option<ServoArc<Stylesheet>>,
+        font_context: &WebFontDocumentContext,
     );
 
     /// Inform the layout that its ScriptThread is about to exit.
@@ -598,6 +603,8 @@ pub struct ReflowRequest {
     pub animating_images: Arc<RwLock<AnimatingImages>>,
     /// The node highlighted by the devtools, if any
     pub highlighted_dom_node: Option<OpaqueNode>,
+    /// The current font context.
+    pub document_context: WebFontDocumentContext,
 }
 
 impl ReflowRequest {

--- a/tests/wpt/meta/content-security-policy/font-src/font-stylesheet-font-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/font-src/font-stylesheet-font-blocked.sub.html.ini
@@ -1,4 +1,0 @@
-[font-stylesheet-font-blocked.sub.html]
-  expected: TIMEOUT
-  [Test font does not load if it does not match font-src.]
-    expected: TIMEOUT

--- a/tests/wpt/meta/referrer-policy/css-integration/font-face/internal-stylesheet.html.ini
+++ b/tests/wpt/meta/referrer-policy/css-integration/font-face/internal-stylesheet.html.ini
@@ -1,3 +1,0 @@
-[internal-stylesheet.html]
-  [Font from internal stylesheet.]
-    expected: FAIL


### PR DESCRIPTION
Rebase of #37021 with review comments applied. These changes bundle up the required information from the relevant global when a stylesheet is added so that any requests for web fonts match the specification.

Testing: Newly passing tests.
Fixes: #36590
