### PR TITLE
script: Add `cx_no_gc`/`cx`/`realm` codegen option and demostrate them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5434,7 +5434,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/sagudev/mozjs?branch=realm#730f7df5976aa1bf43f5ce361bb7035a8644fc63"
+source = "git+https://github.com/servo/mozjs#8bf5bf88e3e5d463d2eb9d1bd0a1f6b2fe7a5d13"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -5446,8 +5446,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.140.5-0"
-source = "git+https://github.com/sagudev/mozjs?branch=realm#730f7df5976aa1bf43f5ce361bb7035a8644fc63"
+version = "0.140.5-1"
+source = "git+https://github.com/servo/mozjs#8bf5bf88e3e5d463d2eb9d1bd0a1f6b2fe7a5d13"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5434,7 +5434,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#77645ed41f588297fd8d7edaee71500f4c83d070"
+source = "git+https://github.com/sagudev/mozjs?branch=noGC#d743c1efbb65030eba1f9239530722891bdb2818"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -5447,7 +5447,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.140.5-0"
-source = "git+https://github.com/servo/mozjs#77645ed41f588297fd8d7edaee71500f4c83d070"
+source = "git+https://github.com/sagudev/mozjs?branch=noGC#d743c1efbb65030eba1f9239530722891bdb2818"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5434,7 +5434,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/sagudev/mozjs?branch=noGC#d743c1efbb65030eba1f9239530722891bdb2818"
+source = "git+https://github.com/sagudev/mozjs?branch=realm#730f7df5976aa1bf43f5ce361bb7035a8644fc63"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -5447,7 +5447,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.140.5-0"
-source = "git+https://github.com/sagudev/mozjs?branch=noGC#d743c1efbb65030eba1f9239530722891bdb2818"
+source = "git+https://github.com/sagudev/mozjs?branch=realm#730f7df5976aa1bf43f5ce361bb7035a8644fc63"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }
 ipc-channel = "0.20.2"
 itertools = "0.14"
-js = { package = "mozjs", git = "https://github.com/servo/mozjs" }
+js = { package = "mozjs", git = "https://github.com/sagudev/mozjs", branch = "noGC" }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 layout_api = { path = "components/shared/layout" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }
 ipc-channel = "0.20.2"
 itertools = "0.14"
-js = { package = "mozjs", git = "https://github.com/sagudev/mozjs", branch = "realm" }
+js = { package = "mozjs", git = "https://github.com/servo/mozjs" }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 layout_api = { path = "components/shared/layout" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }
 ipc-channel = "0.20.2"
 itertools = "0.14"
-js = { package = "mozjs", git = "https://github.com/sagudev/mozjs", branch = "noGC" }
+js = { package = "mozjs", git = "https://github.com/sagudev/mozjs", branch = "realm" }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 layout_api = { path = "components/shared/layout" }

--- a/components/script/dom/bindings/import.rs
+++ b/components/script/dom/bindings/import.rs
@@ -5,6 +5,10 @@
 pub(crate) mod base {
     pub(crate) use std::ptr;
 
+    #[allow(unused_imports)]
+    pub(crate) use js::context::JSContext;
+    #[allow(unused_imports)]
+    pub(crate) use js::realm::CurrentRealm;
     pub(crate) use js::rust::{HandleObject, MutableHandleObject};
 
     pub(crate) use crate::script_runtime::{CanGc, JSContext as SafeJSContext};

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -760,7 +760,7 @@ impl EventTarget {
 
         let cx = GlobalScope::get_cx();
         let options = unsafe {
-            CompileOptionsWrapper::new(*cx, &handler.url.to_string(), handler.line as u32)
+            CompileOptionsWrapper::new_raw(*cx, &handler.url.to_string(), handler.line as u32)
         };
 
         // Step 3.9, subsection Scope steps 1-6

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2865,7 +2865,7 @@ impl GlobalScope {
             rooted!(in(*cx) let mut compiled_script = std::ptr::null_mut::<JSScript>());
             match code {
                 SourceCode::Text(text_code) => {
-                    let mut options = CompileOptionsWrapper::new(*cx, filename, line_number);
+                    let mut options = CompileOptionsWrapper::new_raw(*cx, filename, line_number);
                     if let Some(introduction_type) = introduction_type {
                         options.set_introduction_type(introduction_type);
                     }

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -10,6 +10,7 @@ use constellation_traits::{
     Job, JobError, JobResult, JobResultValue, JobType, ScriptToConstellationMessage,
 };
 use dom_struct::dom_struct;
+use js::realm::CurrentRealm;
 
 use crate::dom::bindings::codegen::Bindings::ServiceWorkerContainerBinding::{
     RegistrationOptions, ServiceWorkerContainerMethods,
@@ -63,16 +64,16 @@ impl ServiceWorkerContainerMethods<crate::DomTypeHolder> for ServiceWorkerContai
     /// and <https://w3c.github.io/ServiceWorker/#start-register> - B
     fn Register(
         &self,
+        realm: &mut CurrentRealm,
         script_url: USVString,
         options: &RegistrationOptions,
-        comp: InRealm,
         can_gc: CanGc,
     ) -> Rc<Promise> {
         // A: Step 2.
         let global = self.client.global();
 
         // A: Step 1
-        let promise = Promise::new_in_current_realm(comp, can_gc);
+        let promise = Promise::new_in_current_realm(InRealm::already(&realm.into()), can_gc);
         let USVString(ref script_url) = script_url;
 
         // A: Step 3

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -25,7 +25,7 @@ use ipc_channel::ipc::IpcSender;
 use js::jsapi::JS_AddInterruptCallback;
 use js::jsval::UndefinedValue;
 use js::panic::maybe_resume_unwind;
-use js::rust::{HandleValue, MutableHandleValue, ParentRuntime};
+use js::rust::{CompileOptionsWrapper, HandleValue, MutableHandleValue, ParentRuntime};
 use mime::Mime;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
@@ -737,15 +737,10 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
                 },
             };
 
-            let options = self
-                .runtime
-                .borrow()
-                .as_ref()
-                .unwrap()
-                .new_compile_options(url.as_str(), 1);
             #[allow(unsafe_code)]
             let mut cx =
                 unsafe { js::context::JSContext::from_ptr(js::rust::Runtime::get().unwrap()) };
+            let options = CompileOptionsWrapper::new(&cx, url.as_str(), 1);
             let result = js::rust::evaluate_script(
                 &mut cx,
                 self.reflector().get_jsobject(),

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -477,7 +477,7 @@ impl ModuleTree {
         let _ac = JSAutoRealm::new(*cx, *global.reflector().get_jsobject());
 
         let mut compile_options =
-            unsafe { CompileOptionsWrapper::new(*cx, url.as_str(), line_number as u32) };
+            unsafe { CompileOptionsWrapper::new_raw(*cx, url.as_str(), line_number as u32) };
         if let Some(introduction_type) = introduction_type {
             compile_options.set_introduction_type(introduction_type);
         }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -21,6 +21,7 @@ DOMInterfaces = {
 
 'AbortSignal': {
     'canGc':['Abort', 'Any', 'Timeout'],
+    'cx': ['ThrowIfAborted'],
 },
 
 'AbstractRange': {
@@ -607,7 +608,7 @@ DOMInterfaces = {
 },
 
 'ServiceWorkerContainer': {
-    'inRealms': ['Register'],
+    'realm': ['Register'],
     'canGc': ['Register'],
 },
 

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -287,6 +287,7 @@ class Descriptor(DescriptorProvider):
         self.concreteType = "%s%s" % (prefix, typeName)
         self.register = desc.get('register', True)
         self.path = desc.get('path', pathDefault)
+        self.realmMethods = [name for name in desc.get('realm', [])]
         self.inRealmMethods = [name for name in desc.get('inRealms', [])]
         self.canGcMethods = [name for name in desc.get('canGc', [])]
         self.additionalTraits = [name for name in desc.get('additionalTraits', [])]

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -287,7 +287,11 @@ class Descriptor(DescriptorProvider):
         self.concreteType = "%s%s" % (prefix, typeName)
         self.register = desc.get('register', True)
         self.path = desc.get('path', pathDefault)
+
+        self.cx_no_gcMethods = [name for name in desc.get('cx_no_gc', [])]
+        self.cxMethods = [name for name in desc.get('cx', [])]
         self.realmMethods = [name for name in desc.get('realm', [])]
+
         self.inRealmMethods = [name for name in desc.get('inRealms', [])]
         self.canGcMethods = [name for name in desc.get('canGc', [])]
         self.additionalTraits = [name for name in desc.get('additionalTraits', [])]

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -6,7 +6,8 @@ pub(crate) mod base {
     pub(crate) use std::ptr;
     pub(crate) use std::rc::Rc;
 
-    pub(crate) use js::context::RawJSContext;
+    #[allow(unused_imports)]
+    pub(crate) use js::context::{JSContext, RawJSContext};
     pub(crate) use js::conversions::{
         ConversionBehavior, ConversionResult, FromJSValConvertible, ToJSValConvertible,
     };
@@ -16,6 +17,8 @@ pub(crate) mod base {
     };
     pub(crate) use js::jsval::{JSVal, NullValue, ObjectOrNullValue, ObjectValue, UndefinedValue};
     pub(crate) use js::panic::maybe_resume_unwind;
+    #[allow(unused_imports)]
+    pub(crate) use js::realm::CurrentRealm;
     pub(crate) use js::rust::wrappers::Call;
     pub(crate) use js::rust::{HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
     pub(crate) use js::typedarray::{

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -6,13 +6,13 @@ pub(crate) mod base {
     pub(crate) use std::ptr;
     pub(crate) use std::rc::Rc;
 
+    pub(crate) use js::context::RawJSContext;
     pub(crate) use js::conversions::{
         ConversionBehavior, ConversionResult, FromJSValConvertible, ToJSValConvertible,
     };
     pub(crate) use js::error::throw_type_error;
     pub(crate) use js::jsapi::{
-        HandleValue as RawHandleValue, HandleValueArray, Heap, IsCallable, JS_NewObject, JSContext,
-        JSObject,
+        HandleValue as RawHandleValue, HandleValueArray, Heap, IsCallable, JS_NewObject, JSObject,
     };
     pub(crate) use js::jsval::{JSVal, NullValue, ObjectOrNullValue, ObjectValue, UndefinedValue};
     pub(crate) use js::panic::maybe_resume_unwind;

--- a/components/script_bindings/realms.rs
+++ b/components/script_bindings/realms.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use js::jsapi::{GetCurrentRealmOrNull, JSAutoRealm};
+use js::realm::CurrentRealm;
 
 use crate::DomTypes;
 use crate::interfaces::GlobalScopeHelpers;
@@ -24,6 +25,12 @@ impl AlreadyInRealm {
         unsafe {
             assert!(!GetCurrentRealmOrNull(*cx).is_null());
         }
+        AlreadyInRealm(())
+    }
+}
+
+impl<'a, 'b> From<&'a mut CurrentRealm<'b>> for AlreadyInRealm {
+    fn from(_: &'a mut CurrentRealm<'b>) -> AlreadyInRealm {
         AlreadyInRealm(())
     }
 }


### PR DESCRIPTION
Companion to https://github.com/servo/mozjs/pull/650

We added 3 new options to bindings.conf, each more powerful then the previous one, so one should use the least powerful as possible to keep things flexible:
1 `cx_no_gc` prepends argument `&JSContext`, which allows creating NoGC tokens and using functions that do not trigger GC.
2. `cx` prepends argument `&mut JSContext`, which allows everything that previous one allows, but it also allows calling GC triggering functions.
3. `realm` prepends argument `&mut CurrentRealm`, which can be deref_mut to `&mut JSContext` (so it can do everything that previous can), but it also ensures that there is current entered realm, which can be used for creation of InRealm.

next steps: #40600 

reviewable per commit

Testing: It's just refactoring
try run: https://github.com/sagudev/servo/actions/runs/19287700927