### PR TITLE
script: Align Streams implementation with spec step calls

### DIFF
--- a/components/script/dom/readablestreambyobreader.rs
+++ b/components/script/dom/readablestreambyobreader.rs
@@ -169,7 +169,8 @@ impl ReadableStreamBYOBReader {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreambyobreaderrelease>
     pub(crate) fn release(&self, can_gc: CanGc) -> Fallible<()> {
         // Perform ! ReadableStreamReaderGenericRelease(reader).
-        self.generic_release(can_gc)?;
+        self.generic_release(can_gc)
+            .expect("Generic release failed");
         // Let e be a new TypeError exception.
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let mut error = UndefinedValue());

--- a/components/script/dom/readablestreamdefaultreader.rs
+++ b/components/script/dom/readablestreamdefaultreader.rs
@@ -382,7 +382,8 @@ impl ReadableStreamDefaultReader {
     /// <https://streams.spec.whatwg.org/#abstract-opdef-readablestreamdefaultreaderrelease>
     pub(crate) fn release(&self, can_gc: CanGc) -> Fallible<()> {
         // Perform ! ReadableStreamReaderGenericRelease(reader).
-        self.generic_release(can_gc)?;
+        self.generic_release(can_gc)
+            .expect("Generic release failed");
         // Let e be a new TypeError exception.
         let cx = GlobalScope::get_cx();
         rooted!(in(*cx) let mut error = UndefinedValue());
@@ -513,7 +514,9 @@ impl ReadableStreamDefaultReader {
             let read_request = self.remove_read_request();
 
             // Perform ! ReadableByteStreamControllerFillReadRequestFromQueue(controller, readRequest).
-            controller.fill_read_request_from_queue(cx, &read_request, can_gc)?;
+            controller
+                .fill_read_request_from_queue(cx, &read_request, can_gc)
+                .expect("Fill read request from queue failed");
         }
         Ok(())
     }

--- a/components/script/dom/readablestreamgenericreader.rs
+++ b/components/script/dom/readablestreamgenericreader.rs
@@ -122,7 +122,9 @@ pub(crate) trait ReadableStreamGenericReader {
             self.get_closed_promise().set_promise_is_handled();
 
             // Perform ! stream.[[controller]].[[ReleaseSteps]]().
-            stream.perform_release_steps()?;
+            stream
+                .perform_release_steps()
+                .expect("Stream should have a controller");
 
             // Set stream.[[reader]] to undefined.
             stream.set_reader(None);


### PR DESCRIPTION
updates several methods in `ReadableStream` to use `.expect()` instead of `?` where the spec indicates an infallible operation (denoted by `!`).

Testing: `mach test-wpt /streams/`
Fixes: part of #36906
