### PR TITLE
wpt: Run in headless mode by default unless `--no-headless` is passed

### DIFF
--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -110,7 +110,10 @@ def run_tests(default_binary_path: str, **kwargs: Any) -> int:
         file_ext = os.path.splitext(kwargs["test_list"][0])[1].lower()
         if file_ext in [".htm", ".html", ".js", ".xhtml", ".xht", ".py"]:
             use_mach_logging = True
-    else:
+
+    # Enable headless mode by default, unless `--no-headless` is explicitly passed, in
+    # which case we do not run in headless mode.
+    if kwargs.get("headless", None) is None:
         kwargs["headless"] = True
 
     if use_mach_logging:


### PR DESCRIPTION
This is a more reasonable default as the detection of running one or
more tests is a bit inconsistent. It also makes the behavior of the
command a bit more predictable IMO.

Testing: This was tested manually as there is no tests for this
layer of the test runner
Fixes: #40407.
