### PR TITLE
Net: ServoUrl.into_string().parse() optimization

### DIFF
--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1360,7 +1360,7 @@ async fn http_network_or_cache_fetch(
         Referrer::Client(ref http_request_referrer) => {
             // Step 8.11.1: Let referrerValue be httpRequest’s referrer, serialized and isomorphic
             // encoded.
-            if let Ok(referer) = http_request_referrer.to_string().parse::<Referer>() {
+            if let Ok(referer) = http_request_referrer.as_str().parse::<Referer>() {
                 // Step 8.11.2: Append (`Referer`, referrerValue) to httpRequest’s header list.
                 http_request.headers.typed_insert(referer);
             } else {

--- a/components/net/websocket_loader.rs
+++ b/components/net/websocket_loader.rs
@@ -341,12 +341,8 @@ pub(crate) async fn start_websocket(
     if original_url.scheme() == "ws" && url.scheme() == "https" {
         original_url.as_mut_url().set_scheme("wss").unwrap();
     }
-    let mut builder = ClientRequestBuilder::new(
-        original_url
-            .into_string()
-            .parse()
-            .expect("unable to parse URI"),
-    );
+    let mut builder =
+        ClientRequestBuilder::new(original_url.as_str().parse().expect("unable to parse URI"));
     for (key, value) in client.headers.iter() {
         builder = builder.with_header(
             key.as_str(),


### PR DESCRIPTION
parse takes by reference, so it is enough to use as_str() (which is fast according to the Url documentation) instead of `into_string`.
`into_string()` copies the whole url into a new string.


Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Should not change any functionality.
