### PR TITLE
compositing: Allow WebGL contexts to have different Surfman devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,7 @@ dependencies = [
  "base",
  "bincode",
  "bitflags 2.10.0",
+ "canvas_traits",
  "crossbeam-channel",
  "dpi",
  "embedder_traits",
@@ -8699,9 +8700,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surfman"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6d64f9d99bbbab83405a1aa65ac373e4f98440df9912ea8a3640bf164da234"
+checksum = "04d3973284ef0dc7362cdaee41c2356c4c39a5a5ebd8490c5163ebf21a7adc02"
 dependencies = [
  "bitflags 2.10.0",
  "cfg_aliases",
@@ -8712,7 +8713,6 @@ dependencies = [
  "glow",
  "libc",
  "log",
- "mach2",
  "objc2 0.6.3",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,7 @@ stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-11-01" }
 stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-11-01" }
 stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-11-01" }
 stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-11-01" }
-surfman = { version = "0.10.0", features = ["chains"] }
+surfman = { version = "0.11.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 taffy = { version = "0.9", default-features = false, features = ["calc", "detailed_layout_info", "grid", "std"] }

--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -14,7 +14,10 @@ use base::generic_channel::RoutedReceiver;
 use base::id::{PainterId, WebViewId};
 use bitflags::bitflags;
 use canvas_traits::webgl::WebGLThreads;
-use compositing_traits::{CompositorMsg, WebRenderExternalImageRegistry, WebViewTrait};
+use compositing_traits::{
+    CompositorMsg, PainterSurfmanDetails, PainterSurfmanDetailsMap, WebRenderExternalImageRegistry,
+    WebViewTrait,
+};
 use constellation_traits::EmbedderToConstellationMessage;
 use crossbeam_channel::Sender;
 use dpi::PhysicalSize;
@@ -70,6 +73,10 @@ pub struct IOCompositor {
     /// A handle to the memory profiler which will automatically unregister
     /// when it's dropped.
     _mem_profiler_registration: ProfilerRegistration,
+
+    /// A hashmap of painter ids to the surfman types (like Device, Adapter) that
+    /// are specific to that painter.
+    _painter_surfman_details_map: PainterSurfmanDetailsMap,
 }
 
 /// Why we need to be repainted. This is used for debugging.
@@ -97,6 +104,8 @@ impl IOCompositor {
             CompositorMsg::CollectMemoryReport,
         );
 
+        let mut painter_surfman_details_map = PainterSurfmanDetailsMap::default();
+
         let compositor = Rc::new(RefCell::new(IOCompositor {
             painters: Default::default(),
             shutdown_state: state.shutdown_state,
@@ -104,18 +113,34 @@ impl IOCompositor {
             embedder_to_constellation_sender: state.embedder_to_constellation_sender.clone(),
             time_profiler_chan: state.time_profiler_chan,
             _mem_profiler_registration: registration,
+            _painter_surfman_details_map: painter_surfman_details_map.clone(),
         }));
 
         let painter = Painter::new(
-            state.rendering_context,
+            state.rendering_context.clone(),
             state.compositor_proxy,
             state.event_loop_waker,
             state.refresh_driver,
             state.shaders_path,
             compositor.borrow().embedder_to_constellation_sender.clone(),
+            painter_surfman_details_map.clone(),
             #[cfg(feature = "webxr")]
             state.webxr_registry,
         );
+
+        let connection = state
+            .rendering_context
+            .connection()
+            .expect("Failed to get connection");
+        let adapter = connection
+            .create_adapter()
+            .expect("Failed to create adapter");
+
+        let painter_surfman_details = PainterSurfmanDetails {
+            connection,
+            adapter,
+        };
+        painter_surfman_details_map.insert(painter.painter_id, painter_surfman_details);
 
         compositor
             .borrow_mut()

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -237,7 +237,13 @@ impl WebGLRenderingContext {
 
         let (sender, receiver) = webgl_channel().unwrap();
         webgl_chan
-            .send(WebGLMsg::CreateContext(webgl_version, size, attrs, sender))
+            .send(WebGLMsg::CreateContext(
+                window.webview_id().into(),
+                webgl_version,
+                size,
+                attrs,
+                sender,
+            ))
             .unwrap();
         let result = receiver.recv().unwrap();
 

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -14,6 +14,7 @@ pub use base::generic_channel::GenericReceiver as WebGLReceiver;
 pub use base::generic_channel::GenericSender as WebGLSender;
 /// Result type for send()/recv() calls in in WebGLCommands.
 pub use base::generic_channel::SendResult as WebGLSendResult;
+use base::id::PainterId;
 use euclid::default::{Rect, Size2D};
 use glow::{
     self as gl, NativeBuffer, NativeFence, NativeFramebuffer, NativeProgram, NativeQuery,
@@ -90,6 +91,7 @@ impl WebGLThreads {
 pub enum WebGLMsg {
     /// Creates a new WebGLContext.
     CreateContext(
+        PainterId,
         WebGLVersion,
         Size2D<u32>,
         GLContextAttributes,

--- a/components/shared/compositing/Cargo.toml
+++ b/components/shared/compositing/Cargo.toml
@@ -18,6 +18,7 @@ no-wgl = ["surfman/sm-angle-default"]
 base = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true }
+canvas_traits = { workspace = true }
 crossbeam-channel = { workspace = true }
 dpi = { workspace = true }
 embedder_traits = { workspace = true }

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -4,6 +4,7 @@
 
 //! The interface to the `compositing` crate.
 
+use std::collections::HashMap;
 use std::fmt::{Debug, Error, Formatter};
 
 use base::Epoch;
@@ -15,6 +16,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use strum_macros::IntoStaticStr;
+use surfman::{Adapter, Connection};
 use webrender_api::{DocumentId, FontVariation};
 
 pub mod display_list;
@@ -483,6 +485,28 @@ impl CrossProcessCompositorApi {
             pipeline_id,
             source,
         ));
+    }
+}
+
+#[derive(Clone)]
+pub struct PainterSurfmanDetails {
+    pub connection: Connection,
+    pub adapter: Adapter,
+}
+
+#[derive(Clone, Default)]
+pub struct PainterSurfmanDetailsMap(Arc<Mutex<HashMap<PainterId, PainterSurfmanDetails>>>);
+
+impl PainterSurfmanDetailsMap {
+    pub fn get(&self, painter_id: PainterId) -> Option<PainterSurfmanDetails> {
+        let map = self.0.lock().expect("poisoned");
+        map.get(&painter_id).cloned()
+    }
+
+    pub fn insert(&mut self, painter_id: PainterId, details: PainterSurfmanDetails) {
+        let mut map = self.0.lock().expect("poisoned");
+        let existing = map.insert(painter_id, details);
+        assert!(existing.is_none())
     }
 }
 

--- a/components/shared/compositing/rendering_context.rs
+++ b/components/shared/compositing/rendering_context.rs
@@ -105,7 +105,7 @@ impl Drop for SurfmanRenderingContext {
 
 impl SurfmanRenderingContext {
     fn new(connection: &Connection, adapter: &Adapter) -> Result<Self, Error> {
-        let mut device = connection.create_device(adapter)?;
+        let device = connection.create_device(adapter)?;
 
         let flags = ContextAttributeFlags::ALPHA |
             ContextAttributeFlags::DEPTH |
@@ -441,7 +441,7 @@ impl WindowRenderingContext {
         window_handle: WindowHandle,
         size: PhysicalSize<u32>,
     ) -> Result<(), Error> {
-        let mut device = self.surfman_context.device.borrow_mut();
+        let device = self.surfman_context.device.borrow_mut();
         let mut context = self.surfman_context.context.borrow_mut();
 
         let native_widget = device

--- a/components/webgl/webgl_thread.rs
+++ b/components/webgl/webgl_thread.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 #![allow(unsafe_code)]
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::num::NonZeroU32;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -10,6 +11,7 @@ use std::{slice, thread};
 
 use base::Epoch;
 use base::generic_channel::RoutedReceiver;
+use base::id::PainterId;
 use bitflags::bitflags;
 use byteorder::{ByteOrder, NativeEndian, WriteBytesExt};
 use canvas_traits::webgl;
@@ -25,8 +27,8 @@ use canvas_traits::webgl::{
     WebGLVersion, WebGLVertexArrayId, YAxisTreatment,
 };
 use compositing_traits::{
-    CrossProcessCompositorApi, SerializableImageData, WebRenderExternalImageRegistry,
-    WebRenderImageHandlerType,
+    CrossProcessCompositorApi, PainterSurfmanDetailsMap, SerializableImageData,
+    WebRenderExternalImageRegistry, WebRenderImageHandlerType,
 };
 use euclid::default::Size2D;
 use glow::{
@@ -42,8 +44,8 @@ use pixels::{self, PixelFormat, SnapshotAlphaMode, unmultiply_inplace};
 use rustc_hash::FxHashMap;
 use surfman::chains::{PreserveBuffer, SwapChains, SwapChainsAPI};
 use surfman::{
-    self, Adapter, Connection, Context, ContextAttributeFlags, ContextAttributes, Device,
-    GLVersion, SurfaceAccess, SurfaceInfo, SurfaceType,
+    self, Context, ContextAttributeFlags, ContextAttributes, Device, GLVersion, SurfaceAccess,
+    SurfaceInfo, SurfaceType,
 };
 use webrender_api::units::DeviceIntSize;
 use webrender_api::{
@@ -53,7 +55,7 @@ use webrender_api::{
 
 use crate::webgl_limits::GLLimitsDetect;
 #[cfg(feature = "webxr")]
-use crate::webxr::{WebXRBridge, WebXRBridgeContexts, WebXRBridgeInit};
+use crate::webxr::{WebXRBridge, WebXRBridgeInit};
 
 type GLint = i32;
 
@@ -64,6 +66,7 @@ fn native_uniform_location(location: i32) -> Option<NativeUniformLocation> {
 pub(crate) struct GLContextData {
     pub(crate) ctx: Context,
     pub(crate) gl: Rc<glow::Context>,
+    device: Rc<Device>,
     state: GLState,
     attributes: GLContextAttributes,
 }
@@ -204,7 +207,7 @@ impl Default for GLState {
 /// a set of WebGLContexts living in the same thread.
 pub(crate) struct WebGLThread {
     /// The GPU device.
-    device: Device,
+    device_map: HashMap<PainterId, Rc<Device>>,
     /// Channel used to generate/update or delete `ImageKey`s.
     compositor_api: CrossProcessCompositorApi,
     /// Map of live WebGLContexts.
@@ -222,11 +225,12 @@ pub(crate) struct WebGLThread {
     sender: WebGLSender<WebGLMsg>,
     /// The swap chains used by webrender
     webrender_swap_chains: SwapChains<WebGLContextId, Device>,
-    /// Whether this context is a GL or GLES context.
-    api_type: GlType,
+    /// The per-painter details of the underlying surfman connection.
+    painter_surfman_details_map: PainterSurfmanDetailsMap,
+
     #[cfg(feature = "webxr")]
     /// The bridge to WebXR
-    pub webxr_bridge: WebXRBridge,
+    pub webxr_bridge: Option<WebXRBridge>,
 }
 
 /// The data required to initialize an instance of the WebGLThread type.
@@ -236,11 +240,9 @@ pub(crate) struct WebGLThreadInit {
     pub sender: WebGLSender<WebGLMsg>,
     pub receiver: WebGLReceiver<WebGLMsg>,
     pub webrender_swap_chains: SwapChains<WebGLContextId, Device>,
-    pub connection: Connection,
-    pub adapter: Adapter,
-    pub api_type: GlType,
     #[cfg(feature = "webxr")]
     pub webxr_init: WebXRBridgeInit,
+    pub painter_surfman_details_map: PainterSurfmanDetailsMap,
 }
 
 // A size at which it should be safe to create GL contexts
@@ -255,17 +257,13 @@ impl WebGLThread {
             sender,
             receiver,
             webrender_swap_chains,
-            connection,
-            adapter,
-            api_type,
             #[cfg(feature = "webxr")]
             webxr_init,
+            painter_surfman_details_map,
         }: WebGLThreadInit,
     ) -> Self {
         WebGLThread {
-            device: connection
-                .create_device(&adapter)
-                .expect("Couldn't open WebGL device!"),
+            device_map: Default::default(),
             compositor_api,
             contexts: Default::default(),
             cached_context_info: Default::default(),
@@ -274,9 +272,9 @@ impl WebGLThread {
             sender,
             receiver: receiver.route_preserving_errors(),
             webrender_swap_chains,
-            api_type,
             #[cfg(feature = "webxr")]
-            webxr_bridge: WebXRBridge::new(webxr_init),
+            webxr_bridge: Some(WebXRBridge::new(webxr_init)),
+            painter_surfman_details_map,
         }
     }
 
@@ -306,18 +304,14 @@ impl WebGLThread {
     fn handle_msg(&mut self, msg: WebGLMsg, webgl_chan: &WebGLChan) -> bool {
         trace!("processing {:?}", msg);
         match msg {
-            WebGLMsg::CreateContext(version, size, attributes, result_sender) => {
-                let result = self.create_webgl_context(version, size, attributes);
+            WebGLMsg::CreateContext(painter_id, version, size, attributes, result_sender) => {
+                let result = self.create_webgl_context(painter_id, version, size, attributes);
 
                 result_sender
                     .send(result.map(|(id, limits)| {
-                        let data = Self::make_current_if_needed(
-                            &self.device,
-                            id,
-                            &self.contexts,
-                            &mut self.bound_context_id,
-                        )
-                        .expect("WebGLContext not found");
+                        let data = self
+                            .make_current_if_needed(id)
+                            .expect("WebGLContext not found");
                         let glsl_version = Self::get_glsl_version(&data.gl);
                         let api_type = if data.gl.version().is_embedded {
                             GlType::Gles
@@ -393,62 +387,66 @@ impl WebGLThread {
         false
     }
 
+    fn get_or_create_device_for_painter(&mut self, painter_id: PainterId) -> Rc<Device> {
+        self.device_map
+            .entry(painter_id)
+            .or_insert_with(|| {
+                let surfman_details = self
+                    .painter_surfman_details_map
+                    .get(painter_id)
+                    .expect("no surfman details found for painter");
+                let device = surfman_details
+                    .connection
+                    .create_device(&surfman_details.adapter)
+                    .expect("Couldn't open WebGL device!");
+
+                Rc::new(device)
+            })
+            .clone()
+    }
+
     #[cfg(feature = "webxr")]
     /// Handles a WebXR message
     fn handle_webxr_command(&mut self, command: WebXRCommand) {
         trace!("processing {:?}", command);
-        let mut contexts = WebXRBridgeContexts {
-            contexts: &mut self.contexts,
-            bound_context_id: &mut self.bound_context_id,
+        // Take `webxr_bridge` from the `WebGLThread` in order to avoid a double mutable borrow.
+        let Some(mut webxr_bridge) = self.webxr_bridge.take() else {
+            return;
         };
         match command {
             WebXRCommand::CreateLayerManager(sender) => {
-                let result = self
-                    .webxr_bridge
-                    .create_layer_manager(&mut self.device, &mut contexts);
+                let result = webxr_bridge.create_layer_manager(self);
                 let _ = sender.send(result);
             },
             WebXRCommand::DestroyLayerManager(manager_id) => {
-                self.webxr_bridge.destroy_layer_manager(manager_id);
+                webxr_bridge.destroy_layer_manager(manager_id);
             },
             WebXRCommand::CreateLayer(manager_id, context_id, layer_init, sender) => {
-                let result = self.webxr_bridge.create_layer(
-                    manager_id,
-                    &mut self.device,
-                    &mut contexts,
-                    context_id,
-                    layer_init,
-                );
+                let result = webxr_bridge.create_layer(manager_id, self, context_id, layer_init);
                 let _ = sender.send(result);
             },
             WebXRCommand::DestroyLayer(manager_id, context_id, layer_id) => {
-                self.webxr_bridge.destroy_layer(
-                    manager_id,
-                    &mut self.device,
-                    &mut contexts,
-                    context_id,
-                    layer_id,
-                );
+                webxr_bridge.destroy_layer(manager_id, self, context_id, layer_id);
             },
             WebXRCommand::BeginFrame(manager_id, layers, sender) => {
-                let result = self.webxr_bridge.begin_frame(
-                    manager_id,
-                    &mut self.device,
-                    &mut contexts,
-                    &layers[..],
-                );
+                let result = webxr_bridge.begin_frame(manager_id, self, &layers[..]);
                 let _ = sender.send(result);
             },
             WebXRCommand::EndFrame(manager_id, layers, sender) => {
-                let result = self.webxr_bridge.end_frame(
-                    manager_id,
-                    &mut self.device,
-                    &mut contexts,
-                    &layers[..],
-                );
+                let result = webxr_bridge.end_frame(manager_id, self, &layers[..]);
                 let _ = sender.send(result);
             },
         }
+
+        self.webxr_bridge.replace(webxr_bridge);
+    }
+
+    pub(crate) fn device_for_context(&self, context_id: WebGLContextId) -> Rc<Device> {
+        self.contexts
+            .get(&context_id)
+            .expect("Should be called with a valid WebGLContextId")
+            .device
+            .clone()
     }
 
     /// Handles a WebGLCommand for a specific WebGLContext
@@ -461,15 +459,10 @@ impl WebGLThread {
         if self.cached_context_info.get_mut(&context_id).is_none() {
             return;
         }
-        let data = Self::make_current_if_needed_mut(
-            &self.device,
-            context_id,
-            &mut self.contexts,
-            &mut self.bound_context_id,
-        );
+        let data = self.make_current_if_needed_mut(context_id);
         if let Some(data) = data {
             WebGLImpl::apply(
-                &self.device,
+                &data.device,
                 &data.ctx,
                 &data.gl,
                 &mut data.state,
@@ -483,6 +476,7 @@ impl WebGLThread {
     /// Creates a new WebGLContext
     fn create_webgl_context(
         &mut self,
+        painter_id: PainterId,
         webgl_version: WebGLVersion,
         requested_size: Size2D<u32>,
         attributes: GLContextAttributes,
@@ -495,9 +489,17 @@ impl WebGLThread {
         // Creating a new GLContext may make the current bound context_id dirty.
         // Clear it to ensure that  make_current() is called in subsequent commands.
         self.bound_context_id = None;
+        let painter_surfman_details = self
+            .painter_surfman_details_map
+            .get(painter_id)
+            .expect("PainterSurfmanDetails not found for PainterId");
+        let api_type = match painter_surfman_details.connection.gl_api() {
+            surfman::GLApi::GL => GlType::Gl,
+            surfman::GLApi::GLES => GlType::Gles,
+        };
 
         let requested_flags =
-            attributes.to_surfman_context_attribute_flags(webgl_version, self.api_type);
+            attributes.to_surfman_context_attribute_flags(webgl_version, api_type);
         // Some GL implementations seem to only allow famebuffers
         // to have alpha, depth and stencil if their creating context does.
         // WebGL requires all contexts to be able to create framebuffers with
@@ -508,12 +510,12 @@ impl WebGLThread {
             ContextAttributeFlags::DEPTH |
             ContextAttributeFlags::STENCIL;
         let context_attributes = &ContextAttributes {
-            version: webgl_version.to_surfman_version(self.api_type),
+            version: webgl_version.to_surfman_version(api_type),
             flags,
         };
 
-        let context_descriptor = self
-            .device
+        let device = self.get_or_create_device_for_painter(painter_id);
+        let context_descriptor = device
             .create_context_descriptor(context_attributes)
             .map_err(|err| format!("Failed to create context descriptor: {:?}", err))?;
 
@@ -526,19 +528,17 @@ impl WebGLThread {
         };
         let surface_access = self.surface_access();
 
-        let mut ctx = self
-            .device
+        let mut ctx = device
             .create_context(&context_descriptor, None)
             .map_err(|err| format!("Failed to create the GL context: {:?}", err))?;
-        let surface = self
-            .device
+        let surface = device
             .create_surface(&ctx, surface_access, surface_type)
             .map_err(|err| format!("Failed to create the initial surface: {:?}", err))?;
-        self.device
+        device
             .bind_surface_to_context(&mut ctx, surface)
             .map_err(|err| format!("Failed to bind initial surface: {:?}", err))?;
         // https://github.com/pcwalton/surfman/issues/7
-        self.device
+        device
             .make_context_current(&ctx)
             .map_err(|err| format!("Failed to make new context current: {:?}", err))?;
 
@@ -551,7 +551,7 @@ impl WebGLThread {
         );
 
         self.webrender_swap_chains
-            .create_attached_swap_chain(id, &mut self.device, &mut ctx, surface_access)
+            .create_attached_swap_chain(id, &*device, &mut ctx, surface_access)
             .map_err(|err| format!("Failed to create swap chain: {:?}", err))?;
 
         let swap_chain = self
@@ -562,16 +562,16 @@ impl WebGLThread {
         debug!(
             "Created webgl context {:?}/{:?}",
             id,
-            self.device.context_id(&ctx),
+            device.context_id(&ctx),
         );
 
         let gl = unsafe {
-            Rc::new(match self.api_type {
+            Rc::new(match api_type {
                 GlType::Gl => glow::Context::from_loader_function(|symbol_name| {
-                    self.device.get_proc_address(&ctx, symbol_name)
+                    device.get_proc_address(&ctx, symbol_name)
                 }),
                 GlType::Gles => glow::Context::from_loader_function(|symbol_name| {
-                    self.device.get_proc_address(&ctx, symbol_name)
+                    device.get_proc_address(&ctx, symbol_name)
                 }),
             })
         };
@@ -582,18 +582,17 @@ impl WebGLThread {
         if safe_size != size {
             debug!("Resizing swap chain from {:?} to {:?}", safe_size, size);
             swap_chain
-                .resize(&mut self.device, &mut ctx, size.to_i32())
+                .resize(&device, &mut ctx, size.to_i32())
                 .map_err(|err| format!("Failed to resize swap chain: {:?}", err))?;
         }
 
-        let descriptor = self.device.context_descriptor(&ctx);
-        let descriptor_attributes = self.device.context_descriptor_attributes(&descriptor);
+        let descriptor = device.context_descriptor(&ctx);
+        let descriptor_attributes = device.context_descriptor_attributes(&descriptor);
         let gl_version = descriptor_attributes.version;
         let has_alpha = requested_flags.contains(ContextAttributeFlags::ALPHA);
 
-        self.device.make_context_current(&ctx).unwrap();
-        let framebuffer = self
-            .device
+        device.make_context_current(&ctx).unwrap();
+        let framebuffer = device
             .context_surface_info(&ctx)
             .map_err(|err| format!("Failed to get context surface info: {:?}", err))?
             .ok_or_else(|| "Failed to get context surface info".to_string())?
@@ -634,6 +633,7 @@ impl WebGLThread {
             id,
             GLContextData {
                 ctx,
+                device,
                 gl,
                 state,
                 attributes,
@@ -658,20 +658,20 @@ impl WebGLThread {
         context_id: WebGLContextId,
         requested_size: Size2D<u32>,
     ) -> Result<(), String> {
-        let data = Self::make_current_if_needed_mut(
-            &self.device,
-            context_id,
-            &mut self.contexts,
-            &mut self.bound_context_id,
-        )
-        .expect("Missing WebGL context!");
+        self.make_current_if_needed(context_id)
+            .expect("Missing WebGL context!");
+
+        let data = self
+            .contexts
+            .get_mut(&context_id)
+            .expect("Missing WebGL context!");
 
         let size = clamp_viewport(&data.gl, requested_size);
 
         // Check to see if any of the current framebuffer bindings are the surface we're about to
         // throw out. If so, we'll have to reset them after destroying the surface.
         let framebuffer_rebinding_info =
-            FramebufferRebindingInfo::detect(&self.device, &data.ctx, &data.gl);
+            FramebufferRebindingInfo::detect(&data.device, &data.ctx, &data.gl);
 
         // Resize the swap chains
         if let Some(swap_chain) = self.webrender_swap_chains.get(context_id) {
@@ -681,17 +681,17 @@ impl WebGLThread {
                 .contains(ContextAttributeFlags::ALPHA);
             let clear_color = [0.0, 0.0, 0.0, !alpha as i32 as f32];
             swap_chain
-                .resize(&mut self.device, &mut data.ctx, size.to_i32())
+                .resize(&data.device, &mut data.ctx, size.to_i32())
                 .map_err(|err| format!("Failed to resize swap chain: {:?}", err))?;
             swap_chain
-                .clear_surface(&mut self.device, &mut data.ctx, &data.gl, clear_color)
+                .clear_surface(&data.device, &mut data.ctx, &data.gl, clear_color)
                 .map_err(|err| format!("Failed to clear resized swap chain: {:?}", err))?;
         } else {
             error!("Failed to find swap chain");
         }
 
         // Reset framebuffer bindings as appropriate.
-        framebuffer_rebinding_info.apply(&self.device, &data.ctx, &data.gl);
+        framebuffer_rebinding_info.apply(&data.device, &data.ctx, &data.gl);
         debug_assert_eq!(unsafe { data.gl.get_error() }, gl::NO_ERROR);
 
         let has_alpha = data
@@ -715,27 +715,7 @@ impl WebGLThread {
         }
 
         // We need to make the context current so its resources can be disposed of.
-        Self::make_current_if_needed(
-            &self.device,
-            context_id,
-            &self.contexts,
-            &mut self.bound_context_id,
-        );
-
-        #[cfg(feature = "webxr")]
-        {
-            // Destroy WebXR layers associated with this context
-            let webxr_context_id = webxr_api::ContextId::from(context_id);
-            let mut webxr_contexts = WebXRBridgeContexts {
-                contexts: &mut self.contexts,
-                bound_context_id: &mut self.bound_context_id,
-            };
-            self.webxr_bridge.destroy_all_layers(
-                &mut self.device,
-                &mut webxr_contexts,
-                webxr_context_id,
-            );
-        }
+        self.make_current_if_needed(context_id);
 
         // Release GL context.
         let mut data = match self.contexts.remove(&context_id) {
@@ -743,13 +723,22 @@ impl WebGLThread {
             None => return,
         };
 
+        #[cfg(feature = "webxr")]
+        {
+            // Destroy WebXR layers associated with this context
+            let webxr_context_id = webxr_api::ContextId::from(context_id);
+            if let Some(mut webxr_bridge) = self.webxr_bridge.take() {
+                webxr_bridge.destroy_all_layers(self, webxr_context_id);
+            }
+        }
+
         // Destroy the swap chains
         self.webrender_swap_chains
-            .destroy(context_id, &mut self.device, &mut data.ctx)
+            .destroy(context_id, &data.device, &mut data.ctx)
             .unwrap();
 
         // Destroy the context
-        self.device.destroy_context(&mut data.ctx).unwrap();
+        data.device.destroy_context(&mut data.ctx).unwrap();
 
         // Removing a GLContext may make the current bound context_id dirty.
         self.bound_context_id = None;
@@ -763,13 +752,13 @@ impl WebGLThread {
     ) {
         debug!("handle_swap_buffers()");
         for context_id in context_ids {
-            let data = Self::make_current_if_needed_mut(
-                &self.device,
-                context_id,
-                &mut self.contexts,
-                &mut self.bound_context_id,
-            )
-            .expect("Where's the GL data?");
+            self.make_current_if_needed(context_id)
+                .expect("Where's the GL data?");
+
+            let data = self
+                .contexts
+                .get_mut(&context_id)
+                .expect("Missing WebGL context");
 
             // Ensure there are no pending GL errors from other parts of the pipeline.
             debug_assert_eq!(unsafe { data.gl.get_error() }, gl::NO_ERROR);
@@ -777,7 +766,7 @@ impl WebGLThread {
             // Check to see if any of the current framebuffer bindings are the surface we're about
             // to swap out. If so, we'll have to reset them after destroying the surface.
             let framebuffer_rebinding_info =
-                FramebufferRebindingInfo::detect(&self.device, &data.ctx, &data.gl);
+                FramebufferRebindingInfo::detect(&data.device, &data.ctx, &data.gl);
             debug_assert_eq!(unsafe { data.gl.get_error() }, gl::NO_ERROR);
 
             debug!("Getting swap chain for {:?}", context_id);
@@ -789,7 +778,7 @@ impl WebGLThread {
             debug!("Swapping {:?}", context_id);
             swap_chain
                 .swap_buffers(
-                    &mut self.device,
+                    &data.device,
                     &mut data.ctx,
                     if data.attributes.preserve_drawing_buffer {
                         PreserveBuffer::Yes(&data.gl)
@@ -808,14 +797,14 @@ impl WebGLThread {
                     .contains(ContextAttributeFlags::ALPHA);
                 let clear_color = [0.0, 0.0, 0.0, !alpha as i32 as f32];
                 swap_chain
-                    .clear_surface(&mut self.device, &mut data.ctx, &data.gl, clear_color)
+                    .clear_surface(&data.device, &mut data.ctx, &data.gl, clear_color)
                     .unwrap();
                 debug_assert_eq!(unsafe { data.gl.get_error() }, gl::NO_ERROR);
             }
 
             // Rebind framebuffers as appropriate.
             debug!("Rebinding {:?}", context_id);
-            framebuffer_rebinding_info.apply(&self.device, &data.ctx, &data.gl);
+            framebuffer_rebinding_info.apply(&data.device, &data.ctx, &data.gl);
             debug_assert_eq!(unsafe { data.gl.get_error() }, gl::NO_ERROR);
 
             let SurfaceInfo {
@@ -823,7 +812,7 @@ impl WebGLThread {
                 framebuffer_object,
                 id,
                 ..
-            } = self
+            } = data
                 .device
                 .context_surface_info(&data.ctx)
                 .unwrap()
@@ -850,18 +839,16 @@ impl WebGLThread {
     }
 
     /// Gets a reference to a Context for a given WebGLContextId and makes it current if required.
-    pub(crate) fn make_current_if_needed<'a>(
-        device: &Device,
+    pub(crate) fn make_current_if_needed(
+        &mut self,
         context_id: WebGLContextId,
-        contexts: &'a FxHashMap<WebGLContextId, GLContextData>,
-        bound_id: &mut Option<WebGLContextId>,
-    ) -> Option<&'a GLContextData> {
-        let data = contexts.get(&context_id);
+    ) -> Option<&GLContextData> {
+        let data = self.contexts.get(&context_id);
 
         if let Some(data) = data {
-            if Some(context_id) != *bound_id {
-                device.make_context_current(&data.ctx).unwrap();
-                *bound_id = Some(context_id);
+            if Some(context_id) != self.bound_context_id {
+                data.device.make_context_current(&data.ctx).unwrap();
+                self.bound_context_id = Some(context_id);
             }
         }
 
@@ -869,18 +856,15 @@ impl WebGLThread {
     }
 
     /// Gets a mutable reference to a GLContextWrapper for a WebGLContextId and makes it current if required.
-    pub(crate) fn make_current_if_needed_mut<'a>(
-        device: &Device,
+    pub(crate) fn make_current_if_needed_mut(
+        &mut self,
         context_id: WebGLContextId,
-        contexts: &'a mut FxHashMap<WebGLContextId, GLContextData>,
-        bound_id: &mut Option<WebGLContextId>,
-    ) -> Option<&'a mut GLContextData> {
-        let data = contexts.get_mut(&context_id);
-
+    ) -> Option<&mut GLContextData> {
+        let data = self.contexts.get_mut(&context_id);
         if let Some(ref data) = data {
-            if Some(context_id) != *bound_id {
-                device.make_context_current(&data.ctx).unwrap();
-                *bound_id = Some(context_id);
+            if Some(context_id) != self.bound_context_id {
+                data.device.make_context_current(&data.ctx).unwrap();
+                self.bound_context_id = Some(context_id);
             }
         }
 
@@ -914,7 +898,8 @@ impl WebGLThread {
     /// Helper function to create a `ImageData::External` instance.
     fn external_image_data(&self, context_id: WebGLContextId) -> SerializableImageData {
         // TODO(pcwalton): Add `GL_TEXTURE_EXTERNAL_OES`?
-        let image_buffer_kind = match self.device.surface_gl_texture_target() {
+        let device = self.device_for_context(context_id);
+        let image_buffer_kind = match device.surface_gl_texture_target() {
             gl::TEXTURE_RECTANGLE => ImageBufferKind::TextureRect,
             _ => ImageBufferKind::Texture2D,
         };

--- a/components/webgl/webxr.rs
+++ b/components/webgl/webxr.rs
@@ -3,9 +3,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::num::NonZeroU32;
+use std::rc::Rc;
 
 use canvas_traits::webgl::{
-    WebGLContextId, WebGLMsg, WebGLSender, WebXRCommand, WebXRLayerManagerId, webgl_channel,
+    WebGLMsg, WebGLSender, WebXRCommand, WebXRLayerManagerId, webgl_channel,
 };
 use rustc_hash::FxHashMap;
 use surfman::{Context, Device};
@@ -19,7 +20,7 @@ use webxr_api::{
     SubImages as WebXRSubImages,
 };
 
-use crate::webgl_thread::{GLContextData, WebGLThread};
+use crate::webgl_thread::WebGLThread;
 
 /// Bridge between WebGL and WebXR
 pub(crate) struct WebXRBridge {
@@ -46,14 +47,13 @@ impl WebXRBridge {
 impl WebXRBridge {
     pub(crate) fn create_layer_manager(
         &mut self,
-        device: &mut Device,
         contexts: &mut dyn WebXRContexts<WebXRSurfman>,
     ) -> Result<WebXRLayerManagerId, WebXRError> {
         let factory = self
             .factory_receiver
             .recv()
             .map_err(|_| WebXRError::CommunicationError)?;
-        let manager = factory.build(device, contexts)?;
+        let manager = factory.build(contexts)?;
         let manager_id = WebXRLayerManagerId::new(self.next_manager_id);
         self.next_manager_id = self
             .next_manager_id
@@ -70,7 +70,6 @@ impl WebXRBridge {
     pub(crate) fn create_layer(
         &mut self,
         manager_id: WebXRLayerManagerId,
-        device: &mut Device,
         contexts: &mut dyn WebXRContexts<WebXRSurfman>,
         context_id: WebXRContextId,
         layer_init: WebXRLayerInit,
@@ -79,25 +78,23 @@ impl WebXRBridge {
             .managers
             .get_mut(&manager_id)
             .ok_or(WebXRError::NoMatchingDevice)?;
-        manager.create_layer(device, contexts, context_id, layer_init)
+        manager.create_layer(contexts, context_id, layer_init)
     }
 
     pub(crate) fn destroy_layer(
         &mut self,
         manager_id: WebXRLayerManagerId,
-        device: &mut Device,
         contexts: &mut dyn WebXRContexts<WebXRSurfman>,
         context_id: WebXRContextId,
         layer_id: WebXRLayerId,
     ) {
         if let Some(manager) = self.managers.get_mut(&manager_id) {
-            manager.destroy_layer(device, contexts, context_id, layer_id);
+            manager.destroy_layer(contexts, context_id, layer_id);
         }
     }
 
     pub(crate) fn destroy_all_layers(
         &mut self,
-        device: &mut Device,
         contexts: &mut dyn WebXRContexts<WebXRSurfman>,
         context_id: WebXRContextId,
     ) {
@@ -105,7 +102,7 @@ impl WebXRBridge {
             #[allow(clippy::unnecessary_to_owned)] // Needs mutable borrow later in destroy
             for (other_id, layer_id) in manager.layers().to_vec() {
                 if other_id == context_id {
-                    manager.destroy_layer(device, contexts, context_id, layer_id);
+                    manager.destroy_layer(contexts, context_id, layer_id);
                 }
             }
         }
@@ -114,7 +111,6 @@ impl WebXRBridge {
     pub(crate) fn begin_frame(
         &mut self,
         manager_id: WebXRLayerManagerId,
-        device: &mut Device,
         contexts: &mut dyn WebXRContexts<WebXRSurfman>,
         layers: &[(WebXRContextId, WebXRLayerId)],
     ) -> Result<Vec<WebXRSubImages>, WebXRError> {
@@ -122,13 +118,12 @@ impl WebXRBridge {
             .managers
             .get_mut(&manager_id)
             .ok_or(WebXRError::NoMatchingDevice)?;
-        manager.begin_frame(device, contexts, layers)
+        manager.begin_frame(contexts, layers)
     }
 
     pub(crate) fn end_frame(
         &mut self,
         manager_id: WebXRLayerManagerId,
-        device: &mut Device,
         contexts: &mut dyn WebXRContexts<WebXRSurfman>,
         layers: &[(WebXRContextId, WebXRLayerId)],
     ) -> Result<(), WebXRError> {
@@ -136,7 +131,7 @@ impl WebXRBridge {
             .managers
             .get_mut(&manager_id)
             .ok_or(WebXRError::NoMatchingDevice)?;
-        manager.end_frame(device, contexts, layers)
+        manager.end_frame(contexts, layers)
     }
 }
 
@@ -216,7 +211,6 @@ struct WebXRBridgeManager {
 impl<GL: WebXRTypes> WebXRLayerManagerAPI<GL> for WebXRBridgeManager {
     fn create_layer(
         &mut self,
-        _: &mut GL::Device,
         _: &mut dyn WebXRContexts<GL>,
         context_id: WebXRContextId,
         init: WebXRLayerInit,
@@ -239,7 +233,6 @@ impl<GL: WebXRTypes> WebXRLayerManagerAPI<GL> for WebXRBridgeManager {
 
     fn destroy_layer(
         &mut self,
-        _: &mut GL::Device,
         _: &mut dyn WebXRContexts<GL>,
         context_id: WebXRContextId,
         layer_id: WebXRLayerId,
@@ -260,7 +253,6 @@ impl<GL: WebXRTypes> WebXRLayerManagerAPI<GL> for WebXRBridgeManager {
 
     fn begin_frame(
         &mut self,
-        _: &mut GL::Device,
         _: &mut dyn WebXRContexts<GL>,
         layers: &[(WebXRContextId, WebXRLayerId)],
     ) -> Result<Vec<WebXRSubImages>, WebXRError> {
@@ -279,7 +271,6 @@ impl<GL: WebXRTypes> WebXRLayerManagerAPI<GL> for WebXRBridgeManager {
 
     fn end_frame(
         &mut self,
-        _: &mut GL::Device,
         _: &mut dyn WebXRContexts<GL>,
         layers: &[(WebXRContextId, WebXRLayerId)],
     ) -> Result<(), WebXRError> {
@@ -307,29 +298,18 @@ impl Drop for WebXRBridgeManager {
     }
 }
 
-pub(crate) struct WebXRBridgeContexts<'a> {
-    pub(crate) contexts: &'a mut FxHashMap<WebGLContextId, GLContextData>,
-    pub(crate) bound_context_id: &'a mut Option<WebGLContextId>,
-}
+impl WebXRContexts<WebXRSurfman> for WebGLThread {
+    fn device(&self, context_id: WebXRContextId) -> Option<Rc<Device>> {
+        Some(self.device_for_context(context_id.into()))
+    }
 
-impl WebXRContexts<WebXRSurfman> for WebXRBridgeContexts<'_> {
-    fn context(&mut self, device: &Device, context_id: WebXRContextId) -> Option<&mut Context> {
-        let data = WebGLThread::make_current_if_needed_mut(
-            device,
-            WebGLContextId::from(context_id),
-            self.contexts,
-            self.bound_context_id,
-        )?;
+    fn context(&mut self, context_id: WebXRContextId) -> Option<&mut Context> {
+        let data = self.make_current_if_needed_mut(context_id.into())?;
         Some(&mut data.ctx)
     }
 
-    fn bindings(&mut self, device: &Device, context_id: WebXRContextId) -> Option<&glow::Context> {
-        let data = WebGLThread::make_current_if_needed(
-            device,
-            WebGLContextId::from(context_id),
-            self.contexts,
-            self.bound_context_id,
-        )?;
+    fn bindings(&mut self, context_id: WebXRContextId) -> Option<&glow::Context> {
+        let data = self.make_current_if_needed(context_id.into())?;
         Some(&data.gl)
     }
 }

--- a/components/webxr/gl_utils.rs
+++ b/components/webxr/gl_utils.rs
@@ -6,7 +6,6 @@ use std::collections::HashMap;
 
 use glow as gl;
 use glow::{Context as Gl, HasContext};
-use surfman::Device as SurfmanDevice;
 use webxr_api::{ContextId, GLContexts, LayerId};
 
 use crate::SurfmanGL;
@@ -89,7 +88,6 @@ impl GlClearer {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn clear(
         &mut self,
-        device: &mut SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         layer_id: LayerId,
@@ -97,7 +95,7 @@ impl GlClearer {
         color_target: u32,
         depth_stencil: Option<glow::NativeTexture>,
     ) {
-        let gl = match contexts.bindings(device, context_id) {
+        let gl = match contexts.bindings(context_id) {
             None => return,
             Some(gl) => gl,
         };
@@ -158,12 +156,11 @@ impl GlClearer {
 
     pub(crate) fn destroy_layer(
         &mut self,
-        device: &mut SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         layer_id: LayerId,
     ) {
-        let gl = match contexts.bindings(device, context_id) {
+        let gl = match contexts.bindings(context_id) {
             None => return,
             Some(gl) => gl,
         };

--- a/components/webxr/glwindow/mod.rs
+++ b/components/webxr/glwindow/mod.rs
@@ -279,7 +279,7 @@ impl DeviceAPI for GlWindowDevice {
             Some(target_swap_chain) => {
                 // Rendering to a surfman swap chain
                 target_swap_chain
-                    .swap_buffers(&mut self.device, &mut self.context, PreserveBuffer::No)
+                    .swap_buffers(&self.device, &mut self.context, PreserveBuffer::No)
                     .unwrap();
             },
             None => {
@@ -465,9 +465,9 @@ impl GlWindowDevice {
         }
         let swap_chains = self.swap_chains.clone();
         let viewports = self.viewports();
-        let layer_manager = self.grand_manager.create_layer_manager(move |_, _| {
-            Ok(SurfmanLayerManager::new(viewports, swap_chains))
-        })?;
+        let layer_manager = self
+            .grand_manager
+            .create_layer_manager(move |_| Ok(SurfmanLayerManager::new(viewports, swap_chains)))?;
         self.layer_manager = Some(layer_manager);
         Ok(self.layer_manager.as_mut().unwrap())
     }

--- a/components/webxr/headless/mod.rs
+++ b/components/webxr/headless/mod.rs
@@ -213,9 +213,9 @@ impl HeadlessDevice {
         }
         let swap_chains = SwapChains::new();
         let viewports = self.viewports();
-        let layer_manager = self.grand_manager.create_layer_manager(move |_, _| {
-            Ok(SurfmanLayerManager::new(viewports, swap_chains))
-        })?;
+        let layer_manager = self
+            .grand_manager
+            .create_layer_manager(move |_| Ok(SurfmanLayerManager::new(viewports, swap_chains)))?;
         self.layer_manager = Some(layer_manager);
         Ok(self.layer_manager.as_mut().unwrap())
     }

--- a/components/webxr/openxr/graphics.rs
+++ b/components/webxr/openxr/graphics.rs
@@ -15,13 +15,12 @@ pub trait GraphicsProviderMethods<G: Graphics> {
     fn enable_graphics_extensions(exts: &mut ExtensionSet);
     fn pick_format(formats: &[u32]) -> u32;
     fn create_session(
-        device: &SurfmanDevice,
         instance: &Instance,
         system: SystemId,
     ) -> Result<(Session<G>, FrameWaiter, FrameStream<G>), Error>;
     fn surface_texture_from_swapchain_texture(
         image: <G as Graphics>::SwapchainImage,
-        device: &mut SurfmanDevice,
+        device: &SurfmanDevice,
         context: &mut SurfmanContext,
         size: &Size2D<i32, UnknownUnit>,
     ) -> Result<SurfaceTexture, SurfmanError>;

--- a/components/webxr/openxr/graphics_d3d11.rs
+++ b/components/webxr/openxr/graphics_d3d11.rs
@@ -11,8 +11,8 @@ use openxr::{
     ExtensionSet, FormFactor, FrameStream, FrameWaiter, Graphics, Instance, Session, SystemId,
 };
 use surfman::{
-    Adapter as SurfmanAdapter, Context as SurfmanContext, Device as SurfmanDevice,
-    Error as SurfmanError, SurfaceTexture,
+    Adapter as SurfmanAdapter, Connection as SurfmanConnection, Context as SurfmanContext,
+    Device as SurfmanDevice, Error as SurfmanError, SurfaceTexture,
 };
 use webxr_api::Error;
 use winapi::Interface;
@@ -22,7 +22,6 @@ use winapi::um::d3d11::ID3D11Texture2D;
 use wio::com::ComPtr;
 
 use crate::openxr::graphics::{GraphicsProvider, GraphicsProviderMethods};
-use crate::openxr::{AppInfo, create_instance};
 
 pub type Backend = D3D11;
 
@@ -51,22 +50,19 @@ impl GraphicsProviderMethods<D3D11> for GraphicsProvider {
     }
 
     fn create_session(
-        device: &SurfmanDevice,
         instance: &Instance,
         system: SystemId,
     ) -> Result<(Session<D3D11>, FrameWaiter, FrameStream<D3D11>), Error> {
-        // Get the current surfman device and extract its D3D device. This will ensure
-        // that the OpenXR runtime's texture will be shareable with surfman's surfaces.
+        // FIXME: We should ensure that the OpenXR runtime's texture will be shareable with
+        // surfman's surfaces by validating the requirements of the XR runtime and ensuring that
+        // the WebGL context can use the same device when `makeXRCompatible` is called.
+        let adapter = create_surfman_adapter(instance).ok_or(Error::NoMatchingDevice)?;
+        let connection = SurfmanConnection::new().map_err(|_| Error::NoMatchingDevice)?;
+        let device = connection
+            .create_device(&adapter)
+            .map_err(|_| Error::NoMatchingDevice)?;
         let native_device = device.native_device();
         let d3d_device = native_device.d3d11_device;
-
-        // FIXME: we should be using these graphics requirements to drive the actual
-        //        d3d device creation, rather than assuming the device that surfman
-        //        already created is appropriate. OpenXR returns a validation error
-        //        unless we call this method, so we call it and ignore the results
-        //        in the short term.
-        let _requirements = D3D11::requirements(instance, system)
-            .map_err(|e| Error::BackendSpecific(format!("D3D11::requirements {:?}", e)))?;
 
         unsafe {
             instance
@@ -82,7 +78,7 @@ impl GraphicsProviderMethods<D3D11> for GraphicsProvider {
 
     fn surface_texture_from_swapchain_texture(
         image: <D3D11 as Graphics>::SwapchainImage,
-        device: &mut SurfmanDevice,
+        device: &SurfmanDevice,
         context: &mut SurfmanContext,
         size: &Size2D<i32, UnknownUnit>,
     ) -> Result<SurfaceTexture, SurfmanError> {
@@ -129,14 +125,10 @@ fn get_matching_adapter(
 }
 
 #[expect(unused)]
-pub fn create_surfman_adapter() -> Option<SurfmanAdapter> {
-    let instance = create_instance(false, false, false, &AppInfo::default()).ok()?;
-    let system = instance
-        .instance
-        .system(FormFactor::HEAD_MOUNTED_DISPLAY)
-        .ok()?;
+pub fn create_surfman_adapter(instance: &Instance) -> Option<SurfmanAdapter> {
+    let system = instance.system(FormFactor::HEAD_MOUNTED_DISPLAY).ok()?;
 
-    let requirements = D3D11::requirements(&instance.instance, system).ok()?;
+    let requirements = D3D11::requirements(instance, system).ok()?;
     let adapter = get_matching_adapter(&requirements).ok()?;
     Some(SurfmanAdapter::from_dxgi_adapter(adapter.up()))
 }

--- a/components/webxr/openxr/mod.rs
+++ b/components/webxr/openxr/mod.rs
@@ -471,7 +471,7 @@ impl OpenXrLayer {
 impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
     fn create_layer(
         &mut self,
-        device: &mut SurfmanDevice,
+        device: &SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         init: LayerInit,
@@ -541,7 +541,7 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
 
     fn destroy_layer(
         &mut self,
-        device: &mut SurfmanDevice,
+        device: &SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         layer_id: LayerId,
@@ -574,7 +574,7 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
 
     fn end_frame(
         &mut self,
-        _device: &mut SurfmanDevice,
+        _device: &SurfmanDevice,
         _contexts: &mut dyn GLContexts<SurfmanGL>,
         layers: &[(ContextId, LayerId)],
     ) -> Result<(), Error> {
@@ -727,7 +727,6 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
 
     fn begin_frame(
         &mut self,
-        device: &mut SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         layers: &[(ContextId, LayerId)],
     ) -> Result<Vec<SubImages>, Error> {

--- a/components/webxr/openxr/mod.rs
+++ b/components/webxr/openxr/mod.rs
@@ -446,7 +446,7 @@ impl OpenXrLayer {
 
     fn get_surface_texture(
         &mut self,
-        device: &mut SurfmanDevice,
+        device: &SurfmanDevice,
         context: &mut SurfmanContext,
         index: usize,
     ) -> Result<&SurfaceTexture, SurfmanError> {
@@ -471,7 +471,6 @@ impl OpenXrLayer {
 impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
     fn create_layer(
         &mut self,
-        device: &SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         init: LayerInit,
@@ -510,7 +509,7 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
         };
         let depth_stencil_texture = if has_depth_stencil {
             let gl = contexts
-                .bindings(device, context_id)
+                .bindings(context_id)
                 .ok_or(Error::NoMatchingDevice)?;
             unsafe {
                 let depth_stencil_texture = gl.create_texture().ok();
@@ -541,22 +540,21 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
 
     fn destroy_layer(
         &mut self,
-        device: &SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         layer_id: LayerId,
     ) {
-        self.clearer
-            .destroy_layer(device, contexts, context_id, layer_id);
+        self.clearer.destroy_layer(contexts, context_id, layer_id);
         self.layers.retain(|&ids| ids != (context_id, layer_id));
         if let Some(mut layer) = self.openxr_layers.remove(&layer_id) {
             if let Some(depth_stencil_texture) = layer.depth_stencil_texture {
-                let gl = contexts.bindings(device, context_id).unwrap();
+                let gl = contexts.bindings(context_id).unwrap();
                 unsafe { gl.delete_texture(depth_stencil_texture) };
             }
-            let context = contexts
-                .context(device, context_id)
-                .expect("missing GL context");
+            let device = contexts
+                .device(context_id)
+                .expect("missing device for context");
+            let context = contexts.context(context_id).expect("missing GL context");
             for surface_texture in mem::replace(&mut layer.surface_textures, vec![]) {
                 if let Some(surface_texture) = surface_texture {
                     let mut surface = device
@@ -574,7 +572,6 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
 
     fn end_frame(
         &mut self,
-        _device: &SurfmanDevice,
         _contexts: &mut dyn GLContexts<SurfmanGL>,
         layers: &[(ContextId, LayerId)],
     ) -> Result<(), Error> {
@@ -740,8 +737,9 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
         layers
             .iter()
             .map(|&(context_id, layer_id)| {
+                let device = contexts.device(context_id).ok_or(Error::NoMatchingDevice)?;
                 let context = contexts
-                    .context(device, context_id)
+                    .context(context_id)
                     .ok_or(Error::NoMatchingDevice)?;
                 let openxr_layer = openxr_layers
                     .get_mut(&layer_id)
@@ -759,7 +757,7 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
                 openxr_layer.waited = true;
 
                 let color_surface_texture = openxr_layer
-                    .get_surface_texture(device, context, image as usize)
+                    .get_surface_texture(&device, context, image as usize)
                     .map_err(|e| {
                         Error::BackendSpecific(format!("Layer::get_surface_texture {:?}", e))
                     })?;
@@ -787,7 +785,6 @@ impl LayerManagerAPI<SurfmanGL> for OpenXrLayerManager {
                     })
                     .collect();
                 clearer.clear(
-                    device,
                     contexts,
                     context_id,
                     layer_id,
@@ -843,9 +840,9 @@ impl OpenXrDevice {
         let shared_data_clone = shared_data.clone();
         let mut data = shared_data.lock().unwrap();
 
-        let layer_manager = grand_manager.create_layer_manager(move |device, _| {
+        let layer_manager = grand_manager.create_layer_manager(move |_| {
             let (session, frame_waiter, frame_stream) =
-                GraphicsProvider::create_session(device, &instance_clone, system)?;
+                GraphicsProvider::create_session(&instance_clone, system)?;
             let (passthrough, passthrough_layer) = if supports_passthrough {
                 let flags = PassthroughFlagsFB::IS_RUNNING_AT_CREATION;
                 let purpose = PassthroughLayerPurposeFB::RECONSTRUCTION;


### PR DESCRIPTION
Currently, a single `surfman::Device` is used for all WebGL contexts. This cannot work when we have multiple rendering contexts. So, extract the surfman `Connection` and `Adapter` into a per-painter data structure (`PainterSurfmanDetailsMap`) and store the `Device` directly in the WebGL context.

This patch also modifies the WebXR traits so that the `Device` doesn't need to be explictly passed into most methods.

Testing: Should be covered by existing tests.