### PR TITLE
ohos: Exclude libc++_shared.so to reduce hap size

### DIFF
--- a/support/openharmony/entry/build-profile.json5
+++ b/support/openharmony/entry/build-profile.json5
@@ -8,6 +8,11 @@
       "arguments": "",
       "cppFlags": "",
       "abiFilters": ["arm64-v8a", "x86_64"]
+    },
+    "nativeLib": {
+      "filter": {
+        "excludes": ["**/libc++_shared.so"]
+      }
     }
   },
   "buildOptionSet": [


### PR DESCRIPTION
HDC will inject the `libc++_shared.so` file into hap by default if project include a native module. But i think we don't need it and so we can remove it. It can reduce the hap file size.

<img width="2006" height="562" alt="image" src="https://github.com/user-attachments/assets/9541fe72-8a99-40ae-9202-f76c827e6cc2" />
