### PR TITLE
Remove duplicate entry for 'rustc-dev' in toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -11,7 +11,6 @@ components = [
     # For support/crown
     "rustc-dev",
     "rustfmt",
-    "rustc-dev",
     # For rust-analyzer
     "rust-src",
 ]


### PR DESCRIPTION
Testing: Trivial, Not required

