### PR TITLE
wpt: Remove annotations in `executorservo.py`

### DIFF
--- a/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservo.py
@@ -28,7 +28,7 @@ webdriver = None
 
 
 class ServoExecutor(ProcessTestExecutor):
-    def __init__(self, logger, browser, server_config, headless: bool,
+    def __init__(self, logger, browser, server_config, headless,
                 timeout_multiplier, debug_info,
                  pause_after_test, reftest_screenshot="unexpected"):
         ProcessTestExecutor.__init__(self, logger, browser, server_config,


### PR DESCRIPTION
The upstream WPT runs with Python 3.8 which does not support type
annotations. This is an attempt to get future changes to the file to
merge successfully upstream.
