### PR TITLE
script: Also set the `Theme` on incomplete loads

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2538,6 +2538,10 @@ impl ScriptThread {
         for (_, document) in self.documents.borrow().iter() {
             document.window().handle_theme_change(theme);
         }
+        let mut loads = self.incomplete_loads.borrow_mut();
+        for load in loads.iter_mut() {
+            load.theme = theme;
+        }
     }
 
     // exit_fullscreen creates a new JS promise object, so we need to have entered a realm

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -171,6 +171,16 @@ fn test_theme_change() {
     // The theme persists after a navigation.
     let result = evaluate_javascript(&servo_test, webview.clone(), is_dark_theme_script);
     assert_eq!(result, Ok(JSValue::Boolean(true)));
+
+    // Now test the same thing, but setting the theme immediately after creating the WebView.
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo())
+        .delegate(delegate.clone())
+        .url(Url::parse("data:text/html,page one").unwrap())
+        .build();
+    webview.notify_theme_change(Theme::Dark);
+    let result = evaluate_javascript(&servo_test, webview.clone(), is_dark_theme_script);
+    assert_eq!(result, Ok(JSValue::Boolean(true)));
 }
 
 #[test]


### PR DESCRIPTION
When updating the theme, ensure that it is also set on incomplete loads.
This is particularly necessary to make it so that a non-Light theme is
used when it is set before the page loads.

Testing: This adds a new WebView API test.
Fixes: #40437.
