### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	"image": "mcr.microsoft.com/devcontainers/base:noble",
+	"features": {
+		"ghcr.io/devcontainers/features/rust:1": {
+			"version": "1.91",
+			"profile": "default",
+			"targets": "aarch64-unknown-linux-gnu",
+			"components": "clippy,llvm-tools,rustc-dev,rust-analyzer,rust-src,rustfmt"
+		},
+		"ghcr.io/devcontainers-extra/features/uv:1": {
+			"version": "latest"
+		}
+	},
+	// Uncomment the following when using podman (rootless docker)
+	// Update the uid and gid, to your local users uid and gid (run `echo $UID` and `echo $GID`)
+	// "runArgs": ["--userns=keep-id:uid=1000,gid=1000"],
+	// "containerUser": "vscode",
+	// "updateRemoteUserUID": true,
+
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// This takes more time on the first run compared to pulling a prebuilt image layer,
+	// but makes sure the bootstrapped dependencies are always up to date.
+	"postCreateCommand":
+		"./mach bootstrap --force",
+
+	"containerEnv": {
+		"CC": "clang",
+		"CXX": "clang++",
+		// The default `.venv` directory is mapped into both the host and container, so
+		// using it in the container would be problematic.
+		"UV_PYTHON_INSTALL_DIR": "/home/vscode/.servo_venv"
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"image": "mcr.microsoft.com/devcontainers/base:noble",
 	"features": {
 		"ghcr.io/devcontainers/features/rust:1": {
-			"version": "1.91",
+			"version": "1.91.0",
 			"profile": "default",
 			"components": "clippy,llvm-tools,rustc-dev,rust-analyzer,rust-src,rustfmt"
 		},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,11 +13,21 @@
 			"version": "latest"
 		}
 	},
-	// Uncomment the following when using podman (rootless docker)
+	// Uncomment the following when using podman (rootless)
 	// Update the uid and gid, to your local users uid and gid (run `echo $UID` and `echo $GID`)
 	// "runArgs": ["--userns=keep-id:uid=1000,gid=1000"],
 	// "containerUser": "vscode",
-	// "updateRemoteUserUID": true,
+	
+	// Uncomment the following when using rootless docker 
+	// "containerUser": "root",
+	// "remoteUser": "root",
+	// "updateRemoteUserUID": false,
+
+	// Mount a volume for the virtual environment, to avoid the container venv conflicting with the
+	// host venv, if users build both inside and outside the container.
+	"mounts":  [
+		"source=${localWorkspaceFolderBasename}-venv,target=${containerWorkspaceFolder}/.venv,type=volume"
+	],
 
 
 	// Use 'postCreateCommand' to run commands after the container is created.
@@ -28,9 +38,6 @@
 
 	"containerEnv": {
 		"CC": "clang",
-		"CXX": "clang++",
-		// The default `.venv` directory is mapped into both the host and container, so
-		// using it in the container would be problematic.
-		"UV_PYTHON_INSTALL_DIR": "/home/vscode/.servo_venv"
+		"CXX": "clang++"
 	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,12 +23,6 @@
 	// "remoteUser": "root",
 	// "updateRemoteUserUID": false,
 
-	// Mount a volume for the virtual environment, to avoid the container venv conflicting with the
-	// host venv, if users build both inside and outside the container.
-	"mounts":  [
-		"source=${localWorkspaceFolderBasename}-venv,target=${containerWorkspaceFolder}/.venv,type=volume"
-	],
-
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// This takes more time on the first run compared to pulling a prebuilt image layer,
@@ -38,6 +32,7 @@
 
 	"containerEnv": {
 		"CC": "clang",
-		"CXX": "clang++"
+		"CXX": "clang++",
+		"UV_PROJECT_ENVIRONMENT": ".devcontainer-venv"
 	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
 		"ghcr.io/devcontainers/features/rust:1": {
 			"version": "1.91",
 			"profile": "default",
-			"targets": "aarch64-unknown-linux-gnu",
 			"components": "clippy,llvm-tools,rustc-dev,rust-analyzer,rust-src,rustfmt"
 		},
 		"ghcr.io/devcontainers-extra/features/uv:1": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,9 @@
 [toolchain]
-# Be sure to update the 'rust-overlay' module's url in shell.nix to point to a
-# commit which supports the required rustc version and also update the version
-# in support/crown/rust-toolchain.toml when bumping this!
+# Be sure to also update the rust version in the following places when bumping the version:
+# - the 'rust-overlay' module's url in shell.nix to point to a
+#   commit which supports the required rustc version
+# - the version in support/crown/rust-toolchain.toml
+# - the version in .github/devcontainer.json
 channel = "1.91.0"
 
 components = [


### PR DESCRIPTION
The devcontainer configuration makes it easier for users to setup a working environment, by using docker / podman and a devcontainer IDE plugin (or the CLI).

Testing: Manually tested the configuration in VS code on linux.
Fixes: #40469 
