### PR TITLE
libservo: Trigger a rendering update when waiting for paint readiness in WebView unit tests

### DIFF
--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -35,8 +35,19 @@ fn show_webview_and_wait_for_rendering_to_be_ready(
     let load_webview = webview.clone();
     servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
 
-    // Wait for at least one frame after the load completes.
     delegate.reset();
+
+    // Trigger a change to the display of the document, so that we get at last one
+    // new frame after load is complete.
+    let _ = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "requestAnimationFrame(() => { \
+           document.body.style.background = 'green'; \
+        });",
+    );
+
+    // Wait for at least one frame after the load completes.
     let captured_delegate = delegate.clone();
     servo_test.spin(move || !captured_delegate.new_frame_ready.get());
 }


### PR DESCRIPTION
Some unit tests attempt to wait for the WebView to be paint ready before
executing. The previous code would wait for a frame ready message from
the WebView before running, but this was subject to timing issues due to
the frame being sent before the load complete message. This changes
makes it so that the WebView explicitly triggers another rendering
update and then waits for a frame. It should be guaranteed that the next
frame will be one that reflects load completeness.

Special thanks to jmunroe on Zulip for investigation into this issue.

Testing: This seems to eliminate flaky timeouts on my machine. I ran
the unit tests in a loop, stopping if any error (such as a timeout happened).
Before this would stop within a minute or two, but I could not reproduce
the issue with this change after several minutes.
