### PR TITLE
script: Implement MallocSizeOf for (De)Compressor

### DIFF
--- a/components/script/dom/compressionstream.rs
+++ b/components/script/dom/compressionstream.rs
@@ -13,6 +13,7 @@ use js::jsapi::JSObject;
 use js::jsval::UndefinedValue;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
 use js::typedarray::Uint8Array;
+use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::codegen::Bindings::CompressionStreamBinding::{
@@ -94,6 +95,16 @@ impl Compressor {
     }
 }
 
+impl MallocSizeOf for Compressor {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        match self {
+            Compressor::Deflate(zlib_encoder) => zlib_encoder.size_of(ops),
+            Compressor::DeflateRaw(deflate_encoder) => deflate_encoder.size_of(ops),
+            Compressor::Gzip(gz_encoder) => gz_encoder.size_of(ops),
+        }
+    }
+}
+
 /// <https://compression.spec.whatwg.org/#compressionstream>
 #[dom_struct]
 pub(crate) struct CompressionStream {
@@ -106,7 +117,6 @@ pub(crate) struct CompressionStream {
     format: CompressionFormat,
 
     // <https://compression.spec.whatwg.org/#compressionstream-context>
-    #[ignore_malloc_size_of = "defined in flate2"]
     #[no_trace]
     context: RefCell<Compressor>,
 }

--- a/components/script/dom/decompressionstream.rs
+++ b/components/script/dom/decompressionstream.rs
@@ -12,6 +12,7 @@ use js::jsapi::JSObject;
 use js::jsval::UndefinedValue;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
 use js::typedarray::Uint8Array;
+use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::codegen::Bindings::CompressionStreamBinding::CompressionFormat;
@@ -88,6 +89,16 @@ impl Decompressor {
     }
 }
 
+impl MallocSizeOf for Decompressor {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        match self {
+            Decompressor::Deflate(zlib_decoder) => zlib_decoder.size_of(ops),
+            Decompressor::DeflateRaw(deflate_decoder) => deflate_decoder.size_of(ops),
+            Decompressor::Gzip(gz_decoder) => gz_decoder.size_of(ops),
+        }
+    }
+}
+
 /// <https://compression.spec.whatwg.org/#decompressionstream>
 #[dom_struct]
 pub(crate) struct DecompressionStream {
@@ -100,7 +111,6 @@ pub(crate) struct DecompressionStream {
     format: CompressionFormat,
 
     // <https://compression.spec.whatwg.org/#decompressionstream-context>
-    #[ignore_malloc_size_of = "defined in flate2"]
     #[no_trace]
     context: RefCell<Decompressor>,
 }


### PR DESCRIPTION
Implement `MallocSizeOf` for the internal context of `CompressionStream` and `DecompressionStream`. This helps remove the `ignore_malloc_size_of` annotation in the structs `CompressionStream` and `DecompressionStream`

Testing: Existing tests suffice.
