### PR TITLE
Remove tshark from mach bootstrap

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -169,6 +169,8 @@ jobs:
         timeout-minutes: 10
         run: |
           sudo apt update
+          echo "wireshark-common wireshark-common/install-setuid boolean true" | sudo debconf-set-selections
+          sudo apt install -qy tshark
           ./mach bootstrap --skip-lints
 
       # Always install crown, even on self-hosted runners, because it is tightly

--- a/python/servo/platform/linux.py
+++ b/python/servo/platform/linux.py
@@ -67,7 +67,6 @@ APT_PKGS = [
     "xorg-dev",
     "libxkbcommon0",
     "libxkbcommon-x11-0",
-    "tshark",
 ]
 
 # https://packages.fedoraproject.org
@@ -114,7 +113,6 @@ DNF_PKGS = [
     "vulkan-loader",
     "libxkbcommon",
     "libxkbcommon-x11",
-    "wireshark-cli",
 ]
 
 # https://voidlinux.org/packages/

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -13,7 +13,6 @@ import json
 import logging
 import os
 import os.path as path
-import platform
 import re
 import shutil
 import subprocess
@@ -365,8 +364,7 @@ class MachCommands(CommandBase):
         passed = wpt.run_tests() and passed
 
         print("Running devtools parser tests...")
-        # TODO: Enable these tests on other platforms once mach bootstrap installs tshark(1) for them
-        if platform.system() == "Linux":
+        if shutil.which("tshark"):
             try:
                 result = subprocess.run(
                     ["etc/devtools_parser.py", "--json", "--read-file", "etc/devtools_parser_test.pcap"],
@@ -383,7 +381,7 @@ class MachCommands(CommandBase):
                 print(f"stderr: {repr(e.stderr)}", file=sys.stderr)
                 raise e
         else:
-            print("SKIP")
+            print("SKIP: Install tshark manually")
 
         if all or tests:
             print("Running WebIDL tests...")


### PR DESCRIPTION
`mach bootstrap` no longer installs Wireshark, as it isn't useful for people not working directly on DevTools support. The linux runner that runs `mach test-scripts` now installs it manually, skipping the security prompt.

Testing: Manual test of `mach test-scripts`
Fixes: #40503
