### PR TITLE
xpath: Fix implementation for `preceding::`/`following::` axes

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -952,6 +952,8 @@ impl Node {
         }
     }
 
+    /// Return an iterator that moves from `self` down the tree, choosing the last child
+    /// at each step of the way.
     pub(crate) fn descending_last_children(&self) -> impl Iterator<Item = DomRoot<Node>> + use<> {
         SimpleNodeIterator {
             current: self.GetLastChild(),

--- a/components/xpath/src/eval.rs
+++ b/components/xpath/src/eval.rs
@@ -261,16 +261,8 @@ impl LocationStepExpression {
                 .flatten()
                 .collect(),
             Axis::Ancestor => context.context_node.inclusive_ancestors().skip(1).collect(),
-            Axis::Following => context
-                .context_node
-                .following_nodes(&context.context_node)
-                .skip(1)
-                .collect(),
-            Axis::Preceding => context
-                .context_node
-                .preceding_nodes(&context.context_node)
-                .skip(1)
-                .collect(),
+            Axis::Following => context.context_node.following_nodes().skip(1).collect(),
+            Axis::Preceding => context.context_node.preceding_nodes().skip(1).collect(),
             Axis::FollowingSibling => context.context_node.following_siblings().collect(),
             Axis::PrecedingSibling => context.context_node.preceding_siblings().collect(),
             Axis::Attribute => {

--- a/components/xpath/src/lib.rs
+++ b/components/xpath/src/lib.rs
@@ -228,10 +228,10 @@ mod dummy_implementation {
         fn inclusive_ancestors(&self) -> impl Iterator<Item = Self> {
             iter::empty()
         }
-        fn preceding_nodes(&self, _: &Self) -> impl Iterator<Item = Self> {
+        fn preceding_nodes(&self) -> impl Iterator<Item = Self> {
             iter::empty()
         }
-        fn following_nodes(&self, _: &Self) -> impl Iterator<Item = Self> {
+        fn following_nodes(&self) -> impl Iterator<Item = Self> {
             iter::empty()
         }
         fn preceding_siblings(&self) -> impl Iterator<Item = Self> {

--- a/components/xpath/src/lib.rs
+++ b/components/xpath/src/lib.rs
@@ -46,8 +46,18 @@ pub trait Node: Eq + Clone + fmt::Debug {
     /// A non-shadow-including preorder traversal.
     fn traverse_preorder(&self) -> impl Iterator<Item = Self>;
     fn inclusive_ancestors(&self) -> impl Iterator<Item = Self>;
-    fn preceding_nodes(&self, root: &Self) -> impl Iterator<Item = Self>;
-    fn following_nodes(&self, root: &Self) -> impl Iterator<Item = Self>;
+
+    /// Return an iterator over all nodes that come before `self` in [tree order],
+    /// excluding any ancestors and attribute nodes.
+    ///
+    /// [tree order]: https://dom.spec.whatwg.org/#concept-tree-order
+    fn preceding_nodes(&self) -> impl Iterator<Item = Self>;
+
+    /// Return an iterator over all nodes that come after `self` in [tree order],
+    /// excluding any descendants and attribute nodes.
+    ///
+    /// [tree order]: https://dom.spec.whatwg.org/#concept-tree-order
+    fn following_nodes(&self) -> impl Iterator<Item = Self>;
     fn preceding_siblings(&self) -> impl Iterator<Item = Self>;
     fn following_siblings(&self) -> impl Iterator<Item = Self>;
     fn owner_document(&self) -> Self::Document;

--- a/tests/wpt/mozilla/meta/mozilla/xpathmark-ft.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/xpathmark-ft.html.ini
@@ -1,32 +1,8 @@
 [xpathmark-ft.html]
-  [Expected results for //L/following::*]
-    expected: FAIL
-
-  [Expected results for //L/preceding::*]
-    expected: FAIL
-
-  [Expected results for //*[following::L\]]
-    expected: FAIL
-
-  [Expected results for //*[preceding::L\]]
-    expected: FAIL
-
-  [Expected results for //*[child::* and preceding::Q\]]
-    expected: FAIL
-
-  [Expected results for //*[not(child::*) and preceding::Q\]]
-    expected: FAIL
-
-  [Expected results for //*[preceding::L or following::L\]]
-    expected: FAIL
-
   [Expected results for //L/ancestor::*[2\]]
     expected: FAIL
 
   [Expected results for //L/preceding-sibling::*[1\]]
-    expected: FAIL
-
-  [Expected results for //L/following::*[7\]]
     expected: FAIL
 
   [Expected results for  //L/preceding::*[7\]]


### PR DESCRIPTION
`preceding::` needs to yield all preceding nodes, excluding ancestors.
`following::` needs to yield all following nodes, excluding descendants.

Both `Node::preceding_nodes` and `Node::following_nodes` (which we're currently using) don't quite match these requirements, so we have to engineer some xpath-specific iterators.

Testing: New tests start to pass

