### PR TITLE
webdriver: Remove session requirement from Shutdown command

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -96,7 +96,7 @@ fn extension_routes() -> Vec<(Method, &'static str, ServoExtensionRoute)> {
         ),
         (
             Method::DELETE,
-            "/session/{sessionId}/servo/shutdown",
+            "/servo/shutdown",
             ServoExtensionRoute::Shutdown,
         ),
     ]


### PR DESCRIPTION
Change API endpoint from "/session/{sessionId}/servo/shutdown" to "/servo/shutdown", similar to [Status command](https://w3c.github.io/webdriver/#dfn-status).

This will make it much easier to shutdown Servo properly from wptrunner.