### PR TITLE
servoshell: Rename `Minibrowser` to `Gui`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 /components/fonts @nicoburns
 /components/shared/fonts @nicoburns
 
-# Reviewers for Minibrowser related code
+# Reviewers for servoshell related code
 /ports/servoshell/desktop @atbrakhi
 
 # Reviewers for 2D canvas related code

--- a/ports/servoshell/desktop/mod.rs
+++ b/ports/servoshell/desktop/mod.rs
@@ -12,10 +12,10 @@ mod dialog;
 pub(crate) mod events_loop;
 mod gamepad;
 pub mod geometry;
+mod gui;
 mod headed_window;
 mod headless_window;
 mod keyutils;
-mod minibrowser;
 mod protocols;
 mod tracing;
 #[cfg(feature = "webxr")]


### PR DESCRIPTION
MiniBrowser was considered at some point for the name of servoshell, but
was discarded. The name of the egui portions of servoshell are a
holdover from this. This change renames this struct to `Gui` to better
reflect what it does.

Testing: This just renames some data structures, so should not need new tests.
