### PR TITLE
ohos CI: Try and improve the scenario test stability

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -399,3 +399,8 @@ jobs:
       - name: Test Mossel Slide
         if: ${{ steps.install_hap.outcome == 'success' && ! cancelled() }}
         run: uv run ./etc/ci/scenario/servo_test_slide.py
+      - name: Upload failure screenshots
+        if: ${{ steps.install_hap.outcome == 'success' && ! cancelled() }}
+        uses: actions/upload-artifact@v5
+        with:
+          path: 'servo_scenario_*_error.jpg'

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -13,9 +13,11 @@ import os
 import shutil
 import pathlib
 import subprocess
+import sys
 import time
 from decimal import Decimal
 
+import hdc_py
 from selenium import webdriver
 from selenium.webdriver.common.options import ArgOptions
 from urllib3.exceptions import ProtocolError
@@ -140,3 +142,20 @@ def stop_servo():
     cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
     subprocess.run(cmd, capture_output=True, text=True, timeout=10)
     print("Stop Test Application successful!")
+
+
+def run_test(test_fn, initial_url: str):
+    try:
+        print("Stopping potential old servo instance ...")
+        stop_servo()
+        hdc = hdc_py.HarmonyDeviceConnector()
+        print(f"Starting new servo instance, loading {initial_url} ...")
+        hdc.cmd(f"aa start -a EntryAbility -b org.servo.servo -U {initial_url} --psn --webdriver", timeout=10)
+        setup_hdc_forward()
+        with hdc_py.HarmonyDevicePerfMode():
+            test_fn()
+    except Exception as e:
+        print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
+        stop_servo()
+        sys.exit(1)
+    stop_servo()

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -17,7 +17,7 @@ import sys
 import time
 from decimal import Decimal
 
-from hdc_py import HarmonyDeviceConnector, HarmonyDevicePerfMode
+from hdc_py.hdc import HarmonyDeviceConnector, HarmonyDevicePerfMode
 from selenium import webdriver
 from selenium.webdriver.common.options import ArgOptions
 from urllib3.exceptions import ProtocolError

--- a/etc/ci/scenario/pyproject.toml
+++ b/etc/ci/scenario/pyproject.toml
@@ -2,7 +2,10 @@
 name = "servo_ci_scenario_test"
 version = "0.1.0"
 requires-python = ">3.11"
-dependencies = ["selenium"]
+dependencies = [
+    "selenium",
+    "hdc-py>=0.1.2",
+]
 license = "Apache-2.0 OR MIT"
 
 [tool.uv]

--- a/etc/ci/scenario/servo_test_frame_rate_base_page.py
+++ b/etc/ci/scenario/servo_test_frame_rate_base_page.py
@@ -14,6 +14,7 @@ import sys
 import time
 import subprocess
 
+from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -111,7 +112,8 @@ def operator():
 
 if __name__ == "__main__":
     try:
-        operator()
+        with HarmonyDevicePerfMode():
+            operator()
     except Exception as e:
         print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
         sys.exit(1)

--- a/etc/ci/scenario/servo_test_frame_rate_base_page.py
+++ b/etc/ci/scenario/servo_test_frame_rate_base_page.py
@@ -9,12 +9,9 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import os.path
-import sys
 import time
 import subprocess
 
-from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -24,17 +21,6 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    # Step 1. Start test application
-    print("Starting mossel ...")
-    cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    cmd = [
-        "hdc",
-        "shell",
-        "aa start -a EntryAbility -b org.servo.servo -U https://m.huaweimossel.com --psn --webdriver",
-    ]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    common_function_for_servo_test.setup_hdc_forward()
     driver = common_function_for_servo_test.create_driver()
 
     popup_css_selector = (
@@ -111,11 +97,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    try:
-        with HarmonyDevicePerfMode():
-            operator()
-    except Exception as e:
-        print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
-        sys.exit(1)
-
-    common_function_for_servo_test.stop_servo()
+    common_function_for_servo_test.run_test(operator, "https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_frame_rate_base_page.py
+++ b/etc/ci/scenario/servo_test_frame_rate_base_page.py
@@ -97,4 +97,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "https://m.huaweimossel.com")
+    common_function_for_servo_test.run_test(operator, "mossel_frame_rate_base", "https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_frame_rate_with_carousel.py
+++ b/etc/ci/scenario/servo_test_frame_rate_with_carousel.py
@@ -9,12 +9,9 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import sys
 import time
 import subprocess
-import os.path
 
-from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -24,19 +21,6 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    # Step 1. Open mossel
-    print("Starting mossel ...")
-    cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    cmd = [
-        "hdc",
-        "shell",
-        "aa start -a EntryAbility -b org.servo.servo -U https://m.huaweimossel.com --psn --webdriver",
-    ]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    time.sleep(10)
-
-    common_function_for_servo_test.setup_hdc_forward()
     driver = common_function_for_servo_test.create_driver()
 
     popup_css_selector = (
@@ -116,11 +100,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    try:
-        with HarmonyDevicePerfMode():
-            operator()
-    except Exception as e:
-        print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
-        sys.exit(1)
-
-    common_function_for_servo_test.stop_servo()
+    common_function_for_servo_test.run_test(operator, "https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_frame_rate_with_carousel.py
+++ b/etc/ci/scenario/servo_test_frame_rate_with_carousel.py
@@ -13,6 +13,8 @@ import sys
 import time
 import subprocess
 import os.path
+
+from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -115,7 +117,8 @@ def operator():
 
 if __name__ == "__main__":
     try:
-        operator()
+        with HarmonyDevicePerfMode():
+            operator()
     except Exception as e:
         print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
         sys.exit(1)

--- a/etc/ci/scenario/servo_test_frame_rate_with_carousel.py
+++ b/etc/ci/scenario/servo_test_frame_rate_with_carousel.py
@@ -100,4 +100,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "https://m.huaweimossel.com")
+    common_function_for_servo_test.run_test(operator, "mossel_frame_rate_with_carousel", "https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_frame_rate_with_video.py
+++ b/etc/ci/scenario/servo_test_frame_rate_with_video.py
@@ -13,6 +13,8 @@ import sys
 import time
 import subprocess
 import os.path
+
+from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -102,7 +104,8 @@ def operator():
 
 if __name__ == "__main__":
     try:
-        operator()
+        with HarmonyDevicePerfMode():
+            operator()
     except Exception as e:
         print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
         sys.exit(1)

--- a/etc/ci/scenario/servo_test_frame_rate_with_video.py
+++ b/etc/ci/scenario/servo_test_frame_rate_with_video.py
@@ -88,4 +88,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "https://m.huaweimossel.com")
+    common_function_for_servo_test.run_test(operator, "mossel_framerate_with_video", "https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_frame_rate_with_video.py
+++ b/etc/ci/scenario/servo_test_frame_rate_with_video.py
@@ -9,12 +9,9 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import sys
 import time
 import subprocess
-import os.path
 
-from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -24,18 +21,6 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    # Step 1. Open mossel
-    print("Starting mossel ...")
-    cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    cmd = [
-        "hdc",
-        "shell",
-        "aa start -a EntryAbility -b org.servo.servo -U https://m.huaweimossel.com --psn --webdriver",
-    ]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-
-    common_function_for_servo_test.setup_hdc_forward()
     driver = common_function_for_servo_test.create_driver()
 
     popup_css_selector = (
@@ -103,11 +88,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    try:
-        with HarmonyDevicePerfMode():
-            operator()
-    except Exception as e:
-        print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
-        sys.exit(1)
-
-    common_function_for_servo_test.stop_servo()
+    common_function_for_servo_test.run_test(operator, "https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_open_page_base.py
+++ b/etc/ci/scenario/servo_test_open_page_base.py
@@ -48,4 +48,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "https://m.huaweimossel.com")
+    common_function_for_servo_test.run_test(operator, "open_mossel", "https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_open_page_base.py
+++ b/etc/ci/scenario/servo_test_open_page_base.py
@@ -13,6 +13,8 @@ import sys
 import time
 import subprocess
 import os.path
+
+from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -63,7 +65,8 @@ def operator():
 
 if __name__ == "__main__":
     try:
-        operator()
+        with HarmonyDevicePerfMode():
+            operator()
     except Exception as e:
         print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
         sys.exit(1)

--- a/etc/ci/scenario/servo_test_open_page_base.py
+++ b/etc/ci/scenario/servo_test_open_page_base.py
@@ -9,12 +9,8 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import sys
 import time
-import subprocess
-import os.path
 
-from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -24,18 +20,6 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    # Step 1. Open mossel
-    print("Starting mossel ...")
-    cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    cmd = [
-        "hdc",
-        "shell",
-        "aa start -a EntryAbility -b org.servo.servo -U https://m.huaweimossel.com --psn --webdriver",
-    ]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-
-    common_function_for_servo_test.setup_hdc_forward()
     driver = common_function_for_servo_test.create_driver()
 
     popup_css_selector = (
@@ -64,11 +48,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    try:
-        with HarmonyDevicePerfMode():
-            operator()
-    except Exception as e:
-        print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
-        sys.exit(1)
-
-    common_function_for_servo_test.stop_servo()
+    common_function_for_servo_test.run_test(operator, "https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_open_page_servo.py
+++ b/etc/ci/scenario/servo_test_open_page_servo.py
@@ -13,6 +13,8 @@ import sys
 import time
 import subprocess
 import os.path
+
+from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -47,7 +49,8 @@ def operator():
 
 if __name__ == "__main__":
     try:
-        operator()
+        with HarmonyDevicePerfMode():
+            operator()
     except Exception as e:
         print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
         sys.exit(1)

--- a/etc/ci/scenario/servo_test_open_page_servo.py
+++ b/etc/ci/scenario/servo_test_open_page_servo.py
@@ -33,4 +33,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "open_servo_org","https://servo.org")
+    common_function_for_servo_test.run_test(operator, "open_servo_org", "https://servo.org")

--- a/etc/ci/scenario/servo_test_open_page_servo.py
+++ b/etc/ci/scenario/servo_test_open_page_servo.py
@@ -9,12 +9,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import sys
-import time
-import subprocess
-import os.path
-
-from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -24,15 +18,6 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    # 1. Open Servo
-    print("Starting servo ...")
-    cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    cmd = ["hdc", "shell", "aa start -a EntryAbility -b org.servo.servo --psn --webdriver"]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    time.sleep(10)
-
-    common_function_for_servo_test.setup_hdc_forward()
     driver = common_function_for_servo_test.create_driver()
 
     print("finding components ...")
@@ -48,11 +33,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    try:
-        with HarmonyDevicePerfMode():
-            operator()
-    except Exception as e:
-        print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
-        sys.exit(1)
-
-    common_function_for_servo_test.stop_servo()
+    common_function_for_servo_test.run_test(operator, "https://servo.org")

--- a/etc/ci/scenario/servo_test_open_page_servo.py
+++ b/etc/ci/scenario/servo_test_open_page_servo.py
@@ -33,4 +33,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "https://servo.org")
+    common_function_for_servo_test.run_test(operator, "open_servo_org","https://servo.org")

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -59,4 +59,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "https://m.huaweimossel.com")
+    common_function_for_servo_test.run_test(operator, "mossel_redirection", "https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -9,12 +9,9 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import sys
 import time
 import subprocess
-import os.path
 
-from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -24,18 +21,6 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    # Step 1. Open mossel
-    print("Starting mossel ...")
-    cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    cmd = [
-        "hdc",
-        "shell",
-        "aa start -a EntryAbility -b org.servo.servo -U https://m.huaweimossel.com --psn --webdriver",
-    ]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-
-    common_function_for_servo_test.setup_hdc_forward()
     driver = common_function_for_servo_test.create_driver()
 
     # Step 2. Click to close the pop-up
@@ -74,11 +59,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    try:
-        with HarmonyDevicePerfMode():
-            operator()
-    except Exception as e:
-        print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
-        sys.exit(1)
-
-    common_function_for_servo_test.stop_servo()
+    common_function_for_servo_test.run_test(operator, "https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -13,6 +13,8 @@ import sys
 import time
 import subprocess
 import os.path
+
+from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -73,7 +75,8 @@ def operator():
 
 if __name__ == "__main__":
     try:
-        operator()
+        with HarmonyDevicePerfMode():
+            operator()
     except Exception as e:
         print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
         sys.exit(1)

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -9,12 +9,9 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import sys
 import time
 import subprocess
-import os.path
 
-from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -23,17 +20,8 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    # Step 1. Open mossel
-    print("Starting mossel ...")
-    cmd = ["hdc", "shell", "aa force-stop org.servo.servo"]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    cmd = [
-        "hdc",
-        "shell",
-        "aa start -a EntryAbility -b org.servo.servo -U https://m.huaweimossel.com --psn --webdriver",
-    ]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    common_function_for_servo_test.setup_hdc_forward()
+    # Step 1.Connect to Webdriver
+    print("Connecting to Webdriver server...")
     driver = common_function_for_servo_test.create_driver()
 
     # Step 2. Click to close the pop-up
@@ -76,11 +64,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    try:
-        with HarmonyDevicePerfMode():
-            operator()
-    except Exception as e:
-        print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
-        sys.exit(1)
-
-    common_function_for_servo_test.stop_servo()
+    common_function_for_servo_test.run_test(operator, "https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -64,4 +64,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "https://m.huaweimossel.com")
+    common_function_for_servo_test.run_test(operator, "mossel_slide", "https://m.huaweimossel.com")

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -13,6 +13,8 @@ import sys
 import time
 import subprocess
 import os.path
+
+from hdc_py.hdc import HarmonyDevicePerfMode
 from selenium.common import NoSuchWindowException, NoSuchElementException
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.wait import WebDriverWait
@@ -75,7 +77,8 @@ def operator():
 
 if __name__ == "__main__":
     try:
-        operator()
+        with HarmonyDevicePerfMode():
+            operator()
     except Exception as e:
         print(f"Scenario test {os.path.basename(__file__)} failed with error: {e} (exception: {type(e)})")
         sys.exit(1)

--- a/etc/ci/scenario/uv.lock
+++ b/etc/ci/scenario/uv.lock
@@ -1,0 +1,229 @@
+version = 1
+revision = 3
+requires-python = ">3.11"
+
+[[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.11.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hdc-py"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/55/4532ba90915e69a2c506d4a3dff41f50444d53aff13806db98e9551ef953/hdc_py-0.1.2.tar.gz", hash = "sha256:bfba036c2847d90d045d4967167fcd1eb79c1edb97a2b3fe2d32bd3e02666132", size = 6060, upload-time = "2025-11-23T15:44:33.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/d9c424c98ced5a59f89545d5b6957cc0be99e405b82388a2b6fc04260ae0/hdc_py-0.1.2-py3-none-any.whl", hash = "sha256:99966223db86517e3248a489e95627f3e2fa5c126f55fb290c45e8cba16bdb46", size = 7127, upload-time = "2025-11-23T15:44:32.119Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "outcome"
+version = "1.3.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/df/77698abfac98571e65ffeb0c1fba8ffd692ab8458d617a0eed7d9a8d38f2/outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8", size = 21060, upload-time = "2023-10-26T04:26:04.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/8b/5ab7257531a5d830fc8000c476e63c935488d74609b50f9384a643ec0a62/outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b", size = 10692, upload-time = "2023-10-26T04:26:02.532Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
+name = "selenium"
+version = "4.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "trio" },
+    { name = "trio-websocket" },
+    { name = "typing-extensions" },
+    { name = "urllib3", extra = ["socks"] },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/a0/60a5e7e946420786d57816f64536e21a29f0554706b36f3cba348107024c/selenium-4.38.0.tar.gz", hash = "sha256:c117af6727859d50f622d6d0785b945c5db3e28a45ec12ad85cee2e7cc84fc4c", size = 924101, upload-time = "2025-10-25T02:13:06.752Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/d3/76c8f4a8d99b9f1ebcf9a611b4dd992bf5ee082a6093cfc649af3d10f35b/selenium-4.38.0-py3-none-any.whl", hash = "sha256:ed47563f188130a6fd486b327ca7ba48c5b11fb900e07d6457befdde320e35fd", size = 9694571, upload-time = "2025-10-25T02:13:04.417Z" },
+]
+
+[[package]]
+name = "servo-ci-scenario-test"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "hdc-py" },
+    { name = "selenium" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "hdc-py", specifier = ">=0.1.2" },
+    { name = "selenium" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "trio"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cffi", marker = "implementation_name != 'pypy' and os_name == 'nt'" },
+    { name = "idna" },
+    { name = "outcome" },
+    { name = "sniffio" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/ce/0041ddd9160aac0031bcf5ab786c7640d795c797e67c438e15cfedf815c8/trio-0.32.0.tar.gz", hash = "sha256:150f29ec923bcd51231e1d4c71c7006e65247d68759dd1c19af4ea815a25806b", size = 605323, upload-time = "2025-10-31T07:18:17.466Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/bf/945d527ff706233636c73880b22c7c953f3faeb9d6c7e2e85bfbfd0134a0/trio-0.32.0-py3-none-any.whl", hash = "sha256:4ab65984ef8370b79a76659ec87aa3a30c5c7c83ff250b4de88c29a8ab6123c5", size = 512030, upload-time = "2025-10-31T07:18:15.885Z" },
+]
+
+[[package]]
+name = "trio-websocket"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "outcome" },
+    { name = "trio" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/3c/8b4358e81f2f2cfe71b66a267f023a91db20a817b9425dd964873796980a/trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae", size = 33549, upload-time = "2025-02-25T05:16:58.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/19/eb640a397bba49ba49ef9dbe2e7e5c04202ba045b6ce2ec36e9cadc51e04/trio_websocket-0.12.2-py3-none-any.whl", hash = "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6", size = 21221, upload-time = "2025-02-25T05:16:57.545Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/8d/48e227460422d3f78f52618d8ef7d7a0474c6fcdaddf7f2d1aa25854ea75/wsproto-1.3.1.tar.gz", hash = "sha256:81529992325c28f0d9b86ca66fc973da96eb80ab53410249ce2e502749c7723c", size = 50083, upload-time = "2025-11-12T07:50:48.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/da/539c2d24b13025e54a86ce3215eb9b6297b023937a087db9ef2a436cc7b4/wsproto-1.3.1-py3-none-any.whl", hash = "sha256:297ce79322989c0d286cc158681641cd18bc7632dfb38cf4054696a89179b993", size = 24402, upload-time = "2025-11-12T07:50:47.178Z" },
+]


### PR DESCRIPTION
- Factor out some common code
- Create and use `hdc_py` library, used for enabling (and disabling) performance mode and screen timeout.
- Add screenshots on test failure

The performance mode / screen timeout should hopefully help with the timeouts, or at least the screenshots might help show what's going wrong. 

Testing: This is a CI modification for ohos. [mach try](https://github.com/servo/servo/actions/runs/19614805970/job/56165963814)
