### PR TITLE
servoshell: hide tab bar in full screen mode

### DIFF
--- a/ports/servoshell/desktop/minibrowser.rs
+++ b/ports/servoshell/desktop/minibrowser.rs
@@ -406,27 +406,27 @@ impl Minibrowser {
                         },
                     );
                 });
-            };
 
-            // A simple Tab header strip
-            TopBottomPanel::top("tabs").show(ctx, |ui| {
-                ui.allocate_ui_with_layout(
-                    ui.available_size(),
-                    egui::Layout::left_to_right(egui::Align::Center),
-                    |ui| {
-                        for (id, webview) in state.webviews().into_iter() {
-                            let favicon = favicon_textures
-                                .get(&id)
-                                .map(|(_, favicon)| favicon)
-                                .copied();
-                            Self::browser_tab(ui, webview, event_queue, favicon);
-                        }
-                        if ui.add(Minibrowser::toolbar_button("+")).clicked() {
-                            event_queue.push(MinibrowserEvent::NewWebView);
-                        }
-                    },
-                );
-            });
+                // A simple Tab header strip
+                TopBottomPanel::top("tabs").show(ctx, |ui| {
+                    ui.allocate_ui_with_layout(
+                        ui.available_size(),
+                        egui::Layout::left_to_right(egui::Align::Center),
+                        |ui| {
+                            for (id, webview) in state.webviews().into_iter() {
+                                let favicon = favicon_textures
+                                    .get(&id)
+                                    .map(|(_, favicon)| favicon)
+                                    .copied();
+                                Self::browser_tab(ui, webview, event_queue, favicon);
+                            }
+                            if ui.add(Minibrowser::toolbar_button("+")).clicked() {
+                                event_queue.push(MinibrowserEvent::NewWebView);
+                            }
+                        },
+                    );
+                });
+            };
 
             // The toolbar height is where the Context’s available rect starts.
             // For reasons that are unclear, the TopBottomPanel’s ui cursor exceeds this by one egui


### PR DESCRIPTION
servoshell: hide tab bar in full screen mode

Testing: Tested manually.
Fixes: https://github.com/servo/servo/issues/40789

Before:
<img width="264" height="77" alt="Screenshot 2025-11-21 at 9 05 09 PM" src="https://github.com/user-attachments/assets/fc2c41ea-595c-4f53-9223-e8b7205081ec" />


After:
<img width="273" height="69" alt="Screenshot 2025-11-21 at 9 00 35 PM" src="https://github.com/user-attachments/assets/c19dee7e-b079-41cd-a3fb-02564a84463c" />
