### PR TITLE
layout: Preserve cached layout results of undamaged descendants

### DIFF
--- a/components/layout/dom.rs
+++ b/components/layout/dom.rs
@@ -94,15 +94,19 @@ impl InnerDOMLayoutData {
         }
     }
 
-    fn clear_fragment_layout_cache(&self, clear_inline_content_size: bool) {
+    fn with_each_layout_box_base(&self, callback: impl Fn(&LayoutBoxBase)) {
         if let Some(data) = self.self_box.borrow().as_ref() {
-            data.with_each_base(|base| base.clear_fragment_layout_cache(clear_inline_content_size));
+            data.with_each_base(callback);
         }
+    }
+
+    fn with_each_layout_box_base_including_pseudos(&self, callback: impl Fn(&LayoutBoxBase)) {
+        self.with_each_layout_box_base(&callback);
         for pseudo_layout_data in self.pseudo_boxes.iter() {
             pseudo_layout_data
                 .data
                 .borrow()
-                .clear_fragment_layout_cache(clear_inline_content_size);
+                .with_each_layout_box_base(&callback);
         }
     }
 }
@@ -329,7 +333,7 @@ pub(crate) trait NodeExt<'dom> {
     fn unset_all_pseudo_boxes(&self);
 
     fn fragments_for_pseudo(&self, pseudo_element: Option<PseudoElement>) -> Vec<Fragment>;
-    fn clear_fragment_layout_cache(&self, clear_inline_content_size: bool);
+    fn with_each_layout_box_base_including_pseudos(&self, callback: impl Fn(&LayoutBoxBase));
 
     fn repair_style(&self, context: &SharedStyleContext);
     fn take_restyle_damage(&self) -> LayoutDamage;
@@ -471,9 +475,9 @@ impl<'dom> NodeExt<'dom> for ServoThreadSafeLayoutNode<'dom> {
         self.ensure_inner_layout_data().pseudo_boxes.clear();
     }
 
-    fn clear_fragment_layout_cache(&self, clear_inline_content_size: bool) {
+    fn with_each_layout_box_base_including_pseudos(&self, callback: impl Fn(&LayoutBoxBase)) {
         if let Some(inner_layout_data) = self.inner_layout_data() {
-            inner_layout_data.clear_fragment_layout_cache(clear_inline_content_size);
+            inner_layout_data.with_each_layout_box_base_including_pseudos(callback);
         }
     }
 

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -69,16 +69,6 @@ impl LayoutBoxBase {
         result
     }
 
-    /// Clear cached data accumulated during fragment tree layout, either fragments and
-    /// the cached inline content size, or just fragments.
-    pub(crate) fn clear_fragment_layout_cache(&self, clear_inline_content_size: bool) {
-        self.fragments.borrow_mut().clear();
-        *self.cached_layout_result.borrow_mut() = None;
-        if clear_inline_content_size {
-            *self.cached_inline_content_size.borrow_mut() = None;
-        }
-    }
-
     pub(crate) fn fragments(&self) -> Vec<Fragment> {
         self.fragments.borrow().clone()
     }
@@ -93,6 +83,14 @@ impl LayoutBoxBase {
 
     pub(crate) fn clear_fragments(&self) {
         self.fragments.borrow_mut().clear();
+    }
+
+    /// Clear cached data accumulated during fragment tree layout, either fragments and
+    /// the cached inline content size, or just fragments.
+    pub(crate) fn clear_fragments_and_layout_cache(&self) {
+        self.fragments.borrow_mut().clear();
+        *self.cached_layout_result.borrow_mut() = None;
+        *self.cached_inline_content_size.borrow_mut() = None;
     }
 
     pub(crate) fn repair_style(&mut self, new_style: &Arc<ComputedValues>) {

--- a/components/layout/traversal.rs
+++ b/components/layout/traversal.rs
@@ -15,6 +15,7 @@ use style::values::computed::Display;
 
 use crate::context::LayoutContext;
 use crate::dom::{DOMLayoutData, NodeExt};
+use crate::layout_box_base::LayoutBoxBase;
 
 pub struct RecalcStyle<'a> {
     context: &'a LayoutContext<'a>,
@@ -166,9 +167,13 @@ pub(crate) fn compute_damage_and_repair_style_inner(
     if element_damage != RestyleDamage::reconstruct() &&
         damage_for_parent.contains(RestyleDamage::RELAYOUT)
     {
-        let clear_inline_content_size =
-            (original_element_damage | damage_from_children).contains(RestyleDamage::RELAYOUT);
-        node.clear_fragment_layout_cache(clear_inline_content_size);
+        node.with_each_layout_box_base_including_pseudos(
+            if (original_element_damage | damage_from_children).contains(RestyleDamage::RELAYOUT) {
+                LayoutBoxBase::clear_fragments_and_layout_cache
+            } else {
+                LayoutBoxBase::clear_fragments
+            },
+        );
     }
 
     // If the box will be preserved, update the box's style and also in any fragments


### PR DESCRIPTION
We were previously clearing the cached layout results when the element, an ancestor, or a child had relayout damage. Now we will only clear the cache if the relayout damage is in the element or a descendant.

Testing: Unneeded, no behavior change
