### PR TITLE
layout: Implement query from pointer location to text fragment index.

### DIFF
--- a/components/fonts/glyph.rs
+++ b/components/fonts/glyph.rs
@@ -649,6 +649,32 @@ impl GlyphStore {
         })
     }
 
+    // Scan the glyphs for a given range until we reach a given advance. Returns the index
+    // and advance of the glyph in the range at the given advance, if reached. Otherwise, returns the
+    // the number of glyphs and the advance for the given range.
+    #[inline]
+    pub fn range_index_of_advance(
+        &self,
+        range: &Range<ByteIndex>,
+        advance: Au,
+        extra_word_spacing: Au,
+    ) -> (usize, Au) {
+        let mut index = 0;
+        let mut current_advance = Au::zero();
+        for glyph in self.iter_glyphs_for_byte_range(range) {
+            if glyph.char_is_word_separator() {
+                current_advance += glyph.advance() + extra_word_spacing
+            } else {
+                current_advance += glyph.advance()
+            }
+            if current_advance > advance {
+                break;
+            }
+            index += 1;
+        }
+        (index, current_advance)
+    }
+
     #[inline]
     pub fn advance_for_byte_range(&self, range: &Range<ByteIndex>, extra_word_spacing: Au) -> Au {
         if range.begin() == ByteIndex(0) && range.end() == self.len() {

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -44,7 +44,7 @@ use style::values::specified::text::TextTransformCase;
 use style_traits::{ParsingMode, ToCss};
 
 use crate::ArcRefCell;
-use crate::display_list::StackingContextTree;
+use crate::display_list::{IndexableText, StackingContextTree};
 use crate::dom::NodeExt;
 use crate::flow::inline::construct::{TextTransformation, WhitespaceCollapse, capitalize_string};
 use crate::fragment_tree::{
@@ -1247,8 +1247,12 @@ fn rendered_text_collection_steps(
     items
 }
 
-pub fn process_text_index_request(_node: OpaqueNode, _point: Point2D<Au>) -> Option<usize> {
-    None
+pub fn process_text_index_request(
+    node: OpaqueNode,
+    point: euclid::Point2D<Au, style_traits::CSSPixel>,
+    indexable_text: &IndexableText,
+) -> Option<usize> {
+    indexable_text.text_index(node, point)
 }
 
 pub fn process_resolved_font_style_query<'dom, E>(

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -3219,8 +3219,18 @@ impl VirtualMethods for HTMLInputElement {
                     // now.
                     if let Some(point_in_target) = mouse_event.point_in_target() {
                         let window = self.owner_window();
-                        let index = window
-                            .text_index_query(self.upcast::<Node>(), point_in_target.to_untyped());
+                        let shadow_tree = self.shadow_tree.borrow();
+                        let query_node = shadow_tree
+                            .as_ref()
+                            .and_then(|shadow_tree| {
+                                let ShadowTree::Text(tree) = shadow_tree else {
+                                    return None;
+                                };
+                                tree.text_container.upcast::<Node>().GetFirstChild()
+                            })
+                            .unwrap_or_else(|| DomRoot::from_ref(self.upcast::<Node>()));
+                        let index =
+                            window.text_index_query(&query_node, point_in_target.to_untyped());
                         // Position the caret at the click position or at the end of the current
                         // value.
                         let edit_point_index = match index {


### PR DESCRIPTION
Implements the missing layout query that supports placing the insertion point in a text input based on a mouse input. This is based on the original layout 2013 implementation without putting much thought into whether the newer engine can provide a better architecture.

Testing: TBD. Intending to write a unit test that exercises this.
Fixes: #35432
Fixes: #10083
