### PR TITLE
script: Return only a `JoinHandle` from `ScriptThread` constructor

### DIFF
--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -329,7 +329,7 @@ impl Pipeline {
                     let background_hang_monitor_register = state
                         .background_monitor_register
                         .expect("Couldn't start content, no background monitor has been initiated");
-                    let (_, join_handle) = STF::create(
+                    let join_handle = STF::create(
                         initial_script_state,
                         new_pipeline_info,
                         state.layout_factory,

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -377,9 +377,6 @@ pub(crate) struct ScriptThreadSenders {
 
     #[no_trace]
     pub(crate) devtools_client_to_script_thread_sender: IpcSender<DevtoolScriptControlMsg>,
-
-    #[no_trace]
-    pub(crate) content_process_shutdown_sender: Sender<()>,
 }
 
 #[derive(JSTraceable)]

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -85,7 +85,7 @@ pub use keyboard_types::{
 };
 use layout::LayoutFactoryImpl;
 use layout_api::ScriptThreadFactory;
-use log::{Log, Metadata, Record, debug, error, warn};
+use log::{Log, Metadata, Record, debug, warn};
 use media::{GlApi, NativeDisplay, WindowGLContext};
 use net::image_cache::ImageCacheFactoryImpl;
 use net::protocols::ProtocolRegistry;
@@ -1118,7 +1118,7 @@ pub fn run_content_process(token: String) {
                 );
 
             let layout_factory = Arc::new(LayoutFactoryImpl());
-            let (script_thread_exit_receiver, script_join_handle) = script::ScriptThread::create(
+            let script_join_handle = script::ScriptThread::create(
                 new_event_loop_info.initial_script_state,
                 new_event_loop_info.new_pipeline_info,
                 layout_factory,
@@ -1128,15 +1128,6 @@ pub fn run_content_process(token: String) {
                 background_hang_monitor_register,
             );
 
-            // TODO: Could this just use the JoinHandle here?
-            match script_thread_exit_receiver.recv() {
-                Ok(()) => {},
-                Err(_) => error!("Script-thread shut-down unexpectedly"),
-            }
-
-            // Since we have waited for the ScriptThread to complete, we know it is has already
-            // exited or will soon so we can join first on the script, and then on the BHM worker
-            // threads.
             script_join_handle
                 .join()
                 .expect("Failed to join on the script thread.");

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -25,7 +25,6 @@ use base::generic_channel::GenericSender;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use bitflags::bitflags;
 use compositing_traits::CrossProcessCompositorApi;
-use crossbeam_channel::Receiver;
 use embedder_traits::{Cursor, Theme, UntrustedNodeAddress, ViewportDetails};
 use euclid::Point2D;
 use euclid::default::{Point2D as UntypedPoint2D, Rect};
@@ -367,7 +366,7 @@ pub trait ScriptThreadFactory {
         layout_factory: Arc<dyn LayoutFactory>,
         image_cache_factory: Arc<dyn ImageCacheFactory>,
         background_hang_monitor_register: Box<dyn BackgroundHangMonitorRegister>,
-    ) -> (Receiver<()>, JoinHandle<()>);
+    ) -> JoinHandle<()>;
 }
 
 /// Type of the area of CSS box for query.


### PR DESCRIPTION
The `JoinHandle` was added as a newer return value from this
constructor. Both return values accomplish more or less the same thing.
The difference is that the `Sender` return value is triggered right
before the thread ends while the `JoinHandle` is triggered after thread
completion. One was used in multiprocess mode and one in single process
mode. In any case, the `JoinHandle` works fine for both cases.

Testing: Multiprocess isn't tested currently, but I confirmed that the
ScripThread shut down properly in multiprocess mode with this change.
