### PR TITLE
compositor: Share the `WebGpuExternalImageMap` among all `Painter`s

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -171,7 +171,7 @@ use storage_traits::indexeddb_thread::{IndexedDBThreadMsg, SyncOperation};
 use storage_traits::webstorage_thread::{StorageType, WebStorageThreadMsg};
 use style::global_style_data::StyleThreadPool;
 #[cfg(feature = "webgpu")]
-use webgpu::canvas_context::WGPUImageMap;
+use webgpu::canvas_context::WebGpuExternalImageMap;
 #[cfg(feature = "webgpu")]
 use webgpu_traits::{WebGPU, WebGPURequest};
 use webrender_api::ExternalScrollId;
@@ -234,7 +234,7 @@ struct WebRenderWGPU {
     webrender_external_image_id_manager: WebRenderExternalImageIdManager,
 
     /// WebGPU data that supplied to Webrender for rendering
-    wgpu_image_map: WGPUImageMap,
+    wgpu_image_map: WebGpuExternalImageMap,
 }
 
 /// A browsing context group.
@@ -547,7 +547,7 @@ pub struct InitialConstellationState {
     pub webxr_registry: Option<webxr_api::Registry>,
 
     #[cfg(feature = "webgpu")]
-    pub wgpu_image_map: WGPUImageMap,
+    pub wgpu_image_map: WebGpuExternalImageMap,
 
     /// User content manager
     pub user_content_manager: UserContentManager,

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use canvas_context::WGPUImageMap;
-pub use canvas_context::{ContextData, WGPUExternalImages};
+use canvas_context::WebGpuExternalImageMap;
+pub use canvas_context::{ContextData, WebGpuExternalImages};
 use log::warn;
 use webgpu_traits::{WebGPU, WebGPUMsg};
 use wgpu_thread::WGPU;
@@ -23,7 +23,7 @@ pub mod canvas_context;
 pub fn start_webgpu_thread(
     compositor_api: CrossProcessCompositorApi,
     webrender_external_image_id_manager: WebRenderExternalImageIdManager,
-    wgpu_image_map: WGPUImageMap,
+    wgpu_image_map: WebGpuExternalImageMap,
 ) -> Option<(WebGPU, IpcReceiver<WebGPUMsg>)> {
     if !pref!(dom_webgpu_enabled) {
         return None;

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -36,7 +36,7 @@ use wgpu_types::MemoryHints;
 use wgt::InstanceDescriptor;
 pub use {wgpu_core as wgc, wgpu_types as wgt};
 
-use crate::canvas_context::WGPUImageMap;
+use crate::canvas_context::WebGpuExternalImageMap;
 use crate::poll_thread::Poller;
 
 #[derive(Eq, Hash, PartialEq)]
@@ -106,7 +106,7 @@ pub(crate) struct WGPU {
     error_command_encoders: FxHashMap<id::CommandEncoderId, String>,
     pub(crate) compositor_api: CrossProcessCompositorApi,
     pub(crate) webrender_external_image_id_manager: WebRenderExternalImageIdManager,
-    pub(crate) wgpu_image_map: WGPUImageMap,
+    pub(crate) wgpu_image_map: WebGpuExternalImageMap,
     /// Provides access to poller thread
     pub(crate) poller: Poller,
     /// Store compute passes
@@ -122,7 +122,7 @@ impl WGPU {
         script_sender: IpcSender<WebGPUMsg>,
         compositor_api: CrossProcessCompositorApi,
         webrender_external_image_id_manager: WebRenderExternalImageIdManager,
-        wgpu_image_map: WGPUImageMap,
+        wgpu_image_map: WebGpuExternalImageMap,
     ) -> Self {
         let backend_pref = pref!(dom_webgpu_wgpu_backend);
         let backends = if backend_pref.is_empty() {


### PR DESCRIPTION
This is required so that there can be multiple `WebGpuExternalImages`
for a single `Constellation`.

Testing: This should not change behavior so is covered by existing tests.
