### PR TITLE
`script/dom/`: Change some `#[allow]`s to `#[expect]`s

### DIFF
--- a/components/script/dom/abortsignal.rs
+++ b/components/script/dom/abortsignal.rs
@@ -37,7 +37,6 @@ impl js::gc::Rootable for AbortAlgorithm {}
 /// in order to integrate the abort signal with its various use cases.
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
-#[allow(dead_code)]
 pub(crate) enum AbortAlgorithm {
     /// <https://dom.spec.whatwg.org/#add-an-event-listener>
     DomEventListener(RemovableDomEventListener),
@@ -400,7 +399,7 @@ impl AbortSignalMethods<crate::DomTypeHolder> for AbortSignal {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-abortsignal-throwifaborted>
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn ThrowIfAborted(&self) -> Fallible<()> {
         // The throwIfAborted() method steps are to throw this’s abort reason, if this is aborted.
         if self.aborted() {

--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -60,7 +60,7 @@ impl Attr {
             owner: MutNullableDom::new(owner),
         }
     }
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         document: &Document,
         local_name: LocalName,
@@ -233,7 +233,6 @@ impl Attr {
     }
 }
 
-#[allow(unsafe_code)]
 pub(crate) trait AttrHelpersForLayout<'dom> {
     fn value(self) -> &'dom AttrValue;
     fn as_str(&self) -> &'dom str;
@@ -242,7 +241,7 @@ pub(crate) trait AttrHelpersForLayout<'dom> {
     fn namespace(self) -> &'dom Namespace;
 }
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 impl<'dom> AttrHelpersForLayout<'dom> for LayoutDom<'dom, Attr> {
     #[inline]
     fn value(self) -> &'dom AttrValue {

--- a/components/script/dom/blob.rs
+++ b/components/script/dom/blob.rs
@@ -130,7 +130,7 @@ impl Serializable for Blob {
 
 /// Extract bytes from BlobParts, used by Blob and File constructor
 /// <https://w3c.github.io/FileAPI/#constructorBlob>
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 pub(crate) fn blob_parts_to_bytes(
     mut blobparts: Vec<ArrayBufferOrArrayBufferViewOrBlobOrString>,
 ) -> Result<Vec<u8>, ()> {
@@ -160,7 +160,7 @@ pub(crate) fn blob_parts_to_bytes(
 
 impl BlobMethods<crate::DomTypeHolder> for Blob {
     // https://w3c.github.io/FileAPI/#constructorBlob
-    #[allow(non_snake_case)]
+    #[expect(non_snake_case)]
     fn Constructor(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/bytelengthqueuingstrategy.rs
+++ b/components/script/dom/bytelengthqueuingstrategy.rs
@@ -85,7 +85,7 @@ impl ByteLengthQueuingStrategyMethods<crate::DomTypeHolder> for ByteLengthQueuin
 }
 
 /// <https://streams.spec.whatwg.org/#byte-length-queuing-strategy-size-function>
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 pub(crate) unsafe fn byte_length_queuing_strategy_size(
     cx: *mut JSContext,
     argc: u32,

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -291,7 +291,7 @@ pub(crate) trait LayoutCharacterDataHelpers<'dom> {
 }
 
 impl<'dom> LayoutCharacterDataHelpers<'dom> for LayoutDom<'dom, CharacterData> {
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     #[inline]
     fn data_for_layout(self) -> &'dom str {
         unsafe { self.unsafe_get().data.borrow_for_layout() }

--- a/components/script/dom/client.rs
+++ b/components/script/dom/client.rs
@@ -55,7 +55,7 @@ impl Client {
         self.active_worker.get()
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn set_controller(&self, worker: &ServiceWorker) {
         self.active_worker.set(Some(worker));
     }

--- a/components/script/dom/closeevent.rs
+++ b/components/script/dom/closeevent.rs
@@ -26,7 +26,7 @@ pub(crate) struct CloseEvent {
     reason: DOMString,
 }
 
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 impl CloseEvent {
     pub(crate) fn new_inherited(was_clean: bool, code: u16, reason: DOMString) -> CloseEvent {
         CloseEvent {
@@ -37,7 +37,7 @@ impl CloseEvent {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         global: &GlobalScope,
         type_: Atom,
@@ -53,7 +53,7 @@ impl CloseEvent {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn new_with_proto(
         global: &GlobalScope,
         proto: Option<HandleObject>,

--- a/components/script/dom/compositionevent.rs
+++ b/components/script/dom/compositionevent.rs
@@ -35,7 +35,7 @@ impl CompositionEvent {
         reflect_dom_object(Box::new(CompositionEvent::new_inherited()), window, can_gc)
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         window: &Window,
         type_: DOMString,
@@ -51,7 +51,7 @@ impl CompositionEvent {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn new_with_proto(
         window: &Window,
         proto: Option<HandleObject>,

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -39,7 +39,7 @@ const MAX_LOG_CHILDREN: usize = 15;
 pub(crate) struct Console;
 
 impl Console {
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn build_message(level: LogLevel) -> ConsoleMessageBuilder {
         let cx = GlobalScope::get_cx();
         let caller = unsafe { describe_scripted_caller(*cx) }.unwrap_or_default();
@@ -121,7 +121,7 @@ where
     f()
 }
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 unsafe fn handle_value_to_string(cx: *mut jsapi::JSContext, value: HandleValue) -> DOMString {
     rooted!(in(cx) let mut js_string = std::ptr::null_mut::<jsapi::JSString>());
     match std::ptr::NonNull::new(JS_ValueToSource(cx, value)) {
@@ -133,7 +133,7 @@ unsafe fn handle_value_to_string(cx: *mut jsapi::JSContext, value: HandleValue) 
     }
 }
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 fn console_argument_from_handle_value(
     cx: JSContext,
     handle_value: HandleValue,
@@ -159,7 +159,7 @@ fn console_argument_from_handle_value(
     ConsoleMessageArgument::String(stringified_value.into())
 }
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 fn stringify_handle_value(message: HandleValue) -> DOMString {
     let cx = GlobalScope::get_cx();
     unsafe {
@@ -282,7 +282,7 @@ fn stringify_handle_value(message: HandleValue) -> DOMString {
     }
 }
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 fn maybe_stringify_dom_object(cx: JSContext, value: HandleValue) -> Option<DOMString> {
     // The standard object serialization is not effective for DOM objects,
     // since their properties generally live on the prototype object.
@@ -305,7 +305,7 @@ fn maybe_stringify_dom_object(cx: JSContext, value: HandleValue) -> Option<DOMSt
     let mut repr = format!("{} ", class_name);
     rooted!(in(*cx) let mut value = value.get());
 
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     unsafe extern "C" fn stringified(
         string: *const u16,
         len: u32,
@@ -345,7 +345,6 @@ fn stringify_handle_values(messages: &[HandleValue]) -> DOMString {
 /// to the logger. As `Console::method` and `Console::send_string_message`
 /// already forwards all messages to the logger with appropriate level
 /// this does not need to do anything for these targets.
-#[allow(unused_variables)]
 fn console_message_to_stdout(global: &GlobalScope, message: &DOMString) {
     #[cfg(not(any(target_os = "android", target_env = "ohos")))]
     {
@@ -469,7 +468,7 @@ impl consoleMethods<crate::DomTypeHolder> for Console {
     }
 }
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 fn get_js_stack(cx: *mut jsapi::JSContext) -> Vec<StackFrame> {
     const MAX_FRAME_COUNT: u32 = 128;
 

--- a/components/script/dom/countqueuingstrategy.rs
+++ b/components/script/dom/countqueuingstrategy.rs
@@ -84,7 +84,7 @@ impl CountQueuingStrategyMethods<crate::DomTypeHolder> for CountQueuingStrategy 
 }
 
 /// <https://streams.spec.whatwg.org/#count-queuing-strategy-size-function>
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 pub(crate) unsafe fn count_queuing_strategy_size(
     _cx: *mut JSContext,
     argc: u32,
@@ -129,7 +129,7 @@ pub(crate) fn extract_size_algorithm(
     if strategy.size.is_none() {
         let cx = GlobalScope::get_cx();
         let fun_obj = native_raw_obj_fn!(cx, count_queuing_strategy_size, c"size", 0, 0);
-        #[allow(unsafe_code)]
+        #[expect(unsafe_code)]
         unsafe {
             return QueuingStrategySize::new(cx, fun_obj);
         };

--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -117,8 +117,7 @@ fn create_svg_element(
 }
 
 /// <https://dom.spec.whatwg.org/#concept-create-element>
-#[allow(unsafe_code)]
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn create_html_element(
     name: QualName,
     prefix: Option<Prefix>,

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -46,7 +46,7 @@ impl CryptoMethods<crate::DomTypeHolder> for Crypto {
             .or_init(|| SubtleCrypto::new(&self.global(), can_gc))
     }
 
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     /// <https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues>
     fn GetRandomValues(
         &self,

--- a/components/script/dom/cryptokey.rs
+++ b/components/script/dom/cryptokey.rs
@@ -26,7 +26,6 @@ pub(crate) enum CryptoKeyOrCryptoKeyPair {
 }
 
 /// The underlying cryptographic data this key represents
-#[allow(dead_code)]
 pub(crate) enum Handle {
     P256PrivateKey(p256::SecretKey),
     P384PrivateKey(p384::SecretKey),
@@ -99,7 +98,6 @@ impl CryptoKey {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         global: &GlobalScope,
         key_type: KeyType,

--- a/components/script/dom/csp.rs
+++ b/components/script/dom/csp.rs
@@ -251,7 +251,7 @@ pub(crate) trait GlobalCspReporting {
     );
 }
 
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 fn compute_scripted_caller_source_position() -> SourcePosition {
     let scripted_caller =
         unsafe { describe_scripted_caller(*GlobalScope::get_cx()) }.unwrap_or_default();

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -137,7 +137,7 @@ impl CustomElementRegistry {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     /// Steps 10.1, 10.2
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn check_prototype(
         &self,
         constructor: HandleObject,
@@ -167,7 +167,7 @@ impl CustomElementRegistry {
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     /// This function includes both steps 14.3 and 14.4 which add the callbacks to a map and
     /// process them.
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     unsafe fn get_callbacks(&self, prototype: HandleObject) -> Fallible<LifecycleCallbacks> {
         let cx = GlobalScope::get_cx();
 
@@ -187,7 +187,7 @@ impl CustomElementRegistry {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     /// Step 14.13: Add form associated callbacks to LifecycleCallbacks
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     unsafe fn add_form_associated_callbacks(
         &self,
         prototype: HandleObject,
@@ -205,7 +205,7 @@ impl CustomElementRegistry {
         Ok(())
     }
 
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn get_observed_attributes(&self, constructor: HandleObject) -> Fallible<Vec<DOMString>> {
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let mut observed_attributes = UndefinedValue());
@@ -238,7 +238,7 @@ impl CustomElementRegistry {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     /// Step 14.11: Get the value of `formAssociated`.
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn get_form_associated_value(&self, constructor: HandleObject) -> Fallible<bool> {
         let cx = self.window.get_cx();
         rooted!(in(*cx) let mut form_associated_value = UndefinedValue());
@@ -268,7 +268,7 @@ impl CustomElementRegistry {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     /// Step 14.7: Get `disabledFeatures` value
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn get_disabled_features(&self, constructor: HandleObject) -> Fallible<Vec<DOMString>> {
         let cx = self.window.get_cx();
         rooted!(in(*cx) let mut disabled_features = UndefinedValue());
@@ -302,7 +302,7 @@ impl CustomElementRegistry {
 
 /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
 /// Step 14.4: Get `callbackValue` for all `callbackName` in `lifecycleCallbacks`.
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 fn get_callback(
     cx: JSContext,
     prototype: HandleObject,
@@ -333,7 +333,7 @@ fn get_callback(
 }
 
 impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistry {
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     /// <https://html.spec.whatwg.org/multipage/#dom-customelementregistry-define>
     fn Define(
@@ -693,7 +693,7 @@ pub(crate) struct CustomElementDefinition {
 }
 
 impl CustomElementDefinition {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         name: LocalName,
         local_name: LocalName,
@@ -723,7 +723,7 @@ impl CustomElementDefinition {
     }
 
     /// <https://dom.spec.whatwg.org/#concept-create-element> Step 5.1
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     pub(crate) fn create_element(
         &self,
         document: &Document,
@@ -910,7 +910,7 @@ pub(crate) fn upgrade_element(
 
 /// <https://html.spec.whatwg.org/multipage/#concept-upgrade-an-element>
 /// Steps 9.1-9.4
-#[allow(unsafe_code)]
+#[expect(unsafe_code)]
 fn run_upgrade_constructor(
     definition: &CustomElementDefinition,
     element: &Element,

--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -59,7 +59,7 @@ impl DebuggerGlobalScope {
     ///   pipeline ids, and they may contain debuggees from more than one pipeline
     /// - in web worker threads, it should be set to the pipeline id of the page that created the thread, because
     ///   those threads can’t generate pipeline ids, and they only contain one debuggee from one pipeline
-    #[allow(unsafe_code, clippy::too_many_arguments)]
+    #[expect(unsafe_code, clippy::too_many_arguments)]
     pub(crate) fn new(
         debugger_pipeline_id: PipelineId,
         script_to_devtools_sender: Option<IpcSender<ScriptToDevtoolsControlMsg>>,

--- a/components/script/dom/defaultteereadrequest.rs
+++ b/components/script/dom/defaultteereadrequest.rs
@@ -65,7 +65,7 @@ pub(crate) struct DefaultTeeReadRequest {
     tee_underlying_source: Dom<DefaultTeeUnderlyingSource>,
 }
 impl DefaultTeeReadRequest {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn new(
         stream: &ReadableStream,
@@ -124,7 +124,7 @@ impl DefaultTeeReadRequest {
             ));
     }
     /// <https://streams.spec.whatwg.org/#ref-for-read-request-chunk-steps%E2%91%A2>
-    #[allow(clippy::borrowed_box)]
+    #[expect(clippy::borrowed_box)]
     pub(crate) fn chunk_steps(&self, cx: SafeJSContext, chunk: &Box<Heap<JSVal>>, can_gc: CanGc) {
         let global = &self.stream.global();
         // Set readAgain to false.

--- a/components/script/dom/defaultteeunderlyingsource.rs
+++ b/components/script/dom/defaultteeunderlyingsource.rs
@@ -46,10 +46,10 @@ pub(crate) struct DefaultTeeUnderlyingSource {
     #[conditional_malloc_size_of]
     clone_for_branch_2: Rc<Cell<bool>>,
     #[ignore_malloc_size_of = "mozjs"]
-    #[allow(clippy::redundant_allocation)]
+    #[expect(clippy::redundant_allocation)]
     reason_1: Rc<Box<Heap<Value>>>,
     #[ignore_malloc_size_of = "mozjs"]
-    #[allow(clippy::redundant_allocation)]
+    #[expect(clippy::redundant_allocation)]
     reason_2: Rc<Box<Heap<Value>>>,
     #[conditional_malloc_size_of]
     cancel_promise: Rc<Promise>,
@@ -57,8 +57,8 @@ pub(crate) struct DefaultTeeUnderlyingSource {
 }
 
 impl DefaultTeeUnderlyingSource {
-    #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::redundant_allocation)]
+    #[expect(clippy::too_many_arguments)]
+    #[expect(clippy::redundant_allocation)]
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn new(
         reader: &ReadableStreamDefaultReader,
@@ -153,7 +153,6 @@ impl DefaultTeeUnderlyingSource {
     /// Let cancel1Algorithm be the following steps, taking a reason argument
     /// and
     /// Let cancel2Algorithm be the following steps, taking a reason argument
-    #[allow(unsafe_code)]
     pub(crate) fn cancel_algorithm(
         &self,
         cx: SafeJSContext,
@@ -193,7 +192,7 @@ impl DefaultTeeUnderlyingSource {
         }
     }
 
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn resolve_cancel_promise(&self, cx: SafeJSContext, global: &GlobalScope, can_gc: CanGc) {
         // Let compositeReason be ! CreateArrayFromList(« reason_1, reason_2 »).
         rooted_vec!(let mut reasons_values);

--- a/components/script/dom/dissimilaroriginwindow.rs
+++ b/components/script/dom/dissimilaroriginwindow.rs
@@ -45,7 +45,6 @@ pub(crate) struct DissimilarOriginWindow {
 }
 
 impl DissimilarOriginWindow {
-    #[allow(unsafe_code)]
     pub(crate) fn new(
         global_to_clone_from: &GlobalScope,
         window_proxy: &WindowProxy,

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -597,7 +597,6 @@ pub(crate) struct Document {
     websockets: DOMTracker<WebSocket>,
 }
 
-#[allow(non_snake_case)]
 impl Document {
     /// <https://html.spec.whatwg.org/multipage/#unloading-document-cleanup-steps>
     fn unloading_cleanup_steps(&self) {
@@ -3199,7 +3198,6 @@ pub(crate) enum DocumentSource {
     NotFromParser,
 }
 
-#[allow(unsafe_code)]
 pub(crate) trait LayoutDocumentHelpers<'dom> {
     fn is_html_document_for_layout(&self) -> bool;
     fn quirks_mode(self) -> QuirksMode;

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -205,14 +205,14 @@
 #[macro_use]
 pub(crate) mod macros;
 
-#[allow(unused_imports)]
+#[expect(unused_imports)]
 pub(crate) mod types {
     include!(concat!(env!("OUT_DIR"), "/InterfaceTypes.rs"));
 }
 
 pub(crate) mod abortcontroller;
 pub(crate) mod abortsignal;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod abstractrange;
 pub(crate) mod activation;
 pub(crate) mod animationevent;
@@ -266,7 +266,7 @@ pub(crate) mod defaultteereadrequest;
 pub(crate) mod defaultteeunderlyingsource;
 pub(crate) mod dissimilaroriginlocation;
 pub(crate) mod dissimilaroriginwindow;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod document;
 mod document_embedder_controls;
 pub(crate) mod document_event_handler;
@@ -288,7 +288,7 @@ pub(crate) mod domstringlist;
 pub(crate) mod domstringmap;
 pub(crate) mod domtokenlist;
 pub(crate) mod dynamicmoduleowner;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod element;
 pub(crate) mod elementinternals;
 pub(crate) mod errorevent;
@@ -309,7 +309,7 @@ pub(crate) mod gamepad;
 pub(crate) use self::gamepad::*;
 pub(crate) mod geolocation;
 pub(crate) use self::geolocation::*;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod globalscope;
 pub(crate) mod hashchangeevent;
 pub(crate) mod headers;
@@ -327,7 +327,7 @@ pub(crate) mod media;
 pub(crate) use self::media::*;
 pub(crate) mod messagechannel;
 pub(crate) mod messageevent;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod messageport;
 pub(crate) mod mimetype;
 pub(crate) mod mimetypearray;
@@ -338,10 +338,10 @@ pub(crate) mod namednodemap;
 pub(crate) mod navigationpreloadmanager;
 pub(crate) mod navigator;
 pub(crate) mod navigatorinfo;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod node;
 pub(crate) mod nodeiterator;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod nodelist;
 pub(crate) mod notification;
 pub(crate) mod pagetransitionevent;
@@ -354,13 +354,13 @@ pub(crate) mod permissionstatus;
 pub(crate) mod pipelineid;
 pub(crate) mod plugin;
 pub(crate) mod pluginarray;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod pointerevent;
 pub(crate) mod popstateevent;
 pub(crate) mod processinginstruction;
 pub(crate) mod processingoptions;
 pub(crate) mod progressevent;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod promise;
 pub(crate) mod promisenativehandler;
 pub(crate) mod promiserejectionevent;
@@ -368,7 +368,7 @@ pub(crate) mod quotaexceedederror;
 pub(crate) mod radionodelist;
 pub(crate) mod range;
 pub(crate) mod raredata;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod readablebytestreamcontroller;
 pub(crate) mod readablestream;
 pub(crate) mod readablestreambyobreader;
@@ -388,7 +388,7 @@ mod scrolling_box;
 pub(crate) mod securitypolicyviolationevent;
 pub(crate) mod selection;
 pub(crate) mod servointernals;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod servoparser;
 pub(crate) mod shadowroot;
 pub(crate) mod staticrange;
@@ -413,7 +413,7 @@ pub(crate) mod texttrack;
 pub(crate) mod texttrackcue;
 pub(crate) mod texttrackcuelist;
 pub(crate) mod texttracklist;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod timeranges;
 pub(crate) mod toggleevent;
 pub(crate) mod touch;
@@ -462,9 +462,9 @@ pub(crate) use self::webrtc::*;
 pub(crate) mod transformstream;
 pub(crate) mod transformstreamdefaultcontroller;
 pub(crate) mod wheelevent;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod window;
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) mod windowproxy;
 pub(crate) mod workers;
 pub(crate) use self::workers::*;

--- a/components/script/dom/mouseevent.rs
+++ b/components/script/dom/mouseevent.rs
@@ -211,7 +211,7 @@ impl MouseEvent {
     }
 
     /// <https://w3c.github.io/uievents/#initialize-a-mouseevent>
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn initialize_mouse_event(
         &self,
         type_: DOMString,

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3178,7 +3178,7 @@ impl Node {
     ///
     /// Callers should ensure they pass an UntrustedNodeAddress that points to a valid [`JSObject`]
     /// in memory that represents a [`Node`].
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     pub(crate) unsafe fn from_untrusted_node_address(
         candidate: UntrustedNodeAddress,
     ) -> &'static Self {
@@ -4393,7 +4393,6 @@ impl<'a> UnbindContext<'a> {
     }
 
     /// The index of the inclusive ancestor that was removed from the tree.
-    #[allow(unsafe_code)]
     pub(crate) fn index(&self) -> u32 {
         if let Some(index) = self.index.get() {
             return index;
@@ -4412,7 +4411,7 @@ pub(crate) struct UniqueId {
 unsafe_no_jsmanaged_fields!(UniqueId);
 
 impl MallocSizeOf for UniqueId {
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         if let Some(uuid) = unsafe { &*self.cell.get() } {
             unsafe { ops.malloc_size_of(&**uuid) }
@@ -4431,7 +4430,7 @@ impl UniqueId {
     }
 
     /// The Uuid of that unique ID.
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn borrow(&self) -> &Uuid {
         unsafe {
             let ptr = self.cell.get();

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -125,7 +125,7 @@ pub(crate) struct Notification {
 }
 
 impl Notification {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn new(
         global: &GlobalScope,
         title: DOMString,
@@ -595,7 +595,7 @@ fn create_notification_with_settings_object(
 }
 
 /// <https://notifications.spec.whatwg.org/#create-a-notification
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn create_notification(
     global: &GlobalScope,
     title: DOMString,

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -85,7 +85,6 @@ pub(crate) struct PaintWorkletGlobalScope {
 }
 
 impl PaintWorkletGlobalScope {
-    #[allow(unsafe_code)]
     pub(crate) fn new(
         webview_id: WebViewId,
         pipeline_id: PipelineId,
@@ -222,8 +221,8 @@ impl PaintWorkletGlobalScope {
     }
 
     /// <https://drafts.css-houdini.org/css-paint-api/#invoke-a-paint-callback>
-    #[allow(clippy::too_many_arguments)]
-    #[allow(unsafe_code)]
+    #[expect(clippy::too_many_arguments)]
+    #[expect(unsafe_code)]
     fn invoke_a_paint_callback(
         &self,
         name: &Atom,
@@ -492,7 +491,7 @@ impl PaintDefinition {
 }
 
 impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobalScope {
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     /// <https://drafts.css-houdini.org/css-paint-api/#dom-paintworkletglobalscope-registerpaint>
     fn RegisterPaint(&self, name: DOMString, paint_ctor: Rc<VoidFunction>) -> Fallible<()> {

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -94,7 +94,7 @@ const NAMED_CURVE_P521: &str = "P-521";
 static SUPPORTED_CURVES: &[&str] = &[NAMED_CURVE_P256, NAMED_CURVE_P384, NAMED_CURVE_P521];
 
 /// <https://w3c.github.io/webcrypto/#supported-operation>
-#[allow(dead_code)]
+#[expect(dead_code)]
 enum Operation {
     Encrypt,
     Decrypt,
@@ -1995,7 +1995,7 @@ pub(crate) enum ExportedKey {
 /// our "subtle" structs of the corresponding IDL dictionary types so that they can be easily
 /// passed to another threads.
 #[derive(Clone, Debug, MallocSizeOf)]
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 pub(crate) enum KeyAlgorithmAndDerivatives {
     KeyAlgorithm(SubtleKeyAlgorithm),
     EcKeyAlgorithm(SubtleEcKeyAlgorithm),
@@ -2087,7 +2087,7 @@ trait JsonWebKeyExt {
 
 impl JsonWebKeyExt for JsonWebKey {
     /// <https://w3c.github.io/webcrypto/#concept-parse-a-jwk>
-    #[allow(unsafe_code)]
+    #[expect(unsafe_code)]
     fn parse(cx: JSContext, data: &[u8]) -> Result<JsonWebKey, Error> {
         // Step 1. Let data be the sequence of bytes to be parsed.
         // (It is given as a method paramter.)

--- a/components/script/dom/textdecoder.rs
+++ b/components/script/dom/textdecoder.rs
@@ -24,7 +24,6 @@ use crate::script_runtime::CanGc;
 
 /// <https://encoding.spec.whatwg.org/#textdecoder>
 #[dom_struct]
-#[allow(non_snake_case)]
 pub(crate) struct TextDecoder {
     reflector_: Reflector,
 
@@ -35,7 +34,7 @@ pub(crate) struct TextDecoder {
     do_not_flush: Cell<bool>,
 }
 
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 impl TextDecoder {
     fn new_inherited(encoding: &'static Encoding, fatal: bool, ignoreBOM: bool) -> TextDecoder {
         let decoder = TextDecoderCommon::new_inherited(encoding, fatal, ignoreBOM);
@@ -69,7 +68,6 @@ impl TextDecoder {
     }
 }
 
-#[allow(non_snake_case)]
 impl TextDecoderMethods<crate::DomTypeHolder> for TextDecoder {
     /// <https://encoding.spec.whatwg.org/#dom-textdecoder>
     fn Constructor(

--- a/components/script/dom/textdecodercommon.rs
+++ b/components/script/dom/textdecodercommon.rs
@@ -15,7 +15,7 @@ use crate::dom::bindings::error::{Error, Fallible};
 /// interface in the WebIDL, this also performs decoding.
 ///
 /// <https://encoding.spec.whatwg.org/#textdecodercommon>
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct TextDecoderCommon {
     /// <https://encoding.spec.whatwg.org/#dom-textdecoder-encoding>
@@ -39,7 +39,7 @@ pub(crate) struct TextDecoderCommon {
     io_queue: RefCell<Vec<u8>>,
 }
 
-#[allow(non_snake_case)]
+#[expect(non_snake_case)]
 impl TextDecoderCommon {
     pub(crate) fn new_inherited(
         encoding: &'static Encoding,


### PR DESCRIPTION
This removes some unneeded lints, especially `#[allow(unsafe_code)]`.

Testing: Refactor
Part of: #40383
