### PR TITLE
script: Wrap remaining unsafe code and enable `unsafe_op_in_unsafe_fn`

### DIFF
--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -28,7 +28,6 @@ webxr = ["webxr-api", "script_bindings/webxr"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(crown)'] }
-unsafe_op_in_unsafe_fn = { level = "allow" }
 
 [dependencies]
 accountable-refcell = { workspace = true, optional = true }

--- a/components/script/dom/bindings/function.rs
+++ b/components/script/dom/bindings/function.rs
@@ -30,7 +30,7 @@ macro_rules! native_raw_obj_fn {
         #[expect(unsafe_code)]
         #[allow(clippy::macro_metavars_in_unsafe)]
         unsafe extern "C" fn wrapper(cx: *mut JSContext, argc: u32, vp: *mut JSVal) -> bool {
-            $call(cx, argc, vp)
+            unsafe { $call(cx, argc, vp) }
         }
         #[expect(unsafe_code)]
         #[allow(clippy::macro_metavars_in_unsafe)]

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -109,17 +109,17 @@ unsafe extern "C" fn instance_class_has_proto_at_depth(
     depth: u32,
 ) -> bool {
     let domclass: *const DOMJSClass = clasp as *const _;
-    let domclass = &*domclass;
+    let domclass = unsafe { &*domclass };
     domclass.dom_class.interface_chain[depth as usize] as u32 == proto_id
 }
 
 /// <https://searchfox.org/mozilla-central/rev/c18faaae88b30182e487fa3341bc7d923e22f23a/xpcom/base/CycleCollectedJSRuntime.cpp#792>
 unsafe extern "C" fn instance_class_is_error(clasp: *const js::jsapi::JSClass) -> bool {
-    if !is_dom_class(&*clasp) {
+    if !is_dom_class(unsafe { &*clasp }) {
         return false;
     }
     let domclass: *const DOMJSClass = clasp as *const _;
-    let domclass = &*domclass;
+    let domclass = unsafe { &*domclass };
     let root_interface = domclass.dom_class.interface_chain[0] as u32;
     // TODO: support checking bare Exception prototype as well.
     root_interface == PrototypeList::ID::DOMException as u32

--- a/components/script/dom/bytelengthqueuingstrategy.rs
+++ b/components/script/dom/bytelengthqueuingstrategy.rs
@@ -91,10 +91,10 @@ pub(crate) unsafe fn byte_length_queuing_strategy_size(
     argc: u32,
     vp: *mut JSVal,
 ) -> bool {
-    let args = CallArgs::from_vp(vp, argc);
+    let args = unsafe { CallArgs::from_vp(vp, argc) };
 
     // Step 1.1: Return ? GetV(chunk, "byteLength").
-    let val = HandleValue::from_raw(args.get(0));
+    let val = unsafe { HandleValue::from_raw(args.get(0)) };
 
     // https://tc39.es/ecma262/multipage/abstract-operations.html#sec-getv
     // Let O be ? ToObject(V).
@@ -104,12 +104,14 @@ pub(crate) unsafe fn byte_length_queuing_strategy_size(
     rooted!(in(cx) let object = val.to_object());
 
     // Return ? O.[[Get]](P, V).
-    get_dictionary_property(
-        cx,
-        object.handle(),
-        "byteLength",
-        MutableHandleValue::from_raw(args.rval()),
-        CanGc::note(),
-    )
+    unsafe {
+        get_dictionary_property(
+            cx,
+            object.handle(),
+            "byteLength",
+            MutableHandleValue::from_raw(args.rval()),
+            CanGc::note(),
+        )
+    }
     .unwrap_or(false)
 }

--- a/components/script/dom/countqueuingstrategy.rs
+++ b/components/script/dom/countqueuingstrategy.rs
@@ -90,7 +90,7 @@ pub(crate) unsafe fn count_queuing_strategy_size(
     argc: u32,
     vp: *mut JSVal,
 ) -> bool {
-    let args = CallArgs::from_vp(vp, argc);
+    let args = unsafe { CallArgs::from_vp(vp, argc) };
     // Step 1.1. Return 1.
     args.rval().set(Int32Value(1));
     true

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3638,7 +3638,7 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
     }
 
     unsafe fn from_object(obj: *mut JSObject) -> DomRoot<Self> {
-        GlobalScope::from_object(obj)
+        unsafe { GlobalScope::from_object(obj) }
     }
 
     fn from_reflector(reflector: &impl DomObject, realm: InRealm) -> DomRoot<Self> {

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -2195,17 +2195,19 @@ pub(crate) unsafe fn get_type_and_value_from_message(
 
     // Let type be ! Get(data, "type").
     rooted!(in(*cx) let mut type_ = UndefinedValue());
-    get_dictionary_property(
-        *cx,
-        data_object.handle(),
-        "type",
-        type_.handle_mut(),
-        can_gc,
-    )
+    unsafe {
+        get_dictionary_property(
+            *cx,
+            data_object.handle(),
+            "type",
+            type_.handle_mut(),
+            can_gc,
+        )
+    }
     .expect("Getting the type should not fail.");
 
     // Let value be ! Get(data, "value").
-    get_dictionary_property(*cx, data_object.handle(), "value", value, can_gc)
+    unsafe { get_dictionary_property(*cx, data_object.handle(), "value", value, can_gc) }
         .expect("Getting the value should not fail.");
 
     // Assert: type is a String.

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -49,14 +49,14 @@ impl Deref for TraceableTokenizer {
 #[expect(unsafe_code)]
 unsafe impl JSTraceable for TraceableTokenizer {
     unsafe fn trace(&self, trc: *mut JSTracer) {
-        CustomTraceable::trace(&self.0, trc)
+        unsafe { CustomTraceable::trace(&self.0, trc) }
     }
 }
 
 #[expect(unsafe_code)]
 unsafe impl CustomTraceable for PrefetchSink {
     unsafe fn trace(&self, trc: *mut JSTracer) {
-        <Self as JSTraceable>::trace(self, trc)
+        unsafe { <Self as JSTraceable>::trace(self, trc) }
     }
 }
 

--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -651,7 +651,7 @@ impl<'dom> LayoutShadowRootHelpers<'dom> for LayoutDom<'dom, ShadowRoot> {
         stylist: &mut Stylist,
         guard: &SharedRwLockReadGuard,
     ) {
-        let author_styles = self.unsafe_get().author_styles.borrow_mut_for_layout();
+        let author_styles = unsafe { self.unsafe_get().author_styles.borrow_mut_for_layout() };
         if author_styles.stylesheets.dirty() {
             author_styles.flush::<E>(stylist, guard);
         }

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -140,8 +140,10 @@ pub(crate) unsafe fn uniform_typed<T>(
     T: TypedArrayElementCreator,
 {
     rooted!(in(cx) let mut rval = ptr::null_mut::<JSObject>());
-    <TypedArray<T, *mut JSObject>>::create(cx, CreateWith::Slice(value), rval.handle_mut())
-        .unwrap();
+    unsafe {
+        <TypedArray<T, *mut JSObject>>::create(cx, CreateWith::Slice(value), rval.handle_mut())
+    }
+    .unwrap();
     retval.set(ObjectValue(rval.get()));
 }
 

--- a/components/script/dom/webxr/xrhand.rs
+++ b/components/script/dom/webxr/xrhand.rs
@@ -174,7 +174,7 @@ pub(crate) struct ValueWrapper(pub DomRoot<XRJointSpace>);
 impl ToJSValConvertible for ValueWrapper {
     #[expect(unsafe_code)]
     unsafe fn to_jsval(&self, cx: *mut JSContext, rval: MutableHandleValue) {
-        self.0.to_jsval(cx, rval)
+        unsafe { self.0.to_jsval(cx, rval) }
     }
 }
 

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -734,8 +734,8 @@ impl DedicatedWorkerGlobalScope {
 
 #[expect(unsafe_code)]
 pub(crate) unsafe extern "C" fn interrupt_callback(cx: *mut JSContext) -> bool {
-    let in_realm_proof = AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx));
-    let global = GlobalScope::from_context(cx, InRealm::Already(&in_realm_proof));
+    let in_realm_proof = AlreadyInRealm::assert_for_cx(unsafe { SafeJSContext::from_ptr(cx) });
+    let global = unsafe { GlobalScope::from_context(cx, InRealm::Already(&in_realm_proof)) };
     let worker =
         DomRoot::downcast::<WorkerGlobalScope>(global).expect("global is not a worker scope");
     assert!(worker.is::<DedicatedWorkerGlobalScope>());

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -504,8 +504,8 @@ impl ServiceWorkerGlobalScope {
 
 #[expect(unsafe_code)]
 unsafe extern "C" fn interrupt_callback(cx: *mut JSContext) -> bool {
-    let in_realm_proof = AlreadyInRealm::assert_for_cx(SafeJSContext::from_ptr(cx));
-    let global = GlobalScope::from_context(cx, InRealm::Already(&in_realm_proof));
+    let in_realm_proof = AlreadyInRealm::assert_for_cx(unsafe { SafeJSContext::from_ptr(cx) });
+    let global = unsafe { GlobalScope::from_context(cx, InRealm::Already(&in_realm_proof)) };
     let worker =
         DomRoot::downcast::<WorkerGlobalScope>(global).expect("global is not a worker scope");
     assert!(worker.is::<ServiceWorkerGlobalScope>());

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -484,7 +484,7 @@ struct WorkletThread {
 unsafe impl JSTraceable for WorkletThread {
     unsafe fn trace(&self, trc: *mut JSTracer) {
         debug!("Tracing worklet thread.");
-        self.global_scopes.trace(trc);
+        unsafe { self.global_scopes.trace(trc) };
     }
 }
 

--- a/components/script/init.rs
+++ b/components/script/init.rs
@@ -55,7 +55,7 @@ fn perform_platform_specific_initialization() {}
 
 #[expect(unsafe_code)]
 unsafe extern "C" fn is_dom_object(obj: *mut JSObject) -> bool {
-    !obj.is_null() && (is_platform_object_static(obj) || is_dom_proxy(obj))
+    !obj.is_null() && (is_platform_object_static(obj) || unsafe { is_dom_proxy(obj) })
 }
 
 /// Returns true if JIT is forbidden

--- a/components/script/task.rs
+++ b/components/script/task.rs
@@ -19,7 +19,7 @@ macro_rules! task {
         unsafe impl<F> crate::JSTraceable for $name<F> {
             #[expect(unsafe_code)]
             unsafe fn trace(&self, tracer: *mut ::js::jsapi::JSTracer) {
-                $(self.$field.trace(tracer);)*
+                unsafe { $(self.$field.trace(tracer);)* }
                 // We cannot trace the actual task closure. This is safe because
                 // all referenced values from within the closure are either borrowed
                 // or moved into fields in the struct (and therefore traced).


### PR DESCRIPTION
This is last step toward enabling the default rustc
`unsafe_op_in_unsafe_fn` warning for the script crate. It wraps the
remaining unsafe code in `unsafe {}` and removes the line disabling this
warning from `script`'s `Cargo.toml`. In addition, two variables are
renamed from `v` to something slightly more descriptive.

Testing: This should not change behavior so is covered by existing tests.
