### PR TITLE
fonts: prime per-painter font key cache during `WebView` creation

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -102,7 +102,8 @@ use background_hang_monitor_api::{
 use base::generic_channel::{GenericSender, RoutedReceiver};
 use base::id::{
     BrowsingContextGroupId, BrowsingContextId, HistoryStateId, MessagePortId, MessagePortRouterId,
-    PipelineId, PipelineNamespace, PipelineNamespaceId, PipelineNamespaceRequest, WebViewId,
+    PainterId, PipelineId, PipelineNamespace, PipelineNamespaceId, PipelineNamespaceRequest,
+    WebViewId,
 };
 use base::{Epoch, IpcSend, generic_channel};
 #[cfg(feature = "bluetooth")]
@@ -3065,6 +3066,10 @@ where
             }),
             viewport_details,
         });
+
+        let painter_id = PainterId::from(webview_id);
+        self.system_font_service
+            .prefetch_font_keys_for_painter(painter_id);
     }
 
     #[servo_tracing::instrument(skip_all)]

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -140,6 +140,7 @@ mod font_context {
                         let _ = result_sender.send(());
                         break;
                     },
+                    SystemFontServiceMessage::PrefetchFontKeys(_) => {},
                     SystemFontServiceMessage::Ping => {},
                     SystemFontServiceMessage::CollectMemoryReport(..) => {},
                 }

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -453,9 +453,4 @@ impl PainterId {
     pub fn next() -> Self {
         Self(PAINTER_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
     }
-
-    /// TODO: This should be removed once font keys are generated per-Painter.
-    pub fn first_for_system_font_service() -> Self {
-        Self(0)
-    }
 }

--- a/components/shared/fonts/system_font_service_proxy.rs
+++ b/components/shared/fonts/system_font_service_proxy.rs
@@ -33,6 +33,7 @@ pub enum SystemFontServiceMessage {
         Vec<FontVariation>,
         IpcSender<FontInstanceKey>,
     ),
+    PrefetchFontKeys(PainterId),
     GetFontKey(PainterId, IpcSender<FontKey>),
     GetFontInstanceKey(PainterId, IpcSender<FontInstanceKey>),
     CollectMemoryReport(ReportsChan),
@@ -181,5 +182,11 @@ impl SystemFontServiceProxy {
         result_receiver
             .recv()
             .expect("Failed to communicate with system font service.")
+    }
+
+    pub fn prefetch_font_keys_for_painter(&self, painter_id: PainterId) {
+        let _ = self
+            .sender
+            .send(SystemFontServiceMessage::PrefetchFontKeys(painter_id));
     }
 }


### PR DESCRIPTION
Currently we only prime the font key cache for the very first painter. Replace this with a mechanism to request the System Font Service to prime the key cache whenever a new `WebView` is created.

Testing: This only modifies an internal optimization, so should be covered by existing tests. 
