### PR TITLE
bump(deps): bump servo-media from 5b788a9 to 8aca9f7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7877,7 +7877,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5b788a91d4d69772a4c00f53e7231008df70df9a"
+source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -7890,7 +7890,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#5b788a91d4d69772a4c00f53e7231008df70df9a"
+source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -7911,7 +7911,7 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5b788a91d4d69772a4c00f53e7231008df70df9a"
+source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7921,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5b788a91d4d69772a4c00f53e7231008df70df9a"
+source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -7935,7 +7935,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5b788a91d4d69772a4c00f53e7231008df70df9a"
+source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -7968,7 +7968,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5b788a91d4d69772a4c00f53e7231008df70df9a"
+source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -7978,7 +7978,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5b788a91d4d69772a4c00f53e7231008df70df9a"
+source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
 dependencies = [
  "glib",
  "gstreamer",
@@ -7992,7 +7992,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5b788a91d4d69772a4c00f53e7231008df70df9a"
+source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8007,7 +8007,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5b788a91d4d69772a4c00f53e7231008df70df9a"
+source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -8019,7 +8019,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5b788a91d4d69772a4c00f53e7231008df70df9a"
+source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
 dependencies = [
  "uuid",
 ]
@@ -8027,12 +8027,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5b788a91d4d69772a4c00f53e7231008df70df9a"
+source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5b788a91d4d69772a4c00f53e7231008df70df9a"
+source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
 dependencies = [
  "log",
  "servo-media-streams",

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -2225,7 +2225,7 @@ impl HTMLMediaElement {
         // Step 4.
         let previous_duration = self.duration.get();
         if let Some(duration) = metadata.duration {
-            self.duration.set(duration.as_secs() as f64);
+            self.duration.set(duration.as_secs_f64());
         } else {
             self.duration.set(f64::INFINITY);
         }
@@ -2343,8 +2343,7 @@ impl HTMLMediaElement {
         }
     }
 
-    fn playback_position_changed(&self, position: u64) {
-        let position = position as f64;
+    fn playback_position_changed(&self, position: f64) {
         let _ = self
             .played
             .borrow_mut()


### PR DESCRIPTION
Updated the `PlayerEvent::PositionChanged/SeekDone` events to support precise position timestamps (u64 -> f64).
    
Also set precise time value (seconds with fractional part) for the HTMLMediaElement `duration` from media metadata to sync with `PlayerEvent` changes.

servo-media:
- Pass precise position timestamp within PlayerEvent (https://github.com/servo/media/pull/460)

Testing: No expected changes in test results