### PR TITLE
script: Add message to IndexSizeError

### DIFF
--- a/components/script/dom/audio/analysernode.rs
+++ b/components/script/dom/audio/analysernode.rs
@@ -52,15 +52,15 @@ impl AnalyserNode {
             options.fftSize < 32 ||
             (options.fftSize & (options.fftSize - 1) != 0)
         {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         if *options.maxDecibels <= *options.minDecibels {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         if *options.smoothingTimeConstant < 0. || *options.smoothingTimeConstant > 1. {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         let (send, rcv) = ipc::channel().unwrap();
@@ -186,7 +186,7 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-fftsize>
     fn SetFftSize(&self, value: u32) -> Fallible<()> {
         if !(32..=32768).contains(&value) || (value & (value - 1) != 0) {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
         self.engine.borrow_mut().set_fft_size(value as usize);
         Ok(())
@@ -210,7 +210,7 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-mindecibels>
     fn SetMinDecibels(&self, value: Finite<f64>) -> Fallible<()> {
         if *value >= self.engine.borrow().get_max_decibels() {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
         self.engine.borrow_mut().set_min_decibels(*value);
         Ok(())
@@ -224,7 +224,7 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-maxdecibels>
     fn SetMaxDecibels(&self, value: Finite<f64>) -> Fallible<()> {
         if *value <= self.engine.borrow().get_min_decibels() {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
         self.engine.borrow_mut().set_max_decibels(*value);
         Ok(())
@@ -238,7 +238,7 @@ impl AnalyserNodeMethods<crate::DomTypeHolder> for AnalyserNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-analysernode-smoothingtimeconstant>
     fn SetSmoothingTimeConstant(&self, value: Finite<f64>) -> Fallible<()> {
         if *value < 0. || *value > 1. {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
         self.engine.borrow_mut().set_smoothing_constant(*value);
         Ok(())

--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -240,7 +240,7 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
     /// <https://webaudio.github.io/web-audio-api/#dom-audiobuffer-getchanneldata>
     fn GetChannelData(&self, cx: JSContext, channel: u32, can_gc: CanGc) -> Fallible<Float32Array> {
         if channel >= self.number_of_channels {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         if !self.restore_js_channel_data(cx, can_gc) {
@@ -264,7 +264,7 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
         }
 
         if channel_number >= self.number_of_channels || start_in_channel >= self.length {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         let bytes_to_copy = min(self.length - start_in_channel, destination.len() as u32) as usize;
@@ -280,7 +280,7 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
                 .copy_data_to(cx, &mut dest, offset, offset + bytes_to_copy)
                 .is_err()
             {
-                return Err(Error::IndexSize);
+                return Err(Error::IndexSize(None));
             }
         } else if let Some(ref shared_channels) = *self.shared_channels.borrow() {
             if let Some(shared_channel) = shared_channels.buffers.get(channel_number) {
@@ -306,7 +306,7 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
         }
 
         if channel_number >= self.number_of_channels || start_in_channel > (source.len() as u32) {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         let cx = GlobalScope::get_cx();
@@ -317,12 +317,12 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
         let js_channel = &self.js_channels.borrow()[channel_number as usize];
         if !js_channel.is_initialized() {
             // The array buffer was detached.
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         let bytes_to_copy = min(self.length - start_in_channel, source.len() as u32) as usize;
         js_channel
             .copy_data_from(cx, source, start_in_channel as usize, bytes_to_copy)
-            .map_err(|_| Error::IndexSize)
+            .map_err(|_| Error::IndexSize(None))
     }
 }

--- a/components/script/dom/audio/audionode.rs
+++ b/components/script/dom/audio/audionode.rs
@@ -120,7 +120,7 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
         }
 
         if output >= self.NumberOfOutputs() || input >= destination.NumberOfInputs() {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         // servo-media takes care of ignoring duplicated connections.
@@ -144,7 +144,7 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
         }
 
         if output >= self.NumberOfOutputs() {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         // servo-media takes care of ignoring duplicated connections.
@@ -261,7 +261,7 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
                 if self.context.is_offline() {
                     return Err(Error::InvalidState(None));
                 } else if !(1..=MAX_CHANNEL_COUNT).contains(&value) {
-                    return Err(Error::IndexSize);
+                    return Err(Error::IndexSize(None));
                 }
             },
             EventTargetTypeId::AudioNode(AudioNodeTypeId::PannerNode) => {

--- a/components/script/dom/audio/channelmergernode.rs
+++ b/components/script/dom/audio/channelmergernode.rs
@@ -45,7 +45,7 @@ impl ChannelMergerNode {
         }
 
         if options.numberOfInputs < 1 || options.numberOfInputs > MAX_CHANNEL_COUNT {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         let num_inputs = options.numberOfInputs;

--- a/components/script/dom/audio/channelsplitternode.rs
+++ b/components/script/dom/audio/channelsplitternode.rs
@@ -33,7 +33,7 @@ impl ChannelSplitterNode {
         options: &ChannelSplitterOptions,
     ) -> Fallible<ChannelSplitterNode> {
         if options.numberOfOutputs < 1 || options.numberOfOutputs > MAX_CHANNEL_COUNT {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         let node_options = options.parent.unwrap_or(

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -112,7 +112,10 @@ pub(crate) fn create_dom_exception(
     };
 
     let code = match result {
-        Error::IndexSize => DOMErrorName::IndexSizeError,
+        Error::IndexSize(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::IndexSizeError, custom_message);
+        },
+        Error::IndexSize(None) => DOMErrorName::IndexSizeError,
         Error::NotFound(Some(custom_message)) => {
             return new_custom_exception(DOMErrorName::NotFoundError, custom_message);
         },

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -1219,7 +1219,7 @@ impl CanvasState {
         can_gc: CanGc,
     ) -> Fallible<DomRoot<CanvasGradient>> {
         if *r0 < 0. || *r1 < 0. {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         Ok(CanvasGradient::new(
@@ -1749,7 +1749,7 @@ impl CanvasState {
         can_gc: CanGc,
     ) -> Fallible<DomRoot<ImageData>> {
         if sw == 0 || sh == 0 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
         ImageData::new(global, sw.unsigned_abs(), sh.unsigned_abs(), None, can_gc)
     }
@@ -1780,7 +1780,7 @@ impl CanvasState {
         // overflow or underflow, this should probably be audited.
 
         if sw == 0 || sh == 0 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         if !self.origin_is_clean() {
@@ -2218,7 +2218,7 @@ impl CanvasState {
         self.current_default_path
             .borrow_mut()
             .arc(x, y, r, start, end, ccw)
-            .map_err(|_| Error::IndexSize)
+            .map_err(|_| Error::IndexSize(None))
     }
 
     // https://html.spec.whatwg.org/multipage/#dom-context-2d-arcto
@@ -2226,7 +2226,7 @@ impl CanvasState {
         self.current_default_path
             .borrow_mut()
             .arc_to(cp1x, cp1y, cp2x, cp2y, r)
-            .map_err(|_| Error::IndexSize)
+            .map_err(|_| Error::IndexSize(None))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-ellipse>
@@ -2245,7 +2245,7 @@ impl CanvasState {
         self.current_default_path
             .borrow_mut()
             .ellipse(x, y, rx, ry, rotation, start, end, ccw)
-            .map_err(|_| Error::IndexSize)
+            .map_err(|_| Error::IndexSize(None))
     }
 
     fn text_with_size(

--- a/components/script/dom/canvas/2d/canvasgradient.rs
+++ b/components/script/dom/canvas/2d/canvasgradient.rs
@@ -59,7 +59,7 @@ impl CanvasGradientMethods<crate::DomTypeHolder> for CanvasGradient {
     /// <https://html.spec.whatwg.org/multipage/#dom-canvasgradient-addcolorstop>
     fn AddColorStop(&self, offset: Finite<f64>, color: DOMString) -> ErrorResult {
         if *offset < 0f64 || *offset > 1f64 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         let color = match parse_color(None, &color) {

--- a/components/script/dom/canvas/2d/path2d.rs
+++ b/components/script/dom/canvas/2d/path2d.rs
@@ -139,7 +139,7 @@ impl Path2DMethods<crate::DomTypeHolder> for Path2D {
         self.path
             .borrow_mut()
             .arc_to(x1, y1, x2, y2, radius)
-            .map_err(|_| Error::IndexSize)
+            .map_err(|_| Error::IndexSize(None))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-rect>
@@ -160,7 +160,7 @@ impl Path2DMethods<crate::DomTypeHolder> for Path2D {
         self.path
             .borrow_mut()
             .arc(x, y, radius, start_angle, end_angle, counterclockwise)
-            .map_err(|_| Error::IndexSize)
+            .map_err(|_| Error::IndexSize(None))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-context-2d-ellipse>
@@ -187,7 +187,7 @@ impl Path2DMethods<crate::DomTypeHolder> for Path2D {
                 end_angle,
                 counterclockwise,
             )
-            .map_err(|_| Error::IndexSize)
+            .map_err(|_| Error::IndexSize(None))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-path2d-dev>

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -280,13 +280,13 @@ impl ImageDataMethods<crate::DomTypeHolder> for ImageData {
     ) -> Fallible<DomRoot<Self>> {
         // 1. If one or both of sw and sh are zero, then throw an "IndexSizeError" DOMException.
         if sw == 0 || sh == 0 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         // When a constructor is called for an ImageData that is too large, other browsers throw
         // IndexSizeError rather than RangeError here, so we do the same.
         pixels::compute_rgba8_byte_length_if_within_limit(sw as usize, sh as usize)
-            .ok_or(Error::IndexSize)?;
+            .ok_or(Error::IndexSize(None))?;
 
         // 2. Initialize this given sw, sh, and settings.
         // 3. Initialize the image data of this to transparent black.
@@ -321,13 +321,13 @@ impl ImageDataMethods<crate::DomTypeHolder> for ImageData {
         let length = length / bytes_per_pixel;
         // 5. If length is not an integral multiple of sw, then throw an "IndexSizeError" DOMException.
         if sw == 0 || length % sw as usize != 0 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
         // 6. Let height be length divided by sw.
         let height = length / sw as usize;
         // 7. If sh was given and its value is not equal to height, then throw an "IndexSizeError" DOMException.
         if sh.is_some_and(|x| height != x as usize) {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
         // 8. Initialize this given sw, sh, settings, and source set to data.
         Self::initialize(

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -416,7 +416,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         // dimension or its vertical dimension is zero), then return a promise
         // rejected with an "IndexSizeError" DOMException.
         if self.Width() == 0 || self.Height() == 0 {
-            promise.reject_error(Error::IndexSize, can_gc);
+            promise.reject_error(Error::IndexSize(None), can_gc);
             return promise;
         }
 

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -147,7 +147,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
                 s
             },
             // Step 2.
-            Err(()) => return Err(Error::IndexSize),
+            Err(()) => return Err(Error::IndexSize(None)),
         };
         match split_at_utf16_code_unit_offset(remaining, count) {
             // Steps 3.
@@ -200,7 +200,7 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
                     remaining = r;
                 },
                 // Step 2.
-                Err(()) => return Err(Error::IndexSize),
+                Err(()) => return Err(Error::IndexSize(None)),
             };
             let replacement_after;
             let suffix;

--- a/components/script/dom/css/cssrulelist.rs
+++ b/components/script/dom/css/cssrulelist.rs
@@ -37,7 +37,7 @@ impl Convert<Error> for RulesMutateError {
     fn convert(self) -> Error {
         match self {
             RulesMutateError::Syntax => Error::Syntax(None),
-            RulesMutateError::IndexSize => Error::IndexSize,
+            RulesMutateError::IndexSize => Error::IndexSize(None),
             RulesMutateError::HierarchyRequest => Error::HierarchyRequest,
             RulesMutateError::InvalidState => Error::InvalidState(None),
         }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3046,7 +3046,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
         let minimum_volume = 0.0;
         let maximum_volume = 1.0;
         if *value < minimum_volume || *value > maximum_volume {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         if *value != self.volume.get() {

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -373,7 +373,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
         let number_of_row_elements = rows.Length();
 
         if index < -1 || index > number_of_row_elements as i32 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         let new_row = Element::create(
@@ -458,7 +458,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
         // Step 1: If index is less than −1 or greater than or equal to the number of elements
         // in the rows collection, then throw an "IndexSizeError".
         if !(-1..num_rows).contains(&index) {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         let num_rows = rows.Length() as i32;

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -35,7 +35,7 @@ macro_rules! make_limited_int_setter(
             use $crate::script_runtime::CanGc;
 
             let value = if value < 0 {
-                return Err($crate::dom::bindings::error::Error::IndexSize);
+                return Err($crate::dom::bindings::error::Error::IndexSize(None));
             } else {
                 value
             };
@@ -320,7 +320,7 @@ macro_rules! make_limited_uint_setter(
             use $crate::dom::values::UNSIGNED_LONG_MAX;
             use $crate::script_runtime::CanGc;
             let value = if value == 0 {
-                return Err($crate::dom::bindings::error::Error::IndexSize);
+                return Err($crate::dom::bindings::error::Error::IndexSize(None));
             } else if value > UNSIGNED_LONG_MAX {
                 $default
             } else {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1397,7 +1397,7 @@ impl Node {
         I: DerivedFrom<Node> + DerivedFrom<HTMLElement> + DomObject,
     {
         if index < -1 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         let tr = new_child();
@@ -1415,7 +1415,7 @@ impl Node {
                     .chain(iter::once(None))
                     .nth(index as usize)
                 {
-                    None => return Err(Error::IndexSize),
+                    None => return Err(Error::IndexSize(None)),
                     Some(node) => node,
                 };
                 self.InsertBefore(tr_node, node.as_deref(), can_gc)?;
@@ -1438,7 +1438,7 @@ impl Node {
         G: Fn(&Element) -> bool,
     {
         let element = match index {
-            index if index < -1 => return Err(Error::IndexSize),
+            index if index < -1 => return Err(Error::IndexSize(None)),
             -1 => {
                 let last_child = self.upcast::<Node>().GetLastChild();
                 match last_child.and_then(|node| {
@@ -1452,7 +1452,7 @@ impl Node {
             },
             index => match get_items().Item(index as u32) {
                 Some(element) => element,
-                None => return Err(Error::IndexSize),
+                None => return Err(Error::IndexSize(None)),
             },
         };
 

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -260,7 +260,7 @@ impl Range {
         }
         if offset > node.len() {
             // Step 3.
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
         if let Ordering::Less = bp_position(node, offset, &start_node, self.start_offset()).unwrap()
         {
@@ -360,7 +360,7 @@ impl Range {
 
         // Step 2. If offset is greater than node’s length, then throw an "IndexSizeError" DOMException.
         if offset > node.len() {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         // Step 3. Let bp be the boundary point (node, offset).

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -186,11 +186,11 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     /// <https://w3c.github.io/selection-api/#dom-selection-getrangeat>
     fn GetRangeAt(&self, index: u32) -> Fallible<DomRoot<Range>> {
         if index != 0 {
-            Err(Error::IndexSize)
+            Err(Error::IndexSize(None))
         } else if let Some(range) = self.range.get() {
             Ok(DomRoot::from_ref(&range))
         } else {
-            Err(Error::IndexSize)
+            Err(Error::IndexSize(None))
         }
     }
 
@@ -244,7 +244,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
             }
             if offset > node.len() {
                 // Step 2
-                return Err(Error::IndexSize);
+                return Err(Error::IndexSize(None));
             }
 
             if !self.is_same_root(node) {
@@ -314,7 +314,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
             if offset > node.len() {
                 // As with is_doctype, not explicit in selection spec steps here
                 // but implied by which exceptions are thrown in WPT tests
-                return Err(Error::IndexSize);
+                return Err(Error::IndexSize(None));
             }
 
             // Step 4
@@ -386,7 +386,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         }
 
         if anchor_offset > anchor_node.len() || focus_offset > focus_node.len() {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         // Step 2

--- a/components/script/dom/text.rs
+++ b/components/script/dom/text.rs
@@ -74,7 +74,7 @@ impl TextMethods<crate::DomTypeHolder> for Text {
         let length = cdata.Length();
         if offset > length {
             // Step 2.
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
         // Step 3.
         let count = length - offset;

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -175,7 +175,7 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
 
         // Step 4
         if start > end {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         // Save the original selection state to later pass to set_selection_range, because we will

--- a/components/script/dom/timeranges.rs
+++ b/components/script/dom/timeranges.rs
@@ -160,7 +160,7 @@ impl TimeRangesMethods<crate::DomTypeHolder> for TimeRanges {
         self.ranges
             .start(index)
             .map(Finite::wrap)
-            .map_err(|_| Error::IndexSize)
+            .map_err(|_| Error::IndexSize(None))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-timeranges-end>
@@ -168,6 +168,6 @@ impl TimeRangesMethods<crate::DomTypeHolder> for TimeRanges {
         self.ranges
             .end(index)
             .map(Finite::wrap)
-            .map_err(|_| Error::IndexSize)
+            .map_err(|_| Error::IndexSize(None))
     }
 }

--- a/components/script/dom/vttcue.rs
+++ b/components/script/dom/vttcue.rs
@@ -152,7 +152,7 @@ impl VTTCueMethods<crate::DomTypeHolder> for VTTCue {
     fn SetPosition(&self, value: VTTCueBinding::LineAndPositionSetting) -> ErrorResult {
         if let VTTCueBinding::LineAndPositionSetting::Double(x) = value {
             if *x < 0_f64 || *x > 100_f64 {
-                return Err(Error::IndexSize);
+                return Err(Error::IndexSize(None));
             }
         }
 
@@ -178,7 +178,7 @@ impl VTTCueMethods<crate::DomTypeHolder> for VTTCue {
     /// <https://w3c.github.io/webvtt/#dom-vttcue-size>
     fn SetSize(&self, value: Finite<f64>) -> ErrorResult {
         if *value < 0_f64 || *value > 100_f64 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         self.size.set(*value);

--- a/components/script/dom/vttregion.rs
+++ b/components/script/dom/vttregion.rs
@@ -78,7 +78,7 @@ impl VTTRegionMethods<crate::DomTypeHolder> for VTTRegion {
     /// <https://w3c.github.io/webvtt/#dom-vttregion-width>
     fn SetWidth(&self, value: Finite<f64>) -> ErrorResult {
         if *value < 0_f64 || *value > 100_f64 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         self.width.set(*value);
@@ -104,7 +104,7 @@ impl VTTRegionMethods<crate::DomTypeHolder> for VTTRegion {
     /// <https://w3c.github.io/webvtt/#dom-vttregion-regionanchorx>
     fn SetRegionAnchorX(&self, value: Finite<f64>) -> ErrorResult {
         if *value < 0_f64 || *value > 100_f64 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         self.region_anchor_x.set(*value);
@@ -119,7 +119,7 @@ impl VTTRegionMethods<crate::DomTypeHolder> for VTTRegion {
     /// <https://w3c.github.io/webvtt/#dom-vttregion-regionanchory>
     fn SetRegionAnchorY(&self, value: Finite<f64>) -> ErrorResult {
         if *value < 0_f64 || *value > 100_f64 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         self.region_anchor_y.set(*value);
@@ -134,7 +134,7 @@ impl VTTRegionMethods<crate::DomTypeHolder> for VTTRegion {
     /// <https://w3c.github.io/webvtt/#dom-vttregion-viewportanchorx>
     fn SetViewportAnchorX(&self, value: Finite<f64>) -> ErrorResult {
         if *value < 0_f64 || *value > 100_f64 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         self.viewport_anchor_x.set(*value);
@@ -149,7 +149,7 @@ impl VTTRegionMethods<crate::DomTypeHolder> for VTTRegion {
     /// <https://w3c.github.io/webvtt/#dom-vttregion-viewportanchory>
     fn SetViewportAnchorY(&self, value: Finite<f64>) -> ErrorResult {
         if *value < 0_f64 || *value > 100_f64 {
-            return Err(Error::IndexSize);
+            return Err(Error::IndexSize(None));
         }
 
         self.viewport_anchor_y.set(*value);

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -14,7 +14,7 @@ use crate::script_runtime::JSContext as SafeJSContext;
 #[derive(Clone, Debug, MallocSizeOf)]
 pub enum Error {
     /// IndexSizeError DOMException
-    IndexSize,
+    IndexSize(Option<String>),
     /// NotFoundError DOMException
     NotFound(Option<String>),
     /// HierarchyRequestError DOMException


### PR DESCRIPTION
Adding an optional message to be attached to a IndexSizeError.

The enum definition of IndexSize is now `IndexSize(Option<String>)`. Future PRs should probably add more appropriate messages to some of the `IndexSize(None)`s.

Testing: Just a refactor
Fixes: Partially #39053