### PR TITLE
script: Don't crash when encountering unexpected node types in `Range::createContextualFragment`

### DIFF
--- a/components/script/dom/range.rs
+++ b/components/script/dom/range.rs
@@ -1120,6 +1120,7 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
         // Required to obtain the global, so we do this first. Shouldn't be an
         // observable difference.
         let node = self.start_container();
+
         // Step 1. Let compliantString be the result of invoking the
         // Get Trusted Type compliant string algorithm with TrustedHTML,
         // this's relevant global object, string, "Range createContextualFragment", and "script".
@@ -1129,18 +1130,17 @@ impl RangeMethods<crate::DomTypeHolder> for Range {
             "Range createContextualFragment",
             can_gc,
         )?;
+
         let owner_doc = node.owner_doc();
+
+        // Step 3. Let element be null.
+        // Step 4. If node implements Element, set element to node.
+        // Step 5. Otherwise, if node implements Text or Comment, set element to node's parent element.
         let element = match node.type_id() {
-            // Step 3. Let element be null.
-            NodeTypeId::Document(_) | NodeTypeId::DocumentFragment(_) => None,
-            // Step 4. If node implements Element, set element to node.
             NodeTypeId::Element(_) => Some(DomRoot::downcast::<Element>(node).unwrap()),
-            // Step 5. Otherwise, if node implements Text or Comment, set element to node's parent element.
             NodeTypeId::CharacterData(CharacterDataTypeId::Comment) |
             NodeTypeId::CharacterData(CharacterDataTypeId::Text(_)) => node.GetParentElement(),
-            NodeTypeId::CharacterData(CharacterDataTypeId::ProcessingInstruction) |
-            NodeTypeId::DocumentType => unreachable!(),
-            NodeTypeId::Attr => unreachable!(),
+            _ => None,
         };
 
         // Step 6. If element is null or all of the following are true:

--- a/tests/wpt/tests/html/syntax/serializing-html-fragments/range-on-pi-contextual-fragment-crash.html
+++ b/tests/wpt/tests/html/syntax/serializing-html-fragments/range-on-pi-contextual-fragment-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<head>
+    <title>createContextualFragment should not crash when the end node is a processing instruction</title>
+    <link rel="author" title="Simon Wülker" href="mailto:simon.wuelker@arcor.de">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-range-createcontextualfragment">
+    <link rel="help" href="https://github.com/servo/servo/issues/40719">
+</head>
+<body>
+    <script>
+      let pi =
+          document.createProcessingInstruction("xml-stylesheet",
+					   'href="mycss.css" type="text/css"');
+      let range = document.createRange();
+      range.setEnd(pi, 0)
+      range.createContextualFragment("<div>A</div>");
+    </script>
+</body>

--- a/tests/wpt/tests/html/syntax/serializing-html-fragments/range-on-pi-contextual-fragment-crash.html
+++ b/tests/wpt/tests/html/syntax/serializing-html-fragments/range-on-pi-contextual-fragment-crash.html
@@ -7,9 +7,7 @@
 </head>
 <body>
     <script>
-      let pi =
-          document.createProcessingInstruction("xml-stylesheet",
-					   'href="mycss.css" type="text/css"');
+      let pi = document.createProcessingInstruction("xml-stylesheet", 'href="mycss.css" type="text/css"');
       let range = document.createRange();
       range.setEnd(pi, 0)
       range.createContextualFragment("<div>A</div>");


### PR DESCRIPTION
The spec says that all node types other than element, text and comment should be treated as `None`. We were panicking on a few instead. 

Testing: This change adds a simple crashtest
Fixes: https://github.com/servo/servo/issues/40719
