### PR TITLE
dom: Focus scroll to the element only if it is not visible

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -163,7 +163,7 @@ use crate::dom::node::{
 use crate::dom::nodelist::NodeList;
 use crate::dom::promise::Promise;
 use crate::dom::raredata::ElementRareData;
-use crate::dom::scrolling_box::ScrollingBox;
+use crate::dom::scrolling_box::{ScrollAxisState, ScrollingBox};
 use crate::dom::servoparser::ServoParser;
 use crate::dom::shadowroot::{IsUserAgentWidget, ShadowRoot};
 use crate::dom::text::Text;
@@ -842,11 +842,11 @@ impl Element {
     }
 
     /// <https://drafts.csswg.org/cssom-view/#scroll-a-target-into-view>
-    fn scroll_into_view_with_options(
+    pub(crate) fn scroll_into_view_with_options(
         &self,
         behavior: ScrollBehavior,
-        block: ScrollLogicalPosition,
-        inline: ScrollLogicalPosition,
+        block: ScrollAxisState,
+        inline: ScrollAxisState,
         container: Option<&Element>,
         inner_target_rect: Option<Rect<Au>>,
     ) {
@@ -3433,13 +3433,19 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
         };
 
         // Step 7: If the element does not have any associated box, or is not
-        // available to user-agent features, then return.
+        //         available to user-agent features, then return.
         if !self.has_css_layout_box() {
             return;
         }
 
         // Step 8: Scroll the element into view with behavior, block, inline, and container.
-        self.scroll_into_view_with_options(behavior, block, inline, container, None);
+        self.scroll_into_view_with_options(
+            behavior,
+            ScrollAxisState::new_always_scroll_position(block),
+            ScrollAxisState::new_always_scroll_position(inline),
+            container,
+            None,
+        );
 
         // Step 9: Optionally perform some other action that brings the
         // element to the user’s attention.

--- a/components/script/dom/scrolling_box.rs
+++ b/components/script/dom/scrolling_box.rs
@@ -38,6 +38,48 @@ pub(crate) enum ScrollingBoxAxis {
     Y,
 }
 
+#[derive(Copy, Clone)]
+pub(crate) enum ScrollRequirement {
+    Always,
+    IfNotVisible,
+}
+
+impl ScrollRequirement {
+    fn compute_need_scroll(
+        &self,
+        element_start: f32,
+        element_end: f32,
+        container_size: f32,
+    ) -> bool {
+        match self {
+            ScrollRequirement::Always => true,
+            ScrollRequirement::IfNotVisible => {
+                // Because the element_start and element_end have taken into account the scroll_offset, the
+                // viewport_start and viewport_end should have the root coordinate space.
+                let viewport_start = 0.;
+                let viewport_end = container_size;
+
+                element_end <= viewport_start || element_start >= viewport_end
+            },
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+pub(crate) struct ScrollAxisState {
+    pub(crate) position: ScrollLogicalPosition,
+    pub(crate) requirement: ScrollRequirement,
+}
+
+impl ScrollAxisState {
+    pub fn new_always_scroll_position(position: ScrollLogicalPosition) -> Self {
+        ScrollAxisState {
+            position,
+            requirement: ScrollRequirement::Always,
+        }
+    }
+}
+
 impl ScrollingBox {
     pub(crate) fn new(target: ScrollingBoxSource, overflow: AxesOverflow) -> Self {
         Self {
@@ -148,8 +190,8 @@ impl ScrollingBox {
     /// <https://drafts.csswg.org/cssom-view/#determine-the-scroll-into-view-position>
     pub(crate) fn determine_scroll_into_view_position(
         &self,
-        block: ScrollLogicalPosition,
-        inline: ScrollLogicalPosition,
+        block: ScrollAxisState,
+        inline: ScrollAxisState,
         target_rect: Rect<Au>,
     ) -> LayoutVector2D {
         let device_pixel_ratio = self.node().owner_window().device_pixel_ratio().get();
@@ -203,16 +245,25 @@ impl ScrollingBox {
     }
 
     /// Step 10 from <https://drafts.csswg.org/cssom-view/#determine-the-scroll-into-view-position>:
+    // TODO: we are not considering the coordinate system of the element while deciding the scroll position.
     fn calculate_scroll_position_one_axis(
-        alignment: ScrollLogicalPosition,
+        state: ScrollAxisState,
         element_start: f32,
         element_end: f32,
         container_size: f32,
         current_scroll_offset: f32,
     ) -> f32 {
+        if !state
+            .requirement
+            .compute_need_scroll(element_start, element_end, container_size)
+        {
+            return current_scroll_offset;
+        }
+
         let element_size = element_end - element_start;
+
         current_scroll_offset +
-            match alignment {
+            match state.position {
                 // Step 1 & 5: If inline is "start", then align element start edge with scrolling box start edge.
                 ScrollLogicalPosition::Start => element_start,
                 // Step 2 & 6: If inline is "end", then align element end edge with
@@ -225,8 +276,10 @@ impl ScrollingBox {
                 },
                 // Step 4 & 8: If inline is "nearest",
                 ScrollLogicalPosition::Nearest => {
-                    let viewport_start = current_scroll_offset;
-                    let viewport_end = current_scroll_offset + container_size;
+                    // Because the element_start and element_end have taken into account the scroll_offset, the
+                    // viewport_start and viewport_end should have the root coordinate space.
+                    let viewport_start = 0.;
+                    let viewport_end = container_size;
 
                     // Step 4.2 & 8.2: If element start edge is outside scrolling box start edge and element
                     // size is less than scrolling box size or If element end edge is outside
@@ -249,7 +302,7 @@ impl ScrollingBox {
                     // Step 4.1 & 8.1: If element start edge and element end edge are both outside scrolling
                     // box start edge and scrolling box end edge or an invalid situation: Do nothing.
                     else {
-                        current_scroll_offset
+                        0.
                     }
                 },
             }

--- a/components/script/dom/scrolling_box.rs
+++ b/components/script/dom/scrolling_box.rs
@@ -54,12 +54,10 @@ impl ScrollRequirement {
         match self {
             ScrollRequirement::Always => true,
             ScrollRequirement::IfNotVisible => {
-                // Because the element_start and element_end have taken into account the scroll_offset, the
-                // viewport_start and viewport_end should have the root coordinate space.
-                let viewport_start = 0.;
-                let viewport_end = container_size;
+                let scrollport_start = 0.;
+                let scrollport_end = container_size;
 
-                element_end <= viewport_start || element_start >= viewport_end
+                element_end <= scrollport_start || element_start >= scrollport_end
             },
         }
     }
@@ -276,17 +274,15 @@ impl ScrollingBox {
                 },
                 // Step 4 & 8: If inline is "nearest",
                 ScrollLogicalPosition::Nearest => {
-                    // Because the element_start and element_end have taken into account the scroll_offset, the
-                    // viewport_start and viewport_end should have the root coordinate space.
-                    let viewport_start = 0.;
-                    let viewport_end = container_size;
+                    let scrollport_start = 0.;
+                    let scrollport_end = container_size;
 
                     // Step 4.2 & 8.2: If element start edge is outside scrolling box start edge and element
                     // size is less than scrolling box size or If element end edge is outside
                     // scrolling box end edge and element size is greater than scrolling box size:
                     // Align element start edge with scrolling box start edge.
-                    if (element_start < viewport_start && element_size <= container_size) ||
-                        (element_end > viewport_end && element_size >= container_size)
+                    if (element_start < scrollport_start && element_size <= container_size) ||
+                        (element_end > scrollport_end && element_size >= container_size)
                     {
                         element_start
                     }
@@ -294,8 +290,8 @@ impl ScrollingBox {
                     // size is greater than scrolling box size or If element start edge is outside
                     // scrolling box end edge and element size is less than scrolling box size:
                     // Align element end edge with scrolling box end edge.
-                    else if (element_end > viewport_end && element_size < container_size) ||
-                        (element_start < viewport_start && element_size > container_size)
+                    else if (element_end > scrollport_end && element_size < container_size) ||
+                        (element_start < scrollport_start && element_size > container_size)
                     {
                         element_end - container_size
                     }

--- a/tests/wpt/meta/focus/focus-large-element-in-overflow-hidden-container.html.ini
+++ b/tests/wpt/meta/focus/focus-large-element-in-overflow-hidden-container.html.ini
@@ -1,2 +1,0 @@
-[focus-large-element-in-overflow-hidden-container.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/interaction/focus/processing-model/textarea-scroll-selection.html.ini
+++ b/tests/wpt/meta/html/interaction/focus/processing-model/textarea-scroll-selection.html.ini
@@ -1,0 +1,3 @@
+[textarea-scroll-selection.html]
+  [programatic focus() scrolls selection into view including ancestors]
+    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13515,6 +13515,13 @@
       {}
      ]
     ],
+    "focus_scroll_when_visible.html": [
+     "c5d8888a31d7ab188df936bc0977dc156ea255d5",
+     [
+      null,
+      {}
+     ]
+    ],
     "follow-hyperlink.html": [
      "6ac9eaeb5814a663988ed8c664c113072e329dc5",
      [

--- a/tests/wpt/mozilla/tests/mozilla/focus_scroll_when_visible.html
+++ b/tests/wpt/mozilla/tests/mozilla/focus_scroll_when_visible.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Focused Input shouldn't be scrolled if the input is visible.</title>
+  <link rel="author" title="Jo Steven Novaryo" href="mailto:steven.novaryo@gmail.com">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<style>
+#hidden_container {
+  overflow: hidden;
+  width: 200px;
+  height: 200px;
+}
+input {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  border: 0px;
+  font-size: 10px;
+}
+.overflowing_child {
+  width: 1000px;
+  height: 1000px;
+}
+body {
+  margin: 0;
+}
+</style>
+<body>
+  <div id="hidden_container">
+    <input id="target">
+    <div class="overflowing_child"></div>
+  </div>
+  <script>
+
+  // This should give UAs with smooth scrolling enough time to finish the smooth scroll.
+  const FRAME_DELAY = 1000;
+
+  async function waitForNextFrame() {
+    const startTime = performance.now();
+    return new Promise(resolve => {
+      window.requestAnimationFrame((frameTime) => {
+        if (frameTime < startTime + FRAME_DELAY) {
+          window.requestAnimationFrame(resolve);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  function resetAndSetPosition(top, left) {
+    target.blur();
+    target.style = `top: ${top}px; left: ${left}px`;
+  }
+
+  function assertUnchanged(initialRect) {
+    let focusedRect = target.getBoundingClientRect();
+    assert_equals(initialRect.top, focusedRect.top);
+    assert_equals(initialRect.left, focusedRect.left);
+    assert_equals(initialRect.bottom, focusedRect.bottom);
+    assert_equals(initialRect.right, focusedRect.right);
+  }
+
+  function assertScrollToTheMiddle() {
+    let focusedRect = target.getBoundingClientRect();
+    let containerRect = hidden_container.getBoundingClientRect();
+    assert_equals((containerRect.height - focusedRect.height) / 2, focusedRect.top);
+    assert_equals((containerRect.width - focusedRect.width) / 2, focusedRect.left);
+    assert_equals(containerRect.height - (containerRect.height - focusedRect.height) / 2, focusedRect.bottom);
+    assert_equals(containerRect.width - (containerRect.width - focusedRect.width) / 2, focusedRect.right);
+  }
+
+  promise_test(async t => {
+    resetAndSetPosition(0, 0);
+    let initialRect = target.getBoundingClientRect();
+    await waitForNextFrame();
+    target.focus();
+    await waitForNextFrame();
+    assertUnchanged(initialRect);
+  }, 'Element that could not be scrolled to the center should be unchanged.');
+
+  promise_test(async t => {
+    resetAndSetPosition(100, 100);
+    await waitForNextFrame();
+    let initialRect = target.getBoundingClientRect();
+    target.focus();
+    await waitForNextFrame();
+    assertUnchanged(initialRect);
+  }, 'Element that is completely visible should be unchanged.');
+
+  promise_test(async t => {
+    resetAndSetPosition(125, 125);
+    await waitForNextFrame();
+    let initialRect = target.getBoundingClientRect();
+    target.focus();
+    await waitForNextFrame();
+    assertUnchanged(initialRect);
+  }, 'Element that is halfway visible should be unchanged.');
+
+  promise_test(async t => {
+    resetAndSetPosition(300, 300);
+    await waitForNextFrame();
+    let initialRect = target.getBoundingClientRect();
+    target.focus();
+    await waitForNextFrame();
+    assertScrollToTheMiddle();
+  }, 'Element that completely hidden should be scrolled.');
+  </script>
+</body>
+</html>

--- a/tests/wpt/tests/css/cssom-view/scrollIntoView-nearest-visible-element.html
+++ b/tests/wpt/tests/css/cssom-view/scrollIntoView-nearest-visible-element.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>scrollIntoView nearest shouldn't scroll a completely visible element</title>
+  <link rel="author" title="Jo Steven Novaryo" href="mailto:steven.novaryo@gmail.com">
+  <link rel="help" href="https://drafts.csswg.org/cssom-view/#determine-the-scroll-into-view-position">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+
+<style>
+#container {
+  width: 300px;
+  height: 300px;
+  overflow: scroll;
+}
+
+#target {
+  width: 100px;
+  height: 100px;
+  position: relative;
+  top: 600px;
+  left: 800px;
+  background-color: aqua;
+}
+
+#overflowing {
+  width: 3000px;
+  height: 3000px;
+}
+</style>
+
+<div id="container">
+  <div id="target">
+  </div>
+  <div id="overflowing"></div>
+</div>
+
+<script>
+  test(function() {
+    container.scrollTop = 500;
+    container.scrollLeft = 700;
+    let initial_target_rect = target.getBoundingClientRect();
+    target.scrollIntoView({block: 'nearest', inline: 'nearest'});
+
+    let final_target_rect = target.getBoundingClientRect();
+    assert_equals(initial_target_rect.x, final_target_rect.x, 'Target x position remain unchanged');
+    assert_equals(initial_target_rect.y, final_target_rect.y, 'Target y position remain unchanged');
+  }, "scrollIntoView with `nearest` block and inline option shouldn't scroll a completely visible element");
+</script>
+</html>


### PR DESCRIPTION
Currently when we call a `Focus` we always scroll a focusable element to the center of the container. However, this would causes a different behavior where UAs wouldn't scroll when a focus is called to a visible element. This PR add implementations following the behavior of Firefox [nsFocusManager::ScrollIntoView](https://github.com/mozilla-firefox/firefox/blob/e613f4df351a21871cfeadf7d5b4043ffad157b1/dom/base/nsFocusManager.cpp#L3121), where we are scrolling to the element if it is not visible.

This would enhance the user experience of focusing an input element, where we should avoid moving the element if it is visible.

Incidentally fix a calculation bug for the calculation of `ScrollIntoView` with `nearest` block or inline option.

Testing: Private WPT for the implementation defined behavior and public WPT for the bug.