### PR TITLE
script: Add message to Dom exception Error::NotSupported

### DIFF
--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -204,7 +204,7 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
             *options.sampleRate < MIN_SAMPLE_RATE ||
             *options.sampleRate > MAX_SAMPLE_RATE
         {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         Ok(AudioBuffer::new_with_proto(
             window,

--- a/components/script/dom/audio/audionode.rs
+++ b/components/script/dom/audio/audionode.rs
@@ -53,7 +53,7 @@ impl AudioNode {
         number_of_outputs: u32,
     ) -> Fallible<AudioNode> {
         if options.count == 0 || options.count > MAX_CHANNEL_COUNT {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         let ch = ChannelInfo {
             count: options.count as u8,
@@ -266,14 +266,14 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
             },
             EventTargetTypeId::AudioNode(AudioNodeTypeId::PannerNode) => {
                 if value > 2 {
-                    return Err(Error::NotSupported);
+                    return Err(Error::NotSupported(None));
                 }
             },
             EventTargetTypeId::AudioNode(AudioNodeTypeId::AudioScheduledSourceNode(
                 AudioScheduledSourceNodeTypeId::StereoPannerNode,
             )) => {
                 if value > 2 {
-                    return Err(Error::NotSupported);
+                    return Err(Error::NotSupported(None));
                 }
             },
             EventTargetTypeId::AudioNode(AudioNodeTypeId::ChannelMergerNode) => {
@@ -289,7 +289,7 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
         };
 
         if value == 0 || value > MAX_CHANNEL_COUNT {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         self.channel_count.set(value);
@@ -317,14 +317,14 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
             },
             EventTargetTypeId::AudioNode(AudioNodeTypeId::PannerNode) => {
                 if value == ChannelCountMode::Max {
-                    return Err(Error::NotSupported);
+                    return Err(Error::NotSupported(None));
                 }
             },
             EventTargetTypeId::AudioNode(AudioNodeTypeId::AudioScheduledSourceNode(
                 AudioScheduledSourceNodeTypeId::StereoPannerNode,
             )) => {
                 if value == ChannelCountMode::Max {
-                    return Err(Error::NotSupported);
+                    return Err(Error::NotSupported(None));
                 }
             },
             EventTargetTypeId::AudioNode(AudioNodeTypeId::ChannelMergerNode) => {

--- a/components/script/dom/audio/baseaudiocontext.rs
+++ b/components/script/dom/audio/baseaudiocontext.rs
@@ -129,7 +129,7 @@ impl BaseAudioContext {
             ClientContextId::build(pipeline_id.namespace_id.0, pipeline_id.index.0.get());
         let audio_context_impl = ServoMedia::get()
             .create_audio_context(&client_context_id, options.convert())
-            .map_err(|_| Error::NotSupported)?;
+            .map_err(|_| Error::NotSupported(None))?;
 
         Ok(BaseAudioContext {
             eventtarget: EventTarget::new_inherited(),
@@ -445,7 +445,7 @@ impl BaseAudioContextMethods<crate::DomTypeHolder> for BaseAudioContext {
             length == 0 ||
             *sample_rate <= 0.
         {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         Ok(AudioBuffer::new(
             self.global().as_window(),

--- a/components/script/dom/audio/iirfilternode.rs
+++ b/components/script/dom/audio/iirfilternode.rs
@@ -45,7 +45,7 @@ impl IIRFilterNode {
         if !(1..=20).contains(&options.feedforward.len()) ||
             !(1..=20).contains(&options.feedback.len())
         {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         if options.feedforward.iter().all(|v| **v == 0.0) || *options.feedback[0] == 0.0 {
             return Err(Error::InvalidState(None));

--- a/components/script/dom/audio/offlineaudiocontext.rs
+++ b/components/script/dom/audio/offlineaudiocontext.rs
@@ -83,7 +83,7 @@ impl OfflineAudioContext {
             length == 0 ||
             !(MIN_SAMPLE_RATE..=MAX_SAMPLE_RATE).contains(&sample_rate)
         {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         let pipeline_id = window.pipeline_id();
         let context =

--- a/components/script/dom/audio/pannernode.rs
+++ b/components/script/dom/audio/pannernode.rs
@@ -71,10 +71,10 @@ impl PannerNode {
             ChannelInterpretation::Speakers,
         );
         if node_options.mode == ChannelCountMode::Max {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         if node_options.count > 2 || node_options.count == 0 {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         if *options.maxDistance <= 0. {
             return Err(Error::Range("maxDistance should be positive".into()));

--- a/components/script/dom/audio/stereopannernode.rs
+++ b/components/script/dom/audio/stereopannernode.rs
@@ -46,10 +46,10 @@ impl StereoPannerNode {
             ChannelInterpretation::Speakers,
         );
         if node_options.mode == ChannelCountMode::Max {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         if node_options.count > 2 || node_options.count == 0 {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         let pan = *options.pan;
         let source_node = AudioScheduledSourceNode::new_inherited(

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -132,7 +132,10 @@ pub(crate) fn create_dom_exception(
             return new_custom_exception(DOMErrorName::InvalidCharacterError, custom_message);
         },
         Error::InvalidCharacter(None) => DOMErrorName::InvalidCharacterError,
-        Error::NotSupported => DOMErrorName::NotSupportedError,
+        Error::NotSupported(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::NotSupportedError, custom_message);
+        },
+        Error::NotSupported(None) => DOMErrorName::NotSupportedError,
         Error::InUseAttribute => DOMErrorName::InUseAttributeError,
         Error::InvalidState(Some(custom_message)) => {
             return new_custom_exception(DOMErrorName::InvalidStateError, custom_message);

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -530,7 +530,7 @@ impl Convert<Error> for BluetoothError {
             BluetoothError::Type(message) => Error::Type(message),
             BluetoothError::Network => Error::Network,
             BluetoothError::NotFound => Error::NotFound(None),
-            BluetoothError::NotSupported => Error::NotSupported,
+            BluetoothError::NotSupported => Error::NotSupported(None),
             BluetoothError::Security => Error::Security,
             BluetoothError::InvalidState => Error::InvalidState(None),
         }

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -168,7 +168,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 5.1.
         if !self.Properties().Read() {
-            p.reject_error(NotSupported, can_gc);
+            p.reject_error(NotSupported(None), can_gc);
             return p;
         }
 
@@ -220,7 +220,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
             self.Properties().WriteWithoutResponse() ||
             self.Properties().AuthenticatedSignedWrites())
         {
-            p.reject_error(NotSupported, can_gc);
+            p.reject_error(NotSupported(None), can_gc);
             return p;
         }
 
@@ -255,7 +255,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 5.
         if !(self.Properties().Notify() || self.Properties().Indicate()) {
-            p.reject_error(NotSupported, can_gc);
+            p.reject_error(NotSupported(None), can_gc);
             return p;
         }
 

--- a/components/script/dom/canvas/imagebitmap.rs
+++ b/components/script/dom/canvas/imagebitmap.rs
@@ -596,7 +596,7 @@ impl ImageBitmap {
             ImageBitmapSource::CSSStyleValue(_) => {
                 // TODO: CSSStyleValue is not part of ImageBitmapSource
                 // <https://html.spec.whatwg.org/multipage/#imagebitmapsource>
-                p.reject_error(Error::NotSupported, can_gc);
+                p.reject_error(Error::NotSupported(None), can_gc);
             },
         }
 

--- a/components/script/dom/credentialmanagement/credentialscontainer.rs
+++ b/components/script/dom/credentialmanagement/credentialscontainer.rs
@@ -58,7 +58,7 @@ impl CredentialsContainer {
         if options.signal.as_ref().is_some_and(|s| s.aborted()) {
             return Err(Error::Abort);
         }
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 
     /// <https://www.w3.org/TR/credential-management-1/#abstract-opdef-store-a-credential>
@@ -71,7 +71,7 @@ impl CredentialsContainer {
         if !global.as_window().Document().is_fully_active() {
             return Err(Error::InvalidState(None));
         }
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 
     /// <https://www.w3.org/TR/credential-management-1/#abstract-opdef-create-a-credential>
@@ -90,7 +90,7 @@ impl CredentialsContainer {
         if !document.is_fully_active() {
             return Err(Error::InvalidState(None));
         }
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 }
 
@@ -112,6 +112,6 @@ impl CredentialsContainerMethods<DomTypeHolder> for CredentialsContainer {
 
     /// <https://www.w3.org/TR/credential-management-1/#dom-credentialscontainer-preventsilentaccess>
     fn PreventSilentAccess(&self) -> Fallible<Rc<Promise>> {
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 }

--- a/components/script/dom/credentialmanagement/passwordcredential.rs
+++ b/components/script/dom/credentialmanagement/passwordcredential.rs
@@ -77,7 +77,7 @@ impl PasswordCredentialMethods<DomTypeHolder> for PasswordCredential {
         _can_gc: CanGc,
         _form: &HTMLFormElement,
     ) -> Fallible<DomRoot<PasswordCredential>> {
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 
     fn Constructor_(

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -388,7 +388,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
         // Step 3. If this's custom element definition set contains an item with name name,
         // then throw a "NotSupportedError" DOMException.
         if self.definitions.borrow().contains_key(&name) {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 4. If this's custom element definition set contains an
@@ -399,7 +399,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
             .iter()
             .any(|(_, def)| def.constructor == constructor_)
         {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 6. Let extends be options["extends"] if it exists; otherwise null.
@@ -411,14 +411,14 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
 
             // Step 7.2 If extends is a valid custom element name, then throw a "NotSupportedError" DOMException.
             if is_valid_custom_element_name(&extended_name.str()) {
-                return Err(Error::NotSupported);
+                return Err(Error::NotSupported(None));
             }
 
             // Step 7.3 If the element interface for extends and the HTML namespace is HTMLUnknownElement
             // (e.g., if extends does not indicate an element definition in this specification)
             // then throw a "NotSupportedError" DOMException.
             if !is_extendable_element_interface(&extended_name.str()) {
-                return Err(Error::NotSupported);
+                return Err(Error::NotSupported(None));
             }
 
             // Step 7.4 Set localName to extends.
@@ -430,7 +430,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
 
         // Step 8
         if self.element_definition_is_running.get() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 9
@@ -798,7 +798,7 @@ impl CustomElementDefinition {
             *element.namespace() != ns!(html) ||
             *element.local_name() != self.local_name
         {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 4.1.10. Set result’s namespace prefix to prefix.
@@ -946,7 +946,7 @@ fn run_upgrade_constructor(
         // Step 9.1. If definition's disable shadow is true and element's shadow root is non-null,
         // then throw a "NotSupportedError" DOMException.
         if definition.disable_shadow && element.is_shadow_host() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Go into the constructor's realm

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -5054,7 +5054,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     ) -> Fallible<DomRoot<CDATASection>> {
         // Step 1
         if self.is_html_document {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 2
@@ -5096,7 +5096,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn ImportNode(&self, node: &Node, deep: bool, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
         // Step 1.
         if node.is::<Document>() || node.is::<ShadowRoot>() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 2.
@@ -5113,7 +5113,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn AdoptNode(&self, node: &Node, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
         // Step 1.
         if node.is::<Document>() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 2.
@@ -5184,7 +5184,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
                 &self.window,
                 can_gc,
             ))),
-            _ => Err(Error::NotSupported),
+            _ => Err(Error::NotSupported(None)),
         }
     }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -606,7 +606,7 @@ impl Element {
         // Step 1. If element’s namespace is not the HTML namespace,
         // then throw a "NotSupportedError" DOMException.
         if self.namespace != ns!(html) {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 2. If element’s local name is not a valid shadow host name,
@@ -614,7 +614,7 @@ impl Element {
         if !is_valid_shadow_host_name(self.local_name()) {
             // UA shadow roots may be attached to anything
             if is_ua_widget != IsUserAgentWidget::Yes {
-                return Err(Error::NotSupported);
+                return Err(Error::NotSupported(None));
             }
         }
 
@@ -628,7 +628,7 @@ impl Element {
             // Step 3.2. If definition is not null and definition’s disable shadow
             //  is true, then throw a "NotSupportedError" DOMException.
             if definition.is_some_and(|definition| definition.disable_shadow) {
-                return Err(Error::NotSupported);
+                return Err(Error::NotSupported(None));
             }
         }
 
@@ -641,7 +641,7 @@ impl Element {
             if !current_shadow_root.is_declarative() ||
                 current_shadow_root.shadow_root_mode() != mode
             {
-                return Err(Error::NotSupported);
+                return Err(Error::NotSupported(None));
             }
 
             // Step 4.3.1. Remove all of currentShadowRoot’s children, in tree order.
@@ -3897,7 +3897,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
                 a.enter_formal_activation_state();
                 Ok(())
             },
-            None => Err(Error::NotSupported),
+            None => Err(Error::NotSupported(None)),
         }
     }
 
@@ -3907,7 +3907,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
                 a.exit_formal_activation_state();
                 Ok(())
             },
-            None => Err(Error::NotSupported),
+            None => Err(Error::NotSupported(None)),
         }
     }
 

--- a/components/script/dom/elementinternals.rs
+++ b/components/script/dom/elementinternals.rs
@@ -222,7 +222,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     ) -> ErrorResult {
         // Steps 1-2: If element is not a form-associated custom element, then throw a "NotSupportedError" DOMException
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 3: Set target element's submission value
@@ -248,7 +248,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
         // Step 1. Let element be this's target element.
         // Step 2: If element is not a form-associated custom element, then throw a "NotSupportedError" DOMException.
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 3: If flags contains one or more true values and message is not given or is the empty
@@ -311,7 +311,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
         // This check isn't in the spec but it's in WPT tests and it maintains
         // consistency with other methods that do specify it
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         Ok(self.validation_message.borrow().clone())
     }
@@ -319,7 +319,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-validity>
     fn GetValidity(&self, can_gc: CanGc) -> Fallible<DomRoot<ValidityState>> {
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         Ok(self.validity_state(can_gc))
     }
@@ -327,7 +327,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-labels>
     fn GetLabels(&self, can_gc: CanGc) -> Fallible<DomRoot<NodeList>> {
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         Ok(self.labels_node_list.or_init(|| {
             NodeList::new_labels_list(
@@ -341,7 +341,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-willvalidate>
     fn GetWillValidate(&self) -> Fallible<bool> {
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         Ok(self.is_instance_validatable())
     }
@@ -349,7 +349,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-form>
     fn GetForm(&self) -> Fallible<Option<DomRoot<HTMLFormElement>>> {
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         Ok(self.form_owner.get())
     }
@@ -357,7 +357,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-checkvalidity>
     fn CheckValidity(&self, can_gc: CanGc) -> Fallible<bool> {
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         Ok(self.check_validity(can_gc))
     }
@@ -365,7 +365,7 @@ impl ElementInternalsMethods<crate::DomTypeHolder> for ElementInternals {
     /// <https://html.spec.whatwg.org/multipage#dom-elementinternals-reportvalidity>
     fn ReportValidity(&self, can_gc: CanGc) -> Fallible<bool> {
         if !self.is_target_form_associated() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         Ok(self.report_validity(can_gc))
     }

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -209,7 +209,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
         }
 
         if !self.effects.contains(&type_) {
-            playing_effect_promise.reject_error(Error::NotSupported, can_gc);
+            playing_effect_promise.reject_error(Error::NotSupported(None), can_gc);
             return playing_effect_promise;
         }
 

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -633,7 +633,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         let element = self.as_element();
         // Step 1: If this's is value is not null, then throw a "NotSupportedError" DOMException
         if element.get_is().is_some() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 2: Let definition be the result of looking up a custom element definition
@@ -646,18 +646,18 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
         // Step 3: If definition is null, then throw an "NotSupportedError" DOMException
         let definition = match definition {
             Some(definition) => definition,
-            None => return Err(Error::NotSupported),
+            None => return Err(Error::NotSupported(None)),
         };
 
         // Step 4: If definition's disable internals is true, then throw a "NotSupportedError" DOMException
         if definition.disable_internals {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 5: If this's attached internals is non-null, then throw an "NotSupportedError" DOMException
         let internals = element.ensure_element_internals(can_gc);
         if internals.attached() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 6: If this's custom element state is not "precustomized" or "custom",
@@ -666,7 +666,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
             element.get_custom_element_state(),
             CustomElementState::Precustomized | CustomElementState::Custom
         ) {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         if self.is_form_associated_custom_element() {

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1549,7 +1549,7 @@ impl HTMLMediaElement {
     fn queue_dedicated_media_source_failure_steps(&self) {
         let this = Trusted::new(self);
         let generation_id = self.generation_id.get();
-        self.take_pending_play_promises(Err(Error::NotSupported));
+        self.take_pending_play_promises(Err(Error::NotSupported(None)));
         self.owner_global()
             .task_manager()
             .media_element_task_source()
@@ -3009,7 +3009,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
             .get()
             .is_some_and(|e| e.Code() == MEDIA_ERR_SRC_NOT_SUPPORTED)
         {
-            promise.reject_error(Error::NotSupported, can_gc);
+            promise.reject_error(Error::NotSupported(None), can_gc);
             return promise;
         }
 
@@ -3051,7 +3051,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
         let min_allowed = -64.0;
         let max_allowed = 64.0;
         if *value < min_allowed || *value > max_allowed {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         if *value != self.defaultPlaybackRate.get() {
@@ -3072,7 +3072,7 @@ impl HTMLMediaElementMethods<crate::DomTypeHolder> for HTMLMediaElement {
         let min_allowed = -64.0;
         let max_allowed = 64.0;
         if *value < min_allowed || *value > max_allowed {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         if *value != self.playbackRate.get() {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -3725,7 +3725,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
     fn CloneNode(&self, subtree: bool, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
         // Step 1. If this is a shadow root, then throw a "NotSupportedError" DOMException.
         if self.is::<ShadowRoot>() {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         // Step 2. Return the result of cloning a node given this with subtree set to subtree.

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -491,7 +491,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     fn CompareBoundaryPoints(&self, how: u16, other: &Range) -> Fallible<i16> {
         if how > RangeConstants::END_TO_START {
             // Step 1.
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
         let this_root = self
             .start_container()

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -1205,7 +1205,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     key.algorithm().name(),
                     ALG_SHA1 | ALG_SHA256 | ALG_SHA384 | ALG_SHA512 | ALG_HKDF | ALG_PBKDF2
                 ) {
-                    subtle.reject_promise_with_error(promise, Error::NotSupported);
+                    subtle.reject_promise_with_error(promise, Error::NotSupported(None));
                     return;
                 }
 
@@ -1329,7 +1329,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                     key.algorithm().name(),
                     ALG_SHA1 | ALG_SHA256 | ALG_SHA384 | ALG_SHA512 | ALG_HKDF | ALG_PBKDF2
                 ) {
-                    subtle.reject_promise_with_error(promise, Error::NotSupported);
+                    subtle.reject_promise_with_error(promise, Error::NotSupported(None));
                     return;
                 }
 
@@ -1617,7 +1617,7 @@ impl SubtleKeyAlgorithm {
             ALG_SHA384 => 1024,
             ALG_SHA512 => 1024,
             _ => {
-                return Err(Error::NotSupported);
+                return Err(Error::NotSupported(None));
             },
         };
 
@@ -2332,7 +2332,7 @@ fn normalize_algorithm(
             let Some(&alg_name) = SUPPORTED_ALGORITHMS.iter().find(|supported_algorithm| {
                 supported_algorithm.eq_ignore_ascii_case(&initial_alg.name.str())
             }) else {
-                return Err(Error::NotSupported);
+                return Err(Error::NotSupported(None));
             };
 
             // Step 5.2. Let desiredType be the IDL dictionary type stored at algName in
@@ -2782,7 +2782,7 @@ fn normalize_algorithm(
                     NormalizedAlgorithm::Algorithm(params.into())
                 },
 
-                _ => return Err(Error::NotSupported),
+                _ => return Err(Error::NotSupported(None)),
             };
 
             // Step 11. Return normalizedAlgorithm.
@@ -2823,7 +2823,7 @@ impl NormalizedAlgorithm {
             (ALG_AES_GCM, NormalizedAlgorithm::AesGcmParams(algo)) => {
                 aes_operation::encrypt_aes_gcm(algo, key, plaintext)
             },
-            _ => Err(Error::NotSupported),
+            _ => Err(Error::NotSupported(None)),
         }
     }
 
@@ -2838,7 +2838,7 @@ impl NormalizedAlgorithm {
             (ALG_AES_GCM, NormalizedAlgorithm::AesGcmParams(algo)) => {
                 aes_operation::decrypt_aes_gcm(algo, key, ciphertext)
             },
-            _ => Err(Error::NotSupported),
+            _ => Err(Error::NotSupported(None)),
         }
     }
 
@@ -2851,7 +2851,7 @@ impl NormalizedAlgorithm {
                 ed25519_operation::sign(key, message)
             },
             (ALG_HMAC, NormalizedAlgorithm::Algorithm(_algo)) => hmac_operation::sign(key, message),
-            _ => Err(Error::NotSupported),
+            _ => Err(Error::NotSupported(None)),
         }
     }
 
@@ -2866,7 +2866,7 @@ impl NormalizedAlgorithm {
             (ALG_HMAC, NormalizedAlgorithm::Algorithm(_algo)) => {
                 hmac_operation::verify(key, message, signature)
             },
-            _ => Err(Error::NotSupported),
+            _ => Err(Error::NotSupported(None)),
         }
     }
 
@@ -2884,7 +2884,7 @@ impl NormalizedAlgorithm {
             (ALG_SHA512, NormalizedAlgorithm::Algorithm(algo)) => {
                 sha_operation::digest(algo, message)
             },
-            _ => Err(Error::NotSupported),
+            _ => Err(Error::NotSupported(None)),
         }
     }
 
@@ -2932,7 +2932,7 @@ impl NormalizedAlgorithm {
                 hmac_operation::generate_key(global, algo, extractable, usages, can_gc)
                     .map(CryptoKeyOrCryptoKeyPair::CryptoKey)
             },
-            _ => Err(Error::NotSupported),
+            _ => Err(Error::NotSupported(None)),
         }
     }
 
@@ -2950,7 +2950,7 @@ impl NormalizedAlgorithm {
             (ALG_PBKDF2, NormalizedAlgorithm::Pbkdf2Params(algo)) => {
                 pbkdf2_operation::derive_bits(algo, key, length)
             },
-            _ => Err(Error::NotSupported),
+            _ => Err(Error::NotSupported(None)),
         }
     }
 
@@ -3045,7 +3045,7 @@ impl NormalizedAlgorithm {
             (ALG_PBKDF2, NormalizedAlgorithm::Algorithm(_algo)) => {
                 pbkdf2_operation::import_key(global, format, key_data, extractable, usages, can_gc)
             },
-            _ => Err(Error::NotSupported),
+            _ => Err(Error::NotSupported(None)),
         }
     }
 
@@ -3054,7 +3054,7 @@ impl NormalizedAlgorithm {
             (ALG_AES_KW, NormalizedAlgorithm::Algorithm(_algo)) => {
                 aes_operation::wrap_key_aes_kw(key, plaintext)
             },
-            _ => Err(Error::NotSupported),
+            _ => Err(Error::NotSupported(None)),
         }
     }
 
@@ -3063,7 +3063,7 @@ impl NormalizedAlgorithm {
             (ALG_AES_KW, NormalizedAlgorithm::Algorithm(_algo)) => {
                 aes_operation::unwrap_key_aes_kw(key, ciphertext)
             },
-            _ => Err(Error::NotSupported),
+            _ => Err(Error::NotSupported(None)),
         }
     }
 
@@ -3088,7 +3088,7 @@ impl NormalizedAlgorithm {
             (ALG_PBKDF2, NormalizedAlgorithm::Algorithm(_algo)) => {
                 pbkdf2_operation::get_key_length()
             },
-            _ => Err(Error::NotSupported),
+            _ => Err(Error::NotSupported(None)),
         }
     }
 }
@@ -3110,6 +3110,6 @@ fn perform_export_key_operation(format: KeyFormat, key: &CryptoKey) -> Result<Ex
         ALG_AES_GCM => aes_operation::export_key_aes_gcm(format, key),
         ALG_AES_KW => aes_operation::export_key_aes_kw(format, key),
         ALG_HMAC => hmac_operation::export_key(format, key),
-        _ => Err(Error::NotSupported),
+        _ => Err(Error::NotSupported(None)),
     }
 }

--- a/components/script/dom/subtlecrypto/aes_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_operation.rs
@@ -409,7 +409,7 @@ pub(crate) fn encrypt_aes_gcm(
             log::warn!(
                 "Missing AES-GCM encryption implementation with {key_length}-byte key and {iv_length}-byte IV"
             );
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         },
     };
 
@@ -527,7 +527,7 @@ pub(crate) fn decrypt_aes_gcm(
             log::warn!(
                 "Missing AES-GCM decryption implementation with {key_length}-byte key and {iv_length}-byte IV"
             );
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         },
     };
     if result.is_err() {
@@ -924,7 +924,7 @@ fn import_key_aes(
         // Otherwise:
         _ => {
             // throw a NotSupportedError
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         },
     };
 
@@ -1061,7 +1061,7 @@ fn export_key_aes(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Err
         // Otherwise:
         _ => {
             // throw a NotSupportedError.
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         },
     };
 

--- a/components/script/dom/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdh_operation.rs
@@ -84,7 +84,7 @@ pub(crate) fn generate_key(
                 Handle::P521PublicKey(public_key),
             )
         },
-        _ => return Err(Error::NotSupported),
+        _ => return Err(Error::NotSupported(None)),
     };
 
     // Step 4. Let algorithm be a new EcKeyAlgorithm object.
@@ -238,7 +238,7 @@ pub(crate) fn derive_bits(
                 .raw_secret_bytes()
                 .to_vec()
         },
-        _ => return Err(Error::NotSupported),
+        _ => return Err(Error::NotSupported(None)),
     };
 
     // Step 8.
@@ -369,7 +369,7 @@ pub(crate) fn import_key(
                     // Step 2.10.2. If an error occurred or there are no applicable specifications,
                     // throw a DataError.
                     // NOTE: We currently do not support applicable specifications.
-                    return Err(Error::NotSupported);
+                    return Err(Error::NotSupported(None));
                 },
             };
 
@@ -509,7 +509,7 @@ pub(crate) fn import_key(
                     // Step 2.10.2. If an error occurred or there are no applicable specifications,
                     // throw a DataError.
                     // NOTE: We currently do not support applicable specifications.
-                    return Err(Error::NotSupported);
+                    return Err(Error::NotSupported(None));
                 },
             };
 
@@ -746,7 +746,7 @@ pub(crate) fn import_key(
                     // Step 2.10.2. If an error occurred or there are no applicable specifications,
                     // throw a DataError.
                     // NOTE: We currently do not support applicable specifications.
-                    return Err(Error::NotSupported);
+                    return Err(Error::NotSupported(None));
                 };
 
             // Step 2.11. If the key value is not a valid point on the Elliptic Curve identified by
@@ -829,7 +829,7 @@ pub(crate) fn import_key(
                 // Step. 2.3.2. If an error occured or there are no applicable specifications,
                 // throw a DataError.
                 // NOTE: We currently do not support applicable specifications.
-                return Err(Error::NotSupported);
+                return Err(Error::NotSupported(None));
             };
 
             // Step 2.4. Let algorithm be a new EcKeyAlgorithm object.
@@ -1075,7 +1075,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                         Handle::P256PrivateKey(private_key) => private_key.to_bytes().to_vec(),
                         Handle::P384PrivateKey(private_key) => private_key.to_bytes().to_vec(),
                         Handle::P521PrivateKey(private_key) => private_key.to_bytes().to_vec(),
-                        _ => return Err(Error::NotSupported),
+                        _ => return Err(Error::NotSupported(None)),
                     };
                     jwk.d = Some(Base64UrlUnpadded::encode_string(&d).into());
                 }
@@ -1138,7 +1138,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                     _ => return Err(Error::Operation),
                 }
             } else {
-                return Err(Error::NotSupported);
+                return Err(Error::NotSupported(None));
             };
 
             // Step 3.3. Let result be data.

--- a/components/script/dom/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdsa_operation.rs
@@ -63,7 +63,7 @@ pub(crate) fn sign(
         ALG_SHA256 => Sha256::new_with_prefix(message).finalize().to_vec(),
         ALG_SHA384 => Sha384::new_with_prefix(message).finalize().to_vec(),
         ALG_SHA512 => Sha512::new_with_prefix(message).finalize().to_vec(),
-        _ => return Err(Error::NotSupported),
+        _ => return Err(Error::NotSupported(None)),
     };
 
     // Step 4. Let d be the ECDSA private key associated with key.
@@ -133,7 +133,7 @@ pub(crate) fn sign(
                 .map_err(|_| Error::Operation)?;
             signature.to_vec()
         },
-        _ => return Err(Error::NotSupported),
+        _ => return Err(Error::NotSupported(None)),
     };
 
     // Step 7. Return result.
@@ -163,7 +163,7 @@ pub(crate) fn verify(
         ALG_SHA256 => Sha256::new_with_prefix(message).finalize().to_vec(),
         ALG_SHA384 => Sha384::new_with_prefix(message).finalize().to_vec(),
         ALG_SHA512 => Sha512::new_with_prefix(message).finalize().to_vec(),
-        _ => return Err(Error::NotSupported),
+        _ => return Err(Error::NotSupported(None)),
     };
 
     // Step 4. Let Q be the ECDSA public key associated with key.
@@ -241,7 +241,7 @@ pub(crate) fn verify(
                 _ => false,
             }
         },
-        _ => return Err(Error::NotSupported),
+        _ => return Err(Error::NotSupported(None)),
     };
 
     // Step 8. Return result.
@@ -303,7 +303,7 @@ pub(crate) fn generate_key(
                 Handle::P521PublicKey(public_key),
             )
         },
-        _ => return Err(Error::NotSupported),
+        _ => return Err(Error::NotSupported(None)),
     };
 
     // Step 4. Let algorithm be a new EcKeyAlgorithm object.
@@ -1197,7 +1197,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                         Handle::P256PrivateKey(private_key) => private_key.to_bytes().to_vec(),
                         Handle::P384PrivateKey(private_key) => private_key.to_bytes().to_vec(),
                         Handle::P521PrivateKey(private_key) => private_key.to_bytes().to_vec(),
-                        _ => return Err(Error::NotSupported),
+                        _ => return Err(Error::NotSupported(None)),
                     };
                     jwk.d = Some(Base64UrlUnpadded::encode_string(&d).into());
                 }
@@ -1262,7 +1262,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                     _ => return Err(Error::Operation),
                 }
             } else {
-                return Err(Error::NotSupported);
+                return Err(Error::NotSupported(None));
             };
 
             // Step 3.3. Let result be data.

--- a/components/script/dom/subtlecrypto/hkdf_operation.rs
+++ b/components/script/dom/subtlecrypto/hkdf_operation.rs
@@ -118,7 +118,7 @@ pub(crate) fn import_key(
     // Otherwise:
     else {
         // throw a NotSupportedError.
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 }
 

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -34,9 +34,9 @@ pub(crate) fn sign(key: &CryptoKey, message: &[u8]) -> Result<Vec<u8>, Error> {
             ALG_SHA256 => hmac::HMAC_SHA256,
             ALG_SHA384 => hmac::HMAC_SHA384,
             ALG_SHA512 => hmac::HMAC_SHA512,
-            _ => return Err(Error::NotSupported),
+            _ => return Err(Error::NotSupported(None)),
         },
-        _ => return Err(Error::NotSupported),
+        _ => return Err(Error::NotSupported(None)),
     };
     let sign_key = hmac::Key::new(hash_function, key.handle().as_bytes());
     let mac = hmac::sign(&sign_key, message);
@@ -57,9 +57,9 @@ pub(crate) fn verify(key: &CryptoKey, message: &[u8], signature: &[u8]) -> Resul
             ALG_SHA256 => hmac::HMAC_SHA256,
             ALG_SHA384 => hmac::HMAC_SHA384,
             ALG_SHA512 => hmac::HMAC_SHA512,
-            _ => return Err(Error::NotSupported),
+            _ => return Err(Error::NotSupported(None)),
         },
-        _ => return Err(Error::NotSupported),
+        _ => return Err(Error::NotSupported(None)),
     };
     let sign_key = hmac::Key::new(hash_function, key.handle().as_bytes());
     let mac = hmac::sign(&sign_key, message);
@@ -240,7 +240,7 @@ pub(crate) fn import_key(
                     // Perform any key import steps defined by other applicable specifications,
                     // passing format, jwk and hash and obtaining hash
                     // NOTE: Currently not support applicable specification.
-                    return Err(Error::NotSupported);
+                    return Err(Error::NotSupported(None));
                 },
             }
 
@@ -264,7 +264,7 @@ pub(crate) fn import_key(
         // Otherwise:
         _ => {
             // throw a NotSupportedError.
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         },
     }
 
@@ -337,9 +337,9 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                     ALG_SHA256 => "HS256",
                     ALG_SHA384 => "HS384",
                     ALG_SHA512 => "HS512",
-                    _ => return Err(Error::NotSupported),
+                    _ => return Err(Error::NotSupported(None)),
                 },
-                _ => return Err(Error::NotSupported),
+                _ => return Err(Error::NotSupported(None)),
             };
 
             // Step 7. Set the key_ops attribute of jwk to the usages attribute of key.
@@ -364,7 +364,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
             Ok(ExportedKey::Jwk(Box::new(jwk)))
         },
-        _ => Err(Error::NotSupported),
+        _ => Err(Error::NotSupported(None)),
     }
 }
 

--- a/components/script/dom/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/subtlecrypto/pbkdf2_operation.rs
@@ -50,7 +50,7 @@ pub(crate) fn derive_bits(
         ALG_SHA384 => pbkdf2::PBKDF2_HMAC_SHA384,
         ALG_SHA512 => pbkdf2::PBKDF2_HMAC_SHA512,
         _ => {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         },
     };
 
@@ -88,7 +88,7 @@ pub(crate) fn import_key(
 ) -> Result<DomRoot<CryptoKey>, Error> {
     // Step 1. If format is not "raw", throw a NotSupportedError
     if format != KeyFormat::Raw {
-        return Err(Error::NotSupported);
+        return Err(Error::NotSupported(None));
     }
 
     // Step 2. If usages contains a value that is not "deriveKey" or "deriveBits", then throw a SyntaxError.

--- a/components/script/dom/subtlecrypto/sha_operation.rs
+++ b/components/script/dom/subtlecrypto/sha_operation.rs
@@ -34,7 +34,7 @@ pub(crate) fn digest(
         ALG_SHA384 => digest::digest(&digest::SHA384, message).as_ref().to_vec(),
         ALG_SHA512 => digest::digest(&digest::SHA512, message).as_ref().to_vec(),
         _ => {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         },
     };
 

--- a/components/script/dom/webxr/fakexrdevice.rs
+++ b/components/script/dom/webxr/fakexrdevice.rs
@@ -117,11 +117,11 @@ pub(crate) fn get_views(views: &[FakeXRViewInit]) -> Fallible<MockViewsInit> {
             let (left, right) = match (views[0].eye, views[1].eye) {
                 (XREye::Left, XREye::Right) => (&views[0], &views[1]),
                 (XREye::Right, XREye::Left) => (&views[1], &views[0]),
-                _ => return Err(Error::NotSupported),
+                _ => return Err(Error::NotSupported(None)),
             };
             Ok(MockViewsInit::Stereo(view(left)?, view(right)?))
         },
-        _ => Err(Error::NotSupported),
+        _ => Err(Error::NotSupported(None)),
     }
 }
 

--- a/components/script/dom/webxr/xrmediabinding.rs
+++ b/components/script/dom/webxr/xrmediabinding.rs
@@ -76,7 +76,7 @@ impl XRMediaBindingMethods<crate::DomTypeHolder> for XRMediaBinding {
         _: &XRMediaLayerInit,
     ) -> Fallible<DomRoot<XRQuadLayer>> {
         // https://github.com/servo/servo/issues/27493
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 
     /// <https://immersive-web.github.io/layers/#dom-xrmediabinding-createcylinderlayer>
@@ -86,7 +86,7 @@ impl XRMediaBindingMethods<crate::DomTypeHolder> for XRMediaBinding {
         _: &XRMediaLayerInit,
     ) -> Fallible<DomRoot<XRCylinderLayer>> {
         // https://github.com/servo/servo/issues/27493
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 
     /// <https://immersive-web.github.io/layers/#dom-xrmediabinding-createequirectlayer>
@@ -96,6 +96,6 @@ impl XRMediaBindingMethods<crate::DomTypeHolder> for XRMediaBinding {
         _: &XRMediaLayerInit,
     ) -> Fallible<DomRoot<XREquirectLayer>> {
         // https://github.com/servo/servo/issues/27493
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 }

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -688,7 +688,7 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
         // https://immersive-web.github.io/layers/#updaterenderstatechanges
         // Step 1.
         if init.baseLayer.is_some() && (self.has_layers_feature() || init.layers.is_some()) {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         if let Some(Some(ref layers)) = init.layers {
@@ -845,14 +845,14 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
         if !self.is_immersive() &&
             (ty == XRReferenceSpaceType::Bounded_floor || ty == XRReferenceSpaceType::Unbounded)
         {
-            p.reject_error(Error::NotSupported, can_gc);
+            p.reject_error(Error::NotSupported(None), can_gc);
             return p;
         }
 
         match ty {
             XRReferenceSpaceType::Unbounded => {
                 // XXXmsub2 figure out how to support this
-                p.reject_error(Error::NotSupported, can_gc)
+                p.reject_error(Error::NotSupported(None), can_gc)
             },
             ty => {
                 if ty != XRReferenceSpaceType::Viewer &&
@@ -866,7 +866,7 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
                         .iter()
                         .any(|f| *f == s)
                     {
-                        p.reject_error(Error::NotSupported, can_gc);
+                        p.reject_error(Error::NotSupported(None), can_gc);
                         return p;
                     }
                 }
@@ -937,7 +937,7 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
             .iter()
             .any(|f| f == "hit-test")
         {
-            p.reject_error(Error::NotSupported, can_gc);
+            p.reject_error(Error::NotSupported(None), can_gc);
             return p;
         }
 

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -200,7 +200,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
                     if mode != XRSessionMode::Inline {
                         self.pending_immersive_session.set(false);
                     }
-                    promise.reject_error(Error::NotSupported, can_gc);
+                    promise.reject_error(Error::NotSupported(None), can_gc);
                     return promise;
                 }
             }
@@ -288,7 +288,7 @@ impl XRSystem {
                 if mode != XRSessionMode::Inline {
                     self.pending_immersive_session.set(false);
                 }
-                promise.reject_error(Error::NotSupported, can_gc);
+                promise.reject_error(Error::NotSupported(None), can_gc);
                 return;
             },
         };

--- a/components/script/dom/webxr/xrwebglbinding.rs
+++ b/components/script/dom/webxr/xrwebglbinding.rs
@@ -109,7 +109,7 @@ impl XRWebGLBindingMethods<crate::DomTypeHolder> for XRWebGLBinding {
         _: &XRProjectionLayerInit,
     ) -> Fallible<DomRoot<XRProjectionLayer>> {
         // https://github.com/servo/servo/issues/27468
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 
     /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-createquadlayer>
@@ -119,7 +119,7 @@ impl XRWebGLBindingMethods<crate::DomTypeHolder> for XRWebGLBinding {
         _: &Option<XRQuadLayerInit>,
     ) -> Fallible<DomRoot<XRQuadLayer>> {
         // https://github.com/servo/servo/issues/27493
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 
     /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-createcylinderlayer>
@@ -129,7 +129,7 @@ impl XRWebGLBindingMethods<crate::DomTypeHolder> for XRWebGLBinding {
         _: &Option<XRCylinderLayerInit>,
     ) -> Fallible<DomRoot<XRCylinderLayer>> {
         // https://github.com/servo/servo/issues/27493
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 
     /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-createequirectlayer>
@@ -139,13 +139,13 @@ impl XRWebGLBindingMethods<crate::DomTypeHolder> for XRWebGLBinding {
         _: &Option<XREquirectLayerInit>,
     ) -> Fallible<DomRoot<XREquirectLayer>> {
         // https://github.com/servo/servo/issues/27493
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 
     /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-createcubelayer>
     fn CreateCubeLayer(&self, _: &Option<XRCubeLayerInit>) -> Fallible<DomRoot<XRCubeLayer>> {
         // https://github.com/servo/servo/issues/27493
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 
     /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-getsubimage>
@@ -156,7 +156,7 @@ impl XRWebGLBindingMethods<crate::DomTypeHolder> for XRWebGLBinding {
         _: XREye,
     ) -> Fallible<DomRoot<XRWebGLSubImage>> {
         // https://github.com/servo/servo/issues/27468
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 
     /// <https://immersive-web.github.io/layers/#dom-xrwebglbinding-getviewsubimage>
@@ -166,6 +166,6 @@ impl XRWebGLBindingMethods<crate::DomTypeHolder> for XRWebGLBinding {
         _: &XRView,
     ) -> Fallible<DomRoot<XRWebGLSubImage>> {
         // https://github.com/servo/servo/issues/27468
-        Err(Error::NotSupported)
+        Err(Error::NotSupported(None))
     }
 }

--- a/components/script/dom/xpathexpression.rs
+++ b/components/script/dom/xpathexpression.rs
@@ -67,7 +67,7 @@ impl XPathExpression {
                 NodeTypeId::Element(_)
         );
         if !is_allowed_context_node_type {
-            return Err(Error::NotSupported);
+            return Err(Error::NotSupported(None));
         }
 
         let result_type = XPathResultType::try_from(result_type_num)

--- a/components/script/drag_data_store.rs
+++ b/components/script/drag_data_store.rs
@@ -172,7 +172,7 @@ impl DragDataStore {
                 .values()
                 .any(|item| item.text_type_matches(type_))
             {
-                return Err(Error::NotSupported);
+                return Err(Error::NotSupported(None));
             }
         }
 

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -24,7 +24,7 @@ pub enum Error {
     /// InvalidCharacterError DOMException
     InvalidCharacter(Option<String>),
     /// NotSupportedError DOMException
-    NotSupported,
+    NotSupported(Option<String>),
     /// InUseAttributeError DOMException
     InUseAttribute,
     /// InvalidStateError DOMException


### PR DESCRIPTION
Adding an optional message to Error::NotSupported. Unblocks https://github.com/servo/servo/issues/39050.

The enum definition of NotSupported is now `NotSupported(Option<String>)`. 

Testing: Just a refactor
Fixes: Partially https://github.com/servo/servo/issues/39053