### PR TITLE
script: Pass the right base URI to inline sheets

### DIFF
--- a/tests/wpt/meta/css/css-values/inline-cache-base-uri-cssom.html.ini
+++ b/tests/wpt/meta/css/css-values/inline-cache-base-uri-cssom.html.ini
@@ -1,2 +1,0 @@
-[inline-cache-base-uri-cssom.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-values/urls/resolve-relative-to-base.sub.html.ini
+++ b/tests/wpt/meta/css/css-values/urls/resolve-relative-to-base.sub.html.ini
@@ -1,6 +1,0 @@
-[resolve-relative-to-base.sub.html]
-  [base-relative URL: relative-image-url]
-    expected: FAIL
-
-  [base-relative URL: relative-image-variable-url]
-    expected: FAIL


### PR DESCRIPTION
HTMLStyleElement was creating stylesheets using the URI of the document, ignoring `<base>`.

To avoid having to create the UrlExtraData twice (or clone it), this inlines the `stylesheetcontents_create_callback`.

Testing: 2 WPT are now passing
Fixes: #40550