### PR TITLE
script: Make a Layout-safe version of `Element::each_custom_state`

### DIFF
--- a/components/script/dom/customstateset.rs
+++ b/components/script/dom/customstateset.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::Ref;
+
 use dom_struct::dom_struct;
 use indexmap::IndexSet;
 use script_bindings::codegen::GenericBindings::ElementInternalsBinding::CustomStateSetMethods;
@@ -48,6 +50,10 @@ impl CustomStateSet {
         for state in self.internal.borrow().iter() {
             callback(&AtomIdent::from(&*state.str()));
         }
+    }
+
+    pub(crate) fn set<'a>(&'a self) -> Ref<'a, IndexSet<DOMString>> {
+        self.internal.borrow()
     }
 
     fn states_did_change(&self) {

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -15,7 +15,7 @@ use crate::dom::bindings::codegen::UnionTypes::FileOrUSVStringOrFormData;
 use crate::dom::bindings::error::{Error, ErrorResult, Fallible};
 use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
-use crate::dom::bindings::root::{Dom, DomRoot, MutNullableDom};
+use crate::dom::bindings::root::{Dom, DomRoot, LayoutDom, MutNullableDom};
 use crate::dom::bindings::str::{DOMString, USVString};
 use crate::dom::customstateset::CustomStateSet;
 use crate::dom::element::Element;
@@ -194,6 +194,13 @@ impl ElementInternals {
 
     pub(crate) fn custom_states(&self) -> Option<DomRoot<CustomStateSet>> {
         self.states.get()
+    }
+
+    pub(crate) fn custom_states_for_layout<'a>(&'a self) -> Option<LayoutDom<'a, CustomStateSet>> {
+        #[expect(unsafe_code)]
+        unsafe {
+            self.states.get_inner_as_layout()
+        }
     }
 }
 

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -562,7 +562,7 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
     where
         F: FnMut(&AtomIdent),
     {
-        self.element.each_custom_state(callback);
+        self.element.each_custom_state_for_layout(callback);
     }
 
     /// Returns the implicit scope root for given sheet index and host.
@@ -976,7 +976,7 @@ impl<'dom> ::selectors::Element for ServoLayoutElement<'dom> {
     fn has_custom_state(&self, name: &AtomIdent) -> bool {
         let mut has_state = false;
         self.element
-            .each_custom_state(|state| has_state |= state == name);
+            .each_custom_state_for_layout(|state| has_state |= state == name);
 
         has_state
     }

--- a/tests/wpt/meta/custom-elements/state/state-css-selector.html.ini
+++ b/tests/wpt/meta/custom-elements/state/state-css-selector.html.ini
@@ -1,5 +1,4 @@
 [state-css-selector.html]
-  expected: CRASH
   [state selector influences siblings when state is applied]
     expected: FAIL
 

--- a/tests/wpt/meta/custom-elements/state/state-pseudo-class.html.ini
+++ b/tests/wpt/meta/custom-elements/state/state-pseudo-class.html.ini
@@ -1,4 +1,3 @@
 [state-pseudo-class.html]
-  expected: CRASH
   [:state(foo) and other pseudo classes]
     expected: FAIL


### PR DESCRIPTION
`Element::each_custom_state` is called from Layout, but it creates
`DomRef` types on the stack, which can only be done on the main script
thread. Since layout might be doing styling and element consultation on
workers threads, expose a Layout-safe version of this change, which
doesn't have this issue.

Testing: This fixes two panics encountered during WPT tests.
