### PR TITLE
servodriver: Clear cookies between tests.

### DIFF
--- a/components/net/cookie_storage.rs
+++ b/components/net/cookie_storage.rs
@@ -97,11 +97,15 @@ impl CookieStorage {
         }
     }
 
-    pub fn clear_storage(&mut self, url: &ServoUrl) {
-        let domain = reg_host(url.host_str().unwrap_or(""));
-        let cookies = self.cookies_map.entry(domain).or_default();
-        for cookie in cookies.iter_mut() {
-            cookie.set_expiry_time_in_past();
+    pub fn clear_storage(&mut self, url: Option<&ServoUrl>) {
+        if let Some(url) = url {
+            let domain = reg_host(url.host_str().unwrap_or(""));
+            let cookies = self.cookies_map.entry(domain).or_default();
+            for cookie in cookies.iter_mut() {
+                cookie.set_expiry_time_in_past();
+            }
+        } else {
+            self.cookies_map.clear();
         }
     }
 

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -400,8 +400,14 @@ impl ResourceChannelManager {
                     cancellation_listener.cancel();
                 }
             },
-            CoreResourceMsg::DeleteCookies(request) => {
-                http_state.cookie_jar.write().clear_storage(&request);
+            CoreResourceMsg::DeleteCookies(request, sender) => {
+                http_state
+                    .cookie_jar
+                    .write()
+                    .clear_storage(request.as_ref());
+                if let Some(sender) = sender {
+                    let _ = sender.send(());
+                }
                 return true;
             },
             CoreResourceMsg::DeleteCookie(request, name) => {

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -1544,7 +1544,7 @@ pub(crate) fn handle_delete_cookies(
         .window()
         .as_global_scope()
         .resource_threads()
-        .send(DeleteCookies(url))
+        .send(DeleteCookies(Some(url), None))
         .unwrap();
     reply.send(Ok(())).unwrap();
 }

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -144,6 +144,7 @@ pub enum WebDriverCommandMsg {
     SendAlertText(WebViewId, String),
     FocusBrowsingContext(BrowsingContextId),
     Shutdown,
+    ResetAllCookies(Sender<()>),
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -433,6 +433,14 @@ impl ResourceThreads {
     pub fn clear_cache(&self) {
         let _ = self.core_thread.send(CoreResourceMsg::ClearCache);
     }
+
+    pub fn clear_cookies(&self) {
+        let (sender, receiver) = ipc::channel().unwrap();
+        let _ = self
+            .core_thread
+            .send(CoreResourceMsg::DeleteCookies(None, Some(sender)));
+        let _ = receiver.recv();
+    }
 }
 
 impl IpcSend<CoreResourceMsg> for ResourceThreads {
@@ -514,7 +522,7 @@ pub enum CoreResourceMsg {
     ),
     GetCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
     GetAllCookieDataForUrlAsync(CookieStoreId, ServoUrl, Option<String>),
-    DeleteCookies(ServoUrl),
+    DeleteCookies(Option<ServoUrl>, Option<IpcSender<()>>),
     DeleteCookie(ServoUrl, String),
     DeleteCookieAsync(CookieStoreId, ServoUrl, String),
     NewCookieListener(CookieStoreId, IpcSender<CookieAsyncResponse>, ServoUrl),

--- a/ports/servoshell/webdriver.rs
+++ b/ports/servoshell/webdriver.rs
@@ -137,6 +137,10 @@ impl RunningAppState {
 
         while let Ok(msg) = webdriver_receiver.try_recv() {
             match msg {
+                WebDriverCommandMsg::ResetAllCookies(sender) => {
+                    self.servo().clear_cookies();
+                    let _ = sender.send(());
+                },
                 WebDriverCommandMsg::Shutdown => {
                     self.servo().start_shutting_down();
                 },


### PR DESCRIPTION
To ensure that tests that modify cookies but don't finish cleanly don't leave cookie values that interfere with subsequent tests, we need to clear the cookie storage in between each test that's run.

Testing: Can't test the test runner, just have to watch the patterns in our test runs.
Fixes: #40668
Fixes: #40672
Fixes: #40673
Fixes: #40674
Fixes: #40695
Fixes: #40697
