### PR TITLE
script: Store a `Weak` handle to `ScriptThread` in both `ScriptThread` and `Window`

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -266,7 +266,9 @@ struct PendingLayoutImageAncillaryData {
 pub(crate) struct Window {
     globalscope: GlobalScope,
 
-    /// A weak handle to script thread
+    /// A `Weak` reference to this [`ScriptThread`] used to give to child [`Window`]s so
+    /// they can more easily call methods on the [`ScriptThread`] without constantly having
+    /// to pass it everywhere.
     #[ignore_malloc_size_of = "Weak does not need to be accounted"]
     #[no_trace]
     weak_script_thread: Weak<ScriptThread>,

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -957,7 +957,7 @@ impl ScriptThread {
                 },
             ));
 
-        Rc::new_cyclic(|weak_script_thread| ScriptThread {
+        Rc::new_cyclic(|weak_script_thread| Self {
             documents: DomRefCell::new(DocumentCollection::default()),
             last_render_opportunity_time: Default::default(),
             window_proxies: Default::default(),

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -226,7 +226,8 @@ impl Drop for ScriptUserInteractingGuard {
 // ScriptThread instances are rooted on creation, so this is okay
 #[cfg_attr(crown, allow(crown::unrooted_must_root))]
 pub struct ScriptThread {
-    /// Weak Rc to itself or None if not yet initialized
+    /// A reference to the currently operating `ScriptThread`. This should always be
+    /// upgradable to an `Rc` as long as the `ScriptThread` is running.
     #[no_trace]
     this: Weak<ScriptThread>,
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -855,7 +855,7 @@ impl ScriptThread {
         layout_factory: Arc<dyn LayoutFactory>,
         image_cache_factory: Arc<dyn ImageCacheFactory>,
         background_hang_monitor_register: Box<dyn BackgroundHangMonitorRegister>,
-    ) -> Rc<ScriptThread> {
+    ) -> Rc<Self> {
         let (self_sender, self_receiver) = unbounded();
         let mut runtime =
             Runtime::new(Some(ScriptEventLoopSender::MainThread(self_sender.clone())));


### PR DESCRIPTION
We construct `ScriptThread` in an `Rc` which itself has the given `Weak` for it. It then can give it to `Window` and other elements in the future. We currently only use this for the microtask checkpoint function in `Window`. This is the first step toward eliminating the usage of thread local storage to access the `ScriptThread`.

Testing: This should not change behavior so is covered by existing tests.
Fixes: Part of addressing: https://github.com/servo/servo/issues/37969#issuecomment-3520463442
