### PR TITLE
servoshell: Move `Minibrowser` to headed window

### DIFF
--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -202,7 +202,7 @@ impl RunningAppState {
         }
 
         PumpResult::Continue {
-            need_update,
+            needs_user_interface_update: need_update,
             need_window_redraw,
         }
     }
@@ -468,10 +468,8 @@ impl WebViewDelegate for RunningAppState {
         self.inner_mut().need_update = true;
     }
 
-    fn notify_page_title_changed(&self, webview: servo::WebView, title: Option<String>) {
+    fn notify_page_title_changed(&self, webview: servo::WebView, _: Option<String>) {
         if webview.focused() {
-            let window_title = format!("{} - Servo", title.clone().unwrap_or_default());
-            self.inner().window.set_title(&window_title);
             self.inner_mut().need_update = true;
         }
     }

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -19,7 +19,6 @@ use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, 
 use servo::{RenderingContext, ScreenGeometry, SoftwareRenderingContext, WebView};
 use winit::dpi::PhysicalSize;
 
-use super::app_state::RunningAppState;
 use crate::desktop::window_trait::{MIN_WINDOW_INNER_SIZE, WindowPortsMethods};
 use crate::prefs::ServoShellPreferences;
 
@@ -126,20 +125,12 @@ impl WindowPortsMethods for Window {
         self.fullscreen.get()
     }
 
-    fn handle_winit_event(&self, _: Rc<RunningAppState>, _: winit::event::WindowEvent) {
-        // Not expecting any winit events.
-    }
-
     #[cfg(feature = "webxr")]
     fn new_glwindow(
         &self,
         _events_loop: &winit::event_loop::ActiveEventLoop,
     ) -> Rc<dyn servo::webxr::glwindow::GlWindow> {
         unimplemented!()
-    }
-
-    fn winit_window(&self) -> Option<&winit::window::Window> {
-        None
     }
 
     fn toolbar_height(&self) -> Length<f32, DeviceIndependentPixel> {
@@ -151,10 +142,6 @@ impl WindowPortsMethods for Window {
             DeviceIntRect::from_origin_and_size(self.window_position.get(), self.inner_size.get()),
             self.hidpi_scale_factor(),
         )
-    }
-
-    fn set_toolbar_height(&self, _height: Length<f32, DeviceIndependentPixel>) {
-        unimplemented!("headless Window only")
     }
 
     fn rendering_context(&self) -> Rc<dyn RenderingContext> {

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -14,8 +14,10 @@ use servo::{
     Cursor, InputEventId, InputEventResult, InputMethodControl, RenderingContext, ScreenGeometry,
     WebView,
 };
+use winit::event::WindowEvent;
 
 use super::app_state::RunningAppState;
+use crate::desktop::events_loop::AppEvent;
 
 // This should vary by zoom level and maybe actual text size (focused or under cursor)
 pub(crate) const LINE_HEIGHT: f32 = 76.0;
@@ -31,9 +33,30 @@ pub trait WindowPortsMethods {
     fn device_hidpi_scale_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel>;
     fn hidpi_scale_factor(&self) -> Scale<f32, DeviceIndependentPixel, DevicePixel>;
     fn get_fullscreen(&self) -> bool;
-    fn handle_winit_event(&self, state: Rc<RunningAppState>, event: winit::event::WindowEvent);
-    fn set_title(&self, _title: &str) {}
-    fn set_title_if_changed(&self, _title: &str) -> bool {
+    /// Request that the `Window` rebuild its user interface, if it has one. This should
+    /// not repaint, but should prepare the user interface for painting when it is
+    /// actually requested.
+    fn rebuild_user_interface(&self, _: &RunningAppState) {}
+    /// Inform the `Window` that the state of a `WebView` has changed and that it should
+    /// do an incremental update of user interface state. Returns `true` if the user
+    /// interface actually changed and a rebuild  and repaint is needed, `false` otherwise.
+    fn update_user_interface_state(&self, _: &RunningAppState) -> bool {
+        false
+    }
+    /// Handle a winit [`WindowEvent`]. Returns `true` if the event loop should continue
+    /// and `false` otherwise.
+    ///
+    /// TODO: This should be handled internally in the winit window if possible so that it
+    /// makes more sense when we are mixing headed and headless windows.
+    fn handle_winit_window_event(&self, _: Rc<RunningAppState>, _: WindowEvent) -> bool {
+        false
+    }
+    /// Handle a winit [`AppEvent`]. Returns `true` if the event loop should continue and
+    /// `false` otherwise.
+    ///
+    /// TODO: This should be handled internally in the winit window if possible so that it
+    /// makes more sense when we are mixing headed and headless windows.
+    fn handle_winit_app_event(&self, _: Rc<RunningAppState>, _: AppEvent) -> bool {
         false
     }
     /// Request a new outer size for the window, including external decorations.
@@ -48,9 +71,7 @@ pub trait WindowPortsMethods {
         &self,
         event_loop: &winit::event_loop::ActiveEventLoop,
     ) -> Rc<dyn servo::webxr::glwindow::GlWindow>;
-    fn winit_window(&self) -> Option<&winit::window::Window>;
     fn toolbar_height(&self) -> Length<f32, DeviceIndependentPixel>;
-    fn set_toolbar_height(&self, height: Length<f32, DeviceIndependentPixel>);
     /// This returns [`RenderingContext`] matching the viewport.
     fn rendering_context(&self) -> Rc<dyn RenderingContext>;
     fn show_ime(&self, _input_method: InputMethodControl) {}


### PR DESCRIPTION
Instead of storing the `Minibrowser` egui struct in the
`RunningAppState` which is used for both headed and headless windows,
move it to the headed window implementation. This addresses a lot of
bits of the code that would need to test the existance of the
`Minibrowser` even when it should have always existed.

In addition, event handling for the headed window is moved into the
headed window implementation itself, which eliminates the need to expose
so many methods in `WindowPortsMethods`.

One downside is that it is impossible to support tracing of `AppEvent`s
as accessibilty events are not cloneable. This seems like a small price
to pay for this cleanup though.

This is the first step toward supporting multiple windows in servoshell.

Testing: This should not change behavior and is thus covered by existing tests.
