### PR TITLE
Revert servo/servo#40594 "Allow WebGL contexts to have different Surfman devices"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,7 +1477,6 @@ dependencies = [
  "base",
  "bincode",
  "bitflags 2.10.0",
- "canvas_traits",
  "crossbeam-channel",
  "dpi",
  "embedder_traits",
@@ -8701,9 +8700,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surfman"
-version = "0.11.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d3973284ef0dc7362cdaee41c2356c4c39a5a5ebd8490c5163ebf21a7adc02"
+checksum = "ab6d64f9d99bbbab83405a1aa65ac373e4f98440df9912ea8a3640bf164da234"
 dependencies = [
  "bitflags 2.10.0",
  "cfg_aliases",
@@ -8714,6 +8713,7 @@ dependencies = [
  "glow",
  "libc",
  "log",
+ "mach2",
  "objc2 0.6.3",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ stylo_config = { git = "https://github.com/servo/stylo", branch = "2025-11-01" }
 stylo_dom = { git = "https://github.com/servo/stylo", branch = "2025-11-01" }
 stylo_malloc_size_of = { git = "https://github.com/servo/stylo", branch = "2025-11-01" }
 stylo_traits = { git = "https://github.com/servo/stylo", branch = "2025-11-01" }
-surfman = { version = "0.11.0", features = ["chains"] }
+surfman = { version = "0.10.0", features = ["chains"] }
 syn = { version = "2", default-features = false, features = ["clone-impls", "derive", "parsing"] }
 synstructure = "0.13"
 taffy = { version = "0.9", default-features = false, features = ["calc", "detailed_layout_info", "grid", "std"] }

--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -12,13 +12,13 @@ use std::sync::{Arc, Mutex};
 use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{PainterId, PipelineId, WebViewId};
-use canvas_traits::webgl::WebGLThreads;
+use canvas_traits::webgl::{GlType, WebGLThreads};
 use compositing_traits::display_list::{CompositorDisplayListInfo, ScrollType};
 use compositing_traits::largest_contentful_paint_candidate::LCPCandidate;
 use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::viewport_description::ViewportDescription;
 use compositing_traits::{
-    CompositorProxy, ImageUpdate, PainterSurfmanDetailsMap, PipelineExitSource, SendableFrameTree,
+    CompositorProxy, ImageUpdate, PipelineExitSource, SendableFrameTree,
     WebRenderExternalImageHandlers, WebRenderExternalImageRegistry, WebRenderImageHandlerType,
     WebViewTrait,
 };
@@ -152,7 +152,6 @@ impl Drop for Painter {
 }
 
 impl Painter {
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         rendering_context: Rc<dyn RenderingContext>,
         compositor_proxy: CompositorProxy,
@@ -160,7 +159,6 @@ impl Painter {
         refresh_driver: Option<Rc<dyn RefreshDriver>>,
         shader_path: Option<PathBuf>,
         embedder_to_constellation_sender: Sender<EmbedderToConstellationMessage>,
-        painter_surfman_details_map: PainterSurfmanDetailsMap,
         #[cfg(feature = "webxr")] webxr_registry: Box<dyn webxr::WebXrRegistry>,
     ) -> Self {
         let webrender_gl = rendering_context.gleam_gl_api();
@@ -170,6 +168,12 @@ impl Painter {
             warn!("Failed to make the rendering context current: {:?}", err);
         }
         debug_assert_eq!(webrender_gl.get_error(), gleam::gl::NO_ERROR,);
+
+        // Create the webgl thread
+        let gl_type = match webrender_gl.get_type() {
+            gleam::gl::GlType::Gl => GlType::Gl,
+            gleam::gl::GlType::Gles => GlType::Gles,
+        };
 
         let (external_image_handlers, webrender_external_images) =
             WebRenderExternalImageHandlers::new();
@@ -184,7 +188,7 @@ impl Painter {
             rendering_context.clone(),
             compositor_proxy.cross_process_compositor_api.clone(),
             webrender_external_images.clone(),
-            painter_surfman_details_map,
+            gl_type,
         );
 
         // Set webrender external image handler for WebGL textures

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -237,13 +237,7 @@ impl WebGLRenderingContext {
 
         let (sender, receiver) = webgl_channel().unwrap();
         webgl_chan
-            .send(WebGLMsg::CreateContext(
-                window.webview_id().into(),
-                webgl_version,
-                size,
-                attrs,
-                sender,
-            ))
+            .send(WebGLMsg::CreateContext(webgl_version, size, attrs, sender))
             .unwrap();
         let result = receiver.recv().unwrap();
 

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -14,7 +14,6 @@ pub use base::generic_channel::GenericReceiver as WebGLReceiver;
 pub use base::generic_channel::GenericSender as WebGLSender;
 /// Result type for send()/recv() calls in in WebGLCommands.
 pub use base::generic_channel::SendResult as WebGLSendResult;
-use base::id::PainterId;
 use euclid::default::{Rect, Size2D};
 use glow::{
     self as gl, NativeBuffer, NativeFence, NativeFramebuffer, NativeProgram, NativeQuery,
@@ -91,7 +90,6 @@ impl WebGLThreads {
 pub enum WebGLMsg {
     /// Creates a new WebGLContext.
     CreateContext(
-        PainterId,
         WebGLVersion,
         Size2D<u32>,
         GLContextAttributes,

--- a/components/shared/compositing/Cargo.toml
+++ b/components/shared/compositing/Cargo.toml
@@ -18,7 +18,6 @@ no-wgl = ["surfman/sm-angle-default"]
 base = { workspace = true }
 bincode = { workspace = true }
 bitflags = { workspace = true }
-canvas_traits = { workspace = true }
 crossbeam-channel = { workspace = true }
 dpi = { workspace = true }
 embedder_traits = { workspace = true }

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -4,7 +4,6 @@
 
 //! The interface to the `compositing` crate.
 
-use std::collections::HashMap;
 use std::fmt::{Debug, Error, Formatter};
 
 use base::Epoch;
@@ -16,7 +15,6 @@ use malloc_size_of_derive::MallocSizeOf;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use strum_macros::IntoStaticStr;
-use surfman::{Adapter, Connection};
 use webrender_api::{DocumentId, FontVariation};
 
 pub mod display_list;
@@ -485,28 +483,6 @@ impl CrossProcessCompositorApi {
             pipeline_id,
             source,
         ));
-    }
-}
-
-#[derive(Clone)]
-pub struct PainterSurfmanDetails {
-    pub connection: Connection,
-    pub adapter: Adapter,
-}
-
-#[derive(Clone, Default)]
-pub struct PainterSurfmanDetailsMap(Arc<Mutex<HashMap<PainterId, PainterSurfmanDetails>>>);
-
-impl PainterSurfmanDetailsMap {
-    pub fn get(&self, painter_id: PainterId) -> Option<PainterSurfmanDetails> {
-        let map = self.0.lock().expect("poisoned");
-        map.get(&painter_id).cloned()
-    }
-
-    pub fn insert(&mut self, painter_id: PainterId, details: PainterSurfmanDetails) {
-        let mut map = self.0.lock().expect("poisoned");
-        let existing = map.insert(painter_id, details);
-        assert!(existing.is_none())
     }
 }
 

--- a/components/shared/compositing/rendering_context.rs
+++ b/components/shared/compositing/rendering_context.rs
@@ -105,7 +105,7 @@ impl Drop for SurfmanRenderingContext {
 
 impl SurfmanRenderingContext {
     fn new(connection: &Connection, adapter: &Adapter) -> Result<Self, Error> {
-        let device = connection.create_device(adapter)?;
+        let mut device = connection.create_device(adapter)?;
 
         let flags = ContextAttributeFlags::ALPHA |
             ContextAttributeFlags::DEPTH |
@@ -441,7 +441,7 @@ impl WindowRenderingContext {
         window_handle: WindowHandle,
         size: PhysicalSize<u32>,
     ) -> Result<(), Error> {
-        let device = self.surfman_context.device.borrow_mut();
+        let mut device = self.surfman_context.device.borrow_mut();
         let mut context = self.surfman_context.context.borrow_mut();
 
         let native_widget = device

--- a/components/shared/webxr/layer.rs
+++ b/components/shared/webxr/layer.rs
@@ -24,9 +24,8 @@ pub trait GLTypes {
 }
 
 pub trait GLContexts<GL: GLTypes> {
-    fn device(&self, context_id: ContextId) -> Option<GL::Device>;
-    fn bindings(&mut self, context_id: ContextId) -> Option<&GL::Bindings>;
-    fn context(&mut self, context_id: ContextId) -> Option<&mut GL::Context>;
+    fn bindings(&mut self, device: &GL::Device, context_id: ContextId) -> Option<&GL::Bindings>;
+    fn context(&mut self, device: &GL::Device, context_id: ContextId) -> Option<&mut GL::Context>;
 }
 
 impl GLTypes for () {
@@ -36,15 +35,11 @@ impl GLTypes for () {
 }
 
 impl GLContexts<()> for () {
-    fn device(&self, _: ContextId) -> Option<()> {
-        Some(())
-    }
-
-    fn context(&mut self, _: ContextId) -> Option<&mut ()> {
+    fn context(&mut self, _: &(), _: ContextId) -> Option<&mut ()> {
         Some(self)
     }
 
-    fn bindings(&mut self, _: ContextId) -> Option<&()> {
+    fn bindings(&mut self, _: &(), _: ContextId) -> Option<&()> {
         Some(self)
     }
 }
@@ -80,7 +75,7 @@ impl<GL: GLTypes> LayerGrandManager<GL> {
 
     pub fn create_layer_manager<F, M>(&self, factory: F) -> Result<LayerManager, Error>
     where
-        F: 'static + Send + FnOnce(&mut dyn GLContexts<GL>) -> Result<M, Error>,
+        F: 'static + Send + FnOnce(&mut GL::Device, &mut dyn GLContexts<GL>) -> Result<M, Error>,
         M: 'static + LayerManagerAPI<GL>,
     {
         self.0
@@ -91,6 +86,7 @@ impl<GL: GLTypes> LayerGrandManager<GL> {
 pub trait LayerManagerAPI<GL: GLTypes> {
     fn create_layer(
         &mut self,
+        device: &mut GL::Device,
         contexts: &mut dyn GLContexts<GL>,
         context_id: ContextId,
         init: LayerInit,
@@ -98,6 +94,7 @@ pub trait LayerManagerAPI<GL: GLTypes> {
 
     fn destroy_layer(
         &mut self,
+        device: &mut GL::Device,
         contexts: &mut dyn GLContexts<GL>,
         context_id: ContextId,
         layer_id: LayerId,
@@ -107,12 +104,14 @@ pub trait LayerManagerAPI<GL: GLTypes> {
 
     fn begin_frame(
         &mut self,
+        device: &mut GL::Device,
         contexts: &mut dyn GLContexts<GL>,
         layers: &[(ContextId, LayerId)],
     ) -> Result<Vec<SubImages>, Error>;
 
     fn end_frame(
         &mut self,
+        device: &mut GL::Device,
         contexts: &mut dyn GLContexts<GL>,
         layers: &[(ContextId, LayerId)],
     ) -> Result<(), Error>;
@@ -132,22 +131,22 @@ impl LayerManager {
         context_id: ContextId,
         init: LayerInit,
     ) -> Result<LayerId, Error> {
-        self.0.create_layer(&mut (), context_id, init)
+        self.0.create_layer(&mut (), &mut (), context_id, init)
     }
 
     pub fn destroy_layer(&mut self, context_id: ContextId, layer_id: LayerId) {
-        self.0.destroy_layer(&mut (), context_id, layer_id);
+        self.0.destroy_layer(&mut (), &mut (), context_id, layer_id);
     }
 
     pub fn begin_frame(
         &mut self,
         layers: &[(ContextId, LayerId)],
     ) -> Result<Vec<SubImages>, Error> {
-        self.0.begin_frame(&mut (), layers)
+        self.0.begin_frame(&mut (), &mut (), layers)
     }
 
     pub fn end_frame(&mut self, layers: &[(ContextId, LayerId)]) -> Result<(), Error> {
-        self.0.end_frame(&mut (), layers)
+        self.0.end_frame(&mut (), &mut (), layers)
     }
 }
 
@@ -172,7 +171,13 @@ impl Drop for LayerManager {
 
 #[allow(clippy::type_complexity)]
 pub struct LayerManagerFactory<GL: GLTypes>(
-    Box<dyn Send + FnOnce(&mut dyn GLContexts<GL>) -> Result<Box<dyn LayerManagerAPI<GL>>, Error>>,
+    Box<
+        dyn Send
+            + FnOnce(
+                &mut GL::Device,
+                &mut dyn GLContexts<GL>,
+            ) -> Result<Box<dyn LayerManagerAPI<GL>>, Error>,
+    >,
 );
 
 impl<GL: GLTypes> Debug for LayerManagerFactory<GL> {
@@ -184,17 +189,20 @@ impl<GL: GLTypes> Debug for LayerManagerFactory<GL> {
 impl<GL: GLTypes> LayerManagerFactory<GL> {
     pub fn new<F, M>(factory: F) -> LayerManagerFactory<GL>
     where
-        F: 'static + Send + FnOnce(&mut dyn GLContexts<GL>) -> Result<M, Error>,
+        F: 'static + Send + FnOnce(&mut GL::Device, &mut dyn GLContexts<GL>) -> Result<M, Error>,
         M: 'static + LayerManagerAPI<GL>,
     {
-        LayerManagerFactory(Box::new(move |contexts| Ok(Box::new(factory(contexts)?))))
+        LayerManagerFactory(Box::new(move |device, contexts| {
+            Ok(Box::new(factory(device, contexts)?))
+        }))
     }
 
     pub fn build(
         self,
+        device: &mut GL::Device,
         contexts: &mut dyn GLContexts<GL>,
     ) -> Result<Box<dyn LayerManagerAPI<GL>>, Error> {
-        (self.0)(contexts)
+        (self.0)(device, contexts)
     }
 }
 

--- a/components/webgl/webgl_mode/inprocess.rs
+++ b/components/webgl/webgl_mode/inprocess.rs
@@ -5,11 +5,11 @@
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-use canvas_traits::webgl::{WebGLContextId, WebGLMsg, WebGLThreads, webgl_channel};
+use canvas_traits::webgl::{GlType, WebGLContextId, WebGLMsg, WebGLThreads, webgl_channel};
 use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::{
-    CrossProcessCompositorApi, ExternalImageSource, PainterSurfmanDetailsMap,
-    WebRenderExternalImageApi, WebRenderExternalImageRegistry,
+    CrossProcessCompositorApi, ExternalImageSource, WebRenderExternalImageApi,
+    WebRenderExternalImageRegistry,
 };
 use euclid::default::Size2D;
 use log::debug;
@@ -36,7 +36,7 @@ impl WebGLComm {
         rendering_context: Rc<dyn RenderingContext>,
         compositor_api: CrossProcessCompositorApi,
         external_images: Arc<Mutex<WebRenderExternalImageRegistry>>,
-        painter_surfman_details_map: PainterSurfmanDetailsMap,
+        api_type: GlType,
     ) -> WebGLComm {
         debug!("WebGLThreads::new()");
         let (sender, receiver) = webgl_channel::<WebGLMsg>().unwrap();
@@ -45,6 +45,12 @@ impl WebGLComm {
         let webxr_init = crate::webxr::WebXRBridgeInit::new(sender.clone());
         #[cfg(feature = "webxr")]
         let webxr_layer_grand_manager = webxr_init.layer_grand_manager();
+        let connection = rendering_context
+            .connection()
+            .expect("Failed to get connection");
+        let adapter = connection
+            .create_adapter()
+            .expect("Failed to create adapter");
 
         // This implementation creates a single `WebGLThread` for all the pipelines.
         let init = WebGLThreadInit {
@@ -53,9 +59,11 @@ impl WebGLComm {
             sender: sender.clone(),
             receiver,
             webrender_swap_chains: webrender_swap_chains.clone(),
+            connection,
+            adapter,
+            api_type,
             #[cfg(feature = "webxr")]
             webxr_init,
-            painter_surfman_details_map,
         };
 
         let external = WebGLExternalImages::new(rendering_context, webrender_swap_chains);

--- a/components/webxr/gl_utils.rs
+++ b/components/webxr/gl_utils.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 
 use glow as gl;
 use glow::{Context as Gl, HasContext};
+use surfman::Device as SurfmanDevice;
 use webxr_api::{ContextId, GLContexts, LayerId};
 
 use crate::SurfmanGL;
@@ -88,6 +89,7 @@ impl GlClearer {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn clear(
         &mut self,
+        device: &mut SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         layer_id: LayerId,
@@ -95,7 +97,7 @@ impl GlClearer {
         color_target: u32,
         depth_stencil: Option<glow::NativeTexture>,
     ) {
-        let gl = match contexts.bindings(context_id) {
+        let gl = match contexts.bindings(device, context_id) {
             None => return,
             Some(gl) => gl,
         };
@@ -156,11 +158,12 @@ impl GlClearer {
 
     pub(crate) fn destroy_layer(
         &mut self,
+        device: &mut SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         layer_id: LayerId,
     ) {
-        let gl = match contexts.bindings(context_id) {
+        let gl = match contexts.bindings(device, context_id) {
             None => return,
             Some(gl) => gl,
         };

--- a/components/webxr/glwindow/mod.rs
+++ b/components/webxr/glwindow/mod.rs
@@ -279,7 +279,7 @@ impl DeviceAPI for GlWindowDevice {
             Some(target_swap_chain) => {
                 // Rendering to a surfman swap chain
                 target_swap_chain
-                    .swap_buffers(&self.device, &mut self.context, PreserveBuffer::No)
+                    .swap_buffers(&mut self.device, &mut self.context, PreserveBuffer::No)
                     .unwrap();
             },
             None => {
@@ -465,9 +465,9 @@ impl GlWindowDevice {
         }
         let swap_chains = self.swap_chains.clone();
         let viewports = self.viewports();
-        let layer_manager = self
-            .grand_manager
-            .create_layer_manager(move |_| Ok(SurfmanLayerManager::new(viewports, swap_chains)))?;
+        let layer_manager = self.grand_manager.create_layer_manager(move |_, _| {
+            Ok(SurfmanLayerManager::new(viewports, swap_chains))
+        })?;
         self.layer_manager = Some(layer_manager);
         Ok(self.layer_manager.as_mut().unwrap())
     }

--- a/components/webxr/headless/mod.rs
+++ b/components/webxr/headless/mod.rs
@@ -213,9 +213,9 @@ impl HeadlessDevice {
         }
         let swap_chains = SwapChains::new();
         let viewports = self.viewports();
-        let layer_manager = self
-            .grand_manager
-            .create_layer_manager(move |_| Ok(SurfmanLayerManager::new(viewports, swap_chains)))?;
+        let layer_manager = self.grand_manager.create_layer_manager(move |_, _| {
+            Ok(SurfmanLayerManager::new(viewports, swap_chains))
+        })?;
         self.layer_manager = Some(layer_manager);
         Ok(self.layer_manager.as_mut().unwrap())
     }

--- a/components/webxr/openxr/graphics.rs
+++ b/components/webxr/openxr/graphics.rs
@@ -15,12 +15,13 @@ pub trait GraphicsProviderMethods<G: Graphics> {
     fn enable_graphics_extensions(exts: &mut ExtensionSet);
     fn pick_format(formats: &[u32]) -> u32;
     fn create_session(
+        device: &SurfmanDevice,
         instance: &Instance,
         system: SystemId,
     ) -> Result<(Session<G>, FrameWaiter, FrameStream<G>), Error>;
     fn surface_texture_from_swapchain_texture(
         image: <G as Graphics>::SwapchainImage,
-        device: &SurfmanDevice,
+        device: &mut SurfmanDevice,
         context: &mut SurfmanContext,
         size: &Size2D<i32, UnknownUnit>,
     ) -> Result<SurfaceTexture, SurfmanError>;

--- a/components/webxr/surfman_layer_manager.rs
+++ b/components/webxr/surfman_layer_manager.rs
@@ -5,7 +5,6 @@
 //! An implementation of layer management using surfman
 
 use std::collections::HashMap;
-use std::rc::Rc;
 
 use euclid::{Point2D, Rect, Size2D};
 use glow::{self as gl, Context as Gl, HasContext, PixelUnpackData};
@@ -22,7 +21,7 @@ use crate::gl_utils::GlClearer;
 pub enum SurfmanGL {}
 
 impl GLTypes for SurfmanGL {
-    type Device = Rc<SurfmanDevice>;
+    type Device = SurfmanDevice;
     type Context = SurfmanContext;
     type Bindings = Gl;
 }
@@ -59,6 +58,7 @@ impl SurfmanLayerManager {
 impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
     fn create_layer(
         &mut self,
+        device: &mut SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         init: LayerInit,
@@ -72,10 +72,9 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
             LayerInit::WebGLLayer { stencil, depth, .. } => stencil | depth,
             LayerInit::ProjectionLayer { stencil, depth, .. } => stencil | depth,
         };
-        let device = contexts.device(context_id).ok_or(Error::NoMatchingDevice)?;
         if has_depth_stencil {
             let gl = contexts
-                .bindings(context_id)
+                .bindings(device, context_id)
                 .ok_or(Error::NoMatchingDevice)?;
             let depth_stencil_texture = unsafe { gl.create_texture().ok() };
             unsafe {
@@ -96,10 +95,10 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
                 .insert(layer_id, depth_stencil_texture);
         }
         let context = contexts
-            .context(context_id)
+            .context(device, context_id)
             .ok_or(Error::NoMatchingDevice)?;
         self.swap_chains
-            .create_detached_swap_chain(layer_id, size, &device, context, access)
+            .create_detached_swap_chain(layer_id, size, device, context, access)
             .map_err(|err| Error::BackendSpecific(format!("{:?}", err)))?;
         self.layers.push((context_id, layer_id));
         Ok(layer_id)
@@ -107,22 +106,22 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
 
     fn destroy_layer(
         &mut self,
+        device: &mut SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         context_id: ContextId,
         layer_id: LayerId,
     ) {
-        self.clearer.destroy_layer(contexts, context_id, layer_id);
-        let Some(device) = contexts.device(context_id) else {
-            return;
-        };
-        let Some(context) = contexts.context(context_id) else {
-            return;
+        self.clearer
+            .destroy_layer(device, contexts, context_id, layer_id);
+        let context = match contexts.context(device, context_id) {
+            Some(context) => context,
+            None => return,
         };
         self.layers.retain(|&ids| ids != (context_id, layer_id));
-        let _ = self.swap_chains.destroy(layer_id, &device, context);
+        let _ = self.swap_chains.destroy(layer_id, device, context);
         self.surface_textures.remove(&layer_id);
         if let Some(depth_stencil_texture) = self.depth_stencil_textures.remove(&layer_id) {
-            let gl = contexts.bindings(context_id).unwrap();
+            let gl = contexts.bindings(device, context_id).unwrap();
             if let Some(depth_stencil_texture) = depth_stencil_texture {
                 unsafe {
                     gl.delete_texture(depth_stencil_texture);
@@ -137,15 +136,15 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
 
     fn begin_frame(
         &mut self,
+        device: &mut SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         layers: &[(ContextId, LayerId)],
     ) -> Result<Vec<SubImages>, Error> {
         layers
             .iter()
             .map(|&(context_id, layer_id)| {
-                let device = contexts.device(context_id).ok_or(Error::NoMatchingDevice)?;
                 let context = contexts
-                    .context(context_id)
+                    .context(device, context_id)
                     .ok_or(Error::NoMatchingDevice)?;
                 let swap_chain = self
                     .swap_chains
@@ -153,7 +152,7 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
                     .ok_or(Error::NoMatchingDevice)?;
                 let surface_size = Size2D::from_untyped(swap_chain.size());
                 let surface_texture = swap_chain
-                    .take_surface_texture(&device, context)
+                    .take_surface_texture(device, context)
                     .map_err(|_| Error::NoMatchingDevice)?;
                 let color_texture = device.surface_texture_object(&surface_texture);
                 let color_target = device.surface_gl_texture_target();
@@ -183,6 +182,7 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
                     .collect();
                 self.surface_textures.insert(layer_id, surface_texture);
                 self.clearer.clear(
+                    device,
                     contexts,
                     context_id,
                     layer_id,
@@ -201,19 +201,19 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
 
     fn end_frame(
         &mut self,
+        device: &mut SurfmanDevice,
         contexts: &mut dyn GLContexts<SurfmanGL>,
         layers: &[(ContextId, LayerId)],
     ) -> Result<(), Error> {
         for &(context_id, layer_id) in layers {
             let gl = contexts
-                .bindings(context_id)
+                .bindings(device, context_id)
                 .ok_or(Error::NoMatchingDevice)?;
             unsafe {
                 gl.flush();
             }
-            let device = contexts.device(context_id).ok_or(Error::NoMatchingDevice)?;
             let context = contexts
-                .context(context_id)
+                .context(device, context_id)
                 .ok_or(Error::NoMatchingDevice)?;
             let surface_texture = self
                 .surface_textures
@@ -223,12 +223,11 @@ impl LayerManagerAPI<SurfmanGL> for SurfmanLayerManager {
                 .swap_chains
                 .get(layer_id)
                 .ok_or(Error::NoMatchingDevice)?;
-
             swap_chain
-                .recycle_surface_texture(&device, context, surface_texture)
+                .recycle_surface_texture(device, context, surface_texture)
                 .map_err(|err| Error::BackendSpecific(format!("{:?}", err)))?;
             swap_chain
-                .swap_buffers(&device, context, PreserveBuffer::No)
+                .swap_buffers(device, context, PreserveBuffer::No)
                 .map_err(|err| Error::BackendSpecific(format!("{:?}", err)))?;
         }
         Ok(())


### PR DESCRIPTION
This reverts commit bcbd4a2f19c43e1755a0684e954c7f1ca3c85828.

There was too many intermittents: https://github.com/servo/servo/pull/40699#issuecomment-3544170297. Some PRs fail to merge.

Testing: It still builds. Number of flaky reduced by half.