### PR TITLE
servoshell: Move `webdriver_receiver` to shared base

### DIFF
--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -40,9 +40,6 @@ pub(crate) enum AppState {
 
 pub(crate) struct RunningAppState {
     base: RunningAppStateBase,
-    /// A [`Receiver`] for receiving commands from a running WebDriver server, if WebDriver
-    /// was enabled.
-    webdriver_receiver: Option<Receiver<WebDriverCommandMsg>>,
     inner: RefCell<RunningAppStateInner>,
 }
 
@@ -125,8 +122,7 @@ impl RunningAppState {
             None
         };
         RunningAppState {
-            base: RunningAppStateBase::new(servoshell_preferences, servo),
-            webdriver_receiver,
+            base: RunningAppStateBase::new(servoshell_preferences, servo, webdriver_receiver),
             inner: RefCell::new(RunningAppStateInner {
                 webviews: HashMap::default(),
                 creation_order: Default::default(),
@@ -167,10 +163,6 @@ impl RunningAppState {
 
     pub(crate) fn inner_mut(&self) -> RefMut<'_, RunningAppStateInner> {
         self.inner.borrow_mut()
-    }
-
-    pub(crate) fn webdriver_receiver(&self) -> Option<&Receiver<WebDriverCommandMsg>> {
-        self.webdriver_receiver.as_ref()
     }
 
     pub(crate) fn hidpi_scale_factor_changed(&self) {


### PR DESCRIPTION
This PR eliminates duplicate code while maintaining the same functionality across all platforms.. We move `webdriver_receiver` to shared base where `webdriver_sender` lives

Testing: No functional changes. Existing tests should test this.
Fixes: Part of https://github.com/servo/servo/issues/40530
