### PR TITLE
script: add CanGc as argument to VirtualMethods::children_changed

### DIFF
--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -94,7 +94,7 @@ impl CharacterData {
         if self.is::<Text>() {
             if let Some(parent_node) = node.GetParentNode() {
                 let mutation = ChildrenMutation::ChangeText;
-                vtable_for(&parent_node).children_changed(&mutation);
+                vtable_for(&parent_node).children_changed(&mutation, CanGc::note());
             }
         }
     }

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -4517,9 +4517,9 @@ impl VirtualMethods for Element {
         doc.decrement_dom_count();
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation) {
+    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation);
+            s.children_changed(mutation, can_gc);
         }
 
         let flags = self.selector_flags.get();

--- a/components/script/dom/html/htmldetailselement.rs
+++ b/components/script/dom/html/htmldetailselement.rs
@@ -268,16 +268,18 @@ impl VirtualMethods for HTMLDetailsElement {
         }
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation) {
-        self.super_type().unwrap().children_changed(mutation);
+    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .children_changed(mutation, can_gc);
 
-        self.update_shadow_tree_contents(CanGc::note());
+        self.update_shadow_tree_contents(can_gc);
     }
 
     fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         self.super_type().unwrap().bind_to_tree(context, can_gc);
 
-        self.update_shadow_tree_contents(CanGc::note());
-        self.update_shadow_tree_styles(CanGc::note());
+        self.update_shadow_tree_contents(can_gc);
+        self.update_shadow_tree_styles(can_gc);
     }
 }

--- a/components/script/dom/html/htmlmeterelement.rs
+++ b/components/script/dom/html/htmlmeterelement.rs
@@ -337,19 +337,21 @@ impl VirtualMethods for HTMLMeterElement {
                 &local_name!("value")
         );
         if is_important_attribute {
-            self.update_state(CanGc::note());
+            self.update_state(can_gc);
         }
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation) {
-        self.super_type().unwrap().children_changed(mutation);
+    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .children_changed(mutation, can_gc);
 
-        self.update_state(CanGc::note());
+        self.update_state(can_gc);
     }
 
     fn bind_to_tree(&self, context: &BindContext, can_gc: CanGc) {
         self.super_type().unwrap().bind_to_tree(context, can_gc);
 
-        self.update_state(CanGc::note());
+        self.update_state(can_gc);
     }
 }

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -385,9 +385,9 @@ impl VirtualMethods for HTMLOptionElement {
         }
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation) {
+    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
         if let Some(super_type) = self.super_type() {
-            super_type.children_changed(mutation);
+            super_type.children_changed(mutation, can_gc);
         }
 
         // Changing the descendants of a selected option can change it's displayed label
@@ -401,7 +401,7 @@ impl VirtualMethods for HTMLOptionElement {
                     .selected_option()
                     .is_some_and(|selected_option| self == &*selected_option)
                 {
-                    owner_select.update_shadow_tree(CanGc::note());
+                    owner_select.update_shadow_tree(can_gc);
                 }
             }
         }

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1292,9 +1292,9 @@ impl VirtualMethods for HTMLScriptElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#script-processing-model:the-script-element-26>
-    fn children_changed(&self, mutation: &ChildrenMutation) {
+    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation);
+            s.children_changed(mutation, can_gc);
         }
 
         if self.upcast::<Node>().is_connected() && !self.parser_inserted.get() {

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -727,12 +727,12 @@ impl VirtualMethods for HTMLSelectElement {
             .hide_embedder_control(self.upcast());
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation) {
+    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation);
+            s.children_changed(mutation, can_gc);
         }
 
-        self.update_shadow_tree(CanGc::note());
+        self.update_shadow_tree(can_gc);
     }
 
     fn parse_plain_attribute(&self, local_name: &LocalName, value: DOMString) -> AttrValue {

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -299,8 +299,10 @@ impl VirtualMethods for HTMLStyleElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation) {
-        self.super_type().unwrap().children_changed(mutation);
+    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
+        self.super_type()
+            .unwrap()
+            .children_changed(mutation, can_gc);
 
         // https://html.spec.whatwg.org/multipage/#update-a-style-block
         // Handles the case when:

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -642,9 +642,9 @@ impl VirtualMethods for HTMLTextAreaElement {
             .perform_validation_and_update(ValidationFlags::all(), can_gc);
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation) {
+    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation);
+            s.children_changed(mutation, can_gc);
         }
         if !self.value_dirty.get() {
             self.reset();

--- a/components/script/dom/html/htmltitleelement.rs
+++ b/components/script/dom/html/htmltitleelement.rs
@@ -80,9 +80,9 @@ impl VirtualMethods for HTMLTitleElement {
         Some(self.upcast::<HTMLElement>() as &dyn VirtualMethods)
     }
 
-    fn children_changed(&self, mutation: &ChildrenMutation) {
+    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation);
+            s.children_changed(mutation, can_gc);
         }
 
         // Notify of title changes only after the initial full parsing

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::root::{DomRoot, LayoutDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::{AttributeMutation, Element, LayoutElementHelpers};
-use crate::dom::node::{Node, NodeDamage};
+use crate::dom::node::{ChildrenMutation, Node, NodeDamage};
 use crate::dom::svg::svggraphicselement::SVGGraphicsElement;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
@@ -173,9 +173,9 @@ impl VirtualMethods for SVGSVGElement {
         }
     }
 
-    fn children_changed(&self, mutation: &crate::dom::node::ChildrenMutation) {
+    fn children_changed(&self, mutation: &ChildrenMutation, can_gc: CanGc) {
         if let Some(super_type) = self.super_type() {
-            super_type.children_changed(mutation);
+            super_type.children_changed(mutation, can_gc);
         }
 
         self.invalidate_cached_serialized_subtree();

--- a/components/script/dom/virtualmethods.rs
+++ b/components/script/dom/virtualmethods.rs
@@ -124,9 +124,9 @@ pub(crate) trait VirtualMethods {
     }
 
     /// Called on the parent when its children are changed.
-    fn children_changed(&self, mutation: &ChildrenMutation) {
+    fn children_changed(&self, mutation: &ChildrenMutation, _can_gc: CanGc) {
         if let Some(s) = self.super_type() {
-            s.children_changed(mutation);
+            s.children_changed(mutation, _can_gc);
         }
     }
 


### PR DESCRIPTION
script: add CanGc as argument to VirtualMethods::children_changed

Testing: These changes do not require tests because they are a refactor.
Addresses part of https://github.com/servo/servo/issues/34573