### PR TITLE
libservo: Add `ContextMenuElementInformation` to for the context menu API

### DIFF
--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -39,7 +39,6 @@ use script_bindings::str::DOMString;
 use script_traits::ConstellationInputEvent;
 use servo_config::pref;
 use style_traits::CSSPixel;
-use xml5ever::{local_name, ns};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::refcounted::Trusted;
@@ -506,13 +505,8 @@ impl DocumentEventHandler {
                 .next()
             {
                 let status = anchor
-                    .upcast::<Element>()
-                    .get_attribute(&ns!(), &local_name!("href"))
-                    .and_then(|href| {
-                        let value = href.value();
-                        let url = self.window.get_url();
-                        url.join(&value).map(|url| url.to_string()).ok()
-                    });
+                    .full_href_url_for_user_interface()
+                    .map(|url| url.to_string());
                 self.window
                     .send_to_embedder(EmbedderMsg::Status(self.window.webview_id(), status));
                 return;

--- a/components/script/dom/html/htmlanchorelement.rs
+++ b/components/script/dom/html/htmlanchorelement.rs
@@ -12,6 +12,7 @@ use num_traits::ToPrimitive;
 use servo_url::ServoUrl;
 use style::attr::AttrValue;
 use stylo_atoms::Atom;
+use xml5ever::ns;
 
 use crate::dom::activation::Activatable;
 use crate::dom::attr::Attr;
@@ -31,7 +32,7 @@ use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlhyperlinkelementutils::{HyperlinkElement, HyperlinkElementTraits};
 use crate::dom::html::htmlimageelement::HTMLImageElement;
 use crate::dom::mouseevent::MouseEvent;
-use crate::dom::node::{BindContext, Node};
+use crate::dom::node::{BindContext, Node, NodeTraits};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::links::{LinkRelations, follow_hyperlink};
 use crate::script_runtime::CanGc;
@@ -76,6 +77,14 @@ impl HTMLAnchorElement {
             proto,
             can_gc,
         )
+    }
+
+    /// Get the full URL of the `href` attribute of this `<a>` element, returning `None` if
+    /// the URL could not be joined with the `Document` URL.
+    pub(crate) fn full_href_url_for_user_interface(&self) -> Option<ServoUrl> {
+        self.upcast::<Element>()
+            .get_attribute(&ns!(), &local_name!("href"))?;
+        self.owner_document().base_url().join(&self.Href()).ok()
     }
 }
 

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1439,6 +1439,15 @@ impl HTMLImageElement {
         self.current_request.borrow_mut().image = Some(Image::Raster(broken_image_icon));
         self.upcast::<Node>().dirty(NodeDamage::Other);
     }
+
+    /// Get the full URL of the current image of this `<img>` element, returning `None` if the URL
+    /// could not be joined with the `Document` URL.
+    pub(crate) fn full_image_url_for_user_interface(&self) -> Option<ServoUrl> {
+        self.owner_document()
+            .base_url()
+            .join(&self.CurrentSrc())
+            .ok()
+    }
 }
 
 #[derive(JSTraceable, MallocSizeOf)]

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -726,6 +726,7 @@ impl WebView {
                     id: control_id,
                     position,
                     items: context_menu_request.items,
+                    element_info: context_menu_request.element_info,
                     constellation_proxy,
                     response_sent: false,
                 })

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -8,10 +8,10 @@ use base::generic_channel::{GenericSender, SendResult};
 use base::id::PipelineId;
 use constellation_traits::EmbedderToConstellationMessage;
 use embedder_traits::{
-    AllowOrDeny, AuthenticationResponse, ContextMenuAction, ContextMenuItem, Cursor,
-    EmbedderControlId, EmbedderControlResponse, FilePickerRequest, FilterPattern,
-    GamepadHapticEffectType, InputEventId, InputEventResult, InputMethodType, LoadStatus,
-    MediaSessionEvent, Notification, PermissionFeature, RgbColor, ScreenGeometry,
+    AllowOrDeny, AuthenticationResponse, ContextMenuAction, ContextMenuElementInformation,
+    ContextMenuItem, Cursor, EmbedderControlId, EmbedderControlResponse, FilePickerRequest,
+    FilterPattern, GamepadHapticEffectType, InputEventId, InputEventResult, InputMethodType,
+    LoadStatus, MediaSessionEvent, Notification, PermissionFeature, RgbColor, ScreenGeometry,
     SelectElementOptionOrOptgroup, SimpleDialog, TraversalId, WebResourceRequest,
     WebResourceResponse, WebResourceResponseMsg,
 };
@@ -338,6 +338,7 @@ pub struct ContextMenu {
     pub(crate) id: EmbedderControlId,
     pub(crate) position: DeviceIntRect,
     pub(crate) items: Vec<ContextMenuItem>,
+    pub(crate) element_info: ContextMenuElementInformation,
     pub(crate) response_sent: bool,
     pub(crate) constellation_proxy: ConstellationProxy,
 }
@@ -353,6 +354,12 @@ impl ContextMenu {
     /// The embedder should use this value to position the prompt that is shown to the user.
     pub fn position(&self) -> DeviceIntRect {
         self.position
+    }
+
+    /// A [`ContextMenuElementInformation`] giving details about the element that this [`ContextMenu`]
+    /// was activated on.
+    pub fn element_info(&self) -> &ContextMenuElementInformation {
+        &self.element_info
     }
 
     /// Resolve the context menu by activating the given context menu action.

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -25,6 +25,7 @@ use std::time::SystemTime;
 use base::Epoch;
 use base::generic_channel::{GenericCallback, GenericSender, SendResult};
 use base::id::{PipelineId, WebViewId};
+use bitflags::bitflags;
 use crossbeam_channel::Sender;
 use euclid::{Box2D, Point2D, Scale, Size2D, Vector2D};
 use http::{HeaderMap, Method, StatusCode};
@@ -660,6 +661,7 @@ pub enum EmbedderControlRequest {
 /// right-clicking on web content.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ContextMenuRequest {
+    pub element_info: ContextMenuElementInformation,
     pub items: Vec<ContextMenuItem>,
 }
 
@@ -693,6 +695,34 @@ pub enum ContextMenuAction {
     Copy,
     Paste,
     SelectAll,
+}
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
+    pub struct ContextMenuElementInformationFlags: u8 {
+        /// Whether or not the element this context menu was activated for was a link.
+        const Link = 1 << 1;
+        /// Whether or not the element this context menu was activated for was an image.
+        const Image = 1 << 2;
+        /// Whether or not the element this context menu was activated for was editable
+        /// text.
+        const EditableText = 1 << 3;
+        /// Whether or not the element this context menu was activated for was covered by
+        /// a selection.
+        const Selection = 1 << 4;
+    }
+}
+
+/// Information about the element that a context menu was activated for. values which
+/// do not apply to this element will be `None`.
+///
+/// Note that an element might be both an image and a link, if the element is an `<img>`
+/// tag nested inside of a `<a>` tag.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct ContextMenuElementInformation {
+    pub flags: ContextMenuElementInformationFlags,
+    pub link_url: Option<Url>,
+    pub image_url: Option<Url>,
 }
 
 /// Request to present an IME to the user when an editable element is focused. If `type` is


### PR DESCRIPTION
This new data structure allows passing more information when popping up
context menus. It's possible in the future that it will be adapted into
a more generic "hit test result" type API ala WebKit, but for now, this is probably
enough.

Testing: This change includes new API test assertions.
