### PR TITLE
net: Do not implement `Serialize`/`Deserialize` for `RasterImage` and introduce``SharedRasterImage`

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -13,7 +13,6 @@ use base::id::{PipelineId, WebViewId};
 use base::threadpool::ThreadPool;
 use compositing_traits::{CrossProcessCompositorApi, ImageUpdate, SerializableImageData};
 use imsz::imsz_from_reader;
-use ipc_channel::ipc::IpcSharedMemory;
 use log::{debug, warn};
 use malloc_size_of::{MallocSizeOf as MallocSizeOfTrait, MallocSizeOfOps};
 use malloc_size_of_derive::MallocSizeOf;
@@ -935,7 +934,7 @@ impl ImageCache for ImageCacheImpl {
                 },
                 format: PixelFormat::RGBA8,
                 frames: vec![frame],
-                bytes: Arc::new(IpcSharedMemory::from_bytes(&bytes)),
+                bytes: Arc::new(bytes),
                 id: None,
                 cors_status: vector_image.cors_status,
                 is_opaque: false,

--- a/components/pixels/snapshot.rs
+++ b/components/pixels/snapshot.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::ops::{Bound, Deref, DerefMut, Range, RangeBounds};
+use std::ops::{Deref, DerefMut, Range};
 use std::sync::Arc;
 
 use euclid::default::{Rect, Size2D};
@@ -92,6 +92,7 @@ pub enum SnapshotData {
         #[conditional_malloc_size_of] Arc<IpcSharedMemory>,
         Range<usize>,
     ),
+    SharedMemoryVec(#[conditional_malloc_size_of] Arc<Vec<u8>>, Range<usize>),
     Owned(Vec<u8>),
 }
 
@@ -99,6 +100,7 @@ impl SnapshotData {
     fn to_vec(&self) -> Vec<u8> {
         match &self {
             SnapshotData::SharedMemory(data, byte_range) => Vec::from(&data[byte_range.clone()]),
+            SnapshotData::SharedMemoryVec(data, byte_range) => Vec::from(&data[byte_range.clone()]),
             SnapshotData::Owned(data) => data.clone(),
         }
     }
@@ -107,7 +109,7 @@ impl SnapshotData {
 impl DerefMut for SnapshotData {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
-            SnapshotData::SharedMemory(..) => {
+            SnapshotData::SharedMemory(..) | SnapshotData::SharedMemoryVec(..) => {
                 *self = SnapshotData::Owned(self.to_vec());
                 &mut *self
             },
@@ -122,6 +124,7 @@ impl Deref for SnapshotData {
     fn deref(&self) -> &Self::Target {
         match &self {
             SnapshotData::SharedMemory(data, byte_range) => &data[byte_range.clone()],
+            SnapshotData::SharedMemoryVec(data, byte_range) => &data[byte_range.clone()],
             SnapshotData::Owned(items) => items,
         }
     }
@@ -195,26 +198,16 @@ impl Snapshot {
         }
     }
 
-    pub fn from_shared_memory(
+    pub fn from_arc_vec(
         size: Size2D<u32>,
         format: SnapshotPixelFormat,
         alpha_mode: SnapshotAlphaMode,
-        data: Arc<IpcSharedMemory>,
-        byte_range_bounds: impl RangeBounds<usize>,
+        data: Arc<Vec<u8>>,
+        byte_range_bounds: Range<usize>,
     ) -> Self {
-        let range_start = match byte_range_bounds.start_bound() {
-            Bound::Included(bound) => *bound,
-            Bound::Excluded(bound) => *bound + 1,
-            Bound::Unbounded => 0,
-        };
-        let range_end = match byte_range_bounds.end_bound() {
-            Bound::Included(bound) => *bound + 1,
-            Bound::Excluded(bound) => *bound,
-            Bound::Unbounded => data.len(),
-        };
         Self {
             size,
-            data: SnapshotData::SharedMemory(data, range_start..range_end),
+            data: SnapshotData::SharedMemoryVec(data, byte_range_bounds),
             format,
             alpha_mode,
         }
@@ -288,6 +281,10 @@ impl Snapshot {
     pub fn to_shared(&self) -> SharedSnapshot {
         let (data, byte_range) = match &self.data {
             SnapshotData::SharedMemory(data, byte_range) => (data.clone(), byte_range.clone()),
+            SnapshotData::SharedMemoryVec(data, byte_range) => (
+                Arc::new(IpcSharedMemory::from_bytes(data)),
+                byte_range.clone(),
+            ),
             SnapshotData::Owned(data) => {
                 (Arc::new(IpcSharedMemory::from_bytes(data)), 0..data.len())
             },
@@ -393,6 +390,7 @@ impl From<Snapshot> for Vec<u8> {
     fn from(value: Snapshot) -> Self {
         match value.data {
             SnapshotData::SharedMemory(..) => Vec::from(value.as_raw_bytes()),
+            SnapshotData::SharedMemoryVec(..) => Vec::from(value.as_raw_bytes()),
             SnapshotData::Owned(data) => data,
         }
     }

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -8,6 +8,7 @@ use std::default::Default;
 
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
+use ipc_channel::ipc::IpcSharedMemory;
 use js::rust::HandleObject;
 use net_traits::image_cache::{
     Image, ImageCache, ImageCacheResponseCallback, ImageCacheResult, ImageLoadListener,
@@ -735,7 +736,7 @@ impl HTMLLinkElement {
             let embedder_image = embedder_traits::Image::new(
                 frame.width,
                 frame.height,
-                raster_image.bytes.clone(),
+                std::sync::Arc::new(IpcSharedMemory::from_bytes(&raster_image.bytes)),
                 raster_image.frames[0].byte_range.clone(),
                 format,
             );

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -296,6 +296,11 @@ impl Notification {
 
     /// Create an [`embedder_traits::Notification`].
     fn to_embedder_notification(&self) -> EmbedderNotification {
+        let icon_resource = self
+            .icon_resource
+            .borrow()
+            .as_ref()
+            .map(|image| image.to_shared());
         EmbedderNotification {
             title: self.title.to_string(),
             body: self.body.to_string(),
@@ -325,12 +330,20 @@ impl Notification {
                         .icon_url
                         .as_ref()
                         .and_then(|icon| ServoUrl::parse(icon).ok()),
-                    icon_resource: action.icon_resource.borrow().clone(),
+                    icon_resource: icon_resource.clone(),
                 })
                 .collect(),
-            icon_resource: self.icon_resource.borrow().clone(),
-            badge_resource: self.badge_resource.borrow().clone(),
-            image_resource: self.image_resource.borrow().clone(),
+            icon_resource: icon_resource.clone(),
+            badge_resource: self
+                .badge_resource
+                .borrow()
+                .as_ref()
+                .map(|image| image.to_shared()),
+            image_resource: self
+                .image_resource
+                .borrow()
+                .as_ref()
+                .map(|image| image.to_shared()),
         }
     }
 }

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -32,7 +32,7 @@ use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
 use log::warn;
 use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
-use pixels::RasterImage;
+use pixels::SharedRasterImage;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use servo_geometry::{DeviceIndependentIntRect, DeviceIndependentIntSize};
 use servo_url::ServoUrl;
@@ -1002,16 +1002,16 @@ pub struct Notification {
     /// The URL of an icon. The icon will be displayed as part of the notification.
     pub icon_url: Option<ServoUrl>,
     /// Icon's raw image data and metadata.
-    pub icon_resource: Option<Arc<RasterImage>>,
+    pub icon_resource: Option<Arc<SharedRasterImage>>,
     /// The URL of a badge. The badge is used when there is no enough space to display the notification,
     /// such as on a mobile device's notification bar.
     pub badge_url: Option<ServoUrl>,
     /// Badge's raw image data and metadata.
-    pub badge_resource: Option<Arc<RasterImage>>,
+    pub badge_resource: Option<Arc<SharedRasterImage>>,
     /// The URL of an image. The image will be displayed as part of the notification.
     pub image_url: Option<ServoUrl>,
     /// Image's raw image data and metadata.
-    pub image_resource: Option<Arc<RasterImage>>,
+    pub image_resource: Option<Arc<SharedRasterImage>>,
     /// Actions available for users to choose from for interacting with the notification.
     pub actions: Vec<NotificationAction>,
 }
@@ -1026,7 +1026,7 @@ pub struct NotificationAction {
     /// The URL of an icon. The icon will be displayed with the action.
     pub icon_url: Option<ServoUrl>,
     /// Icon's raw image data and metadata.
-    pub icon_resource: Option<Arc<RasterImage>>,
+    pub icon_resource: Option<Arc<SharedRasterImage>>,
 }
 
 /// Information about a `WebView`'s screen geometry and offset. This is used

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -823,7 +823,6 @@ mod test {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use ipc_channel::ipc::IpcSharedMemory;
     use pixels::{CorsStatus, ImageFrame, ImageMetadata, PixelFormat, RasterImage};
 
     use crate::ImageAnimationState;
@@ -845,7 +844,7 @@ mod test {
             },
             format: PixelFormat::BGRA8,
             id: None,
-            bytes: Arc::new(IpcSharedMemory::from_byte(1, 1)),
+            bytes: Arc::new(vec![1]),
             frames: image_frames,
             cors_status: CorsStatus::Unsafe,
             is_opaque: false,

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -28,7 +28,7 @@ pub type VectorImageId = PendingImageId;
 // Represents either a raster image for which the pixel data is available
 // or a vector image for which only the natural dimensions are available
 // and thus requires a further rasterization step to render.
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub enum Image {
     Raster(#[conditional_malloc_size_of] Arc<RasterImage>),
     Vector(VectorImage),
@@ -65,7 +65,7 @@ impl Image {
 }
 
 /// Indicating either entire image or just metadata availability
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub enum ImageOrMetadataAvailable {
     ImageAvailable { image: Image, url: ServoUrl },
     MetadataAvailable(ImageMetadata, PendingImageId),
@@ -111,7 +111,7 @@ impl ImageLoadListener {
 }
 
 /// The returned image.
-#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub enum ImageResponse {
     /// The requested image was loaded.
     Loaded(Image, ServoUrl),
@@ -125,7 +125,7 @@ pub enum ImageResponse {
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct PendingImageId(pub u64);
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub struct PendingImageResponse {
     pub pipeline_id: PipelineId,
     pub response: ImageResponse,
@@ -139,7 +139,7 @@ pub struct RasterizationCompleteResponse {
     pub requested_size: DeviceIntSize,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub enum ImageCacheResponseMessage {
     NotifyPendingImageLoadStatus(PendingImageResponse),
     VectorImageRasterizationComplete(RasterizationCompleteResponse),


### PR DESCRIPTION
RasterImage is now not seralizeable and backed by Vec<u8> storage. Add a new struct `SharedRasterImage` that allows serializeing. This can be constructed from RasterImage. This introduces some more copying but I think the tradeoff is ok. Newly introduced copies are for favicon response to the embedder and EmbedderNotifications.

Testing: Should not change functionality, so covered by existing tests.
Fixes: https://github.com/servo/servo/issues/39626 and related issues.
