### PR TITLE
script: Trigger rendering update for skipped resize observations.

### DIFF
--- a/tests/wpt/meta/resize-observer/eventloop.html.ini
+++ b/tests/wpt/meta/resize-observer/eventloop.html.ini
@@ -1,3 +1,0 @@
-[eventloop.html]
-  [test1: depths of shadow roots]
-    expected: FAIL


### PR DESCRIPTION
When resize observations are skipped, they get delayed until the next turn of the event loop. In headless tests, we're not guaranteed that this next turn occurs in time, unless some other event happens to run. This leads to intermittent results unless we ensure that the event loop will run again. 

Testing: Newly passing test.
Fixes: #33599
