### PR TITLE
Prefer log over (e)println!

### DIFF
--- a/components/compositing/compositor.rs
+++ b/components/compositing/compositor.rs
@@ -675,11 +675,11 @@ impl IOCompositor {
             .find(|val| create_dir_all(val).is_ok());
 
         let Some(capture_path) = available_path else {
-            eprintln!("Couldn't create a path for WebRender captures.");
+            log::error!("Couldn't create a path for WebRender captures.");
             return;
         };
 
-        println!("Saving WebRender capture to {capture_path:?}");
+        log::info!("Saving WebRender capture to {capture_path:?}");
         self.painter()
             .webrender_api
             .save_capture(capture_path.clone(), CaptureBits::all());

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -2752,7 +2752,7 @@ where
         if self.hard_fail {
             // It's quite difficult to make Servo exit cleanly if some threads have failed.
             // Hard fail exists for test runners so we crash and that's good enough.
-            println!("Pipeline failed in hard-fail mode.  Crashing!");
+            error!("Pipeline failed in hard-fail mode.  Crashing!");
             process::exit(1);
         }
 

--- a/components/script/dom/bindings/error.rs
+++ b/components/script/dom/bindings/error.rs
@@ -405,9 +405,9 @@ fn report_error(
         LAST_EXCEPTION_BACKTRACE.with(|backtrace| {
             if let Some((js_backtrace, rust_backtrace)) = backtrace.borrow_mut().take() {
                 if let Some(stack) = js_backtrace {
-                    eprintln!("JS backtrace:\n{}", stack);
+                    error!("JS backtrace:\n{}", stack);
                 }
-                eprintln!("Rust backtrace:\n{}", rust_backtrace);
+                error!("Rust backtrace:\n{}", rust_backtrace);
             }
         });
     }

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -1131,7 +1131,7 @@ impl HTMLFormElement {
 
         for elem in unhandled_invalid_controls {
             if let Some(validatable) = elem.as_maybe_validatable() {
-                println!("Validation error: {}", validatable.validation_message());
+                error!("Validation error: {}", validatable.validation_message());
             }
             if first {
                 if let Some(html_elem) = elem.downcast::<HTMLElement>() {

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -377,7 +377,7 @@ impl ServiceWorkerGlobalScope {
                     CanGc::note(),
                 ) {
                     Err(_) => {
-                        println!("error loading script {}", serialized_worker_url);
+                        error!("error loading script {}", serialized_worker_url);
                         worker_scope.clear_js_runtime();
                         return;
                     },

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -746,9 +746,9 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
                     if self.is_closing() {
                         // Don't return JSFailed as we might not have
                         // any pending exceptions.
-                        println!("evaluate_script failed (terminated)");
+                        error!("evaluate_script failed (terminated)");
                     } else {
-                        println!("evaluate_script failed");
+                        error!("evaluate_script failed");
                         return Err(Error::JSFailed);
                     }
                 },

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -158,7 +158,7 @@ mod media_platform {
             ) {
                 Ok(b) => b,
                 Err(e) => {
-                    eprintln!("Error initializing GStreamer: {:?}", e);
+                    log::error!("Error initializing GStreamer: {:?}", e);
                     std::process::exit(1);
                 },
             }


### PR DESCRIPTION
Switches to log methods over eprintln in cases where it makes sense. stdout / stderr output may be difficult to view on devices like android / ohos, and has no filter options, so we should prefer log methods.
This PR avoids prints, which are controlled by a debugging option.

Testing: Only changes logging, no functional behavior change. 
