### PR TITLE
script: Eagerly update the `Device` in Layout when it changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,7 +2605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3221,7 +3221,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps 7.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4735,7 +4735,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7346,7 +7346,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7724,7 +7724,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.32.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#a9f1997d4ff9227c14b4555fd2e812bee48891b8"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8031,7 +8031,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.2"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#a9f1997d4ff9227c14b4555fd2e812bee48891b8"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8559,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#a9f1997d4ff9227c14b4555fd2e812bee48891b8"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8616,7 +8616,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#a9f1997d4ff9227c14b4555fd2e812bee48891b8"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8625,12 +8625,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#a9f1997d4ff9227c14b4555fd2e812bee48891b8"
 
 [[package]]
 name = "stylo_derive"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#a9f1997d4ff9227c14b4555fd2e812bee48891b8"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#a9f1997d4ff9227c14b4555fd2e812bee48891b8"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8651,7 +8651,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#a9f1997d4ff9227c14b4555fd2e812bee48891b8"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8668,12 +8668,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#a9f1997d4ff9227c14b4555fd2e812bee48891b8"
 
 [[package]]
 name = "stylo_traits"
 version = "0.8.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#a9f1997d4ff9227c14b4555fd2e812bee48891b8"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -8862,7 +8862,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9088,7 +9088,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#a9f1997d4ff9227c14b4555fd2e812bee48891b8"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9101,7 +9101,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-10-01#85ae0b1664c669a398a790a8ad73201ccd4d412a"
+source = "git+https://github.com/servo/stylo?branch=2025-10-01#a9f1997d4ff9227c14b4555fd2e812bee48891b8"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -10372,7 +10372,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -151,6 +151,10 @@ pub struct LayoutThread {
     /// Whether or not user agent stylesheets have been added to the Stylist or not.
     have_added_user_agent_stylesheets: bool,
 
+    /// Whether or not this [`LayoutImpl`]'s [`Device`] has changed since the last restyle.
+    /// If it has, a restyle is pending.
+    device_has_changed: bool,
+
     /// Is this the first reflow in this LayoutThread?
     have_ever_generated_display_list: Cell<bool>,
 
@@ -225,6 +229,33 @@ impl Drop for LayoutThread {
 impl Layout for LayoutThread {
     fn device(&self) -> &Device {
         self.stylist.device()
+    }
+
+    fn set_theme(&mut self, theme: Theme) -> bool {
+        let theme: PrefersColorScheme = theme.into();
+        let device = self.stylist.device_mut();
+        if theme == device.color_scheme() {
+            return false;
+        }
+
+        device.set_color_scheme(theme);
+        self.device_has_changed = true;
+        true
+    }
+
+    fn set_viewport_details(&mut self, viewport_details: ViewportDetails) -> bool {
+        let device = self.stylist.device_mut();
+        let device_pixel_ratio = Scale::new(viewport_details.hidpi_scale_factor.get());
+        if device.viewport_size() == viewport_details.size &&
+            device.device_pixel_ratio() == device_pixel_ratio
+        {
+            return false;
+        }
+
+        device.set_viewport_size(viewport_details.size);
+        device.set_device_pixel_ratio(device_pixel_ratio);
+        self.device_has_changed = true;
+        true
     }
 
     fn load_web_fonts_from_stylesheet(&self, stylesheet: &ServoArc<Stylesheet>) {
@@ -700,6 +731,7 @@ impl LayoutThread {
             font_context: config.font_context,
             have_added_user_agent_stylesheets: false,
             have_ever_generated_display_list: Cell::new(false),
+            device_has_changed: false,
             need_overflow_calculation: Cell::new(false),
             need_new_display_list: Cell::new(false),
             need_new_stacking_context_tree: Cell::new(false),
@@ -893,25 +925,6 @@ impl LayoutThread {
         })
     }
 
-    fn update_device_if_necessary(
-        &mut self,
-        reflow_request: &ReflowRequest,
-        viewport_changed: bool,
-        guards: &StylesheetGuards,
-    ) -> bool {
-        let had_used_viewport_units = self.stylist.device().used_viewport_units();
-        let theme_changed = self.theme_did_change(reflow_request.theme);
-        if !viewport_changed && !theme_changed {
-            return false;
-        }
-        self.update_device(
-            reflow_request.viewport_details,
-            reflow_request.theme,
-            guards,
-        );
-        (viewport_changed && had_used_viewport_units) || theme_changed
-    }
-
     #[servo_tracing::instrument(skip_all)]
     fn prepare_stylist_for_reflow<'dom>(
         &mut self,
@@ -972,16 +985,23 @@ impl LayoutThread {
         let author_guard = document_shared_lock.read();
         let ua_stylesheets = &*UA_STYLESHEETS;
         let ua_or_user_guard = ua_stylesheets.shared_lock.read();
-        let rayon_pool = STYLE_THREAD_POOL.lock();
-        let rayon_pool = rayon_pool.pool();
-        let rayon_pool = rayon_pool.as_ref();
         let guards = StylesheetGuards {
             author: &author_guard,
             ua_or_user: &ua_or_user_guard,
         };
 
-        let viewport_changed = self.viewport_did_change(reflow_request.viewport_details);
-        if self.update_device_if_necessary(reflow_request, viewport_changed, &guards) {
+        let rayon_pool = STYLE_THREAD_POOL.lock();
+        let rayon_pool = rayon_pool.pool();
+        let rayon_pool = rayon_pool.as_ref();
+
+        let device_has_changed = std::mem::replace(&mut self.device_has_changed, false);
+        if device_has_changed {
+            let sheet_origins_affected_by_device_change = self
+                .stylist
+                .media_features_change_changed_style(&guards, self.device());
+            self.stylist
+                .force_stylesheet_origins_dirty(sheet_origins_affected_by_device_change);
+
             if let Some(mut data) = root_element.mutate_data() {
                 data.hint.insert(RestyleHint::recascade_subtree());
             }
@@ -1053,7 +1073,7 @@ impl LayoutThread {
         }
 
         let root_node = root_element.as_node();
-        let damage_from_environment = if viewport_changed {
+        let damage_from_environment = if device_has_changed {
             RestyleDamage::RELAYOUT
         } else {
             Default::default()
@@ -1353,50 +1373,6 @@ impl LayoutThread {
                 TimerMetadataReflowType::FirstReflow
             },
         })
-    }
-
-    fn viewport_did_change(&mut self, viewport_details: ViewportDetails) -> bool {
-        let new_pixel_ratio = viewport_details.hidpi_scale_factor.get();
-        let new_viewport_size = Size2D::new(
-            Au::from_f32_px(viewport_details.size.width),
-            Au::from_f32_px(viewport_details.size.height),
-        );
-
-        let device = self.stylist.device();
-        let size_did_change = device.au_viewport_size() != new_viewport_size;
-        let pixel_ratio_did_change = device.device_pixel_ratio().get() != new_pixel_ratio;
-
-        size_did_change || pixel_ratio_did_change
-    }
-
-    fn theme_did_change(&self, theme: Theme) -> bool {
-        let theme: PrefersColorScheme = theme.into();
-        theme != self.device().color_scheme()
-    }
-
-    /// Update layout given a new viewport. Returns true if the viewport changed or false if it didn't.
-    fn update_device(
-        &mut self,
-        viewport_details: ViewportDetails,
-        theme: Theme,
-        guards: &StylesheetGuards,
-    ) {
-        let device = Device::new(
-            MediaType::screen(),
-            self.stylist.quirks_mode(),
-            viewport_details.size,
-            Scale::new(viewport_details.hidpi_scale_factor.get()),
-            Box::new(LayoutFontMetricsProvider(self.font_context.clone())),
-            self.stylist.device().default_computed_values().to_arc(),
-            theme.into(),
-        );
-
-        // Preserve any previously computed root font size.
-        device.set_root_font_size(self.stylist.device().root_font_size().px());
-
-        let sheet_origins_affected_by_device_change = self.stylist.set_device(device, guards);
-        self.stylist
-            .force_stylesheet_origins_dirty(sheet_origins_affected_by_device_change);
     }
 }
 

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -67,7 +67,6 @@ impl MixedMessage {
                 ScriptThreadMessage::ExitScriptThread => None,
                 ScriptThreadMessage::SendInputEvent(_, id, _) => Some(*id),
                 ScriptThreadMessage::RefreshCursor(id, ..) => Some(*id),
-                ScriptThreadMessage::Viewport(id, ..) => Some(*id),
                 ScriptThreadMessage::GetTitle(id) => Some(*id),
                 ScriptThreadMessage::SetDocumentActivity(id, ..) => Some(*id),
                 ScriptThreadMessage::SetThrottled(_, id, ..) => Some(*id),

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -160,9 +160,8 @@ fn test_theme_change() {
 
     // Changing the theme updates the current page.
     webview.notify_theme_change(Theme::Dark);
-    let _result = evaluate_javascript(&servo_test, webview.clone(), is_dark_theme_script);
-    // TODO: This is failing due to https://github.com/servo/servo/issues/40129
-    // assert_eq!(result, Ok(JSValue::Boolean(true)));
+    let result = evaluate_javascript(&servo_test, webview.clone(), is_dark_theme_script);
+    assert_eq!(result, Ok(JSValue::Boolean(true)));
 
     delegate.reset();
     webview.load(Url::parse("data:text/html,page two").unwrap());

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -241,6 +241,16 @@ pub trait Layout {
     /// resolve font metrics.
     fn device(&self) -> &Device;
 
+    /// Set the theme on this [`Layout`]'s [`Device`]. The caller should also trigger a
+    /// new layout when this happens, though it can happen later. Returns `true` if the
+    /// [`Theme`] actually changed or `false` otherwise.
+    fn set_theme(&mut self, theme: Theme) -> bool;
+
+    /// Set the [`ViewportDetails`] on this [`Layout`]'s [`Device`]. The caller should also
+    /// trigger a new layout when this happens, though it can happen later. Returns `true`
+    /// if the [`ViewportDetails`] actually changed or `false` otherwise.
+    fn set_viewport_details(&mut self, viewport_details: ViewportDetails) -> bool;
+
     /// Load all fonts from the given stylesheet, returning the number of fonts that
     /// need to be loaded.
     fn load_web_fonts_from_stylesheet(&self, stylesheet: &ServoArc<Stylesheet>);
@@ -488,7 +498,7 @@ bitflags! {
         const PendingRestyles = 1 << 2;
         const HighlightedDOMNodeChanged = 1 << 3;
         const ThemeChanged = 1 << 4;
-        const ViewportSizeChanged = 1 << 5;
+        const ViewportChanged = 1 << 5;
         const PaintWorkletLoaded = 1 << 6;
     }
 }
@@ -583,8 +593,6 @@ pub struct ReflowRequest {
     pub animations: DocumentAnimationSet,
     /// An [`AnimatingImages`] struct used to track images that are animating.
     pub animating_images: Arc<RwLock<AnimatingImages>>,
-    /// The theme for the window
-    pub theme: Theme,
     /// The node highlighted by the devtools, if any
     pub highlighted_dom_node: Option<OpaqueNode>,
 }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -33,7 +33,7 @@ use embedder_traits::{
     InputEventAndId, JavaScriptEvaluationId, MediaSessionActionType, ScriptToEmbedderChan, Theme,
     ViewportDetails, WebDriverScriptCommand,
 };
-use euclid::{Rect, Scale, Size2D, UnknownUnit};
+use euclid::{Scale, Size2D};
 use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use keyboard_types::Modifiers;
 use malloc_size_of_derive::MallocSizeOf;
@@ -161,8 +161,6 @@ pub enum ScriptThreadMessage {
     /// recently hovered cursor position and resetting the cursor. This happens after a
     /// display list update is rendered.
     RefreshCursor(PipelineId),
-    /// Notifies script of the viewport.
-    Viewport(PipelineId, Rect<f32, UnknownUnit>),
     /// Requests that the script thread immediately send the constellation the title of a pipeline.
     GetTitle(PipelineId),
     /// Notifies script thread of a change to one of its document's activity

--- a/tests/wpt/meta/html/semantics/embedded-content/the-img-element/environment-changes/viewport-change.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-img-element/environment-changes/viewport-change.html.ini
@@ -1,10 +1,9 @@
 [viewport-change.html]
-  expected: TIMEOUT
   [img (srcset 1 cand) valid image, resize to wide]
     expected: FAIL
 
   [picture: source (max-width:500px) broken image, img valid image, resize to wide]
-    expected: TIMEOUT
+    expected: FAIL
 
   [picture: source (max-width:500px) valid image, img valid image, resize to wide]
     expected: FAIL
@@ -16,16 +15,10 @@
     expected: FAIL
 
   [picture: source (max-width:500px) valid image, img broken image, resize to narrow]
-    expected: TIMEOUT
+    expected: FAIL
 
   [picture: source (max-width:500px) valid image, img valid image, resize to narrow]
     expected: FAIL
 
   [picture: same URL in source (max-width:500px) and img, resize to narrow]
-    expected: FAIL
-
-  [picture: source (max-width:500px) valid image, img broken image, resize to wide]
-    expected: FAIL
-
-  [picture: source (max-width:500px) broken image, img valid image, resize to narrow]
     expected: FAIL


### PR DESCRIPTION
Instead of waiting for a reflow to update the `Device` in layout, update
it eagerly. This ensures that media queries can be answered correctly in
script before the next reflow. Also, it ensure that a new reflow is
triggered and reflects the change to the theme or viewport.

In addition, an unused viewport-related message from the Constellation
is removed. This would have needed to be updated by change, but since
it's unused I've just removed it.

This depends on https://github.com/servo/stylo/pull/260.

Testing: This fixes a WebView API test and improves
 `/html/semantics/embedded-content/the-img-element/environment-changes/viewport-change.html`.

Fixes: #40395.
Fixes: #40129.
