### PR TITLE
clamp pinch zoom factor if any viewport description.

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -700,7 +700,11 @@ impl WebViewRenderer {
 
         for scroll_event in self.pending_scroll_zoom_events.drain(..) {
             match scroll_event {
-                ScrollZoomEvent::PinchZoom(factor, center) => {
+                ScrollZoomEvent::PinchZoom(mut factor, center) => {
+                    // Clamp the pinch zoom factor according to the viewport description, if any.
+                    if let Some(viewport_description) = self.viewport_description.as_ref() {
+                        factor = viewport_description.clamp_page_zoom(factor);
+                    }
                     new_pinch_zoom.zoom(factor, center);
                 },
                 ScrollZoomEvent::Scroll(scroll_event_info) => {


### PR DESCRIPTION
clamp pinch zoom factor if any viewport description.

Testing: No new WPT test cases passed.
For pages that have set maximum and minimum zoom values, the zoom will be restricted within these limits. You need to enable viewport_meta_enabled.
Fixes: #40390 
