### PR TITLE
serviceworker-next: Fix some message sending related behavior

### DIFF
--- a/components/script/dom/extendablemessageevent.rs
+++ b/components/script/dom/extendablemessageevent.rs
@@ -29,6 +29,7 @@ use crate::dom::serviceworker::ServiceWorker;
 use crate::dom::serviceworkerglobalscope::ServiceWorkerGlobalScope;
 use crate::script_runtime::{CanGc, JSContext};
 
+/// <https://w3c.github.io/ServiceWorker/#dom-extendablemessageevent-source>
 #[derive(Clone, JSTraceable, MallocSizeOf)]
 pub(crate) enum MessageSource {
     Client(DomRoot<Client>),

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -306,6 +306,10 @@ impl ServiceWorkerManager {
                 if let Some(registration) = self.registrations.get_mut(&scope_url) {
                     if let Some(ref worker) = registration.active_worker {
                         worker.forward_dom_message(msg);
+                    } else if let Some(ref worker) = registration.waiting_worker {
+                        worker.forward_dom_message(msg);
+                    } else if let Some(ref worker) = registration.installing_worker {
+                        worker.forward_dom_message(msg);
                     }
                 }
             },

--- a/components/script_bindings/webidls/ExtendableMessageEvent.webidl
+++ b/components/script_bindings/webidls/ExtendableMessageEvent.webidl
@@ -11,6 +11,7 @@ interface ExtendableMessageEvent : ExtendableEvent {
   readonly attribute any data;
   readonly attribute DOMString origin;
   readonly attribute DOMString lastEventId;
+  // Using SameObject breaks codegen. Firefox does this as well.
   /*[SameObject]*/ readonly attribute (Client or ServiceWorker or MessagePort)? source;
   readonly attribute /*FrozenArray<MessagePort>*/any ports;
 };

--- a/components/script_bindings/webidls/ExtendableMessageEvent.webidl
+++ b/components/script_bindings/webidls/ExtendableMessageEvent.webidl
@@ -11,7 +11,7 @@ interface ExtendableMessageEvent : ExtendableEvent {
   readonly attribute any data;
   readonly attribute DOMString origin;
   readonly attribute DOMString lastEventId;
-  // [SameObject] readonly attribute (Client or ServiceWorker /*or MessagePort*/)? source;
+  /*[SameObject]*/ readonly attribute (Client or ServiceWorker or MessagePort)? source;
   readonly attribute /*FrozenArray<MessagePort>*/any ports;
 };
 
@@ -19,6 +19,6 @@ dictionary ExtendableMessageEventInit : ExtendableEventInit {
   any data = null;
   DOMString origin = "";
   DOMString lastEventId = "";
-  // (Client or ServiceWorker /*or MessagePort*/)? source;
+  (Client or ServiceWorker or MessagePort)? source;
   sequence<MessagePort> ports = [];
 };


### PR DESCRIPTION
**Doesn't target main**

Fix the issue that was causing timeouts in serviceworker WPT tests.

Doesn't fully unblock WPT: `dispatch_jsval` needs to accept a `source` parameter, and that `source` needs to be retrieved from `postMessage`. It goes through several layers of indirection, so I've deferred that to a different PR.

Testing: WPT
Fixes: #40767
