### PR TITLE
script: add CanGc as argument to methods in HTMLOptionElement

### DIFF
--- a/components/script/dom/html/htmloptionelement.rs
+++ b/components/script/dom/html/htmloptionelement.rs
@@ -283,11 +283,11 @@ impl HTMLOptionElementMethods<crate::DomTypeHolder> for HTMLOptionElement {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-option-selected>
-    fn SetSelected(&self, selected: bool) {
+    fn SetSelected(&self, selected: bool, can_gc: CanGc) {
         self.dirtiness.set(true);
         self.selectedness.set(selected);
         self.pick_if_selected_and_reset();
-        self.update_select_validity(CanGc::note());
+        self.update_select_validity(can_gc);
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-option-index>

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -2038,10 +2038,11 @@ pub(crate) fn handle_element_click(
                             match container.downcast::<HTMLSelectElement>() {
                                 Some(select_element) => {
                                     if select_element.Multiple() {
-                                        option_element.SetSelected(!option_element.Selected());
+                                        option_element
+                                            .SetSelected(!option_element.Selected(), can_gc);
                                     }
                                 },
-                                None => option_element.SetSelected(true),
+                                None => option_element.SetSelected(true, can_gc),
                             }
 
                             // Step 8.6.4

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -428,7 +428,7 @@ DOMInterfaces = {
 },
 
 'HTMLOptionElement': {
-    'canGc': ['SetText']
+    'canGc': ['SetSelected', 'SetText']
 },
 
 'HTMLOptionsCollection': {


### PR DESCRIPTION
script: add CanGc as argument to methods in HTMLOptionElement

Testing: These changes do not require tests because they are a refactor.
Addresses part of https://github.com/servo/servo/issues/34573