### PR TITLE
servoshell: Close all embedder controls when loading a toplevel page in WebDriver

### DIFF
--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -109,6 +109,10 @@ impl RunningAppStateTrait for RunningAppState {
     fn webview_by_id(&self, id: WebViewId) -> Option<WebView> {
         self.inner().webviews.get(&id).cloned()
     }
+
+    fn dismiss_embedder_controls_for_webview(&self, webview_id: WebViewId) {
+        let _ = self.inner_mut().dialogs.remove(&webview_id);
+    }
 }
 
 impl RunningAppState {

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -51,11 +51,10 @@ impl RunningAppStateBase {
 
 pub trait RunningAppStateTrait {
     fn base(&self) -> &RunningAppStateBase;
-
     #[allow(dead_code)]
     fn base_mut(&mut self) -> &mut RunningAppStateBase;
-
-    fn webview_by_id(&self, id: WebViewId) -> Option<WebView>;
+    fn webview_by_id(&self, _: WebViewId) -> Option<WebView>;
+    fn dismiss_embedder_controls_for_webview(&self, _webview_id: WebViewId) {}
 
     fn servoshell_preferences(&self) -> &ServoShellPreferences {
         &self.base().servoshell_preferences
@@ -170,10 +169,14 @@ pub trait RunningAppStateTrait {
         url: Url,
         load_status_sender: GenericSender<WebDriverLoadStatus>,
     ) {
-        if let Some(webview) = self.webview_by_id(webview_id) {
-            info!("Loading URL in webview {}: {}", webview_id, url);
-            self.set_load_status_sender(webview_id, load_status_sender);
-            webview.load(url);
-        }
+        let Some(webview) = self.webview_by_id(webview_id) else {
+            return;
+        };
+
+        self.dismiss_embedder_controls_for_webview(webview_id);
+
+        info!("Loading URL in webview {}: {}", webview_id, url);
+        self.set_load_status_sender(webview_id, load_status_sender);
+        webview.load(url);
     }
 }


### PR DESCRIPTION
This is a speculative attempt to make WebDriver WPT runs more stable.
Without this change, it seems likely that embedder controls could stay
open indefinitely during WebDriver test runs.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>

Testing: This should (hopefully) decrease the amount of tests that flake
when running WPT.
