### PR TITLE
allow for custom environment variable to set resource directory

### DIFF
--- a/ports/servoshell/resources.rs
+++ b/ports/servoshell/resources.rs
@@ -22,6 +22,11 @@ pub(crate) fn resources_dir_path() -> PathBuf {
     // as we only give permission to read inside the resources directory,
     // not the permissions the "search" for the resources directory.
     let mut dir = CMD_RESOURCE_DIR.lock().unwrap();
+    if let Some(custom_dir) = option_env!("SERVOSHELL_RESOURCES_DIR") {
+        let path = PathBuf::from(custom_dir);
+        *dir = Some(path.clone());
+        return path;
+    }
     if let Some(ref path) = *dir {
         return PathBuf::from(path);
     }


### PR DESCRIPTION
Allows `SERVOSHELL_RESOURCES_DIR` to set the resource directory location. The path given will be canonicalized during runtime, so it doesn't need to be absolute.

Fixes: #40370