### PR TITLE
ci: Fix unit-test coverage

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -425,11 +425,6 @@ jobs:
         run: sudo apt-get install -y lld
       - name: Run unit-tests with coverage
         shell: bash
-        env:
-          RUSTC_BOOTSTRAP: "1"
-          # lld seems to use less memory and prevents OOM errors during linking.
-          # We can remove this after upgrading to Rust 1.90, where lld will be the default.
-          RUSTFLAGS: "-Z linker-features=+lld"
         run: |
           ./mach test-unit --code-coverage \
               --profile=${{ steps.options.outputs.cargo_profile }} \


### PR DESCRIPTION
`linker-features` stabilized in rust 1.90, so using it with -Z causes ci to fail.
lld is also the default on linux now, so we can just remove the feature.

Testing: [Try run](https://github.com/servo/servo/actions/runs/18976287667)
Fixes: #40313
