### PR TITLE
script: Support SVG <use> elements with fragment identifiers

### DIFF
--- a/tests/wpt/meta/svg/linking/reftests/use-template.html.ini
+++ b/tests/wpt/meta/svg/linking/reftests/use-template.html.ini
@@ -1,2 +1,0 @@
-[use-template.html]
-  expected: FAIL


### PR DESCRIPTION
 implements support for SVG <use> elements that reference other elements within the same document using fragment identifiers.

Testing: <img width="2774" height="602" alt="image" src="https://github.com/user-attachments/assets/6e31e215-bf34-4f7e-bd74-0405b583b8aa" />
Fixes: #10951 

