### PR TITLE
script: Housekeeping WebIDL dictionaries of WebCrypto API

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -1745,30 +1745,17 @@ impl From<EcdhKeyDeriveParams> for SubtleEcdhKeyDeriveParams {
     }
 }
 
+/// <https://w3c.github.io/webcrypto/#dfn-AesCtrParams>
 #[derive(Clone, Debug, MallocSizeOf)]
-pub(crate) struct SubtleAesCbcParams {
-    pub(crate) name: String,
-    pub(crate) iv: Vec<u8>,
-}
+struct SubtleAesCtrParams {
+    /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
+    name: String,
 
-impl From<RootedTraceableBox<AesCbcParams>> for SubtleAesCbcParams {
-    fn from(params: RootedTraceableBox<AesCbcParams>) -> Self {
-        let iv = match &params.iv {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
-        };
-        SubtleAesCbcParams {
-            name: params.parent.name.to_string(),
-            iv,
-        }
-    }
-}
+    /// <https://w3c.github.io/webcrypto/#dfn-AesCtrParams-counter>
+    counter: Vec<u8>,
 
-#[derive(Clone, Debug, MallocSizeOf)]
-pub(crate) struct SubtleAesCtrParams {
-    pub(crate) name: String,
-    pub(crate) counter: Vec<u8>,
-    pub(crate) length: u8,
+    /// <https://w3c.github.io/webcrypto/#dfn-AesCtrParams-length>
+    length: u8,
 }
 
 impl From<RootedTraceableBox<AesCtrParams>> for SubtleAesCtrParams {
@@ -1781,34 +1768,6 @@ impl From<RootedTraceableBox<AesCtrParams>> for SubtleAesCtrParams {
             name: params.parent.name.to_string(),
             counter,
             length: params.length,
-        }
-    }
-}
-
-#[derive(Clone, Debug, MallocSizeOf)]
-pub(crate) struct SubtleAesGcmParams {
-    pub(crate) name: String,
-    pub(crate) iv: Vec<u8>,
-    pub(crate) additional_data: Option<Vec<u8>>,
-    pub(crate) tag_length: Option<u8>,
-}
-
-impl From<RootedTraceableBox<AesGcmParams>> for SubtleAesGcmParams {
-    fn from(params: RootedTraceableBox<AesGcmParams>) -> Self {
-        let iv = match &params.iv {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
-        };
-        let additional_data = params.additionalData.as_ref().map(|data| match data {
-            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
-            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
-        });
-
-        SubtleAesGcmParams {
-            name: params.parent.name.to_string(),
-            iv,
-            additional_data,
-            tag_length: params.tagLength,
         }
     }
 }
@@ -1870,6 +1829,65 @@ impl From<AesDerivedKeyParams> for SubtleAesDerivedKeyParams {
         SubtleAesDerivedKeyParams {
             name: params.parent.name.to_string(),
             length: params.length,
+        }
+    }
+}
+
+/// <https://w3c.github.io/webcrypto/#dfn-AesCbcParams>
+#[derive(Clone, Debug, MallocSizeOf)]
+struct SubtleAesCbcParams {
+    /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
+    name: String,
+
+    /// <https://w3c.github.io/webcrypto/#dfn-AesCbcParams-iv>
+    iv: Vec<u8>,
+}
+
+impl From<RootedTraceableBox<AesCbcParams>> for SubtleAesCbcParams {
+    fn from(params: RootedTraceableBox<AesCbcParams>) -> Self {
+        let iv = match &params.iv {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
+        };
+        SubtleAesCbcParams {
+            name: params.parent.name.to_string(),
+            iv,
+        }
+    }
+}
+
+/// <https://w3c.github.io/webcrypto/#dfn-AesGcmParams>
+#[derive(Clone, Debug, MallocSizeOf)]
+struct SubtleAesGcmParams {
+    /// <https://w3c.github.io/webcrypto/#dom-algorithm-name>
+    name: String,
+
+    /// <https://w3c.github.io/webcrypto/#dfn-AesGcmParams-iv>
+    iv: Vec<u8>,
+
+    /// <https://w3c.github.io/webcrypto/#dfn-AesGcmParams-additionalData>
+    additional_data: Option<Vec<u8>>,
+
+    /// <https://w3c.github.io/webcrypto/#dfn-AesGcmParams-tagLength>
+    tag_length: Option<u8>,
+}
+
+impl From<RootedTraceableBox<AesGcmParams>> for SubtleAesGcmParams {
+    fn from(params: RootedTraceableBox<AesGcmParams>) -> Self {
+        let iv = match &params.iv {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
+        };
+        let additional_data = params.additionalData.as_ref().map(|data| match data {
+            ArrayBufferViewOrArrayBuffer::ArrayBufferView(view) => view.to_vec(),
+            ArrayBufferViewOrArrayBuffer::ArrayBuffer(buffer) => buffer.to_vec(),
+        });
+
+        SubtleAesGcmParams {
+            name: params.parent.name.to_string(),
+            iv,
+            additional_data,
+            tag_length: params.tagLength,
         }
     }
 }

--- a/components/script_bindings/webidls/CryptoKey.webidl
+++ b/components/script_bindings/webidls/CryptoKey.webidl
@@ -16,7 +16,7 @@ interface CryptoKey {
   readonly attribute object usages;
 };
 
-// https://w3c.github.io/webcrypto/#dfn-CryptoKeyPair
+// https://w3c.github.io/webcrypto/#keypair
 
 dictionary CryptoKeyPair {
   CryptoKey publicKey;

--- a/components/script_bindings/webidls/SubtleCrypto.webidl
+++ b/components/script_bindings/webidls/SubtleCrypto.webidl
@@ -4,18 +4,6 @@
 
 // https://w3c.github.io/webcrypto/#subtlecrypto-interface
 
-typedef (object or DOMString) AlgorithmIdentifier;
-
-typedef AlgorithmIdentifier HashAlgorithmIdentifier;
-
-dictionary Algorithm {
-  required DOMString name;
-};
-
-dictionary KeyAlgorithm {
-  required DOMString name;
-};
-
 enum KeyFormat { "raw", "spki", "pkcs8", "jwk" };
 
 [SecureContext,Exposed=(Window,Worker),Pref="dom_crypto_subtle_enabled"]
@@ -68,84 +56,115 @@ interface SubtleCrypto {
                          sequence<KeyUsage> keyUsages );
 };
 
-// https://w3c.github.io/webcrypto/#dfn-EcdsaParams
+// https://w3c.github.io/webcrypto/#algorithm-dictionary
+
+typedef (object or DOMString) AlgorithmIdentifier;
+
+typedef AlgorithmIdentifier HashAlgorithmIdentifier;
+
+dictionary Algorithm {
+  required DOMString name;
+};
+
+// https://w3c.github.io/webcrypto/#key-algorithm-dictionary
+
+dictionary KeyAlgorithm {
+  required DOMString name;
+};
+
+// https://w3c.github.io/webcrypto/#EcdsaParams-dictionary
 dictionary EcdsaParams : Algorithm {
   required HashAlgorithmIdentifier hash;
 };
 
-// https://w3c.github.io/webcrypto/#dfn-NamedCurve
+// https://w3c.github.io/webcrypto/#EcKeyGenParams-dictionary
+
 typedef DOMString NamedCurve;
 
-// https://w3c.github.io/webcrypto/#dfn-EcKeyGenParams
 dictionary EcKeyGenParams : Algorithm {
   required NamedCurve namedCurve;
 };
 
-// https://w3c.github.io/webcrypto/#dfn-EcKeyAlgorithm
+// https://w3c.github.io/webcrypto/#EcKeyAlgorithm-dictionary
+
 dictionary EcKeyAlgorithm : KeyAlgorithm {
   required NamedCurve namedCurve;
 };
 
-// https://w3c.github.io/webcrypto/#dfn-EcKeyImportParams
+// https://w3c.github.io/webcrypto/#EcKeyImportParams-dictionary
+
 dictionary EcKeyImportParams : Algorithm {
   required NamedCurve namedCurve;
 };
 
 // https://w3c.github.io/webcrypto/#dh-EcdhKeyDeriveParams
+
 dictionary EcdhKeyDeriveParams : Algorithm {
   required CryptoKey public;
 };
 
-// AES shared
-dictionary AesKeyAlgorithm : KeyAlgorithm {
-  required unsigned short length;
-};
+// https://w3c.github.io/webcrypto/#aes-ctr-params
 
-dictionary AesKeyGenParams : Algorithm {
-  required [EnforceRange] unsigned short length;
-};
-
-dictionary AesDerivedKeyParams : Algorithm {
-  required [EnforceRange] unsigned short length;
-};
-
-// AES_CBC
-dictionary AesCbcParams : Algorithm {
-  required BufferSource iv;
-};
-
-// AES_CTR
 dictionary AesCtrParams : Algorithm {
   required BufferSource counter;
   required [EnforceRange] octet length;
 };
 
+// https://w3c.github.io/webcrypto/#AesKeyAlgorithm-dictionary
+
+dictionary AesKeyAlgorithm : KeyAlgorithm {
+  required unsigned short length;
+};
+
+// https://w3c.github.io/webcrypto/#aes-keygen-params
+
+dictionary AesKeyGenParams : Algorithm {
+  required [EnforceRange] unsigned short length;
+};
+
+// https://w3c.github.io/webcrypto/#aes-derivedkey-params
+
+dictionary AesDerivedKeyParams : Algorithm {
+  required [EnforceRange] unsigned short length;
+};
+
+// https://w3c.github.io/webcrypto/#aes-cbc-params
+
+dictionary AesCbcParams : Algorithm {
+  required BufferSource iv;
+};
+
 // https://w3c.github.io/webcrypto/#aes-gcm-params
+
 dictionary AesGcmParams : Algorithm {
   required BufferSource iv;
   BufferSource additionalData;
   [EnforceRange] octet tagLength;
 };
 
-// https://w3c.github.io/webcrypto/#dfn-HmacImportParams
+// https://w3c.github.io/webcrypto/#hmac-importparams
+
 dictionary HmacImportParams : Algorithm {
   required HashAlgorithmIdentifier hash;
   [EnforceRange] unsigned long length;
 };
 
-// https://w3c.github.io/webcrypto/#dfn-HmacKeyAlgorithm
+// https://w3c.github.io/webcrypto/#HmacKeyAlgorithm-dictionary
+
 dictionary HmacKeyAlgorithm : KeyAlgorithm {
   required KeyAlgorithm hash;
   required unsigned long length;
 };
 
-// https://w3c.github.io/webcrypto/#dfn-HmacKeyGenParams
+// https://w3c.github.io/webcrypto/#hmac-keygen-params
+
 dictionary HmacKeyGenParams : Algorithm {
   required HashAlgorithmIdentifier hash;
   [EnforceRange] unsigned long length;
 };
 
 // https://w3c.github.io/webcrypto/#hkdf-params
+
 dictionary HkdfParams : Algorithm {
   required HashAlgorithmIdentifier hash;
   required BufferSource salt;
@@ -153,13 +172,15 @@ dictionary HkdfParams : Algorithm {
 };
 
 // https://w3c.github.io/webcrypto/#pbkdf2-params
+
 dictionary Pbkdf2Params : Algorithm {
   required BufferSource salt;
   required [EnforceRange] unsigned long iterations;
   required HashAlgorithmIdentifier hash;
 };
 
-// JWK
+// https://w3c.github.io/webcrypto/#JsonWebKey-dictionary
+
 dictionary RsaOtherPrimesInfo {
   // The following fields are defined in Section 6.3.2.7 of JSON Web Algorithms
   DOMString r;


### PR DESCRIPTION
Housekeeping of WebIDL dictionaries of WebCrypto API, including:

- Add/Fix spec links in `SubtleCrypto.webidl` and `CryptoKey.webidl`.
- Sort dictionaries in `subtlecrypto.webidl` based on the spec.
- Sort the `subtle` structs in `subtlecrypto.rs`, based on the spec.
- Reduce unneeded visibility of those `subtle` structs.

Testing: No behavioral change. Existing tests suffice.