### PR TITLE
Script: Do not double copy for javascript source

### DIFF
--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::borrow::Cow;
 use std::cell::RefCell;
 
 use base::id::{Index, PipelineId, PipelineNamespaceId};
@@ -122,7 +123,11 @@ impl DebuggerGlobalScope {
         self.upcast::<GlobalScope>()
     }
 
-    fn evaluate_js(&self, script: &str, can_gc: CanGc) -> Result<(), JavaScriptEvaluationError> {
+    fn evaluate_js(
+        &self,
+        script: Cow<'_, str>,
+        can_gc: CanGc,
+    ) -> Result<(), JavaScriptEvaluationError> {
         rooted!(in (*Self::get_cx()) let mut rval = UndefinedValue());
         self.global_scope.evaluate_js_on_global_with_result(
             script,
@@ -136,7 +141,7 @@ impl DebuggerGlobalScope {
 
     pub(crate) fn execute(&self, can_gc: CanGc) {
         if self
-            .evaluate_js(&resources::read_string(Resource::DebuggerJS), can_gc)
+            .evaluate_js(resources::read_string(Resource::DebuggerJS).into(), can_gc)
             .is_err()
         {
             let ar = enter_realm(self);

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::borrow::Cow;
 use std::cell::{Cell, OnceCell, Ref};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -2821,14 +2822,14 @@ impl GlobalScope {
     /// Evaluate JS code on this global scope.
     pub(crate) fn evaluate_js_on_global_with_result(
         &self,
-        code: &str,
+        code: Cow<'_, str>,
         rval: MutableHandleValue,
         fetch_options: ScriptFetchOptions,
         script_base_url: ServoUrl,
         can_gc: CanGc,
         introduction_type: Option<&'static CStr>,
     ) -> Result<(), JavaScriptEvaluationError> {
-        let source_code = SourceCode::Text(Rc::new(DOMString::from_string((*code).to_string())));
+        let source_code = SourceCode::Text(Rc::new(DOMString::from_string(code.into_owned())));
         self.evaluate_script_on_global_with_result(
             &source_code,
             "",

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -698,7 +698,7 @@ impl WorkletThread {
         // Also, the spec currently doesn't allow exceptions to be propagated
         // to the main script thread.
         // https://github.com/w3c/css-houdini-drafts/issues/407
-        let ok = script.is_some_and(|s| global_scope.evaluate_js(&s, can_gc).is_ok());
+        let ok = script.is_some_and(|s| global_scope.evaluate_js(s.into(), can_gc).is_ok());
 
         if !ok {
             // Step 3.

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use base::generic_channel::GenericSender;
@@ -132,7 +133,7 @@ impl WorkletGlobalScope {
     /// Evaluate a JS script in this global.
     pub(crate) fn evaluate_js(
         &self,
-        script: &str,
+        script: Cow<'_, str>,
         can_gc: CanGc,
     ) -> Result<(), JavaScriptEvaluationError> {
         debug!("Evaluating Dom in a worklet.");

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3527,7 +3527,7 @@ impl ScriptThread {
         let _ac = enter_realm(global_scope);
         rooted!(in(*GlobalScope::get_cx()) let mut jsval = UndefinedValue());
         _ = global_scope.evaluate_js_on_global_with_result(
-            &script_source,
+            script_source,
             jsval.handle_mut(),
             ScriptFetchOptions::default_classic_script(global_scope),
             global_scope.api_base_url(),
@@ -3912,7 +3912,7 @@ impl ScriptThread {
 
         rooted!(in(*context) let mut return_value = UndefinedValue());
         if let Err(err) = global_scope.evaluate_js_on_global_with_result(
-            &script,
+            script.into(),
             return_value.handle_mut(),
             ScriptFetchOptions::default_classic_script(global_scope),
             global_scope.api_base_url(),

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -801,7 +801,7 @@ impl JsTimerTask {
                 //
                 // FIXME(cybai): Use base url properly by saving private reference for timers (#27260)
                 _ = global.evaluate_js_on_global_with_result(
-                    &code_str.str(),
+                    (*code_str.str()).into(),
                     rval.handle_mut(),
                     ScriptFetchOptions::default_classic_script(&global),
                     // Step 9.6. Let base URL be settings object's API base URL.

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -637,7 +637,7 @@ pub(crate) fn handle_execute_script(
             rooted!(in(*cx) let mut rval = UndefinedValue());
             let global = window.as_global_scope();
             let evaluation_result = global.evaluate_js_on_global_with_result(
-                &eval,
+                eval.into(),
                 rval.handle_mut(),
                 ScriptFetchOptions::default_classic_script(global),
                 global.api_base_url(),
@@ -675,7 +675,7 @@ pub(crate) fn handle_execute_async_script(
 
             let global_scope = window.as_global_scope();
             if let Err(error) = global_scope.evaluate_js_on_global_with_result(
-                &eval,
+                eval.into(),
                 rval.handle_mut(),
                 ScriptFetchOptions::default_classic_script(global_scope),
                 global_scope.api_base_url(),


### PR DESCRIPTION
Previously, `evaluate_js_on_global_with_result` took a &str and most cases
of it being called are owned strings. As it itself converts it to a
DOMString which owns the string it double copied it.

We now use Cow<'_, str> as input making both sides happy.

Testing: Does not change functionality.
