### PR TITLE
script: Rename `ExportedKey::Raw` to `ExportedKey::Bytes`

### DIFF
--- a/components/script/dom/subtlecrypto.rs
+++ b/components/script/dom/subtlecrypto.rs
@@ -1247,8 +1247,8 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 //     realm, as defined by [WebIDL].
                 // Step 11. Resolve promise with result.
                 match result {
-                    ExportedKey::Raw(raw) => {
-                        subtle.resolve_promise_with_data(promise, raw);
+                    ExportedKey::Bytes(bytes) => {
+                        subtle.resolve_promise_with_data(promise, bytes);
                     },
                     ExportedKey::Jwk(jwk) => {
                         subtle.resolve_promise_with_jwk(promise, jwk);
@@ -1372,7 +1372,7 @@ impl SubtleCryptoMethods<crate::DomTypeHolder> for SubtleCrypto {
                 //     Step 14.2. Let bytes be the result of UTF-8 encoding json.
                 let cx = GlobalScope::get_cx();
                 let bytes = match exported_key {
-                    ExportedKey::Raw(raw) => raw,
+                    ExportedKey::Bytes(bytes) => bytes,
                     ExportedKey::Jwk(jwk) => match jwk.stringify(cx) {
                         Ok(stringified_jwk) => stringified_jwk.as_bytes().to_vec(),
                         Err(error) => {
@@ -2072,8 +2072,11 @@ where
     }
 }
 
-pub(crate) enum ExportedKey {
-    Raw(Vec<u8>),
+/// The returned type of the successful export key operation. `Bytes` should be used when the key
+/// is exported in "raw", "spki" or "pkcs8" format. `Jwk` should be used when the key is exported
+/// in "jwk" format.
+enum ExportedKey {
+    Bytes(Vec<u8>),
     Jwk(Box<JsonWebKey>),
 }
 

--- a/components/script/dom/subtlecrypto/aes_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_operation.rs
@@ -980,13 +980,13 @@ fn export_key_aes(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Err
             // represented by the [[handle]] internal slot of key.
             // Step 2.2. Let result be data.
             Handle::Aes128(key_data) => {
-                result = ExportedKey::Raw(key_data.clone());
+                result = ExportedKey::Bytes(key_data.clone());
             },
             Handle::Aes192(key_data) => {
-                result = ExportedKey::Raw(key_data.clone());
+                result = ExportedKey::Bytes(key_data.clone());
             },
             Handle::Aes256(key_data) => {
-                result = ExportedKey::Raw(key_data.clone());
+                result = ExportedKey::Bytes(key_data.clone());
             },
             _ => unreachable!(),
         },

--- a/components/script/dom/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdh_operation.rs
@@ -921,7 +921,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
             .map_err(|_| Error::Operation(None))?;
 
-            ExportedKey::Raw(data.to_vec())
+            ExportedKey::Bytes(data.to_vec())
         },
         KeyFormat::Pkcs8 => {
             // Step 3.1. If the [[type]] internal slot of key is not "private", then throw an
@@ -979,7 +979,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             }
             .map_err(|_| Error::Operation(None))?;
 
-            ExportedKey::Raw(data.as_bytes().to_vec())
+            ExportedKey::Bytes(data.as_bytes().to_vec())
         },
         KeyFormat::Jwk => {
             // Step 3.1. Let jwk be a new JsonWebKey dictionary.
@@ -1145,7 +1145,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 3.3. Let result be data.
-            ExportedKey::Raw(data)
+            ExportedKey::Bytes(data)
         },
     };
 

--- a/components/script/dom/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdsa_operation.rs
@@ -1043,7 +1043,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             .map_err(|_| Error::Operation(None))?;
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Raw(data.to_vec())
+            ExportedKey::Bytes(data.to_vec())
         },
         // If format is "pkcs8":
         KeyFormat::Pkcs8 => {
@@ -1104,7 +1104,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             .map_err(|_| Error::Operation(None))?;
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Raw(data.as_bytes().to_vec())
+            ExportedKey::Bytes(data.as_bytes().to_vec())
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
@@ -1270,7 +1270,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 3.3. Let result be data.
-            ExportedKey::Raw(data)
+            ExportedKey::Bytes(data)
         },
         // Otherwise: throw a NotSupportedError. (Unreachable)
     };

--- a/components/script/dom/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/subtlecrypto/ed25519_operation.rs
@@ -448,7 +448,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                 ParsedPublicKey::new(&ED25519, key_data).map_err(|_| Error::Operation(None))?;
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Raw(
+            ExportedKey::Bytes(
                 data.as_der()
                     .map_err(|_| Error::Operation(None))?
                     .as_ref()
@@ -479,7 +479,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                 .map_err(|_| Error::Operation(None))?;
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Raw(data.as_ref().to_vec())
+            ExportedKey::Bytes(data.as_ref().to_vec())
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
@@ -546,7 +546,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             // Step 3.2. Let data be a byte sequence representing the Ed25519 public key
             // represented by the [[handle]] internal slot of key.
             // Step 3.3. Let result be data.
-            ExportedKey::Raw(key_data.to_vec())
+            ExportedKey::Bytes(key_data.to_vec())
         },
         // Otherwise: throw a NotSupportedError. (Unreachable)
     };

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -323,7 +323,7 @@ pub(crate) fn import_key(
 pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
     match format {
         KeyFormat::Raw => match key.handle() {
-            Handle::Hmac(key_data) => Ok(ExportedKey::Raw(key_data.as_slice().to_vec())),
+            Handle::Hmac(key_data) => Ok(ExportedKey::Bytes(key_data.as_slice().to_vec())),
             _ => Err(Error::Operation(None)),
         },
         KeyFormat::Jwk => {

--- a/components/script/dom/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/subtlecrypto/x25519_operation.rs
@@ -519,7 +519,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Raw(data.to_der().map_err(|_| Error::Operation(None))?)
+            ExportedKey::Bytes(data.to_der().map_err(|_| Error::Operation(None))?)
         },
         // If format is "pkcs8":
         KeyFormat::Pkcs8 => {
@@ -555,7 +555,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             };
 
             // Step 3.3. Let result be the result of DER-encoding data.
-            ExportedKey::Raw(data.to_der().map_err(|_| Error::Operation(None))?)
+            ExportedKey::Bytes(data.to_der().map_err(|_| Error::Operation(None))?)
         },
         // If format is "jwk":
         KeyFormat::Jwk => {
@@ -623,7 +623,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             let data = public_key.as_bytes();
 
             // Step 3.3. Let result be data.
-            ExportedKey::Raw(data.to_vec())
+            ExportedKey::Bytes(data.to_vec())
         },
     };
 


### PR DESCRIPTION
The enum variant `ExportedKey::Raw(Vec<u8>)` is actually used when a key is exported in "raw", "spki" or "pkcs8" format. Naming it as `Raw` could be confusing.

This patch renames `ExportedKey::Raw` to `ExportedKey::Bytes`.

Testing: No behavioral change. Existing tests suffice.
