### PR TITLE
wpt: Filter non-stable expected results and create an artifact for it

### DIFF
--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -85,7 +85,7 @@ jobs:
             --total-chunks ${{ inputs.number-of-wpt-chunks }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/linux/raw/${{ matrix.chunk_id }}.log \
             --log-wptreport wpt-full-logs/linux/wptreport/${{ matrix.chunk_id }}.json \
-            --log-raw-unexpected wpt-filtered-logs/linux/${{ matrix.chunk_id }}.log \
+            --log-raw-stable-unexpected wpt-filtered-logs/linux/${{ matrix.chunk_id }}.log \
             --filter-intermittents wpt-filtered-logs/linux/${{ matrix.chunk_id }}.json \
             ${{ inputs.wpt-args }}
         env:
@@ -129,6 +129,17 @@ jobs:
         with:
           name: wpt-filtered-logs-linux
           path: results
+      - name: Aggregate results
+        if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
+        run: |
+          touch stable-unexpected-results.log
+          cat results/linux/*.log > stable-unexpected-results.log || true
+      - name: Upload aggregated results
+        if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: stable-unexpected-results-linux
+          path: stable-unexpected-results.log
       - name: Report results
         if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
         run: |

--- a/.github/workflows/mac-wpt.yml
+++ b/.github/workflows/mac-wpt.yml
@@ -58,7 +58,7 @@ jobs:
             --${{ inputs.profile }} --processes $(sysctl -n hw.logicalcpu) --timeout-multiplier 8 \
             --total-chunks ${{ env.max_chunk_id }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/${{ env.NAME }}/${{ matrix.chunk_id }}.log \
-            --log-raw-unexpected wpt-filtered-logs/${{ env.NAME }}/${{ matrix.chunk_id }}.log \
+            --log-raw-stable-unexpected wpt-filtered-logs/${{ env.NAME }}/${{ matrix.chunk_id }}.log \
             --filter-intermittents wpt-filtered-logs/${{ env.NAME }}/${{ matrix.chunk_id }}.json
             ${{ inputs.wpt-args }}
       - name: Archive results (filtered)
@@ -96,6 +96,17 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           fetch-depth: 2
+      - name: Aggregate results
+        if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
+        run: |
+          touch stable-unexpected-results.log
+          cat results/${{ env.NAME }}/*.log > stable-unexpected-results.log || true
+      - name: Upload aggregated results
+        if: ${{ !cancelled() && !inputs.wpt-sync-from-upstream }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: stable-unexpected-results-${{ env.NAME }}
+          path: stable-unexpected-results.log
       - uses: actions/download-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/python/wpt/__init__.py
+++ b/python/wpt/__init__.py
@@ -52,10 +52,10 @@ def create_parser() -> ArgumentParser:
         help="Filter intermittents against known intermittents and save the filtered output to the given file.",
     )
     parser.add_argument(
-        "--log-raw-unexpected",
+        "--log-raw-stable-unexpected",
         default=None,
         action="store",
-        help="Raw structured log messages for unexpected results."
+        help="Raw structured log messages for stable unexpected results."
         " '--log-raw' Must also be passed in order to use this.",
     )
     return parser

--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -139,9 +139,9 @@ def run_tests(default_binary_path: str, **kwargs: Any) -> int:
     # Write the unexpected-only raw log if that was specified on the command-line.
     if unexpected_raw_log_output_file:
         if not raw_log_outputs:
-            print("'--log-raw-unexpected' not written without '--log-raw'.")
+            print("'--log-raw-stable-unexpected' not written without '--log-raw'.")
         else:
-            write_unexpected_only_raw_log(
+            write_stable_unexpected_only_raw_log(
                 handler.unexpected_results, raw_log_outputs[0].name, unexpected_raw_log_output_file
             )
 
@@ -282,11 +282,14 @@ def filter_intermittents(unexpected_results: List[UnexpectedResult], output_path
     return not any([is_stable_and_unexpected(result) for result in unexpected_results])
 
 
-def write_unexpected_only_raw_log(
+def write_stable_unexpected_only_raw_log(
     unexpected_results: List[UnexpectedResult], raw_log_file: str, filtered_raw_log_file: str
 ) -> None:
-    tests = [result.path for result in unexpected_results]
-    print(f"Writing unexpected-only raw log to {filtered_raw_log_file}")
+    # Only write the data for tests which are not flaky and which do not have issues.
+    # This allows the resulting log file to be used to update baselines after a CI run,
+    # as it will only contain stable unexpected results without issues.
+    tests = [result.path for result in unexpected_results if not result.flaky and not result.issues]
+    print(f"Writing stable unexpected-only raw log to {filtered_raw_log_file}")
 
     with open(filtered_raw_log_file, "w", encoding="utf-8") as output:
         with open(raw_log_file) as input:


### PR DESCRIPTION
This change ensures that the filtered raw log file of WPT results only
contains stable unexpected results and uploads a resulting aggregated
log file as an artifact. This artifact can be used to generate new
baselines of *only* stable unexpected results, so is useful for updating
results given a CI run. A future change will add a `mach` command to do
this automatically.

Testing: The CI should run the code to produce this artifact for every WPT run.
