### PR TITLE
xpath: Handle OOB conditions and non-char-boundaries in `substring`

### DIFF
--- a/components/xpath/src/lib.rs
+++ b/components/xpath/src/lib.rs
@@ -5,7 +5,7 @@
 mod ast;
 mod context;
 mod eval;
-mod eval_function;
+mod functions;
 mod parser;
 mod tokenizer;
 mod value;


### PR DESCRIPTION
This change fixes two panics and cleans up a bunch of the surrounding code.

Testing: I've added new unit tests

