### PR TITLE
devtools: Support reloading tab

### DIFF
--- a/components/script/devtools.rs
+++ b/components/script/devtools.rs
@@ -577,12 +577,6 @@ pub(crate) fn handle_request_animation_frame(
     }
 }
 
-pub(crate) fn handle_reload(documents: &DocumentCollection, id: PipelineId, can_gc: CanGc) {
-    if let Some(win) = documents.find_window(id) {
-        win.Location().reload_without_origin_check(can_gc);
-    }
-}
-
 pub(crate) fn handle_get_css_database(reply: IpcSender<HashMap<String, CssDatabaseProperty>>) {
     let database: HashMap<_, _> = ENABLED_LONGHAND_PROPERTIES
         .iter()

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -2066,7 +2066,7 @@ impl ScriptThread {
             DevtoolScriptControlMsg::RequestAnimationFrame(id, name) => {
                 devtools::handle_request_animation_frame(&documents, id, name)
             },
-            DevtoolScriptControlMsg::Reload(id) => devtools::handle_reload(&documents, id, can_gc),
+            DevtoolScriptControlMsg::Reload(id) => self.handle_reload(id, can_gc),
             DevtoolScriptControlMsg::GetCssDatabase(reply) => {
                 devtools::handle_get_css_database(reply)
             },


### PR DESCRIPTION
Allows to use the reload button from the top bar of `about:debugging`.

<img width="971" height="43" alt="Top bar of about:debugging showing the tab, title, buttons for back, forward and reload and url bar" src="https://github.com/user-attachments/assets/5496fcf1-5ee3-41cc-8fdb-53aad020ea96" />

Testing: Manual testing.
