### PR TITLE
Replace codecov/test-results-action

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -195,8 +195,9 @@ jobs:
       # We upload the test-results to Codecov to help us identify flaky unit-tests.
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
+          report_type: test_results
           files: target/nextest/ci/junit.xml
           disable_search: true
           flags: unittests,unittests-linux,unittests-linux-${{ inputs.profile }}

--- a/.github/workflows/mac-arm64.yml
+++ b/.github/workflows/mac-arm64.yml
@@ -152,8 +152,9 @@ jobs:
       # We upload the test-results to Codecov to help us identify flaky unit-tests.
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
+          report_type: test_results
           files: target/nextest/ci/junit.xml
           disable_search: true
           flags: unittests,unittests-mac-arm64,unittests-mac-arm64-${{ inputs.profile }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -171,8 +171,9 @@ jobs:
       # We upload the test-results to Codecov to help us identify flaky unit-tests.
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
+          report_type: test_results
           files: target/nextest/ci/junit.xml
           disable_search: true
           flags: unittests,unittests-mac,unittests-mac-${{ inputs.profile }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -184,8 +184,9 @@ jobs:
       # We upload the test-results to Codecov to help us identify flaky unit-tests.
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
+          report_type: test_results
           files: target/nextest/ci/junit.xml
           disable_search: true
           flags: unittests,unittests-windows,unittests-windows-${{ inputs.profile }}


### PR DESCRIPTION
https://github.com/codecov/test-results-action
The repository now carries a deprecation warning and warns about upload issues (which we seem to be hitting).
Migrate to the codecov action as recommended.

Testing: CI change
Fixes: Should hopefully fix CI errors.
