### PR TITLE
ci: Fix ohos libservoshell.so artifact path

### DIFF
--- a/python/servo/package_commands.py
+++ b/python/servo/package_commands.py
@@ -64,7 +64,7 @@ PACKAGES = {
         r"production\msi\Servo.zip",
     ],
     "ohos": [
-        "openharmony/aarch64-unknown-linux-ohos/production/libservoshell.so",
+        "aarch64-unknown-linux-ohos/production/libservoshell.so",
         "openharmony/aarch64-unknown-linux-ohos/production/entry/build/"
         + "default/outputs/default/servoshell-default-signed.hap",
     ],


### PR DESCRIPTION
cargo places the shared library artifact under
`target/<target_triple>/<profile>/libservoshell.so`. The openharmony prefix, is something we do in mach for the hap, and is not relevant for the .so (essentially a copy-paste mistake).
Can be compared by looking at the job run of
https://github.com/servo/servo/actions/runs/19125758002/job/54655560361 which failed due to the wrong path.

Testing: Not tested
Fixes: #40467
