### PR TITLE
python: Remove `notify-py` from Python dependencies

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -25,9 +25,6 @@ PyGithub == 1.58.1
 # For Python3 compatibility
 six == 1.16
 
-# For sending build notifications.
-notify-py == 0.3.43
-
 # For wpt scripts and their tests.
 flask
 requests


### PR DESCRIPTION
Support for sending build notifications was removed in #37818, but the
dependency in `requirements.txt` was not removed. This PR fixest that.

Testing: This change just removes an unsued build dependency, so no testing is necessary.
