### PR TITLE
tests: Import the XPathMark-FT test suite

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14700,7 +14700,7 @@
      ]
     ],
     "xpathmark-ft.html": [
-     "aaebd165eefd6b2d0d15592ded7fc93c71cb244d",
+     "8221da5d372893d379781082df777a9ff6f2e5fd",
      [
       null,
       {}

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14700,7 +14700,7 @@
      ]
     ],
     "xpathmark-ft.html": [
-     "4d5325dcee4d9f869723d36309a0d22185780e54",
+     "aaebd165eefd6b2d0d15592ded7fc93c71cb244d",
      [
       null,
       {}

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -10625,6 +10625,10 @@
      "182d72fa7fddab14222e4085b2cc498d79865709",
      []
     ],
+    "alphabet.xml": [
+     "aaf2e1a49542c1eee44d132d270ba1a7169cb873",
+     []
+    ],
     "blank.html": [
      "39654855a826184e75c4278434360ee0a6fb2a59",
      []
@@ -14690,6 +14694,13 @@
     ],
     "xpath-reuse-result-iterator.html": [
      "5f97115a82dba24ae4ca807b1e60ee93b3a526ea",
+     [
+      null,
+      {}
+     ]
+    ],
+    "xpathmark-ft.html": [
+     "4d5325dcee4d9f869723d36309a0d22185780e54",
      [
       null,
       {}

--- a/tests/wpt/mozilla/meta/mozilla/xpathmark-ft.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/xpathmark-ft.html.ini
@@ -1,0 +1,2 @@
+[xpathmark-ft.html]
+  expected: CRASH

--- a/tests/wpt/mozilla/tests/mozilla/alphabet.xml
+++ b/tests/wpt/mozilla/tests/mozilla/alphabet.xml
@@ -1,0 +1,41 @@
+<!-- This version of alphabet.xml has been modified to not need the DTD -->
+<A id="n1" pre="1" post="26" xml:lang="en">
+<B id="n2" pre="2" post="3">
+<C id="n3" pre="3" post="1">clergywoman</C>
+<D id="n4" pre="4" post="2">decadent</D>
+</B>
+<E id="n5" pre="5" post="22">
+<F id="n6" pre="6" post="6">
+<G id="n7" pre="7" post="4">gentility</G>
+<H id="n8" pre="8" post="5" idrefs="n17 n26">happy-go-lucky man</H>
+</F>
+<I id="n9" pre="9" post="9">
+<J id="n10" pre="10" post="7">jigsaw</J>
+<K id="n11" pre="11" post="8">kerchief</K>
+</I>
+<L id="n12" pre="12" post="15">
+<!--L is the twelve-th letter of the English alphabet-->
+The letter L is followed by the letter:
+<M id="n13" pre="13" post="10"/>
+which is followed by the letter:
+<N id="n14" pre="14" post="13">
+<O id="n15" pre="15" post="11">ovenware</O>
+<P id="n16" pre="16" post="12">plentiful</P>
+</N>
+<?myPI value="XPath is nice"?>
+<Q id="n17" pre="17" post="14" idrefs="n8 n26">quarrelsome</Q>
+</L>
+<R id="n18" pre="18" post="18">
+<S id="n19" pre="19" post="16">sage</S>
+<T id="n20" pre="20" post="17">tattered</T>
+</R>
+<U id="n21" pre="21" post="21">
+<V id="n22" pre="22" post="19">voluptuary</V>
+<W id="n23" pre="23" post="20">wriggle</W>
+</U>
+</E>
+<X id="n24" pre="24" post="25">
+<Y id="n25" pre="25" post="23">yawn</Y>
+<Z id="n26" pre="26" post="24" idrefs="n8 n17" xml:lang="it">zuzzurellone</Z>
+</X>
+</A>

--- a/tests/wpt/mozilla/tests/mozilla/xpathmark-ft.html
+++ b/tests/wpt/mozilla/tests/mozilla/xpathmark-ft.html
@@ -8,6 +8,8 @@
     <script src="/resources/testharnessreport.js"></script>
 </head>
 <script>
+setup({ explicit_done: true });
+
 function toArray(result) {
   var array = [];
   while (true) {

--- a/tests/wpt/mozilla/tests/mozilla/xpathmark-ft.html
+++ b/tests/wpt/mozilla/tests/mozilla/xpathmark-ft.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <head>
-    <title>XPathMark Functional Test</title>
+    <title>XPathMark Functional Test (originally authored by Massimo Franceschet)</title>
+    <link rel="author" title="Massimo Franceschet">
     <link rel="author" title="Simon Wülker" href="simon.wuelker@arcor.de">
     <link rel="help" href="https://web.archive.org/web/20070720155520/https://users.dimi.uniud.it/~massimo.franceschet/xpathmark/FT.html">
     <script src="/resources/testharness.js"></script>

--- a/tests/wpt/mozilla/tests/mozilla/xpathmark-ft.html
+++ b/tests/wpt/mozilla/tests/mozilla/xpathmark-ft.html
@@ -1,0 +1,342 @@
+<!doctype html>
+<head>
+    <title>XPathMark Functional Test</title>
+    <link rel="author" title="Simon Wülker" href="simon.wuelker@arcor.de">
+    <link rel="help" href="https://web.archive.org/web/20070720155520/https://users.dimi.uniud.it/~massimo.franceschet/xpathmark/FT.html">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<script>
+function toArray(result) {
+  var array = [];
+  while (true) {
+    var node = result.iterateNext();
+    if (node === null) break;
+    array.push(node);
+  }
+  return array;
+}
+
+function run_tests(xml_document) {
+  // Get all nodes for testing
+  let n = [];
+  // Element ids start at one so add a bogus element for convenience
+  n.push(null);
+  for (let i = 1; i < 27; i++) {
+    n.push(xml_document.getElementById("n" + i));
+  }
+
+  let comment = n[12].childNodes[1];
+  let processing_instruction = n[12].childNodes[7];
+
+  const cases = [
+    // Axes
+    {
+      "query": "//L/*",
+      "expected": [n[13], n[14], n[17]]
+    },
+    {
+      "query": "//L/parent::*",
+      "expected": [n[5]]
+    },
+    {
+      "query": "//L/descendant::*",
+      "expected": [n[13], n[14], n[15], n[16], n[17]]
+    },
+    {
+      "query": "//L/descendant-or-self::*",
+      "expected": [n[12], n[13], n[14], n[15], n[16], n[17]]
+    },
+    {
+      "query": "//L/ancestor::*",
+      "expected": [n[1], n[5]]
+    },
+    {
+      "query": "//L/ancestor-or-self::*",
+      "expected": [n[1], n[5], n[12]]
+    },
+    {
+      "query": "//L/following-sibling::*",
+      "expected": [n[18], n[21]]
+    },
+    {
+      "query": "//L/preceding-sibling::*",
+      "expected": [n[6], n[9]]
+    },
+    {
+      "query": "//L/following::*",
+      "expected": [n[18], n[19], n[20], n[21], n[22], n[23], n[24], n[25], n[26]]
+    },
+    {
+      "query": "//L/preceding::*",
+      // XPathMark thinks n5 should be included, Firefox and Chrome say no
+      "expected": [n[2], n[3], n[4], n[6], n[7], n[8], n[9], n[10], n[11]]
+    },
+    {
+      "query": "//L/self::* ",
+      "expected": [n[12]]
+    },
+    {
+      "query": "//L/@id/parent::*",
+      "expected": [n[12]]
+    },
+    // Filters
+    {
+      "query": "//*[L]",
+      "expected": [n[5]],
+    },
+    {
+      "query": "//*[parent::L]",
+      "expected": [n[13], n[14], n[17]]
+    },
+    {
+      "query": "//*[descendant::L]",
+      "expected": [n[1], n[5]]
+    },
+    {
+      "query": "//*[descendant-or-self::L]",
+      "expected": [n[1], n[5], n[12]]
+    },
+    {
+      "query": "//*[ancestor::L]",
+      "expected": [n[13], n[14], n[15], n[16], n[17]]
+    },
+    {
+      "query": "//*[ancestor-or-self::L]",
+      "expected": [n[12], n[13], n[14], n[15], n[16], n[17]]
+    },
+    {
+      "query": "//*[following-sibling::L]",
+      "expected": [n[6], n[9]]
+    },
+    {
+      "query": "//*[preceding-sibling::L]",
+      "expected": [n[18], n[21]]
+    },
+    {
+      "query": "//*[following::L]",
+      // XPathMark thinks n5 should be included, Firefox and Chrome say no
+      "expected": [n[2], n[3], n[4], n[6], n[7], n[8], n[9], n[10], n[11]]
+    },
+    {
+      "query": "//*[preceding::L]",
+      "expected": [n[18], n[19], n[20], n[21], n[22], n[23], n[24], n[25], n[26]]
+    },
+    {
+      "query": "//*[self::L]",
+      "expected": [n[12]]
+    },
+    {
+      "query": "//*[@id]",
+      "expected": [n[1], n[2], n[3], n[4], n[5], n[6], n[7], n[8], n[9], n[10], n[11], n[12], n[13], n[14], n[15], n[16], n[17], n[18], n[19], n[20], n[21], n[22], n[23], n[24], n[25], n[26]]
+    },
+    // Node tests
+    {
+      "query": "//L/text()",
+      "expected": Array.from(n[12].childNodes).filter(function(node) {
+        return node.nodeType == Node.TEXT_NODE;
+      })
+    },
+    {
+      "query": "//L/comment()",
+      "expected": [comment],
+    },
+    {
+      "query": " //L/processing-instruction()",
+      "expected": [processing_instruction]
+    },
+    {
+      "query": "//L/processing-instruction(\"myPI\")",
+      "expected": [processing_instruction]
+    },
+    {
+      "query": "//L/node()",
+      "expected": n[12].childNodes,
+    },
+    {
+      "query": "//L/N",
+      "expected": [n[14]]
+    },
+    {
+      "query": "//L/*",
+      "expected": [n[13], n[14], n[17]]
+    },
+    // Operators
+    {
+      "query": "//*[child::* and preceding::Q]",
+      "expected": [n[18], n[21], n[24]],
+    },
+    {
+      "query": "//*[not(child::*) and preceding::Q]",
+      "expected": [n[19], n[20], n[22], n[23], n[25], n[26]]
+    },
+    {
+      "query": "//*[preceding::L or following::L]",
+      "expected": [n[2], n[3], n[4], n[6], n[7], n[8], n[9], n[10], n[11], n[18], n[19], n[20], n[21], n[22], n[23], n[24], n[25], n[26]]
+    },
+    {
+      "query": "//L/ancestor::* | //L/descendant::*",
+      "expected": [n[1], n[5], n[13], n[14], n[15], n[16], n[17]]
+    },
+    {
+      "query": "//*[.=\"happy-go-lucky man\"]",
+      "expected": [n[8]]
+    },
+    {
+      "query": "//*[@pre > 12 and @post < 15]",
+      "expected": [n[13], n[14], n[15], n[16], n[17]]
+    },
+    {
+      "query": "//*[@pre != @post]",
+      "expected": [n[1], n[2], n[3], n[4], n[5], n[7], n[8], n[10], n[11], n[12], n[13], n[14], n[15], n[16], n[17], n[19], n[20], n[22], n[23], n[24], n[25], n[26]]
+    },
+    {
+      "query": "//*[((@post * @post + @pre * @pre) div (@post + @pre)) > ((@post - @pre) * (@post - @pre))]",
+      "expected": [n[2], n[6], n[9], n[11], n[12], n[13], n[14], n[17], n[18], n[19], n[20], n[21], n[22], n[23], n[24], n[25], n[26]]
+    },
+    {
+      "query": "//*[@pre mod 2 = 0]",
+      "expected": [n[2], n[4], n[6], n[8], n[10], n[12], n[14], n[16], n[18], n[20], n[22], n[24], n[26]]
+    },
+    // Functions
+    {
+      "query": "//*[contains(.,\"plentiful\")]",
+      "expected": [n[1], n[5], n[12], n[14], n[16]],
+    },
+    {
+      "query": "//*[starts-with(.,\"plentiful\")]",
+      "expected": [n[16]]
+    },
+    {
+      "query": "//*[substring(.,1,9) = \"plentiful\"]",
+      "expected": [n[16]]
+    },
+    {
+      "query": "//*[substring-after(.,\"oven\") = \"ware\"]",
+      "expected": [n[15]]
+    },
+    {
+      "query": "//*[substring-before(.,\"ful\") = \"plenti\"]",
+      "expected":[n[16]]
+    },
+    {
+      "query": "//*[string-length(translate(normalize-space(.),\" \",\"\")) > 100]",
+      "expected": [n[1], n[5]]
+    },
+    {
+      "query": "//*[concat(.,..) = ..]",
+      "expected": [n[13]]
+    },
+    {
+      "query": "//*[ceiling(@pre div @post) = 1]",
+      "expected": [n[1], n[2], n[5], n[6], n[9], n[12], n[18], n[21], n[24]]
+    },
+    {
+      "query": "//*[floor(@pre div @post) = 0]",
+      "expected": [n[1], n[2], n[5], n[12], n[24]]
+    },
+    {
+      "query": "//*[round(@pre div @post) = 0]",
+      "expected": [n[1], n[5]]
+    },
+    {
+      "query": "//*[name(.) = \"X\"]",
+      "expected": [n[24]]
+    },
+    {
+      "query": "//*[lang(\"it\")]",
+      "expected": [n[26]]
+    },
+    {
+      "query": "//L/child::*[last()]",
+      "expected": [n[17]]
+    },
+    {
+      "query": "//L/descendant::*[4]",
+      "expected": [n[16]]
+    },
+    {
+      "query": "//L/ancestor::*[2]",
+      "expected": [n[1]]
+    },
+    {
+      "query": "//L/following-sibling::*[1]",
+      "expected": [n[18]]
+    },
+    {
+      "query": "//L/preceding-sibling::*[1]",
+      "expected": [n[9]]
+    },
+    {
+      "query": "//L/following::*[7]",
+      "expected": [n[24]]
+    },
+    {
+      "query": " //L/preceding::*[7]",
+      "expected": [n[4]]
+    },
+    {
+      "query": "//*[count(ancestor::*) > 3]",
+      "expected": [n[15], n[16]]
+    },
+    {
+      "query": "//*[sum(ancestor::*/@pre) < sum(descendant::*/@pre)]",
+      "expected": [n[1], n[2], n[5], n[6], n[9], n[12], n[14], n[18], n[21], n[24]]
+    },
+    {
+      "query": "id(\"n1 n26\")",
+      "expected": [n[1], n[26]]
+    },
+    {
+      "query": "id(id(//*[.=\"happy-go-lucky man\"]/@idrefs)/@idrefs)",
+      "expected": [n[8], n[17], n[26]]
+    },
+    {
+      "query": "//*[number(@pre) < number(@post)]",
+      "expected": [n[1], n[2], n[5], n[12], n[24]]
+    },
+    {
+      "query": "//*[string(@pre - 1) = \"0\"]",
+      "expected": [n[1]]
+    },
+    {
+      "query": "//*[boolean(@id) = true() and boolean(@idrefs) = false()]",
+      "expected": [n[1], n[2], n[3], n[4], n[5], n[6], n[7], n[9], n[10], n[11], n[12], n[13], n[14], n[15], n[16], n[18], n[19], n[20], n[21], n[22], n[23], n[24], n[25]]
+    }
+  ];
+
+  for (var i = 0; i < cases.length; i++) {
+    const test_case = cases[i];
+    test(() => {
+      if (test_case.expected instanceof String) {
+        let result = xml_document.evaluate(
+          test_case.query,
+          xml_document.documentElement,
+          null,
+          XPathResult.STRING_TYPE,
+          null
+        ).stringValue;
+        assert_equals(result, test_case.expected);
+      } else {
+        let result = xml_document.evaluate(
+          test_case.query,
+          xml_document.documentElement,
+          null,
+          XPathResult.ORDERED_NODE_ITERATOR_TYPE,
+          null
+        );
+        let elements = toArray(result);
+        assert_array_equals(elements, test_case.expected);
+      }
+    }, "Expected results for " + test_case.query);
+  }
+}
+
+var xhr = new XMLHttpRequest();
+xhr.open("GET", "alphabet.xml");
+xhr.onload = function(e) {
+  run_tests(xhr.responseXML);
+  done();
+};
+xhr.send();
+</script>


### PR DESCRIPTION
[XPathMark-FT](https://web.archive.org/web/20070720155520/https://users.dimi.uniud.it/~massimo.franceschet/xpathmark/FT.html) is a test suite targeting xpath 1.0 from 2005. It's not very big, but covers all operators, axes and functions. I've converted it to a web platform test in `mozilla/`.

This exposes numerous new bugs (one of which being https://github.com/servo/servo/issues/40540), which will be fixed in followup changes. Firefox and chrome both pass all tests.

Testing: This change adds new tests
Fixes #39726 
