### PR TITLE
libservo: Fix panic in `Reload` of `ContextMenuAction`

### DIFF
--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -15,7 +15,6 @@ use net_traits::CoreResourceMsg;
 use net_traits::filemanager_thread::FileManagerThreadMsg;
 use rustc_hash::FxHashMap;
 use script_bindings::codegen::GenericBindings::HistoryBinding::HistoryMethods;
-use script_bindings::codegen::GenericBindings::LocationBinding::LocationMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::root::{Dom, DomRoot};
 use script_bindings::script_runtime::CanGc;
@@ -257,7 +256,7 @@ impl DocumentEmbedderControls {
                 let _ = window.History().Forward();
             },
             ContextMenuAction::Reload => {
-                let _ = self.window.Location().Reload(can_gc);
+                self.window.Location().reload_without_origin_check(can_gc);
             },
         }
     }

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -580,11 +580,11 @@ fn test_simple_context_menu() {
     let captured_delegate = delegate.clone();
     servo_test.spin(move || captured_delegate.number_of_controls_shown.get() != 1);
 
-    {
-        let controls = delegate.controls_shown.borrow();
+    let context_menu = {
+        let mut controls = delegate.controls_shown.borrow_mut();
         assert_eq!(controls.len(), 1);
-        let EmbedderControl::ContextMenu(context_menu) = &controls[0] else {
-            unreachable!("Expected embedder control to be an IME");
+        let Some(EmbedderControl::ContextMenu(context_menu)) = controls.pop() else {
+            unreachable!("Expected embedder control to be a ContextMenu");
         };
 
         let items = context_menu.items();
@@ -609,5 +609,12 @@ fn test_simple_context_menu() {
                 ..
             }
         ));
-    }
+
+        context_menu
+    };
+
+    delegate.reset();
+    context_menu.select(ContextMenuAction::Reload);
+
+    servo_test.spin(move || !delegate.load_status_changed.get());
 }


### PR DESCRIPTION
Right now when the Reload action is selected from a right-click context menu, Servo would panic. Context menu's Reload action was calling `Location.Reload()`, which caused the panic. As per [HTML spec](https://html.spec.whatwg.org/multipage/#dom-location-reload) it looks like, to perform a user-requested reload we should be using `reload_without_origin_check()` instead.

Testing: Added a test for `ContextMenuAction::Relaod` action. 