### PR TITLE
libservo: Remove `Servo::animating()`

### DIFF
--- a/components/servo/tests/servo.rs
+++ b/components/servo/tests/servo.rs
@@ -15,7 +15,8 @@ mod common;
 use common::ServoTest;
 
 #[test]
-fn test_simple_servo_is_not_animating_by_default() {
+fn test_simple_start_and_stop_servo() {
     let servo_test = ServoTest::new();
-    assert!(!servo_test.servo().animating());
+    servo_test.servo().start_shutting_down();
+    while servo_test.servo().spin_event_loop() {}
 }

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -175,14 +175,6 @@ impl App {
         self.state = AppState::Running(running_state);
     }
 
-    pub(crate) fn animating(&self) -> bool {
-        match self.state {
-            AppState::Initializing => false,
-            AppState::Running(ref running_app_state) => running_app_state.servo().animating(),
-            AppState::ShuttingDown => false,
-        }
-    }
-
     /// Handle all servo events with headless mode. Return true if the application should
     /// continue.
     pub fn handle_events_with_headless(&mut self) -> bool {

--- a/ports/servoshell/desktop/events_loop.rs
+++ b/ports/servoshell/desktop/events_loop.rs
@@ -102,9 +102,7 @@ impl EventsLoop {
                     if !app.handle_events_with_headless() {
                         break;
                     }
-                    if !app.animating() {
-                        *flag.lock().unwrap() = false;
-                    }
+                    *flag.lock().unwrap() = false;
                 }
             },
         }

--- a/ports/servoshell/egl/android.rs
+++ b/ports/servoshell/egl/android.rs
@@ -679,19 +679,6 @@ impl HostTrait for HostCallbacks {
         .unwrap();
     }
 
-    fn on_animating_changed(&self, animating: bool) {
-        debug!("on_animating_changed");
-        let mut env = self.jvm.get_env().unwrap();
-        let animating = JValue::Bool(animating as jboolean);
-        env.call_method(
-            self.callbacks.as_obj(),
-            "onAnimatingChanged",
-            "(Z)V",
-            &[animating],
-        )
-        .unwrap();
-    }
-
     fn on_ime_show(&self, _: InputMethodControl) {
         let mut env = self.jvm.get_env().unwrap();
         env.call_method(self.callbacks.as_obj(), "onImeShow", "()V", &[])

--- a/ports/servoshell/egl/app_state.rs
+++ b/ports/servoshell/egl/app_state.rs
@@ -443,12 +443,6 @@ impl RunningAppState {
         if !should_continue {
             self.callbacks.host_callbacks.on_shutdown_complete();
         }
-        if self.inner().animating_state_changed.get() {
-            self.inner().animating_state_changed.set(false);
-            self.callbacks
-                .host_callbacks
-                .on_animating_changed(self.servo().animating());
-        }
     }
 
     /// Load an URL.

--- a/ports/servoshell/egl/host_trait.rs
+++ b/ports/servoshell/egl/host_trait.rs
@@ -37,22 +37,6 @@ pub trait HostTrait {
     /// Back/forward state has changed.
     /// Back/forward buttons need to be disabled/enabled.
     fn on_history_changed(&self, can_go_back: bool, can_go_forward: bool);
-    /// Page animation state has changed. If animating, it's recommended
-    /// that the embedder doesn't wait for the wake function to be called
-    /// to call perform_updates. Usually, it means doing:
-    /// ```rust
-    /// while true {
-    ///     servo.perform_updates();
-    ///     servo.present_if_needed();
-    /// }
-    /// ```
-    /// . This will end up calling flush
-    /// which will call swap_buffer which will be blocking long enough to limit
-    /// drawing at 60 FPS.
-    /// If not animating, call perform_updates only when needed (when the embedder
-    /// has events for Servo, or Servo has woken up the embedder event loop via
-    /// EventLoopWaker).
-    fn on_animating_changed(&self, animating: bool);
     /// Servo finished shutting down.
     fn on_shutdown_complete(&self);
     /// A text input is focused.

--- a/ports/servoshell/egl/ohos.rs
+++ b/ports/servoshell/egl/ohos.rs
@@ -980,10 +980,6 @@ impl HostTrait for HostCallbacks {
 
     fn on_history_changed(&self, can_go_back: bool, can_go_forward: bool) {}
 
-    fn on_animating_changed(&self, animating: bool) {
-        // todo: should we tell the vsync thread that it should perform updates?
-    }
-
     fn on_shutdown_complete(&self) {
         if let Some(terminate_fn) = TERMINATE_CALLBACK.get() {
             terminate_fn.call((), ThreadsafeFunctionCallMode::Blocking);

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
@@ -100,8 +100,6 @@ public class JNIServo {
 
         void onAlert(String message);
 
-        void onAnimatingChanged(boolean animating);
-
         void onLoadStarted();
 
         void onLoadEnded();

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/Servo.java
@@ -211,8 +211,6 @@ public class Servo {
     public interface GfxCallbacks {
         void flushGLBuffers();
 
-        void animationStateChanged(boolean animating);
-
         void makeCurrent();
     }
 
@@ -260,10 +258,6 @@ public class Servo {
 
         public void onImeHide() {
             mRunCallback.inUIThread(() -> mClient.onImeHide());
-        }
-
-        public void onAnimatingChanged(boolean animating) {
-            mRunCallback.inGLThread(() -> mGfxCb.animationStateChanged(animating));
         }
 
         public boolean onAllowNavigation(String url) {

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/ServoView.java
@@ -106,10 +106,6 @@ public class ServoView extends SurfaceView
 
 
     @Override
-    public void animationStateChanged(boolean animating) {
-    }
-
-    @Override
     public void makeCurrent() {
     }
 


### PR DESCRIPTION
Instead of relying on `Sevo::animating()` in servoshell to drive the
event loop, it is sufficient to just let the `RefreshDriver` wake it up
when it is time to re-render.

This allows us to remove `Servo::animating()` completely. It is a bit
odd that there is a global API to track this, rather than per-`WebView`
or window, so this change just removes it entirely.

Testing: This should make the main loop of headless servoshell more efficient,
but I do not think this difference is going to be observable in any way.
