### PR TITLE
script: Remove unnecessary `Trusted` wrapper in `RemovableDomEventListener`

### DIFF
--- a/components/script/dom/abortsignal.rs
+++ b/components/script/dom/abortsignal.rs
@@ -21,7 +21,7 @@ use crate::dom::bindings::codegen::Bindings::EventTargetBinding::EventListenerOp
 use crate::dom::bindings::error::{Error, ErrorToJsval, Fallible};
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object_with_proto};
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
@@ -57,8 +57,9 @@ pub(crate) enum AbortAlgorithm {
 }
 
 #[derive(Clone, JSTraceable, MallocSizeOf)]
+#[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
 pub(crate) struct RemovableDomEventListener {
-    pub(crate) event_target: Trusted<EventTarget>,
+    pub(crate) event_target: Dom<EventTarget>,
     pub(crate) ty: DOMString,
     #[conditional_malloc_size_of]
     pub(crate) listener: Option<Rc<EventListener>>,
@@ -210,14 +211,11 @@ impl AbortSignal {
                 deferred_fetch_record.lock().unwrap().abort();
             },
             AbortAlgorithm::DomEventListener(removable_listener) => {
-                removable_listener
-                    .event_target
-                    .root()
-                    .remove_event_listener(
-                        removable_listener.ty.clone(),
-                        &removable_listener.listener,
-                        &removable_listener.options,
-                    );
+                removable_listener.event_target.remove_event_listener(
+                    removable_listener.ty.clone(),
+                    &removable_listener.listener,
+                    &removable_listener.options,
+                );
             },
         }
     }

--- a/components/script/dom/eventtarget.rs
+++ b/components/script/dom/eventtarget.rs
@@ -47,11 +47,10 @@ use crate::dom::bindings::codegen::UnionTypes::{
 };
 use crate::dom::bindings::error::{Error, Fallible, report_pending_exception};
 use crate::dom::bindings::inheritance::Castable;
-use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::{
     DomGlobal, DomObject, Reflector, reflect_dom_object_with_proto,
 };
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::HashMapTracedValues;
 use crate::dom::csp::{CspReporting, InlineCheckType};
@@ -958,7 +957,7 @@ impl EventTarget {
             // Step 6. If listener’s signal is not null, then add the following abort steps to it:
             signal.add(&AbortAlgorithm::DomEventListener(
                 RemovableDomEventListener {
-                    event_target: Trusted::new(self),
+                    event_target: Dom::from_ref(self),
                     ty: ty.clone(),
                     listener: listener.clone(),
                     options: options.parent.clone(),


### PR DESCRIPTION
 Replace `Trusted<EventTarget>` with `Dom<EventTarget>` and add the appropriate crown attribute.

Testing: `./mach build --use-crown` succeed and no difference in behaviour when running `./mach test-wpt tests/wpt/tests/dom/abort`
Fixes: #40631 
