### PR TITLE
servodriver: Shut down Servo elegantly when all tests finish

### DIFF
--- a/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -144,11 +144,11 @@ class ServoWebDriverBrowser(WebDriverBrowser):
         return True
 
     def stop(self, force=False):
-        conn = HTTPConnection(self.host, self.port)
         while self.is_alive():
             self.logger.info("Trying to shut down gracefully by extension command")
             while True:
                 try:
+                    conn = HTTPConnection(self.host, self.port)
                     conn.request("DELETE", "/session/dummy-session-id/servo/shutdown")
                     res = conn.getresponse()
                     self.logger.info(f"Got response status for shutdown command: {res.status}")


### PR DESCRIPTION
Previously, we always kill the instance when tests finish instead of normally shutting down. That blocked clean-ups works, such as Code Coverage we wanted to add, and other things I'm not aware of.

Testing: We have tested for a week and checked the logs of CI to confirm it works normally now.
