### PR TITLE
bootstrap: Run apt update before apt-cache

### DIFF
--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -247,7 +247,10 @@ class Linux(Base):
                 missing_pkgs = list(filter(lambda pkg: pkg not in installable, pkgs))
                 pkgs = list(filter(lambda pkg: pkg in installable, pkgs))
                 if len(missing_pkgs) > 0:
-                    print("Skipping the following required pkgs, as they don't exist in this OS version:", missing_pkgs)
+                    print(
+                        "Skipping the following required packages, as they don't exist in this OS version:",
+                        missing_pkgs,
+                    )
 
             if subprocess.call(["dpkg", "-s"] + pkgs, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) != 0:
                 install = True

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -246,7 +246,8 @@ class Linux(Base):
                 installable = installable.decode("ascii").splitlines()
                 missing_pkgs = list(filter(lambda pkg: pkg not in installable, pkgs))
                 pkgs = list(filter(lambda pkg: pkg in installable, pkgs))
-                print("Skipping the following required pkgs, as they don't exist in this OS version:", missing_pkgs)
+                if len(missing_pkgs) > 0:
+                    print("Skipping the following required pkgs, as they don't exist in this OS version:", missing_pkgs)
 
             if subprocess.call(["dpkg", "-s"] + pkgs, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) != 0:
                 install = True

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -226,10 +226,14 @@ class Linux(Base):
 
             # Try to filter out unknown packages from the list. This is important for Debian
             # as it does not ship all of the packages we want.
+            # We need to run 'apt-get update' first to make sure the package cache is populated.
+            subprocess.run(["sudo", "apt-get", "update"])
             installable = subprocess.check_output(["apt-cache", "--generate", "pkgnames"])
             if installable:
                 installable = installable.decode("ascii").splitlines()
+                missing_pkgs = list(filter(lambda pkg: pkg not in installable, pkgs))
                 pkgs = list(filter(lambda pkg: pkg in installable, pkgs))
+                print("Skipping the following required pkgs, as they don't exist in this OS version:", missing_pkgs)
 
             if subprocess.call(["dpkg", "-s"] + pkgs, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE) != 0:
                 install = True


### PR DESCRIPTION
In a fresh container skipping the apt-update will cause only 4 packages to be installed and the rest filtered. Also add a debug print to inform the user if packages were skipped.

Testing: Manually tested

