### PR TITLE
Update servoshell to v0.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8121,7 +8121,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "android_logger",
  "backtrace",

--- a/Info.plist
+++ b/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.1</string>
+	<string>0.0.2</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "servoshell"
 build = "build.rs"
-version = "0.0.1"
+version = "0.0.2"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/resources/resource_protocol/license.html
+++ b/resources/resource_protocol/license.html
@@ -1558,6 +1558,7 @@
                         <li><a href=" https://github.com/psychon/x11rb ">x11rb-protocol 0.13.2</a></li>
                         <li><a href=" https://github.com/psychon/x11rb ">x11rb 0.13.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">zeroize 1.8.2</a></li>
+                        <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize/derive ">zeroize_derive 1.4.2</a></li>
                     </ul>
                 <pre class="license-text">
                                  Apache License
@@ -7109,8 +7110,8 @@ limitations under the License.
                         <li><a href=" https://github.com/dcchut/async-recursion ">async-recursion 1.1.1</a></li>
                         <li><a href=" https://github.com/image-rs/image-gif ">gif 0.13.3</a></li>
                         <li><a href=" https://github.com/rust-windowing/keyboard-types ">keyboard-types 0.8.3</a></li>
-                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.0-rc.16</a></li>
-                        <li><a href=" https://github.com/image-rs/weezl ">weezl 0.1.10</a></li>
+                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.0-rc.17</a></li>
+                        <li><a href=" https://github.com/image-rs/weezl ">weezl 0.1.12</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7318,8 +7319,8 @@ limitations under the License.</pre>
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/servo/stylo ">servo_arc 0.4.2</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.8.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">servo_arc 0.4.3</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_malloc_size_of 0.9.0</a></li>
                         <li><a href=" https://github.com/servo/webrender ">peek-poke-derive 0.3.0</a></li>
                         <li><a href=" https://github.com/servo/webrender ">peek-poke 0.3.0</a></li>
                         <li><a href=" https://crates.io/crates/wr_malloc_size_of ">wr_malloc_size_of 0.2.2</a></li>
@@ -7348,9 +7349,8 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/pacak/bpaf ">bpaf 0.9.20</a></li>
                         <li><a href=" https://github.com/pacak/bpaf ">bpaf_derive 0.5.17</a></li>
                         <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.19.0</a></li>
-                        <li><a href=" https://github.com/camino-rs/camino ">camino 1.2.1</a></li>
                         <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.43</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.45</a></li>
                         <li><a href=" https://github.com/jethrogb/rust-cexpr ">cexpr 0.6.0</a></li>
                         <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
                         <li><a href=" https://github.com/servo/cgl-rs ">cgl 0.3.2</a></li>
@@ -7369,6 +7369,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-deque 0.8.6</a></li>
                         <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch 0.9.18</a></li>
                         <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-utils 0.8.21</a></li>
+                        <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek ">curve25519-dalek-derive 0.1.1</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">data-url 0.3.2</a></li>
                         <li><a href=" https://github.com/yaahc/displaydoc ">displaydoc 0.2.5</a></li>
                         <li><a href=" https://github.com/rayon-rs/either ">either 1.15.0</a></li>
@@ -7400,7 +7401,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/withoutboats/heck ">heck 0.4.1</a></li>
                         <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                         <li><a href=" https://github.com/hermit-os/hermit-rs ">hermit-abi 0.5.2</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">html5ever 0.35.0</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">html5ever 0.36.1</a></li>
                         <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.10.1</a></li>
                         <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.7</a></li>
                         <li><a href=" https://github.com/servo/rust-url/ ">idna 1.1.0</a></li>
@@ -7423,7 +7424,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
                         <li><a href=" https://github.com/rust-lang/log ">log 0.4.28</a></li>
                         <li><a href=" https://github.com/bholley/malloc_size_of_derive ">malloc_size_of_derive 0.1.3</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">markup5ever 0.35.0</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">markup5ever 0.36.1</a></li>
                         <li><a href=" https://github.com/gfx-rs/metal-rs ">metal 0.32.0</a></li>
                         <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
                         <li><a href=" https://github.com/rust-num/num-bigint ">num-bigint 0.4.6</a></li>
@@ -7455,10 +7456,11 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RazrFalcon/roxmltree ">roxmltree 0.20.0</a></li>
                         <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.26</a></li>
                         <li><a href=" https://github.com/rust-lang-nursery/rustc-hash ">rustc-hash 1.1.0</a></li>
+                        <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 0.38.44</a></li>
                         <li><a href=" https://github.com/bytecodealliance/rustix ">rustix 1.1.2</a></li>
                         <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 2.2.0</a></li>
-                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.34</a></li>
+                        <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.35</a></li>
                         <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                         <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                         <li><a href=" https://github.com/adjivas/sig ">sig 1.0.0</a></li>
@@ -7470,8 +7472,8 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.10</a></li>
                         <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.1</a></li>
                         <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
-                        <li><a href=" https://github.com/servo/string-cache ">string_cache 0.8.9</a></li>
-                        <li><a href=" https://github.com/servo/string-cache ">string_cache_codegen 0.5.4</a></li>
+                        <li><a href=" https://github.com/servo/string-cache ">string_cache 0.9.0</a></li>
+                        <li><a href=" https://github.com/servo/string-cache ">string_cache_codegen 0.6.1</a></li>
                         <li><a href=" https://github.com/servo/surfman ">surfman 0.10.0</a></li>
                         <li><a href=" https://github.com/linebender/svgtypes ">svgtypes 0.15.3</a></li>
                         <li><a href=" https://github.com/gdesmott/system-deps ">system-deps 6.2.2</a></li>
@@ -7482,7 +7484,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/tikv/jemallocator ">tikv-jemallocator 0.6.1</a></li>
                         <li><a href=" https://github.com/bheisler/TinyTemplate ">tinytemplate 1.2.1</a></li>
                         <li><a href=" https://github.com/harfbuzz/ttf-parser ">ttf-parser 0.25.1</a></li>
-                        <li><a href=" https://github.com/snapview/tungstenite-rs ">tungstenite 0.27.0</a></li>
+                        <li><a href=" https://github.com/snapview/tungstenite-rs ">tungstenite 0.28.0</a></li>
                         <li><a href=" https://github.com/seanmonstar/unicase ">unicase 2.8.1</a></li>
                         <li><a href=" https://github.com/RazrFalcon/unicode-bidi-mirroring ">unicode-bidi-mirroring 0.4.0</a></li>
                         <li><a href=" https://github.com/servo/unicode-bidi ">unicode-bidi 0.3.18</a></li>
@@ -7491,7 +7493,6 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.12.0</a></li>
                         <li><a href=" https://github.com/RazrFalcon/unicode-vo ">unicode-vo 0.1.0</a></li>
                         <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
-                        <li><a href=" https://github.com/unicode-rs/unicode-xid ">unicode-xid 0.2.6</a></li>
                         <li><a href=" https://github.com/servo/rust-url ">url 2.5.7</a></li>
                         <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.18.1</a></li>
                         <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
@@ -7502,10 +7503,10 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.105</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.105</a></li>
                         <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.82</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">web_atoms 0.1.3</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">web_atoms 0.2.0</a></li>
                         <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.46.0</a></li>
                         <li><a href=" https://github.com/Stebalien/xattr ">xattr 1.6.1</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">xml5ever 0.35.0</a></li>
+                        <li><a href=" https://github.com/servo/html5ever ">xml5ever 0.36.1</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9415,8 +9416,6 @@ limitations under the License.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/oyvindln/adler2 ">adler2 2.0.1</a></li>
-                        <li><a href=" https://github.com/rust-lang/cargo ">cargo-platform 0.2.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/cargo ">cargo-util-schemas 0.2.0</a></li>
                         <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.4.0</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
@@ -10480,7 +10479,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/googlefonts/fontations ">font-types 0.10.0</a></li>
+                        <li><a href=" https://github.com/googlefonts/fontations ">font-types 0.10.1</a></li>
                         <li><a href=" https://github.com/googlefonts/fontations ">read-fonts 0.35.0</a></li>
                         <li><a href=" https://github.com/googlefonts/fontations ">skrifa 0.37.0</a></li>
                     </ul>
@@ -11186,10 +11185,10 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor-proc-macro 0.0.6</a></li>
-                        <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor 0.5.0</a></li>
+                        <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor-proc-macro 0.0.7</a></li>
+                        <li><a href=" https://github.com/mmastrac/rust-ctor ">ctor 0.6.1</a></li>
                         <li><a href=" https://github.com/mmastrac/rust-ctor ">dtor-proc-macro 0.0.6</a></li>
-                        <li><a href=" https://github.com/mmastrac/rust-ctor ">dtor 0.1.0</a></li>
+                        <li><a href=" https://github.com/mmastrac/rust-ctor ">dtor 0.1.1</a></li>
                     </ul>
                 <pre class="license-text">Apache License
                            Version 2.0, January 2004
@@ -12111,14 +12110,14 @@ limitations under the License.
                         <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
                         <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.100</a></li>
                         <li><a href=" https://github.com/1Password/arboard ">arboard 3.6.1</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.32</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.33</a></li>
                         <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
                         <li><a href=" https://github.com/odilia-app/atspi ">atspi-proxies 0.9.0</a></li>
                         <li><a href=" https://github.com/jrmuizel/build-parallel ">build-parallel 0.1.2</a></li>
                         <li><a href=" https://github.com/emk/cesu8-rs ">cesu8 1.1.0</a></li>
                         <li><a href=" https://github.com/linebender/color ">color 0.3.2</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.31</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.29</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.32</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.30</a></li>
                         <li><a href=" https://github.com/soc/directories-rs ">directories 6.0.0</a></li>
                         <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.5.0</a></li>
                         <li><a href=" https://github.com/soc/dirs-rs ">dirs 6.0.0</a></li>
@@ -12132,10 +12131,10 @@ limitations under the License.
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/emath ">emath 0.33.0</a></li>
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint ">epaint 0.33.0</a></li>
                         <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.0</a></li>
-                        <li><a href=" https://github.com/dtolnay/erased-serde ">erased-serde 0.4.8</a></li>
                         <li><a href=" https://github.com/nical/etagere ">etagere 0.2.15</a></li>
                         <li><a href=" https://github.com/image-rs/fdeflate ">fdeflate 0.3.7</a></li>
                         <li><a href=" https://github.com/linebender/fearless_simd ">fearless_simd 0.3.0</a></li>
+                        <li><a href=" https://github.com/mit-plv/fiat-crypto ">fiat-crypto 0.2.9</a></li>
                         <li><a href=" https://gitlab.com/gilrs-project/gilrs ">gilrs-core 0.6.6</a></li>
                         <li><a href=" https://gitlab.com/gilrs-project/gilrs ">gilrs 0.11.0</a></li>
                         <li><a href=" https://github.com/brendanzab/gl-rs/ ">gl_generator 0.14.0</a></li>
@@ -12156,7 +12155,6 @@ limitations under the License.
                         <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
                         <li><a href=" https://github.com/reem/rust-mac.git ">mac 0.1.1</a></li>
                         <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.4.3</a></li>
-                        <li><a href=" https://github.com/servo/html5ever ">match_token 0.35.0</a></li>
                         <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
                         <li><a href=" https://github.com/gfx-rs/wgpu ">naga 26.0.0</a></li>
                         <li><a href=" https://github.com/rust-windowing/android-ndk-rs ">ndk-context 0.1.1</a></li>
@@ -12194,7 +12192,7 @@ limitations under the License.
                         <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.103</a></li>
                         <li><a href=" https://github.com/aclysma/profiling ">profiling-procmacros 1.0.17</a></li>
                         <li><a href=" https://github.com/aclysma/profiling ">profiling 1.0.17</a></li>
-                        <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.41</a></li>
+                        <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.42</a></li>
                         <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand 0.8.5</a></li>
                         <li><a href=" https://github.com/rust-random/rand ">rand 0.9.2</a></li>
@@ -12208,7 +12206,6 @@ limitations under the License.
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-derive 1.0.0-rc.11</a></li>
                         <li><a href=" https://github.com/SeaQL/sea-query ">sea-query-rusqlite 0.8.0-rc.8</a></li>
                         <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.27</a></li>
-                        <li><a href=" https://github.com/dtolnay/serde-untagged ">serde-untagged 0.1.9</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
                         <li><a href=" https://github.com/serde-rs/bytes ">serde_bytes 0.11.19</a></li>
                         <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
@@ -12221,7 +12218,7 @@ limitations under the License.
                         <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.1</a></li>
                         <li><a href=" https://github.com/gfx-rs/rspirv ">spirv 0.3.0+sdk-1.3.268.0</a></li>
                         <li><a href=" https://github.com/nical/rust_debug ">svg_fmt 0.4.5</a></li>
-                        <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.108</a></li>
+                        <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.110</a></li>
                         <li><a href=" https://github.com/gankra/thin-vec ">thin-vec 0.2.14</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.17</a></li>
@@ -12230,7 +12227,6 @@ limitations under the License.
                         <li><a href=" https://github.com/time-rs/time ">time-core 0.1.6</a></li>
                         <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.24</a></li>
                         <li><a href=" https://github.com/time-rs/time ">time 0.3.44</a></li>
-                        <li><a href=" https://github.com/dtolnay/typeid ">typeid 1.0.3</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-char-property 0.9.0</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-char-range 0.9.0</a></li>
                         <li><a href=" https://github.com/open-i18n/rust-unic/ ">unic-common 0.9.0</a></li>
@@ -13069,10 +13065,48 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             </li>
             <li class="license">
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/x25519-dalek ">x25519-dalek 2.0.1</a>
+                    </p>
+                <pre class="license-text">Copyright (c) 2017-2021 isis agora lovecruft. All rights reserved.
+Copyright (c) 2019-2021 DebugSteven. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS
+IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib 0.2.2</a></li>
                         <li><a href=" https://github.com/dropbox/rust-brotli ">brotli 8.0.2</a></li>
+                        <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek ">curve25519-dalek 4.1.3</a></li>
                         <li><a href=" https://github.com/mitsuhiko/sha1-smol ">sha1_smol 1.0.1</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;. 
@@ -13344,7 +13378,7 @@ express Statement of Purpose.
                 <h3 id="CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.3</a>
+                            <a href=" https://github.com/rustls/webpki-roots ">webpki-roots 1.0.4</a>
                     </p>
                 <pre class="license-text"># Community Data License Agreement - Permissive - Version 2.0
 
@@ -13910,7 +13944,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hyperium/hyper ">hyper 1.7.0</a>
+                            <a href=" https://github.com/hyperium/hyper ">hyper 1.8.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2014-2025 Sean McArthur
 
@@ -14028,8 +14062,7 @@ THE SOFTWARE.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/mbrubeck/rust-debug-unreachable ">new_debug_unreachable 1.0.6</a></li>
-                        <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 2.10.1</a></li>
-                        <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 4.6.0</a></li>
+                        <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float 5.0.0</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2015 Jonathan Reem
 
@@ -14088,34 +14121,7 @@ THE SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/arcnmx/serde-value ">serde-value 0.7.0</a>
-                    </p>
-                <pre class="license-text">Copyright (c) 2016 arcnmx
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/sdroege/async-tungstenite ">async-tungstenite 0.31.0</a>
+                            <a href=" https://github.com/sdroege/async-tungstenite ">async-tungstenite 0.32.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2017 Daniel Abramov
 Copyright (c) 2017 Alexey Galakhov
@@ -14201,7 +14207,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://gitlab.com/timvisee/version-compare ">version-compare 0.2.0</a>
+                            <a href=" https://gitlab.com/timvisee/version-compare ">version-compare 0.2.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2017 Tim Visée
 
@@ -14914,7 +14920,7 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/jamienicol/glslopt-rs ">glslopt 0.1.11</a>
+                            <a href=" https://github.com/jamienicol/glslopt-rs ">glslopt 0.1.12</a>
                     </p>
                 <pre class="license-text">GLSL Optimizer is licensed according to the terms of the MIT license:
 
@@ -15580,11 +15586,11 @@ SOFTWARE.</pre>
                         <li><a href=" https://github.com/rust-windowing/winit ">dpi 0.1.2</a></li>
                         <li><a href=" https://github.com/rust-lang/compiler-builtins ">libm 0.2.15</a></li>
                         <li><a href=" https://github.com/SSheldon/malloc_buf ">malloc_buf 0.0.6</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-build-ohos 1.1.3</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-derive-backend-ohos 1.1.3</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-derive-ohos 1.1.3</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-ohos 1.1.3</a></li>
-                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-sys-ohos 1.1.3</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-build-ohos 1.1.4</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-derive-backend-ohos 1.1.4</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-derive-ohos 1.1.4</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-ohos 1.1.4</a></li>
+                        <li><a href=" https://github.com/ohos-rs/ohos-rs ">napi-sys-ohos 1.1.4</a></li>
                         <li><a href=" https://github.com/rust-bakery/nom ">nom-language 0.1.0</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc-sys 0.3.5</a></li>
                         <li><a href=" https://github.com/madsmtm/objc2 ">objc2-app-kit 0.2.2</a></li>
@@ -15656,7 +15662,7 @@ SOFTWARE.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.17</a></li>
-                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.16</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.17</a></li>
                         <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.48.0</a></li>
                     </ul>
                 <pre class="license-text">MIT License
@@ -15802,7 +15808,6 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/oli-obk/cargo_metadata ">cargo_metadata 0.20.0</a></li>
                         <li><a href=" https://github.com/zeenix/endi ">endi 1.1.0</a></li>
                         <li><a href=" https://github.com/sunfishcode/is-terminal ">is-terminal 0.4.17</a></li>
                         <li><a href=" https://github.com/AltF02/x11-rs.git ">x11-dl 2.21.0</a></li>
@@ -15924,11 +15929,11 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/rust-phf/rust-phf ">phf 0.11.3</a></li>
-                        <li><a href=" https://github.com/rust-phf/rust-phf ">phf_codegen 0.11.3</a></li>
-                        <li><a href=" https://github.com/rust-phf/rust-phf ">phf_generator 0.11.3</a></li>
-                        <li><a href=" https://github.com/rust-phf/rust-phf ">phf_macros 0.11.3</a></li>
-                        <li><a href=" https://github.com/rust-phf/rust-phf ">phf_shared 0.11.3</a></li>
+                        <li><a href=" https://github.com/rust-phf/rust-phf ">phf 0.13.1</a></li>
+                        <li><a href=" https://github.com/rust-phf/rust-phf ">phf_codegen 0.13.1</a></li>
+                        <li><a href=" https://github.com/rust-phf/rust-phf ">phf_generator 0.13.1</a></li>
+                        <li><a href=" https://github.com/rust-phf/rust-phf ">phf_macros 0.13.1</a></li>
+                        <li><a href=" https://github.com/rust-phf/rust-phf ">phf_shared 0.13.1</a></li>
                     </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -15960,7 +15965,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         <li><a href=" https://github.com/image-rs/byteorder-lite ">byteorder-lite 0.1.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
                         <li><a href=" https://github.com/BurntSushi/fst ">fst 0.4.7</a></li>
-                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.15</a></li>
+                        <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.16</a></li>
                         <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.6</a></li>
                         <li><a href=" https://github.com/BurntSushi/quickcheck ">quickcheck 1.0.3</a></li>
                         <li><a href=" https://github.com/BurntSushi/walkdir ">walkdir 2.5.0</a></li>
@@ -16081,7 +16086,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://gitlab.redox-os.org/redox-os/orbclient ">orbclient 0.3.48</a>
+                            <a href=" https://gitlab.redox-os.org/redox-os/orbclient ">orbclient 0.3.49</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -18148,7 +18153,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/servo/rust-cssparser ">cssparser-macros 0.6.1</a></li>
-                        <li><a href=" https://github.com/servo/rust-cssparser ">cssparser 0.35.0</a></li>
+                        <li><a href=" https://github.com/servo/rust-cssparser ">cssparser 0.36.0</a></li>
                     </ul>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -18537,16 +18542,16 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/servo-media-traits ">servo-media-traits 0.1.0</a></li>
                         <li><a href=" https://crates.io/crates/servo-media-webrtc ">servo-media-webrtc 0.1.0</a></li>
                         <li><a href=" https://crates.io/crates/servo-media ">servo-media 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.0-7</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo 0.8.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">selectors 0.32.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.8.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_config 0.8.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.8.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.8.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.8.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.8.0</a></li>
-                        <li><a href=" https://github.com/servo/stylo ">to_shmem 0.2.0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.5-0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo 0.9.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">selectors 0.33.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.9.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_config 0.9.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_derive 0.9.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_dom 0.9.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_static_prefs 0.9.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">stylo_traits 0.9.0</a></li>
+                        <li><a href=" https://github.com/servo/stylo ">to_shmem 0.3.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">to_shmem_derive 0.1.0</a></li>
                         <li><a href=" https://github.com/servo/webrender ">webrender 0.68.0</a></li>
                         <li><a href=" https://github.com/servo/webrender ">webrender_api 0.68.0</a></li>
@@ -18602,7 +18607,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/webgpu ">webgpu 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/webxr ">webxr 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/xpath ">xpath 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.0.1</a></li>
+                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.0.2</a></li>
                         <li><a href=" https://crates.io/crates/task_info ">task_info 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/deny_public_fields_tests ">deny_public_fields_tests 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.0.1</a></li>

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 30
         targetSdk = 33
         versionCode = generatedVersionCode
-        versionName = "0.0.1" // TODO: Parse Servo"s TOML and add git SHA.
+        versionName = "0.0.2"
     }
 
     compileOptions {

--- a/support/openharmony/entry/oh-package.json5
+++ b/support/openharmony/entry/oh-package.json5
@@ -5,7 +5,7 @@
   "name": "servoshell",
   "description": "Please describe the basic information.",
   "main": "",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "dependencies": {
     "libservoshell.so": "file:./src/main/cpp/types/libentry"
   }

--- a/support/openharmony/oh-package.json5
+++ b/support/openharmony/oh-package.json5
@@ -8,6 +8,6 @@
   "name": "servoshell",
   "description": "Servo browser shell",
   "main": "",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "dependencies": {}
 }

--- a/support/windows/Servo.wxs.mako
+++ b/support/windows/Servo.wxs.mako
@@ -6,7 +6,7 @@
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="1.0.0">
+           Version="0.0.2">
     <Package Id="*"
              Keywords="Installer"
              Description="Servo Tech Demo Installer"


### PR DESCRIPTION
Ran ./mach release 0.0.2 to update the version number and update the license.html
This is in preperation for the v0.0.2 release with the next nightly, as discussed on zulip.

Testing: Not tested
