### PR TITLE
deps: De-duplicate phf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -1872,7 +1872,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.13.1",
+ "phf",
  "serde",
  "smallvec",
 ]
@@ -3946,13 +3946,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+checksum = "0d9d4d00c9c60e7c2c0b117590888e7344b685cfc446cbf1031db203ef641246"
 dependencies = [
  "log",
  "markup5ever",
- "match_token",
 ]
 
 [[package]]
@@ -4103,7 +4102,7 @@ dependencies = [
  "hyper 1.7.0",
  "libc",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -5272,24 +5271,13 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+checksum = "3f15cdbe61cdc5cb37f6a5f67561457f5f8e89b116b17bff8b9de1eb172d1dd5"
 dependencies = [
  "log",
  "tendril",
  "web_atoms",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -6548,32 +6536,13 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared 0.13.1",
+ "phf_shared",
  "serde",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -6582,18 +6551,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.5",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -6603,7 +6562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
+ "phf_shared",
 ]
 
 [[package]]
@@ -6612,20 +6571,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -7563,7 +7513,7 @@ dependencies = [
  "p521",
  "parking_lot",
  "percent-encoding",
- "phf 0.11.3",
+ "phf",
  "pixels",
  "pkcs8",
  "profile_traits",
@@ -7636,9 +7586,9 @@ dependencies = [
  "mozjs",
  "num-traits",
  "parking_lot",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "phf_shared 0.11.3",
+ "phf",
+ "phf_codegen",
+ "phf_shared",
  "regex",
  "serde_json",
  "servo_arc",
@@ -7767,15 +7717,15 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.33.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#7481d7f7afe698b1ad141755f6f525857da7bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#89ff0854f6e08b878d7ab6f07e91282db8fdcdc5"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
+ "phf",
+ "phf_codegen",
  "precomputed-hash",
  "rustc-hash 2.1.1",
  "servo_arc",
@@ -8074,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#7481d7f7afe698b1ad141755f6f525857da7bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#89ff0854f6e08b878d7ab6f07e91282db8fdcdc5"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8538,25 +8488,25 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.11.3",
+ "phf_shared",
  "precomputed-hash",
  "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -8603,7 +8553,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#7481d7f7afe698b1ad141755f6f525857da7bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#89ff0854f6e08b878d7ab6f07e91282db8fdcdc5"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8660,7 +8610,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#7481d7f7afe698b1ad141755f6f525857da7bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#89ff0854f6e08b878d7ab6f07e91282db8fdcdc5"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8669,12 +8619,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#7481d7f7afe698b1ad141755f6f525857da7bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#89ff0854f6e08b878d7ab6f07e91282db8fdcdc5"
 
 [[package]]
 name = "stylo_derive"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#7481d7f7afe698b1ad141755f6f525857da7bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#89ff0854f6e08b878d7ab6f07e91282db8fdcdc5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8686,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#7481d7f7afe698b1ad141755f6f525857da7bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#89ff0854f6e08b878d7ab6f07e91282db8fdcdc5"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8695,7 +8645,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#7481d7f7afe698b1ad141755f6f525857da7bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#89ff0854f6e08b878d7ab6f07e91282db8fdcdc5"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8712,12 +8662,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#7481d7f7afe698b1ad141755f6f525857da7bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#89ff0854f6e08b878d7ab6f07e91282db8fdcdc5"
 
 [[package]]
 name = "stylo_traits"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#7481d7f7afe698b1ad141755f6f525857da7bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#89ff0854f6e08b878d7ab6f07e91282db8fdcdc5"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9132,7 +9082,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#7481d7f7afe698b1ad141755f6f525857da7bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#89ff0854f6e08b878d7ab6f07e91282db8fdcdc5"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9145,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#7481d7f7afe698b1ad141755f6f525857da7bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#89ff0854f6e08b878d7ab6f07e91282db8fdcdc5"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -10014,12 +9964,12 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+checksum = "44b72896d90cfd22c495d0ee4960d3dd20ca64180895cb92cd5342ff7482a579"
 dependencies = [
- "phf 0.11.3",
- "phf_codegen 0.11.3",
+ "phf",
+ "phf_codegen",
  "string_cache",
  "string_cache_codegen",
 ]
@@ -11067,9 +11017,9 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xml5ever"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3f1e41afb31a75aef076563b0ad3ecc24f5bd9d12a72b132222664eb76b494"
+checksum = "8f34619344db8fc5f50002db40c735f494bbc2d019bcf45dcfa668acdc964433"
 dependencies = [
  "log",
  "markup5ever",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ gstreamer-video = "0.24"
 harfbuzz-sys = "0.6.1"
 headers = "0.4"
 hitrace = "0.1.5"
-html5ever = "0.35"
+html5ever = "0.36"
 http = "1.3"
 http-body-util = "0.1"
 hyper = "1.7"
@@ -101,7 +101,7 @@ log = "0.4.27"
 mach2 = "0.4"
 malloc_size_of = { package = "servo_malloc_size_of", path = "components/malloc_size_of" }
 malloc_size_of_derive = "0.1"
-markup5ever = "0.35"
+markup5ever = "0.36"
 memmap2 = "0.9.9"
 mime = "0.3.13"
 mime_guess = "2.0.5"
@@ -148,7 +148,7 @@ servo_arc = { git = "https://github.com/servo/stylo", branch = "2025-11-01" }
 skrifa = "0.37.0"
 smallvec = { version = "1.15", features = ["serde", "union"] }
 storage_traits = { path = "components/shared/storage" }
-string_cache = "0.8"
+string_cache = "0.9"
 strum = "0.27"
 strum_macros = "0.27"
 stylo = { git = "https://github.com/servo/stylo", branch = "2025-11-01" }
@@ -195,7 +195,7 @@ wio = "0.2"
 wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.68" }
 x25519-dalek = { version = "2.0.1", features = ["static_secrets"] }
 xi-unicode = "0.3.0"
-xml5ever = "0.35"
+xml5ever = "0.36"
 xpath = { path = "components/xpath" }
 
 # Force tikv-jemalloc-sys to build with at least -O1.

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -102,7 +102,7 @@ p384 = { workspace = true }
 p521 = { workspace = true }
 parking_lot = { workspace = true }
 percent-encoding = { workspace = true }
-phf = "0.11"
+phf = "0.13"
 pixels = { path = "../pixels" }
 pkcs8 = { workspace = true }
 profile_traits = { workspace = true }

--- a/components/script_bindings/Cargo.toml
+++ b/components/script_bindings/Cargo.toml
@@ -33,7 +33,7 @@ malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 num-traits = { workspace = true }
 parking_lot = { workspace = true }
-phf = "0.11"
+phf = "0.13"
 regex = { workspace = true }
 servo_arc = { workspace = true }
 servo_config = { path = "../config" }
@@ -47,8 +47,8 @@ webxr-api = { workspace = true, optional = true }
 xml5ever = { workspace = true }
 
 [build-dependencies]
-phf_codegen = "0.11"
-phf_shared = "0.11"
+phf_codegen = "0.13"
+phf_shared = "0.13"
 serde_json = { workspace = true }
 
 [features]

--- a/components/script_bindings/build.rs
+++ b/components/script_bindings/build.rs
@@ -46,7 +46,7 @@ fn main() {
         let parts = value.as_array().unwrap();
         map.entry(
             Bytes(key),
-            &format!(
+            format!(
                 "Interface {{ define: {}, enabled: {} }}",
                 parts[0].as_str().unwrap(),
                 parts[1].as_str().unwrap()

--- a/deny.toml
+++ b/deny.toml
@@ -191,12 +191,6 @@ skip = [
 
     # usvg depends on svgtypes, which depends on old version of kurbo
     "kurbo",
-
-    # duplicated by cssparser
-    "phf",
-    "phf_codegen",
-    "phf_generator",
-    "phf_shared",
 ]
 
 # github.com organizations to allow git sources for


### PR DESCRIPTION
Other than upgrading phf, phf_codegen and phf_shared to 0.13, this also upgrades html5ever, markup5ever and xml5ever to 0.36, string_cache to 0.9, and Stylo to https://github.com/servo/stylo/pull/266.

Testing: Not needed, no behavior change
Fixes: #40533
