### PR TITLE
layout: Cleanup for replaced elements with widgets

### DIFF
--- a/components/layout/flow/construct.rs
+++ b/components/layout/flow/construct.rs
@@ -557,11 +557,9 @@ impl<'dom> BlockContainerBuilder<'dom, '_> {
                     contents: Contents::NonReplaced(contents),
                 },
             },
-            Contents::Replaced(_) | Contents::Widget(_) | Contents::ReplacedWithWidget(_, _) => {
-                BlockLevelCreator::Independent {
-                    display_inside,
-                    contents,
-                }
+            Contents::Replaced(_) | Contents::Widget(_) => BlockLevelCreator::Independent {
+                display_inside,
+                contents,
             },
         };
         self.block_level_boxes.push(BlockLevelJob {

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -395,7 +395,9 @@ impl IndependentFormattingContext {
     #[inline]
     pub(crate) fn layout_style(&self) -> LayoutStyle<'_> {
         match &self.contents {
-            IndependentFormattingContextContents::Replaced(fc, _) => fc.layout_style(&self.base),
+            IndependentFormattingContextContents::Replaced(replaced, _) => {
+                replaced.layout_style(&self.base)
+            },
             IndependentFormattingContextContents::Flow(fc) => fc.layout_style(&self.base),
             IndependentFormattingContextContents::Flex(fc) => fc.layout_style(),
             IndependentFormattingContextContents::Grid(fc) => fc.layout_style(),

--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -1014,15 +1014,6 @@ impl<'dom> ThreadSafeLayoutElement<'dom> for ServoThreadSafeLayoutElement<'dom> 
     }
 
     fn with_pseudo(&self, pseudo_element: PseudoElement) -> Option<Self> {
-        /*
-            https://drafts.csswg.org/css-pseudo/#generated-content:
-            Also as with regular child elements, the ::before and ::after pseudo-elements
-            are suppressed when their parent, the originating element, is replaced.
-        */
-        if self.has_local_name(&local_name!("video")) && pseudo_element.is_before_or_after() {
-            return None;
-        }
-
         if pseudo_element.is_eager() &&
             self.style_data()
                 .styles

--- a/tests/wpt/tests/css/css-sizing/aspect-ratio/replaced-element-049-ref.html
+++ b/tests/wpt/tests/css/css-sizing/aspect-ratio/replaced-element-049-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>CSS aspect-ratio reference: video with controls</title>
+
+<style>
+video {
+  display: block;
+  border: solid green;
+  width: 300px;
+  height: 300px;
+}
+</style>
+<video controls></video>

--- a/tests/wpt/tests/css/css-sizing/aspect-ratio/replaced-element-049.html
+++ b/tests/wpt/tests/css/css-sizing/aspect-ratio/replaced-element-049.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>CSS aspect-ratio: video with controls</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">
+<link rel="help" href="https://github.com/servo/servo/issues/40770">
+<link rel="match" href="replaced-element-049-ref.html">
+
+<style>
+video {
+  display: block;
+  border: solid green;
+  width: 300px;
+  aspect-ratio: 1;
+}
+</style>
+<video controls></video>


### PR DESCRIPTION
This cleans up the changes done in #40578.

In particular, it removes the unnecessary `Contents::ReplacedWithWidget` since we can handle that with `Contents::Replaced`. It also removes `IndependentFormattingContextContents::ReplacedWithWidget` in favor of `IndependentFormattingContextContents::Replaced`, by adding an optional parameter for the widget.

That ensures that the behavior of replaced elements won't accidentally diverge dependign on whether they have a widget. For example, #40578 forgot to handle `ReplacedWithWidget` in `tentative_block_content_size()`.

Additionally, this removes the hardcoded especial behavior for `<video>` that was added in `ServoThreadSafeLayoutElement::with_pseudo()`.

Testing: Adding a reftest
Fixes: #40708
Fixes: #40770