### PR TITLE
html: Use WeakRef for the `MediaSession` media element

### DIFF
--- a/components/script/dom/media/mediasession.rs
+++ b/components/script/dom/media/mediasession.rs
@@ -25,9 +25,10 @@ use crate::dom::bindings::codegen::Bindings::MediaSessionBinding::{
 };
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
-use crate::dom::bindings::root::{DomRoot, MutNullableDom};
+use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::trace::HashMapTracedValues;
+use crate::dom::bindings::weakref::MutableWeakRef;
 use crate::dom::html::htmlmediaelement::HTMLMediaElement;
 use crate::dom::media::mediametadata::MediaMetadata;
 use crate::dom::window::Window;
@@ -50,7 +51,7 @@ pub(crate) struct MediaSession {
     >,
     /// The media instance controlled by this media session.
     /// For now only HTMLMediaElements are controlled by media sessions.
-    media_instance: MutNullableDom<HTMLMediaElement>,
+    media_instance: MutableWeakRef<HTMLMediaElement>,
 }
 
 impl MediaSession {
@@ -61,7 +62,7 @@ impl MediaSession {
             metadata: DomRefCell::new(None),
             playback_state: DomRefCell::new(MediaSessionPlaybackState::None),
             action_handlers: DomRefCell::new(HashMapTracedValues::new_fx()),
-            media_instance: Default::default(),
+            media_instance: MutableWeakRef::new(None),
         }
     }
 
@@ -84,7 +85,7 @@ impl MediaSession {
         }
 
         // Default action.
-        if let Some(media) = self.media_instance.get() {
+        if let Some(media) = self.media_instance.root() {
             match action {
                 MediaSessionActionType::Play => {
                     let realm = enter_realm(self);

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -349,6 +349,10 @@ DOMInterfaces = {
      "canGc": ['SetText', 'SetRel', 'SetHref', 'SetHash', 'SetHost', 'SetHostname', 'SetPassword', 'SetPathname', 'SetPort', 'SetProtocol', 'SetSearch', 'SetUsername', 'RelList']
 },
 
+"HTMLAudioElement": {
+    'weakReferenceable': True,
+},
+
 "HTMLBodyElement": {
     "canGc": ["SetBackground"]
 },
@@ -417,6 +421,7 @@ DOMInterfaces = {
 'HTMLMediaElement': {
     'canGc': ['AddTextTrack', 'AudioTracks', 'Buffered', 'Load', 'Pause', 'Play', 'Played', 'Seekable', 'SetSrcObject', 'SetCrossOrigin', 'TextTracks', 'VideoTracks'],
     'inRealms': ['Play'],
+    'weakReferenceable': True,
 },
 
 'HTMLMeterElement': {
@@ -473,6 +478,10 @@ DOMInterfaces = {
 
 'HTMLTitleElement': {
     'canGc': ['SetText']
+},
+
+'HTMLVideoElement': {
+    'weakReferenceable': True,
 },
 
 'IDBCursor': {


### PR DESCRIPTION
The media session is allowed to control the state of the media element (play, pause) and is holding DOM reference, so the latest registered media element is not be able to be GCed, so let's use the weak reference to break this dependency.

Note that `weakReference` property was added to interfaces
- HTMLMediaElement: The `Mutable/WeakRef` requires T to be bound by `WeakReferenceable`
- HTMLAudio/VideoElement: The `DOM_WEAK_SLOT` must be reserved by concrete DOM JS class

Testing: No expected testing results changes

The media session UI functionality is implemented for Android and didn't test due lack of testing sample.

Fixes: https://github.com/servo/servo/issues/40854