### PR TITLE
Add servo:config page

### DIFF
--- a/components/config/macro/lib.rs
+++ b/components/config/macro/lib.rs
@@ -22,6 +22,12 @@ fn servo_preferences_derive(input: synstructure::Structure) -> TokenStream {
         unimplemented!()
     };
 
+    let mut exists_match_cases = quote!();
+    for field in named_fields.named.iter() {
+        let name = field.ident.as_ref().unwrap();
+        exists_match_cases.extend(quote!(stringify!(#name) => true,))
+    }
+
     let mut get_match_cases = quote!();
     for field in named_fields.named.iter() {
         let name = field.ident.as_ref().unwrap();
@@ -34,15 +40,35 @@ fn servo_preferences_derive(input: synstructure::Structure) -> TokenStream {
         set_match_cases.extend(quote!(stringify!(#name) => self.#name = value.try_into().unwrap(),))
     }
 
+    let mut type_of_match_cases = quote!();
+    for field in named_fields.named.iter() {
+        let name = field.ident.as_ref().unwrap();
+        let ty = &field.ty;
+        type_of_match_cases.extend(quote!(stringify!(#name) => std::any::type_name::<#ty>(),))
+    }
+
     let mut comparisons = quote!();
     for field in named_fields.named.iter() {
         let name = field.ident.as_ref().unwrap();
         comparisons.extend(quote!(if self.#name != other.#name { changes.push((stringify!(#name), self.#name.clone().into(),)) }))
     }
 
+    let mut all_fields = quote!();
+    for field in named_fields.named.iter() {
+        let name = field.ident.as_ref().unwrap();
+        all_fields.extend(quote!(stringify!(#name),));
+    }
+
     let structure_name = &ast.ident;
     quote! {
         impl #structure_name {
+            pub fn exists(name: &str) -> bool {
+                match name {
+                    #exists_match_cases
+                    _ => { false }
+                }
+            }
+
             pub fn get_value(&self, name: &str) -> PrefValue {
                 match name {
                     #get_match_cases
@@ -57,10 +83,23 @@ fn servo_preferences_derive(input: synstructure::Structure) -> TokenStream {
                 }
             }
 
+            pub fn type_of(name: &str) -> &'static str {
+                match name {
+                    #type_of_match_cases
+                    _ => { panic!("Unknown preference: {:?}", name); }
+                }
+            }
+
             pub fn diff(&self, other: &Self) -> Vec<(&'static str, PrefValue)> {
                 let mut changes = vec![];
                 #comparisons
                 changes
+            }
+
+            pub fn all_fields() -> Vec<&'static str> {
+                vec![
+                    #all_fields
+                ]
             }
         }
     }

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -3,18 +3,21 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::rc::Rc;
-
+use js::gc::MutableHandleValue;
+use js::jsval::UndefinedValue;
 use constellation_traits::ScriptToConstellationMessage;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use profile_traits::mem::MemoryReportResult;
+use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::error::{Error, Fallible};
 use script_bindings::interfaces::ServoInternalsHelpers;
 use script_bindings::script_runtime::JSContext;
 use script_bindings::str::USVString;
-use servo_config::prefs::{self, PrefValue};
+use servo_config::prefs::{self, PrefValue, Preferences};
 
 use crate::dom::bindings::codegen::Bindings::ServoInternalsBinding::ServoInternalsMethods;
+use crate::dom::bindings::import::base::SafeJSContext;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
@@ -23,6 +26,24 @@ use crate::realms::{AlreadyInRealm, InRealm};
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
+
+fn pref_to_jsval(pref: &PrefValue, cx: JSContext, rval: MutableHandleValue, can_gc: CanGc) {
+    match pref {
+        PrefValue::Bool(b) => b.safe_to_jsval(cx, rval, can_gc),
+        PrefValue::Int(i) => i.safe_to_jsval(cx, rval, can_gc),
+        PrefValue::Str(s) => s.safe_to_jsval(cx, rval, can_gc),
+        PrefValue::Float(f) => f.safe_to_jsval(cx, rval, can_gc),
+        PrefValue::Array(arr) => {
+            rooted_vec!(let mut js_arr);
+            for item in arr {
+                rooted!(in(*cx) let mut js_val = UndefinedValue());
+                pref_to_jsval(item, cx, js_val.handle_mut(), can_gc);
+                js_arr.push(js_val.get());
+            }
+            js_arr.safe_to_jsval(cx , rval, can_gc);
+        }
+    }
+}
 
 #[dom_struct]
 pub(crate) struct ServoInternals {
@@ -60,7 +81,47 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
     }
 
     /// <https://servo.org/internal-no-spec>
+    fn PreferenceList(&self) -> Vec<USVString> {
+        Preferences::all_fields()
+            .into_iter()
+            .map(|s| USVString::from(s.to_string()))
+            .collect()
+    }
+
+    /// <https://servo.org/internal-no-spec>
+    fn PreferenceType(&self, name: USVString) -> Fallible<USVString> {
+        if !Preferences::exists(&name) {
+            return Err(Error::NotFound(None));
+        }
+        let type_name = Preferences::type_of(&name);
+        Ok(USVString::from(type_name.to_string()))
+    }
+
+    /// <https://servo.org/internal-no-spec>
+    fn DefaultValue(&self, cx: SafeJSContext, name: USVString, rval: MutableHandleValue) -> Fallible<()> {
+        if !Preferences::exists(&name) {
+            return Err(Error::NotFound(None));
+        }
+        let pref = Preferences::default().get_value(&name);
+        pref_to_jsval(&pref, cx, rval, CanGc::note());
+        Ok(())
+    }
+
+    fn GetPreference(&self, cx: JSContext, name: USVString, rval: MutableHandleValue) -> Fallible<()> {
+        if !Preferences::exists(&name) {
+            return Err(Error::NotFound(None));
+        }
+        let pref = prefs::get().get_value(&name);
+        pref_to_jsval(&pref, cx, rval, CanGc::note());
+        Ok(())
+    }
+
+
+    /// <https://servo.org/internal-no-spec>
     fn GetBoolPreference(&self, name: USVString) -> Fallible<bool> {
+        if !Preferences::exists(&name) {
+            return Err(Error::NotFound(None));
+        }
         if let PrefValue::Bool(b) = prefs::get().get_value(&name) {
             return Ok(b);
         }
@@ -69,6 +130,9 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
 
     /// <https://servo.org/internal-no-spec>
     fn GetIntPreference(&self, name: USVString) -> Fallible<i64> {
+        if !Preferences::exists(&name) {
+            return Err(Error::NotFound(None));
+        }
         if let PrefValue::Int(i) = prefs::get().get_value(&name) {
             return Ok(i);
         }
@@ -77,6 +141,9 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
 
     /// <https://servo.org/internal-no-spec>
     fn GetStringPreference(&self, name: USVString) -> Fallible<USVString> {
+        if !Preferences::exists(&name) {
+            return Err(Error::NotFound(None));
+        }
         if let PrefValue::Str(s) = prefs::get().get_value(&name) {
             return Ok(s.into());
         }

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use constellation_traits::ScriptToConstellationMessage;
 use dom_struct::dom_struct;
 use js::gc::MutableHandleValue;
+use js::jsapi::Heap;
 use js::jsval::UndefinedValue;
 use js::rust::HandleObject;
 use profile_traits::mem::MemoryReportResult;
@@ -39,7 +40,7 @@ fn pref_to_jsval(pref: &PrefValue, cx: JSContext, rval: MutableHandleValue, can_
             for item in arr {
                 rooted!(in(*cx) let mut js_val = UndefinedValue());
                 pref_to_jsval(item, cx, js_val.handle_mut(), can_gc);
-                js_arr.push(js_val.get());
+                js_arr.push(Heap::boxed(js_val.get()));
             }
             js_arr.safe_to_jsval(cx, rval, can_gc);
         },

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -113,6 +113,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
         Ok(())
     }
 
+    /// <https://servo.org/internal-no-spec>
     fn GetPreference(
         &self,
         cx: JSContext,

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -3,10 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::rc::Rc;
-use js::gc::MutableHandleValue;
-use js::jsval::UndefinedValue;
+
 use constellation_traits::ScriptToConstellationMessage;
 use dom_struct::dom_struct;
+use js::gc::MutableHandleValue;
+use js::jsval::UndefinedValue;
 use js::rust::HandleObject;
 use profile_traits::mem::MemoryReportResult;
 use script_bindings::conversions::SafeToJSValConvertible;
@@ -40,8 +41,8 @@ fn pref_to_jsval(pref: &PrefValue, cx: JSContext, rval: MutableHandleValue, can_
                 pref_to_jsval(item, cx, js_val.handle_mut(), can_gc);
                 js_arr.push(js_val.get());
             }
-            js_arr.safe_to_jsval(cx , rval, can_gc);
-        }
+            js_arr.safe_to_jsval(cx, rval, can_gc);
+        },
     }
 }
 
@@ -98,7 +99,12 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
     }
 
     /// <https://servo.org/internal-no-spec>
-    fn DefaultValue(&self, cx: SafeJSContext, name: USVString, rval: MutableHandleValue) -> Fallible<()> {
+    fn DefaultValue(
+        &self,
+        cx: SafeJSContext,
+        name: USVString,
+        rval: MutableHandleValue,
+    ) -> Fallible<()> {
         if !Preferences::exists(&name) {
             return Err(Error::NotFound(None));
         }
@@ -107,7 +113,12 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
         Ok(())
     }
 
-    fn GetPreference(&self, cx: JSContext, name: USVString, rval: MutableHandleValue) -> Fallible<()> {
+    fn GetPreference(
+        &self,
+        cx: JSContext,
+        name: USVString,
+        rval: MutableHandleValue,
+    ) -> Fallible<()> {
         if !Preferences::exists(&name) {
             return Err(Error::NotFound(None));
         }
@@ -115,7 +126,6 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
         pref_to_jsval(&pref, cx, rval, CanGc::note());
         Ok(())
     }
-
 
     /// <https://servo.org/internal-no-spec>
     fn GetBoolPreference(&self, name: USVString) -> Fallible<bool> {

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -100,7 +100,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
     }
 
     /// <https://servo.org/internal-no-spec>
-    fn DefaultValue(
+    fn DefaultPreferenceValue(
         &self,
         cx: SafeJSContext,
         name: USVString,

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -96,7 +96,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
         if !Preferences::exists(&name) {
             return Err(Error::NotFound(None));
         }
-        let type_name = Preferences::type_of(&name);
+        let type_name = Preferences::type_of(&name).split("::").last().unwrap();
         Ok(USVString::from(type_name.to_string()))
     }
 

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -33,6 +33,7 @@ fn pref_to_jsval(pref: &PrefValue, cx: JSContext, rval: MutableHandleValue, can_
     match pref {
         PrefValue::Bool(b) => b.safe_to_jsval(cx, rval, can_gc),
         PrefValue::Int(i) => i.safe_to_jsval(cx, rval, can_gc),
+        PrefValue::UInt(u) => u.safe_to_jsval(cx, rval, can_gc),
         PrefValue::Str(s) => s.safe_to_jsval(cx, rval, can_gc),
         PrefValue::Float(f) => f.safe_to_jsval(cx, rval, can_gc),
         PrefValue::Array(arr) => {

--- a/components/script_bindings/webidls/ServoInternals.webidl
+++ b/components/script_bindings/webidls/ServoInternals.webidl
@@ -12,6 +12,10 @@ Func="ServoInternals::is_servo_internal"]
 interface ServoInternals {
     Promise<object> reportMemory();
 
+    sequence<USVString> preferenceList();
+    [Throws] USVString preferenceType(USVString name);
+    [Throws] any defaultValue(USVString name);
+    [Throws] any getPreference(USVString name);
     [Throws] USVString getStringPreference(USVString name);
     [Throws] long long getIntPreference(USVString name);
     [Throws] boolean getBoolPreference(USVString name);

--- a/components/script_bindings/webidls/ServoInternals.webidl
+++ b/components/script_bindings/webidls/ServoInternals.webidl
@@ -14,7 +14,7 @@ interface ServoInternals {
 
     sequence<USVString> preferenceList();
     [Throws] USVString preferenceType(USVString name);
-    [Throws] any defaultValue(USVString name);
+    [Throws] any defaultPreferenceValue(USVString name);
     [Throws] any getPreference(USVString name);
     [Throws] USVString getStringPreference(USVString name);
     [Throws] long long getIntPreference(USVString name);

--- a/ports/servoshell/desktop/protocols/servo.rs
+++ b/ports/servoshell/desktop/protocols/servo.rs
@@ -6,6 +6,7 @@
 //! Recognized shortcuts:
 //! - servo:default-user-agent
 //! - servo:experimental-preferences
+//! - servo:config
 //! - servo:newtab
 //! - servo:preferences
 
@@ -27,7 +28,7 @@ pub struct ServoProtocolHandler {}
 
 impl ProtocolHandler for ServoProtocolHandler {
     fn privileged_paths(&self) -> &'static [&'static str] {
-        &["preferences"]
+        &["config", "preferences"]
     }
 
     fn is_fetchable(&self) -> bool {
@@ -43,6 +44,12 @@ impl ProtocolHandler for ServoProtocolHandler {
         let url = request.current_url();
 
         match url.path() {
+            "config" => ResourceProtocolHandler::response_for_path(
+                request,
+                done_chan,
+                context,
+                "/config.html",
+            ),
             "newtab" => ResourceProtocolHandler::response_for_path(
                 request,
                 done_chan,

--- a/resources/resource_protocol/config.css
+++ b/resources/resource_protocol/config.css
@@ -1,0 +1,56 @@
+body {
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+input {
+    border-radius: 4px;
+}
+
+.search {
+    height: 24px;
+    width: calc(100% - 6px);
+    margin-top: 12px;
+    margin-bottom: 12px;
+    margin-right: 6px;
+    padding: 4px;
+}
+
+table {
+    border-collapse: collapse;
+}
+
+table, th, td {
+    border: 0;
+}
+
+tr:nth-child(2n) {
+    background-color: #f0f0f0;
+}
+
+.value-editor {
+    margin: 2px;
+    padding: 2px;
+}
+
+.switch-button {
+    margin: 2px;
+    padding: 2px;
+    border-radius: 4px;
+    background: #cfcfcf;
+    border: 0;
+}
+
+.icon {
+    width: 24px;
+    height: 24px;
+}
+
+.hidden {
+    display: none;
+}
+
+.default {
+    font-weight: bold;
+}

--- a/resources/resource_protocol/config.html
+++ b/resources/resource_protocol/config.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Advanced Config</title>
+    <style>
+        body {
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+        }
+
+        input {
+            border-radius: 4px;
+        }
+
+        .search {
+            height: 24px;
+            width: calc(100% - 6px);
+            margin-top: 12px;
+            margin-bottom: 12px;
+            margin-right: 6px;
+            padding: 4px;
+        }
+
+        table {
+            border-collapse: collapse;
+        }
+
+        table, th, td {
+            border: 0;
+        }
+
+        .even {
+            background-color: #f0f0f0;
+        }
+
+        .value-editor {
+            margin: 2px;
+            padding: 2px;
+        }
+
+        .switch-button {
+            margin: 2px;
+            padding: 2px;
+            border-radius: 4px;
+            background: #cfcfcf;
+            border: 0;
+        }
+
+        .icon {
+            width: 24px;
+            height: 24px;
+        }
+
+        .hidden {
+            display: none;
+        }
+
+        .bold {
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <input class="search" type="text" placeholder="Search for a preference ..." oninput="populate(this.value)">
+    <table></table>
+    <template id="boolRow">
+        <tr>
+            <td class="pref-name"></td>
+            <td class="value"></td>
+            <td class="switcher">
+                <button class="switch-button">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
+                    </svg>
+                </button>
+            </td>
+        </tr>
+    </template>
+    <template id="intRow">
+        <tr>
+            <td class="pref-name"></td>
+            <td class="value"><span class="value-entry"></span><input class="value-editor hidden" type="number"></td>
+            <td class="switcher">
+                <button class="switch-button">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
+                    </svg>
+                </button>
+                <button class="switch-button hidden">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                    </svg>
+                </button>
+            </td>
+        </tr>
+    </template>
+    <template id="stringRow">
+        <tr>
+            <td class="pref-name"></td>
+            <td class="value"><span class="value-entry"></span><input class="value-editor hidden" type="text"></td>
+            <td class="switcher">
+                <button class="switch-button">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
+                    </svg>
+                </button>
+                <button class="switch-button hidden">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                    </svg>
+                </button>
+            </td>
+        </tr>
+    </template>
+    <template id="unknownRow">
+        <tr>
+            <td class="pref-name"></td>
+            <td class="value"></td>
+        </tr>
+    </template>
+    <script>
+        let all = navigator.servo.preferenceList();
+        all.sort()
+        const ALL = all;
+
+        function createBoolPref(pref, boolValue, defaultValue, even) {
+            const template = document.querySelector("#boolRow");
+            const clone = template.content.cloneNode(true);
+            clone.querySelector(".pref-name").textContent = pref;
+            clone.querySelector(".value").textContent = boolValue;
+            clone.querySelector(".value").id = "value-" + pref;
+            if (boolValue !== defaultValue) {
+                clone.querySelector(".value").classList.add("bold");
+            }
+            clone.querySelector(".switcher button").onclick = (ev) => {
+                boolValue = !boolValue;
+                if (boolValue === defaultValue) {
+                    document.getElementById("value-" + pref).classList.remove("bold");
+                } else {
+                    document.getElementById("value-" + pref).classList.add("bold");
+                }
+                navigator.servo.setBoolPreference(pref, boolValue);
+                document.getElementById("value-" + pref).textContent = boolValue;
+            };
+            if (even) {
+                clone.querySelector("tr").classList.add("even");
+            }
+            document.querySelector("table").appendChild(clone);
+        }
+
+        function createIntPref(pref, intValue, defaultValue, even) {
+            const template = document.querySelector("#intRow");
+            const clone = template.content.cloneNode(true);
+            clone.querySelector(".pref-name").textContent = pref;
+            clone.querySelector(".value-entry").textContent = intValue;
+            clone.querySelector(".value-entry").id = "value-" + pref;
+            clone.querySelector(".value-editor").id = "input-" + pref;
+            if (intValue !== defaultValue) {
+                clone.querySelector(".value-entry").classList.add("bold");
+            }
+            const editButton = clone.querySelectorAll(".switcher button")[0];
+            const saveButton = clone.querySelectorAll(".switcher button")[1];
+            editButton.onclick = (ev) => {
+                document.getElementById("value-" + pref).classList.add("hidden");
+                const input = document.getElementById("input-" + pref);
+                input.classList.remove("hidden");
+                input.value = intValue;
+                editButton.classList.add("hidden");
+                saveButton.classList.remove("hidden");
+            };
+            saveButton.onclick = (ev) => {
+                const input = document.getElementById("input-" + pref);
+                const newValue = parseInt(input.value);
+                navigator.servo.setIntPreference(pref, newValue);
+                intValue = newValue;
+                document.getElementById("value-" + pref).textContent = intValue;
+                if (intValue === defaultValue) {
+                    document.getElementById("value-" + pref).classList.remove("bold");
+                } else {
+                    document.getElementById("value-" + pref).classList.add("bold");
+                }
+                document.getElementById("value-" + pref).classList.remove("hidden");
+                input.classList.add("hidden");
+                editButton.classList.remove("hidden");
+                saveButton.classList.add("hidden");
+            };
+            if (even) {
+                clone.querySelector("tr").classList.add("even");
+            }
+            document.querySelector("table").appendChild(clone);
+        }
+
+
+        function createStringPref(pref, stringValue, defaultValue, even) {
+            const template = document.querySelector("#stringRow");
+            const clone = template.content.cloneNode(true);
+            clone.querySelector(".pref-name").textContent = pref;
+            clone.querySelector(".value-entry").textContent = stringValue;
+            clone.querySelector(".value-entry").id = "value-" + pref;
+            clone.querySelector(".value-editor").id = "input-" + pref;
+            if (stringValue !== defaultValue) {
+                clone.querySelector(".value-entry").classList.add("bold");
+            }
+            const editButton = clone.querySelectorAll(".switcher button")[0];
+            const saveButton = clone.querySelectorAll(".switcher button")[1];
+            editButton.onclick = (ev) => {
+                document.getElementById("value-" + pref).classList.add("hidden");
+                const input = document.getElementById("input-" + pref);
+                input.classList.remove("hidden");
+                input.value = stringValue;
+                editButton.classList.add("hidden");
+                saveButton.classList.remove("hidden");
+            };
+            saveButton.onclick = (ev) => {
+                const input = document.getElementById("input-" + pref);
+                const newValue = input.value;
+                navigator.servo.setStringPreference(pref, newValue);
+                stringValue = newValue;
+                document.getElementById("value-" + pref).textContent = stringValue;
+                if (stringValue === defaultValue) {
+                    document.getElementById("value-" + pref).classList.remove("bold");
+                } else {
+                    document.getElementById("value-" + pref).classList.add("bold");
+                }
+                document.getElementById("value-" + pref).classList.remove("hidden");
+                input.classList.add("hidden");
+                editButton.classList.remove("hidden");
+                saveButton.classList.add("hidden");
+            };
+            if (even) {
+                clone.querySelector("tr").classList.add("even");
+            }
+            document.querySelector("table").appendChild(clone);
+        }
+
+
+        function populate(filter) {
+            document.querySelector("table").innerHTML = "";
+            let prefs = [];
+            if (filter === "" || filter === null || filter === undefined) {
+                prefs = ALL;
+            } else {
+                // TODO: improve filtering
+                for (let pref of ALL) {
+                    let stripped_pref = pref.replaceAll("_", "");
+                    let stripped_filter = filter.replaceAll("_", "").replaceAll(" ", "").toLowerCase();
+                    if (stripped_pref.includes(stripped_filter)) {
+                        prefs.push(pref);
+                    }
+                }
+            }
+            let counter = 0;
+            for (let pref of prefs) {
+                counter++;
+                let ty = navigator.servo.preferenceType(pref);
+                let value = navigator.servo.getPreference(pref);
+                let defaultValue = navigator.servo.defaultValue(pref);
+                if (ty === "bool") {
+                    createBoolPref(pref, value, defaultValue, counter % 2 === 0);
+                } else if (ty === "i64") {
+                    createIntPref(pref, value, defaultValue, counter % 2 === 0);
+                } else if (ty === "alloc::string::String") {
+                    createStringPref(pref, value, defaultValue, counter % 2 === 0);
+                } else {
+                    const template = document.querySelector("#unknownRow");
+                    const clone = template.content.cloneNode(true);
+                    clone.querySelector(".pref-name").textContent = pref;
+                    clone.querySelector(".value").textContent = value;
+                    if (counter % 2 === 0) {
+                        clone.querySelector("tr").classList.add("even");
+                    }
+                    document.querySelector("table").appendChild(clone);
+                }
+            }
+        }
+        populate();
+    </script>
+</body>
+</html>

--- a/resources/resource_protocol/config.html
+++ b/resources/resource_protocol/config.html
@@ -63,189 +63,222 @@
     </style>
 </head>
 <body>
-    <input class="search" type="text" placeholder="Search for a preference ..." oninput="populate(this.value)">
+    <input class="search" type="text" placeholder="Search for a preference ..." aria-label="Search preferences" oninput="populate(this.value)">
     <table></table>
-    <template id="boolRow">
-        <tr>
-            <td class="pref-name"></td>
-            <td class="value"></td>
-            <td class="switcher">
-                <button class="switch-button">
+    <script>
+        // Helper to create a TD with class and optional text
+        function td(cls, text) {
+            const cell = document.createElement('td');
+            if (cls) cell.className = cls;
+            if (text !== undefined) cell.textContent = text;
+            return cell;
+        }
+
+        class PrefBoolRow extends HTMLTableRowElement {
+            connectedCallback() {
+                // Attributes are provided via data-*
+                const pref = this.getAttribute('data-pref');
+                const defaultValue = this.getAttribute('data-default') === 'true';
+                let value = this.getAttribute('data-value') === 'true';
+
+                const nameCell = td('pref-name', pref);
+                const valueCell = td('value', String(value));
+                valueCell.id = `value-${pref}`;
+                if (value !== defaultValue) valueCell.classList.add('bold');
+
+                const switcher = td('switcher');
+                const btn = document.createElement('button');
+                btn.className = 'switch-button';
+                btn.innerHTML = `
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
-                    </svg>
-                </button>
-            </td>
-        </tr>
-    </template>
-    <template id="intRow">
-        <tr>
-            <td class="pref-name"></td>
-            <td class="value"><span class="value-entry"></span><input class="value-editor hidden" type="number"></td>
-            <td class="switcher">
-                <button class="switch-button">
+                    </svg>`;
+                btn.onclick = () => {
+                    value = !value;
+                    if (value === defaultValue) {
+                        valueCell.classList.remove('bold');
+                    } else {
+                        valueCell.classList.add('bold');
+                    }
+                    navigator.servo.setBoolPreference(pref, value);
+                    valueCell.textContent = String(value);
+                };
+                switcher.appendChild(btn);
+
+                this.appendChild(nameCell);
+                this.appendChild(valueCell);
+                this.appendChild(switcher);
+            }
+        }
+
+        class PrefIntRow extends HTMLTableRowElement {
+            connectedCallback() {
+                const pref = this.getAttribute('data-pref');
+                const defaultValue = parseInt(this.getAttribute('data-default'));
+                let value = parseInt(this.getAttribute('data-value'));
+
+                const nameCell = td('pref-name', pref);
+
+                const valueCell = document.createElement('td');
+                valueCell.className = 'value';
+                const valueSpan = document.createElement('span');
+                valueSpan.className = 'value-entry';
+                valueSpan.id = `value-${pref}`;
+                valueSpan.textContent = String(value);
+                if (value !== defaultValue) valueSpan.classList.add('bold');
+                const input = document.createElement('input');
+                input.type = 'number';
+                input.className = 'value-editor hidden';
+                input.id = `input-${pref}`;
+                valueCell.appendChild(valueSpan);
+                valueCell.appendChild(input);
+
+                const switcher = td('switcher');
+                const editBtn = document.createElement('button');
+                editBtn.className = 'switch-button';
+                editBtn.innerHTML = `
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
-                    </svg>
-                </button>
-                <button class="switch-button hidden">
+                    </svg>`;
+                const saveBtn = document.createElement('button');
+                saveBtn.className = 'switch-button hidden';
+                saveBtn.innerHTML = `
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-                    </svg>
-                </button>
-            </td>
-        </tr>
-    </template>
-    <template id="stringRow">
-        <tr>
-            <td class="pref-name"></td>
-            <td class="value"><span class="value-entry"></span><input class="value-editor hidden" type="text"></td>
-            <td class="switcher">
-                <button class="switch-button">
+                    </svg>`;
+
+                editBtn.onclick = () => {
+                    valueSpan.classList.add('hidden');
+                    input.classList.remove('hidden');
+                    input.value = String(value);
+                    editBtn.classList.add('hidden');
+                    saveBtn.classList.remove('hidden');
+                };
+
+                saveBtn.onclick = () => {
+                    const newValue = parseInt(input.value);
+                    navigator.servo.setIntPreference(pref, newValue);
+                    value = newValue;
+                    valueSpan.textContent = String(value);
+                    if (value === defaultValue) {
+                        valueSpan.classList.remove('bold');
+                    } else {
+                        valueSpan.classList.add('bold');
+                    }
+                    valueSpan.classList.remove('hidden');
+                    input.classList.add('hidden');
+                    editBtn.classList.remove('hidden');
+                    saveBtn.classList.add('hidden');
+                };
+
+                switcher.appendChild(editBtn);
+                switcher.appendChild(saveBtn);
+
+                this.appendChild(nameCell);
+                this.appendChild(valueCell);
+                this.appendChild(switcher);
+            }
+        }
+
+        class PrefStringRow extends HTMLTableRowElement {
+            connectedCallback() {
+                const pref = this.getAttribute('data-pref');
+                const defaultValue = this.getAttribute('data-default') ?? '';
+                let value = this.getAttribute('data-value') ?? '';
+
+                const nameCell = td('pref-name', pref);
+
+                const valueCell = document.createElement('td');
+                valueCell.className = 'value';
+                const valueSpan = document.createElement('span');
+                valueSpan.className = 'value-entry';
+                valueSpan.id = `value-${pref}`;
+                valueSpan.textContent = value;
+                if (value !== defaultValue) valueSpan.classList.add('bold');
+                const input = document.createElement('input');
+                input.type = 'text';
+                input.className = 'value-editor hidden';
+                input.id = `input-${pref}`;
+                valueCell.appendChild(valueSpan);
+                valueCell.appendChild(input);
+
+                const switcher = td('switcher');
+                const editBtn = document.createElement('button');
+                editBtn.className = 'switch-button';
+                editBtn.innerHTML = `
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
-                    </svg>
-                </button>
-                <button class="switch-button hidden">
+                    </svg>`;
+                const saveBtn = document.createElement('button');
+                saveBtn.className = 'switch-button hidden';
+                saveBtn.innerHTML = `
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-                    </svg>
-                </button>
-            </td>
-        </tr>
-    </template>
-    <template id="unknownRow">
-        <tr>
-            <td class="pref-name"></td>
-            <td class="value"></td>
-        </tr>
-    </template>
-    <script>
+                    </svg>`;
+
+                editBtn.onclick = () => {
+                    valueSpan.classList.add('hidden');
+                    input.classList.remove('hidden');
+                    input.value = value;
+                    editBtn.classList.add('hidden');
+                    saveBtn.classList.remove('hidden');
+                };
+
+                saveBtn.onclick = () => {
+                    const newValue = input.value;
+                    navigator.servo.setStringPreference(pref, newValue);
+                    value = newValue;
+                    valueSpan.textContent = value;
+                    if (value === defaultValue) {
+                        valueSpan.classList.remove('bold');
+                    } else {
+                        valueSpan.classList.add('bold');
+                    }
+                    valueSpan.classList.remove('hidden');
+                    input.classList.add('hidden');
+                    editBtn.classList.remove('hidden');
+                    saveBtn.classList.add('hidden');
+                };
+
+                switcher.appendChild(editBtn);
+                switcher.appendChild(saveBtn);
+
+                this.appendChild(nameCell);
+                this.appendChild(valueCell);
+                this.appendChild(switcher);
+            }
+        }
+
+        class PrefUnknownRow extends HTMLTableRowElement {
+            connectedCallback() {
+                const pref = this.getAttribute('data-pref');
+                const value = this.getAttribute('data-value') ?? '';
+
+                this.appendChild(td('pref-name', pref));
+                this.appendChild(td('value', value));
+            }
+        }
+
+        customElements.define('pref-bool-row', PrefBoolRow, { extends: 'tr' });
+        customElements.define('pref-int-row', PrefIntRow, { extends: 'tr' });
+        customElements.define('pref-string-row', PrefStringRow, { extends: 'tr' });
+        customElements.define('pref-unknown-row', PrefUnknownRow, { extends: 'tr' });
+
         let all = navigator.servo.preferenceList();
-        all.sort()
+        all.sort();
         const ALL = all;
 
-        function createBoolPref(pref, boolValue, defaultValue, even) {
-            const template = document.querySelector("#boolRow");
-            const clone = template.content.cloneNode(true);
-            clone.querySelector(".pref-name").textContent = pref;
-            clone.querySelector(".value").textContent = boolValue;
-            clone.querySelector(".value").id = "value-" + pref;
-            if (boolValue !== defaultValue) {
-                clone.querySelector(".value").classList.add("bold");
-            }
-            clone.querySelector(".switcher button").onclick = (ev) => {
-                boolValue = !boolValue;
-                if (boolValue === defaultValue) {
-                    document.getElementById("value-" + pref).classList.remove("bold");
-                } else {
-                    document.getElementById("value-" + pref).classList.add("bold");
-                }
-                navigator.servo.setBoolPreference(pref, boolValue);
-                document.getElementById("value-" + pref).textContent = boolValue;
-            };
-            if (even) {
-                clone.querySelector("tr").classList.add("even");
-            }
-            document.querySelector("table").appendChild(clone);
-        }
-
-        function createIntPref(pref, intValue, defaultValue, even) {
-            const template = document.querySelector("#intRow");
-            const clone = template.content.cloneNode(true);
-            clone.querySelector(".pref-name").textContent = pref;
-            clone.querySelector(".value-entry").textContent = intValue;
-            clone.querySelector(".value-entry").id = "value-" + pref;
-            clone.querySelector(".value-editor").id = "input-" + pref;
-            if (intValue !== defaultValue) {
-                clone.querySelector(".value-entry").classList.add("bold");
-            }
-            const editButton = clone.querySelectorAll(".switcher button")[0];
-            const saveButton = clone.querySelectorAll(".switcher button")[1];
-            editButton.onclick = (ev) => {
-                document.getElementById("value-" + pref).classList.add("hidden");
-                const input = document.getElementById("input-" + pref);
-                input.classList.remove("hidden");
-                input.value = intValue;
-                editButton.classList.add("hidden");
-                saveButton.classList.remove("hidden");
-            };
-            saveButton.onclick = (ev) => {
-                const input = document.getElementById("input-" + pref);
-                const newValue = parseInt(input.value);
-                navigator.servo.setIntPreference(pref, newValue);
-                intValue = newValue;
-                document.getElementById("value-" + pref).textContent = intValue;
-                if (intValue === defaultValue) {
-                    document.getElementById("value-" + pref).classList.remove("bold");
-                } else {
-                    document.getElementById("value-" + pref).classList.add("bold");
-                }
-                document.getElementById("value-" + pref).classList.remove("hidden");
-                input.classList.add("hidden");
-                editButton.classList.remove("hidden");
-                saveButton.classList.add("hidden");
-            };
-            if (even) {
-                clone.querySelector("tr").classList.add("even");
-            }
-            document.querySelector("table").appendChild(clone);
-        }
-
-
-        function createStringPref(pref, stringValue, defaultValue, even) {
-            const template = document.querySelector("#stringRow");
-            const clone = template.content.cloneNode(true);
-            clone.querySelector(".pref-name").textContent = pref;
-            clone.querySelector(".value-entry").textContent = stringValue;
-            clone.querySelector(".value-entry").id = "value-" + pref;
-            clone.querySelector(".value-editor").id = "input-" + pref;
-            if (stringValue !== defaultValue) {
-                clone.querySelector(".value-entry").classList.add("bold");
-            }
-            const editButton = clone.querySelectorAll(".switcher button")[0];
-            const saveButton = clone.querySelectorAll(".switcher button")[1];
-            editButton.onclick = (ev) => {
-                document.getElementById("value-" + pref).classList.add("hidden");
-                const input = document.getElementById("input-" + pref);
-                input.classList.remove("hidden");
-                input.value = stringValue;
-                editButton.classList.add("hidden");
-                saveButton.classList.remove("hidden");
-            };
-            saveButton.onclick = (ev) => {
-                const input = document.getElementById("input-" + pref);
-                const newValue = input.value;
-                navigator.servo.setStringPreference(pref, newValue);
-                stringValue = newValue;
-                document.getElementById("value-" + pref).textContent = stringValue;
-                if (stringValue === defaultValue) {
-                    document.getElementById("value-" + pref).classList.remove("bold");
-                } else {
-                    document.getElementById("value-" + pref).classList.add("bold");
-                }
-                document.getElementById("value-" + pref).classList.remove("hidden");
-                input.classList.add("hidden");
-                editButton.classList.remove("hidden");
-                saveButton.classList.add("hidden");
-            };
-            if (even) {
-                clone.querySelector("tr").classList.add("even");
-            }
-            document.querySelector("table").appendChild(clone);
-        }
-
-
         function populate(filter) {
-            document.querySelector("table").innerHTML = "";
+            const table = document.querySelector('table');
+            table.innerHTML = '';
             let prefs = [];
-            if (filter === "" || filter === null || filter === undefined) {
+            if (filter === '' || filter === null || filter === undefined) {
                 prefs = ALL;
             } else {
                 // TODO: improve filtering
                 for (let pref of ALL) {
-                    let stripped_pref = pref.replaceAll("_", "");
-                    let stripped_filter = filter.replaceAll("_", "").replaceAll(" ", "").toLowerCase();
+                    let stripped_pref = pref.replaceAll('_', '');
+                    let stripped_filter = filter.replaceAll('_', '').replaceAll(' ', '').toLowerCase();
                     if (stripped_pref.includes(stripped_filter)) {
                         prefs.push(pref);
                     }
@@ -257,21 +290,35 @@
                 let ty = navigator.servo.preferenceType(pref);
                 let value = navigator.servo.getPreference(pref);
                 let defaultValue = navigator.servo.defaultValue(pref);
-                if (ty === "bool") {
-                    createBoolPref(pref, value, defaultValue, counter % 2 === 0);
-                } else if (ty === "i64") {
-                    createIntPref(pref, value, defaultValue, counter % 2 === 0);
-                } else if (ty === "alloc::string::String") {
-                    createStringPref(pref, value, defaultValue, counter % 2 === 0);
+                const even = counter % 2 === 0;
+
+                if (ty === 'bool') {
+                    const row = document.createElement('tr', { is: 'pref-bool-row' });
+                    row.setAttribute('data-pref', pref);
+                    row.setAttribute('data-value', String(value));
+                    row.setAttribute('data-default', String(defaultValue));
+                    if (even) row.classList.add('even');
+                    table.appendChild(row);
+                } else if (ty === 'i64') {
+                    const row = document.createElement('tr', { is: 'pref-int-row' });
+                    row.setAttribute('data-pref', pref);
+                    row.setAttribute('data-value', String(value));
+                    row.setAttribute('data-default', String(defaultValue));
+                    if (even) row.classList.add('even');
+                    table.appendChild(row);
+                } else if (ty === 'alloc::string::String') {
+                    const row = document.createElement('tr', { is: 'pref-string-row' });
+                    row.setAttribute('data-pref', pref);
+                    row.setAttribute('data-value', String(value));
+                    row.setAttribute('data-default', String(defaultValue));
+                    if (even) row.classList.add('even');
+                    table.appendChild(row);
                 } else {
-                    const template = document.querySelector("#unknownRow");
-                    const clone = template.content.cloneNode(true);
-                    clone.querySelector(".pref-name").textContent = pref;
-                    clone.querySelector(".value").textContent = value;
-                    if (counter % 2 === 0) {
-                        clone.querySelector("tr").classList.add("even");
-                    }
-                    document.querySelector("table").appendChild(clone);
+                    const row = document.createElement('tr', { is: 'pref-unknown-row' });
+                    row.setAttribute('data-pref', pref);
+                    row.setAttribute('data-value', String(value));
+                    if (even) row.classList.add('even');
+                    table.appendChild(row);
                 }
             }
         }

--- a/resources/resource_protocol/config.html
+++ b/resources/resource_protocol/config.html
@@ -31,7 +31,7 @@
             border: 0;
         }
 
-        .even {
+        tr:nth-child(2n) {
             background-color: #f0f0f0;
         }
 
@@ -77,9 +77,9 @@
         class PrefBoolRow extends HTMLTableRowElement {
             connectedCallback() {
                 // Attributes are provided via data-*
-                const pref = this.getAttribute('data-pref');
-                const defaultValue = this.getAttribute('data-default') === 'true';
-                let value = this.getAttribute('data-value') === 'true';
+                const pref = this.dataset.pref;
+                const defaultValue = this.dataset.default === 'true';
+                let value = this.dataset.value === 'true';
 
                 const nameCell = td('pref-name', pref);
                 const valueCell = td('value', String(value));
@@ -95,11 +95,7 @@
                     </svg>`;
                 btn.onclick = () => {
                     value = !value;
-                    if (value === defaultValue) {
-                        valueCell.classList.remove('bold');
-                    } else {
-                        valueCell.classList.add('bold');
-                    }
+                    valueCell.classList.toggle('bold', value !== defaultValue)
                     navigator.servo.setBoolPreference(pref, value);
                     valueCell.textContent = String(value);
                 };
@@ -111,11 +107,11 @@
             }
         }
 
-        class PrefIntRow extends HTMLTableRowElement {
+        // Unified row for int and string preferences
+        class PrefValueRow extends HTMLTableRowElement {
             connectedCallback() {
-                const pref = this.getAttribute('data-pref');
-                const defaultValue = parseInt(this.getAttribute('data-default'));
-                let value = parseInt(this.getAttribute('data-value'));
+                const pref = this.dataset.pref;
+                const ty = this.dataset.type; // 'i64' or 'alloc::string::String'
 
                 const nameCell = td('pref-name', pref);
 
@@ -124,12 +120,52 @@
                 const valueSpan = document.createElement('span');
                 valueSpan.className = 'value-entry';
                 valueSpan.id = `value-${pref}`;
-                valueSpan.textContent = String(value);
-                if (value !== defaultValue) valueSpan.classList.add('bold');
                 const input = document.createElement('input');
-                input.type = 'number';
                 input.className = 'value-editor hidden';
                 input.id = `input-${pref}`;
+
+                // Per-type state and behavior
+                let defaultValue;
+                let value;
+                let saveFn;
+
+                if (ty === 'i64') {
+                    defaultValue = parseInt(this.dataset.default);
+                    value = parseInt(this.dataset.value);
+                    valueSpan.textContent = String(value);
+                    input.type = 'number';
+                    input.step = '1';
+                    saveFn = () => {
+                        const parsed = parseInt(input.value);
+                        if (Number.isNaN(parsed)) {
+                            input.setCustomValidity('Please enter a valid integer.');
+                            input.reportValidity();
+                            return false;
+                        }
+                        navigator.servo.setIntPreference(pref, parsed);
+                        value = parsed;
+                        valueSpan.textContent = String(value);
+                        valueCell.classList.toggle('bold', value !== defaultValue)
+                        return true;
+                    };
+                } else {
+                    // string, no validation needed
+                    defaultValue = this.dataset.default ?? '';
+                    value = this.dataset.value ?? '';
+                    valueSpan.textContent = value;
+                    input.type = 'text';
+                    saveFn = () => {
+                        const newValue = input.value;
+                        navigator.servo.setStringPreference(pref, newValue);
+                        value = newValue;
+                        valueSpan.textContent = value;
+                        valueCell.classList.toggle('bold', value !== defaultValue)
+                        return true;
+                    };
+                }
+
+                valueSpan.classList.toggle('bold', value !== defaultValue)
+
                 valueCell.appendChild(valueSpan);
                 valueCell.appendChild(input);
 
@@ -146,6 +182,16 @@
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
                     </svg>`;
+
+                const cancelEdit = () => {
+                    // Revert input view and value without saving
+                    input.classList.add('hidden');
+                    valueSpan.classList.remove('hidden');
+                    input.value = String(value);
+                    editBtn.classList.remove('hidden');
+                    saveBtn.classList.add('hidden');
+                    input.setCustomValidity('');
+                };
 
                 editBtn.onclick = () => {
                     valueSpan.classList.add('hidden');
@@ -153,92 +199,29 @@
                     input.value = String(value);
                     editBtn.classList.add('hidden');
                     saveBtn.classList.remove('hidden');
+                    input.focus();
+                    input.setSelectionRange(0, input.value.length);
                 };
 
                 saveBtn.onclick = () => {
-                    const newValue = parseInt(input.value);
-                    navigator.servo.setIntPreference(pref, newValue);
-                    value = newValue;
-                    valueSpan.textContent = String(value);
-                    if (value === defaultValue) {
-                        valueSpan.classList.remove('bold');
-                    } else {
-                        valueSpan.classList.add('bold');
-                    }
+                    const ok = saveFn();
+                    if (!ok) return; // keep editing on validation failure
                     valueSpan.classList.remove('hidden');
                     input.classList.add('hidden');
                     editBtn.classList.remove('hidden');
                     saveBtn.classList.add('hidden');
                 };
 
-                switcher.appendChild(editBtn);
-                switcher.appendChild(saveBtn);
-
-                this.appendChild(nameCell);
-                this.appendChild(valueCell);
-                this.appendChild(switcher);
-            }
-        }
-
-        class PrefStringRow extends HTMLTableRowElement {
-            connectedCallback() {
-                const pref = this.getAttribute('data-pref');
-                const defaultValue = this.getAttribute('data-default') ?? '';
-                let value = this.getAttribute('data-value') ?? '';
-
-                const nameCell = td('pref-name', pref);
-
-                const valueCell = document.createElement('td');
-                valueCell.className = 'value';
-                const valueSpan = document.createElement('span');
-                valueSpan.className = 'value-entry';
-                valueSpan.id = `value-${pref}`;
-                valueSpan.textContent = value;
-                if (value !== defaultValue) valueSpan.classList.add('bold');
-                const input = document.createElement('input');
-                input.type = 'text';
-                input.className = 'value-editor hidden';
-                input.id = `input-${pref}`;
-                valueCell.appendChild(valueSpan);
-                valueCell.appendChild(input);
-
-                const switcher = td('switcher');
-                const editBtn = document.createElement('button');
-                editBtn.className = 'switch-button';
-                editBtn.innerHTML = `
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
-                    </svg>`;
-                const saveBtn = document.createElement('button');
-                saveBtn.className = 'switch-button hidden';
-                saveBtn.innerHTML = `
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
-                    </svg>`;
-
-                editBtn.onclick = () => {
-                    valueSpan.classList.add('hidden');
-                    input.classList.remove('hidden');
-                    input.value = value;
-                    editBtn.classList.add('hidden');
-                    saveBtn.classList.remove('hidden');
-                };
-
-                saveBtn.onclick = () => {
-                    const newValue = input.value;
-                    navigator.servo.setStringPreference(pref, newValue);
-                    value = newValue;
-                    valueSpan.textContent = value;
-                    if (value === defaultValue) {
-                        valueSpan.classList.remove('bold');
-                    } else {
-                        valueSpan.classList.add('bold');
+                // Enter to save, Escape to cancel
+                input.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter') {
+                        e.preventDefault();
+                        saveBtn.click();
+                    } else if (e.key === 'Escape') {
+                        e.preventDefault();
+                        cancelEdit();
                     }
-                    valueSpan.classList.remove('hidden');
-                    input.classList.add('hidden');
-                    editBtn.classList.remove('hidden');
-                    saveBtn.classList.add('hidden');
-                };
+                });
 
                 switcher.appendChild(editBtn);
                 switcher.appendChild(saveBtn);
@@ -251,8 +234,8 @@
 
         class PrefUnknownRow extends HTMLTableRowElement {
             connectedCallback() {
-                const pref = this.getAttribute('data-pref');
-                const value = this.getAttribute('data-value') ?? '';
+                const pref = this.dataset.pref;
+                const value = this.dataset.value ?? '';
 
                 this.appendChild(td('pref-name', pref));
                 this.appendChild(td('value', value));
@@ -260,8 +243,7 @@
         }
 
         customElements.define('pref-bool-row', PrefBoolRow, { extends: 'tr' });
-        customElements.define('pref-int-row', PrefIntRow, { extends: 'tr' });
-        customElements.define('pref-string-row', PrefStringRow, { extends: 'tr' });
+        customElements.define('pref-value-row', PrefValueRow, { extends: 'tr' });
         customElements.define('pref-unknown-row', PrefUnknownRow, { extends: 'tr' });
 
         let all = navigator.servo.preferenceList();
@@ -290,34 +272,31 @@
                 let ty = navigator.servo.preferenceType(pref);
                 let value = navigator.servo.getPreference(pref);
                 let defaultValue = navigator.servo.defaultValue(pref);
-                const even = counter % 2 === 0;
 
                 if (ty === 'bool') {
                     const row = document.createElement('tr', { is: 'pref-bool-row' });
                     row.setAttribute('data-pref', pref);
                     row.setAttribute('data-value', String(value));
                     row.setAttribute('data-default', String(defaultValue));
-                    if (even) row.classList.add('even');
                     table.appendChild(row);
                 } else if (ty === 'i64') {
-                    const row = document.createElement('tr', { is: 'pref-int-row' });
+                    const row = document.createElement('tr', { is: 'pref-value-row' });
                     row.setAttribute('data-pref', pref);
+                    row.setAttribute('data-type', 'i64');
                     row.setAttribute('data-value', String(value));
                     row.setAttribute('data-default', String(defaultValue));
-                    if (even) row.classList.add('even');
                     table.appendChild(row);
                 } else if (ty === 'alloc::string::String') {
-                    const row = document.createElement('tr', { is: 'pref-string-row' });
+                    const row = document.createElement('tr', { is: 'pref-value-row' });
                     row.setAttribute('data-pref', pref);
+                    row.setAttribute('data-type', 'alloc::string::String');
                     row.setAttribute('data-value', String(value));
                     row.setAttribute('data-default', String(defaultValue));
-                    if (even) row.classList.add('even');
                     table.appendChild(row);
                 } else {
                     const row = document.createElement('tr', { is: 'pref-unknown-row' });
                     row.setAttribute('data-pref', pref);
                     row.setAttribute('data-value', String(value));
-                    if (even) row.classList.add('even');
                     table.appendChild(row);
                 }
             }

--- a/resources/resource_protocol/config.html
+++ b/resources/resource_protocol/config.html
@@ -58,7 +58,7 @@
         class PrefValueRow extends HTMLTableRowElement {
             connectedCallback() {
                 const pref = this.dataset.pref;
-                const ty = this.dataset.type; // "i64" or "alloc::string::String"
+                const ty = this.dataset.type; // "i64" or "String"
 
                 const nameCell = td("pref-name", pref);
 
@@ -79,7 +79,7 @@
                 if (ty === "i64") {
                     defaultValue = parseInt(this.dataset.default);
                     value = parseInt(this.dataset.value);
-                    valueSpan.textContent = String(value);
+                    valueSpan.textContent = value;
                     input.type = "number";
                     input.step = "1";
                     saveFn = () => {
@@ -91,7 +91,7 @@
                         }
                         navigator.servo.setIntPreference(pref, parsed);
                         value = parsed;
-                        valueSpan.textContent = String(value);
+                        valueSpan.textContent = value;
                         valueCell.classList.toggle("default", value !== defaultValue)
                         return true;
                     };
@@ -231,10 +231,10 @@
                     row.setAttribute("data-value", String(value));
                     row.setAttribute("data-default", String(defaultValue));
                     table.appendChild(row);
-                } else if (ty === "alloc::string::String") {
+                } else if (ty === "String") {
                     const row = document.createElement("tr", { is: "pref-value-row" });
                     row.setAttribute("data-pref", pref);
-                    row.setAttribute("data-type", "alloc::string::String");
+                    row.setAttribute("data-type", "String");
                     row.setAttribute("data-value", String(value));
                     row.setAttribute("data-default", String(defaultValue));
                     table.appendChild(row);

--- a/resources/resource_protocol/config.html
+++ b/resources/resource_protocol/config.html
@@ -3,74 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <title>Advanced Config</title>
-    <style>
-        body {
-            padding: 0;
-            display: flex;
-            flex-direction: column;
-        }
-
-        input {
-            border-radius: 4px;
-        }
-
-        .search {
-            height: 24px;
-            width: calc(100% - 6px);
-            margin-top: 12px;
-            margin-bottom: 12px;
-            margin-right: 6px;
-            padding: 4px;
-        }
-
-        table {
-            border-collapse: collapse;
-        }
-
-        table, th, td {
-            border: 0;
-        }
-
-        tr:nth-child(2n) {
-            background-color: #f0f0f0;
-        }
-
-        .value-editor {
-            margin: 2px;
-            padding: 2px;
-        }
-
-        .switch-button {
-            margin: 2px;
-            padding: 2px;
-            border-radius: 4px;
-            background: #cfcfcf;
-            border: 0;
-        }
-
-        .icon {
-            width: 24px;
-            height: 24px;
-        }
-
-        .hidden {
-            display: none;
-        }
-
-        .bold {
-            font-weight: bold;
-        }
-    </style>
+    <link rel="stylesheet" href="resource:///config.css">
 </head>
 <body>
-    <input class="search" type="text" placeholder="Search for a preference ..." aria-label="Search preferences" oninput="populate(this.value)">
+    <input class="search" type="text" placeholder="Search for a preference…" aria-label="Search preferences" oninput="populate(this.value)">
     <table></table>
     <script>
         // Helper to create a TD with class and optional text
         function td(cls, text) {
-            const cell = document.createElement('td');
-            if (cls) cell.className = cls;
-            if (text !== undefined) cell.textContent = text;
+            const cell = document.createElement("td");
+            if (cls !== undefined) {
+                cell.className = cls;
+            }
+            if (text !== undefined) {
+                cell.textContent = text;
+            }
             return cell;
         }
 
@@ -78,24 +25,24 @@
             connectedCallback() {
                 // Attributes are provided via data-*
                 const pref = this.dataset.pref;
-                const defaultValue = this.dataset.default === 'true';
-                let value = this.dataset.value === 'true';
+                const defaultValue = this.dataset.default === "true";
+                let value = this.dataset.value === "true";
 
-                const nameCell = td('pref-name', pref);
-                const valueCell = td('value', String(value));
+                const nameCell = td("pref-name", pref);
+                const valueCell = td("value", String(value));
                 valueCell.id = `value-${pref}`;
-                if (value !== defaultValue) valueCell.classList.add('bold');
+                if (value !== defaultValue) valueCell.classList.add("default");
 
-                const switcher = td('switcher');
-                const btn = document.createElement('button');
-                btn.className = 'switch-button';
+                const switcher = td("switcher");
+                const btn = document.createElement("button");
+                btn.className = "switch-button";
                 btn.innerHTML = `
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
                     </svg>`;
                 btn.onclick = () => {
                     value = !value;
-                    valueCell.classList.toggle('bold', value !== defaultValue)
+                    valueCell.classList.toggle("default", value !== defaultValue)
                     navigator.servo.setBoolPreference(pref, value);
                     valueCell.textContent = String(value);
                 };
@@ -111,17 +58,17 @@
         class PrefValueRow extends HTMLTableRowElement {
             connectedCallback() {
                 const pref = this.dataset.pref;
-                const ty = this.dataset.type; // 'i64' or 'alloc::string::String'
+                const ty = this.dataset.type; // "i64" or "alloc::string::String"
 
-                const nameCell = td('pref-name', pref);
+                const nameCell = td("pref-name", pref);
 
-                const valueCell = document.createElement('td');
-                valueCell.className = 'value';
-                const valueSpan = document.createElement('span');
-                valueSpan.className = 'value-entry';
+                const valueCell = document.createElement("td");
+                valueCell.className = "value";
+                const valueSpan = document.createElement("span");
+                valueSpan.className = "value-entry";
                 valueSpan.id = `value-${pref}`;
-                const input = document.createElement('input');
-                input.className = 'value-editor hidden';
+                const input = document.createElement("input");
+                input.className = "value-editor hidden";
                 input.id = `input-${pref}`;
 
                 // Per-type state and behavior
@@ -129,55 +76,55 @@
                 let value;
                 let saveFn;
 
-                if (ty === 'i64') {
+                if (ty === "i64") {
                     defaultValue = parseInt(this.dataset.default);
                     value = parseInt(this.dataset.value);
                     valueSpan.textContent = String(value);
-                    input.type = 'number';
-                    input.step = '1';
+                    input.type = "number";
+                    input.step = "1";
                     saveFn = () => {
                         const parsed = parseInt(input.value);
                         if (Number.isNaN(parsed)) {
-                            input.setCustomValidity('Please enter a valid integer.');
+                            input.setCustomValidity("Please enter a valid integer.");
                             input.reportValidity();
                             return false;
                         }
                         navigator.servo.setIntPreference(pref, parsed);
                         value = parsed;
                         valueSpan.textContent = String(value);
-                        valueCell.classList.toggle('bold', value !== defaultValue)
+                        valueCell.classList.toggle("default", value !== defaultValue)
                         return true;
                     };
                 } else {
                     // string, no validation needed
-                    defaultValue = this.dataset.default ?? '';
-                    value = this.dataset.value ?? '';
+                    defaultValue = this.dataset.default ?? "";
+                    value = this.dataset.value ?? "";
                     valueSpan.textContent = value;
-                    input.type = 'text';
+                    input.type = "text";
                     saveFn = () => {
                         const newValue = input.value;
                         navigator.servo.setStringPreference(pref, newValue);
                         value = newValue;
                         valueSpan.textContent = value;
-                        valueCell.classList.toggle('bold', value !== defaultValue)
+                        valueCell.classList.toggle("default", value !== defaultValue)
                         return true;
                     };
                 }
 
-                valueSpan.classList.toggle('bold', value !== defaultValue)
+                valueSpan.classList.toggle("default", value !== defaultValue)
 
                 valueCell.appendChild(valueSpan);
                 valueCell.appendChild(input);
 
-                const switcher = td('switcher');
-                const editBtn = document.createElement('button');
-                editBtn.className = 'switch-button';
+                const switcher = td("switcher");
+                const editBtn = document.createElement("button");
+                editBtn.className = "switch-button";
                 editBtn.innerHTML = `
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" />
                     </svg>`;
-                const saveBtn = document.createElement('button');
-                saveBtn.className = 'switch-button hidden';
+                const saveBtn = document.createElement("button");
+                saveBtn.className = "switch-button hidden";
                 saveBtn.innerHTML = `
                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
@@ -185,20 +132,20 @@
 
                 const cancelEdit = () => {
                     // Revert input view and value without saving
-                    input.classList.add('hidden');
-                    valueSpan.classList.remove('hidden');
+                    input.classList.add("hidden");
+                    valueSpan.classList.remove("hidden");
                     input.value = String(value);
-                    editBtn.classList.remove('hidden');
-                    saveBtn.classList.add('hidden');
-                    input.setCustomValidity('');
+                    editBtn.classList.remove("hidden");
+                    saveBtn.classList.add("hidden");
+                    input.setCustomValidity("");
                 };
 
                 editBtn.onclick = () => {
-                    valueSpan.classList.add('hidden');
-                    input.classList.remove('hidden');
+                    valueSpan.classList.add("hidden");
+                    input.classList.remove("hidden");
                     input.value = String(value);
-                    editBtn.classList.add('hidden');
-                    saveBtn.classList.remove('hidden');
+                    editBtn.classList.add("hidden");
+                    saveBtn.classList.remove("hidden");
                     input.focus();
                     input.setSelectionRange(0, input.value.length);
                 };
@@ -206,18 +153,18 @@
                 saveBtn.onclick = () => {
                     const ok = saveFn();
                     if (!ok) return; // keep editing on validation failure
-                    valueSpan.classList.remove('hidden');
-                    input.classList.add('hidden');
-                    editBtn.classList.remove('hidden');
-                    saveBtn.classList.add('hidden');
+                    valueSpan.classList.remove("hidden");
+                    input.classList.add("hidden");
+                    editBtn.classList.remove("hidden");
+                    saveBtn.classList.add("hidden");
                 };
 
                 // Enter to save, Escape to cancel
-                input.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter') {
+                input.addEventListener("keydown", (e) => {
+                    if (e.key === "Enter") {
                         e.preventDefault();
                         saveBtn.click();
-                    } else if (e.key === 'Escape') {
+                    } else if (e.key === "Escape") {
                         e.preventDefault();
                         cancelEdit();
                     }
@@ -235,68 +182,66 @@
         class PrefUnknownRow extends HTMLTableRowElement {
             connectedCallback() {
                 const pref = this.dataset.pref;
-                const value = this.dataset.value ?? '';
+                const value = this.dataset.value ?? "";
 
-                this.appendChild(td('pref-name', pref));
-                this.appendChild(td('value', value));
+                this.appendChild(td("pref-name", pref));
+                this.appendChild(td("value", value));
             }
         }
 
-        customElements.define('pref-bool-row', PrefBoolRow, { extends: 'tr' });
-        customElements.define('pref-value-row', PrefValueRow, { extends: 'tr' });
-        customElements.define('pref-unknown-row', PrefUnknownRow, { extends: 'tr' });
+        customElements.define("pref-bool-row", PrefBoolRow, { extends: "tr" });
+        customElements.define("pref-value-row", PrefValueRow, { extends: "tr" });
+        customElements.define("pref-unknown-row", PrefUnknownRow, { extends: "tr" });
 
         let all = navigator.servo.preferenceList();
         all.sort();
         const ALL = all;
 
         function populate(filter) {
-            const table = document.querySelector('table');
-            table.innerHTML = '';
+            const table = document.querySelector("table");
+            table.innerHTML = "";
             let prefs = [];
-            if (filter === '' || filter === null || filter === undefined) {
+            if (filter === "" || filter === null || filter === undefined) {
                 prefs = ALL;
             } else {
                 // TODO: improve filtering
-                for (let pref of ALL) {
-                    let stripped_pref = pref.replaceAll('_', '');
-                    let stripped_filter = filter.replaceAll('_', '').replaceAll(' ', '').toLowerCase();
+                prefs = ALL.filter(pref => {
+                    let stripped_pref = pref.replaceAll("_", "");
+                    let stripped_filter = filter.replaceAll("_", "").replaceAll(" ", "").toLowerCase();
                     if (stripped_pref.includes(stripped_filter)) {
                         prefs.push(pref);
                     }
-                }
+                });
             }
-            let counter = 0;
             for (let pref of prefs) {
-                counter++;
                 let ty = navigator.servo.preferenceType(pref);
                 let value = navigator.servo.getPreference(pref);
-                let defaultValue = navigator.servo.defaultValue(pref);
+                let defaultValue = navigator.servo.defaultPreferenceValue(pref);
 
-                if (ty === 'bool') {
-                    const row = document.createElement('tr', { is: 'pref-bool-row' });
-                    row.setAttribute('data-pref', pref);
-                    row.setAttribute('data-value', String(value));
-                    row.setAttribute('data-default', String(defaultValue));
+                if (ty === "bool") {
+                    const row = document.createElement("tr", { is: "pref-bool-row" });
+                    row.setAttribute("data-pref", pref);
+                    row.setAttribute("data-value", String(value));
+                    row.setAttribute("data-default", String(defaultValue));
                     table.appendChild(row);
-                } else if (ty === 'i64') {
-                    const row = document.createElement('tr', { is: 'pref-value-row' });
-                    row.setAttribute('data-pref', pref);
-                    row.setAttribute('data-type', 'i64');
-                    row.setAttribute('data-value', String(value));
-                    row.setAttribute('data-default', String(defaultValue));
+                } else if (ty === "i64") {
+                    const row = document.createElement("tr", { is: "pref-value-row" });
+                    row.setAttribute("data-pref", pref);
+                    row.setAttribute("data-type", "i64");
+                    row.setAttribute("data-value", String(value));
+                    row.setAttribute("data-default", String(defaultValue));
                     table.appendChild(row);
-                } else if (ty === 'alloc::string::String') {
-                    const row = document.createElement('tr', { is: 'pref-value-row' });
-                    row.setAttribute('data-pref', pref);
-                    row.setAttribute('data-type', 'alloc::string::String');
-                    row.setAttribute('data-value', String(value));
-                    row.setAttribute('data-default', String(defaultValue));
+                } else if (ty === "alloc::string::String") {
+                    const row = document.createElement("tr", { is: "pref-value-row" });
+                    row.setAttribute("data-pref", pref);
+                    row.setAttribute("data-type", "alloc::string::String");
+                    row.setAttribute("data-value", String(value));
+                    row.setAttribute("data-default", String(defaultValue));
                     table.appendChild(row);
                 } else {
-                    const row = document.createElement('tr', { is: 'pref-unknown-row' });
-                    row.setAttribute('data-pref', pref);
-                    row.setAttribute('data-value', String(value));
+                    const row = document.createElement("tr", { is: "pref-unknown-row" });
+                    row.setAttribute("data-pref", pref);
+                    row.setAttribute("data-value", String(value));
                     table.appendChild(row);
                 }
             }


### PR DESCRIPTION
Similar to about:config from firefox. All preferences are editable; editing them mid-runtime is not guaranteed to cause any effects. This is separate from servo:preferences, which selectively groups and exposes preferences. This probably would become more useful if/when preferences become persistent.

<img width="1136" height="880" alt="Screenshot 2025-10-31 at 10 19 57 PM" src="https://github.com/user-attachments/assets/2ef759d8-06a4-457f-b9df-331cc3525338" />


Followup work:
- Remove `getStringPreference`, `getIntPreference`, and `getBoolPreference`. Using `getPreference` and `preferenceType` is more flexible.
- Make more of these config options work on the fly.
- Allow for reverting config options.