### PR TITLE
Don't spawn a channel for ProfilerChan when profiling is off

### DIFF
--- a/components/metrics/lib.rs
+++ b/components/metrics/lib.rs
@@ -324,7 +324,7 @@ mod test {
 
     fn test_metrics() -> ProgressiveWebMetrics {
         let (sender, _) = ipc_channel::ipc::channel().unwrap();
-        let profiler_chan = ProfilerChan(sender);
+        let profiler_chan = ProfilerChan(Some(sender));
         let mut metrics = ProgressiveWebMetrics::new(
             profiler_chan,
             ServoUrl::parse("about:blank").unwrap(),

--- a/components/net/tests/resource_thread.rs
+++ b/components/net/tests/resource_thread.rs
@@ -26,7 +26,7 @@ fn test_exit() {
     let (sender, receiver) = ipc::channel().unwrap();
     let (resource_thread, _private_resource_thread) = new_core_resource_thread(
         None,
-        ProfilerChan(tx),
+        ProfilerChan(Some(tx)),
         MemProfilerChan(mtx),
         create_embedder_proxy(),
         None,

--- a/components/profile/time.rs
+++ b/components/profile/time.rs
@@ -83,9 +83,9 @@ pub struct Profiler {
 
 impl Profiler {
     pub fn create(output: &Option<OutputOptions>, file_path: Option<String>) -> ProfilerChan {
-        let (chan, port) = ipc::channel().unwrap();
         match *output {
             Some(ref option) => {
+                let (chan, port) = ipc::channel().unwrap();
                 // Spawn the time profiler thread
                 let outputoption = option.clone();
                 thread::Builder::new()
@@ -115,41 +115,10 @@ impl Profiler {
                             .expect("Thread spawning failed");
                     },
                 }
+                ProfilerChan(Some(chan))
             },
-            None => {
-                // this is when the -p option hasn't been specified
-                if file_path.is_some() {
-                    // Spawn the time profiler
-                    thread::Builder::new()
-                        .name("TimeProfiler".to_owned())
-                        .spawn(move || {
-                            let trace = file_path.as_ref().and_then(|p| TraceDump::new(p).ok());
-                            let mut profiler = Profiler::new(port, trace, None);
-                            profiler.start();
-                        })
-                        .expect("Thread spawning failed");
-                } else {
-                    // No-op to handle messages when the time profiler is not printing:
-                    thread::Builder::new()
-                        .name("TimeProfiler".to_owned())
-                        .spawn(move || {
-                            loop {
-                                match port.recv() {
-                                    Err(_) => break,
-                                    Ok(ProfilerMsg::Exit(chan)) => {
-                                        let _ = chan.send(());
-                                        break;
-                                    },
-                                    _ => {},
-                                }
-                            }
-                        })
-                        .expect("Thread spawning failed");
-                }
-            },
+            None => ProfilerChan(None),
         }
-
-        ProfilerChan(chan)
     }
 
     pub fn new(

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -17,12 +17,14 @@ pub struct TimerMetadata {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ProfilerChan(pub IpcSender<ProfilerMsg>);
+pub struct ProfilerChan(pub Option<IpcSender<ProfilerMsg>>);
 
 impl ProfilerChan {
     pub fn send(&self, msg: ProfilerMsg) {
-        if let Err(e) = self.0.send(msg) {
-            warn!("Error communicating with the time profiler thread: {}", e);
+        if let Some(sender) = &self.0 {
+            if let Err(e) = sender.send(msg) {
+                warn!("Error communicating with the time profiler thread: {}", e);
+            }
         }
     }
 }


### PR DESCRIPTION
ProfilerChan now takes an Option<> in order to avoid spawning a channel when unnecessary.

Testing: Manual (-p and --profiler-trace-path options still work with these changes).
Fixes: #40810
