### PR TITLE
script: Have `FetchResponseListener::process_response_eof` consume the listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8134,6 +8134,7 @@ dependencies = [
  "unicode-script",
  "url",
  "urlpattern",
+ "utf-8",
  "uuid",
  "webrender",
  "webrender_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ unicode-script = "0.5"
 unicode-segmentation = "1.12.0"
 url = "2.5"
 urlpattern = "0.3"
+utf-8 = "0.7"
 uuid = { version = "1.18.1", features = ["v4", "v5"] }
 vello = "0.6"
 vello_cpu = "0.0.4"

--- a/components/malloc_size_of/Cargo.toml
+++ b/components/malloc_size_of/Cargo.toml
@@ -38,6 +38,7 @@ unicode-bidi = { workspace = true }
 unicode-script = { workspace = true }
 url = { workspace = true }
 urlpattern = { workspace = true }
+utf-8 = { workspace = true }
 uuid = { workspace = true }
 webrender = { workspace = true }
 webrender_api = { workspace = true }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -885,6 +885,7 @@ malloc_size_of_is_0!(taffy::Layout);
 malloc_size_of_is_0!(unicode_bidi::Level);
 malloc_size_of_is_0!(unicode_script::Script);
 malloc_size_of_is_0!(urlpattern::UrlPattern);
+malloc_size_of_is_0!(utf8::Incomplete);
 
 macro_rules! malloc_size_of_is_webrender_malloc_size_of(
     ($($ty:ty),+) => (

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -141,7 +141,7 @@ unicode-script = { workspace = true }
 unicode-segmentation = { workspace = true }
 url = { workspace = true }
 urlpattern = { workspace = true }
-utf-8 = "0.7"
+utf-8 = { workspace = true }
 uuid = { workspace = true, features = ["serde"] }
 webdriver = { workspace = true }
 webgpu_traits = { workspace = true }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -1899,7 +1899,7 @@ impl Document {
             .insecure_requests_policy(self.insecure_requests_policy())
             .has_trustworthy_ancestor_origin(self.has_trustworthy_ancestor_or_current_origin());
         let callback = NetworkListener {
-            context: std::sync::Arc::new(Mutex::new(listener)),
+            context: std::sync::Arc::new(Mutex::new(Some(listener))),
             task_source: self
                 .owner_global()
                 .task_manager()
@@ -1920,7 +1920,7 @@ impl Document {
             .insecure_requests_policy(self.insecure_requests_policy())
             .has_trustworthy_ancestor_origin(self.has_trustworthy_ancestor_or_current_origin());
         let callback = NetworkListener {
-            context: std::sync::Arc::new(Mutex::new(listener)),
+            context: std::sync::Arc::new(Mutex::new(Some(listener))),
             task_source: self
                 .owner_global()
                 .task_manager()

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -9,8 +9,8 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::CStr;
 use std::ops::Index;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::{mem, ptr};
@@ -3326,13 +3326,10 @@ impl GlobalScope {
     pub(crate) fn fetch<Listener: FetchResponseListener>(
         &self,
         request_builder: RequestBuilder,
-        context: Arc<Mutex<Listener>>,
+        context: Listener,
         task_source: SendableTaskSource,
     ) {
-        let network_listener = NetworkListener {
-            context,
-            task_source,
-        };
+        let network_listener = NetworkListener::new(context, task_source);
         self.fetch_with_network_listener(request_builder, network_listener);
     }
 

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -310,7 +310,7 @@ impl FetchResponseListener for ImageContext {
             FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
         );
         if let Ok(response) = response {
-            network_listener::submit_timing(&self, &response, CanGc::note())
+            network_listener::submit_timing(&self, &response, CanGc::note());
         }
     }
 

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -1031,7 +1031,7 @@ impl FetchResponseListener for FaviconFetchContext {
             FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
         );
         if let Ok(response) = response {
-            submit_timing(&self, &response, CanGc::note())
+            submit_timing(&self, &response, CanGc::note());
         }
     }
 

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -17,7 +17,6 @@ use net_traits::image_cache::{
 use net_traits::request::{Destination, Initiator, RequestBuilder, RequestId};
 use net_traits::{
     FetchMetadata, FetchResponseMsg, NetworkError, ReferrerPolicy, ResourceFetchTiming,
-    ResourceTimingType,
 };
 use pixels::PixelFormat;
 use script_bindings::root::Dom;
@@ -538,7 +537,6 @@ impl HTMLLinkElement {
             link: Some(Trusted::new(self)),
             document: Trusted::new(&document),
             global: Trusted::new(&document.global()),
-            resource_timing: ResourceFetchTiming::new(ResourceTimingType::Resource),
             type_: LinkFetchContextType::Prefetch,
             response_body: vec![],
         };
@@ -671,7 +669,6 @@ impl HTMLLinkElement {
                     image_cache: window.image_cache(),
                     id,
                     link: Trusted::new(self),
-                    resource_timing: ResourceFetchTiming::new(ResourceTimingType::Resource),
                 };
                 document.fetch_background(request, fetch_context);
             },
@@ -999,8 +996,6 @@ struct FaviconFetchContext {
 
     /// The base url of the document that the `<link>` element belongs to.
     url: ServoUrl,
-
-    resource_timing: ResourceFetchTiming,
 }
 
 impl FetchResponseListener for FaviconFetchContext {
@@ -1027,26 +1022,17 @@ impl FetchResponseListener for FaviconFetchContext {
     }
 
     fn process_response_eof(
-        &mut self,
+        self,
         request_id: RequestId,
         response: Result<ResourceFetchTiming, NetworkError>,
     ) {
         self.image_cache.notify_pending_response(
             self.id,
-            FetchResponseMsg::ProcessResponseEOF(request_id, response),
+            FetchResponseMsg::ProcessResponseEOF(request_id, response.clone()),
         );
-    }
-
-    fn resource_timing_mut(&mut self) -> &mut ResourceFetchTiming {
-        &mut self.resource_timing
-    }
-
-    fn resource_timing(&self) -> &ResourceFetchTiming {
-        &self.resource_timing
-    }
-
-    fn submit_resource_timing(&mut self) {
-        submit_timing(self, CanGc::note())
+        if let Ok(response) = response {
+            submit_timing(&self, &response, CanGc::note())
+        }
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3597,7 +3597,7 @@ impl FetchResponseListener for HTMLMediaElementFetchListener {
         }
 
         if let Ok(response) = status {
-            network_listener::submit_timing(&self, &response, CanGc::note())
+            network_listener::submit_timing(&self, &response, CanGc::note());
         }
     }
 

--- a/components/script/dom/reportingendpoint.rs
+++ b/components/script/dom/reportingendpoint.rs
@@ -336,7 +336,7 @@ impl FetchResponseListener for CSPReportEndpointFetchListener {
         response: Result<ResourceFetchTiming, NetworkError>,
     ) {
         if let Ok(response) = response {
-            submit_timing(&self, &response, CanGc::note())
+            submit_timing(&self, &response, CanGc::note());
         }
     }
 

--- a/components/script/dom/workers/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/workers/dedicatedworkerglobalscope.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
-use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
@@ -491,12 +491,12 @@ impl DedicatedWorkerGlobalScope {
                     name: TaskSourceName::Networking,
                     canceller: Default::default(),
                 };
-                let context = Arc::new(Mutex::new(ScriptFetchContext::new(
+                let context = ScriptFetchContext::new(
                     Trusted::new(scope),
                     request.url.clone(),
                     worker.clone(),
                     policy_container,
-                )));
+                );
                 global_scope.fetch(request, context, task_source);
 
                 let reporter_name = format!("dedicated-worker-reporter-{}", worker_id);

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -54,7 +54,7 @@ use crate::dom::response::Response;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
 use crate::dom::window::Window;
 use crate::network_listener::{
-    self, FetchResponseListener, ResourceTimingListener, submit_timing_data,
+    self, FetchResponseListener, NetworkListener, ResourceTimingListener, submit_timing_data,
 };
 use crate::realms::{InRealm, enter_realm};
 use crate::script_runtime::CanGc;
@@ -202,7 +202,6 @@ pub(crate) fn Fetch(
     };
     // Step 3. Let request be requestObject’s request.
     let request = request_object.get_request();
-    let timing_type = request.timing_type();
     let request_id = request.id;
 
     // Step 4. If requestObject’s signal is aborted, then:
@@ -240,26 +239,26 @@ pub(crate) fn Fetch(
 
     // Step 9. Let locallyAborted be false.
     // Step 10. Let controller be null.
-    let fetch_context = Arc::new(Mutex::new(FetchContext {
+    let fetch_context = FetchContext {
         fetch_promise: Some(TrustedPromise::new(promise.clone())),
         response_object: Trusted::new(&*response),
         request: Trusted::new(&*request_object),
         global: Trusted::new(global),
-        resource_timing: ResourceFetchTiming::new(timing_type),
         locally_aborted: false,
         canceller: FetchCanceller::new(request_id, global.core_resource_thread()),
-    }));
-
-    // Step 11. Add the following abort steps to requestObject’s signal:
-    signal.add(&AbortAlgorithm::Fetch(fetch_context.clone()));
-
-    // Step 12. Set controller to the result of calling fetch given request and
-    // processResponse given response being these steps:
-    global.fetch(
-        request_init,
+    };
+    let network_listener = NetworkListener::new(
         fetch_context,
         global.task_manager().networking_task_source().to_sendable(),
     );
+    let fetch_context = network_listener.context.clone();
+
+    // Step 11. Add the following abort steps to requestObject’s signal:
+    signal.add(&AbortAlgorithm::Fetch(fetch_context));
+
+    // Step 12. Set controller to the result of calling fetch given request and
+    // processResponse given response being these steps:
+    global.fetch_with_network_listener(request_init, network_listener);
 
     // Step 13. Return p.
     promise
@@ -429,11 +428,10 @@ impl DeferredFetchRecord {
         self.invoke_state.set(DeferredFetchRecordInvokeState::Sent);
         // Step 3. Fetch deferredRecord’s request.
         let url = self.request.url().clone();
-        let fetch_later_listener = Arc::new(Mutex::new(FetchLaterListener {
+        let fetch_later_listener = FetchLaterListener {
             url,
-            resource_timing: ResourceFetchTiming::new(ResourceTimingType::Resource),
             global: self.global.clone(),
-        }));
+        };
         let global = self.global.root();
         let request_init = request_init_from_request(self.request.clone(), &global);
         global.fetch(
@@ -452,8 +450,6 @@ pub(crate) struct FetchContext {
     response_object: Trusted<Response>,
     request: Trusted<Request>,
     global: Trusted<GlobalScope>,
-    #[no_trace]
-    resource_timing: ResourceFetchTiming,
     locally_aborted: bool,
     canceller: FetchCanceller,
 }
@@ -585,29 +581,21 @@ impl FetchResponseListener for FetchContext {
     }
 
     fn process_response_eof(
-        &mut self,
+        self,
         _: RequestId,
-        _response: Result<ResourceFetchTiming, NetworkError>,
+        response: Result<ResourceFetchTiming, NetworkError>,
     ) {
-        let response = self.response_object.root();
-        let _ac = enter_realm(&*response);
-        response.finish(CanGc::note());
+        let response_object = self.response_object.root();
+        let _ac = enter_realm(&*response_object);
+        response_object.finish(CanGc::note());
         // TODO
         // ... trailerObject is not supported in Servo yet.
-    }
 
-    fn resource_timing_mut(&mut self) -> &mut ResourceFetchTiming {
-        &mut self.resource_timing
-    }
-
-    fn resource_timing(&self) -> &ResourceFetchTiming {
-        &self.resource_timing
-    }
-
-    fn submit_resource_timing(&mut self) {
         // navigation submission is handled in servoparser/mod.rs
-        if self.resource_timing.timing_type == ResourceTimingType::Resource {
-            network_listener::submit_timing(self, CanGc::note())
+        if let Ok(response) = response {
+            if response.timing_type == ResourceTimingType::Resource {
+                network_listener::submit_timing(&self, &response, CanGc::note());
+            }
         }
     }
 
@@ -633,8 +621,6 @@ impl ResourceTimingListener for FetchContext {
 struct FetchLaterListener {
     /// URL of this request.
     url: ServoUrl,
-    /// Timing data for this resource.
-    resource_timing: ResourceFetchTiming,
     /// The global object fetching the report uri violation
     global: Trusted<GlobalScope>,
 }
@@ -657,23 +643,13 @@ impl FetchResponseListener for FetchLaterListener {
     }
 
     fn process_response_eof(
-        &mut self,
+        self,
         _: RequestId,
         response: Result<ResourceFetchTiming, NetworkError>,
     ) {
-        _ = response;
-    }
-
-    fn resource_timing_mut(&mut self) -> &mut ResourceFetchTiming {
-        &mut self.resource_timing
-    }
-
-    fn resource_timing(&self) -> &ResourceFetchTiming {
-        &self.resource_timing
-    }
-
-    fn submit_resource_timing(&mut self) {
-        network_listener::submit_timing(self, CanGc::note())
+        if let Ok(response) = response {
+            network_listener::submit_timing(&self, &response, CanGc::note())
+        }
     }
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -648,7 +648,7 @@ impl FetchResponseListener for FetchLaterListener {
         response: Result<ResourceFetchTiming, NetworkError>,
     ) {
         if let Ok(response) = response {
-            network_listener::submit_timing(&self, &response, CanGc::note())
+            network_listener::submit_timing(&self, &response, CanGc::note());
         }
     }
 

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -29,12 +29,19 @@ pub(crate) trait ResourceTimingListener {
 
 pub(crate) fn submit_timing<T: ResourceTimingListener + FetchResponseListener>(
     listener: &T,
+    resource_timing: &ResourceFetchTiming,
     can_gc: CanGc,
 ) {
-    if listener.resource_timing().timing_type != ResourceTimingType::Resource {
+    // TODO timing check https://w3c.github.io/resource-timing/#dfn-timing-allow-check
+    //
+    // TODO Resources for which the fetch was initiated, but was later aborted
+    // (e.g. due to a network error) MAY be included as PerformanceResourceTiming
+    // objects in the Performance Timeline and MUST contain initialized attribute
+    // values for processed substeps of the processing model.
+    if resource_timing.timing_type != ResourceTimingType::Resource {
         warn!(
             "Submitting non-resource ({:?}) timing as resource",
-            listener.resource_timing().timing_type
+            resource_timing.timing_type
         );
         return;
     }
@@ -49,7 +56,7 @@ pub(crate) fn submit_timing<T: ResourceTimingListener + FetchResponseListener>(
         &listener.resource_timing_global(),
         url,
         initiator_type,
-        listener.resource_timing(),
+        resource_timing,
         can_gc,
     );
 }
@@ -85,70 +92,64 @@ pub(crate) trait FetchResponseListener: Send + 'static {
     );
     fn process_response_chunk(&mut self, request_id: RequestId, chunk: Vec<u8>);
     fn process_response_eof(
-        &mut self,
+        self,
         request_id: RequestId,
         response: Result<ResourceFetchTiming, NetworkError>,
     );
-    fn resource_timing(&self) -> &ResourceFetchTiming;
-    fn resource_timing_mut(&mut self) -> &mut ResourceFetchTiming;
-    fn submit_resource_timing(&mut self);
     fn process_csp_violations(&mut self, request_id: RequestId, violations: Vec<Violation>);
 }
 
 /// An off-thread sink for async network event tasks. All such events are forwarded to
 /// a target thread, where they are invoked on the provided context object.
 pub(crate) struct NetworkListener<Listener: FetchResponseListener> {
-    pub(crate) context: Arc<Mutex<Listener>>,
+    pub(crate) context: Arc<Mutex<Option<Listener>>>,
     pub(crate) task_source: SendableTaskSource,
 }
 
 impl<Listener: FetchResponseListener> NetworkListener<Listener> {
+    pub(crate) fn new(context: Listener, task_source: SendableTaskSource) -> Self {
+        Self {
+            context: Arc::new(Mutex::new(Some(context))),
+            task_source,
+        }
+    }
+
     pub(crate) fn notify(&mut self, message: FetchResponseMsg) {
         let context = self.context.clone();
-        self.task_source.queue(task!(network_listener_response: move || {
-            let mut context = context.lock().unwrap();
+        self.task_source
+            .queue(task!(network_listener_response: move || {
+                let mut context = context.lock().unwrap();
+                let Some(fetch_listener) = &mut *context else {
+                    return;
+                };
 
-            let fetch_listener = &mut *context;
-            if !fetch_listener.should_invoke() {
-                return;
-            }
+                if !fetch_listener.should_invoke() {
+                    return;
+                }
 
-            match message {
-                FetchResponseMsg::ProcessRequestBody(request_id) => {
-                    fetch_listener.process_request_body(request_id)
-                },
-                FetchResponseMsg::ProcessRequestEOF(request_id) => {
-                    fetch_listener.process_request_eof(request_id)
-                },
-                FetchResponseMsg::ProcessResponse(request_id, meta) => {
-                    fetch_listener.process_response(request_id, meta)
-                },
-                FetchResponseMsg::ProcessResponseChunk(request_id, data) => {
-                    fetch_listener.process_response_chunk(request_id, data.0)
-                },
-                FetchResponseMsg::ProcessResponseEOF(request_id, data) => {
-                    match data {
-                        Ok(ref response_resource_timing) => {
-                            // update listener with values from response
-                            *fetch_listener.resource_timing_mut() = response_resource_timing.clone();
-                            fetch_listener
-                                .process_response_eof(request_id, Ok(response_resource_timing.clone()));
-                            // TODO timing check https://w3c.github.io/resource-timing/#dfn-timing-allow-check
-
-                            fetch_listener.submit_resource_timing();
-                        },
-                        // TODO Resources for which the fetch was initiated, but was later aborted
-                        // (e.g. due to a network error) MAY be included as PerformanceResourceTiming
-                        // objects in the Performance Timeline and MUST contain initialized attribute
-                        // values for processed substeps of the processing model.
-                        Err(error) => fetch_listener.process_response_eof(request_id, Err(error)),
-                    }
-                },
-                FetchResponseMsg::ProcessCspViolations(request_id, violations) => {
-                    fetch_listener.process_csp_violations(request_id, violations)
-                },
-            }
-        }));
+                match message {
+                    FetchResponseMsg::ProcessRequestBody(request_id) => {
+                        fetch_listener.process_request_body(request_id)
+                    },
+                    FetchResponseMsg::ProcessRequestEOF(request_id) => {
+                        fetch_listener.process_request_eof(request_id)
+                    },
+                    FetchResponseMsg::ProcessResponse(request_id, meta) => {
+                        fetch_listener.process_response(request_id, meta)
+                    },
+                    FetchResponseMsg::ProcessResponseChunk(request_id, data) => {
+                        fetch_listener.process_response_chunk(request_id, data.0)
+                    },
+                    FetchResponseMsg::ProcessResponseEOF(request_id, resource_timing_result) => {
+                        if let Some(fetch_listener) = context.take() {
+                            fetch_listener.process_response_eof(request_id, resource_timing_result);
+                        };
+                    },
+                    FetchResponseMsg::ProcessCspViolations(request_id, violations) => {
+                        fetch_listener.process_csp_violations(request_id, violations)
+                    },
+                }
+            }));
     }
 
     pub(crate) fn into_callback(mut self) -> BoxedFetchCallback {

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -1364,7 +1364,7 @@ impl FetchResponseListener for ModuleContext {
         }
 
         if let Ok(response) = response {
-            network_listener::submit_timing(&self, &response, CanGc::note())
+            network_listener::submit_timing(&self, &response, CanGc::note());
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3657,8 +3657,8 @@ impl ScriptThread {
             .position(|&(pipeline_id, _)| pipeline_id == id);
 
         if let Some(idx) = idx {
-            let (_, mut ctxt) = self.incomplete_parser_contexts.0.borrow_mut().remove(idx);
-            ctxt.process_response_eof(request_id, eof);
+            let (_, context) = self.incomplete_parser_contexts.0.borrow_mut().remove(idx);
+            context.process_response_eof(request_id, eof);
         }
     }
 


### PR DESCRIPTION
The goal of this change is to prevent having to copy so much data out of
listeners when a fetch completes, which will be particularly important
for off-the-main thread parsing of CSS (see #22478). This change has
pros and cons:

Pros:
 - This makes the design of the `FetchResponseListener` a great deal simpler.
   They no longer individually store a dummy `ResourceFetchTiming` that is
   only replaced right before `process_response_eof`.
 - The creation of the `Arc<Mutex<FetchResponseListener>>` in the
   `NetworkListener` is abstracted away from clients and now they just
   pass the `FetchResponseListener` to the fetch methods in the global.

Cons:
 - Now each `FetchResponseListener` must explicitly call `submit_timing`
   instead of having the `NetworkListener` do it. This is arguably a bit
   easier to follow in the code.
 - Since the internal data of the `NetworkListener` is now an
   `Arc<Mutex<Option<FetchResponseListener>>>`, when the fetching code
   needs to share state with the `NetworkListener` it either needs to
   share an `Option` or some sort of internal state. In one case I've
   stored the `Option` and in another case, I've stored a new inner
   shared value.

Testing: This should not change observable behavior and is thus covered by existing tests.
Fixes: #22550
