### PR TITLE
html: Update MediaSession `setPositionState` method

### DIFF
--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -2828,18 +2828,6 @@ impl HTMLMediaElement {
         media_session.send_event(event);
     }
 
-    pub(crate) fn set_duration(&self, duration: f64) {
-        self.duration.set(duration);
-    }
-
-    pub(crate) fn reset(&self) {
-        if let Some(ref player) = *self.player.borrow() {
-            if let Err(err) = player.lock().unwrap().stop() {
-                error!("Could not stop player {:?}", err);
-            }
-        }
-    }
-
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-resource>
     pub(crate) fn origin_is_clean(&self) -> bool {
         // Step 5.local (media provider object).

--- a/components/script_bindings/webidls/MediaSession.webidl
+++ b/components/script_bindings/webidls/MediaSession.webidl
@@ -43,7 +43,7 @@ dictionary MediaSessionSeekToActionDetails : MediaSessionActionDetails {
 };
 
 dictionary MediaPositionState {
-  double duration;
+  unrestricted double duration;
   double playbackRate;
   double position;
 };

--- a/tests/wpt/meta/mediasession/positionstate.html.ini
+++ b/tests/wpt/meta/mediasession/positionstate.html.ini
@@ -1,4 +1,0 @@
-[positionstate.html]
-  [Test setPositionState with negative playback rate]
-    expected: FAIL
-


### PR DESCRIPTION
The MediaSession `setPositionState` method should only update the position state and propagate it to the platform media session UI controller and shouldn't change somehow the properties of the media element directly (duration, playback rate or position).
    
See https://w3c.github.io/mediasession/#dom-mediasession-setpositionstate
    
Testing: Improvements in the following tests
- /mediasession/positionstate.html
    
The media session UI functionality is implemented for Android and didn't test due lack of testing sample.
