### PR TITLE
script: Let `HTMLCanvasElement` manage the `ImageKey` for canvases

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -175,8 +175,8 @@ use style::global_style_data::StyleThreadPool;
 use webgpu::canvas_context::WGPUImageMap;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::{WebGPU, WebGPURequest};
+use webrender_api::ExternalScrollId;
 use webrender_api::units::LayoutVector2D;
-use webrender_api::{ExternalScrollId, ImageKey};
 
 use crate::broadcastchannel::BroadcastChannels;
 use crate::browsingcontext::{
@@ -4487,7 +4487,7 @@ where
     fn handle_create_canvas_paint_thread_msg(
         &mut self,
         size: UntypedSize2D<u64>,
-        response_sender: IpcSender<Option<(GenericSender<CanvasMsg>, CanvasId, ImageKey)>>,
+        response_sender: IpcSender<Option<(GenericSender<CanvasMsg>, CanvasId)>>,
     ) {
         let (canvas_data_sender, canvas_data_receiver) = unbounded();
         let (canvas_sender, canvas_ipc_sender) = self
@@ -4502,9 +4502,7 @@ where
             None
         } else {
             match canvas_data_receiver.recv() {
-                Ok(Some((canvas_id, image_key))) => {
-                    Some((canvas_ipc_sender.clone(), canvas_id, image_key))
-                },
+                Ok(Some(canvas_id)) => Some((canvas_ipc_sender.clone(), canvas_id)),
                 Ok(None) => None,
                 Err(e) => {
                     warn!("Create canvas paint thread id response failed ({})", e);

--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -374,7 +374,7 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
 
     fn as_canvas(&self) -> Option<(CanvasInfo, PhysicalSize<f64>)> {
         let canvas_data = self.canvas_data()?;
-        let source = canvas_data.source;
+        let source = canvas_data.image_key;
         Some((
             CanvasInfo { source },
             PhysicalSize::new(canvas_data.width.into(), canvas_data.height.into()),

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -748,6 +748,17 @@ impl ImageCache for ImageCacheImpl {
         }
     }
 
+    fn get_image_key(&self) -> Option<WebRenderImageKey> {
+        let mut store = self.store.lock().unwrap();
+        if let KeyCacheState::Ready(ref mut cache) = store.key_cache.cache {
+            if let Some(image_key) = cache.pop() {
+                return Some(image_key);
+            }
+        }
+
+        store.compositor_api.generate_image_key_blocking()
+    }
+
     fn get_image(
         &self,
         url: ServoUrl,

--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -514,12 +514,16 @@ impl ImageCacheStore {
                 },
                 None => {
                     self.key_cache.images_pending_keys.push_back(pending_image);
-                    self.compositor_api
-                        .generate_image_key_async(self.pipeline_id);
-                    self.key_cache.cache = KeyCacheState::PendingBatch
+                    self.fetch_more_image_keys();
                 },
             },
         }
+    }
+
+    fn fetch_more_image_keys(&mut self) {
+        self.key_cache.cache = KeyCacheState::PendingBatch;
+        self.compositor_api
+            .generate_image_key_async(self.pipeline_id);
     }
 
     /// Insert received keys into the cache and complete the loading of images.
@@ -754,6 +758,8 @@ impl ImageCache for ImageCacheImpl {
             if let Some(image_key) = cache.pop() {
                 return Some(image_key);
             }
+
+            store.fetch_more_image_keys();
         }
 
         store.compositor_api.generate_image_key_blocking()

--- a/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
+++ b/components/script/dom/canvas/2d/offscreencanvasrenderingcontext2d.rs
@@ -97,10 +97,6 @@ impl CanvasContext for OffscreenCanvasRenderingContext2D {
         self.context.origin_is_clean()
     }
 
-    fn image_key(&self) -> Option<webrender_api::ImageKey> {
-        None
-    }
-
     fn mark_as_dirty(&self) {}
 }
 

--- a/components/script/dom/canvas/imagebitmaprenderingcontext.rs
+++ b/components/script/dom/canvas/imagebitmaprenderingcontext.rs
@@ -7,19 +7,15 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use euclid::default::Size2D;
 use pixels::Snapshot;
-use webrender_api::ImageKey;
 
-use crate::canvas_context::{
-    CanvasContext, CanvasHelpers, HTMLCanvasElementOrOffscreenCanvas,
-    LayoutCanvasRenderingContextHelpers,
-};
+use crate::canvas_context::{CanvasContext, CanvasHelpers, HTMLCanvasElementOrOffscreenCanvas};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::ImageBitmapBinding::ImageBitmapMethods;
 use crate::dom::bindings::codegen::Bindings::ImageBitmapRenderingContextBinding::ImageBitmapRenderingContextMethods;
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
-use crate::dom::bindings::root::{DomRoot, LayoutDom};
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::imagebitmap::ImageBitmap;
 use crate::script_runtime::CanGc;
@@ -94,12 +90,6 @@ impl ImageBitmapRenderingContext {
     }
 }
 
-impl LayoutCanvasRenderingContextHelpers for LayoutDom<'_, ImageBitmapRenderingContext> {
-    fn canvas_data_source(self) -> Option<ImageKey> {
-        None
-    }
-}
-
 impl CanvasContext for ImageBitmapRenderingContext {
     type ID = ();
 
@@ -155,10 +145,6 @@ impl CanvasContext for ImageBitmapRenderingContext {
             .borrow()
             .as_ref()
             .map_or_else(|| self.canvas.size(), |bitmap| bitmap.size())
-    }
-
-    fn image_key(&self) -> Option<ImageKey> {
-        None
     }
 
     fn mark_as_dirty(&self) {}

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2692,15 +2692,15 @@ impl Document {
         );
     }
 
-    pub(crate) fn mark_canvas_as_dirty(&self, canvas: &HTMLCanvasElement) {
+    pub(crate) fn mark_canvas_as_dirty(&self, canvas: &Dom<HTMLCanvasElement>) {
         let mut dirty_canvases = self.dirty_canvases.borrow_mut();
         if dirty_canvases
             .iter()
-            .any(|dirty_canvas| std::ptr::eq(&**dirty_canvas, canvas))
+            .any(|dirty_canvas| dirty_canvas == canvas)
         {
             return;
         }
-        dirty_canvases.push(Dom::from_ref(canvas));
+        dirty_canvases.push(canvas.clone());
     }
 
     /// Whether or not this [`Document`] needs a rendering update, due to changed

--- a/components/script/dom/gpucanvascontext.rs
+++ b/components/script/dom/gpucanvascontext.rs
@@ -5,7 +5,6 @@
 use dom_struct::dom_struct;
 use webrender_api::ImageKey;
 
-use crate::canvas_context::LayoutCanvasRenderingContextHelpers;
 use crate::dom::bindings::codegen::Bindings::GPUCanvasContextBinding::GPUCanvasContextMethods;
 use crate::dom::bindings::codegen::UnionTypes::HTMLCanvasElementOrOffscreenCanvas as RootedHTMLCanvasElementOrOffscreenCanvas;
 use crate::dom::bindings::reflector::Reflector;
@@ -26,12 +25,6 @@ impl GPUCanvasContext {
 impl GPUCanvasContextMethods<crate::DomTypeHolder> for GPUCanvasContext {
     /// <https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-canvas>
     fn Canvas(&self) -> RootedHTMLCanvasElementOrOffscreenCanvas {
-        unimplemented!()
-    }
-}
-
-impl LayoutCanvasRenderingContextHelpers for LayoutDom<'_, GPUCanvasContext> {
-    fn canvas_data_source(self) -> Option<ImageKey> {
         unimplemented!()
     }
 }

--- a/components/script/dom/webgl/webgl2renderingcontext.rs
+++ b/components/script/dom/webgl/webgl2renderingcontext.rs
@@ -29,7 +29,7 @@ use url::Host;
 use webrender_api::ImageKey;
 
 use super::validations::types::TexImageTarget;
-use crate::canvas_context::{CanvasContext, LayoutCanvasRenderingContextHelpers};
+use crate::canvas_context::CanvasContext;
 use crate::dom::bindings::codegen::Bindings::WebGL2RenderingContextBinding::{
     WebGL2RenderingContextConstants as constants, WebGL2RenderingContextMethods,
 };
@@ -43,7 +43,7 @@ use crate::dom::bindings::codegen::UnionTypes::{
 };
 use crate::dom::bindings::error::{ErrorResult, Fallible};
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
-use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom, ToLayout};
+use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
 #[cfg(feature = "webxr")]
@@ -187,6 +187,10 @@ impl WebGL2RenderingContext {
     ) -> Option<DomRoot<WebGL2RenderingContext>> {
         WebGL2RenderingContext::new_inherited(window, canvas, size, attrs, can_gc)
             .map(|ctx| reflect_dom_object(Box::new(ctx), window, can_gc))
+    }
+
+    pub(crate) fn set_image_key(&self, image_key: ImageKey) {
+        self.base.set_image_key(image_key);
     }
 
     #[allow(unsafe_code)]
@@ -989,10 +993,6 @@ impl CanvasContext for WebGL2RenderingContext {
 
     fn mark_as_dirty(&self) {
         self.base.mark_as_dirty()
-    }
-
-    fn image_key(&self) -> Option<ImageKey> {
-        self.base.image_key()
     }
 }
 
@@ -4919,14 +4919,6 @@ impl WebGL2RenderingContextMethods<crate::DomTypeHolder> for WebGL2RenderingCont
         let p = Promise::new(&self.global(), can_gc);
         p.resolve_native(&(), can_gc);
         p
-    }
-}
-
-impl LayoutCanvasRenderingContextHelpers for LayoutDom<'_, WebGL2RenderingContext> {
-    #[allow(unsafe_code)]
-    fn canvas_data_source(self) -> Option<ImageKey> {
-        let this = self.unsafe_get();
-        unsafe { (*this.base.to_layout().unsafe_get()).layout_handle() }
     }
 }
 

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -327,6 +327,10 @@ impl WebGLRenderingContext {
     }
 
     pub(crate) fn update_rendering(&self, canvas_epoch: Epoch) -> bool {
+        if !self.onscreen() {
+            return false;
+        }
+
         let global = self.global();
         let Some(window) = global.downcast::<Window>() else {
             return false;

--- a/components/shared/canvas/canvas.rs
+++ b/components/shared/canvas/canvas.rs
@@ -18,6 +18,7 @@ use pixels::SharedSnapshot;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 use style::color::AbsoluteColor;
+use webrender_api::ImageKey;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Path(pub BezPath);
@@ -447,6 +448,7 @@ pub enum CanvasMsg {
 
 #[derive(Debug, Deserialize, Serialize, strum::Display)]
 pub enum Canvas2dMsg {
+    SetImageKey(ImageKey),
     DrawImage(
         SharedSnapshot,
         Rect<f64>,

--- a/components/shared/canvas/lib.rs
+++ b/components/shared/canvas/lib.rs
@@ -8,7 +8,6 @@
 
 use crossbeam_channel::Sender;
 use euclid::default::Size2D;
-use webrender_api::ImageKey;
 
 use crate::canvas::CanvasId;
 
@@ -18,7 +17,7 @@ pub mod webgl;
 
 pub enum ConstellationCanvasMsg {
     Create {
-        sender: Sender<Option<(CanvasId, ImageKey)>>,
+        sender: Sender<Option<CanvasId>>,
         size: Size2D<u64>,
     },
     Exit(Sender<()>),

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -95,6 +95,8 @@ pub enum WebGLMsg {
         GLContextAttributes,
         WebGLSender<Result<WebGLCreateContextResult, String>>,
     ),
+    /// Set an [`ImageKey`] on a `WebGLContext`.
+    SetImageKey(WebGLContextId, ImageKey),
     /// Resizes a WebGLContext.
     ResizeContext(WebGLContextId, Size2D<u32>, WebGLSender<Result<(), String>>),
     /// Drops a WebGLContext.
@@ -131,8 +133,6 @@ pub struct WebGLCreateContextResult {
     pub glsl_version: WebGLSLVersion,
     /// The GL API used by the context.
     pub api_type: GlType,
-    /// The WebRender image key.
-    pub image_key: ImageKey,
 }
 
 /// Defines the WebGL version
@@ -180,6 +180,14 @@ impl WebGLMsgSender {
     pub fn send(&self, command: WebGLCommand, backtrace: WebGLCommandBacktrace) -> WebGLSendResult {
         self.sender
             .send(WebGLMsg::WebGLCommand(self.ctx_id, command, backtrace))
+    }
+
+    /// Set an [`ImageKey`] on this WebGL context.
+    #[inline]
+    pub fn set_image_key(&self, image_key: ImageKey) {
+        let _ = self
+            .sender
+            .send(WebGLMsg::SetImageKey(self.ctx_id, image_key));
     }
 
     /// Send a resize message

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -38,7 +38,6 @@ use storage_traits::webstorage_thread::StorageType;
 use strum_macros::IntoStaticStr;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::{WebGPU, WebGPUAdapterResponse};
-use webrender_api::ImageKey;
 
 use crate::structured_data::{BroadcastChannelMsg, StructuredSerializedData};
 use crate::{
@@ -574,7 +573,7 @@ pub enum ScriptToConstellationMessage {
     /// 2D canvases may use the GPU and we don't want to give untrusted content access to the GPU.)
     CreateCanvasPaintThread(
         UntypedSize2D<u64>,
-        IpcSender<Option<(GenericSender<CanvasMsg>, CanvasId, ImageKey)>>,
+        IpcSender<Option<(GenericSender<CanvasMsg>, CanvasId)>>,
     ),
     /// Notifies the constellation that this pipeline is requesting focus.
     ///

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -127,7 +127,7 @@ pub enum LayoutElementType {
 }
 
 pub struct HTMLCanvasData {
-    pub source: Option<ImageKey>,
+    pub image_key: Option<ImageKey>,
     pub width: u32,
     pub height: u32,
 }

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -188,6 +188,11 @@ pub trait ImageCacheFactory: Sync + Send {
 pub trait ImageCache: Sync + Send {
     fn memory_report(&self, prefix: &str, ops: &mut MallocSizeOfOps) -> Report;
 
+    /// Get an [`ImageKey`] to be used for external WebRender image management for
+    /// things like canvas rendering. Returns `None` when an [`ImageKey`] cannot
+    /// be generated properly.
+    fn get_image_key(&self) -> Option<ImageKey>;
+
     /// Definitively check whether there is a cached, fully loaded image available.
     fn get_image(
         &self,

--- a/components/shared/webgpu/messages/recv.rs
+++ b/components/shared/webgpu/messages/recv.rs
@@ -62,6 +62,10 @@ pub struct PendingTexture {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebGPURequest {
+    SetImageKey {
+        context_id: WebGPUContextId,
+        image_key: ImageKey,
+    },
     BufferMapAsync {
         sender: IpcSender<Result<Mapping, BufferAccessError>>,
         buffer_id: BufferId,
@@ -158,7 +162,7 @@ pub enum WebGPURequest {
     CreateContext {
         buffer_ids: ArrayVec<BufferId, PRESENTATION_BUFFER_COUNT>,
         size: DeviceIntSize,
-        sender: IpcSender<(WebGPUContextId, ImageKey)>,
+        sender: IpcSender<WebGPUContextId>,
     },
     /// Present texture to WebRender
     Present {


### PR DESCRIPTION
This change makes it so that the `HTMLCanvasElement` is responsible for
managing the `ImageKey` for associated `RenderingContext`s. Only
canvases display their contents into WebRender directly, so this makes
it so that keys are not generated for `OffscreenCanvas`.

The main goal here is that `ImageKey`s are always associated with a
particular `WebView`, which isn't possible in the various canvas
backends yet. This is important because each `WebView` may soon have a
different WebRender instance entirely with its own set of `ImageKey`s.

This also allows for clearing `ImageKey`s when canvases are disconnected
from the DOM in a future change. One tricky thing here is placeholder
canvases, which are meant to be driven from workers.

It seems that the implementation isn't correct for these at the moment
as they need to be updated to the specification. Instead, what is
happening is that any existing context / image is completely lost when
converting to an `OffscreenCanvas`.

Testing: This shouldn't change observable behavior, so is covered by
existing tests.
Fixes: This is part of #40261.
