### PR TITLE
libservo: Notify embedder of protocol handler updates

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -127,8 +127,8 @@ use crate::webview::MINIMUM_WEBVIEW_SIZE;
 pub use crate::webview::{WebView, WebViewBuilder};
 pub use crate::webview_delegate::{
     AllowOrDenyRequest, AuthenticationRequest, ColorPicker, ContextMenu, EmbedderControl,
-    FilePicker, InputMethodControl, NavigationRequest, PermissionRequest, SelectElement,
-    WebResourceLoad, WebViewDelegate,
+    FilePicker, InputMethodControl, NavigationRequest, PermissionRequest,
+    ProtocolHandlerRegistration, SelectElement, WebResourceLoad, WebViewDelegate,
 };
 
 #[cfg(feature = "media-gstreamer")]
@@ -535,6 +535,34 @@ impl Servo {
                         response_sent: false,
                     };
                     webview.delegate().request_navigation(webview, request);
+                }
+            },
+            EmbedderMsg::AllowProtocolHandlerRequest(
+                webview_id,
+                registration_update,
+                response_sender,
+            ) => {
+                if let Some(webview) = self.get_webview_handle(webview_id) {
+                    let ProtocolHandlerUpdateRegistration {
+                        scheme,
+                        url,
+                        register_or_unregister,
+                    } = registration_update;
+                    let protocol_handler_registration = ProtocolHandlerRegistration {
+                        scheme,
+                        url: url.into_url(),
+                        register_or_unregister,
+                    };
+                    let allow_deny_request = AllowOrDenyRequest::new(
+                        response_sender,
+                        AllowOrDeny::Deny,
+                        self.servo_errors.sender(),
+                    );
+                    webview.delegate().request_protocol_handler(
+                        webview,
+                        protocol_handler_registration,
+                        allow_deny_request,
+                    );
                 }
             },
             EmbedderMsg::AllowOpeningWebView(webview_id, response_sender) => {

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -21,7 +21,7 @@ use url::Url;
 use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 
 use crate::responders::ServoErrorSender;
-use crate::{ConstellationProxy, WebView};
+use crate::{ConstellationProxy, RegisterOrUnregister, WebView};
 
 /// A request to navigate a [`WebView`] or one of its inner frames. This can be handled
 /// asynchronously. If not handled, the request will automatically be allowed.
@@ -153,6 +153,13 @@ impl AllowOrDenyRequest {
             self.1.raise_response_send_error(error);
         }
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProtocolHandlerRegistration {
+    pub scheme: String,
+    pub url: Url,
+    pub register_or_unregister: RegisterOrUnregister,
 }
 
 /// A request to authenticate a [`WebView`] navigation. Embedders may choose to prompt
@@ -678,6 +685,18 @@ pub trait WebViewDelegate {
     fn request_unload(&self, _webview: WebView, _unload_request: AllowOrDenyRequest) {}
     /// Move the window to a point.
     fn request_move_to(&self, _webview: WebView, _: DeviceIntPoint) {}
+    /// Whether or not to allow a [`WebView`] to (un)register a protocol handler (e.g. `mailto:`).
+    /// Typically an embedder application will show a permissions prompt when this happens
+    /// to confirm a protocol handler is allowed. By default, requests are denied.
+    /// For more information, see the specification:
+    /// <https://html.spec.whatwg.org/multipage/#custom-handlers>
+    fn request_protocol_handler(
+        &self,
+        _webview: WebView,
+        _protocol_handler_registration: ProtocolHandlerRegistration,
+        _allow_deny_request: AllowOrDenyRequest,
+    ) {
+    }
     /// Try to resize the window that contains this [`WebView`] to the provided outer
     /// size. These resize requests can come from page content. Servo will ensure that the
     /// values are greater than zero, but it is up to the embedder to limit the maximum

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -410,6 +410,23 @@ pub enum AllowOrDeny {
     Deny,
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+/// Whether a protocol handler is requested to be registered or unregistered.
+pub enum RegisterOrUnregister {
+    Register,
+    Unregister,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ProtocolHandlerUpdateRegistration {
+    /// The scheme for the protocol handler
+    pub scheme: String,
+    /// The URL to navigate to when handling requests for scheme
+    pub url: ServoUrl,
+    /// Whether this update is to register or unregister the protocol handler
+    pub register_or_unregister: RegisterOrUnregister,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SelectElementOption {
     /// A unique identifier for the option that can be used to select it.
@@ -540,6 +557,12 @@ pub enum EmbedderMsg {
     ),
     /// Whether or not to allow a pipeline to load a url.
     AllowNavigationRequest(WebViewId, PipelineId, ServoUrl),
+    /// Request to (un)register protocol handler by page content.
+    AllowProtocolHandlerRequest(
+        WebViewId,
+        ProtocolHandlerUpdateRegistration,
+        GenericSender<AllowOrDeny>,
+    ),
     /// Whether or not to allow script to open a new tab/browser
     AllowOpeningWebView(
         WebViewId,


### PR DESCRIPTION
This implements step 2 of the web-facing API's.
Now, the embedder receives a notification whether
a webpage wants to register/unregister a protocol
handler. They can't do anything with it yet, that's for a follow-up PR. But locally testing shows the
following debug log:

```
pid:35180 Requesting to Register for scheme web+test with url https://web-platform.test:8443/html/webappapis/system-state-and-capabilities/the-navigator-object/%s
```

Part of #40615