### PR TITLE
net: Relax the SVG content type detection logic.

### DIFF
--- a/components/net/image_cache.rs
+++ b/components/net/image_cache.rs
@@ -95,7 +95,15 @@ fn decode_bytes_sync(
     content_type: Option<Mime>,
     fontdb: Arc<fontdb::Database>,
 ) -> DecoderMsg {
-    let image = if content_type == Some(mime::IMAGE_SVG) {
+    let is_svg_document = content_type.is_some_and(|content_type| {
+        (
+            content_type.type_(),
+            content_type.subtype(),
+            content_type.suffix(),
+        ) == (mime::IMAGE, mime::SVG, Some(mime::XML))
+    });
+
+    let image = if is_svg_document {
         parse_svg_document_in_memory(bytes, fontdb)
             .ok()
             .map(|svg_tree| {

--- a/tests/wpt/tests/svg/content-type-with-parameters-ref.html
+++ b/tests/wpt/tests/svg/content-type-with-parameters-ref.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SVG data is recognized even when the 'Content-Type' headers includes parameters</title>
+    <style>
+        #box {
+           width: 100px;
+           height: 100px;
+           background-color: red;
+        }
+    </style>
+</head>
+<body>
+   <div id="box"></div>
+</body>
+</html>

--- a/tests/wpt/tests/svg/content-type-with-parameters.html
+++ b/tests/wpt/tests/svg/content-type-with-parameters.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SVG is recognized even when the 'Content-Type' headers includes parameters</title>
+    <link rel="author" title="Mukilan Thiyagrajan" href="mailto:mukilan@igalia.com">
+    <link rel="match" href="content-type-with-parameters-ref.html">
+</head>
+<body>
+    <img src="content-type-with-parameters.svg">
+</body>
+</html>

--- a/tests/wpt/tests/svg/content-type-with-parameters.svg
+++ b/tests/wpt/tests/svg/content-type-with-parameters.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
+    <rect width='100%' height='100%' fill='red'/>
+</svg>
+

--- a/tests/wpt/tests/svg/content-type-with-parameters.svg.headers
+++ b/tests/wpt/tests/svg/content-type-with-parameters.svg.headers
@@ -1,0 +1,1 @@
+Content-Type: image/svg+xml;qs=0.85;charset=utf-8


### PR DESCRIPTION
The current logic fails when the `Content-Type` header includes the character encoding other parameters like `qs`.

Fixes: #40630