### PR TITLE
ci: Remove self-hosted runner timeout jobs

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -70,17 +70,6 @@ jobs:
           # Any other boolean conditions that disable self-hosted runners go here.
           # No need to use self-hosted runners if we’re only measuring binary size.
           force-github-hosted-runner: ${{ !(inputs.speedometer || inputs.dromaeo) || inputs.force-github-hosted-runner }}
-  runner-timeout:
-    needs:
-      - runner-select
-    if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Runner timeout
-        uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
-        with:
-          github_token: '${{ secrets.GITHUB_TOKEN }}'
-          unique-id: '${{ needs.runner-select.outputs.unique-id }}'
 
   bencher:
     needs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,17 +35,6 @@ jobs:
           NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
           # Any other boolean conditions that disable self-hosted runners go here.
           force-github-hosted-runner: ${{ inputs.upload || inputs.force-github-hosted-runner }}
-  runner-timeout:
-    needs:
-      - runner-select
-    if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Runner timeout
-        uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
-        with:
-          github_token: '${{ secrets.GITHUB_TOKEN }}'
-          unique-id: '${{ needs.runner-select.outputs.unique-id }}'
 
   lint:
     needs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -126,17 +126,6 @@ jobs:
           NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
           # Any other boolean conditions that disable self-hosted runners go here.
           force-github-hosted-runner: ${{ inputs.upload || inputs.force-github-hosted-runner }}
-  runner-timeout:
-    needs:
-      - runner-select
-    if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Runner timeout
-        uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
-        with:
-          github_token: '${{ secrets.GITHUB_TOKEN }}'
-          unique-id: '${{ needs.runner-select.outputs.unique-id }}'
 
   build:
     needs:
@@ -320,17 +309,6 @@ jobs:
           NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
           # Any other boolean conditions that disable self-hosted runners go here.
           force-github-hosted-runner: ${{ inputs.force-github-hosted-runner }}
-  runner-timeout-coverage:
-    needs:
-      - runner-select-coverage
-    if: inputs.coverage && fromJSON(needs.runner-select-coverage.outputs.is-self-hosted)
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Runner timeout
-        uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
-        with:
-          github_token: '${{ secrets.GITHUB_TOKEN }}'
-          unique-id: '${{ needs.runner-select-coverage.outputs.unique-id }}'
 
   unit-test-coverage:
     if: inputs.coverage

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -105,17 +105,6 @@ jobs:
           NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
           # Any other boolean conditions that disable self-hosted runners go here.
           force-github-hosted-runner: ${{ inputs.force-github-hosted-runner }}
-  runner-timeout:
-    needs:
-      - runner-select
-    if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Runner timeout
-        uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
-        with:
-          github_token: '${{ secrets.GITHUB_TOKEN }}'
-          unique-id: '${{ needs.runner-select.outputs.unique-id }}'
 
   build:
     needs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,17 +96,6 @@ jobs:
           NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
           # Any other boolean conditions that disable self-hosted runners go here.
           force-github-hosted-runner: ${{ inputs.force-github-hosted-runner }}
-  runner-timeout:
-    needs:
-      - runner-select
-    if: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) }}
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Runner timeout
-        uses: servo/ci-runners/actions/runner-timeout@44317e3cd86c5ff2ef0b08878b90da246bc237da
-        with:
-          github_token: '${{ secrets.GITHUB_TOKEN }}'
-          unique-id: '${{ needs.runner-select.outputs.unique-id }}'
 
   build:
     needs:


### PR DESCRIPTION
the runner timeout jobs are a helpful safeguard against bugs (or github infra failures) that cause jobs to not get picked up by self-hosted runners, but all they do is wait two minutes and cancel the run, clogging up our github-hosted runner capacity (limited to 60).

this patch removes the timeout jobs, based on the expectation that our CI system is reliable enough to not need that automated safeguard.

if you have a build that gets stuck on “Waiting for a runner to pick up this job...”, it may be a bug or a github infra failure. you can cancel the build yourself, but please take a screenshot and report it first!

Testing:
- [mach try windows linux lint](https://github.com/servo/servo/actions/runs/19659755273)