### PR TITLE
script: Finish converting all error message enum variants to Option<String>

### DIFF
--- a/components/script/dom/abortsignal.rs
+++ b/components/script/dom/abortsignal.rs
@@ -142,7 +142,7 @@ impl AbortSignal {
             self.abort_reason.set(abort_reason);
         } else {
             rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-            Error::Abort.to_jsval(cx, &global, rooted_error.handle_mut(), can_gc);
+            Error::Abort(None).to_jsval(cx, &global, rooted_error.handle_mut(), can_gc);
             self.abort_reason.set(rooted_error.get())
         }
 
@@ -373,7 +373,7 @@ impl AbortSignalMethods<crate::DomTypeHolder> for AbortSignal {
             signal.abort_reason.set(abort_reason);
         } else {
             rooted!(in(*cx) let mut rooted_error = UndefinedValue());
-            Error::Abort.to_jsval(cx, global, rooted_error.handle_mut(), can_gc);
+            Error::Abort(None).to_jsval(cx, global, rooted_error.handle_mut(), can_gc);
             signal.abort_reason.set(rooted_error.get())
         }
 
@@ -412,7 +412,7 @@ impl AbortSignalMethods<crate::DomTypeHolder> for AbortSignal {
 
                     let cx = GlobalScope::get_cx();
                     rooted!(in(*cx) let mut reason = UndefinedValue());
-                    Error::Timeout.to_jsval(
+                    Error::Timeout(None).to_jsval(
                         cx,
                         &signal_for_task.global(),
                         reason.handle_mut(),

--- a/components/script/dom/audio/audionode.rs
+++ b/components/script/dom/audio/audionode.rs
@@ -116,7 +116,7 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
         input: u32,
     ) -> Fallible<DomRoot<AudioNode>> {
         if self.context != destination.context {
-            return Err(Error::InvalidAccess);
+            return Err(Error::InvalidAccess(None));
         }
 
         if output >= self.NumberOfOutputs() || input >= destination.NumberOfInputs() {
@@ -140,7 +140,7 @@ impl AudioNodeMethods<crate::DomTypeHolder> for AudioNode {
     /// <https://webaudio.github.io/web-audio-api/#dom-audionode-connect-destinationparam-output>
     fn Connect_(&self, dest: &AudioParam, output: u32) -> Fallible<()> {
         if self.context != dest.context() {
-            return Err(Error::InvalidAccess);
+            return Err(Error::InvalidAccess(None));
         }
 
         if output >= self.NumberOfOutputs() {

--- a/components/script/dom/audio/iirfilternode.rs
+++ b/components/script/dom/audio/iirfilternode.rs
@@ -119,7 +119,7 @@ impl IIRFilterNodeMethods<crate::DomTypeHolder> for IIRFilterNode {
     ) -> Result<(), Error> {
         let len = frequency_hz.len();
         if len != mag_response.len() || len != phase_response.len() {
-            return Err(Error::InvalidAccess);
+            return Err(Error::InvalidAccess(None));
         }
         let feedforward: Vec<f64> = (self.feedforward.iter().map(|v| **v).collect_vec()).to_vec();
         let feedback: Vec<f64> = (self.feedback.iter().map(|v| **v).collect_vec()).to_vec();

--- a/components/script/dom/bindings/constructor.rs
+++ b/components/script/dom/bindings/constructor.rs
@@ -117,7 +117,7 @@ fn html_constructor(
 
     rooted!(in(*cx) let callee = unsafe { UnwrapObjectStatic(call_args.callee()) });
     if callee.is_null() {
-        throw_dom_exception(cx, global, Error::Security, can_gc);
+        throw_dom_exception(cx, global, Error::Security(None), can_gc);
         return Err(());
     }
 

--- a/components/script/dom/bindings/domname.rs
+++ b/components/script/dom/bindings/domname.rs
@@ -191,26 +191,26 @@ pub(crate) fn validate_and_extract(
     match prefix {
         // Step 8. If prefix is non-null and namespace is null,
         //      then throw a "NamespaceError" DOMException.
-        Some(_) if namespace.is_empty() => Err(Error::Namespace),
+        Some(_) if namespace.is_empty() => Err(Error::Namespace(None)),
         // Step 9. If prefix is "xml" and namespace is not the XML namespace,
         //      then throw a "NamespaceError" DOMException.
-        Some("xml") if *namespace != *XML_NAMESPACE => Err(Error::Namespace),
+        Some("xml") if *namespace != *XML_NAMESPACE => Err(Error::Namespace(None)),
         // Step 10. If either qualifiedName or prefix is "xmlns" and namespace
         //      is not the XMLNS namespace, then throw a "NamespaceError" DOMException.
         p if (qualified_name == "xmlns" || p == Some("xmlns")) &&
             *namespace != *XMLNS_NAMESPACE =>
         {
-            Err(Error::Namespace)
+            Err(Error::Namespace(None))
         },
         Some(_) if qualified_name == "xmlns" && *namespace != *XMLNS_NAMESPACE => {
-            Err(Error::Namespace)
+            Err(Error::Namespace(None))
         },
         // Step 11. If namespace is the XMLNS namespace and neither qualifiedName
         //      nor prefix is "xmlns", then throw a "NamespaceError" DOMException.
         p if *namespace == *XMLNS_NAMESPACE &&
             (qualified_name != "xmlns" && p != Some("xmlns")) =>
         {
-            Err(Error::Namespace)
+            Err(Error::Namespace(None))
         },
         // Step 12. Return (namespace, prefix, localName).
         _ => Ok((

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -136,7 +136,10 @@ pub(crate) fn create_dom_exception(
             return new_custom_exception(DOMErrorName::NotSupportedError, custom_message);
         },
         Error::NotSupported(None) => DOMErrorName::NotSupportedError,
-        Error::InUseAttribute => DOMErrorName::InUseAttributeError,
+        Error::InUseAttribute(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::InUseAttributeError, custom_message);
+        },
+        Error::InUseAttribute(None) => DOMErrorName::InUseAttributeError,
         Error::InvalidState(Some(custom_message)) => {
             return new_custom_exception(DOMErrorName::InvalidStateError, custom_message);
         },
@@ -145,22 +148,58 @@ pub(crate) fn create_dom_exception(
             return new_custom_exception(DOMErrorName::SyntaxError, custom_message);
         },
         Error::Syntax(None) => DOMErrorName::SyntaxError,
-        Error::Namespace => DOMErrorName::NamespaceError,
-        Error::InvalidAccess => DOMErrorName::InvalidAccessError,
-        Error::Security => DOMErrorName::SecurityError,
-        Error::Network => DOMErrorName::NetworkError,
-        Error::Abort => DOMErrorName::AbortError,
-        Error::Timeout => DOMErrorName::TimeoutError,
-        Error::InvalidNodeType => DOMErrorName::InvalidNodeTypeError,
+        Error::Namespace(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::NamespaceError, custom_message);
+        },
+        Error::Namespace(None) => DOMErrorName::NamespaceError,
+        Error::InvalidAccess(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::InvalidAccessError, custom_message);
+        },
+        Error::InvalidAccess(None) => DOMErrorName::InvalidAccessError,
+        Error::Security(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::SecurityError, custom_message);
+        },
+        Error::Security(None) => DOMErrorName::SecurityError,
+        Error::Network(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::NetworkError, custom_message);
+        },
+        Error::Network(None) => DOMErrorName::NetworkError,
+        Error::Abort(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::AbortError, custom_message);
+        },
+        Error::Abort(None) => DOMErrorName::AbortError,
+        Error::Timeout(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::TimeoutError, custom_message);
+        },
+        Error::Timeout(None) => DOMErrorName::TimeoutError,
+        Error::InvalidNodeType(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::InvalidNodeTypeError, custom_message);
+        },
+        Error::InvalidNodeType(None) => DOMErrorName::InvalidNodeTypeError,
         Error::DataClone(Some(custom_message)) => {
             return new_custom_exception(DOMErrorName::DataCloneError, custom_message);
         },
         Error::DataClone(None) => DOMErrorName::DataCloneError,
-        Error::Data => DOMErrorName::DataError,
-        Error::TransactionInactive => DOMErrorName::TransactionInactiveError,
-        Error::ReadOnly => DOMErrorName::ReadOnlyError,
-        Error::Version => DOMErrorName::VersionError,
-        Error::NoModificationAllowed => DOMErrorName::NoModificationAllowedError,
+        Error::Data(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::DataError, custom_message);
+        },
+        Error::Data(None) => DOMErrorName::DataError,
+        Error::TransactionInactive(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::TransactionInactiveError, custom_message);
+        },
+        Error::TransactionInactive(None) => DOMErrorName::TransactionInactiveError,
+        Error::ReadOnly(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::ReadOnlyError, custom_message);
+        },
+        Error::ReadOnly(None) => DOMErrorName::ReadOnlyError,
+        Error::Version(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::VersionError, custom_message);
+        },
+        Error::Version(None) => DOMErrorName::VersionError,
+        Error::NoModificationAllowed(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::NoModificationAllowedError, custom_message);
+        },
+        Error::NoModificationAllowed(None) => DOMErrorName::NoModificationAllowedError,
         Error::QuotaExceeded { quota, requested } => {
             return Ok(DomRoot::upcast(QuotaExceededError::new(
                 global,
@@ -170,13 +209,34 @@ pub(crate) fn create_dom_exception(
                 can_gc,
             )));
         },
-        Error::TypeMismatch => DOMErrorName::TypeMismatchError,
-        Error::InvalidModification => DOMErrorName::InvalidModificationError,
-        Error::NotReadable => DOMErrorName::NotReadableError,
-        Error::Operation => DOMErrorName::OperationError,
-        Error::NotAllowed => DOMErrorName::NotAllowedError,
-        Error::Encoding => DOMErrorName::EncodingError,
-        Error::Constraint => DOMErrorName::ConstraintError,
+        Error::TypeMismatch(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::TypeMismatchError, custom_message);
+        },
+        Error::TypeMismatch(None) => DOMErrorName::TypeMismatchError,
+        Error::InvalidModification(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::InvalidModificationError, custom_message);
+        },
+        Error::InvalidModification(None) => DOMErrorName::InvalidModificationError,
+        Error::NotReadable(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::NotReadableError, custom_message);
+        },
+        Error::NotReadable(None) => DOMErrorName::NotReadableError,
+        Error::Operation(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::OperationError, custom_message);
+        },
+        Error::Operation(None) => DOMErrorName::OperationError,
+        Error::NotAllowed(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::NotAllowedError, custom_message);
+        },
+        Error::NotAllowed(None) => DOMErrorName::NotAllowedError,
+        Error::Encoding(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::EncodingError, custom_message);
+        },
+        Error::Encoding(None) => DOMErrorName::EncodingError,
+        Error::Constraint(Some(custom_message)) => {
+            return new_custom_exception(DOMErrorName::ConstraintError, custom_message);
+        },
+        Error::Constraint(None) => DOMErrorName::ConstraintError,
         Error::Type(message) => return Err(JsEngineError::Type(message)),
         Error::Range(message) => return Err(JsEngineError::Range(message)),
         Error::JSFailed => return Err(JsEngineError::JSFailed),

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -313,7 +313,7 @@ where
         };
         // Step 2.
         if uuid_is_blocklisted(canonicalized.as_ref(), Blocklist::All) {
-            p.reject_error(Security, can_gc);
+            p.reject_error(Security(None), can_gc);
             return p;
         }
         Some(canonicalized)
@@ -323,7 +323,7 @@ where
 
     // Step 3 - 4.
     if !connected {
-        p.reject_error(Network, can_gc);
+        p.reject_error(Network(None), can_gc);
         return p;
     }
 
@@ -378,7 +378,7 @@ fn canonicalize_filter(filter: &BluetoothLEScanFilterInit) -> Fallible<Bluetooth
 
                 // Step 3.4.
                 if uuid_is_blocklisted(uuid.as_ref(), Blocklist::All) {
-                    return Err(Security);
+                    return Err(Security(None));
                 }
 
                 services_vec.push(uuid);
@@ -472,7 +472,7 @@ fn canonicalize_filter(filter: &BluetoothLEScanFilterInit) -> Fallible<Bluetooth
 
                 // Step 9.5.
                 if uuid_is_blocklisted(service.as_ref(), Blocklist::All) {
-                    return Err(Security);
+                    return Err(Security(None));
                 }
 
                 // Step 9.6: No need to convert to IDL values since this is only used by native code.
@@ -528,10 +528,10 @@ impl Convert<Error> for BluetoothError {
     fn convert(self) -> Error {
         match self {
             BluetoothError::Type(message) => Error::Type(message),
-            BluetoothError::Network => Error::Network,
+            BluetoothError::Network => Error::Network(None),
             BluetoothError::NotFound => Error::NotFound(None),
             BluetoothError::NotSupported => Error::NotSupported(None),
-            BluetoothError::Security => Error::Security,
+            BluetoothError::Security => Error::Security(None),
             BluetoothError::InvalidState => Error::InvalidState(None),
         }
     }

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -154,13 +154,13 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
-            p.reject_error(Security, can_gc);
+            p.reject_error(Security(None), can_gc);
             return p;
         }
 
         // Step 2.
         if !self.Service().Device().get_gatt(can_gc).Connected() {
-            p.reject_error(Network, can_gc);
+            p.reject_error(Network(None), can_gc);
             return p;
         }
 
@@ -192,7 +192,7 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Writes) {
-            p.reject_error(Security, can_gc);
+            p.reject_error(Security(None), can_gc);
             return p;
         }
 
@@ -203,13 +203,13 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
         };
 
         if vec.len() > MAXIMUM_ATTRIBUTE_LENGTH {
-            p.reject_error(InvalidModification, can_gc);
+            p.reject_error(InvalidModification(None), can_gc);
             return p;
         }
 
         // Step 4.
         if !self.Service().Device().get_gatt(can_gc).Connected() {
-            p.reject_error(Network, can_gc);
+            p.reject_error(Network(None), can_gc);
             return p;
         }
 
@@ -243,13 +243,13 @@ impl BluetoothRemoteGATTCharacteristicMethods<crate::DomTypeHolder>
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
-            p.reject_error(Security, can_gc);
+            p.reject_error(Security(None), can_gc);
             return p;
         }
 
         // Step 2.
         if !self.Service().Device().get_gatt(can_gc).Connected() {
-            p.reject_error(Network, can_gc);
+            p.reject_error(Network(None), can_gc);
             return p;
         }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -102,7 +102,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Reads) {
-            p.reject_error(Security, can_gc);
+            p.reject_error(Security(None), can_gc);
             return p;
         }
 
@@ -114,7 +114,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
             .get_gatt(can_gc)
             .Connected()
         {
-            p.reject_error(Network, can_gc);
+            p.reject_error(Network(None), can_gc);
             return p;
         }
 
@@ -139,7 +139,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
 
         // Step 1.
         if uuid_is_blocklisted(&self.uuid.str(), Blocklist::Writes) {
-            p.reject_error(Security, can_gc);
+            p.reject_error(Security(None), can_gc);
             return p;
         }
 
@@ -149,7 +149,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
             ArrayBufferViewOrArrayBuffer::ArrayBuffer(ab) => ab.to_vec(),
         };
         if vec.len() > MAXIMUM_ATTRIBUTE_LENGTH {
-            p.reject_error(InvalidModification, can_gc);
+            p.reject_error(InvalidModification(None), can_gc);
             return p;
         }
 
@@ -161,7 +161,7 @@ impl BluetoothRemoteGATTDescriptorMethods<crate::DomTypeHolder> for BluetoothRem
             .get_gatt(can_gc)
             .Connected()
         {
-            p.reject_error(Network, can_gc);
+            p.reject_error(Network(None), can_gc);
             return p;
         }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -156,7 +156,7 @@ impl AsyncBluetoothListener for BluetoothRemoteGATTServer {
                     if let Err(e) = self.Device().garbage_collect_the_connection(can_gc) {
                         return promise.reject_error(e, can_gc);
                     }
-                    return promise.reject_error(Error::Network, can_gc);
+                    return promise.reject_error(Error::Network(None), can_gc);
                 }
 
                 // Step 5.2.4.

--- a/components/script/dom/canvas/2d/canvas_state.rs
+++ b/components/script/dom/canvas/2d/canvas_state.rs
@@ -1784,7 +1784,7 @@ impl CanvasState {
         }
 
         if !self.origin_is_clean() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         let (origin, size) = adjust_size_sign(Point2D::new(sx, sy), Size2D::new(sw, sh));

--- a/components/script/dom/canvas/offscreencanvas.rs
+++ b/components/script/dom/canvas/offscreencanvas.rs
@@ -408,7 +408,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
         // output bitmap's origin-clean flag is set to false, then return a
         // promise rejected with a "SecurityError" DOMException.
         if !self.origin_is_clean() {
-            promise.reject_error(Error::Security, can_gc);
+            promise.reject_error(Error::Security(None), can_gc);
             return promise;
         }
 
@@ -449,7 +449,7 @@ impl OffscreenCanvasMethods<crate::DomTypeHolder> for OffscreenCanvas {
                 if snapshot.encode_for_mime_type(&image_type, quality, &mut encoded).is_err() {
                     // Step 7.2.1. If file is null, then reject result with an
                     // "EncodingError" DOMException.
-                    promise.reject_error(Error::Encoding, CanGc::note());
+                    promise.reject_error(Error::Encoding(None), CanGc::note());
                     return;
                 };
 

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -180,7 +180,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security, can_gc);
+            p.reject_error(Error::Security(None), can_gc);
             return p;
         }
 
@@ -219,7 +219,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security, can_gc);
+            p.reject_error(Error::Security(None), can_gc);
             return p;
         }
 
@@ -302,7 +302,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security, can_gc);
+            p.reject_error(Error::Security(None), can_gc);
             return p;
         }
         // 4. Let url be settings’s creation URL.
@@ -340,7 +340,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security, can_gc);
+            p.reject_error(Error::Security(None), can_gc);
             return p;
         }
 
@@ -417,7 +417,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security, can_gc);
+            p.reject_error(Error::Security(None), can_gc);
             return p;
         }
 
@@ -467,7 +467,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security, can_gc);
+            p.reject_error(Error::Security(None), can_gc);
             return p;
         }
 
@@ -516,7 +516,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security, can_gc);
+            p.reject_error(Error::Security(None), can_gc);
             return p;
         }
 
@@ -552,7 +552,7 @@ impl CookieStoreMethods<crate::DomTypeHolder> for CookieStore {
 
         // 3. If origin is an opaque origin, then return a promise rejected with a "SecurityError" DOMException.
         if !origin.is_tuple() {
-            p.reject_error(Error::Security, can_gc);
+            p.reject_error(Error::Security(None), can_gc);
             return p;
         }
 

--- a/components/script/dom/credentialmanagement/credentialscontainer.rs
+++ b/components/script/dom/credentialmanagement/credentialscontainer.rs
@@ -56,7 +56,7 @@ impl CredentialsContainer {
         }
         // Step 5. If options.signal is aborted, then return a promise rejected with options.signal’s abort reason.
         if options.signal.as_ref().is_some_and(|s| s.aborted()) {
-            return Err(Error::Abort);
+            return Err(Error::Abort(None));
         }
         Err(Error::NotSupported(None))
     }

--- a/components/script/dom/crypto.rs
+++ b/components/script/dom/crypto.rs
@@ -56,7 +56,7 @@ impl CryptoMethods<crate::DomTypeHolder> for Crypto {
         let array_type = input.get_array_type();
 
         if !is_integer_buffer(array_type) {
-            Err(Error::TypeMismatch)
+            Err(Error::TypeMismatch(None))
         } else {
             let data = unsafe { input.as_mut_slice() };
             if data.len() > 65536 {

--- a/components/script/dom/css/css.rs
+++ b/components/script/dom/css/css.rs
@@ -109,7 +109,7 @@ impl CSSMethods<crate::DomTypeHolder> for CSS {
                 RegisterPropertyError::InitialValueNotComputationallyIndependent => {
                     Error::Syntax(None)
                 },
-                RegisterPropertyError::AlreadyRegistered => Error::InvalidModification,
+                RegisterPropertyError::AlreadyRegistered => Error::InvalidModification(None),
             })?;
 
         Ok(())

--- a/components/script/dom/css/cssstyledeclaration.rs
+++ b/components/script/dom/css/cssstyledeclaration.rs
@@ -344,7 +344,7 @@ impl CSSStyleDeclaration {
     ) -> ErrorResult {
         // Step 1. If the readonly flag is set, then throw a NoModificationAllowedError exception.
         if self.readonly {
-            return Err(Error::NoModificationAllowed);
+            return Err(Error::NoModificationAllowed(None));
         }
 
         let id = match id {
@@ -529,7 +529,7 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
     fn RemoveProperty(&self, property: DOMString, can_gc: CanGc) -> Fallible<DOMString> {
         // Step 1
         if self.readonly {
-            return Err(Error::NoModificationAllowed);
+            return Err(Error::NoModificationAllowed(None));
         }
 
         let id = match PropertyId::parse_enabled_for_all_content(&property.str()) {
@@ -601,7 +601,7 @@ impl CSSStyleDeclarationMethods<crate::DomTypeHolder> for CSSStyleDeclaration {
 
         // Step 1
         if self.readonly {
-            return Err(Error::NoModificationAllowed);
+            return Err(Error::NoModificationAllowed(None));
         }
 
         let quirks_mode = window.Document().quirks_mode();

--- a/components/script/dom/css/cssstylesheet.rs
+++ b/components/script/dom/css/cssstylesheet.rs
@@ -367,7 +367,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
     /// <https://drafts.csswg.org/cssom/#dom-cssstylesheet-cssrules>
     fn GetCssRules(&self, can_gc: CanGc) -> Fallible<DomRoot<CSSRuleList>> {
         if !self.origin_clean.get() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
         Ok(self.rulelist(can_gc))
     }
@@ -376,12 +376,12 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
     fn InsertRule(&self, rule: DOMString, index: u32, can_gc: CanGc) -> Fallible<u32> {
         // Step 1. If the origin-clean flag is unset, throw a SecurityError exception.
         if !self.origin_clean.get() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         // Step 2. If the disallow modification flag is set, throw a NotAllowedError DOMException.
         if self.disallow_modification() {
-            return Err(Error::NotAllowed);
+            return Err(Error::NotAllowed(None));
         }
 
         self.rulelist(can_gc)
@@ -392,12 +392,12 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
     fn DeleteRule(&self, index: u32, can_gc: CanGc) -> ErrorResult {
         // Step 1. If the origin-clean flag is unset, throw a SecurityError exception.
         if !self.origin_clean.get() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         // Step 2. If the disallow modification flag is set, throw a NotAllowedError DOMException.
         if self.disallow_modification() {
-            return Err(Error::NotAllowed);
+            return Err(Error::NotAllowed(None));
         }
         self.rulelist(can_gc).remove_rule(index)
     }
@@ -453,7 +453,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
         // Step 2. If the constructed flag is not set, or the disallow modification flag is set,
         // reject promise with a NotAllowedError DOMException and return promise.
         if !self.is_constructed() || self.disallow_modification() {
-            return Err(Error::NotAllowed);
+            return Err(Error::NotAllowed(None));
         }
 
         // Step 3. Set the disallow modification flag.
@@ -487,7 +487,7 @@ impl CSSStyleSheetMethods<crate::DomTypeHolder> for CSSStyleSheet {
         // Step 1. If the constructed flag is not set, or the disallow modification flag is set,
         // throw a NotAllowedError DOMException.
         if !self.is_constructed() || self.disallow_modification() {
-            return Err(Error::NotAllowed);
+            return Err(Error::NotAllowed(None));
         }
         self.do_replace_sync(text);
         Ok(())

--- a/components/script/dom/css/fontface.rs
+++ b/components/script/dom/css/fontface.rs
@@ -503,7 +503,7 @@ impl FontFaceMethods<crate::DomTypeHolder> for FontFace {
                             // [[FontStatusPromise]] with a DOMException whose name is "NetworkError"
                             // and set font face’s status attribute to "error".
                             font_face.status.set(FontFaceLoadStatus::Error);
-                            font_face.font_status_promise.reject_error(Error::Network, CanGc::note());
+                            font_face.font_status_promise.reject_error(Error::Network(None), CanGc::note());
                         }
                         Some(template) => {
                             // Step 5.2. Otherwise, font face now represents the loaded font;

--- a/components/script/dom/customelementregistry.rs
+++ b/components/script/dom/customelementregistry.rs
@@ -371,7 +371,7 @@ impl CustomElementRegistryMethods<crate::DomTypeHolder> for CustomElementRegistr
 
         if unwrapped_constructor.is_null() {
             // We do not have permission to access the unwrapped constructor.
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         if unsafe { !IsConstructor(unwrapped_constructor.get()) } {

--- a/components/script/dom/dissimilaroriginlocation.rs
+++ b/components/script/dom/dissimilaroriginlocation.rs
@@ -52,34 +52,34 @@ impl DissimilarOriginLocation {
 impl DissimilarOriginLocationMethods<crate::DomTypeHolder> for DissimilarOriginLocation {
     /// <https://html.spec.whatwg.org/multipage/#dom-location-href>
     fn GetHref(&self) -> Fallible<USVString> {
-        Err(Error::Security)
+        Err(Error::Security(None))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-location-href>
     fn SetHref(&self, _: USVString) -> ErrorResult {
         // TODO: setting href on a cross-origin window should succeed?
-        Err(Error::Security)
+        Err(Error::Security(None))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-location-assign>
     fn Assign(&self, _: USVString) -> Fallible<()> {
         // TODO: setting href on a cross-origin window should succeed?
-        Err(Error::Security)
+        Err(Error::Security(None))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-location-replace>
     fn Replace(&self, _: USVString) -> Fallible<()> {
         // TODO: replacing href on a cross-origin window should succeed?
-        Err(Error::Security)
+        Err(Error::Security(None))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-location-reload>
     fn Reload(&self) -> Fallible<()> {
-        Err(Error::Security)
+        Err(Error::Security(None))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-location-href>
     fn Stringifier(&self) -> Fallible<DOMString> {
-        Err(Error::Security)
+        Err(Error::Security(None))
     }
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -4758,7 +4758,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn SetDomain(&self, value: DOMString) -> ErrorResult {
         // Step 1.
         if !self.has_browsing_context {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         // Step 2. If this Document object's active sandboxing flag set has its sandboxed
@@ -4766,18 +4766,18 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         if self.has_active_sandboxing_flag(
             SandboxingFlagSet::SANDBOXED_DOCUMENT_DOMAIN_BROWSING_CONTEXT_FLAG,
         ) {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         // Steps 3-4.
         let effective_domain = match self.origin.effective_domain() {
             Some(effective_domain) => effective_domain,
-            None => return Err(Error::Security),
+            None => return Err(Error::Security(None)),
         };
 
         // Step 5
         let host = match get_registrable_domain_suffix_of_or_is_equal_to(&value, effective_domain) {
-            None => return Err(Error::Security),
+            None => return Err(Error::Security(None)),
             Some(host) => host,
         };
 
@@ -5540,7 +5540,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         }
 
         if !self.origin.is_tuple() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         let url = self.url();
@@ -5561,7 +5561,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         }
 
         if !self.origin.is_tuple() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         if !cookie.is_valid_for_cookie() {
@@ -5827,7 +5827,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
 
         // Step 4
         if !self.origin.same_origin(&entry_responsible_document.origin) {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         // Step 5
@@ -5937,7 +5937,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
         can_gc: CanGc,
     ) -> Fallible<Option<DomRoot<WindowProxy>>> {
         self.browsing_context()
-            .ok_or(Error::InvalidAccess)?
+            .ok_or(Error::InvalidAccess(None))?
             .open(url, target, features, can_gc)
     }
 
@@ -6018,7 +6018,7 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     fn ServoGetMediaControls(&self, id: DOMString) -> Fallible<DomRoot<ShadowRoot>> {
         match self.media_controls.borrow().get(&*id.str()) {
             Some(m) => Ok(DomRoot::from_ref(m)),
-            None => Err(Error::InvalidAccess),
+            None => Err(Error::InvalidAccess(None)),
         }
     }
 

--- a/components/script/dom/documentorshadowroot.rs
+++ b/components/script/dom/documentorshadowroot.rs
@@ -375,7 +375,7 @@ impl DocumentOrShadowRoot {
             // > If value’s constructed flag is not set, or its constructor document is not equal
             // > to this DocumentOrShadowRoot’s node document, throw a "NotAllowedError" DOMException.
             if !sheet.constructor_document_matches(owner_doc) {
-                return Err(Error::NotAllowed);
+                return Err(Error::NotAllowed(None));
             }
         }
 

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2436,7 +2436,7 @@ impl Element {
         // throw an "InUseAttributeError" DOMException.
         if let Some(owner) = attr.GetOwnerElement() {
             if &*owner != self {
-                return Err(Error::InUseAttribute);
+                return Err(Error::InUseAttribute(None));
             }
         }
 
@@ -3650,7 +3650,7 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
         let parent = match context_parent.type_id() {
             // Step 4: If parent is a Document, throw a "NoModificationAllowedError" DOMException.
-            NodeTypeId::Document(_) => return Err(Error::NoModificationAllowed),
+            NodeTypeId::Document(_) => return Err(Error::NoModificationAllowed(None)),
 
             // Step 5: If parent is a DocumentFragment, set parent to the result of
             // creating an element given this's node document, "body", and the HTML namespace.
@@ -3859,9 +3859,9 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
                 match self.upcast::<Node>().GetParentNode() {
                     // Step 3.2: If context is null or a Document, throw a "NoModificationAllowedError" DOMException.
                     Some(ref node) if node.is::<Document>() => {
-                        return Err(Error::NoModificationAllowed);
+                        return Err(Error::NoModificationAllowed(None));
                     },
-                    None => return Err(Error::NoModificationAllowed),
+                    None => return Err(Error::NoModificationAllowed(None)),
                     // Step 3.1: Set context to this's parent.
                     Some(node) => node,
                 }

--- a/components/script/dom/filereadersync.rs
+++ b/components/script/dom/filereadersync.rs
@@ -47,7 +47,7 @@ impl FileReaderSync {
     }
 
     fn get_blob_bytes(blob: &Blob) -> Result<Vec<u8>, Error> {
-        blob.get_bytes().map_err(|_| Error::NotReadable)
+        blob.get_bytes().map_err(|_| Error::NotReadable(None))
     }
 }
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -716,7 +716,7 @@ impl FileListener {
             Err(_) => match self.state.take() {
                 Some(FileListenerState::Receiving(_, target)) |
                 Some(FileListenerState::Empty(target)) => {
-                    let error = Err(Error::Network);
+                    let error = Err(Error::Network(None));
 
                     match target {
                         FileListenerTarget::Promise(trusted_promise, callback) => {

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -72,7 +72,7 @@ impl History {
 impl History {
     fn traverse_history(&self, direction: TraversalDirection) -> ErrorResult {
         if !self.window.Document().is_fully_active() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
         let msg = ScriptToConstellationMessage::TraverseHistory(direction);
         let _ = self
@@ -196,7 +196,7 @@ impl History {
 
         // Step 2
         if !document.is_fully_active() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         // TODO: Step 3 Optionally abort these steps
@@ -215,13 +215,13 @@ impl History {
                 // relative to the relevant settings object of history.
                 let Ok(url) = ServoUrl::parse_with_base(Some(&document_url), &urlstring.0) else {
                     // Step 6.2 If newURL is failure, then throw a "SecurityError" DOMException.
-                    return Err(Error::Security);
+                    return Err(Error::Security(None));
                 };
 
                 // Step 6.3 If document cannot have its URL rewritten to newURL,
                 // then throw a "SecurityError" DOMException.
                 if !Self::can_have_url_rewritten(&document_url, &url) {
-                    return Err(Error::Security);
+                    return Err(Error::Security(None));
                 }
 
                 url
@@ -335,7 +335,7 @@ impl HistoryMethods<crate::DomTypeHolder> for History {
     /// <https://html.spec.whatwg.org/multipage/#dom-history-state>
     fn GetState(&self, _cx: JSContext, mut retval: MutableHandleValue) -> Fallible<()> {
         if !self.window.Document().is_fully_active() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
         retval.set(self.state.get());
         Ok(())
@@ -344,7 +344,7 @@ impl HistoryMethods<crate::DomTypeHolder> for History {
     /// <https://html.spec.whatwg.org/multipage/#dom-history-length>
     fn GetLength(&self) -> Fallible<u32> {
         if !self.window.Document().is_fully_active() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
         let (sender, recv) = channel(self.global().time_profiler_chan().clone())
             .expect("Failed to create channel to send jsh length.");

--- a/components/script/dom/html/htmlcanvaselement.rs
+++ b/components/script/dom/html/htmlcanvaselement.rs
@@ -511,7 +511,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
         // Step 1: If this canvas element's bitmap's origin-clean flag is set to false,
         // then throw a "SecurityError" DOMException.
         if !self.origin_is_clean() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         // Step 2: If this canvas element's bitmap has no pixels (i.e. either its
@@ -562,7 +562,7 @@ impl HTMLCanvasElementMethods<crate::DomTypeHolder> for HTMLCanvasElement {
         // If this canvas element's bitmap's origin-clean flag is set to false, then throw a
         // "SecurityError" DOMException.
         if !self.origin_is_clean() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         // Step 2. Let result be null.

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -545,7 +545,7 @@ impl HTMLElementMethods<crate::DomTypeHolder> for HTMLElement {
     fn SetOuterText(&self, input: DOMString, can_gc: CanGc) -> Fallible<()> {
         // Step 1: If this's parent is null, then throw a "NoModificationAllowedError" DOMException.
         let Some(parent) = self.upcast::<Node>().GetParentNode() else {
-            return Err(Error::NoModificationAllowed);
+            return Err(Error::NoModificationAllowed(None));
         };
 
         let node = self.upcast::<Node>();

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -1192,7 +1192,7 @@ impl HTMLImageElement {
         if !self.owner_document().is_fully_active() ||
             matches!(self.current_request.borrow().state, State::Broken)
         {
-            promise.reject_error(Error::Encoding, can_gc);
+            promise.reject_error(Error::Encoding(None), can_gc);
         } else if matches!(
             self.current_request.borrow().state,
             State::CompletelyAvailable
@@ -1205,7 +1205,7 @@ impl HTMLImageElement {
             // Note: Despite being not explicitly stated in the specification but if current
             // request's state is unavailable and current URL is empty string (<img> without "src"
             // and "srcset" attributes) then reject promise with an "EncodingError" DOMException.
-            promise.reject_error(Error::Encoding, can_gc);
+            promise.reject_error(Error::Encoding(None), can_gc);
         } else {
             self.image_decode_promises.borrow_mut().push(promise);
         }
@@ -1261,7 +1261,7 @@ impl HTMLImageElement {
             .dom_manipulation_task_source()
             .queue(task!(reject_image_decode_promises: move || {
                 for trusted_promise in trusted_image_decode_promises {
-                    trusted_promise.root().reject_error(Error::Encoding, CanGc::note());
+                    trusted_promise.root().reject_error(Error::Encoding(None), CanGc::note());
                 }
             }));
     }

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -800,7 +800,7 @@ impl HTMLMediaElement {
             self.paused.set(true);
 
             // Step 2.2. Take pending play promises and let promises be the result.
-            self.take_pending_play_promises(Err(Error::Abort));
+            self.take_pending_play_promises(Err(Error::Abort(None)));
 
             // Step 2.3. Queue a media element task given the media element and the following steps:
             let this = Trusted::new(self);
@@ -1703,7 +1703,7 @@ impl HTMLMediaElement {
 
                 // Step 7.6.2. Take pending play promises and reject pending play promises with the
                 // result and an "AbortError" DOMException.
-                self.take_pending_play_promises(Err(Error::Abort));
+                self.take_pending_play_promises(Err(Error::Abort(None)));
                 self.fulfill_in_flight_play_promises(|| ());
             }
 
@@ -2233,7 +2233,7 @@ impl HTMLMediaElement {
 
                     // Step 3.2.3. Take pending play promises and reject pending play promises with
                     // the result and an "AbortError" DOMException.
-                    this.take_pending_play_promises(Err(Error::Abort));
+                    this.take_pending_play_promises(Err(Error::Abort(None)));
                     this.fulfill_in_flight_play_promises(|| ());
                 }
 

--- a/components/script/dom/indexeddb/idbcursor.rs
+++ b/components/script/dom/indexeddb/idbcursor.rs
@@ -485,7 +485,7 @@ pub(crate) fn iterate_cursor(
         // Step 13.2. Set cursor’s value to ! StructuredDeserialize(serialized, targetRealm)
         rooted!(in(*cx) let mut new_cursor_value = UndefinedValue());
         bincode::deserialize(&found_record.value)
-            .map_err(|_| Error::Data)
+            .map_err(|_| Error::Data(None))
             .and_then(|data| {
                 structuredclone::read(global, data, new_cursor_value.handle_mut(), can_gc)
             })?;

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -203,7 +203,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
 
         // Step 3
         if !upgrade_transaction.is_active() {
-            return Err(Error::TransactionInactive);
+            return Err(Error::TransactionInactive(None));
         }
 
         // Step 4
@@ -218,7 +218,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
 
         // Step 6
         if self.object_store_names.borrow().contains(&name) {
-            return Err(Error::Constraint);
+            return Err(Error::Constraint(None));
         }
 
         // Step 7
@@ -229,11 +229,11 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
             match key_path {
                 Some(StringOrStringSequence::String(path)) => {
                     if path.is_empty() {
-                        return Err(Error::InvalidAccess);
+                        return Err(Error::InvalidAccess(None));
                     }
                 },
                 Some(StringOrStringSequence::StringSequence(_)) => {
-                    return Err(Error::InvalidAccess);
+                    return Err(Error::InvalidAccess(None));
                 },
                 None => {},
             }
@@ -294,7 +294,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
 
         // Step 3
         if !transaction.is_active() {
-            return Err(Error::TransactionInactive);
+            return Err(Error::TransactionInactive(None));
         }
 
         // Step 4

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -51,7 +51,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         // Step 3: if origin is an opaque origin,
         // throw a "SecurityError" DOMException and abort these steps.
         if let ImmutableOrigin::Opaque(_) = origin.immutable() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         // Step 4: Let request be a new open request.
@@ -59,7 +59,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
 
         // Step 5: Runs in parallel
         if request.open_database(name, version).is_err() {
-            return Err(Error::Operation);
+            return Err(Error::Operation(None));
         }
 
         // Step 6
@@ -76,7 +76,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         // Step 2: if origin is an opaque origin,
         // throw a "SecurityError" DOMException and abort these steps.
         if let ImmutableOrigin::Opaque(_) = origin.immutable() {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
 
         // Step 3: Let request be a new open request
@@ -84,7 +84,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
 
         // Step 4: Runs in parallel
         if request.delete_database(name.to_string()).is_err() {
-            return Err(Error::Operation);
+            return Err(Error::Operation(None));
         }
 
         // Step 5: Return request

--- a/components/script/dom/indexeddb/idbkeyrange.rs
+++ b/components/script/dom/indexeddb/idbkeyrange.rs
@@ -121,7 +121,7 @@ impl IDBKeyRangeMethods<crate::DomTypeHolder> for IDBKeyRange {
 
         // Step 5. If lowerKey is greater than upperKey, throw a "DataError" DOMException.
         if lower_key > upper_key {
-            return Err(Error::Data);
+            return Err(Error::Data(None));
         }
 
         // Step 6. Create and return a new key range with lower bound set to lowerKey, lower open

--- a/components/script/dom/indexeddb/idbobjectstore.rs
+++ b/components/script/dom/indexeddb/idbobjectstore.rs
@@ -160,7 +160,7 @@ impl IDBObjectStore {
 
         // If transaction is not active, throw a "TransactionInactiveError" DOMException.
         if !transaction.is_active() {
-            return Err(Error::TransactionInactive);
+            return Err(Error::TransactionInactive(None));
         }
 
         Ok(())
@@ -176,7 +176,7 @@ impl IDBObjectStore {
         self.check_transaction_active()?;
 
         if let IDBTransactionMode::Readonly = transaction.get_mode() {
-            return Err(Error::ReadOnly);
+            return Err(Error::ReadOnly(None));
         }
         Ok(())
     }
@@ -202,13 +202,13 @@ impl IDBObjectStore {
 
         // Step 6: If store uses in-line keys and key was given, throw a "DataError" DOMException.
         if !key.is_undefined() && self.uses_inline_keys() {
-            return Err(Error::Data);
+            return Err(Error::Data(None));
         }
 
         // Step 7: If store uses out-of-line keys and has no key generator
         // and key was not given, throw a "DataError" DOMException.
         if !self.uses_inline_keys() && !self.has_key_generator() && key.is_undefined() {
-            return Err(Error::Data);
+            return Err(Error::Data(None));
         }
 
         // Step 8: If key was given, then: convert a value to a key with key
@@ -231,7 +231,7 @@ impl IDBObjectStore {
                     // Step 11.4.1. If store does not have a key generator, throw
                     // a "DataError" DOMException.
                     if !self.has_key_generator() {
-                        return Err(Error::Data);
+                        return Err(Error::Data(None));
                     }
                     // Step 11.4.2. Otherwise, if the steps to check that a key could
                     // be injected into a value with clone and store’s key path return
@@ -242,7 +242,7 @@ impl IDBObjectStore {
                 // Step 11.1. Rethrow any exceptions.
                 Some(extraction_result) => match extraction_result? {
                     // Step 11.2. If kpk is invalid, throw a "DataError" DOMException.
-                    ExtractionResult::Invalid => return Err(Error::Data),
+                    ExtractionResult::Invalid => return Err(Error::Data(None)),
                     // Step 11.3. If kpk is not failure, let key be kpk.
                     ExtractionResult::Key(kpk) => serialized_key = Some(kpk),
                     ExtractionResult::Failure => unreachable!(),

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -57,7 +57,7 @@ impl OpenRequestListener {
 
         // Step 7
         if request_version < db_version {
-            return (Err(Error::Version), false);
+            return (Err(Error::Version(None)), false);
         }
 
         // Step 8-9

--- a/components/script/dom/indexeddb/idbrequest.rs
+++ b/components/script/dom/indexeddb/idbrequest.rs
@@ -86,7 +86,7 @@ impl From<PutItemResult> for IdbResult {
     fn from(value: PutItemResult) -> Self {
         match value {
             PutItemResult::Success => Self::None,
-            PutItemResult::CannotOverwrite => Self::Error(Error::Constraint),
+            PutItemResult::CannotOverwrite => Self::Error(Error::Constraint(None)),
         }
     }
 }
@@ -151,7 +151,7 @@ impl RequestListener {
                 },
                 IdbResult::Value(serialized_data) => {
                     let result = bincode::deserialize(&serialized_data)
-                        .map_err(|_| Error::Data)
+                        .map_err(|_| Error::Data(None))
                         .and_then(|data| {
                             structuredclone::read(&global, data, answer.handle_mut(), can_gc)
                         });
@@ -166,7 +166,7 @@ impl RequestListener {
                     for serialized_data in serialized_values.into_iter() {
                         rooted!(in(*cx) let mut val = UndefinedValue());
                         let result = bincode::deserialize(&serialized_data)
-                            .map_err(|_| Error::Data)
+                            .map_err(|_| Error::Data(None))
                             .and_then(|data| {
                                 structuredclone::read(&global, data, val.handle_mut(), can_gc)
                             });
@@ -250,7 +250,7 @@ impl RequestListener {
         } else {
             // FIXME:(arihant2math) dispatch correct error
             // Substep 2
-            Self::handle_async_request_error(&global, cx, request, Error::Data);
+            Self::handle_async_request_error(&global, cx, request, Error::Data(None));
         }
     }
 
@@ -367,7 +367,7 @@ impl IDBRequest {
 
         // Step 2: Assert: transaction is active.
         if !transaction.is_active() {
-            return Err(Error::TransactionInactive);
+            return Err(Error::TransactionInactive(None));
         }
 
         // Step 3: If request was not given, let request be a new request with source as source.

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -151,7 +151,7 @@ impl Location {
     }
 
     /// Get this `Location` object's [relevant `Document`][1], or
-    /// `Err(Error::Security)` if it's non-null and its origin is not same
+    /// `Err(Error::Security(None))` if it's non-null and its origin is not same
     /// origin-domain with the entry setting object's origin.
     ///
     /// In the specification's terms:
@@ -190,7 +190,7 @@ impl Location {
             }) {
                 Ok(Some(document))
             } else {
-                Err(Error::Security)
+                Err(Error::Security(None))
             }
         } else {
             // The browsing context is null
@@ -199,7 +199,7 @@ impl Location {
     }
 
     /// Get this `Location` object's [relevant url][1] or
-    /// `Err(Error::Security)` if the [relevant `Document`][2] if it's non-null
+    /// `Err(Error::Security(None))` if the [relevant `Document`][2] if it's non-null
     /// and its origin is not same origin-domain with the entry setting object's
     /// origin.
     ///

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -221,7 +221,7 @@ impl Navigator {
         // Step 2. If scheme is neither a safelisted scheme nor
         // a string starting with "web+" followed by one or more ASCII lower alphas, then throw a "SecurityError" DOMException.
         if !SAFELISTED_SCHEMES.contains(&scheme.as_ref()) && !matches_web_plus_protocol(&scheme) {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
         // Step 3. If url does not contain "%s", then throw a "SyntaxError" DOMException.
         if !url.contains("%s") {
@@ -240,11 +240,11 @@ impl Navigator {
         // Step 6. If urlRecord's scheme is not an HTTP(S) scheme or urlRecord's origin
         // is not same origin with environment's origin, then throw a "SecurityError" DOMException.
         if !matches!(url.scheme(), "http" | "https") {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
         let environment_origin = environment.origin().immutable().clone();
         if url.origin() != environment_origin {
-            return Err(Error::Security);
+            return Err(Error::Security(None));
         }
         // Step 7. Assert: the result of Is url potentially trustworthy? given urlRecord is "Potentially Trustworthy".
         assert!(url.is_potentially_trustworthy());

--- a/components/script/dom/paintworkletglobalscope.rs
+++ b/components/script/dom/paintworkletglobalscope.rs
@@ -511,7 +511,7 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
 
         // Step 2-3.
         if self.paint_definitions.borrow().contains_key(&name) {
-            return Err(Error::InvalidModification);
+            return Err(Error::InvalidModification(None));
         }
 
         // Step 4-6.
@@ -550,7 +550,7 @@ impl PaintWorkletGlobalScopeMethods<crate::DomTypeHolder> for PaintWorkletGlobal
 
         // Step 19.
         let Some(context) = PaintRenderingContext2D::new(self, CanGc::note()) else {
-            return Err(Error::Operation);
+            return Err(Error::Operation(None));
         };
         let definition = PaintDefinition::new(
             paint_val.handle(),

--- a/components/script/dom/performance/performanceobserver.rs
+++ b/components/script/dom/performance/performanceobserver.rs
@@ -183,12 +183,12 @@ impl PerformanceObserverMethods<crate::DomTypeHolder> for PerformanceObserver {
             },
             ObserverType::Single => {
                 if options.entryTypes.is_some() {
-                    return Err(Error::InvalidModification);
+                    return Err(Error::InvalidModification(None));
                 }
             },
             ObserverType::Multiple => {
                 if options.type_.is_some() {
-                    return Err(Error::InvalidModification);
+                    return Err(Error::InvalidModification(None));
                 }
             },
         }

--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -256,7 +256,7 @@ impl Range {
         }
         if node.is_doctype() {
             // Step 2.
-            return Err(Error::InvalidNodeType);
+            return Err(Error::InvalidNodeType(None));
         }
         if offset > node.len() {
             // Step 3.
@@ -355,7 +355,7 @@ impl Range {
     ) -> ErrorResult {
         // Step 1. If node is a doctype, then throw an "InvalidNodeTypeError" DOMException.
         if node.is_doctype() {
-            return Err(Error::InvalidNodeType);
+            return Err(Error::InvalidNodeType(None));
         }
 
         // Step 2. If offset is greater than node’s length, then throw an "IndexSizeError" DOMException.
@@ -428,25 +428,25 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
 
     /// <https://dom.spec.whatwg.org/#dom-range-setstartbefore>
     fn SetStartBefore(&self, node: &Node) -> ErrorResult {
-        let parent = node.GetParentNode().ok_or(Error::InvalidNodeType)?;
+        let parent = node.GetParentNode().ok_or(Error::InvalidNodeType(None))?;
         self.SetStart(&parent, node.index())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-setstartafter>
     fn SetStartAfter(&self, node: &Node) -> ErrorResult {
-        let parent = node.GetParentNode().ok_or(Error::InvalidNodeType)?;
+        let parent = node.GetParentNode().ok_or(Error::InvalidNodeType(None))?;
         self.SetStart(&parent, node.index() + 1)
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-setendbefore>
     fn SetEndBefore(&self, node: &Node) -> ErrorResult {
-        let parent = node.GetParentNode().ok_or(Error::InvalidNodeType)?;
+        let parent = node.GetParentNode().ok_or(Error::InvalidNodeType(None))?;
         self.SetEnd(&parent, node.index())
     }
 
     /// <https://dom.spec.whatwg.org/#dom-range-setendafter>
     fn SetEndAfter(&self, node: &Node) -> ErrorResult {
-        let parent = node.GetParentNode().ok_or(Error::InvalidNodeType)?;
+        let parent = node.GetParentNode().ok_or(Error::InvalidNodeType(None))?;
         self.SetEnd(&parent, node.index() + 1)
     }
 
@@ -462,7 +462,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     /// <https://dom.spec.whatwg.org/#dom-range-selectnode>
     fn SelectNode(&self, node: &Node) -> ErrorResult {
         // Steps 1, 2.
-        let parent = node.GetParentNode().ok_or(Error::InvalidNodeType)?;
+        let parent = node.GetParentNode().ok_or(Error::InvalidNodeType(None))?;
         // Step 3.
         let index = node.index();
         // Step 4.
@@ -476,7 +476,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
     fn SelectNodeContents(&self, node: &Node) -> ErrorResult {
         if node.is_doctype() {
             // Step 1.
-            return Err(Error::InvalidNodeType);
+            return Err(Error::InvalidNodeType(None));
         }
         // Step 2.
         let length = node.len();
@@ -1036,7 +1036,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             NodeTypeId::Document(_) |
             NodeTypeId::DocumentType |
             NodeTypeId::DocumentFragment(_) => {
-                return Err(Error::InvalidNodeType);
+                return Err(Error::InvalidNodeType(None));
             },
             _ => (),
         }

--- a/components/script/dom/selection.rs
+++ b/components/script/dom/selection.rs
@@ -240,7 +240,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         if let Some(node) = node {
             if node.is_doctype() {
                 // w3c/selection-api#118
-                return Err(Error::InvalidNodeType);
+                return Err(Error::InvalidNodeType(None));
             }
             if offset > node.len() {
                 // Step 2
@@ -308,7 +308,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         if let Some(range) = self.range.get() {
             if node.is_doctype() {
                 // w3c/selection-api#118
-                return Err(Error::InvalidNodeType);
+                return Err(Error::InvalidNodeType(None));
             }
 
             if offset > node.len() {
@@ -382,7 +382,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
         // Step 1
         if anchor_node.is_doctype() || focus_node.is_doctype() {
             // w3c/selection-api#118
-            return Err(Error::InvalidNodeType);
+            return Err(Error::InvalidNodeType(None));
         }
 
         if anchor_offset > anchor_node.len() || focus_offset > focus_node.len() {
@@ -430,7 +430,7 @@ impl SelectionMethods<crate::DomTypeHolder> for Selection {
     fn SelectAllChildren(&self, node: &Node, can_gc: CanGc) -> ErrorResult {
         if node.is_doctype() {
             // w3c/selection-api#118
-            return Err(Error::InvalidNodeType);
+            return Err(Error::InvalidNodeType(None));
         }
         if !self.is_same_root(node) {
             return Ok(());

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -54,7 +54,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
             .send(ScriptToConstellationMessage::ReportMemory(sender))
             .is_err()
         {
-            promise.reject_error(Error::Operation, can_gc);
+            promise.reject_error(Error::Operation(None), can_gc);
         }
         promise
     }
@@ -64,7 +64,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
         if let PrefValue::Bool(b) = prefs::get().get_value(&name) {
             return Ok(b);
         }
-        Err(Error::TypeMismatch)
+        Err(Error::TypeMismatch(None))
     }
 
     /// <https://servo.org/internal-no-spec>
@@ -72,7 +72,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
         if let PrefValue::Int(i) = prefs::get().get_value(&name) {
             return Ok(i);
         }
-        Err(Error::TypeMismatch)
+        Err(Error::TypeMismatch(None))
     }
 
     /// <https://servo.org/internal-no-spec>
@@ -80,7 +80,7 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
         if let PrefValue::Str(s) = prefs::get().get_value(&name) {
             return Ok(s.into());
         }
-        Err(Error::TypeMismatch)
+        Err(Error::TypeMismatch(None))
     }
 
     /// <https://servo.org/internal-no-spec>

--- a/components/script/dom/staticrange.rs
+++ b/components/script/dom/staticrange.rs
@@ -80,13 +80,13 @@ impl StaticRangeMethods<crate::DomTypeHolder> for StaticRange {
     ) -> Fallible<DomRoot<StaticRange>> {
         match init.startContainer.type_id() {
             NodeTypeId::DocumentType | NodeTypeId::Attr => {
-                return Err(Error::InvalidNodeType);
+                return Err(Error::InvalidNodeType(None));
             },
             _ => (),
         }
         match init.endContainer.type_id() {
             NodeTypeId::DocumentType | NodeTypeId::Attr => {
-                return Err(Error::InvalidNodeType);
+                return Err(Error::InvalidNodeType(None));
             },
             _ => (),
         }

--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -310,14 +310,14 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // attribute of the [[algorithm]] internal slot of key then throw an
                 // InvalidAccessError.
                 if normalized_algorithm.name() != key.algorithm().name() {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
                 // Step 10. If the [[usages]] internal slot of key does not contain an entry that
                 // is "encrypt", then throw an InvalidAccessError.
                 if !key.usages().contains(&KeyUsage::Encrypt) {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
@@ -400,14 +400,14 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // attribute of the [[algorithm]] internal slot of key then throw an
                 // InvalidAccessError.
                 if normalized_algorithm.name() != key.algorithm().name() {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
                 // Step 10. If the [[usages]] internal slot of key does not contain an entry that
                 // is "decrypt", then throw an InvalidAccessError.
                 if !key.usages().contains(&KeyUsage::Decrypt) {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
@@ -490,14 +490,14 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // attribute of the [[algorithm]] internal slot of key then throw an
                 // InvalidAccessError.
                 if normalized_algorithm.name() != key.algorithm().name() {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
                 // Step 10. If the [[usages]] internal slot of key does not contain an entry that
                 // is "sign", then throw an InvalidAccessError.
                 if !key.usages().contains(&KeyUsage::Sign) {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
@@ -587,14 +587,14 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // attribute of the [[algorithm]] internal slot of key then throw an
                 // InvalidAccessError.
                 if normalized_algorithm.name() != key.algorithm().name() {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
                 // Step 11. If the [[usages]] internal slot of key does not contain an entry that
                 // is "verify", then throw an InvalidAccessError.
                 if !key.usages().contains(&KeyUsage::Verify) {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
@@ -867,14 +867,14 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // attribute of the [[algorithm]] internal slot of baseKey then throw an
                 // InvalidAccessError.
                 if normalized_algorithm.name() != base_key.algorithm().name() {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
                 // Step 13. If the [[usages]] internal slot of baseKey does not contain an entry
                 // that is "deriveKey", then throw an InvalidAccessError.
                 if !base_key.usages().contains(&KeyUsage::DeriveKey) {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
@@ -990,14 +990,14 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // attribute of the [[algorithm]] internal slot of baseKey then throw an
                 // InvalidAccessError.
                 if normalized_algorithm.name() != base_key.algorithm().name() {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
                 // Step 9. If the [[usages]] internal slot of baseKey does not contain an entry
                 // that is "deriveBits", then throw an InvalidAccessError.
                 if !base_key.usages().contains(&KeyUsage::DeriveBits) {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
@@ -1212,7 +1212,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 7. If the [[extractable]] internal slot of key is false, then throw an
                 // InvalidAccessError.
                 if !key.Extractable() {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
@@ -1311,14 +1311,14 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // attribute of the [[algorithm]] internal slot of wrappingKey then throw an
                 // InvalidAccessError.
                 if normalized_algorithm.name() != wrapping_key.algorithm().name() {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
                 // Step 10. If the [[usages]] internal slot of wrappingKey does not contain an
                 // entry that is "wrapKey", then throw an InvalidAccessError.
                 if !wrapping_key.usages().contains(&KeyUsage::WrapKey) {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
@@ -1337,7 +1337,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // Step 12. If the [[extractable]] internal slot of key is false, then throw an
                 // InvalidAccessError.
                 if !key.Extractable() {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
@@ -1490,14 +1490,14 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 // attribute of the [[algorithm]] internal slot of unwrappingKey then throw an
                 // InvalidAccessError.
                 if normalized_algorithm.name() != unwrapping_key.algorithm().name() {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
                 // Step 13. If the [[usages]] internal slot of unwrappingKey does not contain an
                 // entry that is "unwrapKey", then throw an InvalidAccessError.
                 if !unwrapping_key.usages().contains(&KeyUsage::UnwrapKey) {
-                    subtle.reject_promise_with_error(promise, Error::InvalidAccess);
+                    subtle.reject_promise_with_error(promise, Error::InvalidAccess(None));
                     return;
                 }
 
@@ -2123,7 +2123,7 @@ trait RsaOtherPrimesInfoExt {
 impl RsaOtherPrimesInfoExt for RsaOtherPrimesInfo {
     fn from_value(value: &serde_json::Value) -> Result<RsaOtherPrimesInfo, Error> {
         let serde_json::Value::Object(object) = value else {
-            return Err(Error::Data);
+            return Err(Error::Data(None));
         };
 
         let mut rsa_other_primes_info: RsaOtherPrimesInfo = Default::default();
@@ -2131,15 +2131,15 @@ impl RsaOtherPrimesInfoExt for RsaOtherPrimesInfo {
             match key.as_str() {
                 "r" => {
                     rsa_other_primes_info.r =
-                        Some(DOMString::from(value.as_str().ok_or(Error::Data)?))
+                        Some(DOMString::from(value.as_str().ok_or(Error::Data(None))?))
                 },
                 "d" => {
                     rsa_other_primes_info.d =
-                        Some(DOMString::from(value.as_str().ok_or(Error::Data)?))
+                        Some(DOMString::from(value.as_str().ok_or(Error::Data(None))?))
                 },
                 "t" => {
                     rsa_other_primes_info.t =
-                        Some(DOMString::from(value.as_str().ok_or(Error::Data)?))
+                        Some(DOMString::from(value.as_str().ok_or(Error::Data(None))?))
                 },
                 _ => {
                     // Additional members can be present in the JWK; if not understood by
@@ -2197,7 +2197,7 @@ impl JsonWebKeyExt for JsonWebKey {
 
         // Step 6. If the kty field of key is not defined, then throw a DataError.
         if key.kty.is_none() {
-            return Err(Error::Data);
+            return Err(Error::Data(None));
         }
 
         // Step 7. Result key.
@@ -2217,14 +2217,14 @@ impl JsonWebKeyExt for JsonWebKey {
 
     fn get_usages_from_key_ops(&self) -> Result<Vec<KeyUsage>, Error> {
         let mut usages = vec![];
-        for op in self.key_ops.as_ref().ok_or(Error::Data)? {
-            usages.push(KeyUsage::from_str(&op.str()).map_err(|_| Error::Data)?);
+        for op in self.key_ops.as_ref().ok_or(Error::Data(None))? {
+            usages.push(KeyUsage::from_str(&op.str()).map_err(|_| Error::Data(None))?);
         }
         Ok(usages)
     }
 
     fn get_rsa_other_primes_info_from_oth(&self) -> Result<&[RsaOtherPrimesInfo], Error> {
-        self.oth.as_deref().ok_or(Error::Data)
+        self.oth.as_deref().ok_or(Error::Data(None))
     }
 
     /// If the key_ops field of jwk is present, and is invalid according to the requirements of
@@ -2241,13 +2241,13 @@ impl JsonWebKeyExt for JsonWebKey {
                 .len() <
                 key_ops.len()
             {
-                return Err(Error::Data);
+                return Err(Error::Data(None));
             }
             // 2. The "use" and "key_ops" JWK members SHOULD NOT be used together; however, if both
             //    are used, the information they convey MUST be consistent.
             if let Some(ref use_) = self.use_ {
                 if key_ops.iter().any(|op| op != use_) {
-                    return Err(Error::Data);
+                    return Err(Error::Data(None));
                 }
             }
 
@@ -2257,7 +2257,7 @@ impl JsonWebKeyExt for JsonWebKey {
                 .iter()
                 .all(|specified_usage| key_ops_as_usages.contains(specified_usage))
             {
-                return Err(Error::Data);
+                return Err(Error::Data(None));
             }
         }
 

--- a/components/script/dom/subtlecrypto/hkdf_operation.rs
+++ b/components/script/dom/subtlecrypto/hkdf_operation.rs
@@ -26,15 +26,15 @@ pub(crate) fn derive_bits(
 ) -> Result<Vec<u8>, Error> {
     // Step 1. If length is null or is not a multiple of 8, then throw an OperationError.
     let Some(length) = length else {
-        return Err(Error::Operation);
+        return Err(Error::Operation(None));
     };
     if length % 8 != 0 {
-        return Err(Error::Operation);
+        return Err(Error::Operation(None));
     };
 
     // Step 2. Let keyDerivationKey be the secret represented by the [[handle]] internal slot of key.
     let Handle::HkdfSecret(key_derivation_key) = key.handle() else {
-        return Err(Error::Operation);
+        return Err(Error::Operation(None));
     };
 
     // Step 3. Let result be the result of performing the HKDF extract and then the HKDF expand
@@ -49,17 +49,17 @@ pub(crate) fn derive_bits(
     match normalized_algorithm.hash.name.as_str() {
         ALG_SHA1 => Hkdf::<Sha1>::new(Some(&normalized_algorithm.salt), key_derivation_key)
             .expand(&normalized_algorithm.info, &mut result)
-            .map_err(|_| Error::Operation)?,
+            .map_err(|_| Error::Operation(None))?,
         ALG_SHA256 => Hkdf::<Sha256>::new(Some(&normalized_algorithm.salt), key_derivation_key)
             .expand(&normalized_algorithm.info, &mut result)
-            .map_err(|_| Error::Operation)?,
+            .map_err(|_| Error::Operation(None))?,
         ALG_SHA384 => Hkdf::<Sha384>::new(Some(&normalized_algorithm.salt), key_derivation_key)
             .expand(&normalized_algorithm.info, &mut result)
-            .map_err(|_| Error::Operation)?,
+            .map_err(|_| Error::Operation(None))?,
         ALG_SHA512 => Hkdf::<Sha512>::new(Some(&normalized_algorithm.salt), key_derivation_key)
             .expand(&normalized_algorithm.info, &mut result)
-            .map_err(|_| Error::Operation)?,
-        _ => return Err(Error::Operation),
+            .map_err(|_| Error::Operation(None))?,
+        _ => return Err(Error::Operation(None)),
     }
 
     // Step 5. Return result.

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -100,7 +100,7 @@ pub(crate) fn generate_key(
         // Otherwise:
         _ => {
             // throw an OperationError.
-            return Err(Error::Operation);
+            return Err(Error::Operation(None));
         },
     };
 
@@ -190,7 +190,7 @@ pub(crate) fn import_key(
 
             // Step 2.2. If the kty field of jwk is not "oct", then throw a DataError.
             if jwk.kty.as_ref().is_none_or(|kty| kty != "oct") {
-                return Err(Error::Data);
+                return Err(Error::Data(None));
             }
 
             // Step 2.3. If jwk does not meet the requirements of Section 6.4 of JSON Web
@@ -198,8 +198,8 @@ pub(crate) fn import_key(
             // NOTE: Done by Step 2.4 and 2.6.
 
             // Step 2.4. Let data be the byte sequence obtained by decoding the k field of jwk.
-            data = Base64UrlUnpadded::decode_vec(&jwk.k.as_ref().ok_or(Error::Data)?.str())
-                .map_err(|_| Error::Data)?;
+            data = Base64UrlUnpadded::decode_vec(&jwk.k.as_ref().ok_or(Error::Data(None))?.str())
+                .map_err(|_| Error::Data(None))?;
 
             // Step 2.5. Set the hash to equal the hash member of normalizedAlgorithm.
             hash = normalized_algorithm.hash.clone();
@@ -210,28 +210,28 @@ pub(crate) fn import_key(
                 ALG_SHA1 => {
                     // If the alg field of jwk is present and is not "HS1", then throw a DataError.
                     if jwk.alg.as_ref().is_some_and(|alg| alg != "HS1") {
-                        return Err(Error::Data);
+                        return Err(Error::Data(None));
                     }
                 },
                 // If the name attribute of hash is "SHA-256":
                 ALG_SHA256 => {
                     // If the alg field of jwk is present and is not "HS256", then throw a DataError.
                     if jwk.alg.as_ref().is_some_and(|alg| alg != "HS256") {
-                        return Err(Error::Data);
+                        return Err(Error::Data(None));
                     }
                 },
                 // If the name attribute of hash is "SHA-384":
                 ALG_SHA384 => {
                     // If the alg field of jwk is present and is not "HS384", then throw a DataError.
                     if jwk.alg.as_ref().is_some_and(|alg| alg != "HS384") {
-                        return Err(Error::Data);
+                        return Err(Error::Data(None));
                     }
                 },
                 // If the name attribute of hash is "SHA-512":
                 ALG_SHA512 => {
                     // If the alg field of jwk is present and is not "HS512", then throw a DataError.
                     if jwk.alg.as_ref().is_some_and(|alg| alg != "HS512") {
-                        return Err(Error::Data);
+                        return Err(Error::Data(None));
                     }
                 },
                 // Otherwise,
@@ -247,7 +247,7 @@ pub(crate) fn import_key(
             // Step 2.7. If usages is non-empty and the use field of jwk is present and is not
             // "sig", then throw a DataError.
             if !usages.is_empty() && jwk.use_.as_ref().is_some_and(|use_| use_ != "sig") {
-                return Err(Error::Data);
+                return Err(Error::Data(None));
             }
 
             // Step 2.8. If the key_ops field of jwk is present, and is invalid according to
@@ -258,7 +258,7 @@ pub(crate) fn import_key(
             // Step 2.9. If the ext field of jwk is present and has the value false and
             // extractable is true, then throw a DataError.
             if jwk.ext.is_some_and(|ext| !ext) && extractable {
-                return Err(Error::Data);
+                return Err(Error::Data(None));
             }
         },
         // Otherwise:
@@ -273,7 +273,7 @@ pub(crate) fn import_key(
 
     // Step 6. If length is zero then throw a DataError.
     if length == 0 {
-        return Err(Error::Data);
+        return Err(Error::Data(None));
     }
 
     // Step 7. If the length member of normalizedAlgorithm is present:
@@ -281,7 +281,7 @@ pub(crate) fn import_key(
         //  If the length member of normalizedAlgorithm is greater than length:
         if given_length > length {
             // throw a DataError.
-            return Err(Error::Data);
+            return Err(Error::Data(None));
         }
         // Otherwise:
         else {
@@ -324,7 +324,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
     match format {
         KeyFormat::Raw => match key.handle() {
             Handle::Hmac(key_data) => Ok(ExportedKey::Raw(key_data.as_slice().to_vec())),
-            _ => Err(Error::Operation),
+            _ => Err(Error::Operation(None)),
         },
         KeyFormat::Jwk => {
             let key_data = key.handle().as_bytes();

--- a/components/script/dom/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/subtlecrypto/pbkdf2_operation.rs
@@ -26,15 +26,15 @@ pub(crate) fn derive_bits(
 ) -> Result<Vec<u8>, Error> {
     // Step 1. If length is null or is not a multiple of 8, then throw an OperationError.
     let Some(length) = length else {
-        return Err(Error::Operation);
+        return Err(Error::Operation(None));
     };
     if length % 8 != 0 {
-        return Err(Error::Operation);
+        return Err(Error::Operation(None));
     };
 
     // Step 2. If the iterations member of normalizedAlgorithm is zero, then throw an OperationError.
     let Ok(iterations) = NonZero::<u32>::try_from(normalized_algorithm.iterations) else {
-        return Err(Error::Operation);
+        return Err(Error::Operation(None));
     };
 
     // Step 3. If length is zero, return an empty byte sequence.

--- a/components/script/dom/webgl/webglrenderingcontext.rs
+++ b/components/script/dom/webgl/webglrenderingcontext.rs
@@ -653,7 +653,7 @@ impl WebGLRenderingContext {
         Ok(Some(match source {
             TexImageSource::ImageBitmap(bitmap) => {
                 if !bitmap.origin_is_clean() {
-                    return Err(Error::Security);
+                    return Err(Error::Security(None));
                 }
 
                 let Some(snapshot) = bitmap.bitmap_data().clone() else {
@@ -704,7 +704,7 @@ impl WebGLRenderingContext {
                     },
                 };
                 if !image.same_origin(document.origin()) {
-                    return Err(Error::Security);
+                    return Err(Error::Security(None));
                 }
 
                 // Vector images are not currently supported here and there are
@@ -737,7 +737,7 @@ impl WebGLRenderingContext {
             // WebGLContext (probably via GetPixels()).
             TexImageSource::HTMLCanvasElement(canvas) => {
                 if !canvas.origin_is_clean() {
-                    return Err(Error::Security);
+                    return Err(Error::Security(None));
                 }
 
                 let Some(snapshot) = canvas.get_image_data() else {
@@ -764,7 +764,7 @@ impl WebGLRenderingContext {
             },
             TexImageSource::HTMLVideoElement(video) => {
                 if !video.origin_is_clean() {
-                    return Err(Error::Security);
+                    return Err(Error::Security(None));
                 }
 
                 let Some(snapshot) = video.get_current_frame_data() else {

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -79,7 +79,7 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
             ))
             .is_err()
         {
-            promise.reject_error(Error::Operation, can_gc);
+            promise.reject_error(Error::Operation(None), can_gc);
         }
         promise
     }

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -215,7 +215,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             for (limit, value) in (*limits).iter() {
                 if !set_limit(&mut required_limits, &limit.str(), *value) {
                     warn!("Unknown GPUDevice limit: {limit}");
-                    promise.reject_error(Error::Operation, can_gc);
+                    promise.reject_error(Error::Operation(None), can_gc);
                     return promise;
                 }
             }
@@ -244,7 +244,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             })
             .is_err()
         {
-            promise.reject_error(Error::Operation, can_gc);
+            promise.reject_error(Error::Operation(None), can_gc);
         }
         // Step 5
         promise
@@ -305,7 +305,7 @@ impl RoutedPromiseListener<WebGPUDeviceResponse> for GPUAdapter {
                     "{}",
                     wgpu_core::instance::RequestDeviceError::LimitsExceeded(l)
                 );
-                promise.reject_error(Error::Operation, can_gc)
+                promise.reject_error(Error::Operation(None), can_gc)
             },
             // 3. user agent otherwise cannot fulfill the request
             (device_id, queue_id, Err(RequestDeviceError::Other(e))) => {

--- a/components/script/dom/webgpu/gpudevice.rs
+++ b/components/script/dom/webgpu/gpudevice.rs
@@ -639,7 +639,7 @@ impl RoutedPromiseListener<WebGPUPoppedErrorScopeResponse> for GPUDevice {
             Ok(None) | Err(PopError::Lost) => {
                 promise.resolve_native(&None::<Option<GPUError>>, can_gc)
             },
-            Err(PopError::Empty) => promise.reject_error(Error::Operation, can_gc),
+            Err(PopError::Empty) => promise.reject_error(Error::Operation(None), can_gc),
             Ok(Some(error)) => {
                 let error = GPUError::from_error(&self.global(), error, can_gc);
                 promise.resolve_native(&error, can_gc);

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -124,14 +124,14 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
         } else {
             (data_size as GPUSize64)
                 .checked_sub(data_offset)
-                .ok_or(Error::Operation)?
+                .ok_or(Error::Operation(None))?
         };
 
         // Step 4
         let valid = data_offset + content_size <= data_size as u64 &&
             content_size * sizeof_element as u64 % wgpu_types::COPY_BUFFER_ALIGNMENT == 0;
         if !valid {
-            return Err(Error::Operation);
+            return Err(Error::Operation(None));
         }
 
         // Step 5&6
@@ -147,7 +147,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
             data: contents,
         }) {
             warn!("Failed to send WriteBuffer({:?}) ({})", buffer.id(), e);
-            return Err(Error::Operation);
+            return Err(Error::Operation(None));
         }
 
         Ok(())
@@ -168,7 +168,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
         let valid = data_layout.offset <= len;
 
         if !valid {
-            return Err(Error::Operation);
+            return Err(Error::Operation(None));
         }
 
         let texture_cv = destination.try_convert()?;
@@ -189,7 +189,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
                 destination.texture.id().0,
                 e
             );
-            return Err(Error::Operation);
+            return Err(Error::Operation(None));
         }
 
         Ok(())

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -449,7 +449,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
         if let Some(code) = code {
             // Fail if the supplied code isn't normal and isn't reserved for libraries, frameworks, and applications
             if code != close_code::NORMAL && !(3000..=4999).contains(&code) {
-                return Err(Error::InvalidAccess);
+                return Err(Error::InvalidAccess(None));
             }
         }
         if let Some(ref reason) = reason {

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -172,7 +172,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
                         "The dom.webxr.unsafe-assume-user-intent preference assumes user intent to enter WebXR."
                     );
                 } else {
-                    promise.reject_error(Error::Security, can_gc);
+                    promise.reject_error(Error::Security(None), can_gc);
                     return promise;
                 }
             }

--- a/components/script/dom/webxr/xrwebgllayer.rs
+++ b/components/script/dom/webxr/xrwebgllayer.rs
@@ -258,9 +258,9 @@ impl XRWebGLLayerMethods<crate::DomTypeHolder> for XRWebGLLayer {
             // Step 9.2. "Initialize layer’s framebuffer to a new opaque framebuffer created with context."
             let size = session
                 .with_session(|session| session.recommended_framebuffer_resolution())
-                .ok_or(Error::Operation)?;
+                .ok_or(Error::Operation(None))?;
             let framebuffer = WebGLFramebuffer::maybe_new_webxr(session, &context, size, can_gc)
-                .ok_or(Error::Operation)?;
+                .ok_or(Error::Operation(None))?;
 
             // Step 9.3. "Allocate and initialize resources compatible with session’s XR device,
             // including GPU accessible memory buffers, as required to support the compositing of layer."
@@ -268,7 +268,7 @@ impl XRWebGLLayerMethods<crate::DomTypeHolder> for XRWebGLLayer {
             let layer_init: LayerInit = init.convert();
             let layer_id = session
                 .with_session(|session| session.create_layer(context_id, layer_init))
-                .map_err(|_| Error::Operation)?;
+                .map_err(|_| Error::Operation(None))?;
 
             // Step 9.4: "If layer’s resources were unable to be created for any reason,
             // throw an OperationError and abort these steps."

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -1253,7 +1253,7 @@ impl Drop for WindowProxyHandler {
 fn throw_security_error(cx: SafeJSContext, realm: InRealm) -> bool {
     if !unsafe { JS_IsExceptionPending(*cx) } {
         let global = unsafe { GlobalScope::from_context(*cx, realm) };
-        throw_dom_exception(cx, &global, Error::Security, CanGc::note());
+        throw_dom_exception(cx, &global, Error::Security(None), CanGc::note());
     }
     false
 }

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -216,7 +216,7 @@ impl RegisterJobResultHandler {
                                 );
                             },
                             JobError::SecurityError => {
-                                promise.reject_error(Error::Security, CanGc::note());
+                                promise.reject_error(Error::Security(None), CanGc::note());
                             },
                         }
 

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -704,12 +704,12 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
                 },
                 can_gc,
             ) {
-                Err(_) => return Err(Error::Network),
+                Err(_) => return Err(Error::Network(None)),
                 Ok((metadata, bytes)) => {
                     // https://html.spec.whatwg.org/multipage/#fetch-a-classic-worker-imported-script
                     // Step 7: Check if response status is not an ok status
                     if !metadata.status.is_success() {
-                        return Err(Error::Network);
+                        return Err(Error::Network(None));
                     }
 
                     // Step 7: Check if the MIME type is not a JavaScript MIME type
@@ -719,7 +719,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
                             SCRIPT_JS_MIMES.contains(&mime.essence_str())
                         });
                     if not_a_javascript_mime_type {
-                        return Err(Error::Network);
+                        return Err(Error::Network(None));
                     }
 
                     (metadata.final_url, String::from_utf8(bytes).unwrap())

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -712,7 +712,7 @@ impl WorkletThread {
             debug!("Failed to load script.");
             let old_counter = pending_tasks_struct.set_counter_to(-1);
             if old_counter > 0 {
-                self.run_in_script_thread(promise.reject_task(Error::Abort));
+                self.run_in_script_thread(promise.reject_task(Error::Abort(None)));
             }
         } else {
             // Step 5.

--- a/components/script/dom/xpathexpression.rs
+++ b/components/script/dom/xpathexpression.rs
@@ -80,7 +80,7 @@ impl XPathExpression {
             &self.parsed_expression,
             DomRoot::from_ref(context_node).into(),
         )
-        .map_err(|_| Error::Operation)?;
+        .map_err(|_| Error::Operation(None))?;
 
         // Cast the result to the type we wanted
         let result_value: Value = match result_type {

--- a/components/script/indexed_db.rs
+++ b/components/script/indexed_db.rs
@@ -145,7 +145,7 @@ impl ConversionResult {
     pub fn into_result(self) -> Result<IndexedDBKeyType, Error> {
         match self {
             ConversionResult::Valid(key) => Ok(key),
-            ConversionResult::Invalid => Err(Error::Data),
+            ConversionResult::Invalid => Err(Error::Data(None)),
         }
     }
 }
@@ -198,7 +198,7 @@ pub fn convert_value_to_key(
                     return Err(Error::JSFailed);
                 }
                 if f.is_nan() {
-                    return Err(Error::Data);
+                    return Err(Error::Data(None));
                 }
                 return Ok(ConversionResult::Valid(IndexedDBKeyType::Date(f)));
             }
@@ -280,7 +280,7 @@ pub fn convert_value_to_key_range(
     // disallowed flag is set, or return an unbounded key range otherwise.
     if input.get().is_undefined() || input.get().is_null() {
         if null_disallowed.is_some_and(|flag| flag) {
-            return Err(Error::Data);
+            return Err(Error::Data(None));
         } else {
             return Ok(IndexedDBKeyRange {
                 lower: None,

--- a/components/script/xpath.rs
+++ b/components/script/xpath.rs
@@ -311,7 +311,7 @@ pub(crate) fn parse_expression(
 ) -> Fallible<xpath::Expression> {
     xpath::parse(expression, resolver.map(XPathWrapper), is_in_html_document).map_err(|error| {
         match error {
-            xpath::ParserError::FailedToResolveNamespacePrefix => Error::Namespace,
+            xpath::ParserError::FailedToResolveNamespacePrefix => Error::Namespace(None),
             _ => Error::Syntax(Some(format!("Failed to parse XPath expression: {error:?}"))),
         }
     })

--- a/components/script_bindings/error.rs
+++ b/components/script_bindings/error.rs
@@ -26,56 +26,56 @@ pub enum Error {
     /// NotSupportedError DOMException
     NotSupported(Option<String>),
     /// InUseAttributeError DOMException
-    InUseAttribute,
+    InUseAttribute(Option<String>),
     /// InvalidStateError DOMException
     InvalidState(Option<String>),
     /// SyntaxError DOMException
     Syntax(Option<String>),
     /// NamespaceError DOMException
-    Namespace,
+    Namespace(Option<String>),
     /// InvalidAccessError DOMException
-    InvalidAccess,
+    InvalidAccess(Option<String>),
     /// SecurityError DOMException
-    Security,
+    Security(Option<String>),
     /// NetworkError DOMException
-    Network,
+    Network(Option<String>),
     /// AbortError DOMException
-    Abort,
+    Abort(Option<String>),
     /// TimeoutError DOMException
-    Timeout,
+    Timeout(Option<String>),
     /// InvalidNodeTypeError DOMException
-    InvalidNodeType,
+    InvalidNodeType(Option<String>),
     /// DataCloneError DOMException
     DataClone(Option<String>),
     /// TransactionInactiveError DOMException
-    TransactionInactive,
+    TransactionInactive(Option<String>),
     /// ReadOnlyError DOMException
-    ReadOnly,
+    ReadOnly(Option<String>),
     /// VersionError DOMException
-    Version,
+    Version(Option<String>),
     /// NoModificationAllowedError DOMException
-    NoModificationAllowed,
+    NoModificationAllowed(Option<String>),
     /// QuotaExceededError DOMException
     QuotaExceeded {
         quota: Option<Finite<f64>>,
         requested: Option<Finite<f64>>,
     },
     /// TypeMismatchError DOMException
-    TypeMismatch,
+    TypeMismatch(Option<String>),
     /// InvalidModificationError DOMException
-    InvalidModification,
+    InvalidModification(Option<String>),
     /// NotReadableError DOMException
-    NotReadable,
+    NotReadable(Option<String>),
     /// DataError DOMException
-    Data,
+    Data(Option<String>),
     /// OperationError DOMException
-    Operation,
+    Operation(Option<String>),
     /// NotAllowedError DOMException
-    NotAllowed,
+    NotAllowed(Option<String>),
     /// EncodingError DOMException
-    Encoding,
+    Encoding(Option<String>),
     /// ConstraintError DOMException
-    Constraint,
+    Constraint(Option<String>),
 
     /// TypeError JavaScript Error
     Type(String),

--- a/components/script_bindings/proxyhandler.rs
+++ b/components/script_bindings/proxyhandler.rs
@@ -529,7 +529,12 @@ pub(crate) fn report_cross_origin_denial<D: DomTypes>(
         if !JS_IsExceptionPending(*cx) {
             let global = D::GlobalScope::from_context(*cx, InRealm::Already(&in_realm_proof));
             // TODO: include `id` and `access` in the exception message
-            <D as DomHelpers<D>>::throw_dom_exception(cx, &global, Error::Security, CanGc::note());
+            <D as DomHelpers<D>>::throw_dom_exception(
+                cx,
+                &global,
+                Error::Security(None),
+                CanGc::note(),
+            );
         }
     }
     false


### PR DESCRIPTION
I used find and replace to finish the job. All this PR does is replace all `Error::<error_name>` occurrences with `Error::<error_name>(None)`. 

Testing: Refactor
Fixes: #39053
