### PR TITLE
devtools: Add Environment actor boilerplate and Object actor encode

### DIFF
--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -64,7 +64,7 @@ pub struct EnvironmentActorMsg {
 /// <https://searchfox.org/firefox-main/source/devtools/server/actors/environment.js>
 pub struct EnvironmentActor {
     pub name: String,
-    pub parent: String,
+    pub parent: Option<String>,
 }
 
 impl Actor for EnvironmentActor {
@@ -86,17 +86,22 @@ impl Actor for EnvironmentActor {
 }
 
 pub trait EnvironmentToProtocol {
-    fn encode(self) -> EnvironmentActorMsg;
+    fn encode(&self, actors: &ActorRegistry) -> EnvironmentActorMsg;
 }
 
 impl EnvironmentToProtocol for EnvironmentActor {
-    fn encode(self) -> EnvironmentActorMsg {
+    fn encode(&self, actors: &ActorRegistry) -> EnvironmentActorMsg {
+        let parent = self
+            .parent
+            .as_ref()
+            .map(|p| actors.find::<EnvironmentActor>(p))
+            .map(|p| Box::new(p.encode(actors)));
         // TODO: Change hardcoded values.
         EnvironmentActorMsg {
-            actor: self.name,
+            actor: self.name(),
             type_: EnvironmentType::Function,
             scope_kind: EnvironmentScope::Function,
-            parent: None,
+            parent,
             bindings: None,
             function: None,
             object: None,

--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// TODO: Remove once the actor is used.
+#![allow(dead_code)]
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::StreamId;
+use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actors::object::ObjectActorMsg;
+use crate::protocol::ClientRequest;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum EnvironmentType {
+    Function,
+    Block,
+    Object,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum EnvironmentScope {
+    Function,
+    Global,
+}
+
+#[derive(Serialize)]
+struct EnvironmentBindings {
+    arguments: Vec<Value>,
+    variables: Map<String, Value>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EnvironmentFunction {
+    display_name: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvironmentActorMsg {
+    actor: String,
+    #[serde(rename = "type")]
+    type_: EnvironmentType,
+    scope_kind: EnvironmentScope,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent: Option<Box<EnvironmentActorMsg>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bindings: Option<EnvironmentBindings>,
+    /// Should be set if `type_` is `EnvironmentType::Function`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    function: Option<EnvironmentFunction>,
+    /// Should be set if `type_` is `EnvironmentType::Object`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    object: Option<ObjectActorMsg>,
+}
+
+/// Resposible for listing the bindings in an environment and assigning new values to them.
+/// Referenced by `FrameActor` when replying to `getEnvironment` messages.
+/// <https://searchfox.org/firefox-main/source/devtools/server/actors/environment.js>
+pub struct EnvironmentActor {
+    pub name: String,
+    pub parent: String,
+}
+
+impl Actor for EnvironmentActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn handle_message(
+        &self,
+        _request: ClientRequest,
+        _registry: &ActorRegistry,
+        _msg_type: &str,
+        _msg: &Map<String, Value>,
+        _id: StreamId,
+    ) -> Result<(), ActorError> {
+        // TODO: Handle messages.
+        Err(ActorError::UnrecognizedPacketType)
+    }
+}
+
+pub trait EnvironmentToProtocol {
+    fn encode(self) -> EnvironmentActorMsg;
+}
+
+impl EnvironmentToProtocol for EnvironmentActor {
+    fn encode(self) -> EnvironmentActorMsg {
+        // TODO: Change hardcoded values.
+        EnvironmentActorMsg {
+            actor: self.name,
+            type_: EnvironmentType::Function,
+            scope_kind: EnvironmentScope::Function,
+            parent: None,
+            bindings: None,
+            function: None,
+            object: None,
+        }
+    }
+}

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -2,11 +2,33 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
 use crate::actor::{Actor, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
+
+#[derive(Serialize)]
+pub struct ObjectPreview {
+    kind: String,
+    url: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ObjectActorMsg {
+    actor: String,
+    #[serde(rename = "type")]
+    type_: String,
+    class: String,
+    own_property_length: i32,
+    extensible: bool,
+    frozen: bool,
+    sealed: bool,
+    is_error: bool,
+    preview: ObjectPreview,
+}
 
 pub struct ObjectActor {
     pub name: String,
@@ -45,6 +67,32 @@ impl ObjectActor {
             name
         } else {
             registry.script_to_actor(uuid)
+        }
+    }
+}
+
+// TODO: Remove once the message is used.
+#[allow(dead_code)]
+pub trait ObjectToProtocol {
+    fn encode(self) -> ObjectActorMsg;
+}
+
+impl ObjectToProtocol for ObjectActor {
+    fn encode(self) -> ObjectActorMsg {
+        // TODO: Review hardcoded values here
+        ObjectActorMsg {
+            actor: self.name,
+            type_: "object".into(),
+            class: "Window".into(),
+            own_property_length: 0,
+            extensible: true,
+            frozen: false,
+            sealed: false,
+            is_error: false,
+            preview: ObjectPreview {
+                kind: "ObjectWithURL".into(),
+                url: "".into(),
+            },
         }
     }
 }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -59,6 +59,7 @@ mod actors {
     pub mod browsing_context;
     pub mod console;
     pub mod device;
+    pub mod environment;
     pub mod framerate;
     pub mod inspector;
     pub mod long_string;


### PR DESCRIPTION
Prequisite for implementing pausing in the debugger. The `EnvironmentActor` will be used in the future from the `FrameActor`, we need the struct defined to start to implement it.

The `ObjectActorMsg` is not only used by the `EnvoironmentActor`, but also by the `ThreadActor` when replying to `interrupt`.

Testing: Deferred until the pause is fully implemented.
Fixes: Part of #36027.