### PR TITLE
script: Add context-based context menu options

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -119,7 +119,7 @@ use compositing_traits::{
 use constellation_traits::{
     AuxiliaryWebViewCreationRequest, AuxiliaryWebViewCreationResponse, DocumentState,
     EmbedderToConstellationMessage, IFrameLoadInfo, IFrameLoadInfoWithData, IFrameSizeMsg, Job,
-    LoadData, LoadOrigin, LogEntry, MessagePortMsg, NavigationHistoryBehavior, PaintMetricEvent,
+    LoadData, LogEntry, MessagePortMsg, NavigationHistoryBehavior, PaintMetricEvent,
     PortMessageTask, PortTransferInfo, SWManagerMsg, SWManagerSenders, ScreenshotReadinessResponse,
     ScriptToConstellationChan, ScriptToConstellationMessage, ServiceWorkerManagerFactory,
     ServiceWorkerMsg, StructuredSerializedData, TraversalDirection, WindowSizeType,
@@ -152,10 +152,7 @@ use log::{debug, error, info, trace, warn};
 use media::WindowGLContext;
 use net::image_cache::ImageCacheFactoryImpl;
 use net_traits::pub_domains::reg_host;
-use net_traits::request::Referrer;
-use net_traits::{
-    self, AsyncRuntime, ReferrerPolicy, ResourceThreads, exit_fetch_thread, start_fetch_thread,
-};
+use net_traits::{self, AsyncRuntime, ResourceThreads, exit_fetch_thread, start_fetch_thread};
 use profile_traits::mem::ProfilerMsg;
 use profile_traits::{mem, time};
 use rand::rngs::SmallRng;
@@ -1399,17 +1396,7 @@ where
             // If there is already a pending page (self.pending_changes), it will not be overridden;
             // However, if the id is not encompassed by another change, it will be.
             EmbedderToConstellationMessage::LoadUrl(webview_id, url) => {
-                let load_data = LoadData::new(
-                    LoadOrigin::Constellation,
-                    url,
-                    None,
-                    Referrer::NoReferrer,
-                    ReferrerPolicy::EmptyString,
-                    None,
-                    None,
-                    false,
-                    SandboxingFlagSet::empty(),
-                );
+                let load_data = LoadData::new_for_new_unrelated_webview(url);
                 let ctx_id = BrowsingContextId::from(webview_id);
                 let pipeline_id = match self.browsing_contexts.get(&ctx_id) {
                     Some(ctx) => ctx.pipeline_id,
@@ -3000,17 +2987,7 @@ where
     ) {
         let pipeline_id = PipelineId::new();
         let browsing_context_id = BrowsingContextId::from(webview_id);
-        let load_data = LoadData::new(
-            LoadOrigin::Constellation,
-            url,
-            None,
-            Referrer::NoReferrer,
-            ReferrerPolicy::EmptyString,
-            None,
-            None,
-            false,
-            SandboxingFlagSet::empty(),
-        );
+        let load_data = LoadData::new_for_new_unrelated_webview(url);
         let is_private = false;
         let throttled = false;
 

--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -5,8 +5,9 @@
 use std::cell::Cell;
 
 use base::{Epoch, IpcSend};
+use constellation_traits::{LoadData, NavigationHistoryBehavior};
 use embedder_traits::{
-    ContextMenuAction, ContextMenuItem, ContextMenuRequest, EmbedderControlId,
+    ContextMenuAction, ContextMenuItem, ContextMenuRequest, EditingActionEvent, EmbedderControlId,
     EmbedderControlRequest, EmbedderControlResponse, EmbedderMsg,
 };
 use euclid::{Point2D, Rect, Size2D};
@@ -14,18 +15,28 @@ use ipc_channel::router::ROUTER;
 use net_traits::CoreResourceMsg;
 use net_traits::filemanager_thread::FileManagerThreadMsg;
 use rustc_hash::FxHashMap;
+use script_bindings::codegen::GenericBindings::HTMLAnchorElementBinding::HTMLAnchorElementMethods;
+use script_bindings::codegen::GenericBindings::HTMLImageElementBinding::HTMLImageElementMethods;
 use script_bindings::codegen::GenericBindings::HistoryBinding::HistoryMethods;
 use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
+use script_bindings::inheritance::Castable;
 use script_bindings::root::{Dom, DomRoot};
 use script_bindings::script_runtime::CanGc;
+use script_bindings::str::USVString;
+use servo_url::ServoUrl;
 use webrender_api::units::{DeviceIntRect, DevicePoint};
 
+use crate::dom::activation::Activatable;
 use crate::dom::bindings::cell::DomRefCell;
-use crate::dom::bindings::inheritance::Castable as _;
+use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::trace::NoTrace;
 use crate::dom::inputevent::HitTestResult;
-use crate::dom::node::{Node, NodeTraits};
-use crate::dom::types::{Element, HTMLElement, HTMLInputElement, HTMLSelectElement, Window};
+use crate::dom::node::{Node, NodeTraits, ShadowIncluding};
+use crate::dom::textcontrol::TextControlElement;
+use crate::dom::types::{
+    Element, HTMLAnchorElement, HTMLElement, HTMLImageElement, HTMLInputElement, HTMLSelectElement,
+    HTMLTextAreaElement, Window,
+};
 use crate::messaging::MainThreadScriptMsg;
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -34,7 +45,7 @@ pub(crate) enum ControlElement {
     ColorInput(DomRoot<HTMLInputElement>),
     FileInput(DomRoot<HTMLInputElement>),
     Ime(DomRoot<HTMLElement>),
-    ContextMenu(DomRoot<Node>),
+    ContextMenu(ContextMenuNodes),
 }
 
 impl ControlElement {
@@ -44,7 +55,7 @@ impl ControlElement {
             ControlElement::ColorInput(element) => element.upcast::<Node>(),
             ControlElement::FileInput(element) => element.upcast::<Node>(),
             ControlElement::Ime(element) => element.upcast::<Node>(),
-            ControlElement::ContextMenu(element) => element,
+            ControlElement::ContextMenu(context_menu_nodes) => &context_menu_nodes.node,
         }
     }
 }
@@ -187,6 +198,11 @@ impl DocumentEmbedderControls {
             return;
         };
 
+        // Never process embedder responses on inactive `Document`s.
+        if !element.node().owner_doc().is_active() {
+            return;
+        }
+
         match (element, response) {
             (
                 ControlElement::Select(select_element),
@@ -207,10 +223,10 @@ impl DocumentEmbedderControls {
                 input_element.handle_file_picker_response(response, can_gc);
             },
             (
-                ControlElement::ContextMenu(element),
+                ControlElement::ContextMenu(context_menu_nodes),
                 EmbedderControlResponse::ContextMenu(action),
             ) => {
-                self.handle_context_menu_action(&element, action, can_gc);
+                context_menu_nodes.handle_context_menu_action(action, can_gc);
             },
             (_, _) => unreachable!(
                 "The response to a form control should always match it's originating type."
@@ -219,39 +235,186 @@ impl DocumentEmbedderControls {
     }
 
     pub(crate) fn show_context_menu(&self, hit_test_result: &HitTestResult) {
-        let items = vec![
+        let mut anchor_element = None;
+        let mut image_element = None;
+        let mut text_input_element = None;
+        for node in hit_test_result
+            .node
+            .inclusive_ancestors(ShadowIncluding::Yes)
+        {
+            if anchor_element.is_none() {
+                if let Some(candidate_anchor_element) = node.downcast::<HTMLAnchorElement>() {
+                    if candidate_anchor_element.is_instance_activatable() {
+                        anchor_element = Some(DomRoot::from_ref(candidate_anchor_element))
+                    }
+                }
+            }
+
+            if image_element.is_none() {
+                if let Some(candidate_image_element) = node.downcast::<HTMLImageElement>() {
+                    image_element = Some(DomRoot::from_ref(candidate_image_element))
+                }
+            }
+
+            if text_input_element.is_none() {
+                if let Some(candidate_text_input_element) = node.as_text_input() {
+                    text_input_element = Some(candidate_text_input_element);
+                }
+            }
+        }
+
+        let mut items = Vec::new();
+        if anchor_element.is_some() {
+            items.extend(vec![
+                ContextMenuItem::Item {
+                    label: "Open Link in New View".into(),
+                    action: ContextMenuAction::OpenLinkInNewWebView,
+                    enabled: true,
+                },
+                ContextMenuItem::Item {
+                    label: "Copy Link".into(),
+                    action: ContextMenuAction::CopyLink,
+                    enabled: true,
+                },
+                ContextMenuItem::Separator,
+            ]);
+        }
+
+        if image_element.is_some() {
+            items.extend(vec![
+                ContextMenuItem::Item {
+                    label: "Open Image in New View".into(),
+                    action: ContextMenuAction::OpenImageInNewView,
+                    enabled: true,
+                },
+                ContextMenuItem::Item {
+                    label: "Copy Image Link".into(),
+                    action: ContextMenuAction::CopyImageLink,
+                    enabled: true,
+                },
+                ContextMenuItem::Separator,
+            ]);
+        }
+
+        if let Some(text_input_element) = &text_input_element {
+            let has_selection = text_input_element.has_selection();
+            items.extend(vec![
+                ContextMenuItem::Item {
+                    label: "Cut".into(),
+                    action: ContextMenuAction::Cut,
+                    enabled: has_selection,
+                },
+                ContextMenuItem::Item {
+                    label: "Copy".into(),
+                    action: ContextMenuAction::Copy,
+                    enabled: has_selection,
+                },
+                ContextMenuItem::Item {
+                    label: "Paste".into(),
+                    action: ContextMenuAction::Paste,
+                    enabled: true,
+                },
+                ContextMenuItem::Item {
+                    label: "Select All".into(),
+                    action: ContextMenuAction::SelectAll,
+                    enabled: text_input_element.has_selectable_text(),
+                },
+                ContextMenuItem::Separator,
+            ]);
+        }
+
+        items.extend(vec![
             ContextMenuItem::Item {
                 label: "Back".into(),
                 action: ContextMenuAction::GoBack,
+                enabled: true,
             },
             ContextMenuItem::Item {
                 label: "Forward".into(),
                 action: ContextMenuAction::GoForward,
+                enabled: true,
             },
             ContextMenuItem::Item {
                 label: "Reload".into(),
                 action: ContextMenuAction::Reload,
+                enabled: true,
             },
-        ];
+        ]);
+
+        let context_menu_nodes = ContextMenuNodes {
+            node: hit_test_result.node.clone(),
+            anchor_element,
+            image_element,
+            text_input_element,
+        };
 
         self.show_embedder_control(
-            ControlElement::ContextMenu(hit_test_result.node.clone()),
+            ControlElement::ContextMenu(context_menu_nodes),
             EmbedderControlRequest::ContextMenu(ContextMenuRequest { items }),
             Some(hit_test_result.point_in_frame.cast_unit()),
         );
     }
+}
 
-    fn handle_context_menu_action(
-        &self,
-        node: &Node,
-        action: Option<ContextMenuAction>,
-        can_gc: CanGc,
-    ) {
+#[derive(JSTraceable, MallocSizeOf)]
+pub(crate) struct ContextMenuNodes {
+    /// The node that this menu was triggered on.
+    node: DomRoot<Node>,
+    /// The first inclusive ancestor of this node that is an `<a>` if one exists.
+    anchor_element: Option<DomRoot<HTMLAnchorElement>>,
+    /// The first inclusive ancestor of this node that is an `<img>` if one exists.
+    image_element: Option<DomRoot<HTMLImageElement>>,
+    /// The first inclusive ancestor of this node which is a text entry field.
+    text_input_element: Option<DomRoot<Element>>,
+}
+
+impl ContextMenuNodes {
+    fn handle_context_menu_action(&self, action: Option<ContextMenuAction>, can_gc: CanGc) {
         let Some(action) = action else {
             return;
         };
 
-        let window = node.owner_window();
+        let window = self.node.owner_window();
+        let set_clipboard_text = |string: USVString| {
+            if string.is_empty() {
+                return;
+            }
+            window.send_to_embedder(EmbedderMsg::SetClipboardText(
+                window.webview_id(),
+                string.to_string(),
+            ));
+        };
+
+        let open_url_in_new_webview = |url_string: USVString| {
+            let Ok(url) = ServoUrl::parse(&url_string) else {
+                return;
+            };
+            let Some(browsing_context) = window.Document().browsing_context() else {
+                return;
+            };
+            let (browsing_context, new) = browsing_context
+                .choose_browsing_context("_blank".into(), true /* nooopener */);
+            let Some(browsing_context) = browsing_context else {
+                return;
+            };
+            assert!(new);
+            let Some(target_document) = browsing_context.document() else {
+                return;
+            };
+
+            let target_window = target_document.window();
+            let target = Trusted::new(target_window);
+            let load_data = LoadData::new_for_new_unrelated_webview(url);
+            let task = task!(open_link_in_new_webview: move || {
+                target.root().load_url(NavigationHistoryBehavior::Replace, false, load_data, CanGc::note());
+            });
+            target_document
+                .owner_global()
+                .task_manager()
+                .dom_manipulation_task_source()
+                .queue(task);
+        };
+
         match action {
             ContextMenuAction::GoBack => {
                 let _ = window.History().Back();
@@ -260,8 +423,101 @@ impl DocumentEmbedderControls {
                 let _ = window.History().Forward();
             },
             ContextMenuAction::Reload => {
-                self.window.Location().reload_without_origin_check(can_gc);
+                window.Location().reload_without_origin_check(can_gc);
+            },
+            ContextMenuAction::CopyLink => {
+                let Some(anchor_element) = &self.anchor_element else {
+                    return;
+                };
+                set_clipboard_text(anchor_element.Href());
+            },
+            ContextMenuAction::OpenLinkInNewWebView => {
+                let Some(anchor_element) = &self.anchor_element else {
+                    return;
+                };
+                open_url_in_new_webview(anchor_element.Href());
+            },
+            ContextMenuAction::CopyImageLink => {
+                let Some(image_element) = &self.image_element else {
+                    return;
+                };
+                set_clipboard_text(image_element.Src());
+            },
+            ContextMenuAction::OpenImageInNewView => {
+                let Some(image_element) = &self.image_element else {
+                    return;
+                };
+                open_url_in_new_webview(image_element.Src());
+            },
+            ContextMenuAction::Cut => {
+                window.Document().event_handler().handle_editing_action(
+                    self.text_input_element.clone(),
+                    EditingActionEvent::Cut,
+                    can_gc,
+                );
+            },
+            ContextMenuAction::Copy => {
+                window.Document().event_handler().handle_editing_action(
+                    self.text_input_element.clone(),
+                    EditingActionEvent::Copy,
+                    can_gc,
+                );
+            },
+            ContextMenuAction::Paste => {
+                window.Document().event_handler().handle_editing_action(
+                    self.text_input_element.clone(),
+                    EditingActionEvent::Paste,
+                    can_gc,
+                );
+            },
+            ContextMenuAction::SelectAll => {
+                if let Some(text_input_element) = &self.text_input_element {
+                    text_input_element.select_all();
+                }
             },
         }
+    }
+}
+
+impl Node {
+    fn as_text_input(&self) -> Option<DomRoot<Element>> {
+        if let Some(input_element) = self
+            .downcast::<HTMLInputElement>()
+            .filter(|input_element| input_element.is_textual_widget())
+        {
+            return Some(DomRoot::from_ref(input_element.upcast::<Element>()));
+        }
+        self.downcast::<HTMLTextAreaElement>()
+            .map(Castable::upcast)
+            .map(DomRoot::from_ref)
+    }
+}
+
+impl Element {
+    fn has_selection(&self) -> bool {
+        self.downcast::<HTMLTextAreaElement>()
+            .map(TextControlElement::has_selection)
+            .or(self
+                .downcast::<HTMLInputElement>()
+                .map(TextControlElement::has_selection))
+            .unwrap_or_default()
+    }
+
+    fn has_selectable_text(&self) -> bool {
+        self.downcast::<HTMLTextAreaElement>()
+            .map(TextControlElement::has_selectable_text)
+            .or(self
+                .downcast::<HTMLInputElement>()
+                .map(TextControlElement::has_selectable_text))
+            .unwrap_or_default()
+    }
+
+    fn select_all(&self) {
+        self.downcast::<HTMLTextAreaElement>()
+            .map(TextControlElement::select_all)
+            .or(self
+                .downcast::<HTMLInputElement>()
+                .map(TextControlElement::select_all))
+            .unwrap_or_default()
     }
 }

--- a/components/script/dom/textcontrol.rs
+++ b/components/script/dom/textcontrol.rs
@@ -21,7 +21,9 @@ use crate::textinput::{SelectionDirection, SelectionState, TextInput, UTF8Bytes}
 pub(crate) trait TextControlElement: DerivedFrom<EventTarget> + DerivedFrom<Node> {
     fn selection_api_applies(&self) -> bool;
     fn has_selectable_text(&self) -> bool;
+    fn has_selection(&self) -> bool;
     fn set_dirty_value_flag(&self, value: bool);
+    fn select_all(&self);
 }
 
 pub(crate) struct TextControlSelection<'a, E: TextControlElement> {
@@ -37,9 +39,10 @@ impl<'a, E: TextControlElement> TextControlSelection<'a, E> {
         TextControlSelection { element, textinput }
     }
 
-    // https://html.spec.whatwg.org/multipage/#dom-textarea/input-select
+    /// <https://html.spec.whatwg.org/multipage/#dom-textarea/input-select>
     pub(crate) fn dom_select(&self) {
-        // Step 1
+        // Step 1: If this element is an input element, and either select() does not apply
+        // to this element or the corresponding control has no selectable text, return.
         if !self.element.has_selectable_text() {
             return;
         }

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -147,8 +147,8 @@ impl LoadData {
         inherited_insecure_requests_policy: Option<InsecureRequestsPolicy>,
         has_trustworthy_ancestor_origin: bool,
         creation_sandboxing_flag_set: SandboxingFlagSet,
-    ) -> LoadData {
-        LoadData {
+    ) -> Self {
+        Self {
             load_origin,
             url,
             creator_pipeline_id,
@@ -167,6 +167,22 @@ impl LoadData {
             destination: Destination::Document,
             creation_sandboxing_flag_set,
         }
+    }
+
+    /// Create a new [`LoadData`] for a completely new top-level `WebView` that isn't created
+    /// via APIs like `window.open`. This is for `WebView`s completely unrelated to others.
+    pub fn new_for_new_unrelated_webview(url: ServoUrl) -> Self {
+        Self::new(
+            LoadOrigin::Constellation,
+            url,
+            None,
+            Referrer::NoReferrer,
+            ReferrerPolicy::EmptyString,
+            None,
+            None,
+            false,
+            SandboxingFlagSet::empty(),
+        )
     }
 }
 

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -669,6 +669,7 @@ pub enum ContextMenuItem {
     Item {
         label: String,
         action: ContextMenuAction,
+        enabled: bool,
     },
     Separator,
 }
@@ -676,11 +677,22 @@ pub enum ContextMenuItem {
 /// A particular action associated with a [`ContextMenuItem`]. These actions are
 /// context-sensitive, which means that some of them are available only for some
 /// page elements.
-#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum ContextMenuAction {
     GoBack,
     GoForward,
     Reload,
+
+    CopyLink,
+    OpenLinkInNewWebView,
+
+    CopyImageLink,
+    OpenImageInNewView,
+
+    Cut,
+    Copy,
+    Paste,
+    SelectAll,
 }
 
 /// Request to present an IME to the user when an editable element is focused. If `type` is


### PR DESCRIPTION
Add context menu options for images, links, and editable text areas. In
addition add the ability to show menu options that are disabled. This
also improves the visual style of the context menu in egui as part of
supporting disabled options.

Testing: This has been manually tested, but we could we should be able to
easily add unit tests when enriching the API with information about the
active element under context menus.
