### PR TITLE
webdriver: Enable implicit wait on error

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -419,8 +419,6 @@ enum VerifyBrowsingContextIsOpen {
     No,
 }
 
-const CAN_EARLY_RETURN: bool = true;
-
 impl Handler {
     fn new(
         embedder_sender: Sender<WebDriverCommandMsg>,
@@ -1414,10 +1412,10 @@ impl Handler {
                 ),
             };
             self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)
-                .map_err(|error| (CAN_EARLY_RETURN, error))?;
+                .map_err(|error| (true, error))?;
             wait_for_ipc_response_flatten(receiver)
                 .map(|value| (!value.is_empty(), value))
-                .map_err(|error| (CAN_EARLY_RETURN, error))
+                .map_err(|error| (true, error))
         })
         .and_then(|response| {
             let resp_value: Vec<WebElement> = response.into_iter().map(WebElement).collect();
@@ -1488,10 +1486,10 @@ impl Handler {
                 ),
             };
             self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)
-                .map_err(|error| (CAN_EARLY_RETURN, error))?;
+                .map_err(|error| (true, error))?;
             wait_for_ipc_response_flatten(receiver)
                 .map(|value| (!value.is_empty(), value))
-                .map_err(|error| (CAN_EARLY_RETURN, error))
+                .map_err(|error| (true, error))
         })
         .and_then(|response| {
             let resp_value: Vec<Value> = response
@@ -1553,10 +1551,10 @@ impl Handler {
                 ),
             };
             self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)
-                .map_err(|error| (CAN_EARLY_RETURN, error))?;
+                .map_err(|error| (true, error))?;
             wait_for_ipc_response_flatten(receiver)
                 .map(|value| (!value.is_empty(), value))
-                .map_err(|error| (CAN_EARLY_RETURN, error))
+                .map_err(|error| (true, error))
         })
         .and_then(|response| {
             let resp_value: Vec<Value> = response

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -1394,12 +1394,10 @@ impl Handler {
         self.implicit_wait(|| {
             let (sender, receiver) = ipc::channel().unwrap();
             let cmd = match parameters.using {
-                LocatorStrategy::CSSSelector => {
-                    WebDriverScriptCommand::FindElementsCSSSelector(
-                        parameters.value.clone(),
-                        sender,
-                    )
-                },
+                LocatorStrategy::CSSSelector => WebDriverScriptCommand::FindElementsCSSSelector(
+                    parameters.value.clone(),
+                    sender,
+                ),
                 LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
                     WebDriverScriptCommand::FindElementsLinkText(
                         parameters.value.clone(),
@@ -1408,20 +1406,18 @@ impl Handler {
                     )
                 },
                 LocatorStrategy::TagName => {
-                    WebDriverScriptCommand::FindElementsTagName(
-                        parameters.value.clone(),
-                        sender,
-                    )
+                    WebDriverScriptCommand::FindElementsTagName(parameters.value.clone(), sender)
                 },
-                LocatorStrategy::XPath => {
-                    WebDriverScriptCommand::FindElementsXpathSelector(
-                        parameters.value.clone(),
-                        sender,
-                    )
-                },
+                LocatorStrategy::XPath => WebDriverScriptCommand::FindElementsXpathSelector(
+                    parameters.value.clone(),
+                    sender,
+                ),
             };
-            self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No).map_err(|error|(CAN_EARLY_RETURN, error))?;
-            wait_for_ipc_response_flatten(receiver).map(|value| (!value.is_empty(), value)).map_err(|error|(CAN_EARLY_RETURN, error))
+            self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)
+                .map_err(|error| (CAN_EARLY_RETURN, error))?;
+            wait_for_ipc_response_flatten(receiver)
+                .map(|value| (!value.is_empty(), value))
+                .map_err(|error| (CAN_EARLY_RETURN, error))
         })
         .and_then(|response| {
             let resp_value: Vec<WebElement> = response.into_iter().map(WebElement).collect();
@@ -1473,30 +1469,29 @@ impl Handler {
                     )
                 },
                 LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
-                     WebDriverScriptCommand::FindElementElementsLinkText(
+                    WebDriverScriptCommand::FindElementElementsLinkText(
                         parameters.value.clone(),
                         element.to_string(),
                         parameters.using == LocatorStrategy::PartialLinkText,
                         sender,
                     )
                 },
-                LocatorStrategy::TagName => {
-                    WebDriverScriptCommand::FindElementElementsTagName(
-                        parameters.value.clone(),
-                        element.to_string(),
-                        sender,
-                    )
-                },
-                LocatorStrategy::XPath => {
-                    WebDriverScriptCommand::FindElementElementsXPathSelector(
-                        parameters.value.clone(),
-                        element.to_string(),
-                        sender,
-                    )
-                },
+                LocatorStrategy::TagName => WebDriverScriptCommand::FindElementElementsTagName(
+                    parameters.value.clone(),
+                    element.to_string(),
+                    sender,
+                ),
+                LocatorStrategy::XPath => WebDriverScriptCommand::FindElementElementsXPathSelector(
+                    parameters.value.clone(),
+                    element.to_string(),
+                    sender,
+                ),
             };
-            self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No).map_err(|error|(CAN_EARLY_RETURN, error))?;
-            wait_for_ipc_response_flatten(receiver).map(|value| (!value.is_empty(), value)).map_err(|error|(CAN_EARLY_RETURN, error))
+            self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)
+                .map_err(|error| (CAN_EARLY_RETURN, error))?;
+            wait_for_ipc_response_flatten(receiver)
+                .map(|value| (!value.is_empty(), value))
+                .map_err(|error| (CAN_EARLY_RETURN, error))
         })
         .and_then(|response| {
             let resp_value: Vec<Value> = response
@@ -1546,23 +1541,22 @@ impl Handler {
                         sender,
                     )
                 },
-                LocatorStrategy::TagName => {
-                    WebDriverScriptCommand::FindShadowElementsTagName(
-                        parameters.value.clone(),
-                        shadow_root.to_string(),
-                        sender,
-                    )
-                },
-                LocatorStrategy::XPath => {
-                    WebDriverScriptCommand::FindShadowElementsXPathSelector(
-                        parameters.value.clone(),
-                        shadow_root.to_string(),
-                        sender,
-                    )
-                },
+                LocatorStrategy::TagName => WebDriverScriptCommand::FindShadowElementsTagName(
+                    parameters.value.clone(),
+                    shadow_root.to_string(),
+                    sender,
+                ),
+                LocatorStrategy::XPath => WebDriverScriptCommand::FindShadowElementsXPathSelector(
+                    parameters.value.clone(),
+                    shadow_root.to_string(),
+                    sender,
+                ),
             };
-            self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No).map_err(|error|(CAN_EARLY_RETURN, error))?;
-            wait_for_ipc_response_flatten(receiver).map(|value| (!value.is_empty(), value)).map_err(|error|(CAN_EARLY_RETURN, error))
+            self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)
+                .map_err(|error| (CAN_EARLY_RETURN, error))?;
+            wait_for_ipc_response_flatten(receiver)
+                .map(|value| (!value.is_empty(), value))
+                .map_err(|error| (CAN_EARLY_RETURN, error))
         })
         .and_then(|response| {
             let resp_value: Vec<Value> = response

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -419,6 +419,21 @@ enum VerifyBrowsingContextIsOpen {
     No,
 }
 
+enum ImplicitWait {
+    Return,
+    #[expect(dead_code)]
+    Continue,
+}
+
+impl From<ImplicitWait> for bool {
+    fn from(implicit_wait: ImplicitWait) -> Self {
+        match implicit_wait {
+            ImplicitWait::Return => true,
+            ImplicitWait::Continue => false,
+        }
+    }
+}
+
 impl Handler {
     fn new(
         embedder_sender: Sender<WebDriverCommandMsg>,
@@ -1412,10 +1427,10 @@ impl Handler {
                 ),
             };
             self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)
-                .map_err(|error| (true, error))?;
+                .map_err(|error| (ImplicitWait::Return.into(), error))?;
             wait_for_ipc_response_flatten(receiver)
                 .map(|value| (!value.is_empty(), value))
-                .map_err(|error| (true, error))
+                .map_err(|error| (ImplicitWait::Return.into(), error))
         })
         .and_then(|response| {
             let resp_value: Vec<WebElement> = response.into_iter().map(WebElement).collect();
@@ -1486,10 +1501,10 @@ impl Handler {
                 ),
             };
             self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)
-                .map_err(|error| (true, error))?;
+                .map_err(|error| (ImplicitWait::Return.into(), error))?;
             wait_for_ipc_response_flatten(receiver)
                 .map(|value| (!value.is_empty(), value))
-                .map_err(|error| (true, error))
+                .map_err(|error| (ImplicitWait::Return.into(), error))
         })
         .and_then(|response| {
             let resp_value: Vec<Value> = response
@@ -1551,10 +1566,10 @@ impl Handler {
                 ),
             };
             self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)
-                .map_err(|error| (true, error))?;
+                .map_err(|error| (ImplicitWait::Return.into(), error))?;
             wait_for_ipc_response_flatten(receiver)
                 .map(|value| (!value.is_empty(), value))
-                .map_err(|error| (true, error))
+                .map_err(|error| (ImplicitWait::Return.into(), error))
         })
         .and_then(|response| {
             let resp_value: Vec<Value> = response

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -421,7 +421,7 @@ enum VerifyBrowsingContextIsOpen {
 
 enum ImplicitWait {
     Return,
-    #[expect(dead_code)]
+    #[expect(dead_code, reason = "This will be used in the next patch")]
     Continue,
 }
 

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -419,8 +419,6 @@ enum VerifyBrowsingContextIsOpen {
     No,
 }
 
-/// The boolean indicates whether implicit_wait can early return before timeout with current result.
-type ImplicitWaitCallbackResult<T> = Result<(bool, T), (bool, WebDriverError)>;
 const CAN_EARLY_RETURN: bool = true;
 
 impl Handler {
@@ -1345,9 +1343,11 @@ impl Handler {
         unwrap_first_element_response(res)
     }
 
+    /// The boolean in callback result indicates whether implicit_wait can early return
+    /// before timeout with current result.
     fn implicit_wait<T>(
         &self,
-        callback: impl Fn() -> ImplicitWaitCallbackResult<T>,
+        callback: impl Fn() -> Result<(bool, T), (bool, WebDriverError)>,
     ) -> Result<T, WebDriverError> {
         let now = Instant::now();
         let (implicit_wait, sleep_interval) = {

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -419,6 +419,10 @@ enum VerifyBrowsingContextIsOpen {
     No,
 }
 
+/// The boolean indicates whether implicit_wait can early return before timeout with current result.
+type ImplicitWaitCallbackResult<T> = Result<(bool, T), (bool, WebDriverError)>;
+const CAN_EARLY_RETURN: bool = true;
+
 impl Handler {
     fn new(
         embedder_sender: Sender<WebDriverCommandMsg>,
@@ -1341,11 +1345,9 @@ impl Handler {
         unwrap_first_element_response(res)
     }
 
-    /// `callback` bound: when it returns Ok, the first value indicates whether
-    /// implicit_wait can early return.
     fn implicit_wait<T>(
         &self,
-        callback: impl Fn() -> Result<(bool, T), WebDriverError>,
+        callback: impl Fn() -> ImplicitWaitCallbackResult<T>,
     ) -> Result<T, WebDriverError> {
         let now = Instant::now();
         let (implicit_wait, sleep_interval) = {
@@ -1363,7 +1365,11 @@ impl Handler {
                         return Ok(value);
                     }
                 },
-                Err(error) => return Err(error),
+                Err((can_early_return, error)) => {
+                    if can_early_return || now.elapsed() >= implicit_wait {
+                        return Err(error);
+                    }
+                },
             }
             sleep(sleep_interval);
         }
@@ -1387,38 +1393,35 @@ impl Handler {
 
         self.implicit_wait(|| {
             let (sender, receiver) = ipc::channel().unwrap();
-            match parameters.using {
+            let cmd = match parameters.using {
                 LocatorStrategy::CSSSelector => {
-                    let cmd = WebDriverScriptCommand::FindElementsCSSSelector(
+                    WebDriverScriptCommand::FindElementsCSSSelector(
                         parameters.value.clone(),
                         sender,
-                    );
-                    self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+                    )
                 },
                 LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
-                    let cmd = WebDriverScriptCommand::FindElementsLinkText(
+                    WebDriverScriptCommand::FindElementsLinkText(
                         parameters.value.clone(),
                         parameters.using == LocatorStrategy::PartialLinkText,
                         sender,
-                    );
-                    self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+                    )
                 },
                 LocatorStrategy::TagName => {
-                    let cmd = WebDriverScriptCommand::FindElementsTagName(
+                    WebDriverScriptCommand::FindElementsTagName(
                         parameters.value.clone(),
                         sender,
-                    );
-                    self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+                    )
                 },
                 LocatorStrategy::XPath => {
-                    let cmd = WebDriverScriptCommand::FindElementsXpathSelector(
+                    WebDriverScriptCommand::FindElementsXpathSelector(
                         parameters.value.clone(),
                         sender,
-                    );
-                    self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+                    )
                 },
-            }
-            wait_for_ipc_response_flatten(receiver).map(|value| (!value.is_empty(), value))
+            };
+            self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No).map_err(|error|(CAN_EARLY_RETURN, error))?;
+            wait_for_ipc_response_flatten(receiver).map(|value| (!value.is_empty(), value)).map_err(|error|(CAN_EARLY_RETURN, error))
         })
         .and_then(|response| {
             let resp_value: Vec<WebElement> = response.into_iter().map(WebElement).collect();
@@ -1461,42 +1464,39 @@ impl Handler {
         self.implicit_wait(|| {
             let (sender, receiver) = ipc::channel().unwrap();
 
-            match parameters.using {
+            let cmd = match parameters.using {
                 LocatorStrategy::CSSSelector => {
-                    let cmd = WebDriverScriptCommand::FindElementElementsCSSSelector(
+                    WebDriverScriptCommand::FindElementElementsCSSSelector(
                         parameters.value.clone(),
                         element.to_string(),
                         sender,
-                    );
-                    self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+                    )
                 },
                 LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
-                    let cmd = WebDriverScriptCommand::FindElementElementsLinkText(
+                     WebDriverScriptCommand::FindElementElementsLinkText(
                         parameters.value.clone(),
                         element.to_string(),
                         parameters.using == LocatorStrategy::PartialLinkText,
                         sender,
-                    );
-                    self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+                    )
                 },
                 LocatorStrategy::TagName => {
-                    let cmd = WebDriverScriptCommand::FindElementElementsTagName(
+                    WebDriverScriptCommand::FindElementElementsTagName(
                         parameters.value.clone(),
                         element.to_string(),
                         sender,
-                    );
-                    self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+                    )
                 },
                 LocatorStrategy::XPath => {
-                    let cmd = WebDriverScriptCommand::FindElementElementsXPathSelector(
+                    WebDriverScriptCommand::FindElementElementsXPathSelector(
                         parameters.value.clone(),
                         element.to_string(),
                         sender,
-                    );
-                    self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+                    )
                 },
-            }
-            wait_for_ipc_response_flatten(receiver).map(|value| (!value.is_empty(), value))
+            };
+            self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No).map_err(|error|(CAN_EARLY_RETURN, error))?;
+            wait_for_ipc_response_flatten(receiver).map(|value| (!value.is_empty(), value)).map_err(|error|(CAN_EARLY_RETURN, error))
         })
         .and_then(|response| {
             let resp_value: Vec<Value> = response
@@ -1530,43 +1530,39 @@ impl Handler {
         self.implicit_wait(|| {
             let (sender, receiver) = ipc::channel().unwrap();
 
-            match parameters.using {
+            let cmd = match parameters.using {
                 LocatorStrategy::CSSSelector => {
-                    let cmd = WebDriverScriptCommand::FindShadowElementsCSSSelector(
+                    WebDriverScriptCommand::FindShadowElementsCSSSelector(
                         parameters.value.clone(),
                         shadow_root.to_string(),
                         sender,
-                    );
-                    self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+                    )
                 },
                 LocatorStrategy::LinkText | LocatorStrategy::PartialLinkText => {
-                    let cmd = WebDriverScriptCommand::FindShadowElementsLinkText(
+                    WebDriverScriptCommand::FindShadowElementsLinkText(
                         parameters.value.clone(),
                         shadow_root.to_string(),
                         parameters.using == LocatorStrategy::PartialLinkText,
                         sender,
-                    );
-                    self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+                    )
                 },
                 LocatorStrategy::TagName => {
-                    let cmd = WebDriverScriptCommand::FindShadowElementsTagName(
+                    WebDriverScriptCommand::FindShadowElementsTagName(
                         parameters.value.clone(),
                         shadow_root.to_string(),
                         sender,
-                    );
-                    self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+                    )
                 },
                 LocatorStrategy::XPath => {
-                    let cmd = WebDriverScriptCommand::FindShadowElementsXPathSelector(
+                    WebDriverScriptCommand::FindShadowElementsXPathSelector(
                         parameters.value.clone(),
                         shadow_root.to_string(),
                         sender,
-                    );
-                    self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No)?;
+                    )
                 },
-            }
-
-            wait_for_ipc_response_flatten(receiver).map(|value| (!value.is_empty(), value))
+            };
+            self.browsing_context_script_command(cmd, VerifyBrowsingContextIsOpen::No).map_err(|error|(CAN_EARLY_RETURN, error))?;
+            wait_for_ipc_response_flatten(receiver).map(|value| (!value.is_empty(), value)).map_err(|error|(CAN_EARLY_RETURN, error))
         })
         .and_then(|response| {
             let resp_value: Vec<Value> = response

--- a/tests/wpt/tests/webdriver/tests/classic/find_element/find.py
+++ b/tests/wpt/tests/webdriver/tests/classic/find_element/find.py
@@ -119,3 +119,29 @@ def test_htmldocument(session, inline, using, value):
     session.url = inline("")
     response = find_element(session, using, value)
     assert_success(response)
+
+
+def test_implicit_wait(session, inline):
+    session.url = inline("""
+        <script>
+            setTimeout(() => {
+                document.body.innerHTML = '<div id="delayed"></div>';
+            }, 300);
+        </script>
+    """)
+    session.timeouts.implicit = 1
+
+    response = find_element(session, "css selector", "#delayed")
+    value = assert_success(response)
+
+    expected = session.execute_script("return document.getElementById('delayed')")
+    assert_same_element(session, value, expected)
+
+
+def test_implicit_wait_timeout(session, inline):
+    session.url = inline("")
+    session.timeouts.implicit = 0.5
+
+    # Element never created
+    response = find_element(session, "css selector", "#nonexistent")
+    assert_error(response, "no such element")


### PR DESCRIPTION
... and reduce code duplication in element retrieval. Note that we are not using the functionality of "wait on error" yet.

Testing: We added WPT tests for "Find element", "Find element from element", "Find element from shadow root" for both successful implicit wait and timeout case.