### PR TITLE
servodriver: Fix incorrect method name.

### DIFF
--- a/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
+++ b/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py
@@ -169,7 +169,7 @@ class ServoWebDriverBrowser(WebDriverBrowser):
 
             retry_cnt += 1
             if retry_cnt >= self.shutdown_retry_attempts:
-                self.logger.warn("Max retry exceeded to normally shut down. Killing instead.")
+                self.logger.warning("Max retry exceeded to normally shut down. Killing instead.")
                 break
             time.sleep(1)
         super().stop(force)


### PR DESCRIPTION
Fixes the following error that occurs when servodriver shutdown times out:
```
Uncaught exception in TestRunnerManager.run:
Traceback (most recent call last):
  File "/Users/jdm/src/alt-servo/tests/wpt/tests/tools/wptrunner/wptrunner/testrunner.py", line 441, in run_loop
    new_state = f()
                ^^^
  File "/Users/jdm/src/alt-servo/tests/wpt/tests/tools/wptrunner/wptrunner/testrunner.py", line 936, in restart_runner
    self.stop_runner(force=self.state.force_stop)
  File "/Users/jdm/src/alt-servo/tests/wpt/tests/tools/wptrunner/wptrunner/testrunner.py", line 959, in stop_runner
    self.browser.stop(force=True)
  File "/Users/jdm/src/alt-servo/tests/wpt/tests/tools/wptrunner/wptrunner/testrunner.py", line 292, in stop
    self.browser.stop(force=force)
  File "/Users/jdm/src/alt-servo/tests/wpt/tests/tools/wptrunner/wptrunner/browsers/servodriver.py", line 172, in stop
    self.logger.warn("Max retry exceeded to normally shut down. Killing instead.")
    ^^^^^^^^^^^^^^^^
AttributeError: 'StructuredLogger' object has no attribute 'warn'
```

Testing: Manual test. Can't test the test harness.