### PR TITLE
Use safe JSContext/AutoRealm/CurrentRealm in codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -823,7 +823,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -841,7 +841,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2605,7 +2605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3221,7 +3221,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps 7.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4734,7 +4734,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5434,7 +5434,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#8bf5bf88e3e5d463d2eb9d1bd0a1f6b2fe7a5d13"
+source = "git+https://github.com/servo/mozjs#16e1e3a363d6114ecc4cba46ecca249d267e136c"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -5446,8 +5446,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.140.5-1"
-source = "git+https://github.com/servo/mozjs#8bf5bf88e3e5d463d2eb9d1bd0a1f6b2fe7a5d13"
+version = "0.140.5-2"
+source = "git+https://github.com/servo/mozjs#16e1e3a363d6114ecc4cba46ecca249d267e136c"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -6914,7 +6914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -7338,7 +7338,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8863,7 +8863,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10373,7 +10373,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5434,7 +5434,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#16e1e3a363d6114ecc4cba46ecca249d267e136c"
+source = "git+https://github.com/servo/mozjs#6521fd997a71efecba706c48bc8f88aa72522e48"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -5447,7 +5447,7 @@ dependencies = [
 [[package]]
 name = "mozjs_sys"
 version = "0.140.5-2"
-source = "git+https://github.com/servo/mozjs#16e1e3a363d6114ecc4cba46ecca249d267e136c"
+source = "git+https://github.com/servo/mozjs#6521fd997a71efecba706c48bc8f88aa72522e48"
 dependencies = [
  "bindgen 0.72.1",
  "cc",

--- a/components/script/dom/bindings/proxyhandler.rs
+++ b/components/script/dom/bindings/proxyhandler.rs
@@ -7,18 +7,16 @@
 #![deny(missing_docs)]
 
 use js::jsapi::{GetObjectRealmOrNull, GetRealmPrincipals, HandleObject as RawHandleObject};
-use js::rust::get_context_realm;
+use js::realm::CurrentRealm;
 use script_bindings::principals::ServoJSPrincipalsRef;
 pub(crate) use script_bindings::proxyhandler::*;
 
-use crate::script_runtime::JSContext as SafeJSContext;
-
 /// <https://html.spec.whatwg.org/multipage/#isplatformobjectsameorigin-(-o-)>
 pub(crate) unsafe fn is_platform_object_same_origin(
-    cx: SafeJSContext,
+    realm: &CurrentRealm,
     obj: RawHandleObject,
 ) -> bool {
-    let subject_realm = unsafe { get_context_realm(*cx) };
+    let subject_realm = realm.realm().as_ptr();
     let obj_realm = unsafe { GetObjectRealmOrNull(*obj) };
     assert!(!obj_realm.is_null());
 

--- a/components/script/dom/bindings/utils.rs
+++ b/components/script/dom/bindings/utils.rs
@@ -12,6 +12,7 @@ use js::glue::{IsWrapper, JSPrincipalsCallbacks, UnwrapObjectDynamic, UnwrapObje
 use js::jsapi::{
     CallArgs, DOMCallbacks, HandleObject as RawHandleObject, JS_FreezeObject, JSContext, JSObject,
 };
+use js::realm::CurrentRealm;
 use js::rust::{HandleObject, MutableHandleValue, get_object_class, is_dom_class};
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::interfaces::{DomHelpers, Interface};
@@ -175,7 +176,7 @@ impl DomHelpers<crate::DomTypeHolder> for crate::DomTypeHolder {
         &PRINCIPALS_CALLBACKS
     }
 
-    fn is_platform_object_same_origin(cx: SafeJSContext, obj: RawHandleObject) -> bool {
+    fn is_platform_object_same_origin(cx: &CurrentRealm, obj: RawHandleObject) -> bool {
         unsafe { is_platform_object_same_origin(cx, obj) }
     }
 

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -18,7 +18,7 @@ pub(crate) mod base {
     pub(crate) use js::jsval::{JSVal, NullValue, ObjectOrNullValue, ObjectValue, UndefinedValue};
     pub(crate) use js::panic::maybe_resume_unwind;
     #[allow(unused_imports)]
-    pub(crate) use js::realm::CurrentRealm;
+    pub(crate) use js::realm::{AutoRealm, CurrentRealm};
     pub(crate) use js::rust::wrappers::Call;
     pub(crate) use js::rust::{HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
     pub(crate) use js::typedarray::{

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -7,6 +7,7 @@ use std::thread::LocalKey;
 
 use js::glue::JSPrincipalsCallbacks;
 use js::jsapi::{CallArgs, HandleObject as RawHandleObject, JSContext as RawJSContext, JSObject};
+use js::realm::CurrentRealm;
 use js::rust::{HandleObject, MutableHandleObject};
 use servo_url::{MutableOrigin, ServoUrl};
 
@@ -49,7 +50,7 @@ pub trait DomHelpers<D: DomTypes> {
 
     fn principals_callbacks() -> &'static JSPrincipalsCallbacks;
 
-    fn is_platform_object_same_origin(cx: JSContext, obj: RawHandleObject) -> bool;
+    fn is_platform_object_same_origin(cx: &CurrentRealm, obj: RawHandleObject) -> bool;
 
     fn interface_map() -> &'static phf::Map<&'static [u8], Interface>;
 
@@ -67,6 +68,7 @@ pub trait DomHelpers<D: DomTypes> {
 /// Operations that must be invoked from the generated bindings.
 #[expect(unsafe_code)]
 pub trait GlobalScopeHelpers<D: DomTypes> {
+    fn from_current_realm(realm: &'_ CurrentRealm) -> DomRoot<D::GlobalScope>;
     /// # Safety
     /// `cx` must point to a valid, non-null RawJSContext.
     unsafe fn from_context(cx: *mut RawJSContext, realm: InRealm) -> DomRoot<D::GlobalScope>;

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -7,6 +7,7 @@
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::ptr;
+use std::ptr::NonNull;
 
 use js::conversions::{ToJSValConvertible, jsstr_to_string};
 use js::glue::{
@@ -17,19 +18,19 @@ use js::jsapi::{
     DOMProxyShadowsResult, GetStaticPrototype, GetWellKnownSymbol, Handle as RawHandle,
     HandleId as RawHandleId, HandleObject as RawHandleObject, HandleValue as RawHandleValue,
     JS_AtomizeAndPinString, JS_DefinePropertyById, JS_GetOwnPropertyDescriptorById,
-    JS_IsExceptionPending, JSAutoRealm, JSContext, JSErrNum, JSFunctionSpec, JSObject,
-    JSPropertySpec, MutableHandle as RawMutableHandle,
-    MutableHandleIdVector as RawMutableHandleIdVector,
+    JS_IsExceptionPending, JSContext, JSErrNum, JSFunctionSpec, JSObject, JSPropertySpec,
+    MutableHandle as RawMutableHandle, MutableHandleIdVector as RawMutableHandleIdVector,
     MutableHandleObject as RawMutableHandleObject, MutableHandleValue as RawMutableHandleValue,
     ObjectOpResult, PropertyDescriptor, SetDOMProxyInformation, SymbolCode, jsid,
 };
 use js::jsid::SymbolId;
 use js::jsval::{ObjectValue, UndefinedValue};
+use js::realm::{AutoRealm, CurrentRealm};
 use js::rust::wrappers::{
     AppendToIdVector, JS_AlreadyHasOwnPropertyById, JS_NewObjectWithGivenProto,
     RUST_INTERNED_STRING_TO_JSID, SetDataPropertyDescriptor,
 };
-use js::rust::{Handle, HandleObject, HandleValue, MutableHandle, MutableHandleObject};
+use js::rust::{Handle, HandleObject, HandleValue, IntoHandle, MutableHandle, MutableHandleObject};
 use js::{jsapi, rooted};
 
 use crate::DomTypes;
@@ -545,37 +546,47 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_set_rawcx<D: DomTypes>(
     receiver: RawHandleValue,
     result: *mut ObjectOpResult,
 ) -> bool {
-    let cx = SafeJSContext::from_ptr(cx);
+    let mut cx = js::context::JSContext::from_ptr(NonNull::new(cx).unwrap());
+    let mut realm = js::realm::CurrentRealm::assert(&mut cx);
+    let proxy_handle = unsafe { HandleObject::from_raw(proxy) };
+    let id = unsafe { Handle::from_raw(id) };
 
-    if !<D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy) {
-        return cross_origin_set::<D>(cx, proxy, id, v, receiver, result);
+    if !<D as DomHelpers<D>>::is_platform_object_same_origin(&realm, proxy) {
+        return cross_origin_set::<D>(
+            SafeJSContext::from_ptr(realm.raw_cx()),
+            proxy,
+            id.into_handle(),
+            v,
+            receiver,
+            result,
+        );
     }
 
     // Safe to enter the Realm of proxy now.
-    let _ac = JSAutoRealm::new(*cx, proxy.get());
+    let mut realm = js::realm::AutoRealm::new_from_handle(&mut realm, proxy_handle);
 
     // OrdinarySet
     // <https://tc39.es/ecma262/#sec-ordinaryset>
-    rooted!(in(*cx) let mut own_desc = PropertyDescriptor::default());
+    rooted!(&in(&mut realm) let mut own_desc = PropertyDescriptor::default());
     let mut is_none = false;
-    if !InvokeGetOwnPropertyDescriptor(
+    if !js::rust::wrappers2::InvokeGetOwnPropertyDescriptor(
         GetProxyHandler(*proxy),
-        *cx,
-        proxy,
+        &mut realm,
+        proxy_handle,
         id,
-        own_desc.handle_mut().into(),
+        own_desc.handle_mut(),
         &mut is_none,
     ) {
         return false;
     }
 
-    let own_desc_handle = own_desc.handle().into();
-    js::jsapi::SetPropertyIgnoringNamedGetter(
-        *cx,
-        proxy,
+    let own_desc_handle = own_desc.handle();
+    js::rust::wrappers2::SetPropertyIgnoringNamedGetter(
+        &mut realm,
+        proxy_handle,
         id,
-        v,
-        receiver,
+        Handle::from_raw(v),
+        Handle::from_raw(receiver),
         if is_none {
             ptr::null()
         } else {
@@ -589,18 +600,22 @@ pub(crate) unsafe extern "C" fn maybe_cross_origin_set_rawcx<D: DomTypes>(
 ///
 /// [`Location`]: https://html.spec.whatwg.org/multipage/#location-getprototypeof
 pub(crate) fn maybe_cross_origin_get_prototype<D: DomTypes>(
-    cx: SafeJSContext,
+    cx: &mut CurrentRealm,
     proxy: RawHandleObject,
     get_proto_object: fn(cx: SafeJSContext, global: HandleObject, rval: MutableHandleObject),
     proto: RawMutableHandleObject,
 ) -> bool {
+    let proxy = unsafe { Handle::from_raw(proxy) };
     // > 1. If ! IsPlatformObjectSameOrigin(this) is true, then return ! OrdinaryGetPrototypeOf(this).
-    if <D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy) {
-        let ac = JSAutoRealm::new(*cx, proxy.get());
-        let global = unsafe { D::GlobalScope::from_context(*cx, InRealm::Entered(&ac)) };
-        get_proto_object(cx, global.reflector().get_jsobject(), unsafe {
-            MutableHandleObject::from_raw(proto)
-        });
+    if <D as DomHelpers<D>>::is_platform_object_same_origin(cx, proxy.into_handle()) {
+        let mut realm = AutoRealm::new_from_handle(cx, proxy);
+        let mut realm = realm.current_realm();
+        let global = D::GlobalScope::from_current_realm(&realm);
+        get_proto_object(
+            unsafe { SafeJSContext::from_ptr(realm.raw_cx()) },
+            global.reflector().get_jsobject(),
+            unsafe { MutableHandleObject::from_raw(proto) },
+        );
         return !proto.is_null();
     }
 

--- a/components/script_bindings/script_runtime.rs
+++ b/components/script_bindings/script_runtime.rs
@@ -22,6 +22,16 @@ impl JSContext {
     pub unsafe fn from_ptr(raw_js_context: *mut RawJSContext) -> Self {
         JSContext(raw_js_context)
     }
+
+    /// For compatibility with [js::context::JSContext]
+    pub fn raw_cx(&self) -> *mut RawJSContext {
+        self.0
+    }
+
+    /// For compatibility with [js::context::JSContext]
+    pub fn raw_cx_no_gc(&self) -> *mut RawJSContext {
+        self.0
+    }
 }
 
 impl Deref for JSContext {


### PR DESCRIPTION
We replace many places that use `SafeJSContext` with `JSContext` and I also rewrote `is_platform_object_same_origin` to use new `JSContext`. Unfortunately using wrappers2 in them causes crashes (in handle code), so I reverted that part in last commit and will fix handles in mozjs later.

Testing: Refactor, but it is covered by WPT tests
Part of #40600
