### PR TITLE
script: Rename `ScriptThreadMessage::AttachLayout` to `ScriptThreadMessage::SpawnPipeline`

### DIFF
--- a/components/background_hang_monitor/tests/hang_monitor_tests.rs
+++ b/components/background_hang_monitor/tests/hang_monitor_tests.rs
@@ -49,7 +49,7 @@ fn test_hang_monitoring() {
     );
 
     // Start an activity.
-    let hang_annotation = HangAnnotation::Script(ScriptHangAnnotation::AttachLayout);
+    let hang_annotation = HangAnnotation::Script(ScriptHangAnnotation::SpawnPipeline);
     background_hang_monitor.notify_activity(hang_annotation);
 
     // Sleep until the "transient" timeout has been reached.
@@ -166,7 +166,7 @@ fn test_hang_monitoring_unregister() {
     );
 
     // Start an activity.
-    let hang_annotation = HangAnnotation::Script(ScriptHangAnnotation::AttachLayout);
+    let hang_annotation = HangAnnotation::Script(ScriptHangAnnotation::SpawnPipeline);
     background_hang_monitor.notify_activity(hang_annotation);
 
     // Unregister the component.

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -43,7 +43,7 @@ use profile::system_reporter;
 use profile_traits::mem::{ProfilerMsg, Reporter};
 use profile_traits::{mem as profile_mem, time};
 use script_traits::{
-    DiscardBrowsingContext, DocumentActivity, InitialScriptState, NewLayoutInfo,
+    DiscardBrowsingContext, DocumentActivity, InitialScriptState, NewPipelineInfo,
     ScriptThreadMessage,
 };
 use serde::{Deserialize, Serialize};
@@ -232,7 +232,7 @@ impl Pipeline {
         // probably requires a general low-memory strategy.
         let (script_chan, (bhm_control_chan, lifeline, join_handle)) = match state.event_loop {
             Some(script_chan) => {
-                let new_layout_info = NewLayoutInfo {
+                let new_pipeline_info = NewPipelineInfo {
                     parent_info: state.parent_pipeline_id,
                     new_pipeline_id: state.id,
                     browsing_context_id: state.browsing_context_id,
@@ -243,7 +243,8 @@ impl Pipeline {
                     theme: state.theme,
                 };
 
-                if let Err(e) = script_chan.send(ScriptThreadMessage::AttachLayout(new_layout_info))
+                if let Err(e) =
+                    script_chan.send(ScriptThreadMessage::SpawnPipeline(new_pipeline_info))
                 {
                     warn!("Sending to script during pipeline creation failed ({})", e);
                 }

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -20,7 +20,7 @@ use js::rust::HandleObject;
 use net_traits::ReferrerPolicy;
 use net_traits::request::Destination;
 use profile_traits::ipc as ProfiledIpc;
-use script_traits::{NewLayoutInfo, UpdatePipelineIdReason};
+use script_traits::{NewPipelineInfo, UpdatePipelineIdReason};
 use servo_url::ServoUrl;
 use style::attr::{AttrValue, LengthOrPercentageOrAuto};
 use stylo_atoms::Atom;
@@ -216,7 +216,7 @@ impl HTMLIFrameElement {
                     .send(ScriptToConstellationMessage::ScriptNewIFrame(load_info))
                     .unwrap();
 
-                let new_layout_info = NewLayoutInfo {
+                let new_pipeline_info = NewPipelineInfo {
                     parent_info: Some(window.pipeline_id()),
                     new_pipeline_id,
                     browsing_context_id,
@@ -228,7 +228,10 @@ impl HTMLIFrameElement {
                 };
 
                 self.pipeline_id.set(Some(new_pipeline_id));
-                ScriptThread::process_attach_layout(new_layout_info, document.origin().clone());
+                ScriptThread::spawn_pipeline_in_current(
+                    new_pipeline_info,
+                    document.origin().clone(),
+                );
             },
             PipelineType::Navigation => {
                 let load_info = IFrameLoadInfoWithData {

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -37,7 +37,7 @@ use js::rust::wrappers::{JS_TransplantObject, NewWindowProxy, SetWindowProxy};
 use js::rust::{Handle, MutableHandle, MutableHandleValue, get_object_class};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 use net_traits::request::Referrer;
-use script_traits::NewLayoutInfo;
+use script_traits::NewPipelineInfo;
 use serde::{Deserialize, Serialize};
 use servo_url::{ImmutableOrigin, ServoUrl};
 use storage_traits::webstorage_thread::WebStorageThreadMsg;
@@ -336,7 +336,7 @@ impl WindowProxy {
 
         let response = response_receiver.recv().unwrap()?;
         let new_browsing_context_id = BrowsingContextId::from(response.new_webview_id);
-        let new_layout_info = NewLayoutInfo {
+        let new_pipeline_info = NewPipelineInfo {
             parent_info: None,
             new_pipeline_id: response.new_pipeline_id,
             browsing_context_id: new_browsing_context_id,
@@ -348,7 +348,7 @@ impl WindowProxy {
             // change this later.
             theme: window.theme(),
         };
-        ScriptThread::process_attach_layout(new_layout_info, document.origin().clone());
+        ScriptThread::spawn_pipeline_in_current(new_pipeline_info, document.origin().clone());
         let new_window_proxy = ScriptThread::find_document(response.new_pipeline_id)
             .and_then(|doc| doc.browsing_context())?;
         if name.to_lowercase() != "_blank" {

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -56,9 +56,9 @@ impl MixedMessage {
         match self {
             MixedMessage::FromConstellation(inner_msg) => match inner_msg {
                 ScriptThreadMessage::StopDelayingLoadEventsMode(id) => Some(*id),
-                ScriptThreadMessage::AttachLayout(new_layout_info) => new_layout_info
+                ScriptThreadMessage::SpawnPipeline(new_pipeline_info) => new_pipeline_info
                     .parent_info
-                    .or(Some(new_layout_info.new_pipeline_id)),
+                    .or(Some(new_pipeline_info.new_pipeline_id)),
                 ScriptThreadMessage::Resize(id, ..) => Some(*id),
                 ScriptThreadMessage::ThemeChange(id, ..) => Some(*id),
                 ScriptThreadMessage::ResizeInactive(id, ..) => Some(*id),

--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -108,7 +108,7 @@ static SECURITY_CALLBACKS: JSSecurityCallbacks = JSSecurityCallbacks {
 
 #[derive(Clone, Copy, Debug, Eq, Hash, JSTraceable, MallocSizeOf, PartialEq)]
 pub(crate) enum ScriptThreadEventCategory {
-    AttachLayout,
+    SpawnPipeline,
     ConstellationMsg,
     DatabaseAccessEvent,
     DevtoolsMsg,
@@ -144,7 +144,7 @@ pub(crate) enum ScriptThreadEventCategory {
 impl From<ScriptThreadEventCategory> for ProfilerCategory {
     fn from(category: ScriptThreadEventCategory) -> Self {
         match category {
-            ScriptThreadEventCategory::AttachLayout => ProfilerCategory::ScriptAttachLayout,
+            ScriptThreadEventCategory::SpawnPipeline => ProfilerCategory::ScriptSpawnPipeline,
             ScriptThreadEventCategory::ConstellationMsg => ProfilerCategory::ScriptConstellationMsg,
             ScriptThreadEventCategory::DatabaseAccessEvent => {
                 ProfilerCategory::ScriptDatabaseAccessEvent
@@ -192,7 +192,7 @@ impl From<ScriptThreadEventCategory> for ProfilerCategory {
 impl From<ScriptThreadEventCategory> for ScriptHangAnnotation {
     fn from(category: ScriptThreadEventCategory) -> Self {
         match category {
-            ScriptThreadEventCategory::AttachLayout => ScriptHangAnnotation::AttachLayout,
+            ScriptThreadEventCategory::SpawnPipeline => ScriptHangAnnotation::SpawnPipeline,
             ScriptThreadEventCategory::ConstellationMsg => ScriptHangAnnotation::ConstellationMsg,
             ScriptThreadEventCategory::DatabaseAccessEvent => {
                 ScriptHangAnnotation::DatabaseAccessEvent

--- a/components/shared/background_hang_monitor/lib.rs
+++ b/components/shared/background_hang_monitor/lib.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 /// The equivalent of script::script_runtime::ScriptEventCategory
 pub enum ScriptHangAnnotation {
-    AttachLayout,
+    SpawnPipeline,
     ConstellationMsg,
     DatabaseAccessEvent,
     DevtoolsMsg,

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -68,7 +68,7 @@ pub enum ProfilerCategory {
     Layout = 0x10,
 
     ImageSaving = 0x51,
-    ScriptAttachLayout = 0x60,
+    ScriptSpawnPipeline = 0x60,
     ScriptConstellationMsg = 0x61,
     ScriptDevtoolsMsg = 0x62,
     ScriptDocumentEvent = 0x63,
@@ -129,7 +129,7 @@ impl ProfilerCategory {
             ProfilerCategory::Compositing => "Compositing",
             ProfilerCategory::Layout => "Layout",
             ProfilerCategory::ImageSaving => "ImageSaving",
-            ProfilerCategory::ScriptAttachLayout => "ScriptAttachLayout",
+            ProfilerCategory::ScriptSpawnPipeline => "ScriptSpawnPipeline",
             ProfilerCategory::ScriptConstellationMsg => "ScriptConstellationMsg",
             ProfilerCategory::ScriptDatabaseAccessEvent => "ScriptDatabaseAccessEvent",
             ProfilerCategory::ScriptDevtoolsMsg => "ScriptDevtoolsMsg",

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -56,9 +56,9 @@ use webgpu_traits::WebGPUMsg;
 use webrender_api::units::{DevicePixel, LayoutVector2D};
 use webrender_api::{ExternalScrollId, ImageKey};
 
-/// The initial data required to create a new layout attached to an existing script thread.
+/// The initial data required to create a new `Pipeline` attached to an existing `ScriptThread`.
 #[derive(Debug, Deserialize, Serialize)]
-pub struct NewLayoutInfo {
+pub struct NewPipelineInfo {
     /// The ID of the parent pipeline and frame type, if any.
     /// If `None`, this is a root pipeline.
     pub parent_info: Option<PipelineId>,
@@ -145,12 +145,14 @@ pub enum UpdatePipelineIdReason {
 /// now) `Layout`.
 #[derive(Deserialize, IntoStaticStr, Serialize)]
 pub enum ScriptThreadMessage {
+    /// Span a new `Pipeline` in this `ScriptThread` and start fetching the contents
+    /// according to the provided `LoadData`. This will ultimately create a `Window`
+    /// and all associated data structures such as `Layout` in the `ScriptThread`.
+    SpawnPipeline(NewPipelineInfo),
     /// Takes the associated window proxy out of "delaying-load-events-mode",
     /// used if a scheduled navigated was refused by the embedder.
     /// <https://html.spec.whatwg.org/multipage/#delaying-load-events-mode>
     StopDelayingLoadEventsMode(PipelineId),
-    /// Gives a channel and ID to a layout, as well as the ID of that layout's parent
-    AttachLayout(NewLayoutInfo),
     /// Window resized.  Sends a DOM event eventually, but first we combine events.
     Resize(PipelineId, ViewportDetails, WindowSizeType),
     /// Theme changed.


### PR DESCRIPTION
The thing that this message does is to spawn a pipeline in a
`ScriptThread`. I believe that the `AttachLayout` name is a relic of a
different time. The corresponding procedure in the `Constellation` is
already called `Pipeline::spawn`.

Testing: This is just a rename, so existing tests should cover this change.
