### PR TITLE
libservo: Expose `CredentialManagementDelegate` to the API

### DIFF
--- a/components/servo/credential_management_delegate.rs
+++ b/components/servo/credential_management_delegate.rs
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use servo_url::ImmutableOrigin;
+
+pub trait CredentialManagementDelegate {
+    /// Stores a secret associated with the given key.
+    /// The secret does not have to be a string.
+    fn store_secret(&self, key: ImmutableOrigin, secret: Vec<u8>) -> Result<(), String>;
+    /// - `Ok(None)` if the secret does not exist
+    /// - `Ok(Some(secret))` if the secret exists
+    /// - `Err` if there was an error retrieving the secret
+    fn retrieve_secret(&self, key: ImmutableOrigin) -> Result<Option<Vec<u8>>, String>;
+    /// Deletes the secret associated with the given key.
+    /// If the secret does not exist, this should still be treated as a success.
+    /// This should only return `Err` if there was an error during deletion.
+    fn delete_secret(&self, key: ImmutableOrigin) -> Result<(), String>;
+}
+
+pub struct DefaultCredentialManagementDelegate {
+    secrets: Mutex<HashMap<ImmutableOrigin, Vec<u8>>>,
+}
+
+impl DefaultCredentialManagementDelegate {
+    pub fn new() -> Self {
+        DefaultCredentialManagementDelegate {
+            secrets: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl CredentialManagementDelegate for DefaultCredentialManagementDelegate {
+    fn store_secret(&self, key: ImmutableOrigin, secret: Vec<u8>) -> Result<(), String> {
+        let mut secrets = self.secrets.lock().map_err(|e| e.to_string())?;
+        secrets.insert(key, secret);
+        Ok(())
+    }
+
+    fn retrieve_secret(&self, key: ImmutableOrigin) -> Result<Option<Vec<u8>>, String> {
+        let secrets = self.secrets.lock().map_err(|e| e.to_string())?;
+        if let Some(secret) = secrets.get(&key) {
+            Ok(Some(secret.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn delete_secret(&self, key: ImmutableOrigin) -> Result<(), String> {
+        let mut secrets = self.secrets.lock().map_err(|e| e.to_string())?;
+        secrets.remove(&key);
+        Ok(())
+    }
+}

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -13,6 +13,7 @@
 //! `ScriptThread` and the `LayoutThread`, as well maintains the navigation context.
 
 mod clipboard_delegate;
+mod credential_management_delegate;
 mod javascript_evaluator;
 mod network_manager;
 mod proxies;

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -486,6 +486,33 @@ impl ServoInner {
                     webview.clipboard_delegate().set_text(webview, string);
                 }
             },
+            EmbedderMsg::StoreSecret(webview_id, origin, secret, result_sender) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    let _ = result_sender.send(
+                        webview
+                            .credential_management_delegate()
+                            .store_secret(origin, secret),
+                    );
+                }
+            },
+            EmbedderMsg::RetrieveSecret(webview_id, origin, result_sender) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    let _ = result_sender.send(
+                        webview
+                            .credential_management_delegate()
+                            .retrieve_secret(origin),
+                    );
+                }
+            },
+            EmbedderMsg::DeleteSecret(webview_id, origin, result_sender) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    let _ = result_sender.send(
+                        webview
+                            .credential_management_delegate()
+                            .delete_secret(origin),
+                    );
+                }
+            },
             EmbedderMsg::SetCursor(webview_id, cursor) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     webview.set_cursor(cursor);

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -33,7 +33,6 @@ use crate::credential_management_delegate::{
 };
 use crate::responders::IpcResponder;
 use crate::webview_delegate::{CreateNewWebViewRequest, DefaultWebViewDelegate, WebViewDelegate};
-use crate::webview_delegate::{DefaultWebViewDelegate, WebViewDelegate};
 use crate::{
     ColorPicker, ContextMenu, EmbedderControl, InputMethodControl, SelectElement, Servo,
     UserContentManager, WebRenderDebugOption,

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -131,7 +131,7 @@ impl WebView {
             rendering_context: builder.rendering_context,
             delegate: builder.delegate,
             clipboard_delegate: Rc::new(DefaultClipboardDelegate),
-            credential_management_delegate: Rc::new(DefaultCredentialManagementDelegate::new()),
+            credential_management_delegate: Rc::new(DefaultCredentialManagementDelegate::default()),
             hidpi_scale_factor: builder.hidpi_scale_factor,
             load_status: LoadStatus::Started,
             status_text: None,

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -28,8 +28,12 @@ use url::Url;
 use webrender_api::units::{DeviceIntRect, DevicePixel, DevicePoint, DeviceSize};
 
 use crate::clipboard_delegate::{ClipboardDelegate, DefaultClipboardDelegate};
+use crate::credential_management_delegate::{
+    CredentialManagementDelegate, DefaultCredentialManagementDelegate,
+};
 use crate::responders::IpcResponder;
 use crate::webview_delegate::{CreateNewWebViewRequest, DefaultWebViewDelegate, WebViewDelegate};
+use crate::webview_delegate::{DefaultWebViewDelegate, WebViewDelegate};
 use crate::{
     ColorPicker, ContextMenu, EmbedderControl, InputMethodControl, SelectElement, Servo,
     UserContentManager, WebRenderDebugOption,
@@ -84,6 +88,7 @@ pub(crate) struct WebViewInner {
     pub(crate) servo: Servo,
     pub(crate) delegate: Rc<dyn WebViewDelegate>,
     pub(crate) clipboard_delegate: Rc<dyn ClipboardDelegate>,
+    pub(crate) credential_management_delegate: Rc<dyn CredentialManagementDelegate>,
 
     rendering_context: Rc<dyn RenderingContext>,
     user_content_manager: Option<Rc<UserContentManager>>,
@@ -126,6 +131,7 @@ impl WebView {
             rendering_context: builder.rendering_context,
             delegate: builder.delegate,
             clipboard_delegate: Rc::new(DefaultClipboardDelegate),
+            credential_management_delegate: Rc::new(DefaultCredentialManagementDelegate::new()),
             hidpi_scale_factor: builder.hidpi_scale_factor,
             load_status: LoadStatus::Started,
             status_text: None,
@@ -243,6 +249,17 @@ impl WebView {
 
     pub fn set_clipboard_delegate(&self, delegate: Rc<dyn ClipboardDelegate>) {
         self.inner_mut().clipboard_delegate = delegate;
+    }
+
+    pub fn credential_management_delegate(&self) -> Rc<dyn CredentialManagementDelegate> {
+        self.inner().credential_management_delegate.clone()
+    }
+
+    pub fn set_credential_management_delegate(
+        &self,
+        delegate: Rc<dyn CredentialManagementDelegate>,
+    ) {
+        self.inner_mut().credential_management_delegate = delegate;
     }
 
     pub fn id(&self) -> WebViewId {

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -32,7 +32,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use pixels::SharedRasterImage;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use servo_geometry::{DeviceIndependentIntRect, DeviceIndependentIntSize};
-use servo_url::ServoUrl;
+use servo_url::{ImmutableOrigin, ServoUrl};
 use strum::{EnumMessage, IntoStaticStr};
 use style::queries::values::PrefersColorScheme;
 use style_traits::CSSPixel;
@@ -451,6 +451,22 @@ pub enum EmbedderMsg {
     GetClipboardText(WebViewId, GenericCallback<Result<String, String>>),
     /// Sets system clipboard contents
     SetClipboardText(WebViewId, String),
+    StoreSecret(
+        WebViewId,
+        ImmutableOrigin,
+        Vec<u8>,
+        GenericSender<Result<(), String>>,
+    ),
+    RetrieveSecret(
+        WebViewId,
+        ImmutableOrigin,
+        GenericSender<Result<Option<Vec<u8>>, String>>,
+    ),
+    DeleteSecret(
+        WebViewId,
+        ImmutableOrigin,
+        GenericSender<Result<(), String>>,
+    ),
     /// Changes the cursor.
     SetCursor(WebViewId, Cursor),
     /// A favicon was detected


### PR DESCRIPTION
Companion for #40388. Exposes the ability for embedders to control how credentials are stored. The default implementation stores credentials in memory and does not persist them; ideally we don't want to store passwords in plaintext on the disk.

Fixes: Partially #38788 