### PR TITLE
Update nixpkgs to current unstable

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,7 +8,7 @@ with import (builtins.fetchTarball {
   # NixOS users: if servoshell crashes with an assertion failure in surfman’s x11/connection.rs,
   # eglInitialize() may be failing, or you may be building with an incompatible version of glibc.
   # Use your system nixpkgs here, change `llvmPackages` below if necessary, then do a clean build.
-  url = "https://github.com/NixOS/nixpkgs/archive/d88bee41dbec574b3c2bf97de37371d90f96475d.tar.gz";
+  url = "https://github.com/NixOS/nixpkgs/archive/a8d610af3f1a5fb71e23e08434d8d61a466fc942.tar.gz";
 }) {
   overlays = [
     (import (builtins.fetchTarball {


### PR DESCRIPTION
This fixes an incompatibility between mesa and wayland 1.23.x which causes a panic

Testing: `./mach test-unit`

NB: These tests failed. I have no way of verifying if they failed because of this change

```
     Summary [   5.146s] 814 tests run: 793 passed (1 slow), 21 failed, 0 skipped
        FAIL [   0.010s] compositing_traits rendering_context::test::test_read_pixels
        FAIL [   0.029s] libservo::webview test_confirm_dialog
        FAIL [   0.035s] libservo::webview test_can_go_forward_and_can_go_back
        FAIL [   0.036s] libservo::servo test_simple_start_and_stop_servo
        FAIL [   0.040s] libservo::multiprocess test_multiprocess_preference_observer
        FAIL [   0.039s] libservo::webview test_alert_dialog
        FAIL [   0.032s] libservo::webview test_control_show_and_hide
        FAIL [   0.031s] libservo::webview test_create_webview_and_immediately_drop_webview_before_shutdown
        FAIL [   0.050s] libservo::webview test_contextual_context_menu_items
        FAIL [   0.028s] libservo::webview test_cursor_change
        FAIL [   0.051s] libservo::webview test_create_webview
        FAIL [   0.030s] libservo::webview test_evaluate_javascript_panic
        FAIL [   0.027s] libservo::webview test_prompt_dialog
        FAIL [   0.031s] libservo::webview test_evaluate_javascript_basic
        FAIL [   0.030s] libservo::webview test_negative_resize_to_request
        FAIL [   0.029s] libservo::webview test_page_zoom
        FAIL [   0.034s] libservo::webview test_resize_webview_zero
        FAIL [   0.033s] libservo::webview test_show_and_hide_ime
        FAIL [   0.027s] libservo::webview test_theme_change
        FAIL [   0.031s] libservo::webview test_simple_context_menu
        FAIL [   0.031s] libservo::webview test_viewport_meta_tag_initial_zoom
error: test run failed
```
