### PR TITLE
testing: Remove ahem.css user stylesheet injection.

### DIFF
--- a/python/wpt/run.py
+++ b/python/wpt/run.py
@@ -68,8 +68,6 @@ def run_tests(default_binary_path: str, **kwargs: Any) -> int:
     # chunks and leads to more consistent timing on GitHub Actions.
     set_if_none(kwargs, "chunk_type", "id_hash")
 
-    kwargs["user_stylesheets"].append(os.path.join(SERVO_ROOT, "tests", "wpt", "tests", "fonts", "ahem.css"))
-
     set_if_none(kwargs, "binary", default_binary_path)
     set_if_none(kwargs, "webdriver_binary", default_binary_path)
 


### PR DESCRIPTION
The current user stylesheet use in our tests is a hack that hides real issues like #40419. Any test that requires ahem.ttf needs to include the stylesheet like any other webpage.