### PR TITLE
script: Introduce HtmlSerialize to support extensible node serialization

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3240,7 +3240,7 @@ impl Node {
         let mut writer = vec![];
         xml_serialize::serialize(
             &mut writer,
-            &HtmlSerialize::new(&self),
+            &HtmlSerialize::new(self),
             xml_serialize::SerializeOpts { traversal_scope },
         )
         .map_err(|error| {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -119,6 +119,7 @@ use crate::dom::pointerevent::{PointerEvent, PointerId};
 use crate::dom::processinginstruction::ProcessingInstruction;
 use crate::dom::range::WeakRangeVec;
 use crate::dom::raredata::NodeRareData;
+use crate::dom::servoparser::html::HtmlSerialize;
 use crate::dom::servoparser::{ServoParser, serialize_html_fragment};
 use crate::dom::shadowroot::{IsUserAgentWidget, LayoutShadowRootHelpers, ShadowRoot};
 use crate::dom::svg::svgsvgelement::{LayoutSVGSVGElementHelpers, SVGSVGElement};
@@ -3239,7 +3240,7 @@ impl Node {
         let mut writer = vec![];
         xml_serialize::serialize(
             &mut writer,
-            &self,
+            &HtmlSerialize::new(&self),
             xml_serialize::SerializeOpts { traversal_scope },
         )
         .map_err(|error| {

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -365,15 +365,23 @@ pub(crate) fn serialize_html_fragment<S: Serializer>(
     Ok(())
 }
 
-// TODO: This trait confuses the concepts of XML serialization and HTML serialization and
-// the impl should go away eventually
-impl Serialize for &Node {
+pub(crate) struct HtmlSerialize<'a> {
+    node: &'a Node,
+}
+
+impl<'a> HtmlSerialize<'a> {
+    pub(crate) fn new(node: &'a Node) -> HtmlSerialize<'a> {
+        HtmlSerialize { node }
+    }
+}
+
+impl Serialize for HtmlSerialize<'_> {
     fn serialize<S>(&self, serializer: &mut S, traversal_scope: TraversalScope) -> io::Result<()>
     where
         S: Serializer,
     {
         serialize_html_fragment(
-            self,
+            self.node,
             serializer,
             traversal_scope,
             false,

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -90,7 +90,7 @@ use crate::script_runtime::{CanGc, IntroductionType};
 use crate::script_thread::ScriptThread;
 
 mod async_html;
-mod html;
+pub(crate) mod html;
 mod prefetch;
 mod xml;
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1681,7 +1681,7 @@ fn serialize_document(doc: &Document) -> Fallible<DOMString> {
     let mut writer = vec![];
     match serialize(
         &mut writer,
-        &HtmlSerialize::new(&doc.upcast::<Node>()),
+        &HtmlSerialize::new(doc.upcast::<Node>()),
         SerializeOpts::default(),
     ) {
         Ok(_) => Ok(DOMString::from(String::from_utf8(writer).unwrap())),

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -66,6 +66,7 @@ use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::progressevent::ProgressEvent;
 use crate::dom::readablestream::ReadableStream;
 use crate::dom::servoparser::ServoParser;
+use crate::dom::servoparser::html::HtmlSerialize;
 use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::dom::xmlhttprequesteventtarget::XMLHttpRequestEventTarget;
@@ -1678,7 +1679,11 @@ impl XHRTimeoutCallback {
 
 fn serialize_document(doc: &Document) -> Fallible<DOMString> {
     let mut writer = vec![];
-    match serialize(&mut writer, &doc.upcast::<Node>(), SerializeOpts::default()) {
+    match serialize(
+        &mut writer,
+        &HtmlSerialize::new(&doc.upcast::<Node>()),
+        SerializeOpts::default(),
+    ) {
         Ok(_) => Ok(DOMString::from(String::from_utf8(writer).unwrap())),
         Err(_) => Err(Error::InvalidState(None)),
     }

--- a/components/script/dom/xmlserializer.rs
+++ b/components/script/dom/xmlserializer.rs
@@ -59,7 +59,7 @@ impl XMLSerializerMethods<crate::DomTypeHolder> for XMLSerializer {
         let mut writer = vec![];
         match serialize(
             &mut writer,
-            &HtmlSerialize::new(&root),
+            &HtmlSerialize::new(root),
             SerializeOpts {
                 traversal_scope: TraversalScope::IncludeNode,
             },

--- a/components/script/dom/xmlserializer.rs
+++ b/components/script/dom/xmlserializer.rs
@@ -12,6 +12,7 @@ use crate::dom::bindings::reflector::{Reflector, reflect_dom_object_with_proto};
 use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::node::Node;
+use crate::dom::servoparser::html::HtmlSerialize;
 use crate::dom::window::Window;
 use crate::script_runtime::CanGc;
 
@@ -58,7 +59,7 @@ impl XMLSerializerMethods<crate::DomTypeHolder> for XMLSerializer {
         let mut writer = vec![];
         match serialize(
             &mut writer,
-            &root,
+            &HtmlSerialize::new(&root),
             SerializeOpts {
                 traversal_scope: TraversalScope::IncludeNode,
             },


### PR DESCRIPTION
XML and HTML serialization routines relied on a single, shared implementation of the `markup5ever::Serialize` trait for the DOM Node type.

These changes introduce the HtmlSerialize type to make it possible to support XML serialization and fix other issues.

Testing: It does not change any behavior and it builds.
Fixes: #40552
