### PR TITLE
CI: Add free disk space in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
       - name: Setup Python
         uses: ./.github/actions/setup-python
       - name: Bootstrap


### PR DESCRIPTION
Should fix docs workflow which currently fails because not enough space is left: https://github.com/servo/servo/actions/runs/18964865479

run: https://github.com/servo/servo/actions/runs/18997885819
