### PR TITLE
config: Enable ResizeObserver by default.

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -309,7 +309,7 @@ impl Preferences {
             dom_offscreen_canvas_enabled: false,
             dom_permissions_enabled: false,
             dom_permissions_testing_allowed_in_nonsecure_contexts: false,
-            dom_resize_observer_enabled: false,
+            dom_resize_observer_enabled: true,
             dom_script_asynch: true,
             dom_serviceworker_enabled: false,
             dom_serviceworker_timeout_seconds: 60,

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -33,7 +33,6 @@ pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
     "dom_notification_enabled",
     "dom_offscreen_canvas_enabled",
     "dom_permissions_enabled",
-    "dom_resize_observer_enabled",
     "dom_webgl2_enabled",
     "dom_webgpu_enabled",
     "layout_columns_enabled",


### PR DESCRIPTION
Per https://github.com/servo/servo/issues/39790#issuecomment-3460233532 we now pass tests for all the related engine features that Servo implements, so there's no benefit to keeping this API disabled. Let's ship it!

Testing: No behaviour change, just updating defaults.
Fixes: #39790
