### PR TITLE
Disallow running `clippy` and `--use-crown` together

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -110,6 +110,6 @@ jobs:
           ./mach bootstrap --skip-nextest
       - name: Clippy
         run: |
-          ./mach clippy --use-crown --locked --github-annotations -- -- --deny warnings
+          ./mach clippy --locked --github-annotations -- -- --deny warnings
       - name: Tidy
         run: ./mach test-tidy --no-progress --all --github-annotations

--- a/python/servo/devenv_commands.py
+++ b/python/servo/devenv_commands.py
@@ -78,6 +78,14 @@ class MachCommands(CommandBase):
         if not params:
             params = []
 
+        if kwargs.get("use_crown", False):
+            print(
+                "Error: `clippy` and `--use-crown` cannot be used together.\n"
+                "`clippy` takes precedence over `crown`, so `crown` would not run.\n"
+                "Please use `./mach check --use-crown` instead to run the crown linter."
+            )
+            return 1
+
         self.ensure_bootstrapped()
         self.ensure_clobbered()
         env = self.build_env()


### PR DESCRIPTION
Prevent users from running `./mach clippy --use-crown` together, which doesn't work as expected.

Testing: Verified error message appears when running `./mach clippy --use-crown`
<img width="1171" height="151" alt="image" src="https://github.com/user-attachments/assets/1a665915-d97c-4c80-9b23-4da815ff82fc" />
Fixes: #39334 

