### PR TITLE
script: remove microtask queue from globalscope

### DIFF
--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -87,7 +87,6 @@ impl DebuggerGlobalScope {
                 ServoUrl::parse_with_base(None, "about:internal/debugger")
                     .expect("Guaranteed by argument"),
                 None,
-                Default::default(),
                 #[cfg(feature = "webgpu")]
                 gpu_id_hub,
                 None,

--- a/components/script/dom/defaultteereadrequest.rs
+++ b/components/script/dom/defaultteereadrequest.rs
@@ -117,13 +117,11 @@ impl DefaultTeeReadRequest {
             chunk: Heap::boxed(*chunk.handle()),
             tee_read_request: Dom::from_ref(self),
         };
-        let global = self.stream.global();
-        let microtask_queue = global.microtask_queue();
-        let cx = GlobalScope::get_cx();
-        microtask_queue.enqueue(
-            Microtask::ReadableStreamTeeReadRequest(tee_read_request_chunk),
-            cx,
-        );
+        self.stream
+            .global()
+            .enqueue_microtask(Microtask::ReadableStreamTeeReadRequest(
+                tee_read_request_chunk,
+            ));
     }
     /// <https://streams.spec.whatwg.org/#ref-for-read-request-chunk-steps%E2%91%A2>
     #[allow(clippy::borrowed_box)]

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -64,9 +64,6 @@ impl DissimilarOriginWindow {
                 global_to_clone_from.origin().clone(),
                 global_to_clone_from.creation_url().clone(),
                 global_to_clone_from.top_level_creation_url().clone(),
-                // FIXME(nox): The microtask queue is probably not important
-                // here, but this whole DOM interface is a hack anyway.
-                global_to_clone_from.microtask_queue().clone(),
                 #[cfg(feature = "webgpu")]
                 global_to_clone_from.wgpu_id_hub(),
                 Some(global_to_clone_from.is_secure_context()),

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4392,9 +4392,7 @@ impl Document {
         self.maybe_mark_animating_nodes_as_dirty();
 
         // > 3. Perform a microtask checkpoint.
-        self.window()
-            .as_global_scope()
-            .perform_a_microtask_checkpoint(can_gc);
+        self.window().perform_a_microtask_checkpoint(can_gc);
 
         // Steps 4 through 7 occur inside `send_pending_events().`
         let _realm = enter_realm(self);

--- a/components/script/dom/promise.rs
+++ b/components/script/dom/promise.rs
@@ -545,13 +545,12 @@ pub(crate) fn wait_for_all(
     // If total is 0, then:
     if promises.is_empty() {
         // Queue a microtask to perform successSteps given « ».
-        global.microtask_queue().enqueue(
-            Microtask::WaitForAllSuccessSteps(WaitForAllSuccessStepsMicrotask {
+        global.enqueue_microtask(Microtask::WaitForAllSuccessSteps(
+            WaitForAllSuccessStepsMicrotask {
                 global: DomRoot::from_ref(global),
                 success_steps,
-            }),
-            cx,
-        );
+            },
+        ));
 
         // Return.
         return;

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -700,7 +700,6 @@ impl ServoParser {
             if is_execution_stack_empty() {
                 self.document
                     .window()
-                    .as_global_scope()
                     .perform_a_microtask_checkpoint(can_gc);
             }
 
@@ -1767,10 +1766,7 @@ fn create_element_for_token(
         document.increment_throw_on_dynamic_markup_insertion_counter();
         // Step 6.2
         if is_execution_stack_empty() {
-            document
-                .window()
-                .as_global_scope()
-                .perform_a_microtask_checkpoint(can_gc);
+            document.window().perform_a_microtask_checkpoint(can_gc);
         }
         // Step 6.3
         custom_element_reaction_stack.push_new_element_queue()

--- a/components/script/dom/workers/abstractworkerglobalscope.rs
+++ b/components/script/dom/workers/abstractworkerglobalscope.rs
@@ -94,9 +94,7 @@ pub(crate) fn run_worker_event_loop<T, WorkerMsg, Event>(
             Some(worker) => worker_scope.handle_worker_post_event(worker),
             None => None,
         };
-        worker_scope
-            .upcast::<GlobalScope>()
-            .perform_a_microtask_checkpoint(can_gc);
+        scope.perform_a_microtask_checkpoint(can_gc);
     }
     worker_scope
         .upcast::<GlobalScope>()

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -112,7 +112,6 @@ impl WorkletGlobalScope {
                 MutableOrigin::new(ImmutableOrigin::new_opaque()),
                 base_url.clone(),
                 None,
-                Default::default(),
                 #[cfg(feature = "webgpu")]
                 init.gpu_id_hub.clone(),
                 init.inherited_secure_context,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3267,7 +3267,6 @@ impl ScriptThread {
             self.webgl_chan.as_ref().map(|chan| chan.channel()),
             #[cfg(feature = "webxr")]
             self.webxr_registry.clone(),
-            self.microtask_queue.clone(),
             self.compositor_api.clone(),
             self.unminify_js,
             self.unminify_css,
@@ -3879,7 +3878,7 @@ impl ScriptThread {
         });
     }
 
-    fn perform_a_microtask_checkpoint(&self, can_gc: CanGc) {
+    pub(crate) fn perform_a_microtask_checkpoint(&self, can_gc: CanGc) {
         // Only perform the checkpoint if we're not shutting down.
         if self.can_continue_running_inner() {
             let globals = self


### PR DESCRIPTION
Remove the microtask queue from `GlobalScope`. The queue is moved inside worker global scopes, while for window globals the script thread's queue is accessed.

Testing: Covered by existing tests
Fixes: #20908
