### PR TITLE
Remove #![allow(dead_code)] from readablestreambyobreader

### DIFF
--- a/components/script/dom/readablestreambyobreader.rs
+++ b/components/script/dom/readablestreambyobreader.rs
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-#![allow(dead_code)]
 
 use std::collections::VecDeque;
 use std::mem;


### PR DESCRIPTION
#![allow(dead_code)]  not needed in readablestreambyobreader(left over stream re-implementation)

PS: this was made using Servo.