### PR TITLE
layout: Rebuild the box tree when the `quotes` attribute changes on a pseudo-element

### DIFF
--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -623,6 +623,16 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
                 return true;
             }
 
+            // Only consider changes to the `quotes` attribute if they actually apply to this
+            // style (if it is a pseudo-element that supports it).
+            if matches!(
+                new.pseudo(),
+                Some(PseudoElement::Before | PseudoElement::After | PseudoElement::Marker),
+            ) && old.get_list().quotes != new.get_list().quotes
+            {
+                return true;
+            }
+
             // NOTE: This should be kept in sync with the checks in `impl
             // StyleExt::establishes_block_formatting_context` for `ComputedValues` in
             // `components/layout/style_ext.rs`.


### PR DESCRIPTION
In incremental layout, changes to the `quotes` attribute of a
pseudo-elment can cause the content of the pseudo-element to change so
should cause a box rebuild. This change does that, hopefully fixing
flaky tests.

Testing: This doesn't have any test changes, but should fix the test situation described in #40419.
