### PR TITLE
libservo: Add a fallback clipboard

### DIFF
--- a/tests/wpt/meta/clipboard-apis/detached-iframe/writeText-readText-on-detached-iframe.https.html.ini
+++ b/tests/wpt/meta/clipboard-apis/detached-iframe/writeText-readText-on-detached-iframe.https.html.ini
@@ -1,4 +1,4 @@
 [writeText-readText-on-detached-iframe.https.html]
-  expected: OK
+  expected: TIMEOUT
   [Verify readText and writeText fails on detached iframe]
-    expected: FAIL
+    expected: TIMEOUT

--- a/tests/wpt/meta/clipboard-apis/text-write-read/async-writeText-readText.https.html.ini
+++ b/tests/wpt/meta/clipboard-apis/text-write-read/async-writeText-readText.https.html.ini
@@ -1,6 +1,0 @@
-[async-writeText-readText.https.html]
-  [Verify write and read clipboard given text: Clipboard write text -> read text test]
-    expected: FAIL
-
-  [Verify write and read clipboard given text: non-Latin1 text encoding test データ]
-    expected: FAIL

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/key_shortcuts.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/key_shortcuts.py.ini
@@ -1,3 +1,0 @@
-[key_shortcuts.py]
-  [test_mod_a_mod_c_right_mod_v_pastes_text]
-    expected: FAIL


### PR DESCRIPTION
Add a fallback implementation of the default clipboard delegate that
works within a single Servo process. This introduces one failure, which
was hidden before.

Testing: This fixes some WPT tests.
