### PR TITLE
script: Use `base64ct` instead of `base64` in SubtleCrypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7490,6 +7490,7 @@ dependencies = [
  "backtrace",
  "base",
  "base64 0.22.1",
+ "base64ct",
  "bincode",
  "bitflags 2.10.0",
  "bluetooth_traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ background_hang_monitor_api = { path = "components/shared/background_hang_monito
 backtrace = "0.3"
 base = { path = "components/shared/base" }
 base64 = "0.22.1"
+base64ct = { version = "1.8", features = ["alloc"] }
 bincode = "1"
 bitflags = "2.10"
 bluetooth_traits = { path = "components/shared/bluetooth" }

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -43,6 +43,7 @@ background_hang_monitor_api = { workspace = true }
 backtrace = { workspace = true }
 base = { workspace = true }
 base64 = { workspace = true }
+base64ct = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true }
 bluetooth_traits = { workspace = true, optional = true }

--- a/components/script/dom/subtlecrypto/aes_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_operation.rs
@@ -8,7 +8,7 @@ use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit, StreamCipher};
 use aes::{Aes128, Aes192, Aes256};
 use aes_gcm::{AeadInPlace, AesGcm, KeyInit};
 use aes_kw::{KekAes128, KekAes192, KekAes256};
-use base64::prelude::*;
+use base64ct::{Base64UrlUnpadded, Encoding};
 use cipher::consts::{U12, U16, U32};
 use rand::TryRngCore;
 use rand::rngs::OsRng;
@@ -849,8 +849,7 @@ fn import_key_aes(
             // NOTE: Done by Step 2.4 and 2.5.
 
             // Step 2.4. Let data be the byte sequence obtained by decoding the k field of jwk.
-            data = base64::engine::general_purpose::STANDARD_NO_PAD
-                .decode(&*jwk.k.as_ref().ok_or(Error::Data)?.as_bytes())
+            data = Base64UrlUnpadded::decode_vec(&jwk.k.as_ref().ok_or(Error::Data)?.str())
                 .map_err(|_| Error::Data)?;
 
             // NOTE: This function is shared by AES-CBC, AES-CTR, AES-GCM and AES-KW.
@@ -997,9 +996,9 @@ fn export_key_aes(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Err
             // the key represented by the [[handle]] internal slot of key, encoded according to
             // Section 6.4 of JSON Web Algorithms [JWA].
             let k = match key.handle() {
-                Handle::Aes128(key) => base64::engine::general_purpose::STANDARD_NO_PAD.encode(key),
-                Handle::Aes192(key) => base64::engine::general_purpose::STANDARD_NO_PAD.encode(key),
-                Handle::Aes256(key) => base64::engine::general_purpose::STANDARD_NO_PAD.encode(key),
+                Handle::Aes128(key) => Base64UrlUnpadded::encode_string(key),
+                Handle::Aes192(key) => Base64UrlUnpadded::encode_string(key),
+                Handle::Aes256(key) => Base64UrlUnpadded::encode_string(key),
                 _ => unreachable!(),
             };
 

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use aws_lc_rs::hmac;
-use base64::prelude::*;
+use base64ct::{Base64UrlUnpadded, Encoding};
 use rand::TryRngCore;
 use rand::rngs::OsRng;
 use script_bindings::codegen::GenericBindings::CryptoKeyBinding::CryptoKeyMethods;
@@ -198,8 +198,7 @@ pub(crate) fn import_key(
             // NOTE: Done by Step 2.4 and 2.6.
 
             // Step 2.4. Let data be the byte sequence obtained by decoding the k field of jwk.
-            data = base64::engine::general_purpose::STANDARD_NO_PAD
-                .decode(&*jwk.k.as_ref().ok_or(Error::Data)?.as_bytes())
+            data = Base64UrlUnpadded::decode_vec(&jwk.k.as_ref().ok_or(Error::Data)?.str())
                 .map_err(|_| Error::Data)?;
 
             // Step 2.5. Set the hash to equal the hash member of normalizedAlgorithm.
@@ -330,7 +329,7 @@ pub(crate) fn export(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, 
         KeyFormat::Jwk => {
             let key_data = key.handle().as_bytes();
             // Step 3. Set the k attribute of jwk to be a string containing data
-            let k = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(key_data);
+            let k = Base64UrlUnpadded::encode_string(key_data);
             // Step 6.
             let hash_algorithm = match key.algorithm() {
                 KeyAlgorithmAndDerivatives::HmacKeyAlgorithm(alg) => match &*alg.hash.name {


### PR DESCRIPTION
The `SubtleCrypto` interface of WebCrypto API needs to encode and decode keys in base64 alphabets when exporting/importing keys in JsonWebKey format.

We currently use the `base64` crate to handle base64 encoding and decoding. This patch switches to use the `base64ct` crate, which is a constant-time implementation of base64 alphabets.

Using constant-time implementation to handle base64 encoding and decoding of cryptographic secret provides a better protection against time-based sidechannel attack.

Remarks: The multi-line changes in `ecdh_operation.rs` are mostly caused by `./mach fmt`.

Testing: Refactoring. Existing tests suffice.
