### PR TITLE
layout: Preserve cached intrinsic sizes of undamaged descendants

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -94,15 +94,15 @@ impl InnerDOMLayoutData {
         }
     }
 
-    fn clear_fragment_layout_cache(&self) {
+    fn clear_fragment_layout_cache(&self, clear_inline_content_size: bool) {
         if let Some(data) = self.self_box.borrow().as_ref() {
-            data.with_each_base(LayoutBoxBase::clear_fragment_layout_cache);
+            data.with_each_base(|base| base.clear_fragment_layout_cache(clear_inline_content_size));
         }
         for pseudo_layout_data in self.pseudo_boxes.iter() {
             pseudo_layout_data
                 .data
                 .borrow()
-                .clear_fragment_layout_cache();
+                .clear_fragment_layout_cache(clear_inline_content_size);
         }
     }
 }
@@ -329,7 +329,7 @@ pub(crate) trait NodeExt<'dom> {
     fn unset_all_pseudo_boxes(&self);
 
     fn fragments_for_pseudo(&self, pseudo_element: Option<PseudoElement>) -> Vec<Fragment>;
-    fn clear_fragment_layout_cache(&self);
+    fn clear_fragment_layout_cache(&self, clear_inline_content_size: bool);
 
     fn repair_style(&self, context: &SharedStyleContext);
     fn take_restyle_damage(&self) -> LayoutDamage;
@@ -471,9 +471,9 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
         self.ensure_inner_layout_data().pseudo_boxes.clear();
     }
 
-    fn clear_fragment_layout_cache(&self) {
+    fn clear_fragment_layout_cache(&self, clear_inline_content_size: bool) {
         if let Some(inner_layout_data) = self.inner_layout_data() {
-            inner_layout_data.clear_fragment_layout_cache();
+            inner_layout_data.clear_fragment_layout_cache(clear_inline_content_size);
         }
     }
 

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -71,10 +71,12 @@ impl LayoutBoxBase {
 
     /// Clear cached data accumulated during fragment tree layout, either fragments and
     /// the cached inline content size, or just fragments.
-    pub(crate) fn clear_fragment_layout_cache(&self) {
+    pub(crate) fn clear_fragment_layout_cache(&self, clear_inline_content_size: bool) {
         self.fragments.borrow_mut().clear();
         *self.cached_layout_result.borrow_mut() = None;
-        *self.cached_inline_content_size.borrow_mut() = None;
+        if clear_inline_content_size {
+            *self.cached_inline_content_size.borrow_mut() = None;
+        }
     }
 
     pub(crate) fn fragments(&self) -> Vec<Fragment> {

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -166,7 +166,9 @@ pub(crate) fn compute_damage_and_repair_style_inner(
     if element_damage != RestyleDamage::reconstruct() &&
         damage_for_parent.contains(RestyleDamage::RELAYOUT)
     {
-        node.clear_fragment_layout_cache();
+        let clear_inline_content_size =
+            (original_element_damage | damage_from_children).contains(RestyleDamage::RELAYOUT);
+        node.clear_fragment_layout_cache(clear_inline_content_size);
     }
 
     // If the box will be preserved, update the box's style and also in any fragments


### PR DESCRIPTION
We were previously clearing the cached intrinsic inline sizes when the element, an ancestor, or a child had relayout damage. However, intrinsic sizes don't depend on ancestors for the most part, so now we will only clear the cache if the relayout damage is in the element or a descendant.

Testing: Not needed, no change in behavior
