### PR TITLE
net: Use async primitives instead of sync in http_fetch

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -201,7 +201,7 @@ fn create_http_states(
         auth_cache: RwLock::new(auth_cache),
         history_states: RwLock::new(FxHashMap::default()),
         http_cache: RwLock::new(http_cache),
-        http_cache_state: Mutex::new(HashMap::new()),
+        http_cache_state: tokio::sync::Mutex::new(HashMap::new()),
         client: create_http_client(create_tls_config(
             ca_certificates.clone(),
             ignore_certificate_errors,
@@ -218,7 +218,7 @@ fn create_http_states(
         auth_cache: RwLock::new(AuthCache::default()),
         history_states: RwLock::new(FxHashMap::default()),
         http_cache: RwLock::new(HttpCache::default()),
-        http_cache_state: Mutex::new(HashMap::new()),
+        http_cache_state: tokio::sync::Mutex::new(HashMap::new()),
         client: create_http_client(create_tls_config(
             ca_certificates,
             ignore_certificate_errors,

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -149,7 +149,7 @@ fn create_http_state(fc: Option<EmbedderProxy>) -> HttpState {
         auth_cache: RwLock::new(net::resource_thread::AuthCache::default()),
         history_states: RwLock::new(FxHashMap::default()),
         http_cache: RwLock::new(net::http_cache::HttpCache::default()),
-        http_cache_state: Mutex::new(HashMap::new()),
+        http_cache_state: tokio::sync::Mutex::new(HashMap::new()),
         client: create_http_client(create_tls_config(
             net::connector::CACertificates::Default,
             false, /* ignore_certificate_errors */


### PR DESCRIPTION
This switches the main primitives originating from http_network_or_fetch into async primitives to allow threads to not block. Blocking threads will block and cannot be used by the threadpool for other work until they stopped being blocked. Using async Mutex here, allows the thread to be returned to the threadpool and do some other work.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: Tested locally and WPT run (https://github.com/Narfinger/servo/actions/runs/19361249709).
