### PR TITLE
fonts: Apply variations for `font-weight`, `font-stretch`

### DIFF
--- a/components/shared/fonts/font_template.rs
+++ b/components/shared/fonts/font_template.rs
@@ -244,6 +244,14 @@ impl FontTemplate {
             .copied()
             .for_each(&mut add_variation);
 
+        // Step 9. Font variations implied by the value of the font-optical-sizing property are applied.
+        if descriptor.optical_sizing == FontOpticalSizing::Auto {
+            add_variation(FontVariation {
+                tag: Tag::new(b"opsz").to_u32(),
+                value: descriptor.pt_size.to_f32_px(),
+            });
+        }
+
         if let Some(font_face_rule) = &self.font_face_rule {
             // Step 6. If the font is defined via an @font-face rule, the font variations implied by the font-variation-settings
             // descriptor in the @font-face rule are applied.
@@ -257,14 +265,6 @@ impl FontTemplate {
                     })
                     .for_each(&mut add_variation);
             }
-        }
-
-        // Step 9. Font variations implied by the value of the font-optical-sizing property are applied.
-        if descriptor.optical_sizing == FontOpticalSizing::Auto {
-            add_variation(FontVariation {
-                tag: Tag::new(b"opsz").to_u32(),
-                value: descriptor.pt_size.to_f32_px(),
-            });
         }
 
         // Step 2. Font variations as enabled by the font-weight, font-width, and font-style properties are applied.

--- a/components/shared/fonts/font_template.rs
+++ b/components/shared/fonts/font_template.rs
@@ -267,6 +267,23 @@ impl FontTemplate {
             });
         }
 
+        // Step 2. Font variations as enabled by the font-weight, font-width, and font-style properties are applied.
+        // FIXME: Apply variations for font-style
+        // NOTE: font-stretch is a legacy alias to font-width
+        if descriptor.weight != FontWeight::NORMAL {
+            add_variation(FontVariation {
+                tag: Tag::new(b"wght").to_u32(),
+                value: descriptor.weight.value(),
+            });
+        }
+
+        if descriptor.stretch != FontStretch::NORMAL {
+            add_variation(FontVariation {
+                tag: Tag::new(b"wdth").to_u32(),
+                value: descriptor.stretch.0.to_float(),
+            });
+        }
+
         variations
     }
 }

--- a/tests/wpt/meta/css/css-fonts/font-face-stretch-auto-variable.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-face-stretch-auto-variable.html.ini
@@ -1,2 +1,0 @@
-[font-face-stretch-auto-variable.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-face-stretch-default-variable.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-face-stretch-default-variable.html.ini
@@ -1,2 +1,0 @@
-[font-face-stretch-default-variable.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-face-weight-auto-variable.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-face-weight-auto-variable.html.ini
@@ -1,2 +1,0 @@
-[font-face-weight-auto-variable.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-face-weight-default-variable.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-face-weight-default-variable.html.ini
@@ -1,2 +1,0 @@
-[font-face-weight-default-variable.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-variation-settings-descriptor-03.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-variation-settings-descriptor-03.html.ini
@@ -1,0 +1,2 @@
+[font-variation-settings-descriptor-03.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-variation-settings-descriptor-04.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-variation-settings-descriptor-04.html.ini
@@ -1,0 +1,2 @@
+[font-variation-settings-descriptor-04.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/variations/font-weight-metrics.html.ini
+++ b/tests/wpt/meta/css/css-fonts/variations/font-weight-metrics.html.ini
@@ -1,2 +1,0 @@
-[font-weight-metrics.html]
-  expected: FAIL


### PR DESCRIPTION
`font-style` is not included yet because it requires us to have information about the selected font, which is not possible yet.

Testing: New tests start to pass
Fixes #37236 
Part of #38800 
