### PR TITLE
webdriver: Do not remove id from `input_state_table` if it still in `input_cancel_list`

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2178,7 +2178,17 @@ impl Handler {
         }
 
         // Step 14. Remove an input source with input state and input id.
-        self.session_mut()?.input_state_table.remove(&id);
+        // It is possible that we only dispatched keydown.
+        // In that case, we cannot remove the id from input state table.
+        // This is a bug in spec: https://github.com/servo/servo/issues/37579#issuecomment-2990762713
+        if self
+            .session()?
+            .input_cancel_list
+            .iter()
+            .all(|(cancel_item_id, _)| &id != cancel_item_id)
+        {
+            self.session_mut()?.input_state_table.remove(&id);
+        }
 
         Ok(WebDriverResponse::Void)
     }


### PR DESCRIPTION
There ~was~ has been a [bug](https://github.com/servo/servo/issues/37579#issuecomment-2990762713) in spec. Our workaround has been: for every keyup/pointerup, we remove a corresponding entry in `input_cancel_list`.

But we missed one thing: it is possible to only dispatch keydown in [element send keys](https://w3c.github.io/webdriver/#dfn-element-send-keys). In that case, we inserted an entry into `input_cancel_list` but removes Id from `input_state_table` in the end. This causes a panic with a followup [release actions](https://w3c.github.io/webdriver/#dfn-release-actions).

This PR makes sure we only remove if it is safe.

Testing: CI no longer panic on https://github.com/servo/servo/blob/dc9696c27d35f407832e6ef2624ee96afe1ba438/components/webdriver_server/actions.rs#L338 for some testdriver tests.