### PR TITLE
script: Issue resource timing for stylesheets before the "load" event

### DIFF
--- a/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-disallow-import.tentative.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable-disallow-import.tentative.html.ini
@@ -1,3 +1,0 @@
-[CSSStyleSheet-constructable-disallow-import.tentative.html]
-  [@import rules should not trigger any loads.]
-    expected: FAIL

--- a/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable.html.ini
+++ b/tests/wpt/meta/css/cssom/CSSStyleSheet-constructable.html.ini
@@ -20,15 +20,6 @@
   [Adopted sheets are ordered after non-adopted sheets in the document]
     expected: FAIL
 
-  [CSSStyleSheet.replaceSync should not trigger any loads from @import rules]
-    expected: FAIL
-
-  [CSSStyleSheet.replace allows, but ignores, import rule inside]
-    expected: FAIL
-
-  [CSSStyleSheet.replace ignores @import rule but still loads other rules]
-    expected: FAIL
-
   [Adopting a shadow host will empty adoptedStyleSheets if adopting to a different document]
     expected: FAIL
 

--- a/tests/wpt/meta/preload/subresource-integrity.html.ini
+++ b/tests/wpt/meta/preload/subresource-integrity.html.ini
@@ -74,16 +74,7 @@
   [Same-origin style with non-matching digest does not re-use preload with non-matching digest.]
     expected: FAIL
 
-  [Same-origin style with matching digest does not reuse preload without digest.]
-    expected: FAIL
-
-  [Same-origin style with matching digest does not reuse preload with matching but stronger digest.]
-    expected: FAIL
-
   [Same-origin style with wrong digest does not reuse preload with correct and stronger digest.]
-    expected: FAIL
-
-  [Same-origin style with matching digest does not reuse preload with matching but weaker digest.]
     expected: FAIL
 
   [Same-origin style with non-matching digest reuses preload with no digest but fails.]
@@ -144,4 +135,46 @@
     expected: FAIL
 
   [Same-origin image with unknown algorithm only.]
+    expected: FAIL
+
+  [Same-origin style with correct sha256 hash.]
+    expected: FAIL
+
+  [Same-origin style with correct sha384 hash.]
+    expected: FAIL
+
+  [Same-origin style with correct sha512 hash.]
+    expected: FAIL
+
+  [Same-origin style with empty integrity.]
+    expected: FAIL
+
+  [Same-origin style with multiple sha256 hashes, including correct.]
+    expected: FAIL
+
+  [Same-origin style with multiple sha256 hashes, including unknown algorithm.]
+    expected: FAIL
+
+  [Same-origin style with sha256 mismatch, sha512 match]
+    expected: FAIL
+
+  [<crossorigin='anonymous'> style with correct hash, ACAO: *]
+    expected: FAIL
+
+  [<crossorigin='use-credentials'> style with correct hash, CORS-eligible]
+    expected: FAIL
+
+  [Cross-origin style, empty integrity]
+    expected: FAIL
+
+  [Same-origin style with correct hash, options.]
+    expected: FAIL
+
+  [Same-origin style with unknown algorithm only.]
+    expected: FAIL
+
+  [Same-origin style with matching digest re-uses preload with matching digest.]
+    expected: FAIL
+
+  [Same-origin style with matching digest re-uses preload with matching digest and options.]
     expected: FAIL

--- a/tests/wpt/meta/resource-timing/no-entries-for-cross-origin-css-fetched-memory-cache.sub.html.ini
+++ b/tests/wpt/meta/resource-timing/no-entries-for-cross-origin-css-fetched-memory-cache.sub.html.ini
@@ -1,0 +1,3 @@
+[no-entries-for-cross-origin-css-fetched-memory-cache.sub.html]
+  [Make sure that resources fetched by cross origin CSS are not in the timeline.]
+    expected: FAIL


### PR DESCRIPTION
Tests seem to assume that resource timing is available during the "load"
event. Doing so causes some tests to pass and others to fail, which
appear to have been false passes.

This is a preparatory change for asynchronous stylesheet parsing, when
resource timing entires must be added before sending stylesheets to
another thread for parsing.

Testing: This change updates WPT test results.
