### PR TITLE
html: Handle new `DurationChanged` event by <media>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7841,7 +7841,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
+source = "git+https://github.com/servo/media#1beaae45bda7ec95ee30d0582851cfc2ceec1742"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -7854,7 +7854,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
+source = "git+https://github.com/servo/media#1beaae45bda7ec95ee30d0582851cfc2ceec1742"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -7875,7 +7875,7 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
+source = "git+https://github.com/servo/media#1beaae45bda7ec95ee30d0582851cfc2ceec1742"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7885,7 +7885,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
+source = "git+https://github.com/servo/media#1beaae45bda7ec95ee30d0582851cfc2ceec1742"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -7899,7 +7899,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
+source = "git+https://github.com/servo/media#1beaae45bda7ec95ee30d0582851cfc2ceec1742"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -7932,7 +7932,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
+source = "git+https://github.com/servo/media#1beaae45bda7ec95ee30d0582851cfc2ceec1742"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -7942,7 +7942,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
+source = "git+https://github.com/servo/media#1beaae45bda7ec95ee30d0582851cfc2ceec1742"
 dependencies = [
  "glib",
  "gstreamer",
@@ -7956,7 +7956,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
+source = "git+https://github.com/servo/media#1beaae45bda7ec95ee30d0582851cfc2ceec1742"
 dependencies = [
  "glib",
  "gstreamer",
@@ -7971,7 +7971,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
+source = "git+https://github.com/servo/media#1beaae45bda7ec95ee30d0582851cfc2ceec1742"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -7983,7 +7983,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
+source = "git+https://github.com/servo/media#1beaae45bda7ec95ee30d0582851cfc2ceec1742"
 dependencies = [
  "uuid",
 ]
@@ -7991,12 +7991,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
+source = "git+https://github.com/servo/media#1beaae45bda7ec95ee30d0582851cfc2ceec1742"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#8aca9f7847d43736bbf78cbf6a9e4d4e440c98fd"
+source = "git+https://github.com/servo/media#1beaae45bda7ec95ee30d0582851cfc2ceec1742"
 dependencies = [
  "log",
  "servo-media-streams",


### PR DESCRIPTION
A new event `PlayerEvent::DurationChanged` has been added to the media engine to simplify handling changes in the duration of a media stream (sometimes the duration could be inaccurate or even determined by the media engine with significant delay after the initial metadata was ready).

This new event eliminates the need to check conditions for two consecutive `MetadataUpdated` events (the initial metadata and the metadata with the changed duration) during the loading phase.

servo-media:
- Add new `PlayerEvent::DurationChanged` event (https://github.com/servo/media/pull/461)

Testing: No expected changes in test results

Fixes: https://github.com/servo/servo/issues/40626