### PR TITLE
wpt: Turn on `selectFiles` and handle asynchronicity in FileAPI test

### DIFF
--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -2063,7 +2063,7 @@ impl HTMLInputElementMethods<crate::DomTypeHolder> for HTMLInputElement {
     }
 
     /// Select the files based on filepaths passed in, enabled by
-    /// `dom.htmlinputelement.select_files.enabled`, used for test purpose.
+    /// `dom_testing_html_input_element_select_files_enabled`, used for test purpose.
     fn SelectFiles(&self, paths: Vec<DOMString>) {
         if self.input_type() == InputType::File {
             self.select_files(Some(paths));

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -7702,7 +7702,7 @@
    "mozilla": {
     "FileAPI": {
      "blob_url_upload.html": [
-      "17c8e3ad0b4fe904a77db8ecb9f63598e4a84b2c",
+      "dcf974d017dbf8499b9967704f8406a132237391",
       [
        null,
        [
@@ -10599,16 +10599,16 @@
     ],
     "FileAPI": {
      "blob_url_upload_ref.html": [
-      "6f95c43ac324528035901d763a02885505b49a9c",
+      "d24414fe19ed423c8b8121f12dd4648f0bf0df28",
       []
      ],
      "file-upload-frame.html": [
-      "13951bb37d06045220de53862bc45a9129c85ad9",
+      "eb2edda26647329cda5509736bcde0236fac0194",
       []
      ],
      "resource": {
       "file-submission.py": [
-       "5f65cebd05ce89b3a51c2382a39b6a6438133b43",
+       "bb10538bb79b85a9ae6aeb54b875099e0edc819a",
        []
       ],
       "upload.txt": [
@@ -12938,14 +12938,14 @@
       ]
      ],
      "file-select.html": [
-      "06a5f30dd441e9f4bb54ba7019469d7280f12310",
+      "066ff828e599ef1c4c6e87d64df19fdbb181f617",
       [
        null,
        {}
       ]
      ],
      "file-upload.html": [
-      "bff5fb1ee7a0908a7761cd7fa02895f732a3f1dd",
+      "56940864bf958be64757c43762c644cb4293ccad",
       [
        null,
        {}

--- a/tests/wpt/mozilla/meta/mozilla/FileAPI/__dir__.ini
+++ b/tests/wpt/mozilla/meta/mozilla/FileAPI/__dir__.ini
@@ -1,0 +1,3 @@
+prefs: [
+  "dom_testing_html_input_element_select_files_enabled:true",
+]

--- a/tests/wpt/mozilla/meta/mozilla/FileAPI/blob_url_upload.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/FileAPI/blob_url_upload.html.ini
@@ -1,2 +1,0 @@
-[blob_url_upload.html]
-  expected: FAIL

--- a/tests/wpt/mozilla/meta/mozilla/FileAPI/file-select.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/FileAPI/file-select.html.ini
@@ -1,4 +1,0 @@
-[file-select.html]
-  [Select a file]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/meta/mozilla/FileAPI/file-upload.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/FileAPI/file-upload.html.ini
@@ -1,4 +1,0 @@
-[file-upload.html]
-  [form submission of uploaded file]
-    expected: FAIL
-

--- a/tests/wpt/mozilla/tests/mozilla/FileAPI/blob_url_upload.html
+++ b/tests/wpt/mozilla/tests/mozilla/FileAPI/blob_url_upload.html
@@ -1,22 +1,27 @@
 <!doctype html>
+<html class="reftest-wait">
 <meta charset="utf-8">
 <title>Blob URL with File Upload</title>
 <link rel="match" href="blob_url_upload_ref.html">
+<script src="/common/reftest-wait.js"></script>
+
 <body>
     <img src="" id="image">
-    <input type="file" id="file-input"">
+    <!-- Hide the input field as it shows the file name, which will
+    introduce differences with the reference file. -->
+    <input style="visibility: hidden;" type="file" id="file-input"">
 </body>
 <script type="text/javascript">
-    var image = document.getElementById("image");
+    var inputElement = document.getElementById("file-input");
+    inputElement.addEventListener("change", () => {
+      var image = document.getElementById("image");
 
-    var inputElem = document.getElementById("file-input");
-
-    inputElem.selectFiles(["./tests/wpt/mozilla/tests/mozilla/test.jpg"]);
-
-    var f = inputElem.files[0];
-
-    var url = URL.createObjectURL(f);
-
-    image.src = url;
-
+      image.addEventListener("load", () => {
+        takeScreenshot();
+      });
+      image.src = URL.createObjectURL(inputElement.files[0]);
+    })
+    inputElement.selectFiles(["./tests/wpt/mozilla/tests/mozilla/test.jpg"]);
 </script>
+
+</html>

--- a/tests/wpt/mozilla/tests/mozilla/FileAPI/blob_url_upload_ref.html
+++ b/tests/wpt/mozilla/tests/mozilla/FileAPI/blob_url_upload_ref.html
@@ -3,5 +3,4 @@
 <title>Reference: Blob URL with File Upload</title>
 <body>
     <img src="../test.jpg" id="image">
-    <input type="file" id="file-input"">
 </body>

--- a/tests/wpt/mozilla/tests/mozilla/FileAPI/file-select.html
+++ b/tests/wpt/mozilla/tests/mozilla/FileAPI/file-select.html
@@ -9,23 +9,20 @@
 <script>
 
 async_test(function() {
-  var e = document.getElementById("file-input");
+  var fileInput = document.getElementById("file-input");
+  assert_true(fileInput.selectFiles != undefined, "selectFiles is not defined")
 
-  assert_true(e.selectFiles != undefined, "selectFiles is not defined")
 
-  e.selectFiles(["./tests/wpt/mozilla/tests/mozilla/test.txt"]);
+  fileInput.addEventListener("change", () => {
+    assert_true(fileInput.files.length > 0, "test.txt is not selected");
 
-  assert_true(e.files.length > 0, "test.txt is not selected");
-
-  var reader = new FileReader;
-
-  reader.onloadend = this.step_func(function(evt) {
-    assert_equals(evt.target.result, "hello, servo\n");
-
-    this.done();
+    var reader = new FileReader;
+    reader.onloadend = this.step_func_done(function(evt) {
+      assert_equals(evt.target.result, "hello, servo\n");
+    });
+    reader.readAsText(fileInput.files[0]);
   });
 
-  reader.readAsText(e.files[0]);
-
+  fileInput.selectFiles(["./tests/wpt/mozilla/tests/mozilla/test.txt"]);
 }, "Select a file");
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/FileAPI/file-upload-frame.html
+++ b/tests/wpt/mozilla/tests/mozilla/FileAPI/file-upload-frame.html
@@ -3,6 +3,9 @@
 </form>
 
 <script type="text/javascript">
-    var e = document.getElementById("file-input");
-    e.selectFiles(["./tests/wpt/mozilla/tests/mozilla/FileAPI/resource/upload.txt"]);
+    var fileInput = document.getElementById("file-input");
+    fileInput.addEventListener("change", () => {
+      parent.postMessage("loadedAndFilesChanged");
+    });
+    fileInput.selectFiles(["./tests/wpt/mozilla/tests/mozilla/FileAPI/resource/upload.txt"]);
 </script>

--- a/tests/wpt/mozilla/tests/mozilla/FileAPI/file-upload.html
+++ b/tests/wpt/mozilla/tests/mozilla/FileAPI/file-upload.html
@@ -19,5 +19,7 @@ function run_test() {
   };
   testdocument.getElementById("testform").submit();
 }
+
+window.addEventListener("message", () => run_test());
 </script>
-<iframe id=testframe src="file-upload-frame.html" onload="run_test();"></iframe>
+<iframe id=testframe src="file-upload-frame.html"></iframe>

--- a/tests/wpt/mozilla/tests/mozilla/FileAPI/resource/file-submission.py
+++ b/tests/wpt/mozilla/tests/mozilla/FileAPI/resource/file-submission.py
@@ -24,6 +24,6 @@ def main(request, response):
     body += b"\r\n" + b"content-type: text/plain\r\n\r\nHello\r\n--" + boundary + b"--\r\n"
 
     if body != request.body:
-        return fail("request body doesn't match: " + body + "+++++++" + request.body)
+        return fail(f"request body doesn't match: {body} +++++++ {request.body}")
 
     return ([("Content-Type", "text/plain")], "OK")


### PR DESCRIPTION
This change fixes the Servo-specific FileAPI tests which need the
special `SelectFiles` API. In addition, file selection is now totally
asynchronous, so update the tests to handle this.

Testing: This change fixes some tests.
Fixes: #40348.
