### PR TITLE
libservo: Make `WebView::set_history` have `crate` visibility

### DIFF
--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -646,7 +646,7 @@ impl WebView {
             .request_screenshot(self.id(), rect, Box::new(callback));
     }
 
-    pub fn set_history(self, new_back_forward_list: Vec<ServoUrl>, new_index: usize) {
+    pub(crate) fn set_history(self, new_back_forward_list: Vec<ServoUrl>, new_index: usize) {
         {
             let mut inner_mut = self.inner_mut();
             inner_mut.back_forward_list_index = new_index;


### PR DESCRIPTION
I mistakenly made this method have public visibility in a recent PR

Testing: This doesn't change behavior and is thus covered by existing tests.
Fixes: #40667
