### PR TITLE
fonts: Compute applied variations depending on originating `@font-face` rule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7739,7 +7739,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.33.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#f319793c6989dba83994fbd10d560b21ad4a0c85"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8046,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#f319793c6989dba83994fbd10d560b21ad4a0c85"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#f319793c6989dba83994fbd10d560b21ad4a0c85"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8644,7 +8644,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#f319793c6989dba83994fbd10d560b21ad4a0c85"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8653,12 +8653,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#f319793c6989dba83994fbd10d560b21ad4a0c85"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
 
 [[package]]
 name = "stylo_derive"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#f319793c6989dba83994fbd10d560b21ad4a0c85"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8670,7 +8670,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#f319793c6989dba83994fbd10d560b21ad4a0c85"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8679,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#f319793c6989dba83994fbd10d560b21ad4a0c85"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8696,12 +8696,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#f319793c6989dba83994fbd10d560b21ad4a0c85"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
 
 [[package]]
 name = "stylo_traits"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#f319793c6989dba83994fbd10d560b21ad4a0c85"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9115,7 +9115,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#f319793c6989dba83994fbd10d560b21ad4a0c85"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9128,7 +9128,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#f319793c6989dba83994fbd10d560b21ad4a0c85"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/components/fonts/font.rs
+++ b/components/fonts/font.rs
@@ -818,7 +818,17 @@ impl FontGroupFamily {
                 }
 
                 if !member.loaded {
-                    member.font = font_context.font(member.template.clone(), font_descriptor);
+                    if servo_config::pref!(layout_variable_fonts_enabled) {
+                        let variation_settings =
+                            member.template.borrow().compute_variations(font_descriptor);
+                        let descriptor_with_variations =
+                            font_descriptor.with_variation_settings(variation_settings);
+                        member.font =
+                            font_context.font(member.template.clone(), &descriptor_with_variations);
+                    } else {
+                        member.font = font_context.font(member.template.clone(), font_descriptor)
+                    }
+
                     member.loaded = true;
                 }
                 if matches!(&member.font, Some(font) if font_predicate(font)) {

--- a/components/fonts/font_store.rs
+++ b/components/fonts/font_store.rs
@@ -173,7 +173,7 @@ impl SimpleFamily {
         let remove_if_template_matches = |template: &mut Option<FontTemplateRef>| {
             if template
                 .as_ref()
-                .is_some_and(|template| template.borrow().stylesheet.as_ref() == Some(stylesheet))
+                .is_some_and(|template| template.borrow().stylesheet() == Some(stylesheet))
             {
                 *template = None;
             }
@@ -333,7 +333,7 @@ impl FontTemplates {
     ) -> bool {
         let length_before = self.templates.len();
         self.templates
-            .retain(|template| template.borrow().stylesheet.as_ref() != Some(stylesheet));
+            .retain(|template| template.borrow().stylesheet() != Some(stylesheet));
 
         if let Some(simple_family) = self.simple_family.as_mut() {
             simple_family.remove_templates_for_stylesheet(stylesheet);

--- a/components/fonts/font_store.rs
+++ b/components/fonts/font_store.rs
@@ -173,7 +173,7 @@ impl SimpleFamily {
         let remove_if_template_matches = |template: &mut Option<FontTemplateRef>| {
             if template
                 .as_ref()
-                .is_some_and(|template| template.borrow().stylesheet() == Some(stylesheet))
+                .is_some_and(|template| template.borrow().stylesheet.as_ref() == Some(stylesheet))
             {
                 *template = None;
             }
@@ -333,7 +333,7 @@ impl FontTemplates {
     ) -> bool {
         let length_before = self.templates.len();
         self.templates
-            .retain(|template| template.borrow().stylesheet() != Some(stylesheet));
+            .retain(|template| template.borrow().stylesheet.as_ref() != Some(stylesheet));
 
         if let Some(simple_family) = self.simple_family.as_mut() {
             simple_family.remove_templates_for_stylesheet(stylesheet);

--- a/components/fonts/platform/freetype/android/font_list.rs
+++ b/components/fonts/platform/freetype/android/font_list.rs
@@ -457,6 +457,7 @@ where
             FontIdentifier::Local(local_font_identifier),
             descriptor,
             None,
+            None,
         ));
     };
 

--- a/components/fonts/platform/freetype/font_list.rs
+++ b/components/fonts/platform/freetype/font_list.rs
@@ -132,6 +132,7 @@ where
                 FontIdentifier::Local(local_font_identifier),
                 descriptor,
                 None,
+                None,
             ))
         }
 

--- a/components/fonts/platform/freetype/ohos/font_list.rs
+++ b/components/fonts/platform/freetype/ohos/font_list.rs
@@ -469,6 +469,7 @@ where
             FontIdentifier::Local(local_font_identifier),
             descriptor,
             None,
+            None,
         ));
     };
 

--- a/components/fonts/platform/macos/font_list.rs
+++ b/components/fonts/platform/macos/font_list.rs
@@ -52,6 +52,7 @@ where
                     FontIdentifier::Local(identifier),
                     descriptor,
                     None,
+                    None,
                 ));
             }
         }

--- a/components/fonts/platform/windows/font_list.rs
+++ b/components/fonts/platform/windows/font_list.rs
@@ -47,6 +47,7 @@ where
                 FontIdentifier::Local(local_font_identifier),
                 template_descriptor,
                 None,
+                None,
             ))
         }
     }

--- a/components/fonts/tests/font.rs
+++ b/components/fonts/tests/font.rs
@@ -30,11 +30,7 @@ fn make_font(path: PathBuf) -> Font {
     let platform_font =
         PlatformFont::new_from_data(identifier.clone(), &data, None, &[], false).unwrap();
 
-    let template = FontTemplate {
-        identifier,
-        descriptor: platform_font.descriptor(),
-        stylesheet: None,
-    };
+    let template = FontTemplate::new(identifier, platform_font.descriptor(), None, None);
     let descriptor = FontDescriptor {
         weight: FontWeight::normal(),
         stretch: FontStretch::hundred(),

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -198,6 +198,7 @@ mod font_context {
                 FontIdentifier::Local(local_font_identifier),
                 handle.descriptor(),
                 None,
+                None,
             ));
         }
     }

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -880,6 +880,7 @@ malloc_size_of_is_0!(style::properties::ComputedValues);
 malloc_size_of_is_0!(style::properties::declaration_block::PropertyDeclarationBlock);
 malloc_size_of_is_0!(style::queries::values::PrefersColorScheme);
 malloc_size_of_is_0!(style::stylesheets::Stylesheet);
+malloc_size_of_is_0!(style::stylesheets::FontFaceRule);
 malloc_size_of_is_0!(style::values::specified::source_size_list::SourceSizeList);
 malloc_size_of_is_0!(taffy::Layout);
 malloc_size_of_is_0!(unicode_bidi::Level);

--- a/components/shared/fonts/font_descriptor.rs
+++ b/components/shared/fonts/font_descriptor.rs
@@ -55,6 +55,15 @@ impl<'a> From<&'a FontStyleStruct> for FontDescriptor {
     }
 }
 
+impl FontDescriptor {
+    pub fn with_variation_settings(&self, variation_settings: Vec<FontVariation>) -> Self {
+        FontDescriptor {
+            variation_settings,
+            ..*self
+        }
+    }
+}
+
 /// A version of `FontStyle` from Stylo that is serializable. Normally this is not
 /// because the specified version of `FontStyle` contains floats.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/shared/fonts/font_template.rs
+++ b/components/shared/fonts/font_template.rs
@@ -6,14 +6,14 @@ use std::fmt::{Debug, Error, Formatter};
 use std::ops::{Deref, RangeInclusive};
 use std::sync::Arc;
 
-use atomic_refcell::AtomicRefCell;
+use atomic_refcell::{AtomicRef, AtomicRefCell};
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 use style::computed_values::font_stretch::T as FontStretch;
 use style::computed_values::font_style::T as FontStyle;
-use style::servo_arc::Arc as ServoArc;
-use style::stylesheets::{DocumentStyleSheet, LockedFontFaceRule};
+use style::stylesheets::{DocumentStyleSheet, FontFaceRule};
 use style::values::computed::font::FontWeight;
+use webrender_api::FontVariation;
 
 use crate::{CSSFontFaceDescriptors, ComputedFontStyleDescriptor, FontDescriptor, FontIdentifier};
 
@@ -142,14 +142,6 @@ impl FontTemplateDescriptor {
     }
 }
 
-/// Data for a font load operation initiated by a `@font-face` rule.
-#[derive(Clone, MallocSizeOf)]
-pub struct FontFaceRuleInitiator {
-    pub stylesheet: DocumentStyleSheet,
-    #[ignore_malloc_size_of = "TODO"]
-    pub font_face_rule: ServoArc<LockedFontFaceRule>,
-}
-
 /// This describes all the information needed to create
 /// font instance handles. It contains a unique
 /// FontTemplateData structure that is platform specific.
@@ -164,7 +156,12 @@ pub struct FontTemplate {
     /// This is not serialized, as it's only useful in the [`super::FontContext`]
     /// that it is created in.
     #[serde(skip)]
-    pub font_face_rule: Option<FontFaceRuleInitiator>,
+    pub stylesheet: Option<DocumentStyleSheet>,
+
+    /// If this font is a web font, this is a reference to the `@font-face` rule that
+    /// created it.
+    #[serde(skip)]
+    pub font_face_rule: Option<FontFaceRule>,
 }
 
 impl Debug for FontTemplate {
@@ -181,11 +178,17 @@ impl FontTemplate {
     pub fn new(
         identifier: FontIdentifier,
         descriptor: FontTemplateDescriptor,
-        font_face_rule: Option<FontFaceRuleInitiator>,
+        stylesheet: Option<DocumentStyleSheet>,
+        font_face_rule: Option<FontFaceRule>,
     ) -> FontTemplate {
+        assert!(
+            (stylesheet.is_some() && font_face_rule.is_some()) ||
+                (stylesheet.is_none() && font_face_rule.is_none())
+        );
         FontTemplate {
             identifier,
             descriptor,
+            stylesheet,
             font_face_rule,
         }
     }
@@ -196,12 +199,14 @@ impl FontTemplate {
     pub fn new_for_local_web_font(
         local_template: FontTemplateRef,
         css_font_template_descriptors: &CSSFontFaceDescriptors,
-        font_face_rule: Option<FontFaceRuleInitiator>,
+        stylesheet: Option<DocumentStyleSheet>,
+        font_face_rule: Option<FontFaceRule>,
     ) -> Result<FontTemplate, &'static str> {
         let mut alias_template = local_template.borrow().clone();
         alias_template
             .descriptor
             .override_values_with_css_font_template_descriptors(css_font_template_descriptors);
+        alias_template.stylesheet = stylesheet;
         alias_template.font_face_rule = font_face_rule;
         Ok(alias_template)
     }
@@ -210,8 +215,48 @@ impl FontTemplate {
         &self.identifier
     }
 
-    pub fn stylesheet(&self) -> Option<&DocumentStyleSheet> {
-        self.font_face_rule.as_ref().map(|rule| &rule.stylesheet)
+    /// <https://drafts.csswg.org/css-fonts-4/#apply-font-matching-variations>
+    pub fn compute_variations(&self, descriptor: &FontDescriptor) -> Vec<FontVariation> {
+        // The steps in this algorithm are inverted order because they are listed in ascending order of precedence.
+        let mut variations: Vec<FontVariation> = vec![];
+
+        let mut add_variation = |variation: FontVariation| {
+            if !variations
+                .iter()
+                .any(|existing_variation| existing_variation.tag == variation.tag)
+            {
+                variations.push(FontVariation {
+                    tag: variation.tag,
+                    value: variation.value,
+                });
+            }
+        };
+
+        // Step 12. Font variations implied by the value of the font-variation-settings property are applied.
+        // These values should be clamped to the values that are supported by the font.
+        // NOTE: Clamping happens inside the PlatformFont.
+        descriptor
+            .variation_settings
+            .iter()
+            .copied()
+            .for_each(&mut add_variation);
+
+        if let Some(font_face_rule) = &self.font_face_rule {
+            // Step 6. If the font is defined via an @font-face rule, the font variations implied by the font-variation-settings
+            // descriptor in the @font-face rule are applied.
+            if let Some(variation_settings) = font_face_rule.variation_settings.as_ref() {
+                variation_settings
+                    .0
+                    .iter()
+                    .map(|variation| FontVariation {
+                        tag: variation.tag.0,
+                        value: variation.value.get(),
+                    })
+                    .for_each(&mut add_variation);
+            }
+        }
+
+        variations
     }
 }
 
@@ -228,6 +273,9 @@ pub trait FontTemplateRefMethods {
     /// Whether or not this character is in the unicode ranges specified in
     /// this temlates `@font-face` definition, if any.
     fn char_in_unicode_range(&self, character: char) -> bool;
+
+    /// Return the `@font-face` rule that defined this template, if any.
+    fn font_face_rule(&self) -> Option<AtomicRef<'_, FontFaceRule>>;
 }
 
 impl FontTemplateRefMethods for FontTemplateRef {
@@ -254,6 +302,10 @@ impl FontTemplateRefMethods for FontTemplateRef {
             .unicode_range
             .as_ref()
             .is_none_or(|ranges| ranges.iter().any(|range| range.contains(&character)))
+    }
+
+    fn font_face_rule(&self) -> Option<AtomicRef<'_, FontFaceRule>> {
+        AtomicRef::filter_map(self.borrow(), |template| template.font_face_rule.as_ref())
     }
 }
 


### PR DESCRIPTION
This change gives the font selection code access to the data from the `@font-face` rule that defined the font - and uses it to apply `font-variation-settings` inside `@font-face` rules.

Testing: We don't run wpt with `layout_variable_fonts_enabled=true` yet. I've attached a test case that is fixed by this PR.
Part of #37236

<details><summary>Testcase</summary>

```html
<!DOCTYPE html>
<html lang="en"><head>
    <style>
        h1, h2, h3, h4, h5, h6 {
            font-family: 'Montserrat', sans-serif;
        }
    </style>
    <style>
        @font-face {
          font-family: 'Montserrat';
          font-display: swap;
          font-variation-settings: "wght" 500;
          src: url(https://fonts.gstatic.com/s/montserrat/v30/JTUSjIg1_i6t8kCHKm459Wlhyw.woff2) format('woff2');
        }
    </style>
    <h2>The hackfest</h2>
</body></html>
```
</details>

