### PR TITLE
xpath: Apply predicate list before sorting result when evaluating location step expression

### DIFF
--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -377,18 +377,16 @@ impl Iterator for PrecedingNodeIteratorWithoutAncestors {
         // Our current subtree is exhausted. Return the root of the subtree and move on to the next one
         // in inverse tree order.
         let Some(next_subtree) = previous_non_ancestor_node(current) else {
-            let current = current.to_owned();
             *self = Self::Done;
-            return Some(current);
+            return None;
         };
 
-        let to_return = current.clone();
         *current = next_subtree;
         *subtree_iterator = current
             .descending_last_children()
             .last()
             .map(|node| node.preceding_nodes(current));
 
-        Some(to_return)
+        self.next()
     }
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -14720,7 +14720,7 @@
      ]
     ],
     "xpathmark-ft.html": [
-     "35e88ea487c18800a46f23de85bfa93cd53bef50",
+     "d2c65f8ff6529b8c8dba26c07484793096c0617a",
      [
       null,
       {}

--- a/tests/wpt/mozilla/meta/mozilla/xpathmark-ft.html.ini
+++ b/tests/wpt/mozilla/meta/mozilla/xpathmark-ft.html.ini
@@ -1,12 +1,3 @@
 [xpathmark-ft.html]
-  [Expected results for //L/ancestor::*[2\]]
-    expected: FAIL
-
-  [Expected results for //L/preceding-sibling::*[1\]]
-    expected: FAIL
-
-  [Expected results for  //L/preceding::*[7\]]
-    expected: FAIL
-
   [Expected results for id(id(//*[.="happy-go-lucky man"\]/@idrefs)/@idrefs)]
     expected: FAIL

--- a/tests/wpt/mozilla/tests/mozilla/xpathmark-ft.html
+++ b/tests/wpt/mozilla/tests/mozilla/xpathmark-ft.html
@@ -301,6 +301,15 @@ function run_tests(xml_document) {
     {
       "query": "//*[boolean(@id) = true() and boolean(@idrefs) = false()]",
       "expected": [n[1], n[2], n[3], n[4], n[5], n[6], n[7], n[9], n[10], n[11], n[12], n[13], n[14], n[15], n[16], n[18], n[19], n[20], n[21], n[22], n[23], n[24], n[25]]
+    },
+    // Tests added by servo developers
+    {
+      "query": "(//L/preceding::*)[7]",
+      "expected": [n[9]]
+    },
+    {
+      "query": "//L/preceding::*[last()]",
+      "expected": [n[2]]
     }
   ];
 


### PR DESCRIPTION
The result of a predicate can depend on the position of the node in its set, and this position is dependent on the axis that the node set came from. This is specified in https://www.w3.org/TR/1999/REC-xpath-19991116/#predicates.

Additionally, this change fixes a small bug in the implementation of `preceding::` (https://github.com/servo/servo/pull/40588) where the root of a subtree would be included twice. That wasn't discovered earlier because nodes are deduplicated at the end of the evaluation.

Testing: New tests start to pass, this change adds more tests

