### PR TITLE
Support `font-optical-sizing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -337,7 +337,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -378,7 +378,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -2175,7 +2175,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2609,7 +2609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3225,7 +3225,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps 7.0.5",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4738,7 +4738,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5776,7 +5776,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7354,7 +7354,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7739,7 +7739,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.33.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#92a4473e02d475c1c5369dfcefe6efc32987d98e"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8046,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#92a4473e02d475c1c5369dfcefe6efc32987d98e"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8587,7 +8587,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#92a4473e02d475c1c5369dfcefe6efc32987d98e"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8644,7 +8644,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#92a4473e02d475c1c5369dfcefe6efc32987d98e"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8653,12 +8653,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#92a4473e02d475c1c5369dfcefe6efc32987d98e"
 
 [[package]]
 name = "stylo_derive"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#92a4473e02d475c1c5369dfcefe6efc32987d98e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8670,7 +8670,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#92a4473e02d475c1c5369dfcefe6efc32987d98e"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8679,7 +8679,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#92a4473e02d475c1c5369dfcefe6efc32987d98e"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8696,12 +8696,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#92a4473e02d475c1c5369dfcefe6efc32987d98e"
 
 [[package]]
 name = "stylo_traits"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#92a4473e02d475c1c5369dfcefe6efc32987d98e"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -8889,7 +8889,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9115,7 +9115,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#92a4473e02d475c1c5369dfcefe6efc32987d98e"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9128,7 +9128,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#94e3763b63beda6f8feaa5d9c7b2be007fa40c76"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#92a4473e02d475c1c5369dfcefe6efc32987d98e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -10400,7 +10400,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/components/fonts/tests/font.rs
+++ b/components/fonts/tests/font.rs
@@ -14,6 +14,7 @@ use fonts::{
     PlatformFontMethods, ShapingFlags, ShapingOptions,
 };
 use servo_url::ServoUrl;
+use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
 use style::properties::longhands::font_variant_caps::computed_value::T as FontVariantCaps;
 use style::values::computed::{FontStretch, FontStyle, FontSynthesis, FontWeight};
 use unicode_script::Script;
@@ -39,6 +40,7 @@ fn make_font(path: PathBuf) -> Font {
         pt_size: Au::from_px(24),
         variation_settings: vec![],
         synthesis_weight: FontSynthesis::Auto,
+        optical_sizing: FontOpticalSizing::Auto,
     };
     Font::new(FontTemplateRef::new(template), descriptor, Some(data), None).unwrap()
 }

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -27,6 +27,7 @@ mod font_context {
     use parking_lot::Mutex;
     use servo_arc::Arc as ServoArc;
     use style::ArcSlice;
+    use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
     use style::properties::longhands::font_variant_caps::computed_value::T as FontVariantCaps;
     use style::properties::style_structs::Font as FontStyleStruct;
     use style::values::computed::font::{
@@ -358,6 +359,7 @@ mod font_context {
             pt_size: Au(10),
             variation_settings: vec![],
             synthesis_weight: FontSynthesis::Auto,
+            optical_sizing: FontOpticalSizing::Auto,
         };
 
         let family = SingleFontFamily::FamilyName(FamilyName {

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -1010,6 +1010,7 @@ malloc_size_of_is_stylo_malloc_size_of!(style::values::specified::box_::Overflow
 malloc_size_of_is_stylo_malloc_size_of!(style::values::specified::font::FontSynthesis);
 malloc_size_of_is_stylo_malloc_size_of!(style::values::specified::TextDecorationLine);
 malloc_size_of_is_stylo_malloc_size_of!(stylo_dom::ElementState);
+malloc_size_of_is_stylo_malloc_size_of!(style::computed_values::font_optical_sizing::T);
 
 impl<T> MallocSizeOf for GenericLengthPercentageOrAuto<T>
 where

--- a/components/shared/fonts/font_descriptor.rs
+++ b/components/shared/fonts/font_descriptor.rs
@@ -6,6 +6,7 @@ use std::ops::{Deref, RangeInclusive};
 
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
+use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
 use style::computed_values::font_variant_caps;
 use style::font_face::{FontFaceRuleData, FontStyle as FontFaceStyle};
 use style::properties::style_structs::Font as FontStyleStruct;
@@ -27,6 +28,7 @@ pub struct FontDescriptor {
     pub pt_size: Au,
     pub variation_settings: Vec<FontVariation>,
     pub synthesis_weight: FontSynthesis,
+    pub optical_sizing: FontOpticalSizing,
 }
 
 impl Eq for FontDescriptor {}
@@ -42,7 +44,6 @@ impl<'a> From<&'a FontStyleStruct> for FontDescriptor {
                 value: setting.value,
             })
             .collect();
-        let synthesis_weight = style.clone_font_synthesis_weight();
         FontDescriptor {
             weight: style.font_weight,
             stretch: style.font_stretch,
@@ -50,7 +51,8 @@ impl<'a> From<&'a FontStyleStruct> for FontDescriptor {
             variant: style.font_variant_caps,
             pt_size: Au::from_f32_px(style.font_size.computed_size().px()),
             variation_settings,
-            synthesis_weight,
+            synthesis_weight: style.clone_font_synthesis_weight(),
+            optical_sizing: style.clone_font_optical_sizing(),
         }
     }
 }

--- a/components/shared/fonts/font_template.rs
+++ b/components/shared/fonts/font_template.rs
@@ -8,7 +8,10 @@ use std::sync::Arc;
 
 use atomic_refcell::{AtomicRef, AtomicRefCell};
 use malloc_size_of_derive::MallocSizeOf;
+use read_fonts::collections::int_set::Domain;
+use read_fonts::types::Tag;
 use serde::{Deserialize, Serialize};
+use style::computed_values::font_optical_sizing::T as FontOpticalSizing;
 use style::computed_values::font_stretch::T as FontStretch;
 use style::computed_values::font_style::T as FontStyle;
 use style::stylesheets::{DocumentStyleSheet, FontFaceRule};
@@ -254,6 +257,14 @@ impl FontTemplate {
                     })
                     .for_each(&mut add_variation);
             }
+        }
+
+        // Step 9. Font variations implied by the value of the font-optical-sizing property are applied.
+        if descriptor.optical_sizing == FontOpticalSizing::Auto {
+            add_variation(FontVariation {
+                tag: Tag::new(b"opsz").to_u32(),
+                value: descriptor.pt_size.to_f32_px(),
+            });
         }
 
         variations


### PR DESCRIPTION
This doesn't quite fix the issue in https://github.com/servo/servo/pull/38642#issuecomment-3193498155, I think macos should still have the wrong behaviour for `font-optical-sizing: none` (but I have no way to verify that).

<details><summary>Manual testcase (fixed by this change)</summary>

```html
<style>
@font-face {
  font-family: "Amstelvar VF";
  src: url("https://mdn.github.io/shared-assets/fonts/variable-fonts/AmstelvarAlpha-VF.woff2")
    format("woff2-variations");
  font-weight: 300 900;
}

p {
  font:
    1.2em "Amstelvar VF",
    Georgia,
    serif;
    font-optical-sizing: none;
  font-size: 4rem;
  margin: 1rem;
  display: inline-block;
}

.p1 {
  font-variation-settings: "wght" 300;
  font-optical-sizing: auto;
}

.p2 {
  font-variation-settings: "wght" 300;
  font-optical-sizing: none;
}

</style>
<div>
  <p class="p1">Weight</p>
  <span>(font-optical-sizing: auto)</span>
</div>
<div>
  <p class="p2">Weight</p>
  <span>(font-optical-sizing: none)</span>
</div>

</div>
```
</details>

Testing: We don't run wpt with `layout_variable_fonts` enabled yet. (But I think we could after this change)
Depends on https://github.com/servo/stylo/pull/271
Part of #38800 
