### PR TITLE
layout: Adjust inset-modified containing block to have non-negative size

### DIFF
--- a/components/layout/geom.rs
+++ b/components/layout/geom.rs
@@ -51,6 +51,21 @@ pub(crate) struct LogicalSides1D<T> {
     pub end: T,
 }
 
+impl<T> LogicalSides1D<T> {
+    pub(crate) fn map<U>(&self, f: impl Fn(&T) -> U) -> LogicalSides1D<U> {
+        LogicalSides1D {
+            start: f(&self.start),
+            end: f(&self.end),
+        }
+    }
+}
+
+impl LogicalSides1D<AutoOr<&LengthPercentage>> {
+    pub(crate) fn percentages_relative_to(&self, basis: Au) -> LogicalSides1D<AutoOr<Au>> {
+        self.map(|value| value.map(|length_percentage| length_percentage.to_used_value(basis)))
+    }
+}
+
 impl<T: fmt::Debug> fmt::Debug for LogicalVec2<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Not using f.debug_struct on purpose here, to keep {:?} output somewhat compact
@@ -480,13 +495,6 @@ impl<T> LogicalSides1D<AutoOr<T>> {
     #[inline]
     pub(crate) fn either_auto(&self) -> bool {
         self.start.is_auto() || self.end.is_auto()
-    }
-}
-
-impl<T: Add + Copy> LogicalSides1D<T> {
-    #[inline]
-    pub(crate) fn sum(&self) -> T::Output {
-        self.start + self.end
     }
 }
 

--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -741,6 +741,13 @@ impl AbsoluteAxisSolver {
         }
     }
 
+    /// Returns the size of the inset-modified containing block.
+    /// <https://drafts.csswg.org/css-position-3/#inset-modified-containing-block>
+    #[inline]
+    fn available_space(&self) -> Au {
+        Au::zero().max(self.containing_size - self.inset_sum())
+    }
+
     #[inline]
     fn automatic_size(&self) -> Size<Au> {
         match self.alignment.value() {
@@ -754,8 +761,7 @@ impl AbsoluteAxisSolver {
     #[inline]
     fn stretch_size(&self) -> Au {
         Au::zero().max(
-            self.containing_size -
-                self.inset_sum() -
+            self.available_space() -
                 self.padding_border_sum -
                 self.computed_margin_start.auto_is(Au::zero) -
                 self.computed_margin_end.auto_is(Au::zero),
@@ -769,8 +775,7 @@ impl AbsoluteAxisSolver {
                 self.computed_margin_end.auto_is(Au::zero),
             )
         } else {
-            let free_space =
-                self.containing_size - self.inset_sum() - self.padding_border_sum - size;
+            let free_space = self.available_space() - self.padding_border_sum - size;
             match (self.computed_margin_start, self.computed_margin_end) {
                 (AuOrAuto::Auto, AuOrAuto::Auto) => {
                     if self.avoid_negative_margin_start && free_space < Au::zero() {
@@ -813,7 +818,7 @@ impl AbsoluteAxisSolver {
             (Some(start), Some(end)) => {
                 let alignment_container = RectAxis {
                     origin: start,
-                    length: self.containing_size - start - end,
+                    length: self.available_space(),
                 };
                 (
                     alignment_container,

--- a/components/layout/positioned.rs
+++ b/components/layout/positioned.rs
@@ -20,9 +20,8 @@ use crate::dom_traversal::{Contents, NodeAndStyleInfo};
 use crate::formatting_contexts::IndependentFormattingContext;
 use crate::fragment_tree::{BoxFragment, Fragment, FragmentFlags, HoistedSharedFragment};
 use crate::geom::{
-    AuOrAuto, LengthPercentageOrAuto, LogicalRect, LogicalSides, LogicalSides1D, LogicalVec2,
-    PhysicalPoint, PhysicalRect, PhysicalSides, PhysicalSize, PhysicalVec, ToLogical,
-    ToLogicalWithContainingBlock,
+    AuOrAuto, LogicalRect, LogicalSides, LogicalSides1D, LogicalVec2, PhysicalPoint, PhysicalRect,
+    PhysicalSides, PhysicalSize, PhysicalVec, ToLogical, ToLogicalWithContainingBlock,
 };
 use crate::layout_box_base::{CacheableLayoutResult, LayoutBoxBase};
 use crate::sizing::{LazySize, Size, SizeConstraint, Sizes};
@@ -476,7 +475,7 @@ impl HoistedAbsolutelyPositionedBox {
 
         // When the "static-position rect" doesn't come into play, we do not do any alignment
         // in the inline axis.
-        let inline_box_offsets = box_offset.inline_sides();
+        let inline_box_offsets = box_offset.inline_sides().percentages_relative_to(cbis);
         let inline_alignment = match inline_box_offsets.either_specified() {
             true => style.clone_justify_self().0,
             false => self.resolved_alignment.inline,
@@ -500,7 +499,7 @@ impl HoistedAbsolutelyPositionedBox {
 
         // When the "static-position rect" doesn't come into play, we re-resolve "align-self"
         // against this containing block.
-        let block_box_offsets = box_offset.block_sides();
+        let block_box_offsets = box_offset.block_sides().percentages_relative_to(cbbs);
         let block_alignment = match block_box_offsets.either_specified() {
             true => style.clone_align_self().0,
             false => self.resolved_alignment.block,
@@ -702,7 +701,7 @@ impl LogicalRect<Au> {
     }
 }
 
-struct AbsoluteAxisSolver<'a> {
+struct AbsoluteAxisSolver {
     axis: Direction,
     containing_size: Au,
     padding_border_sum: Au,
@@ -710,14 +709,14 @@ struct AbsoluteAxisSolver<'a> {
     computed_margin_end: AuOrAuto,
     computed_sizes: Sizes,
     avoid_negative_margin_start: bool,
-    box_offsets: LogicalSides1D<LengthPercentageOrAuto<'a>>,
+    box_offsets: LogicalSides1D<AuOrAuto>,
     static_position_rect_axis: RectAxis,
     alignment: AlignFlags,
     flip_anchor: bool,
     is_table_or_replaced: bool,
 }
 
-impl AbsoluteAxisSolver<'_> {
+impl AbsoluteAxisSolver {
     /// Returns the amount that we need to subtract from the containing block size in order to
     /// obtain the inset-modified containing block that we will use for sizing purposes.
     /// (Note that for alignment purposes, we may re-resolve auto insets to a different value.)
@@ -736,11 +735,9 @@ impl AbsoluteAxisSolver<'_> {
                     self.static_position_rect_axis.origin
                 }
             },
-            (Some(start), None) => start.to_used_value(self.containing_size),
-            (None, Some(end)) => end.to_used_value(self.containing_size),
-            (Some(start), Some(end)) => {
-                start.to_used_value(self.containing_size) + end.to_used_value(self.containing_size)
-            },
+            (Some(start), None) => start,
+            (None, Some(end)) => end,
+            (Some(start), Some(end)) => start + end,
         }
     }
 
@@ -814,27 +811,23 @@ impl AbsoluteAxisSolver<'_> {
                 None,
             ),
             (Some(start), Some(end)) => {
-                let offsets = LogicalSides1D {
-                    start: start.to_used_value(self.containing_size),
-                    end: end.to_used_value(self.containing_size),
-                };
                 let alignment_container = RectAxis {
-                    origin: offsets.start,
-                    length: self.containing_size - offsets.sum(),
+                    origin: start,
+                    length: self.containing_size - start - end,
                 };
                 (
                     alignment_container,
                     containing_block_writing_mode,
                     false,
-                    Some(offsets),
+                    Some(LogicalSides1D { start, end }),
                 )
             },
             // If a single offset is auto, for alignment purposes it resolves to the amount
             // that makes the inset-modified containing block be exactly as big as the abspos.
             // Therefore the free space is zero and the alignment value is irrelevant.
-            (Some(start), None) => return start.to_used_value(self.containing_size),
+            (Some(start), None) => return start,
             (None, Some(end)) => {
-                return self.containing_size - size - end.to_used_value(self.containing_size);
+                return self.containing_size - size - end;
             },
         };
 

--- a/tests/wpt/tests/css/css-position/position-absolute-with-negative-sized-imcb.html
+++ b/tests/wpt/tests/css/css-position/position-absolute-with-negative-sized-imcb.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-position-3/#abspos-insets">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/11478">
+<meta name="assert" content="
+  If the insets of an abspos are big enough that would make the inset-modified
+  containing block (IMCB) have a negative size, the weaker inset is adjusted
+  so that the IMCB size becomes zero instead.
+">
+
+<style>
+.rtl {
+  direction: rtl;
+}
+.container {
+  display: inline-block;
+  margin: 8px;
+  border: 1px solid;
+  position: relative;
+  width: 20px;
+  height: 20px;
+}
+.abspos {
+  position: absolute;
+  background: orange;
+}
+.abspos.case1 {
+  margin: auto;
+  width: 18px;
+  height: 18px;
+}
+.abspos.case2 {
+  inset: 18px;
+  margin: auto;
+}
+.abspos.case3 {
+  inset: 18px;
+  margin: -10px;
+}
+.abspos.case4 {
+  width: 10px;
+  height: 10px;
+  place-self: unsafe center;
+}
+</style>
+
+
+<!-- Case 1: Auto margins, fixed size, varying insets -->
+<div class="container">
+  <div class="abspos case1" style="inset: 0px"
+       data-expected-width="18" data-expected-height="18"
+       data-offset-x="1" data-offset-y="1"></div>
+</div>
+<div class="container">
+  <div class="abspos case1" style="inset: 8px"
+       data-expected-width="18" data-expected-height="18"
+       data-offset-x="8" data-offset-y="1"></div>
+</div>
+<div class="container">
+  <div class="abspos case1" style="inset: 12px"
+       data-expected-width="18" data-expected-height="18"
+       data-offset-x="12" data-offset-y="3"></div>
+</div>
+<div class="container">
+  <div class="abspos case1" style="inset: 18px"
+       data-expected-width="18" data-expected-height="18"
+       data-offset-x="18" data-offset-y="9"></div>
+</div>
+
+<br>
+
+<!-- Case 1, but RTL -->
+<div class="container rtl">
+  <div class="abspos case1" style="inset: 0px"
+       data-expected-width="18" data-expected-height="18"
+       data-offset-x="1" data-offset-y="1"></div>
+</div>
+<div class="container rtl">
+  <div class="abspos case1" style="inset: 8px"
+       data-expected-width="18" data-expected-height="18"
+       data-offset-x="-6" data-offset-y="1"></div>
+</div>
+<div class="container rtl">
+  <div class="abspos case1" style="inset: 12px"
+       data-expected-width="18" data-expected-height="18"
+       data-offset-x="-10" data-offset-y="3"></div>
+</div>
+<div class="container rtl">
+  <div class="abspos case1" style="inset: 18px"
+       data-expected-width="18" data-expected-height="18"
+       data-offset-x="-16" data-offset-y="9"></div>
+</div>
+
+<hr>
+
+<!-- Case 2: Auto margins, fixed insets, varying sizes -->
+<div class="container">
+  <div class="abspos case2" style="border: solid orange 6px;"
+       data-expected-width="12" data-expected-height="12"
+       data-offset-x="18" data-offset-y="12"></div>
+</div>
+<div class="container">
+  <div class="abspos case2" style="width: 12px; height: 12px;"
+       data-expected-width="12" data-expected-height="12"
+       data-offset-x="18" data-offset-y="12"></div>
+</div>
+<div class="container">
+  <div class="abspos case2" style="min-width: 12px; min-height: 12px;"
+       data-expected-width="12" data-expected-height="12"
+       data-offset-x="18" data-offset-y="12"></div>
+</div>
+<div class="container">
+  <div class="abspos case2" style="width: min-content; height: min-content;"
+       data-expected-width="12" data-expected-height="12"
+       data-offset-x="18" data-offset-y="12">
+    <div style="width: 12px; height: 12px"></div>
+  </div>
+</div>
+<div class="container">
+  <div class="abspos case2" style="display: table;"
+       data-expected-width="12" data-expected-height="12"
+       data-offset-x="18" data-offset-y="12">
+    <div style="width: 12px; height: 12px"></div>
+  </div>
+</div>
+
+<br>
+
+<!-- Case 2, but RTL -->
+<div class="container rtl">
+  <div class="abspos case2" style="border: solid orange 6px;"
+       data-expected-width="12" data-expected-height="12"
+       data-offset-x="-10" data-offset-y="12"></div>
+</div>
+<div class="container rtl">
+  <div class="abspos case2" style="width: 12px; height: 12px;"
+       data-expected-width="12" data-expected-height="12"
+       data-offset-x="-10" data-offset-y="12"></div>
+</div>
+<div class="container rtl">
+  <div class="abspos case2" style="min-width: 12px; min-height: 12px;"
+       data-expected-width="12" data-expected-height="12"
+       data-offset-x="-10" data-offset-y="12"></div>
+</div>
+<div class="container rtl">
+  <div class="abspos case2" style="width: min-content; height: min-content;"
+       data-expected-width="12" data-expected-height="12"
+       data-offset-x="-10" data-offset-y="12">
+    <div style="width: 12px; height: 12px"></div>
+  </div>
+</div>
+<div class="container rtl">
+  <div class="abspos case2" style="display: table;"
+       data-expected-width="12" data-expected-height="12"
+       data-offset-x="-10" data-offset-y="12">
+    <div style="width: 12px; height: 12px"></div>
+  </div>
+</div>
+
+<hr>
+
+<!-- Case 3: No margins, fixed insets, auto sizes -->
+<div class="container">
+  <div class="abspos case3"
+       data-expected-width="20" data-expected-height="20"
+       data-offset-x="8" data-offset-y="8"></div>
+</div>
+<div class="container rtl">
+  <div class="abspos case3"
+       data-expected-width="20" data-expected-height="20"
+       data-offset-x="-8" data-offset-y="8"></div>
+</div>
+
+<hr>
+
+<!-- Case 4: Fixed size, unsafe center alignment, varying insets -->
+<div class="container">
+  <div class="abspos case4" style="inset: 5px"
+       data-expected-width="10" data-expected-height="10"
+       data-offset-x="5" data-offset-y="5"></div>
+</div>
+<div class="container">
+  <div class="abspos case4" style="inset: 10px"
+       data-expected-width="10" data-expected-height="10"
+       data-offset-x="5" data-offset-y="5"></div>
+</div>
+<div class="container">
+  <div class="abspos case4" style="inset: 15px"
+       data-expected-width="10" data-expected-height="10"
+       data-offset-x="10" data-offset-y="10"></div>
+</div>
+<div class="container">
+  <div class="abspos case4" style="inset: 20px"
+       data-expected-width="10" data-expected-height="10"
+       data-offset-x="15" data-offset-y="15"></div>
+</div>
+<div class="container">
+  <div class="abspos case4" style="inset: 25px"
+       data-expected-width="10" data-expected-height="10"
+       data-offset-x="20" data-offset-y="20"></div>
+</div>
+
+<br>
+
+<!-- Case 4, but RTL -->
+<div class="container rtl">
+  <div class="abspos case4" style="inset: 5px"
+       data-expected-width="10" data-expected-height="10"
+       data-offset-x="5" data-offset-y="5"></div>
+</div>
+<div class="container rtl">
+  <div class="abspos case4" style="inset: 10px"
+       data-expected-width="10" data-expected-height="10"
+       data-offset-x="5" data-offset-y="5"></div>
+</div>
+<div class="container rtl">
+  <div class="abspos case4" style="inset: 15px"
+       data-expected-width="10" data-expected-height="10"
+       data-offset-x="0" data-offset-y="10"></div>
+</div>
+<div class="container rtl">
+  <div class="abspos case4" style="inset: 20px"
+       data-expected-width="10" data-expected-height="10"
+       data-offset-x="-5" data-offset-y="15"></div>
+</div>
+<div class="container rtl">
+  <div class="abspos case4" style="inset: 25px"
+       data-expected-width="10" data-expected-height="10"
+       data-offset-x="-10" data-offset-y="20"></div>
+</div>
+
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<script>
+checkLayout(".abspos");
+</script>


### PR DESCRIPTION
If the insets of an absolutely positioned box are big enough that the inset-modified containing block (IMCB) would get a negative size, we will now adjust the weaker inset so that the size of the IMCB becomes zero instead.
This affects auto sizes, auto margins, and self-alignment.

This behavior matches Blink for the most part. However, while Blink also ensures a non-negative IMCB size, it doesn't necessarily do so by adjusting the weaker inset, so the alignment may differ.

Blink is fine with adopting this behavior, as resolved by the CSSWG in https://github.com/w3c/csswg-drafts/issues/11478

Testing: Adding new WPT
