### PR TITLE
ohos CI: Compile nightly in production and upload libservoshell.so

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -159,7 +159,7 @@ jobs:
       attestations: write
     uses: ./.github/workflows/ohos.yml
     with:
-      profile: "release"
+      profile: "production"
       upload: true
       github-release-id: ${{ needs.create-draft-release.outputs.release-id }}
     secrets: inherit

--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -63,10 +63,9 @@ PACKAGES = {
         r"production\msi\Servo.zip",
     ],
     "ohos": [
-        (
-            "openharmony/aarch64-unknown-linux-ohos/release/entry/build/"
-            "default/outputs/default/servoshell-default-signed.hap"
-        )
+        "openharmony/aarch64-unknown-linux-ohos/production/libservoshell.so",
+        "openharmony/aarch64-unknown-linux-ohos/production/entry/build/"
+        + "default/outputs/default/servoshell-default-signed.hap",
     ],
 }
 


### PR DESCRIPTION
- Compile the nightly in production mode
- Additionally also upload `libservoshell.so` as an artifact. This makes it easier for interested users on HarmonyOS to test the demo app, since we can't provide a signed version for HarmonyOS, but users can self-sign easily if we provide the pre-compiled binary.

Testing: Not tested
