### PR TITLE
Fix RefCell already borrowed panic in HTMLMediaElement::set_audio_renderer

### DIFF
--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1581,8 +1581,8 @@ impl HTMLMediaElement {
                     this.upcast::<EventTarget>().fire_event(atom!("error"), CanGc::note());
 
                     if let Some(ref player) = *this.player.borrow() {
-                        if let Err(e) = player.lock().unwrap().stop() {
-                            error!("Could not stop player {:?}", e);
+                        if let Err(err) = player.lock().unwrap().stop() {
+                            error!("Could not stop player {:?}", err);
                         }
                     }
 
@@ -2124,8 +2124,8 @@ impl HTMLMediaElement {
         }
 
         if let Some(ref player) = *self.player.borrow() {
-            if let Err(e) = player.lock().unwrap().stop() {
-                error!("Could not stop player {:?}", e);
+            if let Err(err) = player.lock().unwrap().stop() {
+                error!("Could not stop player {:?}", err);
             }
         }
 
@@ -2807,10 +2807,19 @@ impl HTMLMediaElement {
         can_gc: CanGc,
     ) {
         *self.audio_renderer.borrow_mut() = Some(audio_renderer);
-        if let Some(ref player) = *self.player.borrow() {
-            if let Err(e) = player.lock().unwrap().stop() {
-                error!("Could not stop player {:?}", e);
+
+        let had_player = {
+            if let Some(ref player) = *self.player.borrow() {
+                if let Err(err) = player.lock().unwrap().stop() {
+                    error!("Could not stop player {:?}", err);
+                }
+                true
+            } else {
+                false
             }
+        };
+
+        if had_player {
             self.media_element_load_algorithm(can_gc);
         }
     }
@@ -2830,8 +2839,8 @@ impl HTMLMediaElement {
 
     pub(crate) fn reset(&self) {
         if let Some(ref player) = *self.player.borrow() {
-            if let Err(e) = player.lock().unwrap().stop() {
-                error!("Could not stop player {:?}", e);
+            if let Err(err) = player.lock().unwrap().stop() {
+                error!("Could not stop player {:?}", err);
             }
         }
     }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -2,6 +2,13 @@
  "items": {
   "crashtest": {
    "mozilla": {
+    "audioContext_createMediaElementSource-crash.html": [
+     "e70316d3e6d880d8ec9600ff157e81f6047871a4",
+     [
+      null,
+      {}
+     ]
+    ],
     "cache_old_response-crash.html": [
      "d14e7c830f52bb77e81d91b533e0ce6d4a1ede82",
      [

--- a/tests/wpt/mozilla/tests/mozilla/audioContext_createMediaElementSource-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/audioContext_createMediaElementSource-crash.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<audio id="audioElement" src="about:blank">
+<script>
+  (new AudioContext({})).createMediaElementSource(audioElement);
+</script>


### PR DESCRIPTION
Fix RefCell already borrowed panic in HTMLMediaElement::set_audio_renderer

Testing: new crash test should pass.
Fixes: #40720
