### PR TITLE
net: Use callbacks instead of IPC channels in the `ImageCache` API

### DIFF
--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -393,7 +393,7 @@ impl HTMLImageElement {
         let trusted_node = Trusted::new(self);
         let generation = self.generation_id();
         let window = self.owner_window();
-        let sender = window.register_image_cache_listener(id, move |response| {
+        let callback = window.register_image_cache_listener(id, move |response| {
             let trusted_node = trusted_node.clone();
             let window = trusted_node.root().owner_window();
             let callback_type = change_type.clone();
@@ -423,9 +423,11 @@ impl HTMLImageElement {
             }));
         });
 
-        window
-            .image_cache()
-            .add_listener(ImageLoadListener::new(sender, window.pipeline_id(), id));
+        window.image_cache().add_listener(ImageLoadListener::new(
+            callback,
+            window.pipeline_id(),
+            id,
+        ));
     }
 
     fn fetch_request(&self, img_url: &ServoUrl, id: PendingImageId) {

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -8,10 +8,9 @@ use std::default::Default;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
-use ipc_channel::ipc::IpcSender;
 use js::rust::HandleObject;
 use net_traits::image_cache::{
-    Image, ImageCache, ImageCacheResponseMessage, ImageCacheResult, ImageLoadListener,
+    Image, ImageCache, ImageCacheResponseCallback, ImageCacheResult, ImageLoadListener,
     ImageOrMetadataAvailable, ImageResponse, PendingImageId,
 };
 use net_traits::request::{Destination, Initiator, RequestBuilder, RequestId};
@@ -679,10 +678,7 @@ impl HTMLLinkElement {
         };
     }
 
-    fn register_image_cache_callback(
-        &self,
-        id: PendingImageId,
-    ) -> IpcSender<ImageCacheResponseMessage> {
+    fn register_image_cache_callback(&self, id: PendingImageId) -> ImageCacheResponseCallback {
         let trusted_node = Trusted::new(self);
         let window = self.owner_window();
         let request_generation_id = self.get_request_generation_id();

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -224,7 +224,7 @@ impl HTMLVideoElement {
 
         let trusted_node = Trusted::new(self);
         let generation = self.generation_id();
-        let sender = window.register_image_cache_listener(id, move |response| {
+        let callback = window.register_image_cache_listener(id, move |response| {
             let element = trusted_node.root();
 
             // Ignore any image response for a previous request that has been discarded.
@@ -234,7 +234,7 @@ impl HTMLVideoElement {
             element.process_image_response(response.response, CanGc::note());
         });
 
-        image_cache.add_listener(ImageLoadListener::new(sender, window.pipeline_id(), id));
+        image_cache.add_listener(ImageLoadListener::new(callback, window.pipeline_id(), id));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#poster-frame>

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -66,8 +66,8 @@ use malloc_size_of::MallocSizeOf;
 use media::WindowGLContext;
 use net_traits::ResourceThreads;
 use net_traits::image_cache::{
-    ImageCache, ImageCacheResponseMessage, ImageLoadListener, ImageResponse, PendingImageId,
-    PendingImageResponse, RasterizationCompleteResponse,
+    ImageCache, ImageCacheResponseCallback, ImageCacheResponseMessage, ImageLoadListener,
+    ImageResponse, PendingImageId, PendingImageResponse, RasterizationCompleteResponse,
 };
 use num_traits::ToPrimitive;
 use profile_traits::generic_channel as ProfiledGenericChannel;
@@ -276,7 +276,7 @@ pub(crate) struct Window {
     #[no_trace]
     image_cache: Arc<dyn ImageCache>,
     #[no_trace]
-    image_cache_sender: IpcSender<ImageCacheResponseMessage>,
+    image_cache_sender: Sender<ImageCacheResponseMessage>,
     window_proxy: MutNullableDom<WindowProxy>,
     document: MutNullableDom<Document>,
     location: MutNullableDom<Location>,
@@ -657,13 +657,17 @@ impl Window {
         &self,
         id: PendingImageId,
         callback: impl Fn(PendingImageResponse) + 'static,
-    ) -> IpcSender<ImageCacheResponseMessage> {
+    ) -> ImageCacheResponseCallback {
         self.pending_image_callbacks
             .borrow_mut()
             .entry(id)
             .or_default()
             .push(PendingImageCallback(Box::new(callback)));
-        self.image_cache_sender.clone()
+
+        let image_cache_sender = self.image_cache_sender.clone();
+        Box::new(move |message| {
+            let _ = image_cache_sender.send(message);
+        })
     }
 
     fn pending_layout_image_notification(&self, response: PendingImageResponse) {
@@ -3330,11 +3334,14 @@ impl Window {
 
             let mut images = self.pending_images_for_rasterization.borrow_mut();
             if !images.contains_key(&(image.id, image.size)) {
+                let image_cache_sender = self.image_cache_sender.clone();
                 self.image_cache.add_rasterization_complete_listener(
                     pipeline_id,
                     image.id,
                     image.size,
-                    self.image_cache_sender.clone(),
+                    Box::new(move |response| {
+                        let _ = image_cache_sender.send(response);
+                    }),
                 );
             }
 
@@ -3360,7 +3367,7 @@ impl Window {
         script_chan: Sender<MainThreadScriptMsg>,
         layout: Box<dyn Layout>,
         font_context: Arc<FontContext>,
-        image_cache_sender: IpcSender<ImageCacheResponseMessage>,
+        image_cache_sender: Sender<ImageCacheResponseMessage>,
         image_cache: Arc<dyn ImageCache>,
         resource_threads: ResourceThreads,
         storage_threads: StorageThreads,

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -358,11 +358,10 @@ pub(crate) struct ScriptThreadSenders {
     #[no_trace]
     pub(crate) pipeline_to_embedder_sender: ScriptToEmbedderChan,
 
-    /// The shared [`IpcSender`] which is sent to the `ImageCache` when requesting an image. The
-    /// messages on this channel are routed to crossbeam [`Sender`] on the router thread, which
-    /// in turn sends messages to [`ScriptThreadReceivers::image_cache_receiver`].
+    /// The shared [`Sender`] which is sent to the `ImageCache` when requesting an image.
+    /// Messages on this channel are sent to [`ScriptThreadReceivers::image_cache_receiver`].
     #[no_trace]
-    pub(crate) image_cache_sender: IpcSender<ImageCacheResponseMessage>,
+    pub(crate) image_cache_sender: Sender<ImageCacheResponseMessage>,
 
     /// For providing contact with the time profiler.
     #[no_trace]

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -896,13 +896,6 @@ impl ScriptThread {
         );
 
         let (image_cache_sender, image_cache_receiver) = unbounded();
-        let (ipc_image_cache_sender, ipc_image_cache_receiver) = ipc::channel().unwrap();
-        ROUTER.add_typed_route(
-            ipc_image_cache_receiver,
-            Box::new(move |message| {
-                let _ = image_cache_sender.send(message.unwrap());
-            }),
-        );
 
         let receivers = ScriptThreadReceivers {
             constellation_receiver,
@@ -921,7 +914,7 @@ impl ScriptThread {
             constellation_sender: state.constellation_sender,
             pipeline_to_constellation_sender: state.pipeline_to_constellation_sender.sender.clone(),
             pipeline_to_embedder_sender: state.pipeline_to_embedder_sender.clone(),
-            image_cache_sender: ipc_image_cache_sender,
+            image_cache_sender,
             time_profiler_sender: state.time_profiler_sender,
             memory_profiler_sender: state.memory_profiler_sender,
             devtools_server_sender,


### PR DESCRIPTION
Previously, the `ImageCache` would inform consumers of changes to image
availability by messaging an IPC channel. This isn't great, because it
requires serialization and deserialization. Nowadays, `ImageCache`s are
always owned by the same `Global` that uses them. This change replaces
the IPC channel with callback that implements `Send`.

For the case of normal HTML document images, the results are still sent
over the pre-existing Crossbeam channel that was connected via an IPC
route. A followup change might eliminate that channel entirely.

Testing: This should not change observable behavior so is covered by existing tests.
Fixes: #24338.