### PR TITLE
compositing: Do not set scroll offsets of zero when restoring scroll offsets in new display lists

### DIFF
--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -687,7 +687,10 @@ impl Painter {
                     else {
                         continue;
                     };
-
+                    // Skip scroll offsets that are zero, as they are the default.
+                    if offset == LayoutVector2D::zero() {
+                        continue;
+                    }
                     transaction.set_scroll_offsets(
                         external_id,
                         vec![SampledScrollOffset {


### PR DESCRIPTION
This results in a significant reduction in the number of `FrameMsg::SetScrollOffsets`, which in turn greatly reduces the number of `set_scroll_offsets` calls in the WebRender backend. This is beneficial for performance.

Testing: This is an attempt to increase performance, so is covered by existing tests.