### PR TITLE
compositor: Rename `RenderingGroupId` to `PainterId`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use base::generic_channel::RoutedReceiver;
-use base::id::WebViewId;
+use base::id::{PainterId, WebViewId};
 use bitflags::bitflags;
 use canvas_traits::webgl::WebGLThreads;
 use compositing_traits::{CompositorMsg, WebRenderExternalImageRegistry, WebViewTrait};
@@ -130,6 +130,10 @@ impl IOCompositor {
 
     pub(crate) fn painter_mut<'a>(&'a self) -> RefMut<'a, Painter> {
         self.painters[0].borrow_mut()
+    }
+
+    pub fn painter_id(&self) -> PainterId {
+        self.painters[0].borrow().painter_id
     }
 
     pub fn deinit(&mut self) {
@@ -330,7 +334,7 @@ impl IOCompositor {
                 number_of_font_keys,
                 number_of_font_instance_keys,
                 result_sender,
-                _rendering_group_id,
+                _painter_id,
             ) => {
                 let _ = result_sender.send(
                     self.painter_mut()
@@ -411,7 +415,7 @@ impl IOCompositor {
                 number_of_font_keys,
                 number_of_font_instance_keys,
                 result_sender,
-                _rendering_group_id,
+                _painter_id,
             ) => {
                 let _ = result_sender.send(
                     self.painter_mut()

--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 
 use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
-use base::id::{PipelineId, WebViewId};
+use base::id::{PainterId, PipelineId, WebViewId};
 use canvas_traits::webgl::{GlType, WebGLThreads};
 use compositing_traits::display_list::{CompositorDisplayListInfo, ScrollType};
 use compositing_traits::rendering_context::RenderingContext;
@@ -78,6 +78,9 @@ use crate::webview_renderer::{PinchZoomResult, ScrollResult, UnknownWebView, Web
 pub(crate) struct Painter {
     /// The [`RenderingContext`] instance that webrender targets, which is the viewport.
     pub(crate) rendering_context: Rc<dyn RenderingContext>,
+
+    /// The ID of this painter.
+    pub(crate) painter_id: PainterId,
 
     /// Our [`WebViewRenderer`]s, one for every `WebView`.
     pub(crate) webview_renderers: WebViewManager<WebViewRenderer>,
@@ -284,6 +287,7 @@ impl Painter {
         info!("Running on {gl_renderer} with OpenGL version {gl_version}");
 
         let painter = Painter {
+            painter_id: PainterId::next(),
             embedder_to_constellation_sender,
             webview_renderers: Default::default(),
             rendering_context,

--- a/components/compositing/webview_manager.rs
+++ b/components/compositing/webview_manager.rs
@@ -122,7 +122,10 @@ impl WebViewManager<WebViewRenderer> {
 
 #[cfg(test)]
 mod test {
-    use base::id::{BrowsingContextId, Index, PipelineNamespace, PipelineNamespaceId, WebViewId};
+    use base::id::{
+        BrowsingContextId, Index, PipelineNamespace, PipelineNamespaceId, TEST_PAINTER_ID,
+        WebViewId,
+    };
 
     use crate::webview_manager::WebViewManager;
     use crate::webview_renderer::UnknownWebView;
@@ -150,9 +153,10 @@ mod test {
         let mut webviews = WebViewManager::default();
 
         // entry() adds the webview to the map, but not the painting order.
-        webviews.entry(WebViewId::new()).or_insert('a');
-        webviews.entry(WebViewId::new()).or_insert('b');
-        webviews.entry(WebViewId::new()).or_insert('c');
+        let painter_id = TEST_PAINTER_ID;
+        webviews.entry(WebViewId::new(painter_id)).or_insert('a');
+        webviews.entry(WebViewId::new(painter_id)).or_insert('b');
+        webviews.entry(WebViewId::new(painter_id)).or_insert('c');
         assert!(webviews.get(webview_id(0, 1)).is_some());
         assert!(webviews.get(webview_id(0, 2)).is_some());
         assert!(webviews.get(webview_id(0, 3)).is_some());

--- a/components/constellation/webview_manager.rs
+++ b/components/constellation/webview_manager.rs
@@ -83,7 +83,10 @@ impl<WebView> WebViewManager<WebView> {
 
 #[cfg(test)]
 mod test {
-    use base::id::{BrowsingContextId, Index, PipelineNamespace, PipelineNamespaceId, WebViewId};
+    use base::id::{
+        BrowsingContextId, Index, PipelineNamespace, PipelineNamespaceId, TEST_PAINTER_ID,
+        WebViewId,
+    };
 
     use crate::webview_manager::WebViewManager;
 
@@ -119,9 +122,9 @@ mod test {
         let mut webviews = WebViewManager::default();
 
         // add() adds the webview to the map, but does not focus it.
-        webviews.add(WebViewId::new(), 'a');
-        webviews.add(WebViewId::new(), 'b');
-        webviews.add(WebViewId::new(), 'c');
+        webviews.add(WebViewId::new(TEST_PAINTER_ID), 'a');
+        webviews.add(WebViewId::new(TEST_PAINTER_ID), 'b');
+        webviews.add(WebViewId::new(TEST_PAINTER_ID), 'c');
         assert_eq!(
             webviews_sorted(&webviews),
             vec![(id(0, 1), 'a'), (id(0, 2), 'b'), (id(0, 3), 'c'),]

--- a/components/devtools/id.rs
+++ b/components/devtools/id.rs
@@ -158,7 +158,7 @@ pub(crate) fn test_id_map() {
 
     test_sequential_id_assignment!(
         DevtoolsBrowserId,
-        || WebViewId::new(),
+        || WebViewId::new(base::id::TEST_PAINTER_ID),
         |id_map: &mut IdMap, id| id_map.browser_id(id)
     );
     test_sequential_id_assignment!(

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 use std::{iter, str};
 
 use app_units::Au;
-use base::id::RenderingGroupId;
+use base::id::PainterId;
 use bitflags::bitflags;
 use euclid::default::{Point2D, Rect};
 use euclid::num::Zero;
@@ -232,7 +232,7 @@ pub struct Font {
 
     shaper: OnceLock<Shaper>,
     cached_shape_data: RwLock<CachedShapeData>,
-    font_instance_key: RwLock<FxHashMap<RenderingGroupId, FontInstanceKey>>,
+    font_instance_key: RwLock<FxHashMap<PainterId, FontInstanceKey>>,
 
     /// If this is a synthesized small caps font, then this font reference is for
     /// the version of the font used to replace lowercase ASCII letters. It's up
@@ -326,16 +326,12 @@ impl Font {
         })
     }
 
-    pub fn key(
-        &self,
-        rendering_group_id: RenderingGroupId,
-        font_context: &FontContext,
-    ) -> FontInstanceKey {
+    pub fn key(&self, painter_id: PainterId, font_context: &FontContext) -> FontInstanceKey {
         *self
             .font_instance_key
             .write()
-            .entry(rendering_group_id)
-            .or_insert_with(|| font_context.create_font_instance_key(self, rendering_group_id))
+            .entry(painter_id)
+            .or_insert_with(|| font_context.create_font_instance_key(self, painter_id))
     }
 
     /// Return the data for this `Font`. Note that this is currently highly inefficient for system

--- a/components/layout/construct_modern.rs
+++ b/components/layout/construct_modern.rs
@@ -63,7 +63,6 @@ impl<'dom> ModernContainerJob<'dom> {
                     true,  /* has_first_formatted_line */
                     false, /* is_single_line_text_box */
                     builder.info.style.to_bidi_level(),
-                    builder.context.rendering_group_id,
                 )?;
 
                 let block_formatting_context = BlockFormattingContext::from_block_container(

--- a/components/layout/context.rs
+++ b/components/layout/context.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use base::id::RenderingGroupId;
+use base::id::PainterId;
 use embedder_traits::UntrustedNodeAddress;
 use euclid::Size2D;
 use fonts::FontContext;
@@ -45,7 +45,8 @@ pub(crate) struct LayoutContext<'a> {
     /// tree construction. Later passed to display list construction.
     pub image_resolver: Arc<ImageResolver>,
 
-    pub rendering_group_id: RenderingGroupId,
+    /// The [`PainterId`] that identifies which `RenderingContext` that this layout targets.
+    pub painter_id: PainterId,
 }
 
 pub enum ResolvedImage<'a> {

--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -230,7 +230,6 @@ impl<'dom, 'style> BlockContainerBuilder<'dom, 'style> {
             !self.have_already_seen_first_line_for_text_indent,
             self.info.node.is_single_line_text_input(),
             self.info.style.to_bidi_level(),
-            self.context.rendering_group_id,
         )
     }
 

--- a/components/layout/flow/inline/construct.rs
+++ b/components/layout/flow/inline/construct.rs
@@ -5,7 +5,6 @@
 use std::borrow::Cow;
 use std::char::{ToLowercase, ToUppercase};
 
-use base::id::RenderingGroupId;
 use icu_segmenter::WordSegmenter;
 use itertools::izip;
 use style::computed_values::white_space_collapse::T as WhiteSpaceCollapse;
@@ -471,7 +470,6 @@ impl InlineFormattingContextBuilder {
             has_first_formatted_line,
             /* is_single_line_text_input = */ false,
             default_bidi_level,
-            layout_context.rendering_group_id,
         )
     }
 
@@ -482,7 +480,6 @@ impl InlineFormattingContextBuilder {
         has_first_formatted_line: bool,
         is_single_line_text_input: bool,
         default_bidi_level: Level,
-        rendering_group_id: RenderingGroupId,
     ) -> Option<InlineFormattingContext> {
         if self.is_empty {
             return None;
@@ -496,7 +493,6 @@ impl InlineFormattingContextBuilder {
             has_first_formatted_line,
             is_single_line_text_input,
             default_bidi_level,
-            rendering_group_id,
         ))
     }
 }

--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -79,7 +79,6 @@ use std::mem;
 use std::rc::Rc;
 
 use app_units::{Au, MAX_AU};
-use base::id::RenderingGroupId;
 use bitflags::bitflags;
 use construct::InlineFormattingContextBuilder;
 use fonts::{ByteIndex, FontMetrics, GlyphStore};
@@ -1653,7 +1652,6 @@ impl InlineFormattingContext {
         has_first_formatted_line: bool,
         is_single_line_text_input: bool,
         starting_bidi_level: Level,
-        rendering_group_id: RenderingGroupId,
     ) -> Self {
         // This is to prevent a double borrow.
         let text_content: String = builder.text_segments.into_iter().collect();
@@ -1668,11 +1666,10 @@ impl InlineFormattingContext {
                 InlineItem::TextRun(text_run) => {
                     text_run.borrow_mut().segment_and_shape(
                         &text_content,
-                        &layout_context.font_context,
+                        layout_context,
                         &mut new_linebreaker,
                         &mut font_metrics,
                         &bidi_info,
-                        rendering_group_id,
                     );
                 },
                 InlineItem::StartInlineBox(inline_box) => {
@@ -1681,12 +1678,8 @@ impl InlineFormattingContext {
                         &inline_box.base.style,
                         &layout_context.font_context,
                     ) {
-                        inline_box.default_font_index = Some(add_or_get_font(
-                            &font,
-                            &mut font_metrics,
-                            &layout_context.font_context,
-                            rendering_group_id,
-                        ));
+                        inline_box.default_font_index =
+                            Some(add_or_get_font(layout_context, &font, &mut font_metrics));
                     }
                 },
                 InlineItem::Atomic(_, index_in_text, bidi_level) => {

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -987,7 +987,7 @@ impl LayoutThread {
             iframe_sizes: Mutex::default(),
             use_rayon: rayon_pool.is_some(),
             image_resolver: image_resolver.clone(),
-            rendering_group_id: self.webview_id.into(),
+            painter_id: self.webview_id.into(),
         };
 
         let restyle = reflow_request

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -7,7 +7,7 @@
 use std::fmt::{Debug, Error, Formatter};
 
 use base::Epoch;
-use base::id::{PipelineId, RenderingGroupId, WebViewId};
+use base::id::{PainterId, PipelineId, WebViewId};
 use crossbeam_channel::Sender;
 use embedder_traits::{AnimationState, EventLoopWaker};
 use log::warn;
@@ -152,7 +152,7 @@ pub enum CompositorMsg {
         usize,
         usize,
         GenericSender<(Vec<FontKey>, Vec<FontInstanceKey>)>,
-        RenderingGroupId,
+        PainterId,
     ),
     /// Add a font with the given data and font key.
     AddFont(FontKey, Arc<IpcSharedMemory>, u32),
@@ -417,14 +417,14 @@ impl CrossProcessCompositorApi {
         &self,
         number_of_font_keys: usize,
         number_of_font_instance_keys: usize,
-        rendering_group_id: RenderingGroupId,
+        painter_id: PainterId,
     ) -> (Vec<FontKey>, Vec<FontInstanceKey>) {
         let (sender, receiver) = generic_channel::channel().expect("Could not create IPC channel");
         let _ = self.0.send(CompositorMsg::GenerateFontKeys(
             number_of_font_keys,
             number_of_font_instance_keys,
             sender,
-            rendering_group_id,
+            painter_id,
         ));
         receiver.recv().unwrap()
     }
@@ -660,7 +660,6 @@ impl From<SerializableImageData> for ImageData {
 /// layer.
 pub trait WebViewTrait {
     fn id(&self) -> WebViewId;
-    fn rendering_group_id(&self) -> Option<RenderingGroupId>;
     fn screen_geometry(&self) -> Option<ScreenGeometry>;
     fn set_animating(&self, new_value: bool);
 }


### PR DESCRIPTION
And let the Compositor create the `PainterId` when it creates a new `Painter`. Also make inline formatting code take `LayoutContext` rather than threading it via the `InlineFormattingContextBuilder`.


Testing: Should preserve existing behavior, so covered by existing tests.
