### PR TITLE
script: Do not include transforms and inline boxes in ResizeObserver box area queries

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -283,6 +283,7 @@ impl Layout for LayoutThread {
         &self,
         node: TrustedNodeAddress,
         area: BoxAreaType,
+        exclude_transform_and_inline: bool,
     ) -> Option<UntypedRect<Au>> {
         // If we have not built a fragment tree yet, there is no way we have layout information for
         // this query, which can be run without forcing a layout (for IntersectionObserver).
@@ -295,7 +296,12 @@ impl Layout for LayoutThread {
         let stacking_context_tree = stacking_context_tree
             .as_ref()
             .expect("Should always have a StackingContextTree for box area queries");
-        process_box_area_request(stacking_context_tree, node.to_threadsafe(), area)
+        process_box_area_request(
+            stacking_context_tree,
+            node.to_threadsafe(),
+            area,
+            exclude_transform_and_inline,
+        )
     }
 
     /// Get a `Vec` of bounding boxes of this node's `Fragment`s specific area in the coordinate space of

--- a/components/script/dom/intersectionobserver.rs
+++ b/components/script/dom/intersectionobserver.rs
@@ -430,12 +430,14 @@ impl IntersectionObserver {
                     window.box_area_query_without_reflow(
                         &DomRoot::upcast::<Node>(element.clone()),
                         BoxAreaType::Padding,
+                        false,
                     )
                 } else {
                     // > Otherwise, it’s the result of getting the bounding box for the intersection root.
                     window.box_area_query_without_reflow(
                         &DomRoot::upcast::<Node>(element.clone()),
                         BoxAreaType::Border,
+                        false,
                     )
                 }
             },
@@ -515,9 +517,11 @@ impl IntersectionObserver {
 
         // Step 7
         // > Set targetRect to the DOMRectReadOnly obtained by getting the bounding box for target.
-        let maybe_target_rect = document
-            .window()
-            .box_area_query_without_reflow(target.upcast::<Node>(), BoxAreaType::Border);
+        let maybe_target_rect = document.window().box_area_query_without_reflow(
+            target.upcast::<Node>(),
+            BoxAreaType::Border,
+            false,
+        );
 
         // Following the implementation of Gecko, we will skip further processing if these
         // information not available. This would also handle display none element.

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -974,17 +974,17 @@ impl Node {
 
     pub(crate) fn content_box(&self) -> Option<Rect<Au>> {
         self.owner_window()
-            .box_area_query(self, BoxAreaType::Content)
+            .box_area_query(self, BoxAreaType::Content, false)
     }
 
     pub(crate) fn border_box(&self) -> Option<Rect<Au>> {
         self.owner_window()
-            .box_area_query(self, BoxAreaType::Border)
+            .box_area_query(self, BoxAreaType::Border, false)
     }
 
     pub(crate) fn padding_box(&self) -> Option<Rect<Au>> {
         self.owner_window()
-            .box_area_query(self, BoxAreaType::Padding)
+            .box_area_query(self, BoxAreaType::Padding, false)
     }
 
     pub(crate) fn border_boxes(&self) -> Vec<Rect<Au>> {

--- a/components/script/dom/resizeobserver.rs
+++ b/components/script/dom/resizeobserver.rs
@@ -11,6 +11,7 @@ use euclid::default::Rect;
 use euclid::num::Zero;
 use html5ever::ns;
 use js::rust::HandleObject;
+use layout_api::BoxAreaType;
 
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::cell::DomRefCell;
@@ -376,8 +377,8 @@ fn calculate_box_size(target: &Element, observed_box: &ResizeObserverBoxOptions)
             // Note: only taking first fragment,
             // but the spec will expand to cover all fragments.
             let content_box = target
-                .upcast::<Node>()
-                .content_box()
+                .owner_window()
+                .box_area_query(target.upcast(), BoxAreaType::Content, true)
                 .unwrap_or_else(Rect::zero);
 
             Rect::new(
@@ -392,8 +393,8 @@ fn calculate_box_size(target: &Element, observed_box: &ResizeObserverBoxOptions)
             // Note: only taking first fragment,
             // but the spec will expand to cover all fragments.
             let border_box = target
-                .upcast::<Node>()
-                .border_box()
+                .owner_window()
+                .box_area_query(target.upcast(), BoxAreaType::Border, true)
                 .unwrap_or_else(Rect::zero);
 
             Rect::new(
@@ -407,8 +408,8 @@ fn calculate_box_size(target: &Element, observed_box: &ResizeObserverBoxOptions)
         ResizeObserverBoxOptions::Device_pixel_content_box => {
             let device_pixel_ratio = target.owner_window().device_pixel_ratio();
             let content_box = target
-                .upcast::<Node>()
-                .content_box()
+                .owner_window()
+                .box_area_query(target.upcast(), BoxAreaType::Content, true)
                 .unwrap_or_else(Rect::zero);
 
             Rect::new(

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2648,15 +2648,25 @@ impl Window {
         &self,
         node: &Node,
         area: BoxAreaType,
+        exclude_transform_and_inline: bool,
     ) -> Option<UntypedRect<Au>> {
         let layout = self.layout.borrow();
         layout.ensure_stacking_context_tree(self.viewport_details.get());
-        layout.query_box_area(node.to_trusted_node_address(), area)
+        layout.query_box_area(
+            node.to_trusted_node_address(),
+            area,
+            exclude_transform_and_inline,
+        )
     }
 
-    pub(crate) fn box_area_query(&self, node: &Node, area: BoxAreaType) -> Option<UntypedRect<Au>> {
+    pub(crate) fn box_area_query(
+        &self,
+        node: &Node,
+        area: BoxAreaType,
+        exclude_transform_and_inline: bool,
+    ) -> Option<UntypedRect<Au>> {
         self.layout_reflow(QueryMsg::BoxArea);
-        self.box_area_query_without_reflow(node, area)
+        self.box_area_query_without_reflow(node, area, exclude_transform_and_inline)
     }
 
     pub(crate) fn box_areas_query(&self, node: &Node, area: BoxAreaType) -> Vec<UntypedRect<Au>> {

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -299,7 +299,12 @@ pub trait Layout {
     fn set_needs_new_display_list(&self);
 
     fn query_padding(&self, node: TrustedNodeAddress) -> Option<PhysicalSides>;
-    fn query_box_area(&self, node: TrustedNodeAddress, area: BoxAreaType) -> Option<Rect<Au>>;
+    fn query_box_area(
+        &self,
+        node: TrustedNodeAddress,
+        area: BoxAreaType,
+        exclude_transform_and_inline: bool,
+    ) -> Option<Rect<Au>>;
     fn query_box_areas(&self, node: TrustedNodeAddress, area: BoxAreaType) -> Vec<Rect<Au>>;
     fn query_client_rect(&self, node: TrustedNodeAddress) -> Rect<i32>;
     fn query_element_inner_outer_text(&self, node: TrustedNodeAddress) -> String;

--- a/tests/wpt/meta/resize-observer/notify.html.ini
+++ b/tests/wpt/meta/resize-observer/notify.html.ini
@@ -1,7 +1,2 @@
 [notify.html]
   expected: ERROR
-  [test4: transform do not cause notifications]
-    expected: FAIL
-
-  [test6: inline element notifies once with 0x0.]
-    expected: FAIL


### PR DESCRIPTION
These changes implement the restrictions for content rects required by the ResizeObserver specification: inline boxes must return empty rects, and any transforms must be ignored.

Testing: Newly passing tests.
Fixes: #40259
Fixes: #40258