### PR TITLE
script: Fix MutationObserver to use `Dom` instead of `DomRoot`

### DIFF
--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -668,6 +668,7 @@ impl Node {
     }
 
     /// Add a new mutation observer for a given node.
+    #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn add_mutation_observer(&self, observer: RegisteredObserver) {
         self.ensure_rare_data().mutation_observers.push(observer);
     }

--- a/components/script/script_mutation_observers.rs
+++ b/components/script/script_mutation_observers.rs
@@ -55,7 +55,11 @@ impl ScriptMutationObservers {
             let record_queue = mo.record_queue();
 
             // Step 6.1 Let records be a clone of mo’s record queue.
-            let queue: Vec<DomRoot<MutationRecord>> = record_queue.borrow().clone();
+            let queue: Vec<DomRoot<MutationRecord>> = record_queue
+                .borrow()
+                .iter()
+                .map(|record| record.as_rooted())
+                .collect();
 
             // Step 6.2 Empty mo’s record queue.
             record_queue.borrow_mut().clear();


### PR DESCRIPTION
converts MutationObserver's record_queue and node_list, as well as RegisteredObserver's observer field, to use Dom<T> instead.

Testing: `./mach build --use-crown` pass locally
Fixes #40602