### PR TITLE
net: Implement eviction in the HTTP cache using `quick_cache`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db81010a6895d8707f9072e6ce98070579b43b717193d2614014abd5cb17dd43"
 dependencies = [
  "accesskit",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -56,7 +56,7 @@ checksum = "a0089e5c0ac0ca281e13ea374773898d9354cc28d15af9f0f7394d44a495b575"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown",
+ "hashbrown 0.15.5",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -88,7 +88,7 @@ checksum = "d2d63dd5041e49c363d83f5419a896ecb074d309c414036f616dc0b04faca971"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown",
+ "hashbrown 0.15.5",
  "static_assertions",
  "windows 0.61.3",
  "windows-core 0.61.2",
@@ -3398,7 +3398,7 @@ checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
  "bitflags 2.10.0",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3822,12 +3822,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4669,7 +4675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -5533,7 +5539,7 @@ dependencies = [
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown",
+ "hashbrown 0.15.5",
  "hexf-parse",
  "indexmap",
  "libm",
@@ -5676,6 +5682,7 @@ dependencies = [
  "parking_lot",
  "pixels",
  "profile_traits",
+ "quick_cache",
  "rayon",
  "resvg",
  "rustc-hash 2.1.1",
@@ -7067,6 +7074,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick_cache"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ada44a88ef953a3294f6eb55d2007ba44646015e18613d2f213016379203ef3"
+dependencies = [
+ "ahash",
+ "equivalent",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -9902,7 +9920,7 @@ checksum = "a235ba928b3109ad9e7696270edb09445a52ae1c7c08e6d31a19b1cdd6cbc24a"
 dependencies = [
  "bytemuck",
  "fearless_simd",
- "hashbrown",
+ "hashbrown 0.15.5",
  "log",
  "peniko",
  "png",
@@ -10464,7 +10482,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown",
+ "hashbrown 0.15.5",
  "js-sys",
  "log",
  "naga",
@@ -10494,7 +10512,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cfg_aliases",
  "document-features",
- "hashbrown",
+ "hashbrown 0.15.5",
  "indexmap",
  "log",
  "naga",
@@ -10562,7 +10580,7 @@ dependencies = [
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hashbrown",
+ "hashbrown 0.15.5",
  "js-sys",
  "khronos-egl",
  "libc",

--- a/components/config/pref_util.rs
+++ b/components/config/pref_util.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 pub enum PrefValue {
     Float(f64),
     Int(i64),
+    UInt(u64),
     Str(String),
     Bool(bool),
     Array(Vec<PrefValue>),
@@ -85,6 +86,7 @@ macro_rules! impl_from_pref {
 impl_pref_from! {
     f64 => PrefValue::Float,
     i64 => PrefValue::Int,
+    u64 => PrefValue::UInt,
     String => PrefValue::Str,
     &str => PrefValue::Str,
     bool => PrefValue::Bool,
@@ -93,6 +95,7 @@ impl_pref_from! {
 impl_from_pref! {
     PrefValue::Float => f64,
     PrefValue::Int => i64,
+    PrefValue::UInt => u64,
     PrefValue::Str => String,
     PrefValue::Bool => bool,
 }

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -248,6 +248,9 @@ pub struct Preferences {
     pub network_http_cache_disabled: bool,
     /// A url for a http proxy. We treat an empty string as no proxy.
     pub network_http_proxy_uri: String,
+    /// The weight of the http memory cache
+    /// Notice that this is not equal to the number of different urls in the cache.
+    pub network_http_cache_size: u64,
     pub network_local_directory_listing_enabled: bool,
     pub network_mime_sniff: bool,
     /// Force the use of `rust-webpki` verification for CA roots. If this is false (the
@@ -436,6 +439,7 @@ impl Preferences {
             network_enforce_tls_onion: false,
             network_http_cache_disabled: false,
             network_http_proxy_uri: String::new(),
+            network_http_cache_size: 5000,
             network_local_directory_listing_enabled: true,
             network_mime_sniff: false,
             network_use_webpki_roots: false,

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -57,6 +57,7 @@ nom = { workspace = true }
 parking_lot = { workspace = true }
 pixels = { path = "../pixels" }
 profile_traits = { workspace = true }
+quick_cache = { version = "0.6.18", default-features = false, features = ["ahash"] }
 rayon = { workspace = true }
 resvg = { workspace = true }
 rustc-hash = { workspace = true }

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -787,8 +787,10 @@ pub async fn main_fetch(
     // processed before sending the response to Devtools.
     send_response_to_devtools(request, context, &response, None);
 
-    let http_cache = context.state.http_cache.write();
-    http_cache.update_awaiting_consumers(request, &response);
+    context
+        .state
+        .http_cache
+        .update_awaiting_consumers(request, &response);
 
     // Steps 25-27.
     // TODO: remove this line when only asynchronous fetches are used

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -790,7 +790,8 @@ pub async fn main_fetch(
     context
         .state
         .http_cache
-        .update_awaiting_consumers(request, &response);
+        .update_awaiting_consumers(request, &response)
+        .await;
 
     // Steps 25-27.
     // TODO: remove this line when only asynchronous fetches are used

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1857,8 +1857,6 @@ async fn wait_for_inflight_requests(done_chan: &mut DoneChannel, response: &mut 
                 Some(Data::Done) => break, // Return the full response as if it was initially cached as such.
                 Some(Data::Cancelled) => {
                     // The response was cancelled while the fetch was ongoing.
-                    // Set response to None, which will trigger a network fetch below.
-                    //*response = None;
                     break;
                 },
                 _ => panic!("HTTP cache should always send Done or Cancelled"),

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::iter::FromIterator;
 use std::sync::Arc as StdArc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -60,7 +60,7 @@ use net_traits::{
     RedirectEndValue, RedirectStartValue, ReferrerPolicy, ResourceAttribute, ResourceFetchTiming,
     ResourceTimeValue, TlsSecurityInfo, TlsSecurityState,
 };
-use parking_lot::{Condvar, Mutex, RwLock};
+use parking_lot::{Mutex, RwLock};
 use profile_traits::mem::{Report, ReportKind};
 use profile_traits::path;
 use rustc_hash::FxHashMap;
@@ -84,7 +84,9 @@ use crate::fetch::fetch_params::FetchParams;
 use crate::fetch::headers::{SecFetchDest, SecFetchMode, SecFetchSite, SecFetchUser};
 use crate::fetch::methods::{Data, DoneChannel, FetchContext, Target, main_fetch};
 use crate::hsts::HstsList;
-use crate::http_cache::{CacheKey, HttpCache};
+use crate::http_cache::{
+    CacheKey, CachedResourcesOrGuard, HttpCache, construct_response, invalidate, refresh,
+};
 use crate::resource_thread::{AuthCache, AuthCacheEntry};
 use crate::websocket_loader::start_websocket;
 
@@ -99,16 +101,10 @@ pub enum HttpCacheEntryState {
     PendingStore(usize),
 }
 
-type HttpCacheState = Mutex<HashMap<CacheKey, Arc<(Mutex<HttpCacheEntryState>, Condvar)>>>;
-
 pub struct HttpState {
     pub hsts_list: RwLock<HstsList>,
     pub cookie_jar: RwLock<CookieStorage>,
     pub http_cache: HttpCache,
-    /// A map of cache key to entry state,
-    /// reflecting whether the cache entry is ready to read from,
-    /// or whether a concurrent pending store should be awaited.
-    pub http_cache_state: HttpCacheState,
     pub auth_cache: RwLock<AuthCache>,
     pub history_states: RwLock<FxHashMap<HistoryStateId, Vec<u8>>>,
     pub client: ServoClient,
@@ -1550,86 +1546,81 @@ async fn http_network_or_cache_fetch(
     }
 
     // TODO(#33616) Step 8.22 If there’s a proxy-authentication entry, use it as appropriate.
+    {
+        // Enter critical section on cache entry.
+        let mut cache_guard = block_for_cache_ready(
+            context,
+            http_request,
+            done_chan,
+            &mut revalidating_flag,
+            &mut response,
+        )
+        .await;
 
-    block_for_cache_ready(
-        context,
-        http_request,
-        done_chan,
-        &mut revalidating_flag,
-        &mut response,
-    );
+        // TODO(#33616): Step 9. If aborted, then return the appropriate network error for fetchParams.
 
-    wait_for_cached_response(done_chan, &mut response).await;
-
-    // TODO(#33616): Step 9. If aborted, then return the appropriate network error for fetchParams.
-
-    // Step 10. If response is null, then:
-    if response.is_none() {
-        // Step 10.1 If httpRequest’s cache mode is "only-if-cached", then return a network error.
-        if http_request.cache_mode == CacheMode::OnlyIfCached {
-            // The cache will not be updated,
-            // set its state to ready to construct.
-            update_http_cache_state(context, http_request);
-            return Response::network_error(NetworkError::Internal(
-                "Couldn't find response in cache".into(),
-            ));
-        }
-
-        // Step 10.2 Let forwardResponse be the result of running HTTP-network fetch given httpFetchParams,
-        // includeCredentials, and isNewConnectionFetch.
-        let forward_response =
-            http_network_fetch(http_fetch_params, include_credentials, done_chan, context).await;
-
-        let http_request = &mut http_fetch_params.request;
-        // Step 10.3 If httpRequest’s method is unsafe and forwardResponse’s status is in the range 200 to 399,
-        // inclusive, invalidate appropriate stored responses in httpCache, as per the
-        // "Invalidating Stored Responses" chapter of HTTP Caching, and set storedResponse to null.
-        if forward_response.status.in_range(200..=399) && !http_request.method.is_safe() {
-            context
-                .state
-                .http_cache
-                .invalidate(http_request, &forward_response);
-        }
-
-        // Step 10.4 If the revalidatingFlag is set and forwardResponse’s status is 304, then:
-        if revalidating_flag && forward_response.status == StatusCode::NOT_MODIFIED {
-            // Ensure done_chan is None,
-            // since the network response will be replaced by the revalidated stored one.
-            response =
-                context
-                    .state
-                    .http_cache
-                    .refresh(http_request, forward_response.clone(), done_chan);
-            *done_chan = None;
-
-            wait_for_cached_response(done_chan, &mut response).await;
-            if let Some(response) = &mut response {
-                response.cache_state = CacheState::Validated;
-            }
-        }
-
-        // Step 10.5 If response is null, then:
+        // Step 10. If response is null, then:
         if response.is_none() {
-            // Step 10.5.1 Set response to forwardResponse.
-            let forward_response = response.insert(forward_response);
-
-            // Per https://httpwg.org/specs/rfc9111.html#response.cacheability we must not cache responses
-            // if the No-Store directive is present
-            if http_request.cache_mode != CacheMode::NoStore {
-                // Step 10.5.2 Store httpRequest and forwardResponse in httpCache, as per the
-                //             "Storing Responses in Caches" chapter of HTTP Caching.
-                context
-                    .state
-                    .http_cache
-                    .store(http_request, forward_response);
+            // Step 10.1 If httpRequest’s cache mode is "only-if-cached", then return a network error.
+            if http_request.cache_mode == CacheMode::OnlyIfCached {
+                // Exit critical section of cache entry.
+                return Response::network_error(NetworkError::Internal(
+                    "Couldn't find response in cache".into(),
+                ));
             }
-        }
-    }
+
+            // Step 10.2 Let forwardResponse be the result of running HTTP-network fetch given httpFetchParams,
+            // includeCredentials, and isNewConnectionFetch.
+            let forward_response =
+                http_network_fetch(http_fetch_params, include_credentials, done_chan, context)
+                    .await;
+
+            let http_request = &mut http_fetch_params.request;
+            // Step 10.3 If httpRequest’s method is unsafe and forwardResponse’s status is in the range 200 to 399,
+            // inclusive, invalidate appropriate stored responses in httpCache, as per the
+            // "Invalidating Stored Responses" chapter of HTTP Caching, and set storedResponse to null.
+            if let Some(guard) = cache_guard.try_as_mut() &&
+                forward_response.status.in_range(200..=399) &&
+                !http_request.method.is_safe()
+            {
+                invalidate(http_request, &forward_response, guard).await;
+            }
+
+            // Step 10.4 If the revalidatingFlag is set and forwardResponse’s status is 304, then:
+            if revalidating_flag && forward_response.status == StatusCode::NOT_MODIFIED {
+                // Ensure done_chan is None,
+                // since the network response will be replaced by the revalidated stored one.
+                *done_chan = None;
+                if let Some(guard) = cache_guard.try_as_mut() {
+                    response =
+                        refresh(http_request, forward_response.clone(), done_chan, guard).await;
+                }
+
+                if let Some(response) = &mut response {
+                    response.cache_state = CacheState::Validated;
+                }
+            }
+
+            // Step 10.5 If response is null, then:
+            if response.is_none() {
+                // Step 10.5.1 Set response to forwardResponse.
+                let forward_response = response.insert(forward_response);
+
+                // Per https://httpwg.org/specs/rfc9111.html#response.cacheability we must not cache responses
+                // if the No-Store directive is present
+                if http_request.cache_mode != CacheMode::NoStore {
+                    // Step 10.5.2 Store httpRequest and forwardResponse in httpCache, as per the
+                    //             "Storing Responses in Caches" chapter of HTTP Caching.
+                    cache_guard.insert(http_request, forward_response).await;
+                }
+            }
+        };
+    }; // Exit Critical Section on cache entry
+    // `block_for_cache_ready` or `refresh` could start new requests that set the `done_chan`, so
+    // so we need to wait till these requests are finished.
+    wait_for_inflight_requests(done_chan, &mut response).await;
 
     let http_request = &mut http_fetch_params.request;
-    // The cache has been updated, set its state to ready to construct.
-    update_http_cache_state(context, http_request);
-
     let mut response = response.unwrap();
 
     // FIXME: The spec doesn't tell us to do this *here*, but if we don't do it then
@@ -1771,7 +1762,6 @@ async fn http_network_or_cache_fetch(
     // Step 18. Return response.
     response
 }
-
 /// If the cache is not ready to construct a response, wait.
 ///
 /// The cache is not ready if a previous fetch checked the cache, found nothing,
@@ -1780,139 +1770,81 @@ async fn http_network_or_cache_fetch(
 /// Note that this is a different workflow from the one involving `wait_for_cached_response`.
 /// That one happens when a fetch gets a cache hit, and the resource is pending completion from the network.
 ///
-fn block_for_cache_ready(
-    context: &FetchContext,
+async fn block_for_cache_ready<'a>(
+    context: &'a FetchContext,
     http_request: &mut Request,
     done_chan: &mut DoneChannel,
     revalidating_flag: &mut bool,
     response: &mut Option<Response>,
-) {
-    let (lock, cvar) = {
-        let entry_key = CacheKey::new(http_request);
-        let mut state_map = context.state.http_cache_state.lock();
-        &*state_map
-            .entry(entry_key)
-            .or_insert_with(|| {
-                Arc::new((
-                    Mutex::new(HttpCacheEntryState::ReadyToConstruct),
-                    Condvar::new(),
-                ))
-            })
-            .clone()
-    };
+) -> CachedResourcesOrGuard<'a> {
+    let entry_key = CacheKey::new(http_request);
+    let guard_result = context.state.http_cache.get_or_guard(entry_key).await;
 
-    // Start of critical section on http-cache state.
-    let mut state = lock.lock();
-    while let HttpCacheEntryState::PendingStore(_) = *state {
-        let time_out = cvar.wait_for(&mut state, Duration::from_millis(500));
-        if time_out.timed_out() {
-            // After a timeout, ignore the pending store.
-            break;
-        }
-    }
-
-    // TODO(#33616): Step 8.23 Set httpCache to the result of determining the
-    // HTTP cache partition, given httpRequest.
-    // Step 8.25.1 Set storedResponse to the result of selecting a response from the httpCache,
-    //              possibly needing validation, as per the "Constructing Responses from Caches"
-    //              chapter of HTTP Caching, if any.
-    let stored_response = context
-        .state
-        .http_cache
-        .construct_response(http_request, done_chan);
-
-    // Step 8.25.2 If storedResponse is non-null, then:
-    if let Some(response_from_cache) = stored_response {
-        let response_headers = response_from_cache.response.headers.clone();
-        // Substep 1, 2, 3, 4
-        let (cached_response, needs_revalidation) =
-            match (http_request.cache_mode, &http_request.mode) {
-                (CacheMode::ForceCache, _) => (Some(response_from_cache.response), false),
-                (CacheMode::OnlyIfCached, &RequestMode::SameOrigin) => {
-                    (Some(response_from_cache.response), false)
-                },
-                (CacheMode::OnlyIfCached, _) | (CacheMode::NoStore, _) | (CacheMode::Reload, _) => {
-                    (None, false)
-                },
-                (_, _) => (
-                    Some(response_from_cache.response),
-                    response_from_cache.needs_validation,
-                ),
-            };
-
-        if needs_revalidation {
-            *revalidating_flag = true;
-            // Substep 5
-            if let Some(http_date) = response_headers.typed_get::<LastModified>() {
-                let http_date: SystemTime = http_date.into();
-                http_request
-                    .headers
-                    .typed_insert(IfModifiedSince::from(http_date));
-            }
-            if let Some(entity_tag) = response_headers.get(header::ETAG) {
-                http_request
-                    .headers
-                    .insert(header::IF_NONE_MATCH, entity_tag.clone());
-            }
-        } else {
-            // Substep 6
-            *response = cached_response;
-            if let Some(response) = response {
-                response.cache_state = CacheState::Local;
-            }
-        }
-        if response.is_none() {
-            // Ensure the done chan is not set if we're not using the cached response,
-            // as the cache might have set it to Some if it constructed a pending response.
+    match guard_result {
+        CachedResourcesOrGuard::Guard(_) => {
             *done_chan = None;
+        },
+        CachedResourcesOrGuard::Value(ref cached_resources) => {
+            // TODO(#33616): Step 8.23 Set httpCache to the result of determining the
+            // HTTP cache partition, given httpRequest.
+            // Step 8.25.1 Set storedResponse to the result of selecting a response from the httpCache,
+            //              possibly needing validation, as per the "Constructing Responses from Caches"
+            //              chapter of HTTP Caching, if any.
+            let stored_response = construct_response(http_request, done_chan, cached_resources);
+            // Step 8.25.2 If storedResponse is non-null, then:
+            if let Some(response_from_cache) = stored_response {
+                let response_headers = response_from_cache.response.headers.clone();
+                // Substep 1, 2, 3, 4
+                let (cached_response, needs_revalidation) =
+                    match (http_request.cache_mode, &http_request.mode) {
+                        (CacheMode::ForceCache, _) => (Some(response_from_cache.response), false),
+                        (CacheMode::OnlyIfCached, &RequestMode::SameOrigin) => {
+                            (Some(response_from_cache.response), false)
+                        },
+                        (CacheMode::OnlyIfCached, _) |
+                        (CacheMode::NoStore, _) |
+                        (CacheMode::Reload, _) => (None, false),
+                        (_, _) => (
+                            Some(response_from_cache.response),
+                            response_from_cache.needs_validation,
+                        ),
+                    };
 
-            // Update the cache state, incrementing the pending store count,
-            // or starting the count.
-            if let HttpCacheEntryState::PendingStore(i) = *state {
-                let new = i + 1;
-                *state = HttpCacheEntryState::PendingStore(new);
-            } else {
-                *state = HttpCacheEntryState::PendingStore(1);
+                if needs_revalidation {
+                    *revalidating_flag = true;
+                    // Substep 5
+                    if let Some(http_date) = response_headers.typed_get::<LastModified>() {
+                        let http_date: SystemTime = http_date.into();
+                        http_request
+                            .headers
+                            .typed_insert(IfModifiedSince::from(http_date));
+                    }
+                    if let Some(entity_tag) = response_headers.get(header::ETAG) {
+                        http_request
+                            .headers
+                            .insert(header::IF_NONE_MATCH, entity_tag.clone());
+                    }
+                } else {
+                    // Substep 6
+                    *response = cached_response;
+                    if let Some(response) = response {
+                        response.cache_state = CacheState::Local;
+                    }
+                }
+                if response.is_none() {
+                    // Ensure the done chan is not set if we're not using the cached response,
+                    // as the cache might have set it to Some if it constructed a pending response.
+                    *done_chan = None;
+                }
             }
-        }
+        },
     }
-
-    // Notify the next thread waiting in line, if there is any.
-    if *state == HttpCacheEntryState::ReadyToConstruct {
-        cvar.notify_one();
-    }
-    // End of critical section on http-cache state.
-}
-
-/// Decrement the number of pending stores,
-/// and set the state to ready to construct,
-/// if no stores are pending.
-///
-fn update_http_cache_state(context: &FetchContext, http_request: &Request) {
-    let (lock, cvar) = {
-        let entry_key = CacheKey::new(http_request);
-        let mut state_map = context.state.http_cache_state.lock();
-        &*state_map
-            .get_mut(&entry_key)
-            .expect("Entry in http-cache state to have been previously inserted")
-            .clone()
-    };
-    let mut state = lock.lock();
-    if let HttpCacheEntryState::PendingStore(i) = *state {
-        let new = i - 1;
-        if new == 0 {
-            *state = HttpCacheEntryState::ReadyToConstruct;
-            // Notify the next thread waiting in line, if there is any.
-            cvar.notify_one();
-        } else {
-            *state = HttpCacheEntryState::PendingStore(new);
-        }
-    }
+    guard_result
 }
 
 /// Wait for a cached response from channel.
 /// Happens when a fetch gets a cache hit, and the resource is pending completion from the network.
-async fn wait_for_cached_response(done_chan: &mut DoneChannel, response: &mut Option<Response>) {
+async fn wait_for_inflight_requests(done_chan: &mut DoneChannel, response: &mut Option<Response>) {
     if let Some(ref mut ch) = *done_chan {
         // The cache constructed a response with a body of ResponseBody::Receiving.
         // We wait for the response in the cache to "finish",

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1571,12 +1571,18 @@ async fn http_network_or_cache_fetch(
 
             // Step 10.2 Let forwardResponse be the result of running HTTP-network fetch given httpFetchParams,
             // includeCredentials, and isNewConnectionFetch.
+            drop(cache_guard);
             let forward_response =
                 http_network_fetch(http_fetch_params, include_credentials, done_chan, context)
                     .await;
 
             let http_request = &mut http_fetch_params.request;
             let request_key = CacheKey::new(http_request);
+            cache_guard = context
+                .state
+                .http_cache
+                .get_or_guard(request_key.clone())
+                .await;
             // Step 10.3 If httpRequest’s method is unsafe and forwardResponse’s status is in the range 200 to 399,
             // inclusive, invalidate appropriate stored responses in httpCache, as per the
             // "Invalidating Stored Responses" chapter of HTTP Caching, and set storedResponse to null.

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -1858,7 +1858,7 @@ async fn wait_for_inflight_requests(done_chan: &mut DoneChannel, response: &mut 
                 Some(Data::Cancelled) => {
                     // The response was cancelled while the fetch was ongoing.
                     // Set response to None, which will trigger a network fetch below.
-                    *response = None;
+                    //*response = None;
                     break;
                 },
                 _ => panic!("HTTP cache should always send Done or Cancelled"),

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -189,7 +189,6 @@ fn create_http_states(
 ) -> (Arc<HttpState>, Arc<HttpState>) {
     let mut hsts_list = HstsList::default();
     let mut auth_cache = AuthCache::default();
-    let http_cache = HttpCache::default();
     let mut cookie_jar = CookieStorage::new(150);
     if let Some(config_dir) = config_dir {
         base::read_json_from_file(&mut auth_cache, config_dir, "auth_cache.json");
@@ -203,8 +202,7 @@ fn create_http_states(
         cookie_jar: RwLock::new(cookie_jar),
         auth_cache: RwLock::new(auth_cache),
         history_states: RwLock::new(FxHashMap::default()),
-        http_cache,
-        http_cache_state: Mutex::new(HashMap::new()),
+        http_cache: HttpCache::default(),
         client: create_http_client(create_tls_config(
             ca_certificates.clone(),
             ignore_certificate_errors,
@@ -221,7 +219,6 @@ fn create_http_states(
         auth_cache: RwLock::new(AuthCache::default()),
         history_states: RwLock::new(FxHashMap::default()),
         http_cache: HttpCache::default(),
-        http_cache_state: Mutex::new(HashMap::new()),
         client: create_http_client(create_tls_config(
             ca_certificates,
             ignore_certificate_errors,

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -180,6 +180,7 @@ struct ResourceChannelManager {
     cookie_listeners: FxHashMap<CookieStoreId, IpcSender<CookieAsyncResponse>>,
 }
 
+/// This returns a tuple HttpState and a private HttpState.
 fn create_http_states(
     config_dir: Option<&Path>,
     ca_certificates: CACertificates<'static>,
@@ -202,7 +203,7 @@ fn create_http_states(
         cookie_jar: RwLock::new(cookie_jar),
         auth_cache: RwLock::new(auth_cache),
         history_states: RwLock::new(FxHashMap::default()),
-        http_cache: RwLock::new(http_cache),
+        http_cache,
         http_cache_state: Mutex::new(HashMap::new()),
         client: create_http_client(create_tls_config(
             ca_certificates.clone(),
@@ -219,7 +220,7 @@ fn create_http_states(
         cookie_jar: RwLock::new(CookieStorage::new(150)),
         auth_cache: RwLock::new(AuthCache::default()),
         history_states: RwLock::new(FxHashMap::default()),
-        http_cache: RwLock::new(HttpCache::default()),
+        http_cache: HttpCache::default(),
         http_cache_state: Mutex::new(HashMap::new()),
         client: create_http_client(create_tls_config(
             ca_certificates,
@@ -524,7 +525,7 @@ impl ResourceChannelManager {
                 }
             },
             CoreResourceMsg::ClearCache => {
-                http_state.http_cache.write().clear();
+                http_state.http_cache.clear();
             },
             CoreResourceMsg::ToFileManager(msg) => self.resource_manager.filemanager.handle(msg),
             CoreResourceMsg::Exit(sender) => {

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -59,13 +59,13 @@ async fn test_refreshing_resource_sets_done_chan_the_appropriate_value() {
     }
 }
 
-#[test]
-fn test_skip_incomplete_cache_for_range_request_with_no_end_bound() {
+#[tokio::test]
+async fn test_skip_incomplete_cache_for_range_request_with_no_end_bound() {
     let actual_body_len = 10;
     let incomplete_response_body = &[1, 2, 3, 4, 5];
     let url = ServoUrl::parse("https://servo.org").unwrap();
 
-    let mut cache = HttpCache::default();
+    let cache = HttpCache::default();
     let mut headers = HeaderMap::new();
 
     headers.insert(
@@ -100,11 +100,11 @@ fn test_skip_incomplete_cache_for_range_request_with_no_end_bound() {
         .headers
         .insert(EXPIRES, HeaderValue::from_str("0").unwrap());
     initial_incomplete_response.status = StatusCode::PARTIAL_CONTENT.into();
-    cache.store(&request, &initial_incomplete_response);
+    cache.store(&request, &initial_incomplete_response).await;
 
     // Try to construct response from http_cache
     let mut done_chan = None;
-    let consecutive_response = cache.construct_response(&request, &mut done_chan);
+    let consecutive_response = cache.construct_response(&request, &mut done_chan).await;
     assert!(
         consecutive_response.is_none(),
         "Should not construct response from incomplete response!"

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -21,7 +21,6 @@ mod http_loader;
 mod image_cache;
 mod resource_thread;
 mod subresource_integrity;
-use std::collections::HashMap;
 use std::sync::{Arc, Weak};
 
 use base::threadpool::ThreadPool;

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -312,6 +312,7 @@ impl Serialize for WebDriverPrefValue {
                 .map(|value| WebDriverPrefValue(value.clone()))
                 .collect::<Vec<WebDriverPrefValue>>()
                 .serialize(serializer),
+            PrefValue::UInt(u) => serializer.serialize_u64(u),
         }
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -193,6 +193,9 @@ skip = [
 
     # usvg depends on svgtypes, which depends on old version of kurbo
     "kurbo",
+
+    # Dependency by quick_cache and other
+    "hashbrown",
 ]
 
 # github.com organizations to allow git sources for

--- a/tests/wpt/meta/websockets/constructor/014.html.ini
+++ b/tests/wpt/meta/websockets/constructor/014.html.ini
@@ -1,0 +1,8 @@
+[014.html?wss]
+  [WebSockets: serialize establish a connection]
+    expected: FAIL
+
+
+[014.html?default]
+  [WebSockets: serialize establish a connection]
+    expected: FAIL

--- a/tests/wpt/meta/websockets/constructor/014.html.ini
+++ b/tests/wpt/meta/websockets/constructor/014.html.ini
@@ -1,8 +1,0 @@
-[014.html?wss]
-  [WebSockets: serialize establish a connection]
-    expected: FAIL
-
-
-[014.html?default]
-  [WebSockets: serialize establish a connection]
-    expected: FAIL


### PR DESCRIPTION
This uses quick_cache to have a proper cache for http.

Previously, the http cache would just grow over the lifetime of the
servo instance. Now we use the quick_cache crate to have a cache with
proper eviction procedures.

We currently weight the entries by the number of responses for the url.
The cache size is configurable.

Testing: Tested WPT run (https://github.com/Narfinger/servo/actions/runs/19338794789) and websites.
