### PR TITLE
script: Eliminate most usages of `with_script_thread`

### DIFF
--- a/components/script/dom/create.rs
+++ b/components/script/dom/create.rs
@@ -89,7 +89,6 @@ use crate::dom::svg::svgimageelement::SVGImageElement;
 use crate::dom::svg::svgsvgelement::SVGSVGElement;
 use crate::realms::{InRealm, enter_realm};
 use crate::script_runtime::CanGc;
-use crate::script_thread::ScriptThread;
 
 fn create_svg_element(
     name: QualName,
@@ -162,7 +161,7 @@ fn create_html_element(
                 },
                 // Step 4.4. Otherwise, enqueue a custom element upgrade reaction given result and definition.
                 CustomElementCreationMode::Asynchronous => {
-                    ScriptThread::enqueue_upgrade_reaction(&element, definition)
+                    element.enqueue_upgrade_reaction(definition)
                 },
             }
             return element;
@@ -226,7 +225,7 @@ fn create_html_element(
                     result.set_custom_element_state(CustomElementState::Undefined);
                     result.set_custom_element_registry(registry);
                     // Step 4.2.2. Enqueue a custom element upgrade reaction given result and definition.
-                    ScriptThread::enqueue_upgrade_reaction(&result, definition);
+                    result.enqueue_upgrade_reaction(definition);
                     return result;
                 },
             }

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -194,7 +194,6 @@ use crate::mime::{APPLICATION, CHARSET};
 use crate::network_listener::{FetchResponseListener, NetworkListener};
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
 use crate::script_runtime::{CanGc, ScriptThreadEventCategory};
-use crate::script_thread::ScriptThread;
 use crate::stylesheet_set::StylesheetSetRef;
 use crate::task::NonSendTaskBox;
 use crate::task_source::TaskSourceName;
@@ -2079,7 +2078,9 @@ impl Document {
             return;
         }
 
-        ScriptThread::mark_document_with_no_blocked_loads(self);
+        self.window
+            .script_thread()
+            .mark_document_with_no_blocked_loads(self);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#checking-if-unloading-is-canceled>

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -174,7 +174,6 @@ use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidationFlags;
 use crate::dom::virtualmethods::{VirtualMethods, vtable_for};
 use crate::script_runtime::CanGc;
-use crate::script_thread::ScriptThread;
 use crate::stylesheet_loader::StylesheetOwner;
 use crate::task::TaskOnce;
 
@@ -1892,7 +1891,7 @@ impl Element {
                 new_value,
                 attr.namespace().clone(),
             );
-            ScriptThread::enqueue_callback_reaction(self, reaction, None);
+            self.enqueue_callback_reaction(reaction, None);
         }
 
         // Step 3. Run the attribute change steps with element, attribute’s local name, oldValue, newValue, and attribute’s namespace.
@@ -2885,6 +2884,22 @@ impl Element {
             line_number: line_number + 2,
             column_number: 0,
         }
+    }
+
+    pub(crate) fn enqueue_callback_reaction(
+        &self,
+        reaction: CallbackReaction,
+        definition: Option<Rc<CustomElementDefinition>>,
+    ) {
+        self.owner_window()
+            .script_thread()
+            .enqueue_callback_reaction(self, reaction, definition);
+    }
+
+    pub(crate) fn enqueue_upgrade_reaction(&self, definition: Rc<CustomElementDefinition>) {
+        self.owner_window()
+            .script_thread()
+            .enqueue_upgrade_reaction(self, definition);
     }
 }
 

--- a/components/script/dom/html/htmlelement.rs
+++ b/components/script/dom/html/htmlelement.rs
@@ -60,7 +60,6 @@ use crate::dom::shadowroot::ShadowRoot;
 use crate::dom::text::Text;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
-use crate::script_thread::ScriptThread;
 
 #[dom_struct]
 pub(crate) struct HTMLElement {
@@ -1182,11 +1181,7 @@ impl VirtualMethods for HTMLElement {
             {
                 element.set_disabled_state(true);
                 element.set_enabled_state(false);
-                ScriptThread::enqueue_callback_reaction(
-                    element,
-                    CallbackReaction::FormDisabled(true),
-                    None,
-                );
+                element.enqueue_callback_reaction(CallbackReaction::FormDisabled(true), None);
             },
             // Removing the "disabled" attribute may enable a disabled
             // form element, but a fieldset ancestor may keep it disabled.
@@ -1197,11 +1192,7 @@ impl VirtualMethods for HTMLElement {
                 element.set_enabled_state(true);
                 element.check_ancestors_disabled_state_for_form_control();
                 if element.enabled_state() {
-                    ScriptThread::enqueue_callback_reaction(
-                        element,
-                        CallbackReaction::FormDisabled(false),
-                        None,
-                    );
+                    element.enqueue_callback_reaction(CallbackReaction::FormDisabled(false), None);
                 }
             },
             (&local_name!("readonly"), mutation) if self.is_form_associated_custom_element() => {
@@ -1239,11 +1230,7 @@ impl VirtualMethods for HTMLElement {
         if self.is_form_associated_custom_element() && element.enabled_state() {
             element.check_ancestors_disabled_state_for_form_control();
             if element.disabled_state() {
-                ScriptThread::enqueue_callback_reaction(
-                    element,
-                    CallbackReaction::FormDisabled(true),
-                    None,
-                );
+                element.enqueue_callback_reaction(CallbackReaction::FormDisabled(true), None);
             }
         }
     }
@@ -1262,11 +1249,7 @@ impl VirtualMethods for HTMLElement {
             element.check_disabled_attribute();
             element.check_ancestors_disabled_state_for_form_control();
             if element.enabled_state() {
-                ScriptThread::enqueue_callback_reaction(
-                    element,
-                    CallbackReaction::FormDisabled(false),
-                    None,
-                );
+                element.enqueue_callback_reaction(CallbackReaction::FormDisabled(false), None);
             }
         }
     }

--- a/components/script/dom/html/htmlfieldsetelement.rs
+++ b/components/script/dom/html/htmlfieldsetelement.rs
@@ -26,7 +26,6 @@ use crate::dom::validation::Validatable;
 use crate::dom::validitystate::ValidityState;
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
-use crate::script_thread::ScriptThread;
 
 #[dom_struct]
 pub(crate) struct HTMLFieldSetElement {
@@ -216,8 +215,7 @@ impl VirtualMethods for HTMLFieldSetElement {
                                 .downcast::<HTMLElement>()
                                 .is_some_and(|h| h.is_form_associated_custom_element())
                             {
-                                ScriptThread::enqueue_callback_reaction(
-                                    element,
+                                element.enqueue_callback_reaction(
                                     CallbackReaction::FormDisabled(true),
                                     None,
                                 );
@@ -237,8 +235,7 @@ impl VirtualMethods for HTMLFieldSetElement {
                                     .downcast::<HTMLElement>()
                                     .is_some_and(|h| h.is_form_associated_custom_element())
                             {
-                                ScriptThread::enqueue_callback_reaction(
-                                    element,
+                                element.enqueue_callback_reaction(
                                     CallbackReaction::FormDisabled(false),
                                     None,
                                 );

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -85,7 +85,6 @@ use crate::dom::virtualmethods::VirtualMethods;
 use crate::dom::window::Window;
 use crate::links::{LinkRelations, get_element_target};
 use crate::script_runtime::CanGc;
-use crate::script_thread::ScriptThread;
 
 #[dom_struct]
 pub(crate) struct HTMLFormElement {
@@ -1382,11 +1381,9 @@ impl HTMLFormElement {
                 NodeTypeId::Element(ElementTypeId::HTMLElement(HTMLElementTypeId::HTMLElement)) => {
                     let html_element = child.downcast::<HTMLElement>().unwrap();
                     if html_element.is_form_associated_custom_element() {
-                        ScriptThread::enqueue_callback_reaction(
-                            html_element.upcast::<Element>(),
-                            CallbackReaction::FormReset,
-                            None,
-                        )
+                        html_element
+                            .upcast::<Element>()
+                            .enqueue_callback_reaction(CallbackReaction::FormReset, None)
                     }
                 },
                 _ => {},
@@ -1653,8 +1650,7 @@ pub(crate) trait FormControl: DomObject {
             // https://html.spec.whatwg.org/multipage/#custom-element-reactions:reset-the-form-owner
             if let Some(html_elem) = elem.downcast::<HTMLElement>() {
                 if html_elem.is_form_associated_custom_element() {
-                    ScriptThread::enqueue_callback_reaction(
-                        elem,
+                    elem.enqueue_callback_reaction(
                         CallbackReaction::FormAssociated(
                             new_owner.as_ref().map(|form| DomRoot::from_ref(&**form)),
                         ),

--- a/components/script/dom/html/htmlimageelement.rs
+++ b/components/script/dom/html/htmlimageelement.rs
@@ -82,7 +82,6 @@ use crate::microtask::{Microtask, MicrotaskRunnable};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::enter_realm;
 use crate::script_runtime::CanGc;
-use crate::script_thread::ScriptThread;
 
 /// Supported image MIME types as defined by
 /// <https://mimesniff.spec.whatwg.org/#image-mime-type>.
@@ -1212,7 +1211,8 @@ impl HTMLImageElement {
             generation: self.generation.get(),
         };
 
-        ScriptThread::await_stable_state(Microtask::ImageElement(task));
+        self.script_thread()
+            .await_stable_state(Microtask::ImageElement(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#img-environment-changes>
@@ -1223,7 +1223,8 @@ impl HTMLImageElement {
             generation: self.generation.get(),
         };
 
-        ScriptThread::await_stable_state(Microtask::ImageElement(task));
+        self.script_thread()
+            .await_stable_state(Microtask::ImageElement(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#img-environment-changes>
@@ -1947,7 +1948,8 @@ impl HTMLImageElementMethods<crate::DomTypeHolder> for HTMLImageElement {
             promise: promise.clone(),
         };
 
-        ScriptThread::await_stable_state(Microtask::ImageElement(task));
+        self.script_thread()
+            .await_stable_state(Microtask::ImageElement(task));
 
         // Step 3. Return promise.
         promise

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -106,7 +106,6 @@ use crate::microtask::{Microtask, MicrotaskRunnable};
 use crate::network_listener::{self, FetchResponseListener, ResourceTimingListener};
 use crate::realms::{InRealm, enter_realm};
 use crate::script_runtime::CanGc;
-use crate::script_thread::ScriptThread;
 use crate::task_source::SendableTaskSource;
 
 /// A CSS file to style the media controls.
@@ -1058,7 +1057,8 @@ impl HTMLMediaElement {
         // method from below, if microtasks were trait objects, we would be able
         // to put the code directly in this method, without the boilerplate
         // indirections.
-        ScriptThread::await_stable_state(Microtask::MediaElement(task));
+        self.script_thread()
+            .await_stable_state(Microtask::MediaElement(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
@@ -1281,7 +1281,8 @@ impl HTMLMediaElement {
             generation_id: self.generation_id.get(),
         };
 
-        ScriptThread::await_stable_state(Microtask::MediaElement(task));
+        self.script_thread()
+            .await_stable_state(Microtask::MediaElement(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
@@ -1887,7 +1888,8 @@ impl HTMLMediaElement {
             generation_id: self.generation_id.get(),
         };
 
-        ScriptThread::await_stable_state(Microtask::MediaElement(task));
+        self.script_thread()
+            .await_stable_state(Microtask::MediaElement(task));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#concept-media-load-algorithm>
@@ -2738,7 +2740,8 @@ impl HTMLMediaElement {
             generation_id: self.generation_id.get(),
         };
 
-        ScriptThread::await_stable_state(Microtask::MediaElement(task));
+        self.script_thread()
+            .await_stable_state(Microtask::MediaElement(task));
     }
 
     fn playback_state_changed(&self, state: &PlaybackState) {
@@ -3408,7 +3411,8 @@ impl VirtualMethods for HTMLMediaElement {
             let task = MediaElementMicrotask::PauseIfNotInDocument {
                 elem: DomRoot::from_ref(self),
             };
-            ScriptThread::await_stable_state(Microtask::MediaElement(task));
+            self.script_thread()
+                .await_stable_state(Microtask::MediaElement(task));
         }
     }
 

--- a/components/script/dom/html/htmlslotelement.rs
+++ b/components/script/dom/html/htmlslotelement.rs
@@ -10,7 +10,6 @@ use js::gc::RootedVec;
 use js::rust::HandleObject;
 use script_bindings::codegen::InheritTypes::{CharacterDataTypeId, NodeTypeId};
 
-use crate::ScriptThread;
 use crate::dom::attr::Attr;
 use crate::dom::bindings::codegen::Bindings::HTMLSlotElementBinding::{
     AssignedNodesOptions, HTMLSlotElementMethods,
@@ -356,12 +355,13 @@ impl HTMLSlotElement {
         }
         self.is_in_agents_signal_slots.set(true);
 
-        let mutation_observers = ScriptThread::mutation_observers();
         // Step 1. Append slot to slot’s relevant agent’s signal slots.
+        let script_thread = self.owner_window().script_thread();
+        let mutation_observers = script_thread.mutation_observers();
         mutation_observers.add_signal_slot(self);
 
         // Step 2. Queue a mutation observer microtask.
-        mutation_observers.queue_mutation_observer_microtask(ScriptThread::microtask_queue());
+        mutation_observers.queue_mutation_observer_microtask(script_thread.microtask_queue());
     }
 
     pub(crate) fn remove_from_signal_slots(&self) {

--- a/components/script/dom/testing/testworklet.rs
+++ b/components/script/dom/testing/testworklet.rs
@@ -21,7 +21,6 @@ use crate::dom::worklet::Worklet;
 use crate::dom::workletglobalscope::WorkletGlobalScopeType;
 use crate::realms::InRealm;
 use crate::script_runtime::CanGc;
-use crate::script_thread::ScriptThread;
 
 #[dom_struct]
 pub(crate) struct TestWorklet {
@@ -70,8 +69,10 @@ impl TestWorkletMethods<crate::DomTypeHolder> for TestWorklet {
 
     fn Lookup(&self, key: DOMString) -> Option<DOMString> {
         let id = self.worklet.worklet_id();
-        let pool = ScriptThread::worklet_thread_pool(self.global().image_cache());
-        pool.test_worklet_lookup(id, String::from(key))
+        let script_thread = self.global().map_window(|window| window.script_thread())?;
+        script_thread
+            .worklet_thread_pool(self.global().image_cache())
+            .test_worklet_lookup(id, String::from(key))
             .map(DOMString::from)
     }
 }

--- a/components/script/dom/webxr/xrsystem.rs
+++ b/components/script/dom/webxr/xrsystem.rs
@@ -34,7 +34,6 @@ use crate::dom::xrsession::XRSession;
 use crate::dom::xrtest::XRTest;
 use crate::realms::InRealm;
 use crate::script_runtime::CanGc;
-use crate::script_thread::ScriptThread;
 
 #[dom_struct]
 pub(crate) struct XRSystem {
@@ -166,7 +165,7 @@ impl XRSystemMethods<crate::DomTypeHolder> for XRSystem {
         let promise = Promise::new_in_current_realm(comp, can_gc);
 
         if mode != XRSessionMode::Inline {
-            if !ScriptThread::is_user_interacting() {
+            if !window.script_thread().is_user_interacting() {
                 if pref!(dom_webxr_unsafe_assume_user_intent) {
                     warn!(
                         "The dom.webxr.unsafe-assume-user-intent preference assumes user intent to enter WebXR."
@@ -322,7 +321,7 @@ impl XRSystem {
                 task!(fire_sessionavailable_event: move || {
                     // The sessionavailable event indicates user intent to enter an XR session
                     let xr = xr.root();
-                        let _guard = ScriptThread::user_interacting_guard();
+                        let _guard = xr.global().as_window().script_thread().user_interacting_guard();
                         xr.upcast::<EventTarget>().fire_bubbling_event(atom!("sessionavailable"), CanGc::note());
                 })
             );

--- a/components/script/dom/webxr/xrtest.rs
+++ b/components/script/dom/webxr/xrtest.rs
@@ -15,7 +15,6 @@ use js::jsval::JSVal;
 use profile_traits::ipc;
 use webxr_api::{self, Error as XRError, MockDeviceInit, MockDeviceMsg};
 
-use crate::ScriptThread;
 use crate::dom::bindings::callback::ExceptionHandling;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
@@ -180,7 +179,11 @@ impl XRTestMethods<crate::DomTypeHolder> for XRTest {
 
     /// <https://github.com/immersive-web/webxr-test-api/blob/master/explainer.md>
     fn SimulateUserActivation(&self, f: Rc<Function>, can_gc: CanGc) {
-        let _guard = ScriptThread::user_interacting_guard();
+        let _guard = self
+            .global()
+            .as_window()
+            .script_thread()
+            .user_interacting_guard();
         rooted!(in(*GlobalScope::get_cx()) let mut value: JSVal);
         let _ = f.Call__(
             vec![],

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -57,7 +57,6 @@ use crate::fetch::{CspViolationsProcessor, load_whole_resource};
 use crate::messaging::{CommonScriptMsg, MainThreadScriptMsg};
 use crate::realms::InRealm;
 use crate::script_runtime::{CanGc, Runtime, ScriptThreadEventCategory};
-use crate::script_thread::ScriptThread;
 use crate::task::TaskBox;
 use crate::task_source::TaskSourceName;
 
@@ -158,7 +157,11 @@ impl WorkletMethods<crate::DomTypeHolder> for Worklet {
 
         self.droppable_field
             .thread_pool
-            .get_or_init(|| ScriptThread::worklet_thread_pool(self.global().image_cache()))
+            .get_or_init(|| {
+                self.window
+                    .script_thread()
+                    .worklet_thread_pool(self.global().image_cache())
+            })
             .fetch_and_invoke_a_worklet_script(
                 self.window.webview_id(),
                 self.window.pipeline_id(),

--- a/components/script/iframe_collection.rs
+++ b/components/script/iframe_collection.rs
@@ -15,7 +15,6 @@ use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::html::htmliframeelement::HTMLIFrameElement;
 use crate::dom::node::{Node, ShadowIncluding};
 use crate::dom::types::{Document, Window};
-use crate::script_thread::with_script_thread;
 
 #[derive(JSTraceable, MallocSizeOf)]
 #[cfg_attr(crown, crown::unrooted_must_root_lint::must_root)]
@@ -130,13 +129,11 @@ impl IFrameCollection {
                 // to filter asynchronously through the `Constellation`. This allows the new value
                 // to be reflected immediately in layout.
                 let viewport_details = iframe_size.viewport_details;
-                with_script_thread(|script_thread| {
-                    script_thread.handle_resize_message(
-                        iframe_size.pipeline_id,
-                        viewport_details,
-                        WindowSizeType::Resize,
-                    );
-                });
+                window.script_thread().handle_resize_message(
+                    iframe_size.pipeline_id,
+                    viewport_details,
+                    WindowSizeType::Resize,
+                );
 
                 let old_viewport_details =
                     self.set_viewport_details(browsing_context_id, viewport_details);

--- a/components/script_bindings/interfaces.rs
+++ b/components/script_bindings/interfaces.rs
@@ -54,8 +54,8 @@ pub trait DomHelpers<D: DomTypes> {
 
     fn interface_map() -> &'static phf::Map<&'static [u8], Interface>;
 
-    fn push_new_element_queue();
-    fn pop_current_element_queue(can_gc: CanGc);
+    fn push_new_element_queue(global: &D::GlobalScope);
+    fn pop_current_element_queue(global: &D::GlobalScope, can_gc: CanGc);
 
     fn reflect_dom_object<T, U>(obj: Box<T>, global: &U, can_gc: CanGc) -> DomRoot<T>
     where


### PR DESCRIPTION
This change replaces the usage of TLS to access `ScriptThread` with
a `Weak` stored in various places in the DOM.

Testing: TBD
Fixes: #37969