### PR TITLE
Implement `WindowOrWorkerGlobalScope::reportError`

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1329,6 +1329,12 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         Some(DomRoot::from_ref(container))
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#dom-reporterror>
+    fn ReportError(&self, cx: JSContext, error: HandleValue, can_gc: CanGc) {
+        self.as_global_scope()
+            .report_an_exception(cx, error, can_gc);
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#dom-navigator>
     fn Navigator(&self) -> DomRoot<Navigator> {
         self.navigator

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -800,6 +800,12 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
         self.upcast::<GlobalScope>().crypto(CanGc::note())
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#dom-reporterror>
+    fn ReportError(&self, cx: JSContext, error: HandleValue, can_gc: CanGc) {
+        self.upcast::<GlobalScope>()
+            .report_an_exception(cx, error, can_gc);
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#dom-windowbase64-btoa>
     fn Btoa(&self, btoa: DOMString) -> Fallible<DOMString> {
         base64_btoa(btoa)

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -683,7 +683,7 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CreateImageBitmap', 'CreateImageBitmap_', 'CookieStore', 'Fetch', 'FetchLater', 'Open', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException'],
+    'canGc': ['CreateImageBitmap', 'CreateImageBitmap_', 'CookieStore', 'Fetch', 'FetchLater', 'Open', 'ReportError', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException'],
     'inRealms': ['Fetch', 'GetOpener', 'WebdriverCallback'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
 },
@@ -695,7 +695,7 @@ DOMInterfaces = {
 
 'WorkerGlobalScope': {
     'inRealms': ['Fetch'],
-    'canGc': ['Fetch', 'CreateImageBitmap', 'CreateImageBitmap_', 'ImportScripts', 'SetInterval', 'SetTimeout', 'StructuredClone', 'TrustedTypes'],
+    'canGc': ['Fetch', 'CreateImageBitmap', 'CreateImageBitmap_', 'ImportScripts', 'ReportError', 'SetInterval', 'SetTimeout', 'StructuredClone', 'TrustedTypes'],
 },
 
 'Worklet': {

--- a/components/script_bindings/webidls/WindowOrWorkerGlobalScope.webidl
+++ b/components/script_bindings/webidls/WindowOrWorkerGlobalScope.webidl
@@ -10,6 +10,8 @@ typedef (TrustedScript or DOMString or Function) TimerHandler;
 interface mixin WindowOrWorkerGlobalScope {
   [Replaceable] readonly attribute USVString origin;
 
+  undefined reportError(any e);
+
   // base64 utility methods
   [Throws] DOMString btoa(DOMString data);
   [Throws] DOMString atob(DOMString data);

--- a/tests/wpt/meta/html/dom/idlharness.any.js.ini
+++ b/tests/wpt/meta/html/dom/idlharness.any.js.ini
@@ -53,9 +53,6 @@
   [WorkerGlobalScope interface: attribute crossOriginIsolated]
     expected: FAIL
 
-  [WorkerGlobalScope interface: operation reportError(any)]
-    expected: FAIL
-
   [DedicatedWorkerGlobalScope interface: internal [[SetPrototypeOf\]\] method of interface prototype object - setting to a new value via Object.setPrototypeOf should throw a TypeError]
     expected: FAIL
 
@@ -84,12 +81,6 @@
     expected: FAIL
 
   [WorkerGlobalScope interface: self must inherit property "crossOriginIsolated" with the proper type]
-    expected: FAIL
-
-  [WorkerGlobalScope interface: self must inherit property "reportError(any)" with the proper type]
-    expected: FAIL
-
-  [WorkerGlobalScope interface: calling reportError(any) on self with too few arguments must throw TypeError]
     expected: FAIL
 
   [WorkerNavigator interface: member taintEnabled]

--- a/tests/wpt/meta/html/webappapis/scripting/reporterror-cross-realm-method.html.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/reporterror-cross-realm-method.html.ini
@@ -1,3 +1,0 @@
-[reporterror-cross-realm-method.html]
-  [self.reportError() dispatches an "error" event for this's relevant global object]
-    expected: FAIL

--- a/tests/wpt/meta/html/webappapis/scripting/reporterror.any.js.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/reporterror.any.js.ini
@@ -1,26 +1,8 @@
 [reporterror.any.worker.html]
-  [self.reportError(1)]
-    expected: FAIL
-
   [self.reportError(TypeError)]
-    expected: FAIL
-
-  [self.reportError(undefined)]
-    expected: FAIL
-
-  [self.reportError() doesn't invoke getters]
     expected: FAIL
 
 
 [reporterror.any.html]
-  [self.reportError(1)]
-    expected: FAIL
-
   [self.reportError(TypeError)]
-    expected: FAIL
-
-  [self.reportError(undefined)]
-    expected: FAIL
-
-  [self.reportError() doesn't invoke getters]
     expected: FAIL


### PR DESCRIPTION
This web API is alternative API to `throw e`, which is why we can reuse a lot of the existing machinery.

The one testcase that isn't passing yet is because it reports an empty `TypeError`. The current logic in `ErrorInfo` only retrieves the message data, but doesn't include the type of the exception. For that, we need to use `(*report)._base.errorNumber` and map that back to the original type codes. However, deferring that to a follow-up as that requires some more work in mozjs.
