### PR TITLE
script: Improve spec-compliance of Performance resource timing entries

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3116,7 +3116,7 @@ impl Document {
                 );
                 metrics.set_performance_paint_metric(metric_value, first_reflow, metric_type);
                 let entry = binding.upcast::<PerformanceEntry>();
-                self.window.Performance().queue_entry(entry, can_gc);
+                self.window.Performance().queue_entry(entry);
             },
             ProgressiveWebMetricType::LargestContentfulPaint { area, lcp_type } => {
                 let binding = LargestContentfulPaint::new(
@@ -3127,7 +3127,7 @@ impl Document {
                 );
                 metrics.set_largest_contentful_paint(metric_value, area, lcp_type);
                 let entry = binding.upcast::<PerformanceEntry>();
-                self.window.Performance().queue_entry(entry, can_gc);
+                self.window.Performance().queue_entry(entry);
             },
             ProgressiveWebMetricType::TimeToInteractive => {
                 unreachable!("Unexpected non-paint metric.")
@@ -4479,7 +4479,7 @@ impl Document {
         );
         self.window
             .Performance()
-            .queue_entry(entry.upcast::<PerformanceEntry>(), can_gc);
+            .queue_entry(entry.upcast::<PerformanceEntry>());
 
         // Step 4 Run the screen orientation change steps with document.
         // TODO ScreenOrientation hasn't implemented yet

--- a/components/script/dom/performance/performance.rs
+++ b/components/script/dom/performance/performance.rs
@@ -366,14 +366,28 @@ impl Performance {
         self.resource_timing_buffer_current_size.get() <=
             self.resource_timing_buffer_size_limit.get()
     }
+
+    /// <https://w3c.github.io/resource-timing/#dfn-copy-secondary-buffer>
     fn copy_secondary_resource_timing_buffer(&self) {
+        // Step 1. While resource timing secondary buffer is not empty and can add resource timing entry returns true, run the following substeps:
         while self.can_add_resource_timing_entry() {
+            // Step 1.1. Let entry be the oldest PerformanceResourceTiming in resource timing secondary buffer.
             let entry = self
                 .resource_timing_secondary_entries
                 .borrow_mut()
                 .pop_front();
             if let Some(ref entry) = entry {
-                self.queue_entry(entry);
+                // Step 1.2. Add entry to the end of performance entry buffer.
+                self.buffer
+                    .borrow_mut()
+                    .entries
+                    .push(DomRoot::from_ref(entry));
+                // Step 1.3. Increment resource timing buffer current size by 1.
+                self.resource_timing_buffer_current_size
+                    .set(self.resource_timing_buffer_current_size.get() + 1);
+                // Step 1.4. Remove entry from resource timing secondary buffer.
+                // Step 1.5. Decrement resource timing secondary buffer current size by 1.
+                // Handled by popping the entry earlier.
             } else {
                 break;
             }

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -1171,10 +1171,10 @@ impl ParserContext {
             document,
             CanGc::note(),
         );
-        self.pushed_entry_index = document.global().performance().queue_entry(
-            performance_entry.upcast::<PerformanceEntry>(),
-            CanGc::note(),
-        );
+        self.pushed_entry_index = document
+            .global()
+            .performance()
+            .queue_entry(performance_entry.upcast::<PerformanceEntry>());
     }
 }
 

--- a/components/script/network_listener.rs
+++ b/components/script/network_listener.rs
@@ -72,7 +72,7 @@ pub(crate) fn submit_timing_data(
         PerformanceResourceTiming::new(global, url, initiator_type, None, resource_timing, can_gc);
     global
         .performance()
-        .queue_entry(performance_entry.upcast::<PerformanceEntry>(), can_gc);
+        .queue_entry(performance_entry.upcast::<PerformanceEntry>());
 }
 
 pub(crate) trait FetchResponseListener: Send + 'static {

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -560,10 +560,6 @@ DOMInterfaces = {
     'canGc': ['CreateLinearGradient', 'CreatePattern', 'CreateRadialGradient', 'GetTransform'],
 },
 
-'Performance': {
-    'canGc': ['Mark', 'Measure'],
-},
-
 'PerformanceObserver': {
     'canGc': ['SupportedEntryTypes'],
 },

--- a/tests/wpt/meta/resource-timing/buffer-full-add-after-full-event.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-add-after-full-event.html.ini
@@ -1,4 +1,3 @@
 [buffer-full-add-after-full-event.html]
-  expected: TIMEOUT
   [Test that entry was added to the buffer after a buffer full event]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-add-entries-during-callback-that-drop.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-add-entries-during-callback-that-drop.html.ini
@@ -1,4 +1,3 @@
 [buffer-full-add-entries-during-callback-that-drop.html]
-  expected: TIMEOUT
   [Test that entries synchronously added to the buffer during the callback are dropped]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-add-entries-during-callback.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-add-entries-during-callback.html.ini
@@ -1,4 +1,3 @@
 [buffer-full-add-entries-during-callback.html]
-  expected: TIMEOUT
   [Test that entries synchronously added to the buffer during the callback don't get dropped if the buffer is increased]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-decrease-buffer-during-callback.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-decrease-buffer-during-callback.html.ini
@@ -1,4 +1,3 @@
 [buffer-full-decrease-buffer-during-callback.html]
-  expected: TIMEOUT
   [Test that decreasing the buffer limit during the callback does not drop entries]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-increase-buffer-during-callback.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-increase-buffer-during-callback.html.ini
@@ -1,4 +1,3 @@
 [buffer-full-increase-buffer-during-callback.html]
-  expected: TIMEOUT
   [Test that increasing the buffer during the callback is enough for entries not to be dropped]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-inspect-buffer-during-callback.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-inspect-buffer-during-callback.html.ini
@@ -1,4 +1,3 @@
 [buffer-full-inspect-buffer-during-callback.html]
-  expected: TIMEOUT
   [Test that entries in the secondary buffer are not exposed during the callback and before they are copied to the primary buffer]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-set-to-current-buffer.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-set-to-current-buffer.html.ini
@@ -1,4 +1,3 @@
 [buffer-full-set-to-current-buffer.html]
-  expected: TIMEOUT
   [Test that adding entries and firing the buffer full event happen in the right order.]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/resource-timing/buffer-full-store-and-clear-during-callback.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-store-and-clear-during-callback.html.ini
@@ -1,4 +1,3 @@
 [buffer-full-store-and-clear-during-callback.html]
-  expected: TIMEOUT
   [Test that entries overflowing the buffer trigger the buffer full event, can be stored, and make their way to the primary buffer after it's cleared in the buffer full event.]
-    expected: TIMEOUT
+    expected: FAIL


### PR DESCRIPTION
The current implementation doesn't match the specification and is broken in a way that makes nytimes.com endlessly attempt to enqueue resource timing entries, making the page completely unresposive to user input. This PR makes some surgical changes that fix the NYTimes behaviour and add some comments to make it easier to further improve the implementation in the future.

Testing: Various WPT that used to timeout now fail instead.
Fixes: #40808
