### PR TITLE
net/devtools: Expose TLS security info to DevTools network panel

### DIFF
--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -501,6 +501,7 @@ impl DevtoolsInstance {
             NetworkEvent::HttpRequest(req) => req.browsing_context_id,
             NetworkEvent::HttpRequestUpdate(req) => req.browsing_context_id,
             NetworkEvent::HttpResponse(resp) => resp.browsing_context_id,
+            NetworkEvent::SecurityInfo(update) => update.browsing_context_id,
         };
 
         let Some(browsing_context_actor_name) = self.browsing_contexts.get(&browsing_context_id)

--- a/components/devtools/network_handler.rs
+++ b/components/devtools/network_handler.rs
@@ -85,5 +85,19 @@ pub(crate) fn handle_network_event(
                 );
             }
         },
+        NetworkEvent::SecurityInfo(update) => {
+            actor.update_security_info(update.security_info);
+            let resource = actor.resource_updates();
+            let watcher_actor = actors.find::<WatcherActor>(&watcher_name);
+
+            for stream in &mut connections {
+                watcher_actor.resource_array(
+                    resource.clone(),
+                    "network-event".to_string(),
+                    ResourceArrayType::Updated,
+                    stream,
+                );
+            }
+        },
     }
 }

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -47,7 +47,7 @@ use crate::fetch::headers::determine_nosniff;
 use crate::filemanager_thread::FileManager;
 use crate::http_loader::{
     HttpState, determine_requests_referrer, http_fetch, send_early_httprequest_to_devtools,
-    send_response_to_devtools, set_default_accept,
+    send_response_to_devtools, send_security_info_to_devtools, set_default_accept,
 };
 use crate::protocols::{ProtocolRegistry, is_url_potentially_trustworthy};
 use crate::request_interceptor::RequestInterceptor;
@@ -773,6 +773,7 @@ pub async fn main_fetch(
     target.process_response(request, &response);
     // Send Response to Devtools
     send_response_to_devtools(request, context, &response, None);
+    send_security_info_to_devtools(request, context, &response);
 
     // Step 23.
     if !response_loaded {

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -377,6 +377,67 @@ impl FetchTaskTarget for IpcSender<FetchResponseMsg> {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TlsSecurityState {
+    /// The connection used to fetch this resource was not secure.
+    #[default]
+    Insecure,
+    /// This resource was transferred over a connection that used weak encryption.
+    Weak,
+    /// A security error prevented the resource from being loaded.
+    Broken,
+    /// The connection used to fetch this resource was secure.
+    Secure,
+}
+
+impl Display for TlsSecurityState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let text = match self {
+            TlsSecurityState::Insecure => "insecure",
+            TlsSecurityState::Weak => "weak",
+            TlsSecurityState::Broken => "broken",
+            TlsSecurityState::Secure => "secure",
+        };
+        f.write_str(text)
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+pub struct TlsSecurityInfo {
+    // "insecure", "weak", "broken", "secure".
+    #[serde(default)]
+    pub state: TlsSecurityState,
+    // Reasons explaining why the negotiated parameters are considered weak.
+    pub weakness_reasons: Vec<String>,
+    // Negotiated TLS protocol version (e.g. "TLS 1.3").
+    pub protocol_version: Option<String>,
+    // Negotiated cipher suite identifier.
+    pub cipher_suite: Option<String>,
+    // Negotiated key exchange group.
+    pub kea_group_name: Option<String>,
+    // Signature scheme used for certificate verification.
+    pub signature_scheme_name: Option<String>,
+    // Negotiated ALPN protocol (e.g. "h2" for HTTP/2, "http/1.1" for HTTP/1.1).
+    pub alpn_protocol: Option<String>,
+    // Server certificate chain encoded as DER bytes, leaf first.
+    pub certificate_chain_der: Vec<Vec<u8>>,
+    // Certificate Transparency status, if provided.
+    pub certificate_transparency: Option<String>,
+    // HTTP Strict Transport Security flag.
+    pub hsts: bool,
+    // HTTP Public Key Pinning flag (always false, kept for parity).
+    pub hpkp: bool,
+    // Encrypted Client Hello usage flag.
+    pub used_ech: bool,
+    // Delegated credentials usage flag.
+    pub used_delegated_credentials: bool,
+    // OCSP stapling usage flag.
+    pub used_ocsp: bool,
+    // Private DNS usage flag.
+    pub used_private_dns: bool,
+}
+
 impl FetchTaskTarget for IpcSender<WebSocketNetworkEvent> {
     fn process_request_body(&mut self, _: &Request) {}
     fn process_request_eof(&mut self, _: &Request) {}
@@ -900,6 +961,8 @@ pub struct Metadata {
     pub timing: Option<ResourceFetchTiming>,
     /// True if the request comes from a redirection
     pub redirected: bool,
+    /// Detailed TLS metadata associated with the response, if any.
+    pub tls_security_info: Option<TlsSecurityInfo>,
 }
 
 impl Metadata {
@@ -917,6 +980,7 @@ impl Metadata {
             referrer_policy: ReferrerPolicy::EmptyString,
             timing: None,
             redirected: false,
+            tls_security_info: None,
         }
     }
 

--- a/components/shared/net/response.rs
+++ b/components/shared/net/response.rs
@@ -18,7 +18,7 @@ use crate::fetch::headers::extract_mime_type_as_mime;
 use crate::http_status::HttpStatus;
 use crate::{
     FetchMetadata, FilteredMetadata, Metadata, NetworkError, ReferrerPolicy, ResourceFetchTiming,
-    ResourceTimingType,
+    ResourceTimingType, TlsSecurityInfo,
 };
 
 /// [Response type](https://fetch.spec.whatwg.org/#concept-response-type)
@@ -103,6 +103,7 @@ pub struct Response {
     pub body: Arc<Mutex<ResponseBody>>,
     pub cache_state: CacheState,
     pub https_state: HttpsState,
+    pub tls_security_info: Option<TlsSecurityInfo>,
     pub referrer: Option<ServoUrl>,
     pub referrer_policy: ReferrerPolicy,
     /// [CORS-exposed header-name list](https://fetch.spec.whatwg.org/#concept-response-cors-exposed-header-name-list)
@@ -137,6 +138,7 @@ impl Response {
             body: Arc::new(Mutex::new(ResponseBody::Empty)),
             cache_state: CacheState::None,
             https_state: HttpsState::None,
+            tls_security_info: None,
             referrer: None,
             referrer_policy: ReferrerPolicy::EmptyString,
             cors_exposed_header_name_list: vec![],
@@ -169,6 +171,7 @@ impl Response {
             body: Arc::new(Mutex::new(ResponseBody::Empty)),
             cache_state: CacheState::None,
             https_state: HttpsState::None,
+            tls_security_info: None,
             referrer: None,
             referrer_policy: ReferrerPolicy::EmptyString,
             cors_exposed_header_name_list: vec![],
@@ -308,6 +311,9 @@ impl Response {
             metadata.referrer.clone_from(&response.referrer);
             metadata.referrer_policy = response.referrer_policy;
             metadata.redirected = response.actual_response().url_list.len() > 1;
+            metadata
+                .tls_security_info
+                .clone_from(&response.tls_security_info);
             metadata
         }
 


### PR DESCRIPTION
First PR for #40232.

Implement the getSecurityInfo protocol message to allow DevTools clients
to inspect TLS connection details for HTTPS requests, including:
- Protocol version (TLS 1.2/1.3)
- Cipher suite
- Key exchange group
- ALPN protocol
- HSTS and ECH status
- Security state

Security state is simplified (secure/insecure only) and certificate
details are stubbed out; both will be completed in follow-up work.