### PR TITLE
script: fix defaults on formMethod getters on <input> and <button>

### DIFF
--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -139,7 +139,6 @@ impl HTMLButtonElementMethods<crate::DomTypeHolder> for HTMLButtonElement {
         FormMethod,
         "formmethod",
         "get" | "post" | "dialog",
-        missing => "get",
         invalid => "get"
     );
 

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -1897,7 +1897,6 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
         FormEnctype,
         "formenctype",
         "application/x-www-form-urlencoded" | "text/plain" | "multipart/form-data",
-        missing => "",
         invalid => "application/x-www-form-urlencoded"
     );
 
@@ -1909,7 +1908,6 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
         FormMethod,
         "formmethod",
         "get" | "post" | "dialog",
-        missing => "get",
         invalid => "get"
     );
 

--- a/tests/wpt/meta/html/dom/reflection-forms-weekmonth.html.ini
+++ b/tests/wpt/meta/html/dom/reflection-forms-weekmonth.html.ini
@@ -248,9 +248,6 @@
   [input.autocomplete: IDL set to object "test-valueOf"]
     expected: FAIL
 
-  [input.formMethod: IDL get with DOM attribute unset]
-    expected: FAIL
-
   [input.height: typeof IDL attribute]
     expected: FAIL
 

--- a/tests/wpt/meta/html/dom/reflection-forms.html.ini
+++ b/tests/wpt/meta/html/dom/reflection-forms.html.ini
@@ -1130,9 +1130,6 @@
   [input.autocomplete: IDL set to object "test-valueOf"]
     expected: FAIL
 
-  [input.formMethod: IDL get with DOM attribute unset]
-    expected: FAIL
-
   [input.height: typeof IDL attribute]
     expected: FAIL
 
@@ -1599,9 +1596,6 @@
     expected: FAIL
 
   [button.tabIndex: IDL set to -2147483648]
-    expected: FAIL
-
-  [button.formMethod: IDL get with DOM attribute unset]
     expected: FAIL
 
   [select.accessKey: typeof IDL attribute]


### PR DESCRIPTION
Fixes the getters for `formMethod` on `<input>` and `<button>` elements providing a missing value default when they shouldn't.

Testing: 3 new passing tests in `html/dom/reflection-forms.html` and `/html/dom/reflection-forms-weekmonth.html`.
Fixes: #8302. (`formEnctype` seems to have already been fixed since that issue was filed.)
