### PR TITLE
Fixed codegen to prevent double declaration of -webkit- prefixed CSS properties

### DIFF
--- a/components/script_bindings/codegen/run.py
+++ b/components/script_bindings/codegen/run.py
@@ -153,9 +153,6 @@ def attribute_names(property_name: str) -> Iterator[str]:
     if "-" in property_name:
         yield "".join(camel_case(property_name))
 
-    # https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-webkit-cased-attribute
-    if property_name.startswith("-webkit-"):
-        yield "".join(camel_case(property_name, True))
 
 
 # https://drafts.csswg.org/cssom/#css-property-to-idl-attribute


### PR DESCRIPTION
Removed the following on `script_bindings/codegen/run.py`:
```
# https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-webkit-cased-attribute
    if property_name.startswith("-webkit-"):
        yield "".join(camel_case(property_name, True))
```

Credits to @jdm !

Fixes: [issue #40545 ]
