### PR TITLE
libservo: Have `WebView` take a `RenderingContext` rather than `Servo`

### DIFF
--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -5,11 +5,9 @@
 #![deny(unsafe_code)]
 
 use std::cell::Cell;
-use std::path::PathBuf;
 use std::rc::Rc;
 
 use base::generic_channel::RoutedReceiver;
-use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::{CompositorMsg, CompositorProxy};
 use constellation_traits::EmbedderToConstellationMessage;
 use crossbeam_channel::Sender;
@@ -51,13 +49,9 @@ pub struct InitialCompositorState {
     /// A shared state which tracks whether Servo has started or has finished
     /// shutting down.
     pub shutdown_state: Rc<Cell<ShutdownState>>,
-    /// The target [`RenderingContext`] of this renderer.
-    pub rendering_context: Rc<dyn RenderingContext>,
     /// An [`EventLoopWaker`] used in order to wake up the embedder when it is
     /// time to paint.
     pub event_loop_waker: Box<dyn EventLoopWaker>,
-    /// A [`PathBuf`] which can be used to override WebRender shaders.
-    pub shaders_path: Option<PathBuf>,
     /// If WebXR is enabled, a [`WebXrRegistry`] to register WebXR threads.
     #[cfg(feature = "webxr")]
     pub webxr_registry: Box<dyn WebXrRegistry>,

--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -54,7 +54,7 @@ impl ::servo::WebViewDelegate for AppState {
     }
 
     fn request_open_auxiliary_webview(&self, parent_webview: WebView) -> Option<WebView> {
-        let webview = WebViewBuilder::new_auxiliary(&self.servo)
+        let webview = WebViewBuilder::new_auxiliary(&self.servo, self.rendering_context.clone())
             .hidpi_scale_factor(Scale::new(self.window.scale_factor() as f32))
             .delegate(parent_webview.delegate())
             .build();
@@ -94,7 +94,7 @@ impl ApplicationHandler<WakerEvent> for App {
 
             let _ = rendering_context.make_current();
 
-            let servo = ServoBuilder::new(rendering_context.clone())
+            let servo = ServoBuilder::default()
                 .event_loop_waker(Box::new(waker.clone()))
                 .build();
             servo.setup_logging();
@@ -110,11 +110,12 @@ impl ApplicationHandler<WakerEvent> for App {
             let url = Url::parse("https://demo.servo.org/experiments/twgl-tunnel/")
                 .expect("Guaranteed by argument");
 
-            let webview = WebViewBuilder::new(&app_state.servo)
-                .url(url)
-                .hidpi_scale_factor(Scale::new(app_state.window.scale_factor() as f32))
-                .delegate(app_state.clone())
-                .build();
+            let webview =
+                WebViewBuilder::new(&app_state.servo, app_state.rendering_context.clone())
+                    .url(url)
+                    .hidpi_scale_factor(Scale::new(app_state.window.scale_factor() as f32))
+                    .delegate(app_state.clone())
+                    .build();
 
             webview.focus_and_raise_to_top(true);
 

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -287,10 +287,8 @@ impl Servo {
             embedder_to_constellation_sender: constellation_proxy.sender().clone(),
             time_profiler_chan: time_profiler_chan.clone(),
             mem_profiler_chan: mem_profiler_chan.clone(),
-            rendering_context: builder.rendering_context,
             shutdown_state: shutdown_state.clone(),
             event_loop_waker,
-            shaders_path: opts.shaders_path.clone(),
             #[cfg(feature = "webxr")]
             webxr_registry: builder.webxr_registry,
         });
@@ -1134,7 +1132,6 @@ struct DefaultWebXrRegistry;
 impl webxr::WebXrRegistry for DefaultWebXrRegistry {}
 
 pub struct ServoBuilder {
-    rendering_context: Rc<dyn RenderingContext>,
     opts: Option<Box<Opts>>,
     preferences: Option<Box<Preferences>>,
     event_loop_waker: Box<dyn EventLoopWaker>,
@@ -1144,20 +1141,21 @@ pub struct ServoBuilder {
     webxr_registry: Box<dyn webxr::WebXrRegistry>,
 }
 
-impl ServoBuilder {
-    pub fn new(rendering_context: Rc<dyn RenderingContext>) -> Self {
+impl Default for ServoBuilder {
+    fn default() -> Self {
         Self {
-            rendering_context,
-            opts: None,
-            preferences: None,
+            opts: Default::default(),
+            preferences: Default::default(),
             event_loop_waker: Box::new(DefaultEventLoopWaker),
-            user_content_manager: UserContentManager::default(),
-            protocol_registry: ProtocolRegistry::default(),
+            user_content_manager: Default::default(),
+            protocol_registry: Default::default(),
             #[cfg(feature = "webxr")]
             webxr_registry: Box::new(DefaultWebXrRegistry),
         }
     }
+}
 
+impl ServoBuilder {
     pub fn build(self) -> Servo {
         Servo::new(self)
     }

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -62,7 +62,7 @@ impl ServoTest {
         }
 
         let user_event_triggered = Arc::new(AtomicBool::new(false));
-        let builder = ServoBuilder::new(rendering_context.clone())
+        let builder = ServoBuilder::default()
             .event_loop_waker(Box::new(EventLoopWakerImpl(user_event_triggered)));
         let builder = customize(builder);
         let servo = Rc::new(builder.build());

--- a/components/servo/tests/multiprocess.rs
+++ b/components/servo/tests/multiprocess.rs
@@ -26,7 +26,7 @@ fn test_multiprocess_preference_observer() {
     });
 
     let delegate = Rc::new(WebViewDelegateImpl::default());
-    let webview = WebViewBuilder::new(servo_test.servo())
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
         .delegate(delegate.clone())
         .build();
 

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -137,7 +137,7 @@ impl App {
             protocols::resource::ResourceProtocolHandler::default(),
         );
 
-        let servo_builder = ServoBuilder::new(window.rendering_context())
+        let servo_builder = ServoBuilder::default()
             .opts(self.opts.clone())
             .preferences(self.preferences.clone())
             .user_content_manager(user_content_manager)

--- a/ports/servoshell/desktop/app_state.rs
+++ b/ports/servoshell/desktop/app_state.rs
@@ -129,7 +129,7 @@ impl RunningAppState {
     }
 
     pub(crate) fn create_toplevel_webview(self: &Rc<Self>, url: Url) -> WebView {
-        let webview = WebViewBuilder::new(self.servo())
+        let webview = WebViewBuilder::new(self.servo(), self.inner().window.rendering_context())
             .url(url)
             .hidpi_scale_factor(self.inner().window.hidpi_scale_factor())
             .delegate(self.clone())
@@ -514,10 +514,11 @@ impl WebViewDelegate for RunningAppState {
         &self,
         parent_webview: servo::WebView,
     ) -> Option<servo::WebView> {
-        let webview = WebViewBuilder::new_auxiliary(self.servo())
-            .hidpi_scale_factor(self.inner().window.hidpi_scale_factor())
-            .delegate(parent_webview.delegate())
-            .build();
+        let webview =
+            WebViewBuilder::new_auxiliary(self.servo(), self.inner().window.rendering_context())
+                .hidpi_scale_factor(self.inner().window.hidpi_scale_factor())
+                .delegate(parent_webview.delegate())
+                .build();
 
         webview.notify_theme_change(self.inner().window.theme());
         // When WebDriver is enabled, do not focus and raise the WebView to the top,

--- a/ports/servoshell/egl/android/simpleservo.rs
+++ b/ports/servoshell/egl/android/simpleservo.rs
@@ -91,7 +91,7 @@ pub fn init(
         RefCell::new(init_opts.coordinates),
     ));
 
-    let servo_builder = ServoBuilder::new(rendering_context.clone())
+    let servo_builder = ServoBuilder::default()
         .opts(opts)
         .preferences(preferences)
         .event_loop_waker(waker.clone());

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -264,7 +264,7 @@ impl WebViewDelegate for RunningAppState {
     }
 
     fn request_open_auxiliary_webview(&self, parent_webview: WebView) -> Option<WebView> {
-        let webview = WebViewBuilder::new_auxiliary(self.servo())
+        let webview = WebViewBuilder::new_auxiliary(self.servo(), self.rendering_context.clone())
             .delegate(parent_webview.delegate())
             .hidpi_scale_factor(self.inner().hidpi_scale_factor)
             .build();
@@ -390,7 +390,7 @@ impl RunningAppState {
     }
 
     pub(crate) fn create_and_focus_toplevel_webview(self: &Rc<Self>, url: Url) -> WebView {
-        let webview = WebViewBuilder::new(self.servo())
+        let webview = WebViewBuilder::new(self.servo(), self.rendering_context.clone())
             .url(url)
             .hidpi_scale_factor(self.inner().hidpi_scale_factor)
             .delegate(self.clone())

--- a/ports/servoshell/egl/ohos/simpleservo.rs
+++ b/ports/servoshell/egl/ohos/simpleservo.rs
@@ -199,7 +199,7 @@ pub fn init(
         RefCell::new(coordinates),
     ));
 
-    let servo = ServoBuilder::new(rendering_context.clone())
+    let servo = ServoBuilder::default()
         .opts(opts)
         .preferences(preferences)
         .event_loop_waker(waker.clone())


### PR DESCRIPTION
This is the last major change before we can try to implement support for
multiple windows in Servo. This change makes it so that each `WebView`
(via `WebViewBuilder`) takes the `RenderingContext` as an argument,
rather than `Servo` (via `ServoBuilder`) as a whole.

In the compositor, when registering the `RenderingContext`, if a
`Painter` is found for it, it is returned. Otherwise, a new `Painter`
(and WebRender instance) is created for it. There is currently no way to
unregister a `RenderingContext`. We should come up with a good metric
for when is the best time to clean up `Painter`s and WebRender instances
for defunct `RenderingContext`s. This could perhaps be done via a `Weak`
handle to the `RenderingContext`.

Testing: This should not really change observable behavior, so should be
covered by existing tests.
Fixes: #13995 
Closes: #40261