### PR TITLE
Fix compilation warning for `background_hang_monitor`

### DIFF
--- a/components/background_hang_monitor/sampler.rs
+++ b/components/background_hang_monitor/sampler.rs
@@ -58,6 +58,7 @@ impl Default for NativeStack {
 }
 
 impl NativeStack {
+    #[cfg_attr(target_os = "windows", expect(dead_code))]
     pub fn process_register(
         &mut self,
         instruction_ptr: *mut std::ffi::c_void,

--- a/components/background_hang_monitor/sampler_windows.rs
+++ b/components/background_hang_monitor/sampler_windows.rs
@@ -12,8 +12,7 @@ pub struct WindowsSampler {
 }
 
 impl WindowsSampler {
-    #[expect(unsafe_code, dead_code)]
-    pub fn new_boxed() -> Box<dyn Sampler> {
+    pub(super) fn new_boxed() -> Box<dyn Sampler> {
         let thread_id = 0; // TODO: use windows::Win32::System::Threading::GetThreadId
         Box::new(WindowsSampler { thread_id })
     }


### PR DESCRIPTION
Fix warnings exposed by 0a0a20a9c6b7983ed96fb86715ada5b9f6d61f2e