### PR TITLE
compositing: Allow mapping from WebRender key types to `PainterId`

### DIFF
--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -277,6 +277,10 @@ impl Painter {
                 upload_method,
                 workers,
                 size_of_op: Some(servo_allocator::usable_size),
+                // This ensures that we can use the `PainterId` as the `IdNamespace`, which allows mapping
+                // from `FontKey`, `FontInstanceKey`, and `ImageKey` back to `PainterId`.
+                namespace_alloc_by_client: true,
+                shared_font_namespace: Some(painter_id.into()),
                 ..Default::default()
             },
             None,
@@ -285,7 +289,7 @@ impl Painter {
 
         webrender.set_external_image_handler(external_image_handlers);
 
-        let webrender_api = webrender_api_sender.create_api();
+        let webrender_api = webrender_api_sender.create_api_by_client(painter_id.into());
         let webrender_document = webrender_api.add_document(rendering_context.size2d().to_i32());
 
         let gl_renderer = webrender_gl.get_string(gleam::gl::RENDERER);

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -18,7 +18,10 @@ use malloc_size_of_derive::MallocSizeOf;
 use parking_lot::Mutex;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use webrender_api::{ExternalScrollId, PipelineId as WebRenderPipelineId};
+use webrender_api::{
+    ExternalScrollId, FontInstanceKey, FontKey, IdNamespace, ImageKey,
+    PipelineId as WebRenderPipelineId,
+};
 
 use crate::generic_channel::{self, GenericReceiver, GenericSender};
 
@@ -447,7 +450,7 @@ impl fmt::Display for PainterId {
     }
 }
 
-static PAINTER_ID: AtomicU32 = AtomicU32::new(0);
+static PAINTER_ID: AtomicU32 = AtomicU32::new(1);
 
 impl PainterId {
     pub fn next() -> Self {
@@ -457,5 +460,35 @@ impl PainterId {
     /// TODO: This should be removed once font keys are generated per-Painter.
     pub fn first_for_system_font_service() -> Self {
         Self(0)
+    }
+}
+
+impl From<PainterId> for IdNamespace {
+    fn from(painter_id: PainterId) -> Self {
+        IdNamespace(painter_id.0)
+    }
+}
+
+impl From<IdNamespace> for PainterId {
+    fn from(id_namespace: IdNamespace) -> Self {
+        PainterId(id_namespace.0)
+    }
+}
+
+impl From<FontKey> for PainterId {
+    fn from(font_key: FontKey) -> Self {
+        font_key.0.into()
+    }
+}
+
+impl From<FontInstanceKey> for PainterId {
+    fn from(font_instance_key: FontInstanceKey) -> Self {
+        font_instance_key.0.into()
+    }
+}
+
+impl From<ImageKey> for PainterId {
+    fn from(image_key: ImageKey) -> Self {
+        image_key.0.into()
     }
 }


### PR DESCRIPTION
In order to properly select the appropriate `Painter` when dealing with
incoming keys to the renderer API, we ensure that these keys carry the
`PainterId` encoded as `IdNamespace` inside them. This should eliminate
the need to pass the `WebViewId` or `PainterId` with messages involving
these keys.

Testing: This should not change observable behavior, so should be covered
by existing tests.
