### PR TITLE
servoshell: Add a `VsyncRefreshDriver` for Android

### DIFF
--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -275,6 +275,14 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_scroll<'local>(
     });
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn Java_org_servo_servoview_JNIServo_doFrame<'local>(
+    mut env: JNIEnv<'local>,
+    _: JClass<'local>,
+) {
+    call(&mut env, |s| s.notify_vsync());
+}
+
 enum KeyCode {
     Delete,
     ForwardDelete,

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -15,7 +15,9 @@ pub use servo::{MediaSessionPlaybackState, WindowRenderingContext};
 use crate::egl::android::resources::ResourceReaderInstance;
 #[cfg(feature = "webxr")]
 use crate::egl::app_state::XrDiscoveryWebXrRegistry;
-use crate::egl::app_state::{Coordinates, RunningAppState, ServoWindowCallbacks};
+use crate::egl::app_state::{
+    Coordinates, RunningAppState, ServoWindowCallbacks, VsyncRefreshDriver,
+};
 use crate::egl::host_trait::HostTrait;
 use crate::prefs::{ArgumentParsingResult, parse_command_line_arguments};
 
@@ -87,10 +89,12 @@ pub fn init(
         RefCell::new(init_opts.coordinates),
     ));
 
+    let refresh_driver = Rc::new(VsyncRefreshDriver::default());
     let servo_builder = ServoBuilder::new(rendering_context.clone())
         .opts(opts)
         .preferences(preferences)
-        .event_loop_waker(waker.clone());
+        .event_loop_waker(waker.clone())
+        .refresh_driver(refresh_driver.clone());
 
     #[cfg(feature = "webxr")]
     let servo_builder = servo_builder.webxr_registry(Box::new(XrDiscoveryWebXrRegistry::new(
@@ -114,7 +118,7 @@ pub fn init(
             rendering_context,
             servo,
             window_callbacks,
-            None,
+            Some(refresh_driver),
             servoshell_preferences,
             webdriver_receiver,
         );

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
@@ -69,6 +69,8 @@ public class JNIServo {
 
     public native void setExperimentalMode(boolean enable);
 
+    public native void doFrame();
+
     public static class ServoOptions {
       public String args;
       public String url;

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
@@ -171,6 +171,10 @@ public class Servo {
         mRunCallback.inGLThread(() -> mJNI.setExperimentalMode(enable));
     }
 
+    public void onDoFrame() {
+        mRunCallback.inGLThread(() -> mJNI.doFrame());
+    }
+
     public interface Client {
         void onAlert(String message);
 

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -36,7 +36,8 @@ import java.util.ArrayList;
 public class ServoView extends SurfaceView
                         implements
                         GfxCallbacks,
-                        RunCallback {
+                        RunCallback,
+                        Choreographer.FrameCallback {
     private static final String LOGTAG = "ServoView";
     private GLThread mGLThread;
     private Handler mGLLooperHandler;
@@ -157,6 +158,14 @@ public class ServoView extends SurfaceView
         return true;
     }
 
+    @Override
+    public void doFrame(long frameTimeNanos) {
+        if (mServo != null) {
+            mServo.onDoFrame();
+        }
+        Choreographer.getInstance().postFrameCallback(this);
+    }
+
     // Calls from Activity
     public void onPause() {
         if (mServo != null) {
@@ -238,6 +247,8 @@ public class ServoView extends SurfaceView
                 mPaused = false;
                 mServoView.mServo.resumeCompositor(surface, coords);
             }
+
+            Choreographer.getInstance().postFrameCallback(mServoView);
 
         }
 


### PR DESCRIPTION
This adds an implementation of `VsyncRefreshDriver` ensuring that frame
updates are driven by the system compositor.

Testing: This should increase the smoothness of animations, but I'm
not sure how to test that exactly.
