### PR TITLE
script: Remove all uses of LayoutDom<Attr>

### DIFF
--- a/components/script/dom/attr.rs
+++ b/components/script/dom/attr.rs
@@ -16,7 +16,7 @@ use crate::dom::bindings::cell::{DomRefCell, Ref};
 use crate::dom::bindings::codegen::Bindings::AttrBinding::AttrMethods;
 use crate::dom::bindings::codegen::UnionTypes::TrustedHTMLOrTrustedScriptOrTrustedScriptURLOrString as TrustedTypeOrString;
 use crate::dom::bindings::error::Fallible;
-use crate::dom::bindings::root::{DomRoot, LayoutDom, MutNullableDom};
+use crate::dom::bindings::root::{DomRoot, MutNullableDom};
 use crate::dom::bindings::str::DOMString;
 use crate::dom::document::Document;
 use crate::dom::element::Element;
@@ -185,6 +185,11 @@ impl Attr {
         self.value.borrow()
     }
 
+    #[allow(unsafe_code)]
+    pub(crate) unsafe fn value_for_layout(&self) -> &AttrValue {
+        unsafe { self.value.borrow_for_layout() }
+    }
+
     fn set_value(&self, value: DOMString) {
         *self.value.borrow_mut() = AttrValue::String(value.into());
     }
@@ -229,30 +234,6 @@ impl Attr {
             Some(ref prefix) => DOMString::from(format!("{}:{}", prefix, &**self.local_name())),
             None => DOMString::from(&**self.local_name()),
         }
-    }
-}
-
-pub(crate) trait AttrHelpersForLayout<'dom> {
-    fn value(self) -> &'dom AttrValue;
-    fn local_name(self) -> &'dom LocalName;
-    fn namespace(self) -> &'dom Namespace;
-}
-
-#[expect(unsafe_code)]
-impl<'dom> AttrHelpersForLayout<'dom> for LayoutDom<'dom, Attr> {
-    #[inline]
-    fn value(self) -> &'dom AttrValue {
-        unsafe { self.unsafe_get().value.borrow_for_layout() }
-    }
-
-    #[inline]
-    fn local_name(self) -> &'dom LocalName {
-        &self.unsafe_get().identifier.local_name.0
-    }
-
-    #[inline]
-    fn namespace(self) -> &'dom Namespace {
-        &self.unsafe_get().identifier.namespace.0
     }
 }
 

--- a/components/script/dom/bindings/root.rs
+++ b/components/script/dom/bindings/root.rs
@@ -27,7 +27,7 @@
 use std::cell::{OnceCell, UnsafeCell};
 use std::default::Default;
 use std::hash::{Hash, Hasher};
-use std::{mem, ptr};
+use std::ptr;
 
 use js::jsapi::{Heap, JSObject, JSTracer, Value};
 use js::rust::HandleValue;
@@ -383,15 +383,6 @@ where
     pub(crate) fn unsafe_get(self) -> &'dom T {
         assert_in_layout();
         self.value
-    }
-
-    /// Transforms a slice of `Dom<T>` into a slice of `LayoutDom<T>`.
-    // FIXME(nox): This should probably be done through a ToLayout trait.
-    pub(crate) unsafe fn to_layout_slice(slice: &'dom [Dom<T>]) -> &'dom [LayoutDom<'dom, T>] {
-        // This doesn't compile if Dom and LayoutDom don't have the same
-        // representation.
-        let _ = mem::transmute::<Dom<T>, LayoutDom<T>>;
-        unsafe { &*(slice as *const [Dom<T>] as *const [LayoutDom<T>]) }
     }
 }
 

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -42,7 +42,6 @@ use style::values::{AtomIdent, AtomString};
 use stylo_atoms::Atom;
 use stylo_dom::ElementState;
 
-use crate::dom::attr::AttrHelpersForLayout;
 use crate::dom::bindings::inheritance::{
     Castable, CharacterDataTypeId, DocumentFragmentTypeId, ElementTypeId, HTMLElementTypeId,
     NodeTypeId, TextTypeId,
@@ -307,13 +306,11 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
     }
 
     #[inline(always)]
-    fn each_attr_name<F>(&self, mut callback: F)
+    fn each_attr_name<F>(&self, callback: F)
     where
         F: FnMut(&style::LocalName),
     {
-        for attr in self.element.attrs() {
-            callback(style::values::GenericAtomIdent::cast(attr.local_name()))
-        }
+        self.element.for_each_attr_name(callback);
     }
 
     fn each_part<F>(&self, mut callback: F)


### PR DESCRIPTION
If we want to construct `Attr` nodes lazily (https://github.com/servo/servo/issues/36697) then we can't hand them to layout.

I've replaced the few places where we use `LayoutDom<'dom, Attr>` with more specific queries on the `LayoutDom<'dom, Element>` itself.

Testing: Regressions are covered by existing tests
Part of https://github.com/servo/servo/issues/36697
