### PR TITLE
xpath: Enforce tree order in node sets during evaluation

### DIFF
--- a/components/script/dom/xpathexpression.rs
+++ b/components/script/dom/xpathexpression.rs
@@ -97,7 +97,7 @@ impl XPathExpression {
                 Value::Boolean(_) => XPathResultType::Boolean,
                 Value::Number(_) => XPathResultType::Number,
                 Value::String(_) => XPathResultType::String,
-                Value::Nodeset(_) => XPathResultType::UnorderedNodeIterator,
+                Value::NodeSet(_) => XPathResultType::UnorderedNodeIterator,
             }
         } else {
             result_type

--- a/components/script/dom/xpathresult.rs
+++ b/components/script/dom/xpathresult.rs
@@ -7,7 +7,6 @@ use std::cell::{Cell, RefCell};
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
-use xpath::NodesetHelpers;
 
 use crate::dom::bindings::codegen::Bindings::XPathResultBinding::{
     XPathResultConstants, XPathResultMethods,
@@ -73,16 +72,8 @@ impl From<Value> for XPathResultValue {
             Value::Boolean(b) => XPathResultValue::Boolean(b),
             Value::Number(n) => XPathResultValue::Number(n),
             Value::String(s) => XPathResultValue::String(s.into()),
-            Value::Nodeset(nodes) => {
-                // Put the evaluation result into (unique) document order. This also re-roots them
-                // so that we are sure we can hold them for the lifetime of this XPathResult.
-                let rooted_nodes = nodes.document_order_unique();
-                XPathResultValue::Nodeset(
-                    rooted_nodes
-                        .into_iter()
-                        .map(XPathWrapper::into_inner)
-                        .collect(),
-                )
+            Value::NodeSet(nodes) => {
+                XPathResultValue::Nodeset(nodes.into_iter().map(XPathWrapper::into_inner).collect())
             },
         }
     }

--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -7,7 +7,6 @@
 use std::cell::Ref;
 use std::cmp::Ordering;
 use std::fmt::Debug;
-use std::hash::Hash;
 use std::rc::Rc;
 
 use html5ever::{LocalName, Namespace, Prefix};
@@ -18,6 +17,7 @@ use script_bindings::root::Dom;
 use script_bindings::script_runtime::CanGc;
 use script_bindings::str::DOMString;
 use style::Atom;
+use style::dom::OpaqueNode;
 
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::XPathNSResolverBinding::XPathNSResolver;
@@ -50,6 +50,8 @@ impl xpath::Node for XPathWrapper<DomRoot<Node>> {
     type Document = XPathWrapper<DomRoot<Document>>;
     type Attribute = XPathWrapper<DomRoot<Attr>>;
     type Element = XPathWrapper<DomRoot<Element>>;
+    /// A opaque handle to a node with the sole purpose of comparing one node with another.
+    type Opaque = OpaqueNode;
 
     fn is_comment(&self) -> bool {
         self.0.is::<Comment>()
@@ -126,7 +128,7 @@ impl xpath::Node for XPathWrapper<DomRoot<Node>> {
         XPathWrapper(self.0.owner_document())
     }
 
-    fn to_opaque(&self) -> impl Eq + Hash {
+    fn to_opaque(&self) -> Self::Opaque {
         self.0.to_opaque()
     }
 

--- a/components/xpath/src/lib.rs
+++ b/components/xpath/src/lib.rs
@@ -189,6 +189,7 @@ mod dummy_implementation {
         type Document = DummyDocument;
         type Attribute = DummyAttribute;
         type Element = DummyElement;
+        type Opaque = usize;
 
         fn is_comment(&self) -> bool {
             false
@@ -232,7 +233,7 @@ mod dummy_implementation {
         fn owner_document(&self) -> Self::Document {
             DummyDocument
         }
-        fn to_opaque(&self) -> impl Eq + Hash {
+        fn to_opaque(&self) -> Self::Opaque {
             0
         }
         fn as_processing_instruction(&self) -> Option<Self::ProcessingInstruction> {

--- a/components/xpath/src/lib.rs
+++ b/components/xpath/src/lib.rs
@@ -18,7 +18,7 @@ use ast::QName;
 use context::EvaluationCtx;
 use markup5ever::{LocalName, Namespace, Prefix};
 pub use parser::{Error as ParserError, parse};
-pub use value::{NodesetHelpers, Value};
+pub use value::{NodeSet, Value};
 
 pub trait Dom {
     type Node: Node;
@@ -31,6 +31,7 @@ pub trait Node: Eq + Clone + fmt::Debug {
     type Document: Document<Node = Self>;
     type Attribute: Attribute<Node = Self>;
     type Element: Element<Node = Self>;
+    type Opaque: Eq + Hash + 'static;
 
     fn is_comment(&self) -> bool;
     fn is_text(&self) -> bool;
@@ -50,7 +51,7 @@ pub trait Node: Eq + Clone + fmt::Debug {
     fn preceding_siblings(&self) -> impl Iterator<Item = Self>;
     fn following_siblings(&self) -> impl Iterator<Item = Self>;
     fn owner_document(&self) -> Self::Document;
-    fn to_opaque(&self) -> impl Eq + Hash;
+    fn to_opaque(&self) -> Self::Opaque;
     fn as_processing_instruction(&self) -> Option<Self::ProcessingInstruction>;
     fn as_attribute(&self) -> Option<Self::Attribute>;
     fn as_element(&self) -> Option<Self::Element>;
@@ -68,6 +69,7 @@ pub trait ProcessingInstruction {
 pub trait Document {
     type Node: Node<Document = Self>;
 
+    /// Return an iterator over elements with the given ID in tree order.
     fn get_elements_with_id(&self, id: &str)
     -> impl Iterator<Item = <Self::Node as Node>::Element>;
 }
@@ -100,7 +102,12 @@ pub fn evaluate_parsed_xpath<D: Dom>(
 ) -> Result<Value<D::Node>, Error> {
     let context = EvaluationCtx::<D>::new(context_node);
     match expr.evaluate(&context) {
-        Ok(value) => {
+        Ok(mut value) => {
+            if let Value::NodeSet(node_set) = &mut value {
+                node_set.deduplicate();
+                node_set.sort();
+            }
+
             log::debug!("Evaluated XPath: {value:?}");
             Ok(value)
         },

--- a/tests/wpt/tests/domxpath/node-set-tree-order.html
+++ b/tests/wpt/tests/domxpath/node-set-tree-order.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Tree order of node sets during evaluation</title>
+  <link rel="author" title="Simon Wülker" href="mailto:simon.wuelker@arcor.de">
+  <link rel="help" href="https://github.com/servo/servo/issues/40435">
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+    <div id="container">
+        <span></span>
+        <p id="p"></p>
+    </div>
+    <script>
+    function toArray(result) {
+      var a = [];
+      while (true) {
+        var node = result.iterateNext();
+        if (node === null) break;
+        a.push(node);
+      }
+      return a;
+    }
+
+    let container = document.getElementById("container");
+    test(() => {
+      // If the result of "(./p | ./span)" is not in tree order then "last()" will filter the wrong element,
+      // causing the span to be returned.
+
+      let result = document.evaluate("(./p | ./span)[last()]", container, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+      assert_array_equals(toArray(result), [document.getElementById("p")])
+    }, "Temporary node sets created during evaluation must be in tree order");
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This change adds `NodeSet`, which is more or less a `Vec<Node>` that knows whether it is sorted, and can sort itself if it isn't. This allows us to efficiently enforce tree order in intermediary node sets that occur during evaluation.

Notably, in many cases it is not necessary to sort at all, because all location step expressions yield node sets that are either already sorted (`Axis::DescendantOrSelf` for example), or that are in inverse tree order (`Axis::PrecedingSiblings` for example).

There's still optimization work left to be done. When merging two node sets that are already sorted then we could use merge sort instead of appending one to the other and naively sorting. But I suspect that the sorting algorithm used by the standard library is already well tuned to handle such cases...

Testing: This change adds a web platform test
Fixes https://github.com/servo/servo/issues/40435
