### PR TITLE
replace RootedVec<JSVal> with ValueArray

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5412,7 +5412,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#18029eac79a9f80043a30cc809184e569a47fd0f"
+source = "git+https://github.com/Taym95/mozjs?branch=re-export-mozjs_sys-jsgc-ValueArray#3a41a08971b14efa647b529830d5e5b7280df8fa"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -5425,7 +5425,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.140.0-8"
-source = "git+https://github.com/servo/mozjs#18029eac79a9f80043a30cc809184e569a47fd0f"
+source = "git+https://github.com/Taym95/mozjs?branch=re-export-mozjs_sys-jsgc-ValueArray#3a41a08971b14efa647b529830d5e5b7280df8fa"
 dependencies = [
  "bindgen 0.71.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,8 @@ imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }
 ipc-channel = "0.20.2"
 itertools = "0.14"
-js = { package = "mozjs", git = "https://github.com/servo/mozjs" }
+# js = { package = "mozjs", git = "https://github.com/Taym94/mozjs", branch = "re-export-mozjs_sys-jsgc-ValueArray" }
+js = { package = "mozjs", git = "https://github.com/Taym95/mozjs", branch = "re-export-mozjs_sys-jsgc-ValueArray" }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 layout_api = { path = "components/shared/layout" }

--- a/components/script/dom/defaultteeunderlyingsource.rs
+++ b/components/script/dom/defaultteeunderlyingsource.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use dom_struct::dom_struct;
+use js::gc::ValueArray;
 use js::jsapi::{HandleValueArray, Heap, NewArrayObject, Value};
 use js::jsval::{ObjectValue, UndefinedValue};
 use js::rust::HandleValue as SafeHandleValue;
@@ -196,10 +197,8 @@ impl DefaultTeeUnderlyingSource {
     #[allow(unsafe_code)]
     fn resolve_cancel_promise(&self, cx: SafeJSContext, global: &GlobalScope, can_gc: CanGc) {
         // Let compositeReason be ! CreateArrayFromList(« reason_1, reason_2 »).
-        rooted_vec!(let mut reasons_values);
-        reasons_values.push(self.reason_1.get());
-        reasons_values.push(self.reason_2.get());
-
+        rooted!(in(*cx) let mut reasons_values =
+            ValueArray::new([ self.reason_1.get(), self.reason_2.get() ]));
         let reasons_values_array = HandleValueArray::from(&reasons_values);
         rooted!(in(*cx) let reasons = unsafe { NewArrayObject(*cx, &reasons_values_array) });
         rooted!(in(*cx) let reasons_value = ObjectValue(reasons.get()));

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -14,6 +14,7 @@ use base::id::{PipelineId, WebViewId};
 use crossbeam_channel::{Sender, unbounded};
 use dom_struct::dom_struct;
 use euclid::{Scale, Size2D};
+use js::gc::ValueArray;
 use js::jsapi::{
     HandleValueArray, Heap, IsCallable, IsConstructor, JS_ClearPendingException,
     JS_IsExceptionPending, JSAutoRealm, JSObject, NewArrayObject, Value,
@@ -320,13 +321,12 @@ impl PaintWorkletGlobalScope {
         let arguments_value_array = HandleValueArray::from(&arguments_values);
         rooted!(in(*cx) let argument_object = unsafe { NewArrayObject(*cx, &arguments_value_array) });
 
-        rooted_vec!(let mut callback_args);
-        callback_args.push(ObjectValue(
-            rendering_context.reflector().get_jsobject().get(),
-        ));
-        callback_args.push(ObjectValue(paint_size.reflector().get_jsobject().get()));
-        callback_args.push(ObjectValue(properties.reflector().get_jsobject().get()));
-        callback_args.push(ObjectValue(argument_object.get()));
+        rooted!(in(*cx) let mut callback_args = ValueArray::new([
+            ObjectValue(rendering_context.reflector().get_jsobject().get()),
+            ObjectValue(paint_size.reflector().get_jsobject().get()),
+            ObjectValue(properties.reflector().get_jsobject().get()),
+            ObjectValue(argument_object.get()),
+        ]));
         let args = HandleValueArray::from(&callback_args);
 
         rooted!(in(*cx) let mut result = UndefinedValue());

--- a/components/script/indexed_db.rs
+++ b/components/script/indexed_db.rs
@@ -74,6 +74,24 @@ pub fn key_type_to_jsval(
                 values.push(Heap::boxed(value.get()));
             }
             values.safe_to_jsval(cx, result, can_gc);
+
+            // rooted!(in(*cx) let mut arr = unsafe { js::jsapi::NewArrayObject1(*cx, a.len() as _) });
+            // let mut i: u32 = 0;
+            // for key in a {
+            //     rooted!(in(*cx) let mut v: js::jsval::JSVal);
+            //     key_type_to_jsval(cx, key, v.handle_mut(), can_gc);
+            //     unsafe {
+            //         assert!(js::jsapi::JS_DefineElement(
+            //             *cx,
+            //             arr.handle().into(),
+            //             i,
+            //             v.handle().into(),
+            //             js::jsapi::JSPROP_ENUMERATE as u32
+            //         ));
+            //     }
+            //     i += 1;
+            // }
+            // result.set(js::jsval::ObjectValue(arr.get()));
         },
     }
 }


### PR DESCRIPTION
Replace RootedVec<JSVal> with ValueArray

Testing: existing tests should pass.
Fixes: #40141
