### PR TITLE
Compositor: Add touch compatibility handling for mouse move events

### DIFF
--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -1381,10 +1381,13 @@ impl Painter {
         if let Some(webview_renderer) = self.webview_renderers.get_mut(webview_id) {
             match &event.event {
                 InputEvent::MouseMove(event) => {
-                    let event_point = event
-                        .point
-                        .as_device_point(webview_renderer.device_pixels_per_page_pixel());
-                    self.last_mouse_move_position = Some(event_point);
+                    // We only track the last mouse move position for non-touch events.
+                    if !event.is_compatibility_event_for_touch {
+                        let event_point = event
+                            .point
+                            .as_device_point(webview_renderer.device_pixels_per_page_pixel());
+                        self.last_mouse_move_position = Some(event_point);
+                    }
                 },
                 InputEvent::MouseLeftViewport(_) => {
                     self.last_mouse_move_position = None;

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -642,7 +642,7 @@ impl WebViewRenderer {
         let button = MouseButton::Left;
         self.dispatch_input_event_with_hit_testing(
             render_api,
-            InputEvent::MouseMove(MouseMoveEvent::new(point.into())).into(),
+            InputEvent::MouseMove(MouseMoveEvent::new_compatibility_for_touch(point.into())).into(),
         );
         self.dispatch_input_event_with_hit_testing(
             render_api,

--- a/components/shared/embedder/input_events.rs
+++ b/components/shared/embedder/input_events.rs
@@ -199,11 +199,22 @@ pub enum MouseButtonAction {
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct MouseMoveEvent {
     pub point: WebViewPoint,
+    pub is_compatibility_event_for_touch: bool,
 }
 
 impl MouseMoveEvent {
     pub fn new(point: WebViewPoint) -> Self {
-        Self { point }
+        Self {
+            point,
+            is_compatibility_event_for_touch: false,
+        }
+    }
+
+    pub fn new_compatibility_for_touch(point: WebViewPoint) -> Self {
+        Self {
+            point,
+            is_compatibility_event_for_touch: true,
+        }
     }
 }
 


### PR DESCRIPTION
Every time a touchmove event is added, it updates the cursor, causing frequent hit testing and affecting the performance of scrolling. Adding a flag to mark the current touchmove is done for compatibility with touch events. In this case, the last_mouse_move_position will not be updated.

Testing: No new use cases will be approved; it's just for performance optimization.
Fixes: A solution for #39433
