### PR TITLE
devtools: Frame actor boilerplate

### DIFF
--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-// TODO: Remove once the actor is used.
-
 use serde::Serialize;
 use serde_json::{Map, Value};
 

--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 // TODO: Remove once the actor is used.
-#![allow(dead_code)]
 
 use serde::Serialize;
 use serde_json::{Map, Value};
@@ -17,15 +16,15 @@ use crate::protocol::ClientRequest;
 #[serde(rename_all = "camelCase")]
 pub enum EnvironmentType {
     Function,
-    Block,
-    Object,
+    _Block,
+    _Object,
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum EnvironmentScope {
     Function,
-    Global,
+    _Global,
 }
 
 #[derive(Serialize)]

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// TODO: Remove once the actor is used
+#![allow(dead_code)]
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::StreamId;
+use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actors::environment::{EnvironmentActor, EnvironmentActorMsg, EnvironmentToProtocol};
+use crate::protocol::ClientRequest;
+
+#[derive(Serialize)]
+struct FrameEnvironmentReply {
+    from: String,
+    #[serde(flatten)]
+    environment: EnvironmentActorMsg,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FrameState {
+    OnStack,
+    Suspended,
+    Dead,
+}
+
+#[derive(Serialize)]
+pub struct FrameWhere {
+    actor: String,
+    line: u32,
+    column: u32,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameActorMsg {
+    actor: String,
+    #[serde(rename = "type")]
+    type_: String,
+    arguments: Vec<Value>,
+    async_cause: Option<String>,
+    display_name: String,
+    oldest: bool,
+    state: FrameState,
+    #[serde(rename = "where")]
+    where_: FrameWhere,
+}
+
+/// Represents an stack frame. Used by `ThreadActor` when replying to interrupt messages.
+/// <https://searchfox.org/firefox-main/source/devtools/server/actors/frame.js>
+pub struct FrameActor {
+    pub name: String,
+    pub source_actor: String,
+}
+
+impl Actor for FrameActor {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    // https://searchfox.org/firefox-main/source/devtools/shared/specs/frame.js
+    fn handle_message(
+        &self,
+        request: ClientRequest,
+        registry: &ActorRegistry,
+        msg_type: &str,
+        _msg: &Map<String, Value>,
+        _id: StreamId,
+    ) -> Result<(), ActorError> {
+        match msg_type {
+            "getEnvironment" => {
+                let environment = EnvironmentActor {
+                    name: registry.new_name("environment"),
+                    parent: None,
+                };
+                let msg = FrameEnvironmentReply {
+                    from: self.name(),
+                    environment: environment.encode(registry),
+                };
+                registry.register_later(Box::new(environment));
+                request.reply_final(&msg)?
+            },
+            _ => return Err(ActorError::UnrecognizedPacketType),
+        };
+        Ok(())
+    }
+}
+
+pub trait FrameToProtocol {
+    fn encode(self) -> FrameActorMsg;
+}
+
+impl FrameToProtocol for FrameActor {
+    fn encode(self) -> FrameActorMsg {
+        // TODO: Handle other states
+        let state = FrameState::OnStack;
+        let async_cause = if let FrameState::OnStack = state {
+            None
+        } else {
+            Some("await".into())
+        };
+        FrameActorMsg {
+            actor: self.name,
+            type_: "call".into(),
+            arguments: vec![],
+            async_cause,
+            display_name: "".into(), // TODO: get display name
+            oldest: true,
+            state,
+            where_: FrameWhere {
+                actor: self.source_actor,
+                line: 1, // TODO: get from breakpoint?
+                column: 1,
+            },
+        }
+    }
+}

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -60,6 +60,7 @@ mod actors {
     pub mod console;
     pub mod device;
     pub mod environment;
+    pub mod frame;
     pub mod framerate;
     pub mod inspector;
     pub mod long_string;


### PR DESCRIPTION
Prequisite for implementing pausing in the debugger. This will be part of the `ThreadActor` response to `interrupt`. Continuation of #38824.

Depends on #40787 for `EnvironmentActor*`.

Testing: Deferred until the pause is fully implemented.
Fixes: Part of #36027.