### PR TITLE
servoshell: Implement `WebDriverCommandMsg::TakeScreenshot` for egl

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -535,20 +535,13 @@ impl App {
                     running_state.set_alert_text_of_newest_dialog(webview_id, text);
                 },
                 WebDriverCommandMsg::TakeScreenshot(webview_id, rect, result_sender) => {
-                    let Some(webview) = running_state.webview_by_id(webview_id) else {
-                        if let Err(error) =
-                            result_sender.send(Err(ScreenshotCaptureError::WebViewDoesNotExist))
-                        {
-                            warn!("Failed to send response to TakeScreenshot: {error}");
-                        }
-                        continue;
-                    };
-                    let rect = rect.map(|rect| rect.to_box2d().into());
-                    webview.take_screenshot(rect, move |result| {
-                        if let Err(error) = result_sender.send(result) {
-                            warn!("Failed to send response to TakeScreenshot: {error}");
-                        }
-                    });
+                    if let Some(webview) = running_state.webview_by_id(webview_id) {
+                        running_state.handle_webdriver_screenshot(webview, rect, result_sender);
+                    } else if let Err(error) =
+                        result_sender.send(Err(ScreenshotCaptureError::WebViewDoesNotExist))
+                    {
+                        error!("Failed to send response to TakeScreenshot: {error}");
+                    }
                 },
             };
         }

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -10,7 +10,7 @@ use dpi::PhysicalSize;
 use euclid::{Point2D, Rect, Scale, Size2D};
 use image::{DynamicImage, ImageFormat};
 use keyboard_types::{CompositionEvent, CompositionState, Key, KeyState, NamedKey};
-use log::{debug, error, info, warn};
+use log::{error, info, warn};
 use raw_window_handle::{RawWindowHandle, WindowHandle};
 use servo::base::generic_channel::GenericSender;
 use servo::base::id::WebViewId;
@@ -22,10 +22,10 @@ use servo::{
     AllowOrDenyRequest, ContextMenuResult, EmbedderControl, EmbedderControlId, ImeEvent,
     InputEvent, InputEventId, InputEventResult, KeyboardEvent, LoadStatus, MediaSessionActionType,
     MediaSessionEvent, MouseButton, MouseButtonAction, MouseButtonEvent, MouseMoveEvent,
-    NavigationRequest, PermissionRequest, RefreshDriver, RenderingContext, ScreenGeometry, Scroll,
-    Servo, ServoDelegate, ServoError, TouchEvent, TouchEventType, TouchId, TraversalId,
-    WebDriverCommandMsg, WebDriverLoadStatus, WebDriverScriptCommand, WebView, WebViewBuilder,
-    WebViewDelegate, WindowRenderingContext,
+    NavigationRequest, PermissionRequest, RefreshDriver, RenderingContext, ScreenGeometry,
+    ScreenshotCaptureError, Scroll, Servo, ServoDelegate, ServoError, TouchEvent, TouchEventType,
+    TouchId, TraversalId, WebDriverCommandMsg, WebDriverLoadStatus, WebDriverScriptCommand,
+    WebView, WebViewBuilder, WebViewDelegate, WindowRenderingContext,
 };
 use url::Url;
 
@@ -783,6 +783,15 @@ impl RunningAppState {
                                 "Could not find WebView ({webview_id:?}) for WebDriver event: {input_event:?}"
                             );
                         };
+                    },
+                    WebDriverCommandMsg::TakeScreenshot(webview_id, rect, result_sender) => {
+                        if let Some(webview) = self.webview_by_id(webview_id) {
+                            self.handle_webdriver_screenshot(webview, rect, result_sender);
+                        } else if let Err(error) =
+                            result_sender.send(Err(ScreenshotCaptureError::WebViewDoesNotExist))
+                        {
+                            error!("Failed to send response to TakeScreenshot: {error}");
+                        }
                     },
                     _ => {
                         info!("Received unsupported WebDriver command: {:?}", msg);

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -10,7 +10,7 @@ use dpi::PhysicalSize;
 use euclid::{Point2D, Rect, Scale, Size2D};
 use image::{DynamicImage, ImageFormat};
 use keyboard_types::{CompositionEvent, CompositionState, Key, KeyState, NamedKey};
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use raw_window_handle::{RawWindowHandle, WindowHandle};
 use servo::base::generic_channel::GenericSender;
 use servo::base::id::WebViewId;


### PR DESCRIPTION
Move the screenshot handler to `RunningAppStateBase` to be shared between egl and desktop. This enables screenshot/element screenshot capability for egl.

Testing: Existing test. For egl, tested on Ohos.
Fixes: Part of #40279 
