### PR TITLE
servo: Add bidirectional message ports to public embedding API.

### DIFF
--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -82,6 +82,9 @@ mod from_compositor {
                 },
                 Self::RequestScreenshotReadiness(..) => target!("RequestScreenshotReadiness"),
                 Self::EmbedderControlResponse(..) => target!("EmbedderControlResponse"),
+                Self::CreateEntangledMessagePorts(..) => target!("CreateEntangledMessagePorts"),
+                Self::PostMessageToWebView(..) => target!("PostMessageToWebView"),
+                Self::PostMessageToMessagePort(..) => target!("PostMessageToMessagePort"),
             }
         }
     }

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -22,7 +22,7 @@ use base::id::{
 };
 use constellation_traits::{
     BlobData, BlobImpl, BroadcastChannelMsg, FileBlob, MessagePortImpl, MessagePortMsg,
-    PortMessageTask, ScriptToConstellationChan, ScriptToConstellationMessage,
+    PortMessageTask, PostMessageData, ScriptToConstellationChan, ScriptToConstellationMessage,
 };
 use content_security_policy::CspList;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
@@ -1486,8 +1486,23 @@ impl GlobalScope {
             // consisting of all MessagePort objects in deserializeRecord.[[TransferredValues]],
             // if any, maintaining their relative order.
             // Note: both done in `structuredclone::read`.
-            if let Ok(ports) = structuredclone::read(self, data, message_clone.handle_mut(), can_gc)
-            {
+            let structured_clone_result = match data {
+                PostMessageData::StructuredClone(data) => {
+                    structuredclone::read(self, data, message_clone.handle_mut(), can_gc)
+                },
+                PostMessageData::Serialized(data) => {
+                    let ports = crate::embedder_js::jsvalue_to_jsval(
+                        cx,
+                        self,
+                        &data,
+                        message_clone.handle_mut(),
+                        comp,
+                        can_gc,
+                    );
+                    Ok(ports)
+                },
+            };
+            if let Ok(ports) = structured_clone_result {
                 // Note: if this port is used to transfer a stream, we handle the events in Rust.
                 if let Some(transform) = cross_realm_transform.as_ref() {
                     match transform {
@@ -1746,7 +1761,7 @@ impl GlobalScope {
                 );
             } else {
                 // If this is a newly-created port, let the constellation immediately know.
-                let port_impl = MessagePortImpl::new(*dom_port.message_port_id());
+                let port_impl = MessagePortImpl::new(*dom_port.message_port_id(), false);
                 message_ports.insert(
                     *dom_port.message_port_id(),
                     ManagedMessagePort {

--- a/components/script/embedder_js.rs
+++ b/components/script/embedder_js.rs
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::ffi::CString;
+
+use constellation_traits::MessagePortImpl;
+use embedder_traits::JSValue;
+use js::jsapi::{Heap, JS_NewPlainObject, JSPROP_ENUMERATE};
+use js::jsval::{JSVal, NullValue};
+use js::rust::MutableHandleValue;
+use js::rust::wrappers::JS_DefineProperty;
+use script_bindings::conversions::SafeToJSValConvertible;
+use script_bindings::realms::InRealm;
+use script_bindings::root::DomRoot;
+use script_bindings::script_runtime::{CanGc, JSContext};
+
+use crate::dom::bindings::transferable::Transferable;
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::messageport::MessagePort;
+
+#[expect(unsafe_code)]
+pub(crate) fn jsvalue_to_jsval(
+    cx: JSContext,
+    global: &GlobalScope,
+    data: &JSValue,
+    mut out: MutableHandleValue,
+    in_realm: InRealm,
+    can_gc: CanGc,
+) -> Vec<DomRoot<MessagePort>> {
+    let mut ports = vec![];
+    match data {
+        JSValue::Undefined => ().safe_to_jsval(cx, out, can_gc),
+        JSValue::Null => out.set(NullValue()),
+        JSValue::Boolean(b) => b.safe_to_jsval(cx, out, can_gc),
+        JSValue::Number(n) => n.safe_to_jsval(cx, out, can_gc),
+        JSValue::String(s) => s.safe_to_jsval(cx, out, can_gc),
+        JSValue::Element(..) |
+        JSValue::ShadowRoot(..) |
+        JSValue::Frame(..) |
+        JSValue::Window(..) => todo!(),
+        JSValue::Array(a) => {
+            rooted_vec!(let mut values);
+            for v in a {
+                rooted!(in(*cx) let mut value: JSVal);
+                let inner_ports =
+                    jsvalue_to_jsval(cx, global, v, value.handle_mut(), in_realm, can_gc);
+                values.push(Heap::boxed(value.get()));
+                ports.extend(inner_ports);
+            }
+            values.safe_to_jsval(cx, out, can_gc);
+        },
+        JSValue::Object(o) => {
+            rooted!(in(*cx) let mut obj = unsafe { JS_NewPlainObject(*cx) });
+            assert!(!obj.handle().is_null());
+            for (key, value) in o {
+                let Ok(key) = CString::new(key.as_bytes()) else {
+                    continue;
+                };
+                rooted!(in(*cx) let mut js_value: JSVal);
+                let inner_ports =
+                    jsvalue_to_jsval(cx, global, value, js_value.handle_mut(), in_realm, can_gc);
+                unsafe {
+                    assert!(JS_DefineProperty(
+                        *cx,
+                        obj.handle(),
+                        key.as_ptr(),
+                        js_value.handle(),
+                        JSPROP_ENUMERATE as _,
+                    ));
+                }
+                ports.extend(inner_ports);
+            }
+        },
+        JSValue::MessagePort { id, entangled, .. } => {
+            let mut port_impl = MessagePortImpl::new(*id, true);
+            port_impl.entangle(*entangled);
+            port_impl.start();
+            port_impl.set_has_been_shipped();
+            let port = MessagePort::transfer_receive(global, *id, port_impl).unwrap();
+            port.safe_to_jsval(cx, out, can_gc);
+            ports.push(port);
+        },
+    }
+    ports
+}

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -39,6 +39,7 @@ mod init;
 mod layout_image;
 
 pub(crate) mod document_collection;
+mod embedder_js;
 pub(crate) mod iframe_collection;
 pub(crate) mod image_animation;
 pub mod layout_dom;

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -38,8 +38,8 @@ use canvas_traits::webgl::WebGLPipeline;
 use chrono::{DateTime, Local};
 use compositing_traits::{CrossProcessCompositorApi, PipelineExitSource};
 use constellation_traits::{
-    JsEvalResult, LoadData, LoadOrigin, NavigationHistoryBehavior, ScreenshotReadinessResponse,
-    ScriptToConstellationChan, ScriptToConstellationMessage, StructuredSerializedData,
+    JsEvalResult, LoadData, LoadOrigin, NavigationHistoryBehavior, PostMessageData,
+    ScreenshotReadinessResponse, ScriptToConstellationChan, ScriptToConstellationMessage,
     WindowSizeType,
 };
 use crossbeam_channel::unbounded;
@@ -2748,7 +2748,7 @@ impl ScriptThread {
         source_with_ancestry: Vec<BrowsingContextId>,
         origin: Option<ImmutableOrigin>,
         source_origin: ImmutableOrigin,
-        data: StructuredSerializedData,
+        data: PostMessageData,
     ) {
         let window = self.documents.borrow().find_window(pipeline_id);
         match window {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -19,6 +19,7 @@
 
 mod clipboard_delegate;
 mod javascript_evaluator;
+mod message_port;
 mod proxies;
 mod responders;
 mod servo_delegate;
@@ -117,6 +118,7 @@ pub use {
 #[cfg(feature = "bluetooth")]
 pub use {bluetooth, bluetooth_traits};
 
+pub use crate::message_port::{MessagePort, MessagePortDelegate};
 use crate::proxies::ConstellationProxy;
 use crate::responders::ServoErrorChannel;
 pub use crate::servo_delegate::{ServoDelegate, ServoError};
@@ -188,6 +190,7 @@ pub struct Servo {
     delegate: RefCell<Rc<dyn ServoDelegate>>,
     compositor: Rc<RefCell<IOCompositor>>,
     constellation_proxy: ConstellationProxy,
+    embedder_proxy: EmbedderProxy,
     embedder_receiver: Receiver<EmbedderMsg>,
     /// A struct that tracks ongoing JavaScript evaluations and is responsible for
     /// calling the callback when the evaluation is complete.
@@ -297,7 +300,7 @@ impl Servo {
             embedder_to_constellation_receiver,
             &compositor.borrow(),
             opts.config_dir.clone(),
-            embedder_proxy,
+            embedder_proxy.clone(),
             compositor_proxy.clone(),
             time_profiler_chan,
             mem_profiler_chan,
@@ -317,6 +320,7 @@ impl Servo {
                 constellation_proxy.clone(),
             ))),
             constellation_proxy,
+            embedder_proxy,
             embedder_receiver,
             shutdown_state,
             webviews: Default::default(),
@@ -891,6 +895,17 @@ impl Servo {
                 };
                 if let Err(error) = response_sender.send(screen_metrics()) {
                     warn!("Failed to respond to GetScreenMetrics: {error}");
+                }
+            },
+            EmbedderMsg::PostMessage(webview_id, message_port_id, data) => {
+                let Some(webview) = self.get_webview_handle(webview_id) else {
+                    return;
+                };
+                let Some(message_port) = webview.message_port(message_port_id) else {
+                    return;
+                };
+                if let Some(delegate) = message_port.delegate() {
+                    delegate.post_message_received(webview, message_port.clone(), data);
                 }
             },
         }

--- a/components/servo/message_port.rs
+++ b/components/servo/message_port.rs
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use base::id::{MessagePortId, MessagePortRouterId, WebViewId};
+use constellation_traits::{EmbedderToConstellationMessage, MessagePortMsg, PostMessageData};
+use embedder_traits::{EmbedderMsg, EmbedderProxy, JSValue};
+use ipc_channel::ipc;
+use ipc_channel::router::ROUTER;
+
+use crate::{ConstellationProxy, WebView};
+
+pub trait MessagePortDelegate {
+    /// Invoked when a message is posted on an entangled MessagePort. The
+    /// posted data is provided as an argument, and only includes seralized
+    /// versions of fundamental JS data types.
+    fn post_message_received(&self, _webview: WebView, _message_port: MessagePort, _data: JSValue) {
+    }
+}
+
+enum MessagePortState {
+    Ready {
+        id: MessagePortId,
+        webview_id: WebViewId,
+        entangled_id: MessagePortId,
+        constellation_proxy: ConstellationProxy,
+        delegate: Option<Rc<dyn MessagePortDelegate>>,
+    },
+    Detached,
+}
+
+#[derive(Clone)]
+pub struct MessagePort(Rc<RefCell<MessagePortState>>);
+
+#[derive(Debug, PartialEq)]
+pub struct MessagePortDetached;
+
+impl MessagePort {
+    fn new(
+        constellation_proxy: ConstellationProxy,
+        webview_id: WebViewId,
+        port_id: MessagePortId,
+        entangled_id: MessagePortId,
+    ) -> MessagePort {
+        MessagePort(Rc::new(RefCell::new(MessagePortState::Ready {
+            constellation_proxy,
+            webview_id,
+            id: port_id,
+            entangled_id,
+            delegate: None,
+        })))
+    }
+
+    pub(crate) fn new_entangled(
+        constellation_proxy: ConstellationProxy,
+        embedder_proxy: EmbedderProxy,
+        webview_id: WebViewId,
+    ) -> (MessagePort, MessagePort) {
+        let (port_control_sender, port_control_receiver) =
+            ipc::channel().expect("ipc channel failure");
+        ROUTER.add_typed_route(
+            port_control_receiver,
+            Box::new(move |message| match message.unwrap() {
+                MessagePortMsg::CompleteTransfer(..) => unreachable!(),
+                MessagePortMsg::CompletePendingTransfer(..) => unreachable!(),
+                MessagePortMsg::CompleteDisentanglement(..) => unreachable!(),
+                MessagePortMsg::NewTask(message_port_id, task) => {
+                    let data = match task.data {
+                        PostMessageData::StructuredClone(..) => unreachable!(),
+                        PostMessageData::Serialized(data) => data,
+                    };
+                    let _ = embedder_proxy.send(EmbedderMsg::PostMessage(
+                        webview_id,
+                        message_port_id,
+                        data,
+                    ));
+                },
+            }),
+        );
+        let first_id = MessagePortId::new();
+        let second_id = MessagePortId::new();
+        let router_id = MessagePortRouterId::new();
+        constellation_proxy.send(EmbedderToConstellationMessage::CreateEntangledMessagePorts(
+            router_id,
+            port_control_sender,
+            first_id,
+            second_id,
+        ));
+
+        let first = MessagePort::new(constellation_proxy.clone(), webview_id, first_id, second_id);
+        let second = MessagePort::new(constellation_proxy, webview_id, second_id, first_id);
+
+        (first, second)
+    }
+
+    /// Post the provided [JSValue] to the MessagePort that is entangled with this one.
+    pub fn post_message(&self, js_value: JSValue) -> Result<(), MessagePortDetached> {
+        let inner = self.0.borrow();
+        let MessagePortState::Ready {
+            entangled_id,
+            constellation_proxy,
+            ..
+        } = &*inner
+        else {
+            return Err(MessagePortDetached);
+        };
+        constellation_proxy.send(EmbedderToConstellationMessage::PostMessageToMessagePort(
+            *entangled_id,
+            js_value,
+        ));
+        Ok(())
+    }
+
+    /// Set the delegate of this MessagePort. Does nothing if this MessagePort
+    /// has already been transferred.
+    pub fn set_delegate(&self, new_delegate: Rc<dyn MessagePortDelegate>) {
+        match &mut *self.0.borrow_mut() {
+            MessagePortState::Ready { delegate, .. } => *delegate = Some(new_delegate),
+            MessagePortState::Detached => {},
+        }
+    }
+
+    pub fn delegate(&self) -> Option<Rc<dyn MessagePortDelegate>> {
+        match &*self.0.borrow() {
+            MessagePortState::Ready { delegate, .. } => delegate.clone(),
+            MessagePortState::Detached => None,
+        }
+    }
+
+    /// Prepare this MessagePort to be transferred as part of a PostMessage operation.
+    /// This object will no longer be usable afterwards.
+    pub fn into_jsvalue(&self) -> Result<JSValue, MessagePortDetached> {
+        let value = {
+            let state = self.0.borrow();
+            let &MessagePortState::Ready {
+                webview_id,
+                id,
+                entangled_id,
+                ..
+            } = &*state
+            else {
+                return Err(MessagePortDetached);
+            };
+            JSValue::MessagePort {
+                webview_id,
+                id,
+                entangled: entangled_id,
+            }
+        };
+        *self.0.borrow_mut() = MessagePortState::Detached;
+        Ok(value)
+    }
+
+    pub(crate) fn id(&self) -> Option<MessagePortId> {
+        match &*self.0.borrow() {
+            MessagePortState::Ready { id, .. } => Some(*id),
+            MessagePortState::Detached => None,
+        }
+    }
+}

--- a/components/shared/constellation/structured_data/transferable.rs
+++ b/components/shared/constellation/structured_data/transferable.rs
@@ -66,17 +66,26 @@ pub struct MessagePortImpl {
 
     /// The UUID of this port.
     message_port_id: MessagePortId,
+
+    ///
+    forbid_structured_clone: bool,
 }
 
 impl MessagePortImpl {
     /// Create a new messageport impl.
-    pub fn new(port_id: MessagePortId) -> MessagePortImpl {
+    pub fn new(port_id: MessagePortId, forbid_structured_clone: bool) -> MessagePortImpl {
         MessagePortImpl {
             state: MessagePortState::Disabled(false),
             entangled_port: None,
             message_buffer: None,
             message_port_id: port_id,
+            forbid_structured_clone,
         }
+    }
+
+    ///
+    pub fn forbid_structured_clone(&self) -> bool {
+        self.forbid_structured_clone
     }
 
     /// Get the Id.

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -22,8 +22,8 @@ use canvas_traits::webgl::WebGLPipeline;
 use compositing_traits::CrossProcessCompositorApi;
 use compositing_traits::largest_contentful_paint_candidate::LargestContentfulPaintType;
 use constellation_traits::{
-    KeyboardScroll, LoadData, NavigationHistoryBehavior, ScriptToConstellationChan,
-    StructuredSerializedData, WindowSizeType,
+    KeyboardScroll, LoadData, NavigationHistoryBehavior, PostMessageData,
+    ScriptToConstellationChan, WindowSizeType,
 };
 use crossbeam_channel::{RecvTimeoutError, Sender};
 use devtools_traits::ScriptToDevtoolsControlMsg;
@@ -204,7 +204,7 @@ pub enum ScriptThreadMessage {
         /// <https://html.spec.whatwg.org/multipage/#dom-messageevent-origin>
         source_origin: ImmutableOrigin,
         /// The data to be posted.
-        data: Box<StructuredSerializedData>,
+        data: Box<PostMessageData>,
     },
     /// Updates the current pipeline ID of a given iframe.
     /// First PipelineId is for the parent, second is the new PipelineId for the frame.

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -267,6 +267,9 @@ impl Serialize for SendableJSValue {
                 .map(|(k, v)| (k.clone(), SendableJSValue(v.clone())))
                 .collect::<HashMap<String, SendableJSValue>>()
                 .serialize(serializer),
+            JSValue::MessagePort { .. } => {
+                unreachable!("MessagePort objects must be serialized as JSValue::Object")
+            },
         }
     }
 }


### PR DESCRIPTION
These changes expose a new embedding API for creating entangled MessagePorts that can be sent to the active document in a webview. This provides an asynchronous, bidrectional communication channel between the embedder and the page content. This also introduces a generic PostMessage API for webviews that can also be used for one-way communication from the embedder to content. This PR replaces #38581 because suggested changes from that PR required lots of rewriting.

Testing: New unit tests added.
Fixes: https://github.com/servo/servo/issues/35665
