### PR TITLE
OHOS: Set the correct input type for url field

### DIFF
--- a/support/openharmony/entry/src/main/ets/pages/Index.ets
+++ b/support/openharmony/entry/src/main/ets/pages/Index.ets
@@ -101,7 +101,7 @@ struct Index {
             this.xComponentContext?.goForward()
           })
         TextInput({ placeholder: 'URL', text: $$this.urlToLoad })
-          .type(InputType.Normal)
+          .type(InputType.URL)
           .width('76%')
           .onChange((value) => {
             this.urlToLoad = value


### PR DESCRIPTION
This makes it mostly that the correct keyboard will be selected and we don't start with an uppercase letter.

Testing: Compiled on OHOS and looked on the phone.
