### PR TITLE
paint: Do trigger animations when a non-animation paint happens

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -124,6 +124,8 @@ bitflags! {
         const NewWebRenderFrame = 1 << 2;
         /// The window has been resized and will need to be synchronously repainted.
         const Resize = 1 << 3;
+        /// A fling has started and a repaint needs to happen to process the animation.
+        const StartedFlinging = 1 << 4;
     }
 }
 

--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -354,7 +354,7 @@ impl Painter {
             return false;
         }
 
-        !self.refresh_driver.wait_to_paint(repaint_reason)
+        !self.refresh_driver.wait_to_paint()
     }
 
     /// Returns true if any animation callbacks (ie `requestAnimationFrame`) are waiting for a response.
@@ -1338,7 +1338,7 @@ impl Painter {
                 _ => {},
             }
 
-            webview_renderer.notify_input_event(&self.webrender_api, event);
+            webview_renderer.notify_input_event(&self.webrender_api, &self.needs_repaint, event);
         }
         self.disable_lcp_calculation_for_webview(webview_id);
     }
@@ -1404,7 +1404,12 @@ impl Painter {
             warn!("Handled input event for unknown webview: {webview_id}");
             return;
         };
-        webview_renderer.notify_input_event_handled(&self.webrender_api, input_event_id, result);
+        webview_renderer.notify_input_event_handled(
+            &self.webrender_api,
+            &self.needs_repaint,
+            input_event_id,
+            result,
+        );
     }
 
     pub(crate) fn refresh_cursor(&self) {


### PR DESCRIPTION
Otherwise the `RefreshObsever` can get wedged. This does mean that we
will overpaint a bit when processing input events and animating, but we
could integrate scroll / zoom event handling with the animation loop to
eliminate this overpaint.

Testing: This kind of fix for touch interaction is currently very hard to test as it
relies heavily on the order that operations happen between Servo and the
`RefreshDriver`. It is easy to reproduce in interactive usage though and this
change fixes it.
