### PR TITLE
ci: Use new queue API for self-hosted runners

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -49,7 +49,7 @@ jobs:
   # Runs the underlying job (“workload”) on a self-hosted runner if available,
   # with the help of a `runner-select` job and a `runner-timeout` job.
   runner-select:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       unique-id: ${{ steps.select.outputs.unique-id }}
       selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
@@ -74,7 +74,7 @@ jobs:
     needs:
       - runner-select
     if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Runner timeout
         uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@0b9edd49381b22c14e5b123f21377269864ddf54
+        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: ubuntu-22.04
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Runner timeout
-        uses: servo/ci-runners/actions/runner-timeout@0b9edd49381b22c14e5b123f21377269864ddf54
+        uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           unique-id: '${{ needs.runner-select.outputs.unique-id }}'
@@ -88,7 +88,7 @@ jobs:
     name: Bencher (${{ inputs.target }}) [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@0b9edd49381b22c14e5b123f21377269864ddf54
+      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-${{ inputs.target }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@0b9edd49381b22c14e5b123f21377269864ddf54
+        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Runner timeout
-        uses: servo/ci-runners/actions/runner-timeout@0b9edd49381b22c14e5b123f21377269864ddf54
+        uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           unique-id: '${{ needs.runner-select.outputs.unique-id }}'
@@ -53,7 +53,7 @@ jobs:
     name: Lint [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@0b9edd49381b22c14e5b123f21377269864ddf54
+      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           fetch-depth: 2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
   # Runs the underlying job (“workload”) on a self-hosted runner if available,
   # with the help of a `runner-select` job and a `runner-timeout` job.
   runner-select:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       unique-id: ${{ steps.select.outputs.unique-id }}
       selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
@@ -39,7 +39,7 @@ jobs:
     needs:
       - runner-select
     if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Runner timeout
         uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@0b9edd49381b22c14e5b123f21377269864ddf54
+        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Runner timeout
-        uses: servo/ci-runners/actions/runner-timeout@0b9edd49381b22c14e5b123f21377269864ddf54
+        uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           unique-id: '${{ needs.runner-select.outputs.unique-id }}'
@@ -144,7 +144,7 @@ jobs:
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@0b9edd49381b22c14e5b123f21377269864ddf54
+      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}
@@ -306,7 +306,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@0b9edd49381b22c14e5b123f21377269864ddf54
+        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -327,7 +327,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Runner timeout
-        uses: servo/ci-runners/actions/runner-timeout@0b9edd49381b22c14e5b123f21377269864ddf54
+        uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           unique-id: '${{ needs.runner-select-coverage.outputs.unique-id }}'
@@ -339,7 +339,7 @@ jobs:
     runs-on: ${{ needs.runner-select-coverage.outputs.selected-runner-label }}
     continue-on-error: true
     steps:
-      - uses: servo/ci-runners/actions/checkout@0b9edd49381b22c14e5b123f21377269864ddf54
+      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -103,7 +103,7 @@ jobs:
   # Runs the underlying job (“workload”) on a self-hosted runner if available,
   # with the help of a `runner-select` job and a `runner-timeout` job.
   runner-select:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       unique-id: ${{ steps.select.outputs.unique-id }}
       selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
@@ -130,7 +130,7 @@ jobs:
     needs:
       - runner-select
     if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Runner timeout
         uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
@@ -298,7 +298,7 @@ jobs:
   # with the help of a `runner-select` job and a `runner-timeout` job.
   runner-select-coverage:
     if: inputs.coverage
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       unique-id: ${{ steps.select.outputs.unique-id }}
       selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
@@ -324,7 +324,7 @@ jobs:
     needs:
       - runner-select-coverage
     if: inputs.coverage && fromJSON(needs.runner-select-coverage.outputs.is-self-hosted)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Runner timeout
         uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -85,7 +85,7 @@ jobs:
   # Runs the underlying job (“workload”) on a self-hosted runner if available,
   # with the help of a `runner-select` job and a `runner-timeout` job.
   runner-select:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       unique-id: ${{ steps.select.outputs.unique-id }}
       selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
@@ -109,7 +109,7 @@ jobs:
     needs:
       - runner-select
     if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Runner timeout
         uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@0b9edd49381b22c14e5b123f21377269864ddf54
+        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: macos-15-intel
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Runner timeout
-        uses: servo/ci-runners/actions/runner-timeout@0b9edd49381b22c14e5b123f21377269864ddf54
+        uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           unique-id: '${{ needs.runner-select.outputs.unique-id }}'
@@ -130,7 +130,7 @@ jobs:
       - name: Kill XProtectBehaviorService
         run: |
           echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
-      - uses: servo/ci-runners/actions/checkout@0b9edd49381b22c14e5b123f21377269864ddf54
+      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
 
       - if: runner.environment != 'self-hosted'
         name: Setup Python

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -76,7 +76,7 @@ jobs:
   # Runs the underlying job (“workload”) on a self-hosted runner if available,
   # with the help of a `runner-select` job and a `runner-timeout` job.
   runner-select:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       unique-id: ${{ steps.select.outputs.unique-id }}
       selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
@@ -100,7 +100,7 @@ jobs:
     needs:
       - runner-select
     if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Runner timeout
         uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@0b9edd49381b22c14e5b123f21377269864ddf54
+        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: windows-2022
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Runner timeout
-        uses: servo/ci-runners/actions/runner-timeout@0b9edd49381b22c14e5b123f21377269864ddf54
+        uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
         with:
           github_token: '${{ secrets.GITHUB_TOKEN }}'
           unique-id: '${{ needs.runner-select.outputs.unique-id }}'
@@ -114,7 +114,7 @@ jobs:
     name: Windows Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@0b9edd49381b22c14e5b123f21377269864ddf54
+      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
 
       - name: ccache
         # FIXME: “Error: Restoring cache failed: Error: Unable to locate executable file: sh.”


### PR DESCRIPTION
this patch enables CI jobs to queue for self-hosted runners by bumping our actions to servo/ci-runners#69, and bumping our runner-select and runner-timeout jobs to ubuntu-24.04 (for better retry support in curl).

this should further speed up our builds by allowing more jobs to run on self-hosted runners: if a job would take 5x as long on github-hosted runners, then we can wait up to 80% of that time for a self-hosted runner and still win.

for now, though, jobs will queue for self-hosted runners for up to [**one hour**](https://github.com/servo/ci-runners/blob/44317e3cd86c5ff2ef0b08878b90da246bc237da/actions/runner-select/action.yml#L131-L133) (note that you won’t have to wait if the servers are down). if your request for a self-hosted runner can’t be satisfied immediately, it will look like [this](https://github.com/servo/servo/actions/runs/19624089967/job/56189690571#step:2:161):

```
POST https://ci0.servo.org/queue/enqueue?unique_id=92a9e758-f8e2-4301-b4a4-304178a656ae&qualified_repo=servo/servo&run_id=19624089967

POST https://ci0.servo.org/queue/take/92a9e758-f8e2-4301-b4a4-304178a656ae
curl: (22) The requested URL returned error: 503
curl: (22) The requested URL returned error: 503
curl: (22) The requested URL returned error: 503
... [repeating for up to one hour]
```

to check where you are in the queue, go to <https://ci0.servo.org/queue/> (it’s currently very rudimentary):

<img width="1370" height="797" alt="image" src="https://github.com/user-attachments/assets/57d7e651-8250-48f4-8321-df5c575924ac" />

Testing:
- mach try windows: [1](https://github.com/servo/servo/actions/runs/19624074289/job/56189642435#step:2:161), [2](https://github.com/servo/servo/actions/runs/19624077577/job/56189654083#step:2:161), [3](https://github.com/servo/servo/actions/runs/19624079336/job/56189657185#step:2:161), [4](https://github.com/servo/servo/actions/runs/19624089967/job/56189690571#step:2:161), [5](https://github.com/servo/servo/actions/runs/19624100902/job/56189714525#step:2:161), [6](https://github.com/servo/servo/actions/runs/19624102672/job/56189717605#step:2:161)
- mach try windows linux lint: [1](https://github.com/servo/servo/actions/runs/19624555146), [2](https://github.com/servo/servo/actions/runs/19624560177), [3](https://github.com/servo/servo/actions/runs/19624562199), [4](https://github.com/servo/servo/actions/runs/19624564171), [5](https://github.com/servo/servo/actions/runs/19624566167), [6](https://github.com/servo/servo/actions/runs/19624568092)