### PR TITLE
script: Start preparation to use safer JSContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,7 +823,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -841,7 +841,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2171,7 +2171,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2605,7 +2605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3221,7 +3221,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps 7.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4735,7 +4735,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5444,7 +5444,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#18029eac79a9f80043a30cc809184e569a47fd0f"
+source = "git+https://github.com/servo/mozjs#d2783b7992f0ae0fba09efc7ad260717e3df624e"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -5457,7 +5457,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.140.0-8"
-source = "git+https://github.com/servo/mozjs#18029eac79a9f80043a30cc809184e569a47fd0f"
+source = "git+https://github.com/servo/mozjs#d2783b7992f0ae0fba09efc7ad260717e3df624e"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -5770,7 +5770,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6923,7 +6923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -7347,7 +7347,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8863,7 +8863,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10373,7 +10373,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -521,7 +521,7 @@ impl Window {
 
     #[expect(unsafe_code)]
     pub(crate) fn get_cx(&self) -> JSContext {
-        unsafe { JSContext::from_ptr(self.js_runtime.borrow().as_ref().unwrap().cx()) }
+        unsafe { JSContext::from_ptr(js::rust::Runtime::get().unwrap().as_ptr()) }
     }
 
     pub(crate) fn get_js_runtime(&self) -> Ref<'_, Option<Rc<Runtime>>> {

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -22,7 +22,8 @@ use base::IpcSend;
 use base::id::{PipelineId, WebViewId};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use dom_struct::dom_struct;
-use js::jsapi::{GCReason, JS_GC, JS_GetGCParameter, JSGCParamKey, JSTracer};
+use js::jsapi::{GCReason, JSGCParamKey, JSTracer};
+use js::rust::wrappers2::{JS_GC, JS_GetGCParameter};
 use malloc_size_of::malloc_size_of_is_0;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{Destination, RequestBuilder, RequestMode};
@@ -601,7 +602,7 @@ impl WorkletThread {
     /// The current memory usage of the thread
     #[expect(unsafe_code)]
     fn current_memory_usage(&self) -> u32 {
-        unsafe { JS_GetGCParameter(self.runtime.cx(), JSGCParamKey::JSGC_BYTES) }
+        unsafe { JS_GetGCParameter(self.runtime.cx_no_gc(), JSGCParamKey::JSGC_BYTES) }
     }
 
     /// Perform a GC.

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -801,6 +801,7 @@ impl Runtime {
         let cx_opts;
         let job_queue;
         unsafe {
+            let cx = runtime.cx();
             job_queue = CreateJobQueue(
                 &JOB_QUEUE_TRAPS,
                 &*microtask_queue as *const _ as *const c_void,
@@ -854,6 +855,7 @@ impl Runtime {
         cx_opts.set_wasmIon_(pref!(js_wasm_ion_enabled));
 
         unsafe {
+            let cx = runtime.cx();
             // TODO: handle js.throw_on_asmjs_validation_failure (needs new Spidermonkey)
             JS_SetGlobalJitCompilerOption(
                 cx,

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -11,7 +11,7 @@ use core::ffi::c_char;
 use std::cell::Cell;
 use std::ffi::{CStr, CString};
 use std::io::{Write, stdout};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::os::raw::c_void;
 use std::rc::Rc;
 use std::sync::Mutex;
@@ -23,29 +23,32 @@ use js::conversions::jsstr_to_string;
 use js::gc::StackGCVector;
 use js::glue::{
     CollectServoSizes, CreateJobQueue, DeleteJobQueue, DispatchablePointer, DispatchableRun,
-    JS_GetReservedSlot, JobQueueTraps, RUST_js_GetErrorMessage, SetBuildId, SetUpEventLoopDispatch,
+    JS_GetReservedSlot, JobQueueTraps, RUST_js_GetErrorMessage, SetBuildId,
     StreamConsumerConsumeChunk, StreamConsumerNoteResponseURLs, StreamConsumerStreamEnd,
     StreamConsumerStreamError,
 };
 use js::jsapi::{
-    AsmJSOption, BuildIdCharVector, CompilationType, ContextOptionsRef,
-    Dispatchable_MaybeShuttingDown, GCDescription, GCOptions, GCProgress, GCReason,
-    GetPromiseUserInputEventHandlingState, Handle as RawHandle, HandleObject, HandleString,
-    HandleValue as RawHandleValue, Heap, InitConsumeStreamCallback, JS_AddExtraGCRootsTracer,
-    JS_InitDestroyPrincipalsCallback, JS_InitReadPrincipalsCallback, JS_NewObject,
-    JS_NewStringCopyUTF8N, JS_SetGCCallback, JS_SetGCParameter, JS_SetGlobalJitCompilerOption,
-    JS_SetOffthreadIonCompilationEnabled, JS_SetReservedSlot, JS_SetSecurityCallbacks,
-    JSCLASS_RESERVED_SLOTS_MASK, JSCLASS_RESERVED_SLOTS_SHIFT, JSClass, JSClassOps,
-    JSContext as RawJSContext, JSGCParamKey, JSGCStatus, JSJitCompilerOption, JSObject,
-    JSSecurityCallbacks, JSString, JSTracer, JobQueue, MimeType, MutableHandleObject,
-    MutableHandleString, PromiseRejectionHandlingState, PromiseUserInputEventHandlingState,
-    RuntimeCode, SetDOMCallbacks, SetGCSliceCallback, SetJobQueue, SetPreserveWrapperCallbacks,
-    SetProcessBuildIdOp, SetPromiseRejectionTrackerCallback, StreamConsumer as JSStreamConsumer,
+    AsmJSOption, BuildIdCharVector, CompilationType, Dispatchable_MaybeShuttingDown, GCDescription,
+    GCOptions, GCProgress, GCReason, GetPromiseUserInputEventHandlingState, Handle as RawHandle,
+    HandleObject, HandleString, HandleValue as RawHandleValue, Heap, JS_NewObject,
+    JS_NewStringCopyUTF8N, JS_SetReservedSlot, JSCLASS_RESERVED_SLOTS_MASK,
+    JSCLASS_RESERVED_SLOTS_SHIFT, JSClass, JSClassOps, JSContext as RawJSContext, JSGCParamKey,
+    JSGCStatus, JSJitCompilerOption, JSObject, JSSecurityCallbacks, JSString, JSTracer, JobQueue,
+    MimeType, MutableHandleObject, MutableHandleString, PromiseRejectionHandlingState,
+    PromiseUserInputEventHandlingState, RuntimeCode, SetProcessBuildIdOp,
+    StreamConsumer as JSStreamConsumer,
 };
 use js::jsval::{JSVal, ObjectValue, UndefinedValue};
 use js::panic::wrap_panic;
 pub(crate) use js::rust::ThreadSafeJSContext;
 use js::rust::wrappers::{GetPromiseIsHandled, JS_GetPromiseResult};
+use js::rust::wrappers2::{
+    ContextOptionsRef, InitConsumeStreamCallback, JS_AddExtraGCRootsTracer,
+    JS_InitDestroyPrincipalsCallback, JS_InitReadPrincipalsCallback, JS_SetGCCallback,
+    JS_SetGCParameter, JS_SetGlobalJitCompilerOption, JS_SetOffthreadIonCompilationEnabled,
+    JS_SetSecurityCallbacks, SetDOMCallbacks, SetGCSliceCallback, SetJobQueue,
+    SetPreserveWrapperCallbacks, SetPromiseRejectionTrackerCallback, SetUpEventLoopDispatch,
+};
 use js::rust::{
     Handle, HandleObject as RustHandleObject, HandleValue, IntoHandle, JSEngine, JSEngineHandle,
     ParentRuntime, Runtime as RustRuntime,
@@ -711,14 +714,12 @@ impl Runtime {
         parent: Option<ParentRuntime>,
         networking_task_source: Option<SendableTaskSource>,
     ) -> Runtime {
-        let (cx, runtime) = if let Some(parent) = parent {
-            let runtime = unsafe { RustRuntime::create_with_parent(parent) };
-            let cx = runtime.cx();
-            (cx, runtime)
+        let mut runtime = if let Some(parent) = parent {
+            unsafe { RustRuntime::create_with_parent(parent) }
         } else {
-            let runtime = RustRuntime::new(JS_ENGINE.lock().unwrap().as_ref().unwrap().clone());
-            (runtime.cx(), runtime)
+            RustRuntime::new(JS_ENGINE.lock().unwrap().as_ref().unwrap().clone())
         };
+        let cx = runtime.cx();
 
         unsafe {
             JS_AddExtraGCRootsTracer(cx, Some(trace_rust_roots), ptr::null_mut());
@@ -814,7 +815,9 @@ impl Runtime {
 
             EnsureModuleHooksInitialized(runtime.rt());
 
-            set_gc_zeal_options(cx);
+            let cx = runtime.cx();
+
+            set_gc_zeal_options(cx.raw_cx());
 
             // Enable or disable the JITs.
             cx_opts = &mut *ContextOptionsRef(cx);
@@ -983,6 +986,12 @@ impl Deref for Runtime {
     type Target = RustRuntime;
     fn deref(&self) -> &RustRuntime {
         &self.rt
+    }
+}
+
+impl DerefMut for Runtime {
+    fn deref_mut(&mut self) -> &mut RustRuntime {
+        &mut self.rt
     }
 }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -61,11 +61,10 @@ use hyper_serde::Serde;
 use ipc_channel::ipc;
 use ipc_channel::router::ROUTER;
 use js::glue::GetWindowProxyClass;
-use js::jsapi::{
-    JS_AddInterruptCallback, JSContext as UnsafeJSContext, JSTracer, SetWindowProxyClass,
-};
+use js::jsapi::{JSContext as UnsafeJSContext, JSTracer};
 use js::jsval::UndefinedValue;
 use js::rust::ParentRuntime;
+use js::rust::wrappers2::{JS_AddInterruptCallback, SetWindowProxyClass};
 use layout_api::{LayoutConfig, LayoutFactory, RestyleReason, ScriptThreadFactory};
 use media::WindowGLContext;
 use metrics::MAX_TASK_NS;
@@ -861,7 +860,7 @@ impl ScriptThread {
         system_font_service: Arc<SystemFontServiceProxy>,
     ) -> ScriptThread {
         let (self_sender, self_receiver) = unbounded();
-        let runtime = Runtime::new(Some(SendableTaskSource {
+        let mut runtime = Runtime::new(Some(SendableTaskSource {
             sender: ScriptEventLoopSender::MainThread(self_sender.clone()),
             pipeline_id: state.id,
             name: TaskSourceName::Networking,
@@ -1002,7 +1001,7 @@ impl ScriptThread {
 
     #[expect(unsafe_code)]
     pub(crate) fn get_cx(&self) -> JSContext {
-        unsafe { JSContext::from_ptr(self.js_runtime.cx()) }
+        unsafe { JSContext::from_ptr(js::rust::Runtime::get().unwrap().as_ptr()) }
     }
 
     /// Check if we are closing.


### PR DESCRIPTION
This PR is companion to https://github.com/servo/mozjs/pull/638, currently it only make stuff compile. In follwups we will start passing/using safer JSContext down everywhere.

Testing: Not needed as it's just refactorings.
try run: https://github.com/sagudev/servo/actions/runs/19196312972/job/54879090390