### PR TITLE
WebGLBuffer: follow spec for buffer binding restrictions

### DIFF
--- a/tests/wpt/webgl/meta/conformance2/buffers/buffer-type-restrictions.html.ini
+++ b/tests/wpt/webgl/meta/conformance2/buffers/buffer-type-restrictions.html.ini
@@ -1,6 +1,0 @@
-[buffer-type-restrictions.html]
-  [WebGL test #29]
-    expected: FAIL
-
-  [WebGL test #41]
-    expected: FAIL


### PR DESCRIPTION
WebGLBuffer: follow spec for buffer binding restrictions

Testing: more WebGLBuffer pass
