### PR TITLE
script: Replace strings for performance entry types with dedicated enum.

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -66,6 +66,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap};
 use script_bindings::interfaces::GlobalScopeHelpers;
 use servo_url::{ImmutableOrigin, MutableOrigin, ServoUrl};
 use storage_traits::StorageThreads;
+use strum::VariantArray;
 use timers::{TimerEventRequest, TimerId};
 use uuid::Uuid;
 #[cfg(feature = "webgpu")]
@@ -119,7 +120,7 @@ use crate::dom::htmlscriptelement::ScriptOrigin;
 use crate::dom::messageport::MessagePort;
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
 use crate::dom::performance::performance::Performance;
-use crate::dom::performance::performanceobserver::VALID_ENTRY_TYPES;
+use crate::dom::performance::performanceentry::EntryType;
 use crate::dom::promise::Promise;
 use crate::dom::readablestream::{CrossRealmTransformReadable, ReadableStream};
 use crate::dom::reportingobserver::ReportingObserver;
@@ -3182,9 +3183,9 @@ impl GlobalScope {
     ) {
         self.frozen_supported_performance_entry_types.get_or_init(
             || {
-                VALID_ENTRY_TYPES
+                EntryType::VARIANTS
                     .iter()
-                    .map(|t| DOMString::from(t.to_string()))
+                    .map(|t| DOMString::from(t.as_str()))
                     .collect()
             },
             cx,

--- a/components/script/dom/macros.rs
+++ b/components/script/dom/macros.rs
@@ -718,7 +718,7 @@ macro_rules! window_event_handlers(
 
 /// DOM struct implementation for simple interfaces inheriting from PerformanceEntry.
 macro_rules! impl_performance_entry_struct(
-    ($binding:ident, $struct:ident, $type:expr) => (
+    ($binding:ident, $struct:ident, $type:path) => (
         use base::cross_process_instant::CrossProcessInstant;
         use time::Duration;
 
@@ -726,7 +726,7 @@ macro_rules! impl_performance_entry_struct(
         use crate::dom::bindings::root::DomRoot;
         use crate::dom::bindings::str::DOMString;
         use crate::dom::globalscope::GlobalScope;
-        use crate::dom::performance::performanceentry::PerformanceEntry;
+        use crate::dom::performance::performanceentry::{EntryType, PerformanceEntry};
         use crate::script_runtime::CanGc;
         use dom_struct::dom_struct;
 
@@ -740,7 +740,7 @@ macro_rules! impl_performance_entry_struct(
                 -> $struct {
                 $struct {
                     entry: PerformanceEntry::new_inherited(name,
-                                                           DOMString::from($type),
+                                                           $type,
                                                            Some(start_time),
                                                            duration)
                 }

--- a/components/script/dom/performance/largestcontentfulpaint.rs
+++ b/components/script/dom/performance/largestcontentfulpaint.rs
@@ -7,7 +7,7 @@ use dom_struct::dom_struct;
 use script_traits::ProgressiveWebMetricType;
 use time::Duration;
 
-use super::performanceentry::PerformanceEntry;
+use super::performanceentry::{EntryType, PerformanceEntry};
 use crate::dom::bindings::codegen::Bindings::LargestContentfulPaintBinding::LargestContentfulPaintMethods;
 use crate::dom::bindings::codegen::Bindings::PerformanceBinding::DOMHighResTimeStamp;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
@@ -36,7 +36,7 @@ impl LargestContentfulPaint {
         LargestContentfulPaint {
             entry: PerformanceEntry::new_inherited(
                 DOMString::from(""),
-                DOMString::from("largest-contentful-paint"),
+                EntryType::LargestContentfulPaint,
                 Some(render_time),
                 Duration::ZERO,
             ),

--- a/components/script/dom/performance/performancemark.rs
+++ b/components/script/dom/performance/performancemark.rs
@@ -2,4 +2,4 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-impl_performance_entry_struct!(PerformanceMarkBinding, PerformanceMark, "mark");
+impl_performance_entry_struct!(PerformanceMarkBinding, PerformanceMark, EntryType::Mark);

--- a/components/script/dom/performance/performancemeasure.rs
+++ b/components/script/dom/performance/performancemeasure.rs
@@ -2,4 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-impl_performance_entry_struct!(PerformanceMeasureBinding, PerformanceMeasure, "measure");
+impl_performance_entry_struct!(
+    PerformanceMeasureBinding,
+    PerformanceMeasure,
+    EntryType::Measure
+);

--- a/components/script/dom/performance/performanceobserverentrylist.rs
+++ b/components/script/dom/performance/performanceobserverentrylist.rs
@@ -5,7 +5,7 @@
 use dom_struct::dom_struct;
 
 use super::performance::PerformanceEntryList;
-use super::performanceentry::PerformanceEntry;
+use super::performanceentry::{EntryType, PerformanceEntry};
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::PerformanceObserverEntryListBinding::PerformanceObserverEntryListMethods;
 use crate::dom::bindings::reflector::{Reflector, reflect_dom_object};
@@ -49,6 +49,9 @@ impl PerformanceObserverEntryListMethods<crate::DomTypeHolder> for PerformanceOb
 
     /// <https://w3c.github.io/performance-timeline/#dom-performanceobserver>
     fn GetEntriesByType(&self, entry_type: DOMString) -> Vec<DomRoot<PerformanceEntry>> {
+        let Ok(entry_type) = EntryType::try_from(&*entry_type.str()) else {
+            return Vec::new();
+        };
         self.entries
             .borrow()
             .get_entries_by_name_and_type(None, Some(entry_type))
@@ -60,6 +63,15 @@ impl PerformanceObserverEntryListMethods<crate::DomTypeHolder> for PerformanceOb
         name: DOMString,
         entry_type: Option<DOMString>,
     ) -> Vec<DomRoot<PerformanceEntry>> {
+        let entry_type = match entry_type {
+            Some(entry_type) => {
+                let Ok(entry_type) = EntryType::try_from(&*entry_type.str()) else {
+                    return Vec::new();
+                };
+                Some(entry_type)
+            },
+            None => None,
+        };
         self.entries
             .borrow()
             .get_entries_by_name_and_type(Some(name), entry_type)

--- a/components/script/dom/performance/performancepainttiming.rs
+++ b/components/script/dom/performance/performancepainttiming.rs
@@ -7,7 +7,7 @@ use dom_struct::dom_struct;
 use script_traits::ProgressiveWebMetricType;
 use time::Duration;
 
-use super::performanceentry::PerformanceEntry;
+use super::performanceentry::{EntryType, PerformanceEntry};
 use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
@@ -34,7 +34,7 @@ impl PerformancePaintTiming {
         PerformancePaintTiming {
             entry: PerformanceEntry::new_inherited(
                 name,
-                DOMString::from("paint"),
+                EntryType::Paint,
                 Some(start_time),
                 Duration::ZERO,
             ),

--- a/components/script/dom/performance/performanceresourcetiming.rs
+++ b/components/script/dom/performance/performanceresourcetiming.rs
@@ -8,7 +8,7 @@ use net_traits::ResourceFetchTiming;
 use servo_url::ServoUrl;
 use time::Duration;
 
-use super::performanceentry::PerformanceEntry;
+use super::performanceentry::{EntryType, PerformanceEntry};
 use crate::dom::bindings::codegen::Bindings::PerformanceBinding::DOMHighResTimeStamp;
 use crate::dom::bindings::codegen::Bindings::PerformanceResourceTimingBinding::PerformanceResourceTimingMethods;
 use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
@@ -83,9 +83,9 @@ impl PerformanceResourceTiming {
         fetch_start: Option<CrossProcessInstant>,
     ) -> PerformanceResourceTiming {
         let entry_type = if initiator_type == InitiatorType::Navigation {
-            DOMString::from("navigation")
+            EntryType::Navigation
         } else {
-            DOMString::from("resource")
+            EntryType::Resource
         };
         PerformanceResourceTiming {
             entry: PerformanceEntry::new_inherited(
@@ -129,7 +129,7 @@ impl PerformanceResourceTiming {
         PerformanceResourceTiming {
             entry: PerformanceEntry::new_inherited(
                 DOMString::from(url.into_string()),
-                DOMString::from("resource"),
+                EntryType::Resource,
                 resource_timing.start_time,
                 duration,
             ),

--- a/components/script/dom/visibilitystateentry.rs
+++ b/components/script/dom/visibilitystateentry.rs
@@ -16,7 +16,7 @@ use crate::dom::bindings::reflector::reflect_dom_object;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::globalscope::GlobalScope;
-use crate::dom::performance::performanceentry::PerformanceEntry;
+use crate::dom::performance::performanceentry::{EntryType, PerformanceEntry};
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -37,7 +37,7 @@ impl VisibilityStateEntry {
         VisibilityStateEntry {
             entry: PerformanceEntry::new_inherited(
                 name,
-                DOMString::from("visibility-state"),
+                EntryType::VisibilityState,
                 Some(timestamp),
                 Duration::ZERO,
             ),

--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -68,8 +68,6 @@ def run_tests(default_binary_path: str, **kwargs: Any) -> int:
     # chunks and leads to more consistent timing on GitHub Actions.
     set_if_none(kwargs, "chunk_type", "id_hash")
 
-    kwargs["user_stylesheets"].append(os.path.join(SERVO_ROOT, "tests", "wpt", "tests", "fonts", "ahem.css"))
-
     set_if_none(kwargs, "binary", default_binary_path)
     set_if_none(kwargs, "webdriver_binary", default_binary_path)
 

--- a/tests/wpt/meta/navigation-timing/test-navigation-type-reload.html.ini
+++ b/tests/wpt/meta/navigation-timing/test-navigation-type-reload.html.ini
@@ -14,9 +14,6 @@
   [Reload domComplete > Original domComplete]
     expected: FAIL
 
-  [Reload domContentLoadedEventEnd > Original domContentLoadedEventEnd]
-    expected: FAIL
-
   [Reload domContentLoadedEventStart > Original domContentLoadedEventStart]
     expected: FAIL
 

--- a/tests/wpt/meta/resource-timing/buffer-full-add-then-clear.html.ini
+++ b/tests/wpt/meta/resource-timing/buffer-full-add-then-clear.html.ini
@@ -1,3 +1,0 @@
-[buffer-full-add-then-clear.html]
-  [Test that if the buffer is cleared after entries were added to the secondary buffer, those entries make it into the primary one]
-    expected: FAIL

--- a/tests/wpt/meta/resource-timing/cors-preflight.any.js.ini
+++ b/tests/wpt/meta/resource-timing/cors-preflight.any.js.ini
@@ -1,4 +1,6 @@
 [cors-preflight.any.html]
+  expected: ERROR
+
   [PerformanceResourceTiming sizes fetch with preflight test]
     expected: FAIL
 

--- a/tests/wpt/meta/user-timing/measure.html.ini
+++ b/tests/wpt/meta/user-timing/measure.html.ini
@@ -3,21 +3,6 @@
   [window.performance.getEntriesByName("measure_no_start_no_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
     expected: FAIL
 
-  [window.performance.getEntriesByName("measure_start_no_end")[0\].startTime is correct]
-    expected: FAIL
-
-  [window.performance.getEntriesByName("measure_start_no_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
-    expected: FAIL
-
-  [window.performance.getEntriesByName("measure_start_end")[0\].startTime is correct]
-    expected: FAIL
-
-  [window.performance.getEntriesByName("measure_start_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
-    expected: FAIL
-
-  [window.performance.getEntriesByName("measure_no_start_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
-    expected: FAIL
-
   [window.performance.getEntriesByName("measure_no_start_no_end")[1\].duration is approximately correct (up to 20ms difference allowed)]
     expected: FAIL
 

--- a/tests/wpt/meta/user-timing/measure_associated_with_navigation_timing.html.ini
+++ b/tests/wpt/meta/user-timing/measure_associated_with_navigation_timing.html.ini
@@ -1,12 +1,3 @@
 [measure_associated_with_navigation_timing.html]
   [Measure of navigationStart to loadEventEnd should be positive value.]
     expected: FAIL
-
-  [Measure of current mark to navigationStart should be negative value.]
-    expected: FAIL
-
-  [Measure from domComplete event to most recent mark "a" should have longer duration.]
-    expected: FAIL
-
-  [Measure from most recent mark to navigationStart should have longer duration.]
-    expected: FAIL

--- a/tests/wpt/meta/user-timing/measure_navigation_timing.html.ini
+++ b/tests/wpt/meta/user-timing/measure_navigation_timing.html.ini
@@ -11,9 +11,6 @@
   [window.performance.getEntriesByName("measure_nav_start_mark_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
     expected: FAIL
 
-  [window.performance.getEntriesByName("measure_mark_start_nav_end")[0\].startTime is correct]
-    expected: FAIL
-
   [window.performance.getEntriesByName("measure_mark_start_nav_end")[0\].duration is approximately correct (up to 20ms difference allowed)]
     expected: FAIL
 

--- a/tests/wpt/meta/workers/worker-performance.worker.js.ini
+++ b/tests/wpt/meta/workers/worker-performance.worker.js.ini
@@ -2,8 +2,5 @@
   [Can use performance.getEntriesByType in workers]
     expected: FAIL
 
-  [Performance marks and measures seem to be working correctly in workers]
-    expected: FAIL
-
   [performance.setResourceTimingBufferSize in workers]
     expected: FAIL


### PR DESCRIPTION
This both reduces unnecessary string comparisons and fixes several cases where two string arguments were passed in the wrong order.

Depends on https://github.com/servo/servo/pull/40811.

Testing: New passing tests.