### PR TITLE
Remove `dom_uievent_which` from experimental features

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -28,7 +28,6 @@ pub(crate) static EXPERIMENTAL_PREFS: &[&str] = &[
     "dom_async_clipboard_enabled",
     "dom_fontface_enabled",
     "dom_intersection_observer_enabled",
-    "dom_uievent_which_enabled",
     "dom_navigator_protocol_handlers_enabled",
     "dom_navigator_sendbeacon_enabled",
     "dom_notification_enabled",


### PR DESCRIPTION
`UIEvent.which` was implemented in #40109 and is enabled by default, we don't need it to be listed in the experimental features.

Testing: No change of behavior.