### PR TITLE
Allow webdriver to automatically accept custom protocol handlers

### DIFF
--- a/components/net/protocols/blob.rs
+++ b/components/net/protocols/blob.rs
@@ -84,4 +84,8 @@ impl ProtocolHandler for BlobProtocolHander {
 
         Box::pin(ready(response))
     }
+
+    fn clone_box(&self) -> Box<dyn ProtocolHandler> {
+        Box::new(BlobProtocolHander::default())
+    }
 }

--- a/components/net/protocols/data.rs
+++ b/components/net/protocols/data.rs
@@ -57,4 +57,8 @@ impl ProtocolHandler for DataProtocolHander {
     fn is_fetchable(&self) -> bool {
         true
     }
+
+    fn clone_box(&self) -> Box<dyn ProtocolHandler> {
+        Box::new(DataProtocolHander::default())
+    }
 }

--- a/components/net/protocols/file.rs
+++ b/components/net/protocols/file.rs
@@ -108,4 +108,8 @@ impl ProtocolHandler for FileProtocolHander {
 
         Box::pin(ready(response))
     }
+
+    fn clone_box(&self) -> Box<dyn ProtocolHandler> {
+        Box::new(FileProtocolHander::default())
+    }
 }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -605,7 +605,7 @@ pub(crate) struct Document {
 
     /// <https://html.spec.whatwg.org/multipage/#registerprotocolhandler()-automation-mode>
     #[no_trace]
-    protocol_handler_automation_mode: RefCell<CustomHandlersAutomationMode>,
+    protocol_handler_automation_mode: Cell<CustomHandlersAutomationMode>,
 
     /// Reflect the value of that preferences to prevent paying the cost of a RwLock access.
     layout_animations_test_enabled: bool,
@@ -888,8 +888,12 @@ impl Document {
         &self.origin
     }
 
+    pub(crate) fn protocol_handler_automation_mode(&self) -> CustomHandlersAutomationMode {
+        self.protocol_handler_automation_mode.get()
+    }
+
     pub(crate) fn set_protocol_handler_automation_mode(&self, mode: CustomHandlersAutomationMode) {
-        *self.protocol_handler_automation_mode.borrow_mut() = mode;
+        self.protocol_handler_automation_mode.set(mode);
     }
 
     /// <https://dom.spec.whatwg.org/#concept-document-url>

--- a/components/shared/net/filemanager_thread.rs
+++ b/components/shared/net/filemanager_thread.rs
@@ -20,6 +20,7 @@ use crate::blob_url_store::{BlobBuf, BlobURLStoreError};
 pub type FileOrigin = String;
 
 /// A token modulating access to a file for a blob URL.
+#[derive(Clone)]
 pub enum FileTokenCheck {
     /// Checking against a token not required,
     /// used for accessing a file

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -518,6 +518,7 @@ pub enum CoreResourceMsg {
     DeleteCookie(ServoUrl, String),
     DeleteCookieAsync(CookieStoreId, ServoUrl, String),
     NewCookieListener(CookieStoreId, IpcSender<CookieAsyncResponse>, ServoUrl),
+    RegisterProtocolHandler(String, ServoUrl, IpcSender<()>),
     RemoveCookieListener(CookieStoreId),
     /// Get a history state by a given history state id
     GetHistoryState(HistoryStateId, IpcSender<Option<Vec<u8>>>),

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -133,6 +133,10 @@ impl App {
             "resource",
             protocols::resource::ResourceProtocolHandler::default(),
         );
+        let _ = protocol_registry.register_page_content_handler(
+            "mailto".to_owned(),
+            "https://mail.proton.me/inbox/#mailto=%s".to_owned(),
+        );
 
         let servo_builder = ServoBuilder::default()
             .opts(self.opts.clone())

--- a/ports/servoshell/desktop/protocols/resource.rs
+++ b/ports/servoshell/desktop/protocols/resource.rs
@@ -105,4 +105,8 @@ impl ProtocolHandler for ResourceProtocolHandler {
 
         Self::response_for_path(request, done_chan, context, url.path())
     }
+
+    fn clone_box(&self) -> Box<dyn ProtocolHandler> {
+        Box::new(ResourceProtocolHandler::default())
+    }
 }

--- a/ports/servoshell/desktop/protocols/servo.rs
+++ b/ports/servoshell/desktop/protocols/servo.rs
@@ -84,6 +84,10 @@ impl ProtocolHandler for ServoProtocolHandler {
             ))),
         }
     }
+
+    fn clone_box(&self) -> Box<dyn ProtocolHandler> {
+        Box::new(ServoProtocolHandler::default())
+    }
 }
 
 fn json_response(

--- a/ports/servoshell/desktop/protocols/urlinfo.rs
+++ b/ports/servoshell/desktop/protocols/urlinfo.rs
@@ -50,4 +50,8 @@ impl ProtocolHandler for UrlInfoProtocolHander {
     fn is_secure(&self) -> bool {
         true
     }
+
+    fn clone_box(&self) -> Box<dyn ProtocolHandler> {
+        Box::new(UrlInfoProtocolHander::default())
+    }
 }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -10746,6 +10746,12 @@
      "33834c3ef095fa9c0080017e1b65b2eb8413eac4",
      []
     ],
+    "protocol-handlers": {
+     "mailto.html": [
+      "772a0c266ebb22b172b82e06ae65f28423793474",
+      []
+     ]
+    },
     "remove_link_styles.css": [
      "1984cf7df21686c499942929ac342dddb160af6a",
      []

--- a/tests/wpt/mozilla/tests/mozilla/protocol-handlers/mailto.html
+++ b/tests/wpt/mozilla/tests/mozilla/protocol-handlers/mailto.html
@@ -1,0 +1,5 @@
+<html>
+<head>
+    <a href="mailto:info@servo.org" target="__blank">Mail with Proton to info@servo.org</a>
+</head>
+</html>

--- a/tests/wpt/tests/html/webappapis/system-state-and-capabilities/the-navigator-object/resources/handler-tools.js
+++ b/tests/wpt/tests/html/webappapis/system-state-and-capabilities/the-navigator-object/resources/handler-tools.js
@@ -35,6 +35,7 @@ function runTest({ includeNull = false } = {}) {
     }
     a.href = `${scheme}:${codePoints.join("")}`;
     a.target = "_blank";
+    console.log(a.href);
     a.click();
     await new Promise(resolve => {
       bc.onmessage = t.step_func(e => {


### PR DESCRIPTION
This reads the `protocol_handler_automation_mode` and if it is
`autoAccept`, then we should eagerly register the protocol handler.
We do this by updating the `ProtocolRegistry` in the resource thread,
where we need to clone it (since there can be ongoing fetches). To
be able to clone handlers, we need a new method on the trait.

Part of #40615