### PR TITLE
webdriver: implement protocol handler automation mode

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -25,7 +25,8 @@ use data_url::mime::Mime;
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use dom_struct::dom_struct;
 use embedder_traits::{
-    AllowOrDeny, AnimationState, EmbedderMsg, FocusSequenceNumber, Image, LoadStatus,
+    AllowOrDeny, AnimationState, CustomHandlersAutomationMode, EmbedderMsg, FocusSequenceNumber,
+    Image, LoadStatus,
 };
 use encoding_rs::{Encoding, UTF_8};
 use html5ever::{LocalName, Namespace, QualName, local_name, ns};
@@ -601,6 +602,10 @@ pub(crate) struct Document {
 
     /// <https://html.spec.whatwg.org/multipage/#details-name-group>
     details_name_groups: DomRefCell<Option<DetailsNameGroups>>,
+
+    /// <https://html.spec.whatwg.org/multipage/#registerprotocolhandler()-automation-mode>
+    #[no_trace]
+    protocol_handler_automation_mode: RefCell<CustomHandlersAutomationMode>,
 }
 
 impl Document {
@@ -878,6 +883,10 @@ impl Document {
 
     pub(crate) fn origin(&self) -> &MutableOrigin {
         &self.origin
+    }
+
+    pub(crate) fn set_protocol_handler_automation_mode(&self, mode: CustomHandlersAutomationMode) {
+        *self.protocol_handler_automation_mode.borrow_mut() = mode;
     }
 
     /// <https://dom.spec.whatwg.org/#concept-document-url>
@@ -3540,6 +3549,7 @@ impl Document {
             favicon: RefCell::new(None),
             websockets: DOMTracker::new(),
             details_name_groups: Default::default(),
+            protocol_handler_automation_mode: Default::default(),
         }
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2434,6 +2434,13 @@ impl ScriptThread {
                 drop(documents);
                 webdriver_handlers::handle_execute_async_script(window, script, reply, can_gc);
             },
+            WebDriverScriptCommand::SetProtocolHandlerAutomationMode(mode) => {
+                webdriver_handlers::set_protocol_handler_automation_mode(
+                    &documents,
+                    pipeline_id,
+                    mode,
+                )
+            },
         }
     }
 

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -11,8 +11,9 @@ use base::generic_channel::GenericSender;
 use base::id::{BrowsingContextId, PipelineId};
 use cookie::Cookie;
 use embedder_traits::{
-    JSValue, JavaScriptEvaluationError, JavaScriptEvaluationResultSerializationError,
-    WebDriverFrameId, WebDriverJSResult, WebDriverLoadStatus,
+    CustomHandlersAutomationMode, JSValue, JavaScriptEvaluationError,
+    JavaScriptEvaluationResultSerializationError, WebDriverFrameId, WebDriverJSResult,
+    WebDriverLoadStatus,
 };
 use euclid::default::{Point2D, Rect, Size2D};
 use hyper_serde::Serde;
@@ -2209,4 +2210,14 @@ fn scroll_into_view(
     });
     // Step 2. Run scrollIntoView
     element.ScrollIntoView(options);
+}
+
+pub(crate) fn set_protocol_handler_automation_mode(
+    documents: &DocumentCollection,
+    pipeline: PipelineId,
+    mode: CustomHandlersAutomationMode,
+) {
+    if let Some(document) = documents.find_document(pipeline) {
+        document.set_protocol_handler_automation_mode(mode);
+    }
 }

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -15,6 +15,7 @@ use euclid::{Rect, Size2D};
 use hyper_serde::Serde;
 use image::RgbaImage;
 use ipc_channel::ipc::IpcSender;
+use malloc_size_of_derive::MallocSizeOf;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use servo_geometry::DeviceIndependentIntRect;
@@ -67,6 +68,15 @@ impl WebDriverUserPromptAction {
             _ => None,
         }
     }
+}
+
+/// <https://html.spec.whatwg.org/multipage/#registerprotocolhandler()-automation-mode>
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
+pub enum CustomHandlersAutomationMode {
+    AutoAccept,
+    AutoReject,
+    #[default]
+    None,
 }
 
 /// Messages to the constellation originating from the WebDriver server.
@@ -211,6 +221,7 @@ pub enum WebDriverScriptCommand {
     WillSendKeys(String, String, bool, IpcSender<Result<bool, ErrorStatus>>),
     AddLoadStatusSender(WebViewId, GenericSender<WebDriverLoadStatus>),
     RemoveLoadStatusSender(WebViewId),
+    SetProtocolHandlerAutomationMode(CustomHandlersAutomationMode),
 }
 
 pub type WebDriverJSResult = Result<JSValue, JavaScriptEvaluationError>;

--- a/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-fragment-nosw.https.html.ini
+++ b/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-fragment-nosw.https.html.ini
@@ -1,2 +1,4 @@
 [protocol-handler-fragment-nosw.https.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [registerProtocolHandler() and a handler with %s in the fragment (does not use a service worker)]
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-fragment.https.html.ini
+++ b/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-fragment.https.html.ini
@@ -1,2 +1,3 @@
 [protocol-handler-fragment.https.html]
-  expected: ERROR
+  [registerProtocolHandler() and a handler with %s in the fragment]
+    expected: FAIL

--- a/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-path.https.html.ini
+++ b/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-path.https.html.ini
@@ -1,2 +1,3 @@
 [protocol-handler-path.https.html]
-  expected: ERROR
+  [registerProtocolHandler() and a handler with %s in the path]
+    expected: FAIL

--- a/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-query-nosw.https.html.ini
+++ b/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-query-nosw.https.html.ini
@@ -1,2 +1,4 @@
 [protocol-handler-query-nosw.https.html]
-  expected: ERROR
+  expected: TIMEOUT
+  [registerProtocolHandler() and a handler with %s in the query (does not use a service worker)]
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-query.https.html.ini
+++ b/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/protocol-handler-query.https.html.ini
@@ -1,2 +1,3 @@
 [protocol-handler-query.https.html]
-  expected: ERROR
+  [registerProtocolHandler() and a handler with %s in the query]
+    expected: FAIL


### PR DESCRIPTION
The tests now start running rather than erroring, but they aren't working yet as we don't currently use protocol handlers yet. That's for follow-up PRs, as that requires more plumbing.

Part of #40615