### PR TITLE
compositing: Make `RefreshDriver` per-`RenderingContext`

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -171,7 +171,6 @@ impl IOCompositor {
         let painter = Painter::new(
             state.rendering_context.clone(),
             state.compositor_proxy,
-            state.refresh_driver,
             state.shaders_path,
             &compositor,
         );

--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -13,7 +13,7 @@ use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::{CompositorMsg, CompositorProxy};
 use constellation_traits::EmbedderToConstellationMessage;
 use crossbeam_channel::Sender;
-use embedder_traits::{EventLoopWaker, RefreshDriver, ShutdownState};
+use embedder_traits::{EventLoopWaker, ShutdownState};
 use profile_traits::{mem, time};
 #[cfg(feature = "webxr")]
 use webxr::WebXrRegistry;
@@ -56,8 +56,6 @@ pub struct InitialCompositorState {
     /// An [`EventLoopWaker`] used in order to wake up the embedder when it is
     /// time to paint.
     pub event_loop_waker: Box<dyn EventLoopWaker>,
-    /// An optional [`RefreshDriver`] provided by the embedder.
-    pub refresh_driver: Option<Rc<dyn RefreshDriver>>,
     /// A [`PathBuf`] which can be used to override WebRender shaders.
     pub shaders_path: Option<PathBuf>,
     /// If WebXR is enabled, a [`WebXrRegistry`] to register WebXR threads.

--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -25,7 +25,7 @@ use crossbeam_channel::Sender;
 use dpi::PhysicalSize;
 use embedder_traits::{
     CompositorHitTestResult, InputEvent, InputEventAndId, InputEventId, InputEventResult,
-    RefreshDriver, ScreenshotCaptureError, Scroll, ViewportDetails, WebViewPoint, WebViewRect,
+    ScreenshotCaptureError, Scroll, ViewportDetails, WebViewPoint, WebViewRect,
 };
 use euclid::{Point2D, Scale};
 use gleam::gl::RENDERER;
@@ -144,7 +144,6 @@ impl Painter {
     pub(crate) fn new(
         rendering_context: Rc<dyn RenderingContext>,
         compositor_proxy: CompositorProxy,
-        refresh_driver: Option<Rc<dyn RefreshDriver>>,
         shader_path: Option<PathBuf>,
         compositor: &IOCompositor,
     ) -> Self {
@@ -182,7 +181,7 @@ impl Painter {
         let embedder_to_constellation_sender = compositor.embedder_to_constellation_sender.clone();
         let refresh_driver = Rc::new(BaseRefreshDriver::new(
             compositor.event_loop_waker.clone_box(),
-            refresh_driver,
+            rendering_context.refresh_driver(),
         ));
         let animation_refresh_driver_observer = Rc::new(AnimationRefreshDriverObserver::new(
             embedder_to_constellation_sender.clone(),

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -290,7 +290,6 @@ impl Servo {
             rendering_context: builder.rendering_context,
             shutdown_state: shutdown_state.clone(),
             event_loop_waker,
-            refresh_driver: builder.refresh_driver,
             shaders_path: opts.shaders_path.clone(),
             #[cfg(feature = "webxr")]
             webxr_registry: builder.webxr_registry,
@@ -1141,7 +1140,6 @@ pub struct ServoBuilder {
     event_loop_waker: Box<dyn EventLoopWaker>,
     user_content_manager: UserContentManager,
     protocol_registry: ProtocolRegistry,
-    refresh_driver: Option<Rc<dyn RefreshDriver>>,
     #[cfg(feature = "webxr")]
     webxr_registry: Box<dyn webxr::WebXrRegistry>,
 }
@@ -1155,7 +1153,6 @@ impl ServoBuilder {
             event_loop_waker: Box::new(DefaultEventLoopWaker),
             user_content_manager: UserContentManager::default(),
             protocol_registry: ProtocolRegistry::default(),
-            refresh_driver: None,
             #[cfg(feature = "webxr")]
             webxr_registry: Box::new(DefaultWebXrRegistry),
         }
@@ -1177,11 +1174,6 @@ impl ServoBuilder {
 
     pub fn event_loop_waker(mut self, event_loop_waker: Box<dyn EventLoopWaker>) -> Self {
         self.event_loop_waker = event_loop_waker;
-        self
-    }
-
-    pub fn refresh_driver(mut self, refresh_driver: Rc<dyn RefreshDriver>) -> Self {
-        self.refresh_driver = Some(refresh_driver);
         self
     }
 

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -261,6 +261,9 @@ pub trait RefreshDriver {
     /// Servo will call this method when it wants to be informed of the next frame start
     /// time. Implementors should call the callback when it is time to start preparing
     /// the new frame.
+    ///
+    /// Multiple callbacks may be registered for the same frame. It is up to the implementation
+    /// to call *all* callbacks that have been registered since the last frame.
     fn observe_next_frame(&self, start_frame_callback: Box<dyn Fn() + Send + 'static>);
 }
 

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -75,11 +75,13 @@ pub fn init(
     };
 
     let size = init_opts.coordinates.viewport.size;
+    let refresh_driver = Rc::new(VsyncRefreshDriver::default());
     let rendering_context = Rc::new(
-        WindowRenderingContext::new(
+        WindowRenderingContext::new_with_refresh_driver(
             display_handle,
             window_handle,
             PhysicalSize::new(size.width as u32, size.height as u32),
+            refresh_driver.clone(),
         )
         .expect("Could not create RenderingContext"),
     );
@@ -89,12 +91,10 @@ pub fn init(
         RefCell::new(init_opts.coordinates),
     ));
 
-    let refresh_driver = Rc::new(VsyncRefreshDriver::default());
     let servo_builder = ServoBuilder::new(rendering_context.clone())
         .opts(opts)
         .preferences(preferences)
-        .event_loop_waker(waker.clone())
-        .refresh_driver(refresh_driver.clone());
+        .event_loop_waker(waker.clone());
 
     #[cfg(feature = "webxr")]
     let servo_builder = servo_builder.webxr_registry(Box::new(XrDiscoveryWebXrRegistry::new(

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -181,11 +181,13 @@ pub fn init(
 
     let window_handle = unsafe { WindowHandle::borrow_raw(window_handle) };
 
+    let refresh_driver = Rc::new(VsyncRefreshDriver::default());
     let rendering_context = Rc::new(
-        WindowRenderingContext::new(
+        WindowRenderingContext::new_with_refresh_driver(
             display_handle,
             window_handle,
             PhysicalSize::new(window_size.width as u32, window_size.height as u32),
+            refresh_driver.clone(),
         )
         .expect("Could not create RenderingContext"),
     );
@@ -197,12 +199,10 @@ pub fn init(
         RefCell::new(coordinates),
     ));
 
-    let refresh_driver = Rc::new(VsyncRefreshDriver::default());
     let servo = ServoBuilder::new(rendering_context.clone())
         .opts(opts)
         .preferences(preferences)
         .event_loop_waker(waker.clone())
-        .refresh_driver(refresh_driver.clone())
         .build();
 
     // Initialize WebDriver server if port is specified


### PR DESCRIPTION
Instead of having a global `RefreshDriver` for all of Servo, let each
`RenderingContext` have its own `RefreshDriver`. This allows for things
like per-monitor `RefreshDriver`s and helps to ensure that multiple
`BaseRefreshDriver`s can be created for the same `RefreshDriver`.

Testing: This shouldn't change behavior and thus is covered by existing tests.
