### PR TITLE
webdriver: Print details when fail to start server

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -137,7 +137,7 @@ pub fn start_server(
                 extension_routes(),
             ) {
                 Ok(listening) => info!("WebDriver server listening on {}", listening.socket),
-                Err(_) => panic!("Unable to start WebDriver HTTP server"),
+                Err(e) => panic!("Unable to start WebDriver HTTP server {e:?}"),
             }
         })
         .expect("Thread spawning failed");

--- a/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/executors/executorservodriver.py
@@ -22,7 +22,7 @@ def do_delayed_imports():
 
         def get_prefs(self, *prefs):
             body = {"prefs": list(prefs)}
-            return self.session.send_session_command("POST", "servo/prefs/get", body)
+            return self.session.send_session_command("GET", "servo/prefs/get", body)
 
         def set_prefs(self, prefs):
             body = {"prefs": prefs}
@@ -31,6 +31,11 @@ def do_delayed_imports():
         def reset_prefs(self, *prefs):
             body = {"prefs": list(prefs)}
             return self.session.send_session_command("POST", "servo/prefs/reset", body)
+
+        def shutdown(self):
+            body = {}
+            return self.session.send_session_command("DELETE", "servo/shutdown", body)
+
 
         def change_prefs(self, old_prefs, new_prefs):
             # Servo interprets reset with an empty list as reset everything


### PR DESCRIPTION
This has made life much easier to debug servodriver.