### PR TITLE
Reduce unnecessary type conversion and share `WebDriverCommandMsg::LoadUrl` handler across platform

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -32,7 +32,6 @@ use net_traits::CoreResourceMsg::{
 use script_bindings::codegen::GenericBindings::ShadowRootBinding::ShadowRootMethods;
 use script_bindings::conversions::is_array_like;
 use script_bindings::num::Finite;
-use servo_url::ServoUrl;
 use webdriver::error::ErrorStatus;
 
 use crate::document_collection::DocumentCollection;
@@ -1796,7 +1795,7 @@ pub(crate) fn handle_get_css(
 pub(crate) fn handle_get_url(
     documents: &DocumentCollection,
     pipeline: PipelineId,
-    reply: IpcSender<ServoUrl>,
+    reply: IpcSender<String>,
     _can_gc: CanGc,
 ) {
     reply
@@ -1804,8 +1803,8 @@ pub(crate) fn handle_get_url(
             // TODO: Return an error if the pipeline doesn't exist.
             documents
                 .find_document(pipeline)
-                .map(|document| document.url())
-                .unwrap_or_else(|| ServoUrl::parse("about:blank").expect("infallible")),
+                .map(|document| document.url().into_string())
+                .unwrap_or_else(|| "about:blank".to_string()),
         )
         .unwrap();
 }

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -18,8 +18,8 @@ use ipc_channel::ipc::IpcSender;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use servo_geometry::DeviceIndependentIntRect;
-use servo_url::ServoUrl;
 use style_traits::CSSPixel;
+use url::Url;
 use webdriver::error::ErrorStatus;
 use webrender_api::units::DevicePixel;
 
@@ -77,7 +77,7 @@ pub enum WebDriverCommandMsg {
     /// Get the viewport size.
     GetViewportSize(WebViewId, IpcSender<Size2D<u32, DevicePixel>>),
     /// Load a URL in the top-level browsing context with the given ID.
-    LoadUrl(WebViewId, ServoUrl, GenericSender<WebDriverLoadStatus>),
+    LoadUrl(WebViewId, Url, GenericSender<WebDriverLoadStatus>),
     /// Refresh the top-level browsing context with the given ID.
     Refresh(WebViewId, GenericSender<WebDriverLoadStatus>),
     /// Navigate the webview with the given ID to the previous page in the browsing context's history.
@@ -201,7 +201,7 @@ pub enum WebDriverScriptCommand {
         IpcSender<Result<BrowsingContextId, ErrorStatus>>,
     ),
     GetParentFrameId(IpcSender<Result<BrowsingContextId, ErrorStatus>>),
-    GetUrl(IpcSender<ServoUrl>),
+    GetUrl(IpcSender<String>),
     GetPageSource(IpcSender<Result<String, ErrorStatus>>),
     IsEnabled(String, IpcSender<Result<bool, ErrorStatus>>),
     IsSelected(String, IpcSender<Result<bool, ErrorStatus>>),

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -655,15 +655,9 @@ impl Handler {
         self.verify_top_level_browsing_context_is_open(webview_id)?;
         // Step 3. If URL is not an absolute URL or is not an absolute URL with fragment
         // or not a local scheme, return error with error code invalid argument.
-        let url = match ServoUrl::parse(&parameters.url[..]) {
-            Ok(url) => url,
-            Err(_) => {
-                return Err(WebDriverError::new(
-                    ErrorStatus::InvalidArgument,
-                    "Invalid URL",
-                ));
-            },
-        };
+        let url = ServoUrl::parse(&parameters.url)
+            .map(|url| url.into_url())
+            .map_err(|_| WebDriverError::new(ErrorStatus::InvalidArgument, "Invalid URL"))?;
 
         // Step 4. Handle any user prompt.
         self.handle_any_user_prompts(webview_id)?;
@@ -806,7 +800,7 @@ impl Handler {
         let url = wait_for_ipc_response(receiver)?;
 
         Ok(WebDriverResponse::Generic(ValueResponse(
-            serde_json::to_value(url.as_str())?,
+            serde_json::to_value(url)?,
         )))
     }
 

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -445,10 +445,7 @@ impl App {
                     };
                 },
                 WebDriverCommandMsg::LoadUrl(webview_id, url, load_status_sender) => {
-                    if let Some(webview) = running_state.webview_by_id(webview_id) {
-                        running_state.set_load_status_sender(webview_id, load_status_sender);
-                        webview.load(url.into_url());
-                    }
+                    running_state.handle_webdriver_load_url(webview_id, url, load_status_sender);
                 },
                 WebDriverCommandMsg::Refresh(webview_id, load_status_sender) => {
                     if let Some(webview) = running_state.webview_by_id(webview_id) {

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -612,21 +612,7 @@ impl RunningAppState {
             while let Ok(msg) = webdriver_receiver.try_recv() {
                 match msg {
                     WebDriverCommandMsg::LoadUrl(webview_id, url, load_status_sender) => {
-                        info!("Loading URL in webview {}: {}", webview_id, url);
-
-                        if let Some(webview) = self.webview_by_id(webview_id) {
-                            self.set_load_status_sender(webview_id, load_status_sender.clone());
-                            self.inner_mut().focused_webview_id = Some(webview_id);
-                            webview.focus();
-                            let url_string = url.to_string();
-                            webview.load(url.into_url());
-                            info!(
-                                "Successfully loaded URL {} in focused webview {}",
-                                url_string, webview_id
-                            );
-                        } else {
-                            warn!("WebView {} not found for LoadUrl command", webview_id);
-                        }
+                        self.handle_webdriver_load_url(webview_id, url, load_status_sender);
                     },
                     WebDriverCommandMsg::NewWebView(response_sender, load_status_sender) => {
                         info!("Creating new webview via WebDriver");

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use crossbeam_channel::Sender;
 use euclid::Rect;
 use image::RgbaImage;
-use log::{error, warn};
+use log::{error, info, warn};
 use servo::base::generic_channel::GenericSender;
 use servo::base::id::WebViewId;
 use servo::ipc_channel::ipc::IpcSender;
@@ -19,6 +19,7 @@ use servo::{
     InputEvent, InputEventId, ScreenshotCaptureError, Servo, TraversalId, WebDriverJSResult,
     WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView,
 };
+use url::Url;
 
 use crate::prefs::ServoShellPreferences;
 
@@ -160,6 +161,19 @@ pub trait RunningAppStateTrait {
             _ => {
                 self.set_script_command_interrupt_sender(None);
             },
+        }
+    }
+
+    fn handle_webdriver_load_url(
+        &self,
+        webview_id: WebViewId,
+        url: Url,
+        load_status_sender: GenericSender<WebDriverLoadStatus>,
+    ) {
+        if let Some(webview) = self.webview_by_id(webview_id) {
+            info!("Loading URL in webview {}: {}", webview_id, url);
+            self.set_load_status_sender(webview_id, load_status_sender);
+            webview.load(url);
         }
     }
 }


### PR DESCRIPTION
- Reduces unnecessary type conversion between `ServoUrl`, `Url`, string slice
- Share `WebDriverCommandMsg::LoadUrl` handler across platform

Testing: Covered by existing test. Manually tested for OHOS.
