### PR TITLE
servoshell: Always use `ControlFlow::Wait` on winit

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -626,11 +626,7 @@ impl ApplicationHandler<AppEvent> for App {
         }
 
         // Block until the window gets an event
-        if !self.animating() || self.suspended.get() {
-            event_loop.set_control_flow(ControlFlow::Wait);
-        } else {
-            event_loop.set_control_flow(ControlFlow::Poll);
-        }
+        event_loop.set_control_flow(ControlFlow::Wait);
 
         // Consume and handle any events from the servoshell UI.
         self.handle_servoshell_ui_events();


### PR DESCRIPTION
Nowadays the renderer will always wake up the event loop when it needs to paint
a new frame, so we can always use `ControlFlow::Wait`. This should be a
more efficient way to run animations.

Testing: This should not change behavior, but should make servoshell a bit more
efficient.
Closes: #21855
