### PR TITLE
servoshell: Share WebView management between desktop and EGL platforms

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -202,7 +202,7 @@ impl App {
 
         match state.pump_event_loop() {
             PumpResult::Shutdown => {
-                state.shutdown();
+                state.webview_collection_mut().clear();
                 self.state = AppState::ShuttingDown;
             },
             PumpResult::Continue {
@@ -250,7 +250,7 @@ impl App {
 
         match state.pump_event_loop() {
             PumpResult::Shutdown => {
-                state.shutdown();
+                state.webview_collection_mut().clear();
                 self.state = AppState::ShuttingDown;
             },
             PumpResult::Continue { .. } => state.repaint_servo_if_necessary(),

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use std::cell::{Cell, Ref, RefCell, RefMut};
-use std::collections::HashMap;
 use std::rc::Rc;
 
 use crossbeam_channel::Receiver;
@@ -11,7 +10,6 @@ use euclid::{Point2D, Rect, Scale, Size2D};
 use keyboard_types::{CompositionEvent, CompositionState, Key, KeyState, NamedKey};
 use log::{debug, error, info, warn};
 use raw_window_handle::{RawWindowHandle, WindowHandle};
-use servo::base::generic_channel::GenericSender;
 use servo::base::id::WebViewId;
 use servo::servo_geometry::DeviceIndependentPixel;
 use servo::webrender_api::units::{
@@ -80,17 +78,6 @@ pub struct RunningAppState {
 
 struct RunningAppStateInner {
     need_present: bool,
-    /// List of top-level browsing contexts.
-    /// Modified by EmbedderMsg::WebViewOpened and EmbedderMsg::WebViewClosed,
-    /// and we exit if it ever becomes empty.
-    webviews: HashMap<WebViewId, WebView>,
-
-    /// The order in which the webviews were created.
-    creation_order: Vec<WebViewId>,
-
-    /// The webview that is currently focused.
-    /// Modified by EmbedderMsg::WebViewFocused and EmbedderMsg::WebViewBlurred.
-    focused_webview_id: Option<WebViewId>,
 
     /// Whether or not the animation state has changed. This is used to trigger
     /// host callbacks indicating that animation state has changed.
@@ -190,14 +177,9 @@ impl WebViewDelegate for RunningAppState {
     }
 
     fn notify_closed(&self, webview: WebView) {
-        {
-            let mut inner_mut = self.inner_mut();
-            inner_mut.webviews.retain(|&id, _| id != webview.id());
-            inner_mut.creation_order.retain(|&id| id != webview.id());
-            inner_mut.focused_webview_id = None;
-        }
+        self.webview_collection_mut().remove(webview.id());
 
-        if let Some(newest_webview) = self.newest_webview() {
+        if let Some(newest_webview) = self.webview_collection().newest() {
             newest_webview.focus();
         } else {
             self.servo().start_shutting_down();
@@ -206,10 +188,11 @@ impl WebViewDelegate for RunningAppState {
 
     fn notify_focus_changed(&self, webview: WebView, focused: bool) {
         if focused {
-            self.inner_mut().focused_webview_id = Some(webview.id());
+            self.webview_collection_mut()
+                .set_focused(Some(webview.id()));
             webview.show(true);
-        } else if self.inner().focused_webview_id == Some(webview.id()) {
-            self.inner_mut().focused_webview_id = None;
+        } else if self.webview_collection().focused_id() == Some(webview.id()) {
+            self.webview_collection_mut().set_focused(None);
         }
     }
 
@@ -285,7 +268,7 @@ impl WebViewDelegate for RunningAppState {
             .delegate(parent_webview.delegate())
             .hidpi_scale_factor(self.inner().hidpi_scale_factor)
             .build();
-        self.add(webview.clone());
+        self.add_webview(webview.clone());
         Some(webview)
     }
 
@@ -363,7 +346,7 @@ impl RunningAppStateTrait for RunningAppState {
     }
 
     fn webview_by_id(&self, id: WebViewId) -> Option<WebView> {
-        self.inner().webviews.get(&id).cloned()
+        self.webview_collection().get(id).cloned()
     }
 }
 
@@ -397,9 +380,6 @@ impl RunningAppState {
             refresh_driver,
             inner: RefCell::new(RunningAppStateInner {
                 need_present: false,
-                webviews: Default::default(),
-                creation_order: vec![],
-                focused_webview_id: None,
                 animating_state_changed,
                 hidpi_scale_factor: Scale::new(hidpi_scale_factor),
                 visible_input_methods: Default::default(),
@@ -410,15 +390,6 @@ impl RunningAppState {
         app_state
     }
 
-    pub fn webviews(&self) -> Vec<(WebViewId, WebView)> {
-        let inner = self.inner();
-        inner
-            .creation_order
-            .iter()
-            .map(|id| (*id, inner.webviews.get(id).unwrap().clone()))
-            .collect()
-    }
-
     pub(crate) fn create_and_focus_toplevel_webview(self: &Rc<Self>, url: Url) -> WebView {
         let webview = WebViewBuilder::new(self.servo())
             .url(url)
@@ -427,24 +398,13 @@ impl RunningAppState {
             .build();
 
         webview.focus();
-        self.add(webview.clone());
+        self.add_webview(webview.clone());
         webview
-    }
-
-    pub(crate) fn add(&self, webview: WebView) {
-        let webview_id = webview.id();
-        self.inner_mut().creation_order.push(webview_id);
-        self.inner_mut().webviews.insert(webview_id, webview);
-        info!(
-            "Added webview with ID: {:?}, total webviews: {}",
-            webview_id,
-            self.inner().webviews.len()
-        );
     }
 
     /// The focused webview will not be immediately valid via `active_webview()`
     pub(crate) fn focus_webview(&self, id: WebViewId) {
-        if let Some(webview) = self.inner().webviews.get(&id) {
+        if let Some(webview) = self.webview_collection().get(id) {
             webview.focus();
         } else {
             error!("We could not find the webview with this id {id}");
@@ -460,26 +420,9 @@ impl RunningAppState {
     }
 
     fn get_browser_id(&self) -> Result<WebViewId, &'static str> {
-        let webview_id = match self.inner().focused_webview_id {
-            Some(id) => id,
-            None => return Err("No focused WebViewId yet."),
-        };
-        Ok(webview_id)
-    }
-
-    pub(crate) fn newest_webview(&self) -> Option<WebView> {
-        self.inner()
-            .creation_order
-            .last()
-            .and_then(|id| self.inner().webviews.get(id).cloned())
-    }
-
-    pub(crate) fn active_webview(&self) -> WebView {
-        self.inner()
-            .focused_webview_id
-            .and_then(|id| self.inner().webviews.get(&id).cloned())
-            .or(self.newest_webview())
-            .expect("Should always have an active WebView")
+        self.webview_collection()
+            .focused_id()
+            .ok_or("No focused WebViewId yet.")
     }
 
     /// Request shutdown. Will call on_shutdown_complete.
@@ -521,13 +464,13 @@ impl RunningAppState {
             return;
         };
 
-        self.active_webview().load(url.into_url());
+        self.active_webview_or_panic().load(url.into_url());
     }
 
     /// Reload the page.
     pub fn reload(&self) {
         info!("reload");
-        self.active_webview().reload();
+        self.active_webview_or_panic().reload();
         self.perform_updates();
     }
 
@@ -539,14 +482,14 @@ impl RunningAppState {
     /// Go back in history.
     pub fn go_back(&self) {
         info!("go_back");
-        self.active_webview().go_back(1);
+        self.active_webview_or_panic().go_back(1);
         self.perform_updates();
     }
 
     /// Go forward in history.
     pub fn go_forward(&self) {
         info!("go_forward");
-        self.active_webview().go_forward(1);
+        self.active_webview_or_panic().go_forward(1);
         self.perform_updates();
     }
 
@@ -554,8 +497,9 @@ impl RunningAppState {
     pub fn resize(&self, coordinates: Coordinates) {
         info!("resize to {:?}", coordinates,);
         let size = coordinates.viewport.size;
-        self.active_webview().move_resize(size.to_f32().into());
-        self.active_webview()
+        self.active_webview_or_panic()
+            .move_resize(size.to_f32().into());
+        self.active_webview_or_panic()
             .resize(PhysicalSize::new(size.width as u32, size.height as u32));
         *self.callbacks.coordinates.borrow_mut() = coordinates;
         self.perform_updates();
@@ -567,7 +511,8 @@ impl RunningAppState {
     pub fn scroll(&self, dx: f32, dy: f32, x: f32, y: f32) {
         let scroll = Scroll::Delta(DeviceVector2D::new(dx, dy).into());
         let point = DevicePoint::new(x, y).into();
-        self.active_webview().notify_scroll_event(scroll, point);
+        self.active_webview_or_panic()
+            .notify_scroll_event(scroll, point);
         self.perform_updates();
     }
 
@@ -611,12 +556,9 @@ impl RunningAppState {
                         self.servo().execute_webdriver_command(msg);
                     },
                     WebDriverCommandMsg::GetFocusedWebView(response_sender) => {
-                        let focused_id = self
-                            .inner()
-                            .focused_webview_id
-                            .and_then(|id| self.inner().webviews.get(&id).cloned());
+                        let focused_id = self.webview_collection().focused_id();
 
-                        if let Err(error) = response_sender.send(focused_id.map(|w| w.id())) {
+                        if let Err(error) = response_sender.send(focused_id) {
                             warn!("Failed to send response of GetFocusedWebView: {error}");
                         }
                     },
@@ -708,7 +650,7 @@ impl RunningAppState {
 
     /// Touch event: press down
     pub fn touch_down(&self, x: f32, y: f32, pointer_id: i32) {
-        self.active_webview()
+        self.active_webview_or_panic()
             .notify_input_event(InputEvent::Touch(TouchEvent::new(
                 TouchEventType::Down,
                 TouchId(pointer_id),
@@ -719,7 +661,7 @@ impl RunningAppState {
 
     /// Touch event: move touching finger
     pub fn touch_move(&self, x: f32, y: f32, pointer_id: i32) {
-        self.active_webview()
+        self.active_webview_or_panic()
             .notify_input_event(InputEvent::Touch(TouchEvent::new(
                 TouchEventType::Move,
                 TouchId(pointer_id),
@@ -730,7 +672,7 @@ impl RunningAppState {
 
     /// Touch event: Lift touching finger
     pub fn touch_up(&self, x: f32, y: f32, pointer_id: i32) {
-        self.active_webview()
+        self.active_webview_or_panic()
             .notify_input_event(InputEvent::Touch(TouchEvent::new(
                 TouchEventType::Up,
                 TouchId(pointer_id),
@@ -741,7 +683,7 @@ impl RunningAppState {
 
     /// Cancel touch event
     pub fn touch_cancel(&self, x: f32, y: f32, pointer_id: i32) {
-        self.active_webview()
+        self.active_webview_or_panic()
             .notify_input_event(InputEvent::Touch(TouchEvent::new(
                 TouchEventType::Cancel,
                 TouchId(pointer_id),
@@ -752,7 +694,7 @@ impl RunningAppState {
 
     /// Register a mouse movement.
     pub fn mouse_move(&self, x: f32, y: f32) {
-        self.active_webview()
+        self.active_webview_or_panic()
             .notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(
                 DevicePoint::new(x, y).into(),
             )));
@@ -761,7 +703,7 @@ impl RunningAppState {
 
     /// Register a mouse button press.
     pub fn mouse_down(&self, x: f32, y: f32, button: MouseButton) {
-        self.active_webview()
+        self.active_webview_or_panic()
             .notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
                 MouseButtonAction::Down,
                 button,
@@ -772,7 +714,7 @@ impl RunningAppState {
 
     /// Register a mouse button release.
     pub fn mouse_up(&self, x: f32, y: f32, button: MouseButton) {
-        self.active_webview()
+        self.active_webview_or_panic()
             .notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
                 MouseButtonAction::Up,
                 button,
@@ -784,7 +726,7 @@ impl RunningAppState {
     /// Start pinchzoom.
     /// x/y are pinch origin coordinates.
     pub fn pinchzoom_start(&self, factor: f32, x: f32, y: f32) {
-        self.active_webview()
+        self.active_webview_or_panic()
             .pinch_zoom(factor, DevicePoint::new(x, y));
         self.perform_updates();
     }
@@ -792,7 +734,7 @@ impl RunningAppState {
     /// Pinchzoom.
     /// x/y are pinch origin coordinates.
     pub fn pinchzoom(&self, factor: f32, x: f32, y: f32) {
-        self.active_webview()
+        self.active_webview_or_panic()
             .pinch_zoom(factor, DevicePoint::new(x, y));
         self.perform_updates();
     }
@@ -800,21 +742,21 @@ impl RunningAppState {
     /// End pinchzoom.
     /// x/y are pinch origin coordinates.
     pub fn pinchzoom_end(&self, factor: f32, x: f32, y: f32) {
-        self.active_webview()
+        self.active_webview_or_panic()
             .pinch_zoom(factor, DevicePoint::new(x, y));
         self.perform_updates();
     }
 
     pub fn key_down(&self, key: Key) {
         let key_event = KeyboardEvent::from_state_and_key(KeyState::Down, key);
-        self.active_webview()
+        self.active_webview_or_panic()
             .notify_input_event(InputEvent::Keyboard(key_event));
         self.perform_updates();
     }
 
     pub fn key_up(&self, key: Key) {
         let key_event = KeyboardEvent::from_state_and_key(KeyState::Up, key);
-        self.active_webview()
+        self.active_webview_or_panic()
             .notify_input_event(InputEvent::Keyboard(key_event));
         self.perform_updates();
     }
@@ -824,7 +766,7 @@ impl RunningAppState {
         if text.is_empty() {
             return;
         }
-        let active_webview = self.active_webview();
+        let active_webview = self.active_webview_or_panic();
         active_webview.notify_input_event(InputEvent::Keyboard(KeyboardEvent::from_state_and_key(
             KeyState::Down,
             Key::Named(NamedKey::Process),
@@ -870,20 +812,20 @@ impl RunningAppState {
 
     pub fn media_session_action(&self, action: MediaSessionActionType) {
         info!("Media session action {:?}", action);
-        self.active_webview()
+        self.active_webview_or_panic()
             .notify_media_session_action_event(action);
         self.perform_updates();
     }
 
     pub fn set_throttled(&self, throttled: bool) {
         info!("set_throttled");
-        self.active_webview().set_throttled(throttled);
+        self.active_webview_or_panic().set_throttled(throttled);
         self.perform_updates();
     }
 
     pub fn ime_dismissed(&self) {
         info!("ime_dismissed");
-        self.active_webview()
+        self.active_webview_or_panic()
             .notify_input_event(InputEvent::Ime(ImeEvent::Dismissed));
         self.perform_updates();
     }
@@ -894,7 +836,7 @@ impl RunningAppState {
         }
 
         self.inner_mut().need_present = false;
-        self.active_webview().paint();
+        self.active_webview_or_panic().paint();
         self.rendering_context.present();
 
         if self.servoshell_preferences().exit_after_stable_image &&

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -41,6 +41,7 @@ use xcomponent_sys::{
 
 use super::app_state::{Coordinates, RunningAppState};
 use super::host_trait::HostTrait;
+use crate::running_app_state::RunningAppStateTrait;
 
 mod resources;
 mod simpleservo;
@@ -212,7 +213,7 @@ impl ServoAction {
                 if let Some(native_webview_components) =
                     NATIVE_WEBVIEWS.lock().unwrap().get(*arkts_id as usize)
                 {
-                    if servo.active_webview().id() != native_webview_components.id {
+                    if servo.active_webview_or_panic().id() != native_webview_components.id {
                         servo.focus_webview(native_webview_components.id);
                         servo.pause_compositor();
                         let (window_handle, _, coordinates) = simpleservo::get_raw_window_handle(
@@ -221,7 +222,7 @@ impl ServoAction {
                         );
                         servo.resume_compositor(window_handle, coordinates);
                         let url = servo
-                            .active_webview()
+                            .active_webview_or_panic()
                             .url()
                             .map(|u| u.to_string())
                             .unwrap_or(String::from("about:blank"));
@@ -326,7 +327,7 @@ extern "C" fn on_surface_created_cb(xcomponent: *mut OH_NativeXComponent, window
                 .lock()
                 .unwrap()
                 .push(NativeWebViewComponents {
-                    id: servo.active_webview().id(),
+                    id: servo.active_webview_or_panic().id(),
                     xcomponent: xc,
                     window,
                 });

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -24,6 +24,7 @@ use url::Url;
 
 use crate::prefs::ServoShellPreferences;
 
+#[derive(Default)]
 pub struct WebViewCollection {
     /// List of top-level browsing contexts.
     /// Modified by EmbedderMsg::WebViewOpened and EmbedderMsg::WebViewClosed,
@@ -39,14 +40,6 @@ pub struct WebViewCollection {
 }
 
 impl WebViewCollection {
-    pub fn new() -> Self {
-        Self {
-            webviews: HashMap::new(),
-            creation_order: Vec::new(),
-            focused_webview_id: None,
-        }
-    }
-
     pub fn add(&mut self, webview: WebView) {
         let id = webview.id();
         self.creation_order.push(id);
@@ -127,12 +120,6 @@ impl WebViewCollection {
     }
 }
 
-impl Default for WebViewCollection {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 pub struct RunningAppStateBase {
     pub(crate) webview_collection: RefCell<WebViewCollection>,
 
@@ -165,7 +152,7 @@ impl RunningAppStateBase {
         webdriver_receiver: Option<Receiver<WebDriverCommandMsg>>,
     ) -> Self {
         Self {
-            webview_collection: RefCell::new(WebViewCollection::new()),
+            webview_collection: RefCell::default(),
             webdriver_senders: RefCell::default(),
             pending_webdriver_events: Default::default(),
             webdriver_receiver,
@@ -203,7 +190,7 @@ pub trait RunningAppStateTrait {
         self.base().webview_collection.borrow_mut()
     }
 
-    /// Returns all webviews in creation order.
+    /// Returns all [`WebView`]s in creation order.
     fn webviews(&self) -> Vec<(WebViewId, WebView)> {
         self.webview_collection()
             .all_in_creation_order()
@@ -227,15 +214,15 @@ pub trait RunningAppStateTrait {
         self.webview_collection().newest().cloned()
     }
 
-    /// Gets the "active" webview: the focused webview if there is one,
-    /// otherwise the most recently created webview.
+    /// Gets the "active" [`WebView`]: the focused [`WebView`] if there is one,
+    /// otherwise the most recently created [`WebView`].
     #[allow(dead_code)]
     fn active_webview(&self) -> Option<WebView> {
         self.webview_collection().active().cloned()
     }
 
-    /// Gets the "active" webview, panicking if there is none.
-    /// This is a convenience method for platforms that assume there's always an active webview.
+    /// Gets the "active" [`WebView`], panicking if there is none.
+    /// This is a convenience method for platforms that assume there's always an active [`WebView`].
     #[allow(dead_code)]
     fn active_webview_or_panic(&self) -> WebView {
         self.active_webview()


### PR DESCRIPTION
Desktop and EGL implementations were maintaining identical WebView collection logic (HashMap, creation order tracking, focus management).

Extracted this into a shared WebViewCollection struct in RunningAppStateBase. Both platforms now use the common implementation through trait methods


Testing: Existing tests should cover this change. 
Fixes: part of #40530
