### PR TITLE
move unit tests to a separate mod test

### DIFF
--- a/components/layout/flow/inline/line_breaker.rs
+++ b/components/layout/flow/inline/line_breaker.rs
@@ -54,67 +54,72 @@ impl LineBreaker {
     }
 }
 
-#[test]
-fn test_linebreaker_ranges() {
-    let linebreaker = LineBreaker::new("abc def");
-    assert_eq!(linebreaker.linebreaks, [4, 7]);
-    assert_eq!(
-        linebreaker.linebreaks_in_range_after_current_offset(0..5),
-        0..1
-    );
-    // The last linebreak should not be included for the text range we are interested in.
-    assert_eq!(
-        linebreaker.linebreaks_in_range_after_current_offset(0..7),
-        0..1
-    );
+#[cfg(test)]
+mod test {
+    use super::*;
 
-    let linebreaker = LineBreaker::new("abc d def");
-    assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
-    assert_eq!(
-        linebreaker.linebreaks_in_range_after_current_offset(0..5),
-        0..1
-    );
-    assert_eq!(
-        linebreaker.linebreaks_in_range_after_current_offset(0..7),
-        0..2
-    );
-    assert_eq!(
-        linebreaker.linebreaks_in_range_after_current_offset(0..9),
-        0..2
-    );
-
-    assert_eq!(
-        linebreaker.linebreaks_in_range_after_current_offset(4..9),
-        0..2
-    );
-
-    std::panic::catch_unwind(|| {
+    #[test]
+    fn test_linebreaker_ranges() {
         let linebreaker = LineBreaker::new("abc def");
-        linebreaker.linebreaks_in_range_after_current_offset(5..2);
-    })
-    .expect_err("Reversed range should cause an assertion failure.");
-}
+        assert_eq!(linebreaker.linebreaks, [4, 7]);
+        assert_eq!(
+            linebreaker.linebreaks_in_range_after_current_offset(0..5),
+            0..1
+        );
+        // The last linebreak should not be included for the text range we are interested in.
+        assert_eq!(
+            linebreaker.linebreaks_in_range_after_current_offset(0..7),
+            0..1
+        );
 
-#[test]
-fn test_linebreaker_stateful_advance() {
-    let mut linebreaker = LineBreaker::new("abc d def");
-    assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
-    assert!(linebreaker.advance_to_linebreaks_in_range(0..7) == &[4, 6]);
-    assert!(linebreaker.advance_to_linebreaks_in_range(8..9).is_empty());
+        let linebreaker = LineBreaker::new("abc d def");
+        assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
+        assert_eq!(
+            linebreaker.linebreaks_in_range_after_current_offset(0..5),
+            0..1
+        );
+        assert_eq!(
+            linebreaker.linebreaks_in_range_after_current_offset(0..7),
+            0..2
+        );
+        assert_eq!(
+            linebreaker.linebreaks_in_range_after_current_offset(0..9),
+            0..2
+        );
 
-    // We've already advanced, so a range from the beginning shouldn't affect things.
-    assert!(linebreaker.advance_to_linebreaks_in_range(0..9).is_empty());
+        assert_eq!(
+            linebreaker.linebreaks_in_range_after_current_offset(4..9),
+            0..2
+        );
 
-    linebreaker.current_offset = 0;
+        std::panic::catch_unwind(|| {
+            let linebreaker = LineBreaker::new("abc def");
+            linebreaker.linebreaks_in_range_after_current_offset(5..2);
+        })
+        .expect_err("Reversed range should cause an assertion failure.");
+    }
 
-    // Sending a value out of range shoudn't break things.
-    assert!(linebreaker.advance_to_linebreaks_in_range(0..999) == &[4, 6]);
-
-    linebreaker.current_offset = 0;
-
-    std::panic::catch_unwind(|| {
+    #[test]
+    fn test_linebreaker_stateful_advance() {
         let mut linebreaker = LineBreaker::new("abc d def");
-        linebreaker.advance_to_linebreaks_in_range(2..0);
-    })
-    .expect_err("Reversed range should cause an assertion failure.");
+        assert_eq!(linebreaker.linebreaks, [4, 6, 9]);
+        assert!(linebreaker.advance_to_linebreaks_in_range(0..7) == &[4, 6]);
+        assert!(linebreaker.advance_to_linebreaks_in_range(8..9).is_empty());
+
+        // We've already advanced, so a range from the beginning shouldn't affect things.
+        assert!(linebreaker.advance_to_linebreaks_in_range(0..9).is_empty());
+
+        linebreaker.current_offset = 0;
+
+        // Sending a value out of range shoudn't break things.
+        assert!(linebreaker.advance_to_linebreaks_in_range(0..999) == &[4, 6]);
+
+        linebreaker.current_offset = 0;
+
+        std::panic::catch_unwind(|| {
+            let mut linebreaker = LineBreaker::new("abc d def");
+            linebreaker.advance_to_linebreaks_in_range(2..0);
+        })
+        .expect_err("Reversed range should cause an assertion failure.");
+    }
 }

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -711,199 +711,212 @@ pub trait WebViewDelegate {
 pub(crate) struct DefaultWebViewDelegate;
 impl WebViewDelegate for DefaultWebViewDelegate {}
 
-#[test]
-fn test_allow_deny_request() {
-    use base::generic_channel;
+#[cfg(test)]
+mod test {
+    use super::*;
 
-    use crate::ServoErrorChannel;
+    #[test]
+    fn test_allow_deny_request() {
+        use base::generic_channel;
 
-    for default_response in [AllowOrDeny::Allow, AllowOrDeny::Deny] {
-        // Explicit allow yields allow and nothing else
+        use crate::ServoErrorChannel;
+
+        for default_response in [AllowOrDeny::Allow, AllowOrDeny::Deny] {
+            // Explicit allow yields allow and nothing else
+            let errors = ServoErrorChannel::default();
+            let (sender, receiver) =
+                generic_channel::channel().expect("Failed to create IPC channel");
+            let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+            request.allow();
+            assert_eq!(receiver.try_recv().ok(), Some(AllowOrDeny::Allow));
+            assert_eq!(receiver.try_recv().ok(), None);
+            assert!(errors.try_recv().is_none());
+
+            // Explicit deny yields deny and nothing else
+            let errors = ServoErrorChannel::default();
+            let (sender, receiver) =
+                generic_channel::channel().expect("Failed to create IPC channel");
+            let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+            request.deny();
+            assert_eq!(receiver.try_recv().ok(), Some(AllowOrDeny::Deny));
+            assert_eq!(receiver.try_recv().ok(), None);
+            assert!(errors.try_recv().is_none());
+
+            // No response yields default response and nothing else
+            let errors = ServoErrorChannel::default();
+            let (sender, receiver) =
+                generic_channel::channel().expect("Failed to create IPC channel");
+            let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+            drop(request);
+            assert_eq!(receiver.try_recv().ok(), Some(default_response));
+            assert_eq!(receiver.try_recv().ok(), None);
+            assert!(errors.try_recv().is_none());
+
+            // Explicit allow when receiver disconnected yields error
+            let errors = ServoErrorChannel::default();
+            let (sender, receiver) =
+                generic_channel::channel().expect("Failed to create IPC channel");
+            let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+            drop(receiver);
+            request.allow();
+            assert!(errors.try_recv().is_some());
+
+            // Explicit deny when receiver disconnected yields error
+            let errors = ServoErrorChannel::default();
+            let (sender, receiver) =
+                generic_channel::channel().expect("Failed to create IPC channel");
+            let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+            drop(receiver);
+            request.deny();
+            assert!(errors.try_recv().is_some());
+
+            // No response when receiver disconnected yields no error
+            let errors = ServoErrorChannel::default();
+            let (sender, receiver) =
+                generic_channel::channel().expect("Failed to create IPC channel");
+            let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+            drop(receiver);
+            drop(request);
+            assert!(errors.try_recv().is_none());
+        }
+    }
+
+    #[test]
+    fn test_authentication_request() {
+        use base::generic_channel;
+
+        use crate::ServoErrorChannel;
+
+        let url = Url::parse("https://example.com").expect("Guaranteed by argument");
+
+        // Explicit response yields that response and nothing else
         let errors = ServoErrorChannel::default();
         let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-        let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
-        request.allow();
-        assert_eq!(receiver.try_recv().ok(), Some(AllowOrDeny::Allow));
+        let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
+        request.authenticate("diffie".to_owned(), "hunter2".to_owned());
+        assert_eq!(
+            receiver.try_recv().ok(),
+            Some(Some(AuthenticationResponse {
+                username: "diffie".to_owned(),
+                password: "hunter2".to_owned(),
+            }))
+        );
         assert_eq!(receiver.try_recv().ok(), None);
         assert!(errors.try_recv().is_none());
 
-        // Explicit deny yields deny and nothing else
+        // No response yields None response and nothing else
         let errors = ServoErrorChannel::default();
         let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-        let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
-        request.deny();
-        assert_eq!(receiver.try_recv().ok(), Some(AllowOrDeny::Deny));
-        assert_eq!(receiver.try_recv().ok(), None);
-        assert!(errors.try_recv().is_none());
-
-        // No response yields default response and nothing else
-        let errors = ServoErrorChannel::default();
-        let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-        let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+        let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
         drop(request);
-        assert_eq!(receiver.try_recv().ok(), Some(default_response));
+        assert_eq!(receiver.try_recv().ok(), Some(None));
         assert_eq!(receiver.try_recv().ok(), None);
         assert!(errors.try_recv().is_none());
 
-        // Explicit allow when receiver disconnected yields error
+        // Explicit response when receiver disconnected yields error
         let errors = ServoErrorChannel::default();
         let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-        let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+        let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
         drop(receiver);
-        request.allow();
-        assert!(errors.try_recv().is_some());
-
-        // Explicit deny when receiver disconnected yields error
-        let errors = ServoErrorChannel::default();
-        let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-        let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
-        drop(receiver);
-        request.deny();
+        request.authenticate("diffie".to_owned(), "hunter2".to_owned());
         assert!(errors.try_recv().is_some());
 
         // No response when receiver disconnected yields no error
         let errors = ServoErrorChannel::default();
         let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-        let request = AllowOrDenyRequest::new(sender, default_response, errors.sender());
+        let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
         drop(receiver);
         drop(request);
         assert!(errors.try_recv().is_none());
     }
-}
 
-#[test]
-fn test_authentication_request() {
-    use base::generic_channel;
+    #[test]
+    fn test_web_resource_load() {
+        use base::generic_channel;
+        use http::{HeaderMap, Method, StatusCode};
 
-    use crate::ServoErrorChannel;
+        use crate::ServoErrorChannel;
 
-    let url = Url::parse("https://example.com").expect("Guaranteed by argument");
-
-    // Explicit response yields that response and nothing else
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-    let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
-    request.authenticate("diffie".to_owned(), "hunter2".to_owned());
-    assert_eq!(
-        receiver.try_recv().ok(),
-        Some(Some(AuthenticationResponse {
-            username: "diffie".to_owned(),
-            password: "hunter2".to_owned(),
-        }))
-    );
-    assert_eq!(receiver.try_recv().ok(), None);
-    assert!(errors.try_recv().is_none());
-
-    // No response yields None response and nothing else
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-    let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
-    drop(request);
-    assert_eq!(receiver.try_recv().ok(), Some(None));
-    assert_eq!(receiver.try_recv().ok(), None);
-    assert!(errors.try_recv().is_none());
-
-    // Explicit response when receiver disconnected yields error
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-    let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
-    drop(receiver);
-    request.authenticate("diffie".to_owned(), "hunter2".to_owned());
-    assert!(errors.try_recv().is_some());
-
-    // No response when receiver disconnected yields no error
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-    let request = AuthenticationRequest::new(url.clone(), false, sender, errors.sender());
-    drop(receiver);
-    drop(request);
-    assert!(errors.try_recv().is_none());
-}
-
-#[test]
-fn test_web_resource_load() {
-    use base::generic_channel;
-    use http::{HeaderMap, Method, StatusCode};
-
-    use crate::ServoErrorChannel;
-
-    let web_resource_request = || WebResourceRequest {
-        method: Method::GET,
-        headers: HeaderMap::default(),
-        url: Url::parse("https://example.com").expect("Guaranteed by argument"),
-        is_for_main_frame: false,
-        is_redirect: false,
-    };
-    let web_resource_response = || {
-        WebResourceResponse::new(Url::parse("https://diffie.test").expect("Guaranteed by argument"))
+        let web_resource_request = || WebResourceRequest {
+            method: Method::GET,
+            headers: HeaderMap::default(),
+            url: Url::parse("https://example.com").expect("Guaranteed by argument"),
+            is_for_main_frame: false,
+            is_redirect: false,
+        };
+        let web_resource_response = || {
+            WebResourceResponse::new(
+                Url::parse("https://diffie.test").expect("Guaranteed by argument"),
+            )
             .status_code(StatusCode::IM_A_TEAPOT)
-    };
+        };
 
-    // Explicit intercept with explicit cancel yields Start and Cancel and nothing else
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-    let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
-    request.intercept(web_resource_response()).cancel();
-    assert!(matches!(
-        receiver.try_recv(),
-        Ok(WebResourceResponseMsg::Start(_))
-    ));
-    assert!(matches!(
-        receiver.try_recv(),
-        Ok(WebResourceResponseMsg::CancelLoad)
-    ));
-    assert!(matches!(receiver.try_recv(), Err(_)));
-    assert!(errors.try_recv().is_none());
+        // Explicit intercept with explicit cancel yields Start and Cancel and nothing else
+        let errors = ServoErrorChannel::default();
+        let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
+        let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
+        request.intercept(web_resource_response()).cancel();
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(WebResourceResponseMsg::Start(_))
+        ));
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(WebResourceResponseMsg::CancelLoad)
+        ));
+        assert!(matches!(receiver.try_recv(), Err(_)));
+        assert!(errors.try_recv().is_none());
 
-    // Explicit intercept with no further action yields Start and FinishLoad and nothing else
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-    let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
-    drop(request.intercept(web_resource_response()));
-    assert!(matches!(
-        receiver.try_recv(),
-        Ok(WebResourceResponseMsg::Start(_))
-    ));
-    assert!(matches!(
-        receiver.try_recv(),
-        Ok(WebResourceResponseMsg::FinishLoad)
-    ));
-    assert!(matches!(receiver.try_recv(), Err(_)));
-    assert!(errors.try_recv().is_none());
+        // Explicit intercept with no further action yields Start and FinishLoad and nothing else
+        let errors = ServoErrorChannel::default();
+        let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
+        let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
+        drop(request.intercept(web_resource_response()));
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(WebResourceResponseMsg::Start(_))
+        ));
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(WebResourceResponseMsg::FinishLoad)
+        ));
+        assert!(matches!(receiver.try_recv(), Err(_)));
+        assert!(errors.try_recv().is_none());
 
-    // No response yields DoNotIntercept and nothing else
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-    let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
-    drop(request);
-    assert!(matches!(
-        receiver.try_recv(),
-        Ok(WebResourceResponseMsg::DoNotIntercept)
-    ));
-    assert!(matches!(receiver.try_recv(), Err(_)));
-    assert!(errors.try_recv().is_none());
+        // No response yields DoNotIntercept and nothing else
+        let errors = ServoErrorChannel::default();
+        let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
+        let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
+        drop(request);
+        assert!(matches!(
+            receiver.try_recv(),
+            Ok(WebResourceResponseMsg::DoNotIntercept)
+        ));
+        assert!(matches!(receiver.try_recv(), Err(_)));
+        assert!(errors.try_recv().is_none());
 
-    // Explicit intercept with explicit cancel when receiver disconnected yields error
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-    let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
-    drop(receiver);
-    request.intercept(web_resource_response()).cancel();
-    assert!(errors.try_recv().is_some());
+        // Explicit intercept with explicit cancel when receiver disconnected yields error
+        let errors = ServoErrorChannel::default();
+        let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
+        let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
+        drop(receiver);
+        request.intercept(web_resource_response()).cancel();
+        assert!(errors.try_recv().is_some());
 
-    // Explicit intercept with no further action when receiver disconnected yields error
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-    let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
-    drop(receiver);
-    drop(request.intercept(web_resource_response()));
-    assert!(errors.try_recv().is_some());
+        // Explicit intercept with no further action when receiver disconnected yields error
+        let errors = ServoErrorChannel::default();
+        let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
+        let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
+        drop(receiver);
+        drop(request.intercept(web_resource_response()));
+        assert!(errors.try_recv().is_some());
 
-    // No response when receiver disconnected yields no error
-    let errors = ServoErrorChannel::default();
-    let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
-    let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
-    drop(receiver);
-    drop(request);
-    assert!(errors.try_recv().is_none());
+        // No response when receiver disconnected yields no error
+        let errors = ServoErrorChannel::default();
+        let (sender, receiver) = generic_channel::channel().expect("Failed to create IPC channel");
+        let request = WebResourceLoad::new(web_resource_request(), sender, errors.sender());
+        drop(receiver);
+        drop(request);
+        assert!(errors.try_recv().is_none());
+    }
 }

--- a/components/shared/base/text.rs
+++ b/components/shared/base/text.rs
@@ -44,21 +44,26 @@ pub fn is_cjk(codepoint: char) -> bool {
     unicode_plane(codepoint) == 2 || unicode_plane(codepoint) == 3
 }
 
-#[test]
-fn test_is_cjk() {
-    // Test characters from different CJK blocks
-    assert_eq!(is_cjk('〇'), true);
-    assert_eq!(is_cjk('㐀'), true);
-    assert_eq!(is_cjk('あ'), true);
-    assert_eq!(is_cjk('ア'), true);
-    assert_eq!(is_cjk('㆒'), true);
-    assert_eq!(is_cjk('ㆣ'), true);
-    assert_eq!(is_cjk('龥'), true);
-    assert_eq!(is_cjk('𰾑'), true);
-    assert_eq!(is_cjk('𰻝'), true);
+#[cfg(test)]
+mod test {
+    use super::*;
 
-    // Test characters from outside CJK blocks
-    assert_eq!(is_cjk('a'), false);
-    assert_eq!(is_cjk('🙂'), false);
-    assert_eq!(is_cjk('©'), false);
+    #[test]
+    fn test_is_cjk() {
+        // Test characters from different CJK blocks
+        assert_eq!(is_cjk('〇'), true);
+        assert_eq!(is_cjk('㐀'), true);
+        assert_eq!(is_cjk('あ'), true);
+        assert_eq!(is_cjk('ア'), true);
+        assert_eq!(is_cjk('㆒'), true);
+        assert_eq!(is_cjk('ㆣ'), true);
+        assert_eq!(is_cjk('龥'), true);
+        assert_eq!(is_cjk('𰾑'), true);
+        assert_eq!(is_cjk('𰻝'), true);
+
+        // Test characters from outside CJK blocks
+        assert_eq!(is_cjk('a'), false);
+        assert_eq!(is_cjk('🙂'), false);
+        assert_eq!(is_cjk('©'), false);
+    }
 }

--- a/components/shared/storage/indexeddb_thread.rs
+++ b/components/shared/storage/indexeddb_thread.rs
@@ -243,21 +243,6 @@ pub struct IndexedDBRecord {
     pub value: Vec<u8>,
 }
 
-#[test]
-fn test_as_singleton() {
-    let key = IndexedDBKeyType::Number(1.0);
-    let key2 = IndexedDBKeyType::Number(2.0);
-    let range = IndexedDBKeyRange::only(key.clone());
-    assert!(range.is_singleton());
-    assert!(range.as_singleton().is_some());
-    let range = IndexedDBKeyRange::new(Some(key), Some(key2.clone()), false, false);
-    assert!(!range.is_singleton());
-    assert!(range.as_singleton().is_none());
-    let full_range = IndexedDBKeyRange::new(None, None, false, false);
-    assert!(!full_range.is_singleton());
-    assert!(full_range.as_singleton().is_none());
-}
-
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub enum PutItemResult {
     Success,
@@ -462,4 +447,24 @@ pub enum IndexedDBThreadMsg {
         IndexedDBTxnMode,
         AsyncOperation,
     ),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_as_singleton() {
+        let key = IndexedDBKeyType::Number(1.0);
+        let key2 = IndexedDBKeyType::Number(2.0);
+        let range = IndexedDBKeyRange::only(key.clone());
+        assert!(range.is_singleton());
+        assert!(range.as_singleton().is_some());
+        let range = IndexedDBKeyRange::new(Some(key), Some(key2.clone()), false, false);
+        assert!(!range.is_singleton());
+        assert!(range.as_singleton().is_none());
+        let full_range = IndexedDBKeyRange::new(None, None, false, false);
+        assert!(!full_range.is_singleton());
+        assert!(full_range.as_singleton().is_none());
+    }
 }


### PR DESCRIPTION
move unit tests to a separate mod test

Testing: existing unit test still runs with mach test-unit.

This change will reduce the amount of code that the compiler has to compile when we are not running tests.