### PR TITLE
script: Choose correct document for xpath queries

### DIFF
--- a/tests/wpt/mozilla/meta/mozilla/xpathmark-ft.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/xpathmark-ft.html.ini
@@ -1,90 +1,15 @@
 [xpathmark-ft.html]
   expected: ERROR
-  [Expected results for //L/*]
-    expected: FAIL
-
-  [Expected results for //L/parent::*]
-    expected: FAIL
-
-  [Expected results for //L/descendant::*]
-    expected: FAIL
-
-  [Expected results for //L/descendant-or-self::*]
-    expected: FAIL
-
-  [Expected results for //L/ancestor::*]
-    expected: FAIL
-
-  [Expected results for //L/ancestor-or-self::*]
-    expected: FAIL
-
-  [Expected results for //L/following-sibling::*]
-    expected: FAIL
-
-  [Expected results for //L/preceding-sibling::*]
-    expected: FAIL
-
   [Expected results for //L/following::*]
     expected: FAIL
 
   [Expected results for //L/preceding::*]
     expected: FAIL
 
-  [Expected results for //L/self::* ]
-    expected: FAIL
-
-  [Expected results for //L/@id/parent::*]
-    expected: FAIL
-
-  [Expected results for //*[L\]]
-    expected: FAIL
-
-  [Expected results for //*[parent::L\]]
-    expected: FAIL
-
-  [Expected results for //*[descendant::L\]]
-    expected: FAIL
-
-  [Expected results for //*[descendant-or-self::L\]]
-    expected: FAIL
-
-  [Expected results for //*[ancestor::L\]]
-    expected: FAIL
-
-  [Expected results for //*[ancestor-or-self::L\]]
-    expected: FAIL
-
-  [Expected results for //*[following-sibling::L\]]
-    expected: FAIL
-
-  [Expected results for //*[preceding-sibling::L\]]
-    expected: FAIL
-
   [Expected results for //*[following::L\]]
     expected: FAIL
 
   [Expected results for //*[preceding::L\]]
-    expected: FAIL
-
-  [Expected results for //*[self::L\]]
-    expected: FAIL
-
-  [Expected results for //L/text()]
-    expected: FAIL
-
-  [Expected results for //L/comment()]
-    expected: FAIL
-
-  [Expected results for  //L/processing-instruction()]
-    expected: FAIL
-
-  [Expected results for //L/processing-instruction("myPI")]
-    expected: FAIL
-
-  [Expected results for //L/node()]
-    expected: FAIL
-
-  [Expected results for //L/N]
     expected: FAIL
 
   [Expected results for //*[child::* and preceding::Q\]]
@@ -96,22 +21,10 @@
   [Expected results for //*[preceding::L or following::L\]]
     expected: FAIL
 
-  [Expected results for //L/ancestor::* | //L/descendant::*]
-    expected: FAIL
-
   [Expected results for //*[string-length(translate(normalize-space(.)," ","")) > 100\]]
     expected: FAIL
 
-  [Expected results for //L/child::*[last()\]]
-    expected: FAIL
-
-  [Expected results for //L/descendant::*[4\]]
-    expected: FAIL
-
   [Expected results for //L/ancestor::*[2\]]
-    expected: FAIL
-
-  [Expected results for //L/following-sibling::*[1\]]
     expected: FAIL
 
   [Expected results for //L/preceding-sibling::*[1\]]


### PR DESCRIPTION
The result of an xpath query can depend on whether or not the document is a HTMLDocument. We should always use the document that `document.evaluate` was called on. Instead, we were using the document of the relevant window. This makes a difference when a script creates a document and calls `document.evaluate` on that.

Testing: New tests start to pass

