### PR TITLE
tidy: Minor cleanup of licenseck.py

### DIFF
--- a/python/tidy/licenseck.py
+++ b/python/tidy/licenseck.py
@@ -27,9 +27,9 @@ option. This file may not be copied, modified, or distributed \
 except according to those terms.\
 """
 
+# List of accepted `COPYRIGHT` disclaimers.
 COPYRIGHT = [
     "See the COPYRIGHT file at the top-level directory of this distribution",
-    "See http://rust-lang.org/COPYRIGHT",
 ]
 
 # The valid licenses, in the form we'd expect to see them in a Cargo.toml file.
@@ -37,37 +37,4 @@ licenses_toml = [
     'license = "MPL-2.0"',
     'license = "MIT/Apache-2.0"',
     'license = "MIT OR Apache-2.0"',
-]
-
-# The valid dependency licenses, in the form we'd expect to see them in a Cargo.toml file.
-licenses_dep_toml = [
-    # Licenses that are compatible with Servo's licensing
-    'license = "Apache-2 / MIT"',
-    'license = "Apache-2.0 / MIT"',
-    'license = "Apache-2.0"',
-    'license = "Apache-2.0/MIT"',
-    'license = "BSD-2-Clause"',
-    'license = "BSD-3-Clause"',
-    'license = "BSD-3-Clause/MIT"',
-    'license = "CC0-1.0"',
-    'license = "ISC"',
-    'license = "MIT / Apache-2.0"',
-    'license = "MIT OR Apache-2.0"',
-    'license = "MIT"',
-    'license = "MIT/Apache-2.0"',
-    'license = "MPL-2.0"',
-    'license = "Unlicense/MIT"',
-    'license = "zlib-acknowledgement"',
-    'license-file = "LICENSE-MIT"',
-    'license=  "MIT / Apache-2.0"',
-    # Whitelisted crates whose licensing has been checked manually
-    'name = "device"',
-    'name = "dylib"',
-    'name = "ipc-channel"',
-    'name = "mozjs_sys"',
-    'name = "freetype"',
-    'name = "js"',
-    'name = "servo-freetype-sys"',
-    'name = "webrender"',
-    'name = "webrender_api"',
 ]


### PR DESCRIPTION
- Remove unused accepted Copyright line `See http://rust-lang.org/COPYRIGHT`. This URL now yields a 404, and we don't seem to use this line anywhere in the project so we can remove it. Note: We should probably use a regex anyway, so we can match the whole required expression, but thats a different topic.
- Remove unused `licenses_dep_toml` table. We use cargo deny for checking the licenses of our rust dependencies.

Testing: Changing tidy is covered by `./mach test-tidy` in CI
