### PR TITLE
Add bump-version command

### DIFF
--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "servoshell"
 build = "build.rs"
-version.workspace = true
+version = "0.0.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -592,12 +592,15 @@ class PackageCommands(CommandBase):
     @Command("bump-version", description="Bump Servo version", category="package")
     @CommandArgument("target", type=str, help="Target version to bump to")
     def bump_version(self, target: str) -> int:
+        # Todo: Also update assemblyIdentity.version in ports/servoshell/platform/windows/servo.exe.manifest
+        #   Note: assemblyIdentity requires 4 version components, while we usually use 3.
         replacements = {
             "ports/servoshell/Cargo.toml": r'^version ?= ?"(?P<version>.*?)"',
             "support/windows/Servo.wxs.mako": r'<Product(.|\n)*Version="(?P<version>.*?)".*>',
             "Info.plist": r"<key>CFBundleShortVersionString</key>\n\s*<string>(?P<version>.*?)</string>",
             "support/android/apk/servoapp/build.gradle.kts": r'versionName\s*=\s*"(?P<version>.*?)"',
             "support/openharmony/oh-package.json5": r'"version"\s*:\s*"(?P<version>.*?)"',
+            "support/openharmony/entry/oh-package.json5": r'"version"\s*:\s*"(?P<version>.*?)"',
         }
 
         for filename, expression in replacements.items():

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -593,11 +593,11 @@ class PackageCommands(CommandBase):
     @CommandArgument("target", type=str, help="Target version to bump to")
     def bump_version(self, target: str) -> int:
         replacements = {
-            "ports/servoshell/Cargo.toml": r'^version ?= ?"(?P<version>.*)"',
-            "support/windows/Servo.wxs.mako": r'<Product(.|\n)*Version="(?P<version>.*)".*>',
-            "Info.plist": r"<key>CFBundleShortVersionString</key>\n\s*<string>(?P<version>.*)</string>",
-            "support/android/apk/servoapp/build.gradle.kts": r'versionName\s*=\s*"(?P<version>.*)"',
-            "support/openharmony/oh-package.json5": r'"version"\s*:\s*"(?P<version>.*)"',
+            "ports/servoshell/Cargo.toml": r'^version ?= ?"(?P<version>.*?)"',
+            "support/windows/Servo.wxs.mako": r'<Product(.|\n)*Version="(?P<version>.*?)".*>',
+            "Info.plist": r"<key>CFBundleShortVersionString</key>\n\s*<string>(?P<version>.*?)</string>",
+            "support/android/apk/servoapp/build.gradle.kts": r'versionName\s*=\s*"(?P<version>.*?)"',
+            "support/openharmony/oh-package.json5": r'"version"\s*:\s*"(?P<version>.*?)"',
         }
 
         for filename, expression in replacements.items():


### PR DESCRIPTION
Comprehensively sets the version across Cargo.toml and all installer/config files (i.e. `Info.plist`, `Servo.wxs.mako`, etc.)

Testing: Manual
Fixes: #40312