### PR TITLE
devtools: move test for IdMap to a separate mod test

### DIFF
--- a/components/devtools/id.rs
+++ b/components/devtools/id.rs
@@ -80,95 +80,100 @@ impl DevtoolsOuterWindowId {
     }
 }
 
-#[test]
-pub(crate) fn test_id_map() {
-    use std::thread;
+#[cfg(test)]
+mod test {
+    use super::*;
 
-    use base::id::{PipelineNamespace, PipelineNamespaceId};
-    use crossbeam_channel::unbounded;
+    #[test]
+    pub(crate) fn test_id_map() {
+        use std::thread;
 
-    macro_rules! test_sequential_id_assignment {
-        ($id_type:ident, $new_id_function:expr, $map_id_function:expr) => {
-            let (sender, receiver) = unbounded();
-            let sender1 = sender.clone();
-            let sender2 = sender.clone();
-            let sender3 = sender.clone();
-            let threads = [
-                thread::spawn(move || {
-                    PipelineNamespace::install(PipelineNamespaceId(1));
-                    sender1.send($new_id_function()).expect("Send failed");
-                    sender1.send($new_id_function()).expect("Send failed");
-                    sender1.send($new_id_function()).expect("Send failed");
-                }),
-                thread::spawn(move || {
-                    PipelineNamespace::install(PipelineNamespaceId(2));
-                    sender2.send($new_id_function()).expect("Send failed");
-                    sender2.send($new_id_function()).expect("Send failed");
-                    sender2.send($new_id_function()).expect("Send failed");
-                }),
-                thread::spawn(move || {
-                    PipelineNamespace::install(PipelineNamespaceId(3));
-                    sender3.send($new_id_function()).expect("Send failed");
-                    sender3.send($new_id_function()).expect("Send failed");
-                    sender3.send($new_id_function()).expect("Send failed");
-                }),
-            ];
-            for thread in threads {
-                thread.join().expect("Thread join failed");
-            }
-            let mut id_map = IdMap::default();
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(1)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(2)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(3)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(4)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(5)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(6)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(7)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(8)
-            );
-            assert_eq!(
-                $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
-                $id_type(9)
-            );
-        };
+        use base::id::{PipelineNamespace, PipelineNamespaceId};
+        use crossbeam_channel::unbounded;
+
+        macro_rules! test_sequential_id_assignment {
+            ($id_type:ident, $new_id_function:expr, $map_id_function:expr) => {
+                let (sender, receiver) = unbounded();
+                let sender1 = sender.clone();
+                let sender2 = sender.clone();
+                let sender3 = sender.clone();
+                let threads = [
+                    thread::spawn(move || {
+                        PipelineNamespace::install(PipelineNamespaceId(1));
+                        sender1.send($new_id_function()).expect("Send failed");
+                        sender1.send($new_id_function()).expect("Send failed");
+                        sender1.send($new_id_function()).expect("Send failed");
+                    }),
+                    thread::spawn(move || {
+                        PipelineNamespace::install(PipelineNamespaceId(2));
+                        sender2.send($new_id_function()).expect("Send failed");
+                        sender2.send($new_id_function()).expect("Send failed");
+                        sender2.send($new_id_function()).expect("Send failed");
+                    }),
+                    thread::spawn(move || {
+                        PipelineNamespace::install(PipelineNamespaceId(3));
+                        sender3.send($new_id_function()).expect("Send failed");
+                        sender3.send($new_id_function()).expect("Send failed");
+                        sender3.send($new_id_function()).expect("Send failed");
+                    }),
+                ];
+                for thread in threads {
+                    thread.join().expect("Thread join failed");
+                }
+                let mut id_map = IdMap::default();
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(1)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(2)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(3)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(4)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(5)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(6)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(7)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(8)
+                );
+                assert_eq!(
+                    $map_id_function(&mut id_map, receiver.recv().expect("Recv failed")),
+                    $id_type(9)
+                );
+            };
+        }
+
+        test_sequential_id_assignment!(
+            DevtoolsBrowserId,
+            || WebViewId::new(base::id::TEST_PAINTER_ID),
+            |id_map: &mut IdMap, id| id_map.browser_id(id)
+        );
+        test_sequential_id_assignment!(
+            DevtoolsBrowsingContextId,
+            || BrowsingContextId::new(),
+            |id_map: &mut IdMap, id| id_map.browsing_context_id(id)
+        );
+        test_sequential_id_assignment!(
+            DevtoolsOuterWindowId,
+            || PipelineId::new(),
+            |id_map: &mut IdMap, id| id_map.outer_window_id(id)
+        );
     }
-
-    test_sequential_id_assignment!(
-        DevtoolsBrowserId,
-        || WebViewId::new(base::id::TEST_PAINTER_ID),
-        |id_map: &mut IdMap, id| id_map.browser_id(id)
-    );
-    test_sequential_id_assignment!(
-        DevtoolsBrowsingContextId,
-        || BrowsingContextId::new(),
-        |id_map: &mut IdMap, id| id_map.browsing_context_id(id)
-    );
-    test_sequential_id_assignment!(
-        DevtoolsOuterWindowId,
-        || PipelineId::new(),
-        |id_map: &mut IdMap, id| id_map.outer_window_id(id)
-    );
 }


### PR DESCRIPTION
devtools: move test for IdMap to a separate mod test

Testing: existing unit test still runs with mach test-unit.

This change will reduce the amount of code that the compiler has to compile when we are not running tests.
