### PR TITLE
tests: Remove duplicate xpath test

### DIFF
--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14720,7 +14720,7 @@
      ]
     ],
     "xpathmark-ft.html": [
-     "8221da5d372893d379781082df777a9ff6f2e5fd",
+     "35e88ea487c18800a46f23de85bfa93cd53bef50",
      [
       null,
       {}

--- a/tests/wpt/mozilla/meta/mozilla/xpathmark-ft.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/xpathmark-ft.html.ini
@@ -1,5 +1,4 @@
 [xpathmark-ft.html]
-  expected: ERROR
   [Expected results for //L/following::*]
     expected: FAIL
 

--- a/tests/wpt/mozilla/tests/mozilla/xpathmark-ft.html
+++ b/tests/wpt/mozilla/tests/mozilla/xpathmark-ft.html
@@ -160,10 +160,6 @@ function run_tests(xml_document) {
       "query": "//L/N",
       "expected": [n[14]]
     },
-    {
-      "query": "//L/*",
-      "expected": [n[13], n[14], n[17]]
-    },
     // Operators
     {
       "query": "//*[child::* and preceding::Q]",


### PR DESCRIPTION
The test query `//L/*` is present twice in the xpathmark-FT test suite. Our WPT harness was complaining about that, so I've removed the second test instance.

Depends on https://github.com/servo/servo/pull/40564
Testing: The relevant test is now `OK`

