### PR TITLE
Replace calls to ".filter_map()" followed by ".next()" with ".find_map()"

### DIFF
--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -716,17 +716,14 @@ impl FontGroup {
         FontPredicate: Fn(&FontRef) -> bool,
     {
         let font_descriptor = self.descriptor.clone();
-        self.families
-            .iter_mut()
-            .filter_map(|font_group_family| {
-                font_group_family.find(
-                    &font_descriptor,
-                    font_context,
-                    &template_predicate,
-                    &font_predicate,
-                )
-            })
-            .next()
+        self.families.iter_mut().find_map(|font_group_family| {
+            font_group_family.find(
+                &font_descriptor,
+                font_context,
+                &template_predicate,
+                &font_predicate,
+            )
+        })
     }
 
     /// Attempts to find a suitable fallback font which matches the given `template_predicate` and
@@ -756,7 +753,7 @@ impl FontGroup {
                         FontFamilyDescriptor::new(family, FontSearchScope::Local)
                     }),
             )
-            .filter_map(|family_descriptor| {
+            .find_map(|family_descriptor| {
                 FontGroupFamily {
                     family_descriptor,
                     members: None,
@@ -768,7 +765,6 @@ impl FontGroup {
                     &font_predicate,
                 )
             })
-            .next()
     }
 }
 
@@ -816,7 +812,7 @@ impl FontGroupFamily {
         FontPredicate: Fn(&FontRef) -> bool,
     {
         self.members(font_descriptor, font_context)
-            .filter_map(|member| {
+            .find_map(|member| {
                 if !template_predicate(member.template.clone()) {
                     return None;
                 }
@@ -831,7 +827,6 @@ impl FontGroupFamily {
 
                 None
             })
-            .next()
     }
 
     fn members(

--- a/components/fonts/font_store.rs
+++ b/components/fonts/font_store.rs
@@ -166,10 +166,7 @@ impl SimpleFamily {
             (false, true) => [&self.italic, &self.bold_italic, &self.regular, &self.bold],
             (false, false) => [&self.regular, &self.bold, &self.italic, &self.bold_italic],
         };
-        preference
-            .iter()
-            .filter_map(|template| (*template).clone())
-            .next()
+        preference.iter().find_map(|template| (*template).clone())
     }
 
     fn remove_templates_for_stylesheet(&mut self, stylesheet: &DocumentStyleSheet) {

--- a/components/script/dom/characterdata.rs
+++ b/components/script/dom/characterdata.rs
@@ -273,16 +273,14 @@ impl CharacterDataMethods<crate::DomTypeHolder> for CharacterData {
     fn GetPreviousElementSibling(&self) -> Option<DomRoot<Element>> {
         self.upcast::<Node>()
             .preceding_siblings()
-            .filter_map(DomRoot::downcast)
-            .next()
+            .find_map(DomRoot::downcast)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-nextelementsibling>
     fn GetNextElementSibling(&self) -> Option<DomRoot<Element>> {
         self.upcast::<Node>()
             .following_siblings()
-            .filter_map(DomRoot::downcast)
-            .next()
+            .find_map(DomRoot::downcast)
     }
 }
 

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4820,10 +4820,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
     /// <https://dom.spec.whatwg.org/#dom-document-doctype>
     fn GetDoctype(&self) -> Option<DomRoot<DocumentType>> {
-        self.upcast::<Node>()
-            .children()
-            .filter_map(DomRoot::downcast)
-            .next()
+        self.upcast::<Node>().children().find_map(DomRoot::downcast)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-documentelement>
@@ -5290,12 +5287,8 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-head>
     fn GetHead(&self) -> Option<DomRoot<HTMLHeadElement>> {
-        self.get_html_element().and_then(|root| {
-            root.upcast::<Node>()
-                .children()
-                .filter_map(DomRoot::downcast)
-                .next()
-        })
+        self.get_html_element()
+            .and_then(|root| root.upcast::<Node>().children().find_map(DomRoot::downcast))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-document-currentscript>
@@ -5481,8 +5474,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn GetLastElementChild(&self) -> Option<DomRoot<Element>> {
         self.upcast::<Node>()
             .rev_children()
-            .filter_map(DomRoot::downcast)
-            .next()
+            .find_map(DomRoot::downcast)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-childelementcount>

--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -373,8 +373,7 @@ impl DocumentEventHandler {
         let Some(new_target) = hit_test_result
             .node
             .inclusive_ancestors(ShadowIncluding::No)
-            .filter_map(DomRoot::downcast::<Element>)
-            .next()
+            .find_map(DomRoot::downcast::<Element>)
         else {
             return;
         };
@@ -502,8 +501,7 @@ impl DocumentEventHandler {
             if let Some(anchor) = target
                 .upcast::<Node>()
                 .inclusive_ancestors(ShadowIncluding::No)
-                .filter_map(DomRoot::downcast::<HTMLAnchorElement>)
-                .next()
+                .find_map(DomRoot::downcast::<HTMLAnchorElement>)
             {
                 let status = anchor
                     .upcast::<Element>()
@@ -527,9 +525,7 @@ impl DocumentEventHandler {
             previous_hover_target
                 .upcast::<Node>()
                 .inclusive_ancestors(ShadowIncluding::No)
-                .filter_map(DomRoot::downcast::<HTMLAnchorElement>)
-                .next()
-                .is_some()
+                .any(|node| node.is::<HTMLAnchorElement>())
         }) {
             self.window
                 .send_to_embedder(EmbedderMsg::Status(self.window.webview_id(), None));
@@ -572,8 +568,7 @@ impl DocumentEventHandler {
         let Some(element) = hit_test_result
             .node
             .inclusive_ancestors(ShadowIncluding::Yes)
-            .filter_map(DomRoot::downcast::<Element>)
-            .next()
+            .find_map(DomRoot::downcast::<Element>)
         else {
             return;
         };
@@ -850,8 +845,7 @@ impl DocumentEventHandler {
         let Some(el) = hit_test_result
             .node
             .inclusive_ancestors(ShadowIncluding::No)
-            .filter_map(DomRoot::downcast::<Element>)
-            .next()
+            .find_map(DomRoot::downcast::<Element>)
         else {
             self.update_active_touch_points_when_early_return(event);
             return Default::default();
@@ -1122,8 +1116,7 @@ impl DocumentEventHandler {
         let Some(el) = hit_test_result
             .node
             .inclusive_ancestors(ShadowIncluding::No)
-            .filter_map(DomRoot::downcast::<Element>)
-            .next()
+            .find_map(DomRoot::downcast::<Element>)
         else {
             return Default::default();
         };
@@ -1527,8 +1520,7 @@ impl DocumentEventHandler {
             };
             let Some(element) = node
                 .inclusive_ancestors(ShadowIncluding::No)
-                .filter_map(DomRoot::downcast::<Element>)
-                .next()
+                .find_map(DomRoot::downcast::<Element>)
             else {
                 return;
             };

--- a/components/script/dom/documentfragment.rs
+++ b/components/script/dom/documentfragment.rs
@@ -102,8 +102,7 @@ impl DocumentFragmentMethods<crate::DomTypeHolder> for DocumentFragment {
     fn GetLastElementChild(&self) -> Option<DomRoot<Element>> {
         self.upcast::<Node>()
             .rev_children()
-            .filter_map(DomRoot::downcast::<Element>)
-            .next()
+            .find_map(DomRoot::downcast::<Element>)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-childelementcount>

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -3687,16 +3687,14 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     fn GetPreviousElementSibling(&self) -> Option<DomRoot<Element>> {
         self.upcast::<Node>()
             .preceding_siblings()
-            .filter_map(DomRoot::downcast)
-            .next()
+            .find_map(DomRoot::downcast)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-nondocumenttypechildnode-nextelementsibling>
     fn GetNextElementSibling(&self) -> Option<DomRoot<Element>> {
         self.upcast::<Node>()
             .following_siblings()
-            .filter_map(DomRoot::downcast)
-            .next()
+            .find_map(DomRoot::downcast)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-children>
@@ -3714,8 +3712,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
     fn GetLastElementChild(&self) -> Option<DomRoot<Element>> {
         self.upcast::<Node>()
             .rev_children()
-            .filter_map(DomRoot::downcast::<Element>)
-            .next()
+            .find_map(DomRoot::downcast::<Element>)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-parentnode-childelementcount>
@@ -4700,16 +4697,14 @@ impl SelectorsElement for SelectorWrapper<'_> {
     fn prev_sibling_element(&self) -> Option<Self> {
         self.node
             .preceding_siblings()
-            .filter_map(DomRoot::downcast)
-            .next()
+            .find_map(DomRoot::downcast)
             .map(SelectorWrapper::Owned)
     }
 
     fn next_sibling_element(&self) -> Option<Self> {
         self.node
             .following_siblings()
-            .filter_map(DomRoot::downcast)
-            .next()
+            .find_map(DomRoot::downcast)
             .map(SelectorWrapper::Owned)
     }
 

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1623,8 +1623,7 @@ pub(crate) trait FormControl: DomObject {
         let has_form_id = elem.has_attribute(&local_name!("form"));
         let nearest_form_ancestor = node
             .ancestors()
-            .filter_map(DomRoot::downcast::<HTMLFormElement>)
-            .next();
+            .find_map(DomRoot::downcast::<HTMLFormElement>);
 
         // Step 1
         if old_owner.is_some() &&

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1025,8 +1025,7 @@ impl HTMLMediaElement {
         } else if let Some(source) = self
             .upcast::<Node>()
             .children()
-            .filter_map(DomRoot::downcast::<HTMLSourceElement>)
-            .next()
+            .find_map(DomRoot::downcast::<HTMLSourceElement>)
         {
             // Otherwise, if the media element does not have an assigned media provider object and
             // does not have a src attribute, but does have a source element child, then let mode be

--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -367,8 +367,7 @@ impl VirtualMethods for HTMLOptionElement {
         if let Some(select) = context
             .parent
             .inclusive_ancestors(ShadowIncluding::No)
-            .filter_map(DomRoot::downcast::<HTMLSelectElement>)
-            .next()
+            .find_map(DomRoot::downcast::<HTMLSelectElement>)
         {
             select
                 .validity_state(can_gc)

--- a/components/script/dom/html/htmltableelement.rs
+++ b/components/script/dom/html/htmltableelement.rs
@@ -210,10 +210,7 @@ impl HTMLTableElementMethods<crate::DomTypeHolder> for HTMLTableElement {
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-caption>
     fn GetCaption(&self) -> Option<DomRoot<HTMLTableCaptionElement>> {
-        self.upcast::<Node>()
-            .children()
-            .filter_map(DomRoot::downcast)
-            .next()
+        self.upcast::<Node>().children().find_map(DomRoot::downcast)
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-table-caption>

--- a/components/script/dom/radionodelist.rs
+++ b/components/script/dom/radionodelist.rs
@@ -87,7 +87,7 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
     fn Value(&self) -> DOMString {
         self.upcast::<NodeList>()
             .iter()
-            .filter_map(|node| {
+            .find_map(|node| {
                 // Step 1
                 node.downcast::<HTMLInputElement>().and_then(|input| {
                     if input.input_type() == InputType::Radio && input.Checked() {
@@ -103,7 +103,6 @@ impl RadioNodeListMethods<crate::DomTypeHolder> for RadioNodeList {
                     }
                 })
             })
-            .next()
             // Step 2
             .unwrap_or(DOMString::from(""))
     }

--- a/components/script/dom/validitystate.rs
+++ b/components/script/dom/validitystate.rs
@@ -167,8 +167,7 @@ impl ValidityState {
             .element
             .upcast::<Node>()
             .ancestors()
-            .filter_map(DomRoot::downcast::<HTMLFieldSetElement>)
-            .next()
+            .find_map(DomRoot::downcast::<HTMLFieldSetElement>)
         {
             fieldset.update_validity(can_gc);
         }

--- a/components/shared/net/mime_classifier.rs
+++ b/components/shared/net/mime_classifier.rs
@@ -640,8 +640,7 @@ impl MIMEChecker for GroupedClassifier {
     fn classify(&self, data: &[u8]) -> Option<Mime> {
         self.byte_matchers
             .iter()
-            .filter_map(|matcher| matcher.classify(data))
-            .next()
+            .find_map(|matcher| matcher.classify(data))
     }
 
     fn validate(&self) -> Result<(), String> {


### PR DESCRIPTION
The two are semantically equivalent, but `find_map` is more concise.

Testing: Covered by existing tests
