### PR TITLE
Bump mozjs to 140.5-5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5445,7 +5445,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.2"
-source = "git+https://github.com/servo/mozjs#e1f9c3a3e5e2ebd78bbff7ed8ce4f2d9ee991b46"
+source = "git+https://github.com/servo/mozjs#256cc579e514bc3159d987c0cdf167e8c2820235"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -5457,8 +5457,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.140.5-3"
-source = "git+https://github.com/servo/mozjs#e1f9c3a3e5e2ebd78bbff7ed8ce4f2d9ee991b46"
+version = "0.140.5-5"
+source = "git+https://github.com/servo/mozjs#256cc579e514bc3159d987c0cdf167e8c2820235"
 dependencies = [
  "bindgen 0.72.1",
  "cc",


### PR DESCRIPTION
Companion PR to https://github.com/servo/mozjs/pull/671
Fixes issues with ohos related patches in spidermonkey, specifically when compiling servo with --debug-mozjs.

Testing: Covered by existing tests

