### PR TITLE
xpath: Don't expect ancestor-or-self axis to be in tree order

### DIFF
--- a/components/xpath/src/eval.rs
+++ b/components/xpath/src/eval.rs
@@ -298,8 +298,7 @@ impl LocationStepExpression {
                 Axis::FollowingSibling |
                 Axis::Attribute |
                 Axis::Self_ |
-                Axis::DescendantOrSelf |
-                Axis::AncestorOrSelf
+                Axis::DescendantOrSelf
         ) {
             // The elements on these axis values are already in tree order
             nodes.assume_sorted();

--- a/tests/wpt/mozilla/meta/mozilla/xpathmark-ft.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/xpathmark-ft.html.ini
@@ -1,2 +1,127 @@
 [xpathmark-ft.html]
-  expected: CRASH
+  expected: ERROR
+  [Expected results for //L/*]
+    expected: FAIL
+
+  [Expected results for //L/parent::*]
+    expected: FAIL
+
+  [Expected results for //L/descendant::*]
+    expected: FAIL
+
+  [Expected results for //L/descendant-or-self::*]
+    expected: FAIL
+
+  [Expected results for //L/ancestor::*]
+    expected: FAIL
+
+  [Expected results for //L/ancestor-or-self::*]
+    expected: FAIL
+
+  [Expected results for //L/following-sibling::*]
+    expected: FAIL
+
+  [Expected results for //L/preceding-sibling::*]
+    expected: FAIL
+
+  [Expected results for //L/following::*]
+    expected: FAIL
+
+  [Expected results for //L/preceding::*]
+    expected: FAIL
+
+  [Expected results for //L/self::* ]
+    expected: FAIL
+
+  [Expected results for //L/@id/parent::*]
+    expected: FAIL
+
+  [Expected results for //*[L\]]
+    expected: FAIL
+
+  [Expected results for //*[parent::L\]]
+    expected: FAIL
+
+  [Expected results for //*[descendant::L\]]
+    expected: FAIL
+
+  [Expected results for //*[descendant-or-self::L\]]
+    expected: FAIL
+
+  [Expected results for //*[ancestor::L\]]
+    expected: FAIL
+
+  [Expected results for //*[ancestor-or-self::L\]]
+    expected: FAIL
+
+  [Expected results for //*[following-sibling::L\]]
+    expected: FAIL
+
+  [Expected results for //*[preceding-sibling::L\]]
+    expected: FAIL
+
+  [Expected results for //*[following::L\]]
+    expected: FAIL
+
+  [Expected results for //*[preceding::L\]]
+    expected: FAIL
+
+  [Expected results for //*[self::L\]]
+    expected: FAIL
+
+  [Expected results for //L/text()]
+    expected: FAIL
+
+  [Expected results for //L/comment()]
+    expected: FAIL
+
+  [Expected results for  //L/processing-instruction()]
+    expected: FAIL
+
+  [Expected results for //L/processing-instruction("myPI")]
+    expected: FAIL
+
+  [Expected results for //L/node()]
+    expected: FAIL
+
+  [Expected results for //L/N]
+    expected: FAIL
+
+  [Expected results for //*[child::* and preceding::Q\]]
+    expected: FAIL
+
+  [Expected results for //*[not(child::*) and preceding::Q\]]
+    expected: FAIL
+
+  [Expected results for //*[preceding::L or following::L\]]
+    expected: FAIL
+
+  [Expected results for //L/ancestor::* | //L/descendant::*]
+    expected: FAIL
+
+  [Expected results for //*[string-length(translate(normalize-space(.)," ","")) > 100\]]
+    expected: FAIL
+
+  [Expected results for //L/child::*[last()\]]
+    expected: FAIL
+
+  [Expected results for //L/descendant::*[4\]]
+    expected: FAIL
+
+  [Expected results for //L/ancestor::*[2\]]
+    expected: FAIL
+
+  [Expected results for //L/following-sibling::*[1\]]
+    expected: FAIL
+
+  [Expected results for //L/preceding-sibling::*[1\]]
+    expected: FAIL
+
+  [Expected results for //L/following::*[7\]]
+    expected: FAIL
+
+  [Expected results for  //L/preceding::*[7\]]
+    expected: FAIL
+
+  [Expected results for id(id(//*[.="happy-go-lucky man"\]/@idrefs)/@idrefs)]
+    expected: FAIL


### PR DESCRIPTION
Depends on https://github.com/servo/servo/pull/40541

We still don't really pass any tests because we incorrectly compare local names case-sensitively. Needs more investigation.

Testing: New tests start to not-crash
Fixes https://github.com/servo/servo/issues/40540
