### PR TITLE
webgl: Ensure all Surfman surfaces are released properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10052,6 +10052,7 @@ dependencies = [
  "ipc-channel",
  "itertools 0.14.0",
  "log",
+ "parking_lot",
  "pixels",
  "rustc-hash 2.1.1",
  "surfman",

--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -161,8 +161,10 @@ impl Painter {
 
         // Set WebRender external image handler for WebGL textures.
         let image_handler = Box::new(WebGLExternalImages::new(
+            compositor.webgl_threads(),
             rendering_context.clone(),
             compositor.swap_chains.clone(),
+            compositor.busy_webgl_contexts_map.clone(),
         ));
         external_image_handlers.set_handler(image_handler, WebRenderImageHandlerType::WebGl);
 

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2598,7 +2598,6 @@ where
             generic_channel::channel().expect("Failed to create IPC channel!");
         let (indexeddb_ipc_sender, indexeddb_ipc_receiver) =
             ipc::channel().expect("Failed to create IPC channel!");
-        let mut webgl_threads_receiver = None;
 
         debug!("Exiting core resource threads.");
         if let Err(e) = self
@@ -2685,16 +2684,6 @@ where
             }
         }
 
-        if let Some(webgl_threads) = self.webgl_threads.as_ref() {
-            let (sender, receiver) = ipc::channel().expect("Failed to create IPC channel!");
-            webgl_threads_receiver = Some(receiver);
-            debug!("Exiting WebGL thread.");
-
-            if let Err(e) = webgl_threads.exit(sender) {
-                warn!("Exit WebGL Thread failed ({e})");
-            }
-        }
-
         debug!("Exiting GLPlayer thread.");
         WindowGLContext::get().exit();
 
@@ -2716,14 +2705,6 @@ where
         }
         if let Err(e) = indexeddb_ipc_receiver.recv() {
             warn!("Exit indexeddb thread failed ({:?})", e);
-        }
-        if self.webgl_threads.is_some() {
-            if let Err(e) = webgl_threads_receiver
-                .expect("webgl_threads_receiver to be Some")
-                .recv()
-            {
-                warn!("Exit WebGL thread failed ({:?})", e);
-            }
         }
 
         debug!("Shutting-down IPC router thread in constellation.");

--- a/components/webgl/Cargo.toml
+++ b/components/webgl/Cargo.toml
@@ -28,6 +28,7 @@ half = "2"
 ipc-channel = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
+parking_lot = { workspace = true }
 pixels = { path = "../pixels" }
 rustc-hash = { workspace = true }
 surfman = { workspace = true }


### PR DESCRIPTION
This change ensures that all Surfman surfaces used for WebRendering
rendering are released in the WebGL thread properly by:

- Moving `WebGLThread` shutdown to the renderer. The renderer starts it,
  so it makes sense that the renderer also shuts it down when it can
  guarantee that no WebRender painting is currently happening and no
  images will be in use again.
- Delaying WebGL context release until all WebRender operations have
  finished. This ensures that the `SwapChain` is still available for use
  in the external image handler.

The second point is accomplished by sharing a usage map between the
renderer and the `WebGLThread` which tracks whether WebRender is
currently rendering a particular context. In addition, once the WebGL
external image handler is notified that WebRender has finished
rendering, it informs the WebGLThread so that it can released any
contexts already marked for deletion.

Testing: This fixes very common intermittent crashes when running
`/_webgl/conformance` locally. It should reduce the incidence of these flaky
crashes on the CI.
Fixes: #40399.
Fixes: #40417.

