### PR TITLE
Tweak automatic release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,6 @@
+# This file allows configuring the automatic changelog generation on releases.
+# See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+changelog:
+  exclude:
+    authors:
+      - dependabot[bot]

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,3 +4,4 @@ changelog:
   exclude:
     authors:
       - dependabot[bot]
+      - servo-wpt-sync


### PR DESCRIPTION
When drafting github releases, there is an option
to automatically generate a list of changes based on merged PR titles.
For now we simply exclude dependabot PRs, but in the future we might want to use labels to further optimise the automatic release notes usefulness.
Documentation:  https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes


Testing: Not tested, no impact on servo itself.
