### PR TITLE
script: servoparser line number pass to CSP

### DIFF
--- a/components/script/dom/csp.rs
+++ b/components/script/dom/csp.rs
@@ -47,6 +47,7 @@ pub(crate) trait CspReporting {
         el: &Element,
         type_: InlineCheckType,
         source: &str,
+        current_line: u32,
     ) -> bool;
     fn is_trusted_type_policy_creation_allowed(
         &self,
@@ -154,6 +155,7 @@ impl CspReporting for Option<CspList> {
         el: &Element,
         type_: InlineCheckType,
         source: &str,
+        current_line: u32,
     ) -> bool {
         let Some(csp_list) = self else {
             return false;
@@ -164,7 +166,9 @@ impl CspReporting for Option<CspList> {
         let (result, violations) =
             csp_list.should_elements_inline_type_behavior_be_blocked(&element, type_, source);
 
-        global.report_csp_violations(violations, Some(el), None);
+        let source_position = el.compute_source_position(current_line.saturating_sub(2).max(1));
+
+        global.report_csp_violations(violations, Some(el), Some(source_position));
 
         result == CheckResult::Blocked
     }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2500,6 +2500,12 @@ impl Document {
         self.current_parser.get()
     }
 
+    pub(crate) fn get_current_parser_line(&self) -> u32 {
+        self.get_current_parser()
+            .map(|parser| parser.get_current_line())
+            .unwrap_or(0)
+    }
+
     /// A reference to the [`IFrameCollection`] of this [`Document`], holding information about
     /// `<iframe>`s found within it.
     pub(crate) fn iframes(&self) -> Ref<'_, IFrameCollection> {

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2401,6 +2401,7 @@ impl Element {
                             self,
                             InlineCheckType::StyleAttribute,
                             source,
+                            doc.get_current_parser_line(),
                         )
                     {
                         return;

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -682,6 +682,7 @@ impl EventTarget {
                     element.upcast(),
                     InlineCheckType::ScriptAttribute,
                     source,
+                    line as u32,
                 )
             {
                 return;

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -697,6 +697,7 @@ impl HTMLScriptElement {
                     element,
                     InlineCheckType::Script,
                     &text.str(),
+                    self.line_number as u32,
                 )
         {
             warn!("Blocking inline script due to CSP");

--- a/components/script/dom/html/htmlstyleelement.rs
+++ b/components/script/dom/html/htmlstyleelement.rs
@@ -123,6 +123,7 @@ impl HTMLStyleElement {
                 self.upcast(),
                 InlineCheckType::Style,
                 &node.child_text_content().str(),
+                doc.get_current_parser_line(),
             )
         {
             return;

--- a/components/script/dom/servoparser/async_html.rs
+++ b/components/script/dom/servoparser/async_html.rs
@@ -232,6 +232,7 @@ pub(crate) struct Tokenizer {
     parsing_algorithm: ParsingAlgorithm,
     #[conditional_malloc_size_of]
     custom_element_reaction_stack: Rc<CustomElementReactionStack>,
+    current_line: Cell<u64>,
 }
 
 impl Tokenizer {
@@ -259,6 +260,7 @@ impl Tokenizer {
             url,
             parsing_algorithm: algorithm,
             custom_element_reaction_stack,
+            current_line: Cell::new(1),
         };
         tokenizer.insert_node(0, Dom::from_ref(document.upcast()));
 
@@ -381,6 +383,10 @@ impl Tokenizer {
             .unwrap();
     }
 
+    pub(crate) fn get_current_line(&self) -> u32 {
+        self.current_line.get() as u32
+    }
+
     fn insert_node(&self, id: ParseNodeId, node: Dom<Node>) {
         assert!(self.nodes.borrow_mut().insert(id, node).is_none());
     }
@@ -464,6 +470,7 @@ impl Tokenizer {
                 attrs,
                 current_line,
             } => {
+                self.current_line.set(current_line);
                 let attrs = attrs
                     .into_iter()
                     .map(|attr| ElementAttribute::new(attr.name, DOMString::from(attr.value)))

--- a/components/script/dom/servoparser/html.rs
+++ b/components/script/dom/servoparser/html.rs
@@ -118,6 +118,10 @@ impl Tokenizer {
     pub(crate) fn set_plaintext_state(&self) {
         self.inner.set_plaintext_state();
     }
+
+    pub(crate) fn get_current_line(&self) -> u32 {
+        self.inner.sink.sink.current_line.get() as u32
+    }
 }
 
 /// <https://html.spec.whatwg.org/multipage/#html-fragment-serialisation-algorithm>

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -487,6 +487,10 @@ impl ServoParser {
         self.script_nesting_level() > 0 && !self.aborted.get()
     }
 
+    pub(crate) fn get_current_line(&self) -> u32 {
+        self.tokenizer.get_current_line()
+    }
+
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     fn new_inherited(document: &Document, tokenizer: Tokenizer, kind: ParserKind) -> Self {
         // Store the whole input for the devtools Sources panel, if the devtools server is running
@@ -847,6 +851,14 @@ impl Tokenizer {
             Tokenizer::Html(ref tokenizer) => tokenizer.set_plaintext_state(),
             Tokenizer::AsyncHtml(ref tokenizer) => tokenizer.set_plaintext_state(),
             Tokenizer::Xml(_) => unimplemented!(),
+        }
+    }
+
+    fn get_current_line(&self) -> u32 {
+        match *self {
+            Tokenizer::Html(ref tokenizer) => tokenizer.get_current_line(),
+            Tokenizer::AsyncHtml(ref tokenizer) => tokenizer.get_current_line(),
+            Tokenizer::Xml(ref tokenizer) => tokenizer.get_current_line(),
         }
     }
 }

--- a/components/script/dom/servoparser/xml.rs
+++ b/components/script/dom/servoparser/xml.rs
@@ -66,4 +66,8 @@ impl Tokenizer {
     pub(crate) fn url(&self) -> &ServoUrl {
         &self.inner.sink.sink.base_url
     }
+
+    pub(crate) fn get_current_line(&self) -> u32 {
+        self.inner.sink.sink.current_line.get() as u32
+    }
 }


### PR DESCRIPTION
takes over the initial work from @zazabap in PR #38675 (Thanks @zazabap!)

Testing: 
`./mach test-wpt content-security-policy/securitypolicyviolation/blockeduri-inline.html`
`./mach test-wpt /css/CSS2/abspos/abspos-containing-block-initial-001.xht`
Fixes #38167  
Closes #38675