### PR TITLE
compositing: Support per-Painter operations and message handling

### DIFF
--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -31,7 +31,7 @@ mod from_constellation {
         fn log_target(&self) -> &'static str {
             match self {
                 Self::ChangeRunningAnimationsState(..) => target!("ChangeRunningAnimationsState"),
-                Self::CreateOrUpdateWebView(..) => target!("CreateOrUpdateWebView"),
+                Self::SetFrameTreeForWebView(..) => target!("CreateOrUpdateWebView"),
                 Self::RemoveWebView(..) => target!("RemoveWebView"),
                 Self::SetThrottled(..) => target!("SetThrottled"),
                 Self::NewWebRenderFrameReady(..) => target!("NewWebRenderFrameReady"),

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -31,7 +31,7 @@ mod from_constellation {
         fn log_target(&self) -> &'static str {
             match self {
                 Self::ChangeRunningAnimationsState(..) => target!("ChangeRunningAnimationsState"),
-                Self::SetFrameTreeForWebView(..) => target!("CreateOrUpdateWebView"),
+                Self::SetFrameTreeForWebView(..) => target!("SetFrameTreeForWebView"),
                 Self::RemoveWebView(..) => target!("RemoveWebView"),
                 Self::SetThrottled(..) => target!("SetThrottled"),
                 Self::NewWebRenderFrameReady(..) => target!("NewWebRenderFrameReady"),

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3857,7 +3857,7 @@ where
         self.notify_history_changed(webview_id);
 
         self.trim_history(webview_id);
-        self.update_webview_in_compositor(webview_id);
+        self.set_frame_tree_for_webview(webview_id);
     }
 
     #[servo_tracing::instrument(skip_all)]
@@ -4751,7 +4751,7 @@ where
         self.notify_focus_state(change.new_pipeline_id);
 
         self.notify_history_changed(change.webview_id);
-        self.update_webview_in_compositor(change.webview_id);
+        self.set_frame_tree_for_webview(change.webview_id);
     }
 
     /// Update the focus state of the specified pipeline that recently became
@@ -5465,7 +5465,7 @@ where
 
     /// Send the frame tree for the given webview to the compositor.
     #[servo_tracing::instrument(skip_all)]
-    fn update_webview_in_compositor(&mut self, webview_id: WebViewId) {
+    fn set_frame_tree_for_webview(&mut self, webview_id: WebViewId) {
         // Note that this function can panic, due to ipc-channel creation failure.
         // avoiding this panic would require a mechanism for dealing
         // with low-resource scenarios.
@@ -5473,7 +5473,9 @@ where
         if let Some(frame_tree) = self.browsing_context_to_sendable(browsing_context_id) {
             debug!("{}: Sending frame tree", browsing_context_id);
             self.compositor_proxy
-                .send(CompositorMsg::CreateOrUpdateWebView(frame_tree));
+                .send(CompositorMsg::SetFrameTreeForWebView(
+                    webview_id, frame_tree,
+                ));
         }
     }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -221,8 +221,11 @@ impl Drop for LayoutThread {
         let (keys, instance_keys) = self
             .font_context
             .collect_unused_webrender_resources(true /* all */);
-        self.compositor_api
-            .remove_unused_font_resources(keys, instance_keys)
+        self.compositor_api.remove_unused_font_resources(
+            self.webview_id.into(),
+            keys,
+            instance_keys,
+        )
     }
 }
 
@@ -1323,8 +1326,11 @@ impl LayoutThread {
         let (keys, instance_keys) = self
             .font_context
             .collect_unused_webrender_resources(false /* all */);
-        self.compositor_api
-            .remove_unused_font_resources(keys, instance_keys);
+        self.compositor_api.remove_unused_font_resources(
+            self.webview_id.into(),
+            keys,
+            instance_keys,
+        );
 
         self.have_ever_generated_display_list.set(true);
         self.need_new_display_list.set(false);

--- a/components/net/tests/image_cache.rs
+++ b/components/net/tests/image_cache.rs
@@ -28,7 +28,7 @@ fn create_test_image_cache() -> (Arc<dyn ImageCache>, Receiver<PipelineId>) {
     let (sender, receiver) = unbounded();
     let compositor_api =
         CrossProcessCompositorApi::dummy_with_callback(Some(Box::new(move |msg| {
-            if let compositing_traits::CompositorMsg::GenerateImageKeysForPipeline(pipeline_id) =
+            if let compositing_traits::CompositorMsg::GenerateImageKeysForPipeline(_, pipeline_id) =
                 msg
             {
                 let _ = sender.send(pipeline_id);

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -2799,6 +2799,7 @@ impl Document {
             results.insert(ReflowPhasesRun::UpdatedImageData);
             self.waiting_on_canvas_image_updates.set(true);
             self.window().compositor_api().delay_new_frame_for_canvas(
+                self.webview_id(),
                 self.window().pipeline_id(),
                 current_rendering_epoch,
                 image_keys,

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2354,7 +2354,7 @@ impl Window {
             self.reflow(ReflowGoal::UpdateScrollNode(scroll_id, Vector2D::new(x, y)));
         if reflow_phases_run.needs_frame() {
             self.compositor_api()
-                .generate_frame(vec![self.webview_id()]);
+                .generate_frame(vec![self.webview_id().into()]);
         }
 
         // > If the scroll position did not change as a result of the user interaction or programmatic
@@ -2608,7 +2608,7 @@ impl Window {
         // See <https://github.com/servo/servo/issues/14719>
         if self.Document().update_the_rendering().needs_frame() {
             self.compositor_api()
-                .generate_frame(vec![self.webview_id()]);
+                .generate_frame(vec![self.webview_id().into()]);
         }
     }
 

--- a/components/script/image_animation.rs
+++ b/components/script/image_animation.rs
@@ -78,7 +78,9 @@ impl ImageAnimationManager {
                 ))
             })
             .collect();
-        window.compositor_api().update_images(updates);
+        window
+            .compositor_api()
+            .update_images(window.webview_id().into(), updates);
 
         self.maybe_schedule_update(window, now);
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1100,7 +1100,7 @@ impl ScriptThread {
         // steps per doc in docs. Currently `<iframe>` resizing depends on a parent being able to
         // queue resize events on a child and have those run in the same call to this method, so
         // that needs to be sorted out to fix this.
-        let mut webviews_generating_frames = HashSet::new();
+        let mut painters_generating_frames = HashSet::new();
         for pipeline_id in documents_in_order.iter() {
             let document = self
                 .documents
@@ -1196,17 +1196,17 @@ impl ScriptThread {
             // > Step 22: For each doc of docs, update the rendering or user interface of
             // > doc and its node navigable to reflect the current state.
             if document.update_the_rendering().needs_frame() {
-                webviews_generating_frames.insert(document.webview_id());
+                painters_generating_frames.insert(document.webview_id().into());
             }
 
             // TODO: Process top layer removals according to
             // https://drafts.csswg.org/css-position-4/#process-top-layer-removals.
         }
 
-        let should_generate_frame = !webviews_generating_frames.is_empty();
+        let should_generate_frame = !painters_generating_frames.is_empty();
         if should_generate_frame {
             self.compositor_api
-                .generate_frame(webviews_generating_frames.into_iter().collect());
+                .generate_frame(painters_generating_frames.into_iter().collect());
         }
 
         // Perform a microtask checkpoint as the specifications says that *update the rendering*

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -124,7 +124,7 @@ impl WebView {
                     .servo
                     .compositor
                     .borrow()
-                    .rendering_context_size()
+                    .rendering_context_size(painter_id)
                     .to_f32()
             },
             |size| Size2D::new(size.width as f32, size.height as f32),
@@ -363,7 +363,7 @@ impl WebView {
         self.inner()
             .compositor
             .borrow()
-            .resize_rendering_context(new_size);
+            .resize_rendering_context(self.id(), new_size);
     }
 
     pub fn hidpi_scale_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel> {
@@ -578,7 +578,10 @@ impl WebView {
     }
 
     pub fn capture_webrender(&self) {
-        self.inner().compositor.borrow().capture_webrender();
+        self.inner()
+            .compositor
+            .borrow()
+            .capture_webrender(self.id());
     }
 
     pub fn toggle_sampling_profiler(&self, rate: Duration, max_duration: Duration) {
@@ -601,7 +604,7 @@ impl WebView {
 
     /// Paint the contents of this [`WebView`] into its `RenderingContext`.
     pub fn paint(&self) {
-        self.inner().compositor.borrow().render();
+        self.inner().compositor.borrow().render(self.id());
     }
 
     /// Evaluate the specified string of JavaScript code. Once execution is complete or an error


### PR DESCRIPTION
Currently, only the first `Painter` is used for all operations in the `Compositor`. This change modifies the compositor API and message handling to allow routing the operations to the correct `Painter` via a provided `PainterId` or `WebViewId`.

This change is to enable support for per-`WebView`s  `RenderingContext`s.

Testing: This change shouldn't change behavior, so existing WPT tests should cover it.

