### PR TITLE
mach try: Don't run commit hooks

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -931,7 +931,19 @@ class MachCommands(CommandBase):
         commit_message = subprocess.check_output(["git", "show", "-s", "--format=%s"]).decode().strip()
         commit_message = f"{commit_message} ({try_string})"
 
-        result = call(["git", "commit", "--quiet", "--allow-empty", "-m", commit_message, "-m", f"{config.to_json()}"])
+        result = call(
+            [
+                "git",
+                "commit",
+                "--no-verify",
+                "--quiet",
+                "--allow-empty",
+                "-m",
+                commit_message,
+                "-m",
+                f"{config.to_json()}",
+            ]
+        )
         if result != 0:
             return result
 


### PR DESCRIPTION
An implementation detail of `./mach try` is that it creates a git commit containing information about the try configuration. Adding `--no-verify` skips running git pre-commit hooks, which could cause the commit to fail. This is useful for draft / work-in-progress branches, where you quickly want to commit something and test CI works, before fixing lints / formatting etc.

Testing: Manually tested with `./mach try`.
Fixes: #40475
