### PR TITLE
script: Don't rely on Attr nodes when communicating with layout

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -11,7 +11,6 @@ use dom_struct::dom_struct;
 use html5ever::{LocalName, Namespace, Prefix, local_name, ns};
 use style::attr::{AttrIdentifier, AttrValue};
 use style::values::GenericAtomIdent;
-use stylo_atoms::Atom;
 
 use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
@@ -235,8 +234,6 @@ impl Attr {
 
 pub(crate) trait AttrHelpersForLayout<'dom> {
     fn value(self) -> &'dom AttrValue;
-    fn as_str(&self) -> &'dom str;
-    fn to_tokens(self) -> Option<&'dom [Atom]>;
     fn local_name(self) -> &'dom LocalName;
     fn namespace(self) -> &'dom Namespace;
 }
@@ -246,19 +243,6 @@ impl<'dom> AttrHelpersForLayout<'dom> for LayoutDom<'dom, Attr> {
     #[inline]
     fn value(self) -> &'dom AttrValue {
         unsafe { self.unsafe_get().value.borrow_for_layout() }
-    }
-
-    #[inline]
-    fn as_str(&self) -> &'dom str {
-        self.value()
-    }
-
-    #[inline]
-    fn to_tokens(self) -> Option<&'dom [Atom]> {
-        match *self.value() {
-            AttrValue::TokenList(_, ref tokens) => Some(tokens),
-            _ => None,
-        }
     }
 
     #[inline]

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -970,11 +970,11 @@ pub(crate) fn get_attr_for_layout<'dom>(
     elem: LayoutDom<'dom, Element>,
     namespace: &Namespace,
     name: &LocalName,
-) -> Option<LayoutDom<'dom, Attr>> {
+) -> Option<&'dom AttrValue> {
     elem.attrs()
         .iter()
         .find(|attr| name == attr.local_name() && namespace == attr.namespace())
-        .cloned()
+        .map(|attr| attr.value())
 }
 
 pub(crate) trait LayoutElementHelpers<'dom> {
@@ -1039,8 +1039,7 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
         case_sensitivity: CaseSensitivity,
     ) -> bool {
         get_attr_for_layout(self, &ns!(), attr_name).is_some_and(|attr| {
-            attr.to_tokens()
-                .unwrap()
+            attr.as_tokens()
                 .iter()
                 .any(|atom| case_sensitivity.eq_atom(atom, name))
         })
@@ -1048,13 +1047,11 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
 
     #[inline]
     fn get_classes_for_layout(self) -> Option<&'dom [Atom]> {
-        get_attr_for_layout(self, &ns!(), &local_name!("class"))
-            .map(|attr| attr.to_tokens().unwrap())
+        get_attr_for_layout(self, &ns!(), &local_name!("class")).map(|attr| attr.as_tokens())
     }
 
     fn get_parts_for_layout(self) -> Option<&'dom [Atom]> {
-        get_attr_for_layout(self, &ns!(), &local_name!("part"))
-            .map(|attr| attr.to_tokens().unwrap())
+        get_attr_for_layout(self, &ns!(), &local_name!("part")).map(|attr| attr.as_tokens())
     }
 
     fn synthesize_presentational_hints_for_legacy_attributes<V>(self, hints: &mut V)
@@ -1488,12 +1485,12 @@ impl<'dom> LayoutElementHelpers<'dom> for LayoutDom<'dom, Element> {
         namespace: &Namespace,
         name: &LocalName,
     ) -> Option<&'dom AttrValue> {
-        get_attr_for_layout(self, namespace, name).map(|attr| attr.value())
+        get_attr_for_layout(self, namespace, name)
     }
 
     #[inline]
     fn get_attr_val_for_layout(self, namespace: &Namespace, name: &LocalName) -> Option<&'dom str> {
-        get_attr_for_layout(self, namespace, name).map(|attr| attr.as_str())
+        get_attr_for_layout(self, namespace, name).map(|attr| &**attr)
     }
 
     #[inline]


### PR DESCRIPTION
When script is looking up an attribute for layout then it only needs to care about the attribute value. The `Attr` node itself is not required. If we want to lazily construct attribute nodes in the future (https://github.com/servo/servo/issues/36697) then we should use `Attr` as little as possible.

This also ends up simplifying the code by accident.

Testing: No behaviour change intended, regressions are covered by existing tests.
Part of https://github.com/servo/servo/issues/36697
