### PR TITLE
servoshell: Make event loop implementations more similar to each other

### DIFF
--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -19,6 +19,7 @@ use servo::webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize, 
 use servo::{RenderingContext, ScreenGeometry, SoftwareRenderingContext, WebView};
 use winit::dpi::PhysicalSize;
 
+use super::app_state::RunningAppState;
 use crate::desktop::window_trait::{MIN_WINDOW_INNER_SIZE, WindowPortsMethods};
 use crate::prefs::ServoShellPreferences;
 
@@ -84,6 +85,10 @@ impl WindowPortsMethods for Window {
 
     fn set_position(&self, point: DeviceIntPoint) {
         self.window_position.set(point);
+    }
+
+    fn request_repaint(&self, state: &RunningAppState) {
+        state.repaint_servo_if_necessary();
     }
 
     fn request_resize(&self, webview: &WebView, new_size: DeviceIntSize) -> Option<DeviceIntSize> {

--- a/ports/servoshell/desktop/window_trait.rs
+++ b/ports/servoshell/desktop/window_trait.rs
@@ -48,17 +48,17 @@ pub trait WindowPortsMethods {
     ///
     /// TODO: This should be handled internally in the winit window if possible so that it
     /// makes more sense when we are mixing headed and headless windows.
-    fn handle_winit_window_event(&self, _: Rc<RunningAppState>, _: WindowEvent) -> bool {
-        false
-    }
+    fn handle_winit_window_event(&self, _: Rc<RunningAppState>, _: WindowEvent) {}
     /// Handle a winit [`AppEvent`]. Returns `true` if the event loop should continue and
     /// `false` otherwise.
     ///
     /// TODO: This should be handled internally in the winit window if possible so that it
     /// makes more sense when we are mixing headed and headless windows.
-    fn handle_winit_app_event(&self, _: Rc<RunningAppState>, _: AppEvent) -> bool {
-        false
-    }
+    fn handle_winit_app_event(&self, _: Rc<RunningAppState>, _: AppEvent) {}
+    /// Request that the window redraw itself. It is up to the window to do this
+    /// once the windowing system is ready. If this is a headless window, the redraw
+    /// will happen immediately.
+    fn request_repaint(&self, _: &RunningAppState);
     /// Request a new outer size for the window, including external decorations.
     /// This should be the same as `window.outerWidth` and `window.outerHeight``
     fn request_resize(&self, webview: &WebView, outer_size: DeviceIntSize)


### PR DESCRIPTION
Unify the way that the headed and headless event loop pump the servo
event loop. In addition, make the headless event loop data strucures
match more closely the ones from winit.

This is a step toward adding multiple window support to servoshell, as
the servo event loop pump will need to support multiple windows. This
changes means that this fix will only have to happen in one place
instead of two.

Testing: This should not change behavior and thus is covered by existing tests.
