### PR TITLE
servoshell: Move `servo` to `RunningAppStateBase`

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -55,6 +55,7 @@ use crate::desktop::accelerated_gl_media::setup_gl_accelerated_media;
 use crate::desktop::keyutils::CMD_OR_CONTROL;
 use crate::desktop::window_trait::MIN_WINDOW_INNER_SIZE;
 use crate::prefs::ServoShellPreferences;
+use crate::running_app_state::RunningAppStateTrait;
 
 pub(crate) const INITIAL_WINDOW_TITLE: &str = "Servo";
 

--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -33,6 +33,7 @@ use super::headed_window::Window as ServoWindow;
 use crate::desktop::headed_window::INITIAL_WINDOW_TITLE;
 use crate::desktop::window_trait::WindowPortsMethods;
 use crate::prefs::{EXPERIMENTAL_PREFS, ServoShellPreferences};
+use crate::running_app_state::RunningAppStateTrait;
 
 pub struct Minibrowser {
     rendering_context: Rc<OffscreenRenderingContext>,

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -29,6 +29,7 @@ use simpleservo::{APP, InitOptions, MediaSessionPlaybackState};
 use super::app_state::{Coordinates, RunningAppState};
 use super::host_trait::HostTrait;
 use crate::prefs::EXPERIMENTAL_PREFS;
+use crate::running_app_state::RunningAppStateTrait;
 
 struct HostCallbacks {
     callbacks: GlobalRef,

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -16,7 +16,7 @@ use servo::base::id::WebViewId;
 use servo::ipc_channel::ipc::IpcSender;
 use servo::style_traits::CSSPixel;
 use servo::{
-    InputEvent, InputEventId, ScreenshotCaptureError, TraversalId, WebDriverJSResult,
+    InputEvent, InputEventId, ScreenshotCaptureError, Servo, TraversalId, WebDriverJSResult,
     WebDriverLoadStatus, WebDriverSenders, WebView,
 };
 
@@ -32,14 +32,18 @@ pub struct RunningAppStateBase {
 
     /// servoshell specific preferences created during startup of the application.
     pub(crate) servoshell_preferences: ServoShellPreferences,
+
+    /// A handle to the Servo instance.
+    pub(crate) servo: Servo,
 }
 
 impl RunningAppStateBase {
-    pub fn new(servoshell_preferences: ServoShellPreferences) -> Self {
+    pub fn new(servoshell_preferences: ServoShellPreferences, servo: Servo) -> Self {
         Self {
             webdriver_senders: RefCell::default(),
             pending_webdriver_events: Default::default(),
             servoshell_preferences,
+            servo,
         }
     }
 }
@@ -52,6 +56,10 @@ pub trait RunningAppStateTrait {
 
     fn servoshell_preferences(&self) -> &ServoShellPreferences {
         &self.base().servoshell_preferences
+    }
+
+    fn servo(&self) -> &Servo {
+        &self.base().servo
     }
 
     fn set_pending_traversal(


### PR DESCRIPTION
There are several code duplicates in servoshell. In this PR, we extract `servo` from the desktop and EGL implementations into a shared `RunningAppStateBase` trait. This eliminates duplicate code while maintaining the same functionality across all platforms.

This is part of refactoring effort to consolidate shared code between desktop and EGL implementations.

Testing: No functional changes. Existing tests should test this.
