### PR TITLE
script: extend the prevention of the firing of load events to all iframes

### DIFF
--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -581,7 +581,7 @@ impl HTMLIFrameElement {
             !self.pending_navigation.get() &&
                 !self.upcast::<Element>().has_attribute(&local_name!("src"))
         } else {
-            true
+            !self.pending_navigation.get()
         };
         if should_fire_event {
             // Step 6. Fire an event named load at element.

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -576,11 +576,20 @@ impl HTMLIFrameElement {
         // for the initial blank document if we know that a navigation is ongoing,
         // which can be deducted from `pending_navigation` or the presence of an src.
         //
+        // Additionally, to prevent a race condition with navigations,
+        // in all cases, skip the load event if there is a pending navigation.
+        // See #40348
+        //
         // TODO: run these step synchronously as part of processing the iframe attributes.
         let should_fire_event = if self.is_initial_blank_document() {
+            // If this is the initial blank doc:
+            // do not fire if there is a pending navigation,
+            // or if the iframe has an src.
             !self.pending_navigation.get() &&
                 !self.upcast::<Element>().has_attribute(&local_name!("src"))
         } else {
+            // If this is not the initial blank doc:
+            // do not fire if there is a pending navigation.
             !self.pending_navigation.get()
         };
         if should_fire_event {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13523,7 +13523,7 @@
      ]
     ],
     "form_submit_about.html": [
-     "ec572ab0bc608c8cf5dd43f4159d3a67fc31a0de",
+     "e620f72cfcff77174e7e856119fb7ad06ad9e4da",
      [
       null,
       {}

--- a/tests/wpt/mozilla/tests/mozilla/form_submit_about.html
+++ b/tests/wpt/mozilla/tests/mozilla/form_submit_about.html
@@ -9,7 +9,9 @@
             var numOnLoads = 0
             var t = async_test("about:blank as form target")
             var iframe = document.getElementById('foo')
-            iframe.onload = t.step_func(function(e) { if (++numOnLoads == 2) t.done() })
+            // Note: we should fire two events, but for now we are skippng the first
+            // to fix various intermittent issues. See #31973
+            iframe.onload = t.step_func(function(e) { if (++numOnLoads == 1) t.done() })
         </script>
     </body>
 </html>


### PR DESCRIPTION
This extends the preventing of the firing of the load events when there is a pending navigation from the initial blank document only to all iframes. Part of https://github.com/servo/servo/issues/31973

Testing: tests/wpt/mozilla/tests/mozilla/FileAPI/file-upload.html
Fixes: This should fix the intermittency of https://github.com/servo/servo/issues/40348
