### PR TITLE
servoshell: Implement context menu in servoshell

### DIFF
--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -2428,6 +2428,7 @@ impl HTMLInputElement {
                     allow_select_multiple: self.Multiple(),
                     accept_current_paths_for_testing,
                 }),
+                None,
             );
     }
 
@@ -2810,6 +2811,7 @@ impl HTMLInputElement {
             document.embedder_controls().show_embedder_control(
                 ControlElement::ColorInput(DomRoot::from_ref(self)),
                 EmbedderControlRequest::ColorPicker(current_color),
+                None,
             );
         }
     }
@@ -2893,6 +2895,7 @@ impl HTMLInputElement {
                     insertion_point: self.GetSelectionEnd(),
                     multiline: false,
                 }),
+                None,
             );
     }
 }

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -398,6 +398,7 @@ impl HTMLSelectElement {
             .show_embedder_control(
                 ControlElement::Select(DomRoot::from_ref(self)),
                 EmbedderControlRequest::SelectElement(options, selected_index),
+                None,
             );
     }
 

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -223,6 +223,7 @@ impl HTMLTextAreaElement {
                     insertion_point: self.GetSelectionEnd(),
                     multiline: false,
                 }),
+                None,
             );
     }
 }

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -122,11 +122,10 @@ use crate::responders::ServoErrorChannel;
 pub use crate::servo_delegate::{ServoDelegate, ServoError};
 use crate::webview::MINIMUM_WEBVIEW_SIZE;
 pub use crate::webview::{WebView, WebViewBuilder};
-use crate::webview_delegate::ContextMenu;
 pub use crate::webview_delegate::{
-    AllowOrDenyRequest, AuthenticationRequest, ColorPicker, EmbedderControl, FilePicker,
-    InputMethodControl, NavigationRequest, PermissionRequest, SelectElement, WebResourceLoad,
-    WebViewDelegate,
+    AllowOrDenyRequest, AuthenticationRequest, ColorPicker, ContextMenu, EmbedderControl,
+    FilePicker, InputMethodControl, NavigationRequest, PermissionRequest, SelectElement,
+    WebResourceLoad, WebViewDelegate,
 };
 
 #[cfg(feature = "media-gstreamer")]

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -664,7 +664,7 @@ pub struct ContextMenuRequest {
 }
 
 /// An item in a context menu.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum ContextMenuItem {
     Item {
         label: String,
@@ -676,7 +676,7 @@ pub enum ContextMenuItem {
 /// A particular action associated with a [`ContextMenuItem`]. These actions are
 /// context-sensitive, which means that some of them are available only for some
 /// page elements.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
 pub enum ContextMenuAction {
     GoBack,
     GoForward,


### PR DESCRIPTION
This PR adds context menu support with clickable menu items in the Minibrowser. The menu appears on right click and supports basic navigation actions (Back, Forward, Reload).


Testing: We already have tests for ContextMenu in WebView API test.

