### PR TITLE
devtools: Expose cache status for requests in network monitor.

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -465,6 +465,7 @@ pub fn send_response_to_devtools(
         meta.headers.map(Serde::into_inner),
         meta.status,
         body_data,
+        response.cache_state,
         request,
         context.devtools_chan.clone(),
     );
@@ -475,6 +476,7 @@ pub fn send_response_values_to_devtools(
     headers: Option<HeaderMap>,
     status: HttpStatus,
     body: Option<Vec<u8>>,
+    cache_state: CacheState,
     request: &Request,
     devtools_chan: Option<StdArc<Mutex<Sender<DevtoolsControlMsg>>>>,
 ) {
@@ -484,11 +486,13 @@ pub fn send_response_values_to_devtools(
         request.target_webview_id,
     ) {
         let browsing_context_id = webview_id.into();
+        let from_cache = matches!(cache_state, CacheState::Local | CacheState::Validated);
 
         let devtoolsresponse = DevtoolsHttpResponse {
             headers,
             status,
             body,
+            from_cache,
             pipeline_id,
             browsing_context_id,
         };
@@ -2200,6 +2204,7 @@ async fn http_network_fetch(
                     Some(headers),
                     status,
                     Some(devtools_response_body),
+                    CacheState::None,
                     &devtools_request,
                     devtools_chan,
                 );

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -1487,6 +1487,7 @@ fn test_fetch_with_devtools() {
         headers: Some(response_headers),
         status: HttpStatus::default(),
         body: Some(content.as_bytes().to_vec()),
+        from_cache: false,
         pipeline_id: TEST_PIPELINE_ID,
         browsing_context_id: TEST_WEBVIEW_ID.into(),
     };

--- a/components/net/tests/http_loader.rs
+++ b/components/net/tests/http_loader.rs
@@ -423,6 +423,7 @@ fn test_request_and_response_data_with_network_messages() {
         headers: Some(response_headers),
         status: HttpStatus::default(),
         body: Some(content.as_bytes().to_vec()),
+        from_cache: false,
         pipeline_id: TEST_PIPELINE_ID,
         browsing_context_id: TEST_WEBVIEW_ID.into(),
     };

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -464,6 +464,7 @@ pub struct HttpResponse {
     pub headers: Option<HeaderMap>,
     pub status: HttpStatus,
     pub body: Option<Vec<u8>>,
+    pub from_cache: bool,
     pub pipeline_id: PipelineId,
     pub browsing_context_id: BrowsingContextId,
 }

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -59,7 +59,7 @@ impl ResponseBody {
 }
 
 /// [Cache state](https://fetch.spec.whatwg.org/#concept-response-cache-state)
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub enum CacheState {
     None,
     Local,


### PR DESCRIPTION
Expose cache status for requests in network monitor.

Testing: Net tests pass. No existing test infrastructure for devtools, adding them seems outside the scope of this PR.
Fixes: #40237
