### PR TITLE
compositor: Update doc of `ExternalScrollId` in `ScrollResult`

### DIFF
--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -709,7 +709,7 @@ impl Painter {
         }
         for update in scroll_offset_updates {
             transaction.set_scroll_offsets(
-                update.external_scroll_id,
+                update.hit_test_result.external_scroll_id,
                 vec![SampledScrollOffset {
                     offset: update.offset,
                     generation: 0,

--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -709,7 +709,7 @@ impl Painter {
         }
         for update in scroll_offset_updates {
             transaction.set_scroll_offsets(
-                update.hit_test_result.external_scroll_id,
+                update.external_scroll_id,
                 vec![SampledScrollOffset {
                     offset: update.offset,
                     generation: 0,

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -60,6 +60,8 @@ pub(crate) enum ScrollZoomEvent {
 #[derive(Clone, Debug)]
 pub(crate) struct ScrollResult {
     pub hit_test_result: CompositorHitTestResult,
+    /// This is necessary as the `external_scroll_id` of [CompositorHitTestResult] can be different.
+    /// Currently, we scroll the first possible inclusive ancestor.
     pub external_scroll_id: ExternalScrollId,
     pub offset: LayoutVector2D,
 }

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -60,8 +60,10 @@ pub(crate) enum ScrollZoomEvent {
 #[derive(Clone, Debug)]
 pub(crate) struct ScrollResult {
     pub hit_test_result: CompositorHitTestResult,
-    /// This is necessary as the `external_scroll_id` of [CompositorHitTestResult] can be different.
-    /// Currently, we scroll the first possible inclusive ancestor.
+    /// The [`ExternalScrollId`] of the node that was actually scrolled.
+    ///
+    /// Note that this is an inclusive ancestor of `external_scroll_id` in
+    /// [`Self::hit_test_result`].
     pub external_scroll_id: ExternalScrollId,
     pub offset: LayoutVector2D,
 }

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -60,6 +60,7 @@ pub(crate) enum ScrollZoomEvent {
 #[derive(Clone, Debug)]
 pub(crate) struct ScrollResult {
     pub hit_test_result: CompositorHitTestResult,
+    pub external_scroll_id: ExternalScrollId,
     pub offset: LayoutVector2D,
 }
 
@@ -763,7 +764,7 @@ impl WebViewRenderer {
                 scroll_result.hit_test_result.pipeline_id,
             );
             self.dispatch_scroll_event(
-                scroll_result.hit_test_result.external_scroll_id,
+                scroll_result.external_scroll_id,
                 scroll_result.hit_test_result.clone(),
             );
         }
@@ -812,7 +813,7 @@ impl WebViewRenderer {
                     scroll_location,
                     ScrollType::InputEvents,
                 );
-                if let Some((_, offset)) = scroll_result {
+                if let Some((external_scroll_id, offset)) = scroll_result {
                     // We would like to cache the hit test for the node that that actually scrolls
                     // while panning, which we don't know until right now (as some nodes
                     // might be at the end of their scroll area). In particular, directionality of
@@ -824,6 +825,7 @@ impl WebViewRenderer {
                     );
                     return Some(ScrollResult {
                         hit_test_result,
+                        external_scroll_id,
                         offset,
                     });
                 }
@@ -884,6 +886,7 @@ impl WebViewRenderer {
 
         let scroll_result = ScrollResult {
             hit_test_result,
+            external_scroll_id,
             offset,
         };
         (pinch_zoom_result, vec![scroll_result])

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -60,7 +60,6 @@ pub(crate) enum ScrollZoomEvent {
 #[derive(Clone, Debug)]
 pub(crate) struct ScrollResult {
     pub hit_test_result: CompositorHitTestResult,
-    pub external_scroll_id: ExternalScrollId,
     pub offset: LayoutVector2D,
 }
 
@@ -764,7 +763,7 @@ impl WebViewRenderer {
                 scroll_result.hit_test_result.pipeline_id,
             );
             self.dispatch_scroll_event(
-                scroll_result.external_scroll_id,
+                scroll_result.hit_test_result.external_scroll_id,
                 scroll_result.hit_test_result.clone(),
             );
         }
@@ -813,7 +812,7 @@ impl WebViewRenderer {
                     scroll_location,
                     ScrollType::InputEvents,
                 );
-                if let Some((external_scroll_id, offset)) = scroll_result {
+                if let Some((_, offset)) = scroll_result {
                     // We would like to cache the hit test for the node that that actually scrolls
                     // while panning, which we don't know until right now (as some nodes
                     // might be at the end of their scroll area). In particular, directionality of
@@ -825,7 +824,6 @@ impl WebViewRenderer {
                     );
                     return Some(ScrollResult {
                         hit_test_result,
-                        external_scroll_id,
                         offset,
                     });
                 }
@@ -886,7 +884,6 @@ impl WebViewRenderer {
 
         let scroll_result = ScrollResult {
             hit_test_result,
-            external_scroll_id,
             offset,
         };
         (pinch_zoom_result, vec![scroll_result])


### PR DESCRIPTION
The original attempt is to remove it. But we can't do this. Add doc to explain why.

Testing: This should change nothing.
Fixes: Preparing for #40663.
