### PR TITLE
html: Add <media> `current` and `official` playback positions

### DIFF
--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/seeking/seek-to-max-value.htm.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/seeking/seek-to-max-value.htm.ini
@@ -1,4 +1,0 @@
-[seek-to-max-value.htm]
-  [seek to Number.MAX_VALUE]
-    expected: FAIL
-

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/seeking/seek-to-negative-time.htm.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/seeking/seek-to-negative-time.htm.ini
@@ -1,3 +1,0 @@
-[seek-to-negative-time.htm]
-  [seek to negative time]
-    expected: FAIL


### PR DESCRIPTION
Follow the HTML specification and split the previous `playback position` to `current playback position` (a time on the media timeline) and `official playbac position` (an approximation of the current playback position that is kept stable while scripts are running) which must be set to `the current playback position` any time the user agent provides a stable state.

See https://html.spec.whatwg.org/multipage/#current-playback-position
See https://html.spec.whatwg.org/multipage/#official-playback-position

Note that at this point, there are no difference between the `current` and `official` playback positions (as the time on the media timeline), except the `seek` case. 

Testing: Improvements in the following tests
- html/semantics/embedded-content/media-elements/seeking/seek-to-max-value.htm
- html/semantics/embedded-content/media-elements/seeking/seek-to-negative-time.htm

Fixes: https://github.com/servo/servo/issues/34496