### PR TITLE
script: Add new KeyFormat and KeyUsage for modern algorithms

### DIFF
--- a/components/script/dom/subtlecrypto/aes_operation.rs
+++ b/components/script/dom/subtlecrypto/aes_operation.rs
@@ -823,7 +823,7 @@ fn import_key_aes(
     let data;
     match format {
         // If format is "raw":
-        KeyFormat::Raw => {
+        KeyFormat::Raw | KeyFormat::Raw_secret => {
             // Step 2.1. Let data be keyData.
             data = key_data.to_vec();
 
@@ -975,7 +975,7 @@ fn export_key_aes(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Err
     let result;
     match format {
         // If format is "raw":
-        KeyFormat::Raw => match key.handle() {
+        KeyFormat::Raw | KeyFormat::Raw_secret => match key.handle() {
             // Step 2.1. Let data be a byte sequence containing the raw octets of the key
             // represented by the [[handle]] internal slot of key.
             // Step 2.2. Let result be data.

--- a/components/script/dom/subtlecrypto/ecdh_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdh_operation.rs
@@ -774,7 +774,7 @@ pub(crate) fn import_key(
                 can_gc,
             )
         },
-        KeyFormat::Raw => {
+        KeyFormat::Raw | KeyFormat::Raw_public => {
             // Step 2.1. If the namedCurve member of normalizedAlgorithm is not a named curve, then
             // throw a DataError.
             if !SUPPORTED_CURVES
@@ -855,6 +855,11 @@ pub(crate) fn import_key(
                 handle,
                 can_gc,
             )
+        },
+        // Otherwise:
+        _ => {
+            // throw a NotSupportedError.
+            return Err(Error::NotSupported(None));
         },
     };
 
@@ -1106,7 +1111,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             // Step 3.4. Let result be jwk.
             ExportedKey::Jwk(Box::new(jwk))
         },
-        KeyFormat::Raw => {
+        KeyFormat::Raw | KeyFormat::Raw_public => {
             // Step 3.1. If the [[type]] internal slot of key is not "public", then throw an
             // InvalidAccessError.
             if key.Type() != KeyType::Public {
@@ -1146,6 +1151,11 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
             // Step 3.3. Let result be data.
             ExportedKey::Bytes(data)
+        },
+        // Otherwise:
+        _ => {
+            // throw a NotSupportedError.
+            return Err(Error::NotSupported(None));
         },
     };
 

--- a/components/script/dom/subtlecrypto/ecdsa_operation.rs
+++ b/components/script/dom/subtlecrypto/ecdsa_operation.rs
@@ -893,7 +893,7 @@ pub(crate) fn import_key(
             )
         },
         // If format is "raw":
-        KeyFormat::Raw => {
+        KeyFormat::Raw | KeyFormat::Raw_public => {
             // Step 2.1. If the namedCurve member of normalizedAlgorithm is not a named curve, then
             // throw a DataError.
             if !SUPPORTED_CURVES
@@ -974,6 +974,11 @@ pub(crate) fn import_key(
                 handle,
                 can_gc,
             )
+        },
+        // Otherwise:
+        _ => {
+            // throw a NotSupportedError.
+            return Err(Error::NotSupported(None));
         },
     };
 
@@ -1231,7 +1236,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             ExportedKey::Jwk(Box::new(jwk))
         },
         // If format is "raw":
-        KeyFormat::Raw => {
+        KeyFormat::Raw | KeyFormat::Raw_public => {
             // Step 3.1. If the [[type]] internal slot of key is not "public", then throw an
             // InvalidAccessError.
             if key.Type() != KeyType::Public {
@@ -1272,7 +1277,11 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             // Step 3.3. Let result be data.
             ExportedKey::Bytes(data)
         },
-        // Otherwise: throw a NotSupportedError. (Unreachable)
+        // Otherwise:
+        _ => {
+            // throw a NotSupportedError.
+            return Err(Error::NotSupported(None));
+        },
     };
 
     // Step 4. Return result.

--- a/components/script/dom/subtlecrypto/ed25519_operation.rs
+++ b/components/script/dom/subtlecrypto/ed25519_operation.rs
@@ -380,7 +380,7 @@ pub(crate) fn import_key(
             // NOTE: Done in Step 2.9
         },
         // If format is "raw":
-        KeyFormat::Raw => {
+        KeyFormat::Raw | KeyFormat::Raw_public => {
             // Step 2.1. If usages contains a value which is not "verify" then throw a SyntaxError.
             if usages.iter().any(|usage| *usage != KeyUsage::Verify) {
                 return Err(Error::Syntax(None));
@@ -410,7 +410,11 @@ pub(crate) fn import_key(
                 can_gc,
             )
         },
-        // Otherwise: throw a NotSupportedError. (Unreachable)
+        // Otherwise:
+        _ => {
+            // throw a NotSupportedError.
+            return Err(Error::NotSupported(None));
+        },
     };
 
     // Step 3. Return key
@@ -536,7 +540,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             ExportedKey::Jwk(Box::new(jwk))
         },
         // If format is "raw":
-        KeyFormat::Raw => {
+        KeyFormat::Raw | KeyFormat::Raw_public => {
             // Step 3.1. If the [[type]] internal slot of key is not "public", then throw an
             // InvalidAccessError.
             if key.Type() != KeyType::Public {
@@ -548,7 +552,11 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             // Step 3.3. Let result be data.
             ExportedKey::Bytes(key_data.to_vec())
         },
-        // Otherwise: throw a NotSupportedError. (Unreachable)
+        // Otherwise:
+        _ => {
+            // throw a NotSupportedError.
+            return Err(Error::NotSupported(None));
+        },
     };
 
     // Step 4. Return result.

--- a/components/script/dom/subtlecrypto/hkdf_operation.rs
+++ b/components/script/dom/subtlecrypto/hkdf_operation.rs
@@ -78,7 +78,7 @@ pub(crate) fn import_key(
     // Step 1. Let keyData be the key data to be imported.
 
     // Step 2. If format is "raw":
-    if format == KeyFormat::Raw {
+    if matches!(format, KeyFormat::Raw | KeyFormat::Raw_secret) {
         // Step 2.1. If usages contains a value that is not "deriveKey" or "deriveBits", then throw
         // a SyntaxError.
         if usages

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -174,7 +174,7 @@ pub(crate) fn import_key(
     let data;
     match format {
         // If format is "raw":
-        KeyFormat::Raw => {
+        KeyFormat::Raw | KeyFormat::Raw_secret => {
             // Step 4.1. Let data be keyData.
             data = key_data.to_vec();
 
@@ -322,7 +322,7 @@ pub(crate) fn import_key(
 /// <https://w3c.github.io/webcrypto/#hmac-operations-export-key>
 pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedKey, Error> {
     match format {
-        KeyFormat::Raw => match key.handle() {
+        KeyFormat::Raw | KeyFormat::Raw_secret => match key.handle() {
             Handle::Hmac(key_data) => Ok(ExportedKey::Bytes(key_data.as_slice().to_vec())),
             _ => Err(Error::Operation(None)),
         },
@@ -364,7 +364,11 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
             Ok(ExportedKey::Jwk(Box::new(jwk)))
         },
-        _ => Err(Error::NotSupported(None)),
+        // Otherwise:
+        _ => {
+            // throw a NotSupportedError.
+            return Err(Error::NotSupported(None));
+        },
     }
 }
 

--- a/components/script/dom/subtlecrypto/hmac_operation.rs
+++ b/components/script/dom/subtlecrypto/hmac_operation.rs
@@ -367,7 +367,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
         // Otherwise:
         _ => {
             // throw a NotSupportedError.
-            return Err(Error::NotSupported(None));
+            Err(Error::NotSupported(None))
         },
     }
 }

--- a/components/script/dom/subtlecrypto/pbkdf2_operation.rs
+++ b/components/script/dom/subtlecrypto/pbkdf2_operation.rs
@@ -87,7 +87,7 @@ pub(crate) fn import_key(
     can_gc: CanGc,
 ) -> Result<DomRoot<CryptoKey>, Error> {
     // Step 1. If format is not "raw", throw a NotSupportedError
-    if format != KeyFormat::Raw {
+    if !matches!(format, KeyFormat::Raw | KeyFormat::Raw_secret) {
         return Err(Error::NotSupported(None));
     }
 

--- a/components/script/dom/subtlecrypto/x25519_operation.rs
+++ b/components/script/dom/subtlecrypto/x25519_operation.rs
@@ -441,7 +441,7 @@ pub(crate) fn import_key(
             )
         },
         // If format is "raw":
-        KeyFormat::Raw => {
+        KeyFormat::Raw | KeyFormat::Raw_public => {
             // Step 2.1. If usages is not empty then throw a SyntaxError.
             if !usages.is_empty() {
                 return Err(Error::Syntax(None));
@@ -473,7 +473,11 @@ pub(crate) fn import_key(
                 can_gc,
             )
         },
-        // Otherwise: throw a NotSupportedError. (Unreachable)
+        // Otherwise:
+        _ => {
+            // throw a NotSupportedError.
+            return Err(Error::NotSupported(None));
+        },
     };
 
     // Step 3. Return key
@@ -608,7 +612,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
             ExportedKey::Jwk(Box::new(jwk))
         },
         // If format is "raw":
-        KeyFormat::Raw => {
+        KeyFormat::Raw | KeyFormat::Raw_public => {
             // Step 3.1. If the [[type]] internal slot of key is not "public", then throw an
             // InvalidAccessError.
             if key.Type() != KeyType::Public {
@@ -624,6 +628,11 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
 
             // Step 3.3. Let result be data.
             ExportedKey::Bytes(data.to_vec())
+        },
+        // Otherwise:
+        _ => {
+            // throw a NotSupportedError.
+            return Err(Error::NotSupported(None));
         },
     };
 

--- a/components/script_bindings/webidls/CryptoKey.webidl
+++ b/components/script_bindings/webidls/CryptoKey.webidl
@@ -6,7 +6,7 @@
 
 enum KeyType { "public", "private", "secret" };
 
-enum KeyUsage { "encrypt", "decrypt", "sign", "verify", "deriveKey", "deriveBits", "wrapKey", "unwrapKey" };
+// enum KeyUsage { "encrypt", "decrypt", "sign", "verify", "deriveKey", "deriveBits", "wrapKey", "unwrapKey" };
 
 [SecureContext, Exposed=(Window,Worker), /*Serializable,*/ Pref="dom_crypto_subtle_enabled"]
 interface CryptoKey {
@@ -22,3 +22,7 @@ dictionary CryptoKeyPair {
   CryptoKey publicKey;
   CryptoKey privateKey;
 };
+
+// https://wicg.github.io/webcrypto-modern-algos/#subtlecrypto-interface-keyusage
+
+enum KeyUsage { "encrypt", "decrypt", "sign", "verify", "deriveKey", "deriveBits", "wrapKey", "unwrapKey", "encapsulateKey", "encapsulateBits", "decapsulateKey", "decapsulateBits" };

--- a/components/script_bindings/webidls/SubtleCrypto.webidl
+++ b/components/script_bindings/webidls/SubtleCrypto.webidl
@@ -4,7 +4,7 @@
 
 // https://w3c.github.io/webcrypto/#subtlecrypto-interface
 
-enum KeyFormat { "raw", "spki", "pkcs8", "jwk" };
+// enum KeyFormat { "raw", "spki", "pkcs8", "jwk" };
 
 [SecureContext,Exposed=(Window,Worker),Pref="dom_crypto_subtle_enabled"]
 interface SubtleCrypto {
@@ -213,6 +213,16 @@ dictionary JsonWebKey {
   sequence<RsaOtherPrimesInfo> oth;
   DOMString k;
 };
+
+// https://wicg.github.io/webcrypto-modern-algos/#subtlecrypto-interface-keyformat
+// * For all existing symmetric algorithms in [webcrypto], "raw-secret"
+//   acts as an alias of "raw".
+// * For all existing asymmetric algorithms in [webcrypto], "raw-public"
+//   acts as an alias of "raw".
+// * In the deriveKey() method, in the import key step, "raw-secret"
+//   must be used as the format instead of "raw".
+
+enum KeyFormat { "raw-public", "raw-private", "raw-seed", "raw-secret", "raw", "spki", "pkcs8", "jwk" };
 
 // https://wicg.github.io/webcrypto-modern-algos/#cshake-params
 


### PR DESCRIPTION
The specification of Modern Algorithms in the Web Cryptography API (https://wicg.github.io/webcrypto-modern-algos/) adds new key formats and key usages to support modern cryptographic algorithms.

This patch adds those new key formats and key usages, preparing for the implementation of the new algorithms.

Testing: No behavioral changes in existing cryptographic algorithms. Existing tests suffice.
Fixes: Part of #40687