### PR TITLE
compositor: Allow `GenerateFrame` to take `Vec<WebViewId>`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -286,7 +286,7 @@ impl IOCompositor {
                     display_list_receiver,
                 );
             },
-            CompositorMsg::GenerateFrame => {
+            CompositorMsg::GenerateFrame(_webview_ids) => {
                 self.painter_mut().generate_frame_for_script();
             },
             CompositorMsg::GenerateImageKey(sender) => {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2347,7 +2347,8 @@ impl Window {
         let reflow_phases_run =
             self.reflow(ReflowGoal::UpdateScrollNode(scroll_id, Vector2D::new(x, y)));
         if reflow_phases_run.needs_frame() {
-            self.compositor_api().generate_frame();
+            self.compositor_api()
+                .generate_frame(vec![self.webview_id()]);
         }
 
         // > If the scroll position did not change as a result of the user interaction or programmatic
@@ -2600,7 +2601,8 @@ impl Window {
         //
         // See <https://github.com/servo/servo/issues/14719>
         if self.Document().update_the_rendering().needs_frame() {
-            self.compositor_api().generate_frame();
+            self.compositor_api()
+                .generate_frame(vec![self.webview_id()]);
         }
     }
 

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -131,9 +131,9 @@ pub enum CompositorMsg {
         /// An [ipc::IpcBytesReceiver] used to send the raw data of the display list.
         display_list_receiver: ipc::IpcBytesReceiver,
     },
-    /// Ask the renderer to generate a frame for the current set of display lists that
-    /// have been sent to the renderer.
-    GenerateFrame,
+    /// Ask the renderer to generate a frame for the current set of display lists
+    /// from the given `WebViewId`s that have been sent to the renderer.
+    GenerateFrame(Vec<WebViewId>),
     /// Create a new image key. The result will be returned via the
     /// provided channel sender.
     GenerateImageKey(GenericSender<ImageKey>),
@@ -344,8 +344,8 @@ impl CrossProcessCompositorApi {
     }
 
     /// Ask the Servo renderer to generate a new frame after having new display lists.
-    pub fn generate_frame(&self) {
-        if let Err(error) = self.0.send(CompositorMsg::GenerateFrame) {
+    pub fn generate_frame(&self, webview_ids: Vec<WebViewId>) {
+        if let Err(error) = self.0.send(CompositorMsg::GenerateFrame(webview_ids)) {
             warn!("Error generating frame: {error}");
         }
     }


### PR DESCRIPTION
This change simply allows `GenerateFrame` to carry a list of `WebViewId`s and modifies `update_the_rendering` to collect `WebViewId`s and pass them in the `GenerateFrame` message. The list of `WebViewId`s is currently not used and that will be handled in a follow-up patch.

Testing: Covered by existing tests.

