### PR TITLE
CI: Limit github runner mac to macos-arm-unit-tests only on merge queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           {
             echo 'result<<EOF'
-            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'fail-fast full macos bencher production-bencher coverage' || 'fail-fast full' }}
+            python ./python/servo/try_parser.py ${{ github.event_name == 'pull_request' && 'linux-unit-tests lint' || github.event_name == 'push' && 'fail-fast full macos bencher production-bencher coverage' || 'fail-fast full macos-arm-unit-tests' }}
             echo EOF
            } >> $GITHUB_OUTPUT
 

--- a/python/servo/try_parser.py
+++ b/python/servo/try_parser.py
@@ -206,8 +206,8 @@ class Config(object):
                 continue  # skip over keyword
             if word == "full":
                 words.extend(["linux-unit-tests", "linux-wpt", "linux-bencher"])
-                words.extend(["macos-arm-unit-tests", "windows-unit-tests", "android", "ohos", "lint"])
-                words.extend(["linux-build-libservo", "macos-arm-build-libservo", "windows-build-libservo"])
+                words.extend(["windows-unit-tests", "android", "ohos", "lint"])
+                words.extend(["linux-build-libservo", "windows-build-libservo"])
                 continue  # skip over keyword
             if word == "bencher":
                 words.extend(
@@ -303,19 +303,6 @@ class TestParser(unittest.TestCase):
                         "unit_tests": True,
                         "build_libservo": True,
                         "bencher": True,
-                        "build_args": "",
-                        "coverage": False,
-                        "wpt_args": "",
-                        "number_of_wpt_chunks": 20,
-                    },
-                    {
-                        "name": "MacOS Arm64 (Unit Tests, Build libservo)",
-                        "workflow": "macos-arm64",
-                        "wpt": False,
-                        "profile": "release",
-                        "unit_tests": True,
-                        "build_libservo": True,
-                        "bencher": False,
                         "build_args": "",
                         "coverage": False,
                         "wpt_args": "",


### PR DESCRIPTION
Based on the chat here: https://github.com/servo/servo/issues/40596#issuecomment-3528514438 we limit mac-arm (those are bottlenecks as they are not self hosted) to merge queue (so we know that main is good so we can skip run there) and we do not run MSRV check there to further limit uses.

Testing: None, because it's just infra.
Temp fixes: #40596
