### PR TITLE
script: Flatten nested match arms in `NormalizedAlgorithm`

### DIFF
--- a/components/script/dom/subtlecrypto/hkdf_operation.rs
+++ b/components/script/dom/subtlecrypto/hkdf_operation.rs
@@ -75,7 +75,7 @@ pub(crate) fn derive_bits(
 }
 
 /// <https://w3c.github.io/webcrypto/#hkdf-operations-import-key>
-pub(crate) fn import(
+pub(crate) fn import_key(
     global: &GlobalScope,
     format: KeyFormat,
     key_data: &[u8],

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -320,7 +320,7 @@ pub(crate) fn import_key(
 }
 
 /// <https://w3c.github.io/webcrypto/#hmac-operations-export-key>
-pub(crate) fn export(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
+pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
     match format {
         KeyFormat::Raw => match key.handle() {
             Handle::Hmac(key_data) => Ok(ExportedKey::Raw(key_data.as_slice().to_vec())),

--- a/components/script/dom/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/subtlecrypto/pbkdf2_operation.rs
@@ -78,7 +78,7 @@ pub(crate) fn derive_bits(
 }
 
 /// <https://w3c.github.io/webcrypto/#pbkdf2-operations-import-key>
-pub(crate) fn import(
+pub(crate) fn import_key(
     global: &GlobalScope,
     format: KeyFormat,
     key_data: &[u8],


### PR DESCRIPTION
This patch flattens nested match arms in `NormalizedAlgorithm` to simplify our code. Moreover, primarily matching the algorithm names, instead of matching the enum variant types, makes more sense, since some algorithms share the same enum variant type.

Testing: Refactoring. Existing tests suffice.
