### PR TITLE
script/layout: Implement Element.currentCSSZoom attribute

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -92,9 +92,9 @@ use crate::display_list::{
 };
 use crate::query::{
     get_the_text_steps, process_box_area_request, process_box_areas_request,
-    process_client_rect_request, process_node_scroll_area_request, process_offset_parent_query,
-    process_padding_request, process_resolved_font_style_query, process_resolved_style_request,
-    process_scroll_container_query, process_text_index_request,
+    process_client_rect_request, process_current_css_zoom_query, process_node_scroll_area_request,
+    process_offset_parent_query, process_padding_request, process_resolved_font_style_query,
+    process_resolved_style_request, process_scroll_container_query, process_text_index_request,
 };
 use crate::traversal::{RecalcStyle, compute_damage_and_repair_style};
 use crate::{BoxTree, FragmentTree};
@@ -332,6 +332,12 @@ impl Layout for LayoutThread {
     fn query_client_rect(&self, node: TrustedNodeAddress) -> UntypedRect<i32> {
         let node = unsafe { ServoLayoutNode::new(&node) };
         process_client_rect_request(node.to_threadsafe())
+    }
+
+    #[servo_tracing::instrument(skip_all)]
+    fn query_current_css_zoom(&self, node: TrustedNodeAddress) -> f32 {
+        let node = unsafe { ServoLayoutNode::new(&node) };
+        process_current_css_zoom_query(node)
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -1674,6 +1680,7 @@ impl ReflowPhases {
                 QueryMsg::ResolvedStyleQuery |
                 QueryMsg::ScrollingAreaOrOffsetQuery => Self::StackingContextTreeConstruction,
                 QueryMsg::ClientRectQuery |
+                QueryMsg::CurrentCSSZoomQuery |
                 QueryMsg::ElementInnerOuterTextQuery |
                 QueryMsg::InnerWindowDimensionsQuery |
                 QueryMsg::PaddingQuery |

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -155,6 +155,25 @@ pub fn process_client_rect_request(node: ServoThreadSafeLayoutNode<'_>) -> Rect<
         .unwrap_or_default()
 }
 
+/// Process a query for the current CSS zoom of an element.
+/// <https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom>
+///
+/// Returns the effective zoom of the element, which is the product of all zoom
+/// values from the element up to the root. Returns 1.0 if the element is not
+/// being rendered (has no associated box).
+pub fn process_current_css_zoom_query(node: ServoLayoutNode<'_>) -> f32 {
+    let Some(layout_data) = node.to_threadsafe().inner_layout_data() else {
+        return 1.0;
+    };
+    let layout_box = layout_data.self_box.borrow();
+    let Some(layout_box) = layout_box.as_ref() else {
+        return 1.0;
+    };
+    layout_box
+        .with_first_base(|base| base.style.effective_zoom.value())
+        .unwrap_or(1.0)
+}
+
 /// <https://drafts.csswg.org/cssom-view/#scrolling-area>
 pub fn process_node_scroll_area_request(
     requested_node: Option<ServoThreadSafeLayoutNode<'_>>,

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -93,6 +93,7 @@ use crate::dom::bindings::domname::{
 };
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::{Castable, ElementTypeId, HTMLElementTypeId, NodeTypeId};
+use crate::dom::bindings::num::Finite;
 use crate::dom::bindings::refcounted::{Trusted, TrustedPromise};
 use crate::dom::bindings::reflector::DomObject;
 use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom, ToLayout};
@@ -3473,6 +3474,12 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     /// <https://drafts.csswg.org/cssom-view/#dom-element-clientheight>
     fn ClientHeight(&self) -> i32 {
         self.client_rect().size.height
+    }
+
+    // https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom
+    fn CurrentCSSZoom(&self) -> Finite<f64> {
+        let window = self.owner_window();
+        Finite::wrap(window.current_css_zoom_query(self.upcast::<Node>()) as f64)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-element-sethtmlunsafe>

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2690,6 +2690,13 @@ impl Window {
             .query_client_rect(node.to_trusted_node_address())
     }
 
+    pub(crate) fn current_css_zoom_query(&self, node: &Node) -> f32 {
+        self.layout_reflow(QueryMsg::CurrentCSSZoomQuery);
+        self.layout
+            .borrow()
+            .query_current_css_zoom(node.to_trusted_node_address())
+    }
+
     /// Find the scroll area of the given node, if it is not None. If the node
     /// is None, find the scroll area of the viewport.
     pub(crate) fn scrolling_area_query(&self, node: Option<&Node>) -> UntypedRect<i32> {

--- a/components/script_bindings/webidls/Element.webidl
+++ b/components/script_bindings/webidls/Element.webidl
@@ -119,6 +119,8 @@ partial interface Element {
   readonly attribute long clientLeft;
   readonly attribute long clientWidth;
   readonly attribute long clientHeight;
+
+  readonly attribute double currentCSSZoom;
 };
 
 // https://html.spec.whatwg.org/multipage/#dom-parsing-and-serialization

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -307,6 +307,7 @@ pub trait Layout {
     ) -> Option<Rect<Au>>;
     fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> Vec<Rect<Au>>;
     fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32>;
+    fn query_current_css_zoom(&self, node: TrustedNodeAddress) -> f32;
     fn query_element_inner_outer_text(&self, node: TrustedNodeAddress) -> String;
     fn query_offset_parent(&self, node: TrustedNodeAddress) -> OffsetParentResponse;
     /// Query the scroll container for the given node. If node is `None`, the scroll container for
@@ -434,6 +435,7 @@ pub enum QueryMsg {
     BoxArea,
     BoxAreas,
     ClientRectQuery,
+    CurrentCSSZoomQuery,
     ElementInnerOuterTextQuery,
     ElementsFromPoint,
     InnerWindowDimensionsQuery,

--- a/tests/wpt/meta/css/css-fonts/generic-family-keywords-003.html.ini
+++ b/tests/wpt/meta/css/css-fonts/generic-family-keywords-003.html.ini
@@ -5,9 +5,6 @@
   [@font-face matching for quoted and unquoted ui-serif (drawing text in a canvas)]
     expected: FAIL
 
-  [@font-face matching for quoted and unquoted ui-sans-serif (drawing text in a canvas)]
-    expected: FAIL
-
   [@font-face matching for quoted and unquoted ui-monospace (drawing text in a canvas)]
     expected: FAIL
 
@@ -26,13 +23,7 @@
   [@font-face matching for quoted and unquoted monospace (drawing text in a canvas)]
     expected: FAIL
 
-  [@font-face matching for quoted and unquoted system-ui (drawing text in a canvas)]
-    expected: FAIL
-
   [@font-face matching for quoted and unquoted generic(fangsong) (drawing text in a canvas)]
-    expected: FAIL
-
-  [@font-face matching for quoted and unquoted generic(kai) (drawing text in a canvas)]
     expected: FAIL
 
   [@font-face matching for quoted and unquoted generic(khmer-mul) (drawing text in a canvas)]

--- a/tests/wpt/meta/css/cssom-view/idlharness.html.ini
+++ b/tests/wpt/meta/css/cssom-view/idlharness.html.ini
@@ -545,18 +545,6 @@
   [VisualViewport interface: self.visualViewport must inherit property "onscrollend" with the proper type]
     expected: FAIL
 
-  [Element interface: document.createElement("div") must inherit property "currentCSSZoom" with the proper type]
-    expected: FAIL
-
-  [Element interface: document.createElement("img") must inherit property "currentCSSZoom" with the proper type]
-    expected: FAIL
-
-  [Element interface: attribute currentCSSZoom]
-    expected: FAIL
-
-  [Element interface: document.createElementNS("x", "y") must inherit property "currentCSSZoom" with the proper type]
-    expected: FAIL
-
   [Document interface: operation caretPositionFromPoint(double, double, ShadowRoot...)]
     expected: FAIL
 

--- a/tests/wpt/meta/resize-observer/zoom.html.ini
+++ b/tests/wpt/meta/resize-observer/zoom.html.ini
@@ -1,3 +1,0 @@
-[zoom.html]
-  [ResizeObserver sizes account for zoom]
-    expected: FAIL


### PR DESCRIPTION
Implements the `currentCSSZoom` readonly attribute on the Element interface as [spec](https://drafts.csswg.org/cssom-view/#dom-element-currentcsszoom).
- Adds a new layout query (`CurrentCSSZoomQuery`) that traverses from the target element up through its ancestors
- Accumulates the product of all `zoom` CSS property values to compute the effective zoom
- Returns 1.0 for elements that are not being rendered (display: none or no layout data)

Testing: Updated WPT (removed 4 FAIL expectations from `idlharness.html.ini`). Behavior tests in Element-currentCSSZoom.html remain as expected FAIL because the underlying CSS `zoom` property implementation in Servo does not yet apply zoom values to layout (the zoom property is parsed but computed values remain 1.0).
Fixes: #40256