### PR TITLE
libservo: Integrate context menu into the show_embedder_control API

### DIFF
--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -9,7 +9,6 @@ use std::mem;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
-use base::generic_channel;
 use constellation_traits::{KeyboardScroll, ScriptToConstellationMessage};
 use embedder_traits::{
     Cursor, EditingActionEvent, EmbedderMsg, GamepadEvent as EmbedderGamepadEvent,
@@ -763,15 +762,10 @@ impl DocumentEventHandler {
 
         // Step 4. If result is true, then show the UA context menu
         if result {
-            let (sender, receiver) =
-                generic_channel::channel().expect("Failed to create IPC channel.");
-            self.window.send_to_embedder(EmbedderMsg::ShowContextMenu(
-                self.window.webview_id(),
-                sender,
-                None,
-                vec![],
-            ));
-            let _ = receiver.recv().unwrap();
+            self.window
+                .Document()
+                .embedder_controls()
+                .show_context_menu(hit_test_result);
         };
     }
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -122,6 +122,7 @@ use crate::responders::ServoErrorChannel;
 pub use crate::servo_delegate::{ServoDelegate, ServoError};
 use crate::webview::MINIMUM_WEBVIEW_SIZE;
 pub use crate::webview::{WebView, WebViewBuilder};
+use crate::webview_delegate::ContextMenu;
 pub use crate::webview_delegate::{
     AllowOrDenyRequest, AuthenticationRequest, ColorPicker, EmbedderControl, FilePicker,
     InputMethodControl, NavigationRequest, PermissionRequest, SelectElement, WebResourceLoad,
@@ -523,13 +524,6 @@ impl Servo {
                     );
                 }
             },
-            EmbedderMsg::ShowContextMenu(webview_id, ipc_sender, title, items) => {
-                if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview
-                        .delegate()
-                        .show_context_menu(webview, ipc_sender, title, items);
-                }
-            },
             EmbedderMsg::AllowNavigationRequest(webview_id, pipeline_id, servo_url) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     let request = NavigationRequest {
@@ -830,6 +824,15 @@ impl Servo {
                                 insertion_point: input_method_request.insertion_point,
                                 position,
                                 multiline: input_method_request.multiline,
+                            })
+                        },
+                        EmbedderControlRequest::ContextMenu(context_menu_request) => {
+                            EmbedderControl::ContextMenu(ContextMenu {
+                                id: control_id,
+                                position,
+                                items: context_menu_request.items,
+                                constellation_proxy,
+                                response_sent: false,
                             })
                         },
                         EmbedderControlRequest::FilePicker { .. } => unreachable!(

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -762,6 +762,7 @@ impl WebViewDelegate for RunningAppState {
             EmbedderControl::SimpleDialog(simple_dialog) => {
                 self.show_simple_dialog(webview, simple_dialog);
             },
+            EmbedderControl::ContextMenu(..) => {},
         }
     }
 

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -766,8 +766,6 @@ impl HostTrait for HostCallbacks {
         .unwrap();
     }
 
-    fn show_context_menu(&self, _title: Option<String>, _items: Vec<String>) {}
-
     fn on_panic(&self, _reason: String, _backtrace: Option<String>) {}
 }
 

--- a/ports/servoshell/egl/host_trait.rs
+++ b/ports/servoshell/egl/host_trait.rs
@@ -18,8 +18,6 @@ pub trait HostTrait {
     /// way that makes them impossible to mistake for browser UI.
     /// TODO: This API needs to be reworked to match the new model of how responses are sent.
     fn show_simple_dialog(&self, _webview: WebView, dialog: SimpleDialog);
-    /// Show context menu
-    fn show_context_menu(&self, title: Option<String>, items: Vec<String>);
     /// Notify that the load status of the page has changed.
     /// Started:
     ///  - "Reload button" should be disabled.

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -937,10 +937,6 @@ impl HostTrait for HostCallbacks {
         };
     }
 
-    fn show_context_menu(&self, title: Option<String>, items: Vec<String>) {
-        warn!("show_context_menu not implemented")
-    }
-
     fn notify_load_status_changed(&self, load_status: LoadStatus) {
         // Note: It seems that we don't necessarily get 1 `LoadStatus::Complete` for each
         // each time `LoadStatus::Started` is called. Presumably this requires some API changes,


### PR DESCRIPTION
This PR integrates showing context menus into the
`WebViewDelegate::show_embedder_control` API. In addition,
`ContextMenuItem` and `ContextMenuAction` data types are exposed which
abstract away the different components of the context menu. Later
changes will implement this API for servoshell as well as add
element-specific actions such as "Select All" and "Copy Image URL".

Testing: This change adds a WebView API test.
