### PR TITLE
net: Simplify `FetchResponseListener` and move it to `script`

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -38,11 +38,11 @@ use layout_api::{
 use metrics::{InteractiveFlag, InteractiveWindow, ProgressiveWebMetrics};
 use net_traits::CookieSource::NonHTTP;
 use net_traits::CoreResourceMsg::{GetCookiesForUrl, SetCookiesForUrl};
+use net_traits::ReferrerPolicy;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::pub_domains::is_pub_domain;
 use net_traits::request::{InsecureRequestsPolicy, PreloadedResources, RequestBuilder};
 use net_traits::response::HttpsState;
-use net_traits::{FetchResponseListener, ReferrerPolicy};
 use percent_encoding::percent_decode;
 use profile_traits::ipc as profile_ipc;
 use profile_traits::time::TimerMetadataFrameType;
@@ -191,7 +191,7 @@ use crate::iframe_collection::IFrameCollection;
 use crate::image_animation::ImageAnimationManager;
 use crate::messaging::{CommonScriptMsg, MainThreadScriptMsg};
 use crate::mime::{APPLICATION, CHARSET};
-use crate::network_listener::{NetworkListener, PreInvoke};
+use crate::network_listener::{FetchResponseListener, NetworkListener};
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
 use crate::script_runtime::{CanGc, ScriptThreadEventCategory};
 use crate::script_thread::ScriptThread;
@@ -1889,7 +1889,7 @@ impl Document {
             .https_state(self.https_state.get())
     }
 
-    pub(crate) fn fetch<Listener: FetchResponseListener + PreInvoke + Send + 'static>(
+    pub(crate) fn fetch<Listener: FetchResponseListener>(
         &self,
         load: LoadType,
         mut request: RequestBuilder,
@@ -1911,7 +1911,7 @@ impl Document {
             .fetch_async_with_callback(load, request, callback);
     }
 
-    pub(crate) fn fetch_background<Listener: FetchResponseListener + PreInvoke + Send + 'static>(
+    pub(crate) fn fetch_background<Listener: FetchResponseListener>(
         &self,
         mut request: RequestBuilder,
         listener: Listener,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -56,8 +56,7 @@ use net_traits::request::{
 };
 use net_traits::response::HttpsState;
 use net_traits::{
-    CoreResourceMsg, CoreResourceThread, FetchResponseListener, ReferrerPolicy, ResourceThreads,
-    fetch_async,
+    CoreResourceMsg, CoreResourceThread, ReferrerPolicy, ResourceThreads, fetch_async,
 };
 use profile_traits::{ipc as profile_ipc, mem as profile_mem, time as profile_time};
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -136,7 +135,7 @@ use crate::dom::workletglobalscope::WorkletGlobalScope;
 use crate::dom::writablestream::CrossRealmTransformWritable;
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::Microtask;
-use crate::network_listener::{NetworkListener, PreInvoke};
+use crate::network_listener::{FetchResponseListener, NetworkListener};
 use crate::realms::{InRealm, enter_realm};
 use crate::script_module::{
     DynamicModuleList, ImportMap, ModuleScript, ModuleTree, ResolvedModule, ScriptFetchOptions,
@@ -3319,7 +3318,7 @@ impl GlobalScope {
         Ok(())
     }
 
-    pub(crate) fn fetch<Listener: FetchResponseListener + PreInvoke + Send + 'static>(
+    pub(crate) fn fetch<Listener: FetchResponseListener>(
         &self,
         request_builder: RequestBuilder,
         context: Arc<Mutex<Listener>>,
@@ -3332,9 +3331,7 @@ impl GlobalScope {
         self.fetch_with_network_listener(request_builder, network_listener);
     }
 
-    pub(crate) fn fetch_with_network_listener<
-        Listener: FetchResponseListener + PreInvoke + Send + 'static,
-    >(
+    pub(crate) fn fetch_with_network_listener<Listener: FetchResponseListener>(
         &self,
         request_builder: RequestBuilder,
         network_listener: NetworkListener<Listener>,

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -23,8 +23,8 @@ use net_traits::image_cache::{
 };
 use net_traits::request::{CorsSettings, Destination, Initiator, RequestId};
 use net_traits::{
-    FetchMetadata, FetchResponseListener, FetchResponseMsg, NetworkError, ReferrerPolicy,
-    ResourceFetchTiming, ResourceTimingType,
+    FetchMetadata, FetchResponseMsg, NetworkError, ReferrerPolicy, ResourceFetchTiming,
+    ResourceTimingType,
 };
 use num_traits::ToPrimitive;
 use pixels::{CorsStatus, ImageMetadata, Snapshot};
@@ -81,7 +81,7 @@ use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::fetch::create_a_potential_cors_request;
 use crate::microtask::{Microtask, MicrotaskRunnable};
-use crate::network_listener::{self, PreInvoke, ResourceTimingListener};
+use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::enter_realm;
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
@@ -240,6 +240,10 @@ struct ImageContext {
 }
 
 impl FetchResponseListener for ImageContext {
+    fn should_invoke(&self) -> bool {
+        !self.aborted
+    }
+
     fn process_request_body(&mut self, _: RequestId) {}
     fn process_request_eof(&mut self, _: RequestId) {}
 
@@ -342,12 +346,6 @@ impl ResourceTimingListener for ImageContext {
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
         self.doc.root().global()
-    }
-}
-
-impl PreInvoke for ImageContext {
-    fn should_invoke(&self) -> bool {
-        !self.aborted
     }
 }
 

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -16,8 +16,8 @@ use net_traits::image_cache::{
 };
 use net_traits::request::{Destination, Initiator, RequestBuilder, RequestId};
 use net_traits::{
-    FetchMetadata, FetchResponseListener, FetchResponseMsg, NetworkError, ReferrerPolicy,
-    ResourceFetchTiming, ResourceTimingType,
+    FetchMetadata, FetchResponseMsg, NetworkError, ReferrerPolicy, ResourceFetchTiming,
+    ResourceTimingType,
 };
 use pixels::PixelFormat;
 use script_bindings::root::Dom;
@@ -58,7 +58,7 @@ use crate::dom::processingoptions::{
 use crate::dom::types::{EventTarget, GlobalScope};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::links::LinkRelations;
-use crate::network_listener::{PreInvoke, ResourceTimingListener, submit_timing};
+use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::script_runtime::CanGc;
 use crate::stylesheet_loader::{ElementStylesheetLoader, StylesheetContextSource, StylesheetOwner};
 
@@ -1072,11 +1072,5 @@ impl ResourceTimingListener for FaviconFetchContext {
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
         self.link.root().upcast::<Node>().owner_doc().global()
-    }
-}
-
-impl PreInvoke for FaviconFetchContext {
-    fn should_invoke(&self) -> bool {
-        true
     }
 }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -25,8 +25,8 @@ use layout_api::MediaFrame;
 use media::{GLPlayerMsg, GLPlayerMsgForward, WindowGLContext};
 use net_traits::request::{Destination, RequestId};
 use net_traits::{
-    CoreResourceThread, FetchMetadata, FetchResponseListener, FilteredMetadata, NetworkError,
-    ResourceFetchTiming, ResourceTimingType,
+    CoreResourceThread, FetchMetadata, FilteredMetadata, NetworkError, ResourceFetchTiming,
+    ResourceTimingType,
 };
 use pixels::RasterImage;
 use script_bindings::codegen::GenericBindings::TimeRangesBinding::TimeRangesMethods;
@@ -100,7 +100,7 @@ use crate::dom::videotracklist::VideoTrackList;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::fetch::{FetchCanceller, create_a_potential_cors_request};
 use crate::microtask::{Microtask, MicrotaskRunnable};
-use crate::network_listener::{self, PreInvoke, ResourceTimingListener};
+use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::{InRealm, enter_realm};
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
@@ -3601,26 +3601,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
         let global = &self.resource_timing_global();
         global.report_csp_violations(violations, None, None);
     }
-}
 
-impl ResourceTimingListener for HTMLMediaElementFetchListener {
-    fn resource_timing_information(&self) -> (InitiatorType, ServoUrl) {
-        let initiator_type = InitiatorType::LocalName(
-            self.element
-                .root()
-                .upcast::<Element>()
-                .local_name()
-                .to_string(),
-        );
-        (initiator_type, self.url.clone())
-    }
-
-    fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
-        self.element.root().owner_document().global()
-    }
-}
-
-impl PreInvoke for HTMLMediaElementFetchListener {
     fn should_invoke(&self) -> bool {
         let element = self.element.root();
 
@@ -3646,6 +3627,23 @@ impl PreInvoke for HTMLMediaElementFetchListener {
         }
 
         true
+    }
+}
+
+impl ResourceTimingListener for HTMLMediaElementFetchListener {
+    fn resource_timing_information(&self) -> (InitiatorType, ServoUrl) {
+        let initiator_type = InitiatorType::LocalName(
+            self.element
+                .root()
+                .upcast::<Element>()
+                .local_name()
+                .to_string(),
+        );
+        (initiator_type, self.url.clone())
+    }
+
+    fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
+        self.element.root().owner_document().global()
     }
 }
 

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -19,10 +19,7 @@ use net_traits::request::{
     CorsSettings, CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata,
     RequestBuilder, RequestId,
 };
-use net_traits::{
-    FetchMetadata, FetchResponseListener, Metadata, NetworkError, ResourceFetchTiming,
-    ResourceTimingType,
-};
+use net_traits::{FetchMetadata, Metadata, NetworkError, ResourceFetchTiming, ResourceTimingType};
 use script_bindings::domstring::BytesView;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::attr::AttrValue;
@@ -64,7 +61,7 @@ use crate::dom::trustedscripturl::TrustedScriptURL;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::fetch::create_a_potential_cors_request;
-use crate::network_listener::{self, PreInvoke, ResourceTimingListener};
+use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::enter_realm;
 use crate::script_module::{
     ImportMap, ModuleOwner, ScriptFetchOptions, fetch_external_module_script,
@@ -512,8 +509,6 @@ impl ResourceTimingListener for ClassicContext {
         self.elem.root().owner_document().global()
     }
 }
-
-impl PreInvoke for ClassicContext {}
 
 /// Steps 1-2 of <https://html.spec.whatwg.org/multipage/#fetch-a-classic-script>
 // This function is also used to prefetch a script in `script::dom::servoparser::prefetch`.

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -16,8 +16,8 @@ use net_traits::image_cache::{
 };
 use net_traits::request::{CredentialsMode, Destination, RequestBuilder, RequestId};
 use net_traits::{
-    CoreResourceThread, FetchMetadata, FetchResponseListener, FetchResponseMsg, NetworkError,
-    ResourceFetchTiming, ResourceTimingType,
+    CoreResourceThread, FetchMetadata, FetchResponseMsg, NetworkError, ResourceFetchTiming,
+    ResourceTimingType,
 };
 use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 use servo_media::player::video::VideoFrame;
@@ -42,7 +42,7 @@ use crate::dom::node::{Node, NodeTraits};
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::fetch::FetchCanceller;
-use crate::network_listener::{self, PreInvoke, ResourceTimingListener};
+use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -510,12 +510,6 @@ impl ResourceTimingListener for PosterFrameFetchContext {
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
         self.elem.root().owner_document().global()
-    }
-}
-
-impl PreInvoke for PosterFrameFetchContext {
-    fn should_invoke(&self) -> bool {
-        true
     }
 }
 

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -15,9 +15,7 @@ use net_traits::request::{
     CredentialsMode, Destination, RequestBuilder, RequestId, RequestMode,
     is_cors_safelisted_request_content_type,
 };
-use net_traits::{
-    FetchMetadata, FetchResponseListener, NetworkError, ResourceFetchTiming, ResourceTimingType,
-};
+use net_traits::{FetchMetadata, NetworkError, ResourceFetchTiming, ResourceTimingType};
 use servo_config::pref;
 use servo_url::ServoUrl;
 
@@ -55,7 +53,7 @@ use crate::dom::webgpu::gpu::GPU;
 use crate::dom::window::Window;
 #[cfg(feature = "webxr")]
 use crate::dom::xrsystem::XRSystem;
-use crate::network_listener::{PreInvoke, ResourceTimingListener, submit_timing};
+use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::script_runtime::{CanGc, JSContext};
 
 pub(super) fn hardware_concurrency() -> u64 {
@@ -501,11 +499,5 @@ impl ResourceTimingListener for BeaconFetchListener {
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
         self.global.root()
-    }
-}
-
-impl PreInvoke for BeaconFetchListener {
-    fn should_invoke(&self) -> bool {
-        true
     }
 }

--- a/components/script/dom/notification.rs
+++ b/components/script/dom/notification.rs
@@ -24,8 +24,7 @@ use net_traits::image_cache::{
 };
 use net_traits::request::{Destination, RequestBuilder, RequestId};
 use net_traits::{
-    FetchMetadata, FetchResponseListener, FetchResponseMsg, NetworkError, ResourceFetchTiming,
-    ResourceTimingType,
+    FetchMetadata, FetchResponseMsg, NetworkError, ResourceFetchTiming, ResourceTimingType,
 };
 use pixels::RasterImage;
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -61,7 +60,7 @@ use crate::dom::promise::Promise;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
 use crate::dom::serviceworkerregistration::ServiceWorkerRegistration;
 use crate::fetch::create_a_potential_cors_request;
-use crate::network_listener::{self, PreInvoke, ResourceTimingListener};
+use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 
 // TODO: Service Worker API (persistent notification)
@@ -804,12 +803,6 @@ impl ResourceTimingListener for ResourceFetchListener {
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
         self.notification.root().global()
-    }
-}
-
-impl PreInvoke for ResourceFetchListener {
-    fn should_invoke(&self) -> bool {
-        true
     }
 }
 

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -18,8 +18,7 @@ use net_traits::request::{
 };
 use net_traits::response::{Response, ResponseBody};
 use net_traits::{
-    FetchMetadata, FetchResponseListener, NetworkError, ReferrerPolicy, ResourceFetchTiming,
-    ResourceTimingType,
+    FetchMetadata, NetworkError, ReferrerPolicy, ResourceFetchTiming, ResourceTimingType,
 };
 pub use nom_rfc8288::complete::LinkDataOwned as LinkHeader;
 use nom_rfc8288::complete::link_lenient as parse_link_header;
@@ -38,7 +37,7 @@ use crate::dom::medialist::MediaList;
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::types::HTMLLinkElement;
 use crate::fetch::create_a_potential_cors_request;
-use crate::network_listener::{PreInvoke, ResourceTimingListener, submit_timing};
+use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::script_runtime::CanGc;
 
 trait ValueForKeyInLinkHeader {
@@ -556,12 +555,5 @@ impl ResourceTimingListener for LinkFetchContext {
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
         self.global.root()
-    }
-}
-
-impl PreInvoke for LinkFetchContext {
-    fn should_invoke(&self) -> bool {
-        // Prefetch and preload requests are never aborted.
-        true
     }
 }

--- a/components/script/dom/reportingendpoint.rs
+++ b/components/script/dom/reportingendpoint.rs
@@ -13,9 +13,7 @@ use net_traits::request::{
     CredentialsMode, Destination, RequestBody, RequestId, RequestMode,
     create_request_body_with_content,
 };
-use net_traits::{
-    FetchMetadata, FetchResponseListener, NetworkError, ResourceFetchTiming, ResourceTimingType,
-};
+use net_traits::{FetchMetadata, NetworkError, ResourceFetchTiming, ResourceTimingType};
 use script_bindings::str::DOMString;
 use serde::Serialize;
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -30,7 +28,7 @@ use crate::dom::csppolicyviolationreport::serialize_disposition;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::fetch::create_a_potential_cors_request;
-use crate::network_listener::{PreInvoke, ResourceTimingListener, submit_timing};
+use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::script_runtime::CanGc;
 
 /// <https://w3c.github.io/reporting/#endpoint>
@@ -366,11 +364,5 @@ impl ResourceTimingListener for CSPReportEndpointFetchListener {
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
         self.global.root()
-    }
-}
-
-impl PreInvoke for CSPReportEndpointFetchListener {
-    fn should_invoke(&self) -> bool {
-        true
     }
 }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -27,8 +27,8 @@ use net_traits::mime_classifier::{ApacheBugFlag, MediaType, MimeClassifier, NoSn
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::RequestId;
 use net_traits::{
-    FetchMetadata, FetchResponseListener, LoadContext, Metadata, NetworkError, ReferrerPolicy,
-    ResourceFetchTiming, ResourceTimingType,
+    FetchMetadata, LoadContext, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming,
+    ResourceTimingType,
 };
 use profile_traits::time::{
     ProfilerCategory, ProfilerChan, TimerMetadata, TimerMetadataFrameType, TimerMetadataReflowType,
@@ -84,7 +84,7 @@ use crate::dom::shadowroot::IsUserAgentWidget;
 use crate::dom::text::Text;
 use crate::dom::types::HTMLMediaElement;
 use crate::dom::virtualmethods::vtable_for;
-use crate::network_listener::PreInvoke;
+use crate::network_listener::FetchResponseListener;
 use crate::realms::enter_realm;
 use crate::script_runtime::{CanGc, IntroductionType};
 use crate::script_thread::ScriptThread;
@@ -1394,8 +1394,6 @@ impl FetchResponseListener for ParserContext {
         global.report_csp_violations(violations, None, None);
     }
 }
-
-impl PreInvoke for ParserContext {}
 
 pub(crate) struct FragmentContext<'a> {
     pub(crate) context_elem: &'a Node,

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -33,8 +33,7 @@ use net_traits::request::{
     RequestBuilder as NetRequestInit, RequestId,
 };
 use net_traits::{
-    FetchMetadata, FetchResponseListener, Metadata, NetworkError, ReferrerPolicy,
-    ResourceFetchTiming, ResourceTimingType,
+    FetchMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming, ResourceTimingType,
 };
 use profile_traits::mem::{ProcessReports, perform_memory_report};
 use servo_url::{MutableOrigin, ServoUrl};
@@ -88,7 +87,7 @@ use crate::dom::workernavigator::WorkerNavigator;
 use crate::fetch::{CspViolationsProcessor, Fetch, load_whole_resource};
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::{Microtask, MicrotaskQueue, UserMicrotask};
-use crate::network_listener::{PreInvoke, ResourceTimingListener, submit_timing};
+use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::realms::{InRealm, enter_realm};
 use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{CanGc, IntroductionType, JSContext, JSContextHelper, Runtime};
@@ -273,8 +272,6 @@ impl ResourceTimingListener for ScriptFetchContext {
         self.scope.root().global()
     }
 }
-
-impl PreInvoke for ScriptFetchContext {}
 
 // https://html.spec.whatwg.org/multipage/#the-workerglobalscope-common-interface
 #[dom_struct]

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -19,9 +19,9 @@ use net_traits::request::{
     Request as NetTraitsRequest, RequestBuilder, RequestId, RequestMode, ServiceWorkersMode,
 };
 use net_traits::{
-    CoreResourceMsg, CoreResourceThread, FetchChannels, FetchMetadata, FetchResponseListener,
-    FetchResponseMsg, FilteredMetadata, Metadata, NetworkError, ResourceFetchTiming,
-    ResourceTimingType, cancel_async_fetch,
+    CoreResourceMsg, CoreResourceThread, FetchChannels, FetchMetadata, FetchResponseMsg,
+    FilteredMetadata, Metadata, NetworkError, ResourceFetchTiming, ResourceTimingType,
+    cancel_async_fetch,
 };
 use servo_url::ServoUrl;
 use timers::TimerEventRequest;
@@ -53,7 +53,9 @@ use crate::dom::request::Request;
 use crate::dom::response::Response;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
 use crate::dom::window::Window;
-use crate::network_listener::{self, PreInvoke, ResourceTimingListener, submit_timing_data};
+use crate::network_listener::{
+    self, FetchResponseListener, ResourceTimingListener, submit_timing_data,
+};
 use crate::realms::{InRealm, enter_realm};
 use crate::script_runtime::CanGc;
 
@@ -456,8 +458,6 @@ pub(crate) struct FetchContext {
     canceller: FetchCanceller,
 }
 
-impl PreInvoke for FetchContext {}
-
 impl FetchContext {
     /// Step 11 of <https://fetch.spec.whatwg.org/#dom-global-fetch>
     pub(crate) fn abort_fetch(
@@ -689,12 +689,6 @@ impl ResourceTimingListener for FetchLaterListener {
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
         self.global.root()
-    }
-}
-
-impl PreInvoke for FetchLaterListener {
-    fn should_invoke(&self) -> bool {
-        true
     }
 }
 

--- a/components/script/layout_image.rs
+++ b/components/script/layout_image.rs
@@ -11,8 +11,7 @@ use std::sync::Arc;
 use net_traits::image_cache::{ImageCache, PendingImageId};
 use net_traits::request::{Destination, RequestBuilder as FetchRequestInit, RequestId};
 use net_traits::{
-    FetchMetadata, FetchResponseListener, FetchResponseMsg, NetworkError, ResourceFetchTiming,
-    ResourceTimingType,
+    FetchMetadata, FetchResponseMsg, NetworkError, ResourceFetchTiming, ResourceTimingType,
 };
 use servo_url::ServoUrl;
 
@@ -24,7 +23,7 @@ use crate::dom::document::Document;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::node::{Node, NodeTraits};
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
-use crate::network_listener::{self, PreInvoke, ResourceTimingListener};
+use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::script_runtime::CanGc;
 
 struct LayoutImageContext {
@@ -94,8 +93,6 @@ impl ResourceTimingListener for LayoutImageContext {
         self.doc.root().global()
     }
 }
-
-impl PreInvoke for LayoutImageContext {}
 
 pub(crate) fn fetch_image_for_layout(
     url: ServoUrl,

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -4,8 +4,10 @@
 
 use std::sync::{Arc, Mutex};
 
+use content_security_policy::Violation;
+use net_traits::request::RequestId;
 use net_traits::{
-    Action, BoxedFetchCallback, FetchResponseListener, FetchResponseMsg, ResourceFetchTiming,
+    BoxedFetchCallback, FetchMetadata, FetchResponseMsg, NetworkError, ResourceFetchTiming,
     ResourceTimingType,
 };
 use servo_url::ServoUrl;
@@ -18,15 +20,7 @@ use crate::dom::performance::performanceresourcetiming::{
     InitiatorType, PerformanceResourceTiming,
 };
 use crate::script_runtime::CanGc;
-use crate::task::TaskOnce;
 use crate::task_source::SendableTaskSource;
-
-/// An off-thread sink for async network event tasks. All such events are forwarded to
-/// a target thread, where they are invoked on the provided context object.
-pub(crate) struct NetworkListener<Listener: PreInvoke + Send + 'static> {
-    pub(crate) context: Arc<Mutex<Listener>>,
-    pub(crate) task_source: SendableTaskSource,
-}
 
 pub(crate) trait ResourceTimingListener {
     fn resource_timing_information(&self) -> (InitiatorType, ServoUrl);
@@ -74,50 +68,90 @@ pub(crate) fn submit_timing_data(
         .queue_entry(performance_entry.upcast::<PerformanceEntry>(), can_gc);
 }
 
-impl<Listener: PreInvoke + Send + 'static> NetworkListener<Listener> {
-    pub(crate) fn notify<A: Action<Listener> + Send + 'static>(&mut self, action: A) {
-        self.task_source.queue(ListenerTask {
-            context: self.context.clone(),
-            action,
-        });
-    }
-}
-
-// helps type inference
-impl<Listener: FetchResponseListener + PreInvoke + Send + 'static> NetworkListener<Listener> {
-    pub(crate) fn notify_fetch(&mut self, action: FetchResponseMsg) {
-        self.notify(action);
-    }
-
-    pub(crate) fn into_callback(mut self) -> BoxedFetchCallback {
-        Box::new(move |response_msg| self.notify_fetch(response_msg))
-    }
-}
-
-/// A gating mechanism that runs before invoking the task on the target thread.
-/// If the `should_invoke` method returns false, the task is discarded without
-/// being invoked.
-pub(crate) trait PreInvoke {
+pub(crate) trait FetchResponseListener: Send + 'static {
+    /// A gating mechanism that runs before invoking the listener methods on the target
+    /// thread. If the `should_invoke` method returns false, the listener does not receive
+    /// the notification.
     fn should_invoke(&self) -> bool {
         true
     }
+
+    fn process_request_body(&mut self, request_id: RequestId);
+    fn process_request_eof(&mut self, request_id: RequestId);
+    fn process_response(
+        &mut self,
+        request_id: RequestId,
+        metadata: Result<FetchMetadata, NetworkError>,
+    );
+    fn process_response_chunk(&mut self, request_id: RequestId, chunk: Vec<u8>);
+    fn process_response_eof(
+        &mut self,
+        request_id: RequestId,
+        response: Result<ResourceFetchTiming, NetworkError>,
+    );
+    fn resource_timing(&self) -> &ResourceFetchTiming;
+    fn resource_timing_mut(&mut self) -> &mut ResourceFetchTiming;
+    fn submit_resource_timing(&mut self);
+    fn process_csp_violations(&mut self, request_id: RequestId, violations: Vec<Violation>);
 }
 
-/// A task for moving the async network events between threads.
-struct ListenerTask<A: Action<Listener> + Send + 'static, Listener: PreInvoke + Send> {
-    context: Arc<Mutex<Listener>>,
-    action: A,
+/// An off-thread sink for async network event tasks. All such events are forwarded to
+/// a target thread, where they are invoked on the provided context object.
+pub(crate) struct NetworkListener<Listener: FetchResponseListener> {
+    pub(crate) context: Arc<Mutex<Listener>>,
+    pub(crate) task_source: SendableTaskSource,
 }
 
-impl<A, Listener> TaskOnce for ListenerTask<A, Listener>
-where
-    A: Action<Listener> + Send + 'static,
-    Listener: PreInvoke + Send,
-{
-    fn run_once(self) {
-        let mut context = self.context.lock().unwrap();
-        if context.should_invoke() {
-            self.action.process(&mut *context);
-        }
+impl<Listener: FetchResponseListener> NetworkListener<Listener> {
+    pub(crate) fn notify(&mut self, message: FetchResponseMsg) {
+        let context = self.context.clone();
+        self.task_source.queue(task!(network_listener_response: move || {
+            let mut context = context.lock().unwrap();
+
+            let fetch_listener = &mut *context;
+            if !fetch_listener.should_invoke() {
+                return;
+            }
+
+            match message {
+                FetchResponseMsg::ProcessRequestBody(request_id) => {
+                    fetch_listener.process_request_body(request_id)
+                },
+                FetchResponseMsg::ProcessRequestEOF(request_id) => {
+                    fetch_listener.process_request_eof(request_id)
+                },
+                FetchResponseMsg::ProcessResponse(request_id, meta) => {
+                    fetch_listener.process_response(request_id, meta)
+                },
+                FetchResponseMsg::ProcessResponseChunk(request_id, data) => {
+                    fetch_listener.process_response_chunk(request_id, data)
+                },
+                FetchResponseMsg::ProcessResponseEOF(request_id, data) => {
+                    match data {
+                        Ok(ref response_resource_timing) => {
+                            // update listener with values from response
+                            *fetch_listener.resource_timing_mut() = response_resource_timing.clone();
+                            fetch_listener
+                                .process_response_eof(request_id, Ok(response_resource_timing.clone()));
+                            // TODO timing check https://w3c.github.io/resource-timing/#dfn-timing-allow-check
+
+                            fetch_listener.submit_resource_timing();
+                        },
+                        // TODO Resources for which the fetch was initiated, but was later aborted
+                        // (e.g. due to a network error) MAY be included as PerformanceResourceTiming
+                        // objects in the Performance Timeline and MUST contain initialized attribute
+                        // values for processed substeps of the processing model.
+                        Err(error) => fetch_listener.process_response_eof(request_id, Err(error)),
+                    }
+                },
+                FetchResponseMsg::ProcessCspViolations(request_id, violations) => {
+                    fetch_listener.process_csp_violations(request_id, violations)
+                },
+            }
+        }));
+    }
+
+    pub(crate) fn into_callback(mut self) -> BoxedFetchCallback {
+        Box::new(move |response_msg| self.notify(response_msg))
     }
 }

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -40,8 +40,7 @@ use net_traits::request::{
     CredentialsMode, Destination, ParserMetadata, Referrer, RequestBuilder, RequestId, RequestMode,
 };
 use net_traits::{
-    FetchMetadata, FetchResponseListener, Metadata, NetworkError, ReferrerPolicy,
-    ResourceFetchTiming, ResourceTimingType,
+    FetchMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming, ResourceTimingType,
 };
 use script_bindings::domstring::BytesView;
 use script_bindings::error::Fallible;
@@ -77,7 +76,9 @@ use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::types::Console;
 use crate::dom::window::Window;
 use crate::dom::worker::TrustedWorkerAddress;
-use crate::network_listener::{self, NetworkListener, PreInvoke, ResourceTimingListener};
+use crate::network_listener::{
+    self, FetchResponseListener, NetworkListener, ResourceTimingListener,
+};
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
 use crate::script_runtime::{CanGc, IntroductionType, JSContext as SafeJSContext};
 use crate::task::TaskBox;
@@ -1396,8 +1397,6 @@ impl ResourceTimingListener for ModuleContext {
         self.owner.global()
     }
 }
-
-impl PreInvoke for ModuleContext {}
 
 #[allow(unsafe_code, non_snake_case)]
 /// A function to register module hooks (e.g. listening on resolving modules,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -73,8 +73,8 @@ use net_traits::image_cache::{ImageCache, ImageCacheFactory, ImageCacheResponseM
 use net_traits::request::{Referrer, RequestId};
 use net_traits::response::ResponseInit;
 use net_traits::{
-    FetchMetadata, FetchResponseListener, FetchResponseMsg, Metadata, NetworkError,
-    ResourceFetchTiming, ResourceThreads, ResourceTimingType,
+    FetchMetadata, FetchResponseMsg, Metadata, NetworkError, ResourceFetchTiming, ResourceThreads,
+    ResourceTimingType,
 };
 use percent_encoding::percent_decode;
 use profile_traits::mem::{ProcessReports, ReportsChan, perform_memory_report};
@@ -144,6 +144,7 @@ use crate::messaging::{
 use crate::microtask::{Microtask, MicrotaskQueue};
 use crate::mime::{APPLICATION, MimeExt, TEXT, XML};
 use crate::navigation::{InProgressLoad, NavigationListener};
+use crate::network_listener::FetchResponseListener;
 use crate::realms::enter_realm;
 use crate::script_module::ScriptFetchOptions;
 use crate::script_mutation_observers::ScriptMutationObservers;

--- a/components/script/security_manager.rs
+++ b/components/script/security_manager.rs
@@ -9,9 +9,7 @@ use headers::{ContentType, HeaderMap, HeaderMapExt};
 use net_traits::request::{
     CredentialsMode, Destination, RequestBody, RequestId, create_request_body_with_content,
 };
-use net_traits::{
-    FetchMetadata, FetchResponseListener, NetworkError, ResourceFetchTiming, ResourceTimingType,
-};
+use net_traits::{FetchMetadata, NetworkError, ResourceFetchTiming, ResourceTimingType};
 use servo_url::ServoUrl;
 use stylo_atoms::Atom;
 
@@ -30,7 +28,7 @@ use crate::dom::reportingobserver::ReportingObserver;
 use crate::dom::securitypolicyviolationevent::SecurityPolicyViolationEvent;
 use crate::dom::types::GlobalScope;
 use crate::fetch::create_a_potential_cors_request;
-use crate::network_listener::{PreInvoke, ResourceTimingListener, submit_timing};
+use crate::network_listener::{FetchResponseListener, ResourceTimingListener, submit_timing};
 use crate::script_runtime::CanGc;
 use crate::task::TaskOnce;
 
@@ -237,11 +235,5 @@ impl ResourceTimingListener for CSPReportUriFetchListener {
 
     fn resource_timing_global(&self) -> DomRoot<GlobalScope> {
         self.global.root()
-    }
-}
-
-impl PreInvoke for CSPReportUriFetchListener {
-    fn should_invoke(&self) -> bool {
-        true
     }
 }

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -9,8 +9,8 @@ use encoding_rs::UTF_8;
 use mime::{self, Mime};
 use net_traits::request::{CorsSettings, Destination, RequestId};
 use net_traits::{
-    FetchMetadata, FetchResponseListener, FilteredMetadata, Metadata, NetworkError, ReferrerPolicy,
-    ResourceFetchTiming, ResourceTimingType,
+    FetchMetadata, FilteredMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming,
+    ResourceTimingType,
 };
 use servo_arc::Arc;
 use servo_url::ServoUrl;
@@ -39,7 +39,7 @@ use crate::dom::node::NodeTraits;
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::shadowroot::ShadowRoot;
 use crate::fetch::create_a_potential_cors_request;
-use crate::network_listener::{self, PreInvoke, ResourceTimingListener};
+use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::script_runtime::CanGc;
 use crate::unminify::{
     BeautifyFileType, create_output_file, create_temp_files, execute_js_beautify,
@@ -123,8 +123,6 @@ impl StylesheetContext {
         style_content
     }
 }
-
-impl PreInvoke for StylesheetContext {}
 
 impl FetchResponseListener for StylesheetContext {
     fn process_request_body(&mut self, _: RequestId) {}


### PR DESCRIPTION
`FetchReponseListener` has traditionally lived in `net` even though it
is only used in `script` currently. Because of the two way dependency,
it has also use a lot of templating to implement something pretty basic
(call methods on a trait object).

This change moves the trait to `script` and removes several levels of
templating, making the code quite a bit shorter and easier to
understand.

This change is preparation for fixing #22550 and implementing
off-the-main-thread CSS parsing.

Testing: This should not change any behavior so is covered by existing tests.
