### PR TITLE
Fix duplicate carets in <textarea>

### DIFF
--- a/components/layout/flow/inline/text_run.rs
+++ b/components/layout/flow/inline/text_run.rs
@@ -156,7 +156,7 @@ impl TextRunSegment {
                 self.bidi_level,
                 ServoRange::<ByteIndex>::new(
                     byte_processed + ByteIndex(self.range.start as isize),
-                    ByteIndex(self.range.len() as isize) - byte_processed,
+                    run.range.length(),
                 ),
             );
             byte_processed = byte_processed + run.range.length();


### PR DESCRIPTION
This fixes a bug where <textarea> would render with many carets. Reports vary, but in my case it would would be at the start and end of every "word", as long as those cursors came before the actual cursor.

The actual cursor would render normally, except that it does not render immediately after a line break. This appears to be a separate issue.

The issue occurs because `push_glyph_store_to_unbreakable_segment` gets passed too long of a range. This bypasses the check here: https://github.com/servo/servo/blob/bbbfe6d2999b012487b0be2546d89c55fa4950bf/components/layout/flow/inline/mod.rs#L1438-L1440

Testing: Tested with `./mach test-unit`. No new tests were added. Perhaps someone has an idea of how one could test this. Also tested manually in multiple scenarios, including with a text input. I was not able to get Servo to soft wrap in a textbox, maybe Servo does not support that currently. Ultimately I am not super confident about this solution as it interacts with line wrapping, and I would like to hear some feedback
Fixes: https://github.com/servo/servo/issues/40075