### PR TITLE
mach: Normalize the `--profile` argument to build commands

### DIFF
--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -94,6 +94,14 @@ class BuildType:
     def as_cargo_arg(self) -> List[str]:
         return ["--profile", self.profile]
 
+    def from_string(profile: str) -> BuildType:
+        if profile == "dev":
+            return BuildType.dev()
+        elif profile == "release":
+            return BuildType.release()
+        else:
+            return BuildType.custom(profile)
+
     def __eq__(self, other: object) -> bool:
         raise Exception("BUG: do not compare BuildType with ==")
 
@@ -773,7 +781,7 @@ class CommandBase(object):
         elif prod:
             return BuildType.prod()
         else:
-            return BuildType.custom(profile)
+            return BuildType.from_string(profile)
 
     def configure_build_target(self, kwargs: dict[str, Any], suppress_log: bool = False) -> None:
         if hasattr(self.context, "target"):


### PR DESCRIPTION
The current logic treats the explict version of release and dev build specification i.e the `--profile release` and `--profile dev` options as custom profiles. This breaks other logic that explictly check for release and dev profile types, like the android build.

Normalize the `--profile` argument so that the strings `release` and `dev` are treated correctly as `BuildType.Kind.RELEASE` and `BuildType.Kind.DEV` respectively.

Fixes: #40752

Testing: Tested manually that building android with `--profile release` creates the correct directory structure.