### PR TITLE
background_hang_monitor: Clean up `Sampler` a bit and use `allow(dead_code)`

### DIFF
--- a/components/background_hang_monitor/lib.rs
+++ b/components/background_hang_monitor/lib.rs
@@ -25,3 +25,37 @@ mod sampler_mac;
 mod sampler_windows;
 
 pub use self::background_hang_monitor::*;
+#[cfg(any(
+    not(feature = "sampler"),
+    all(
+        target_os = "linux",
+        any(
+            target_arch = "arm",
+            target_arch = "aarch64",
+            target_env = "ohos",
+            target_env = "musl"
+        )
+    ),
+))]
+pub use crate::sampler::DummySampler as SamplerImpl;
+#[cfg(all(
+    feature = "sampler",
+    target_os = "linux",
+    not(any(
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_env = "ohos",
+        target_env = "musl"
+    ))
+))]
+pub use crate::sampler_linux::LinuxSampler as SamplerImpl;
+#[cfg(all(feature = "sampler", target_os = "android"))]
+pub use crate::sampler_linux::LinuxSampler as SamplerImpl;
+#[cfg(all(feature = "sampler", target_os = "macos"))]
+pub use crate::sampler_mac::MacOsSampler as SamplerImpl;
+#[cfg(all(
+    feature = "sampler",
+    target_os = "windows",
+    any(target_arch = "x86_64", target_arch = "x86")
+))]
+pub use crate::sampler_windows::WindowsSampler as SamplerImpl;

--- a/components/background_hang_monitor/sampler.rs
+++ b/components/background_hang_monitor/sampler.rs
@@ -15,7 +15,7 @@ pub trait Sampler: Send {
 pub struct DummySampler;
 
 impl DummySampler {
-    #[expect(dead_code)]
+    #[allow(dead_code)]
     pub fn new_boxed() -> Box<dyn Sampler> {
         Box::new(DummySampler)
     }
@@ -31,7 +31,7 @@ impl Sampler for DummySampler {
 pub type Address = *const u8;
 
 /// The registers used for stack unwinding
-#[expect(dead_code)]
+#[allow(dead_code)]
 pub struct Registers {
     /// Instruction pointer.
     pub instruction_ptr: Address,
@@ -47,15 +47,17 @@ pub struct NativeStack {
     count: usize,
 }
 
-impl NativeStack {
-    pub fn new() -> Self {
+impl Default for NativeStack {
+    fn default() -> Self {
         NativeStack {
             instruction_ptrs: [ptr::null_mut(); MAX_NATIVE_FRAMES],
             stack_ptrs: [ptr::null_mut(); MAX_NATIVE_FRAMES],
             count: 0,
         }
     }
+}
 
+impl NativeStack {
     pub fn process_register(
         &mut self,
         instruction_ptr: *mut std::ffi::c_void,

--- a/components/background_hang_monitor/sampler_linux.rs
+++ b/components/background_hang_monitor/sampler_linux.rs
@@ -166,7 +166,7 @@ impl Sampler for LinuxSampler {
                 .wait_through_intr()
                 .expect("msg2 failed");
 
-            let mut native_stack = NativeStack::new();
+            let mut native_stack = NativeStack::default();
             unsafe {
                 backtrace::trace_unsynchronized(|frame| {
                     let ip = frame.ip();

--- a/components/background_hang_monitor/sampler_mac.rs
+++ b/components/background_hang_monitor/sampler_mac.rs
@@ -116,7 +116,7 @@ unsafe fn frame_pointer_stack_walk(regs: Registers) -> NativeStack {
     // Note: this function will only work with code build with:
     // --dev,
     // or --with-frame-pointer.
-    let mut native_stack = NativeStack::new();
+    let mut native_stack = NativeStack::default();
     unsafe {
         let pthread_t = libc::pthread_self();
         let stackaddr = libc::pthread_get_stackaddr_np(pthread_t);


### PR DESCRIPTION
This clean up the way that the `SamplerImpl` is defined slightly and
switches to using `allow(dead_code)` as this code isn't dead on all
platforms. This fixes a build warning.

Testing: This should not change behavior and is thus covered by existing tests.
