### PR TITLE
bhm: Fix a build warning about unexpectedly used `dead_code`

### DIFF
--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -76,7 +76,7 @@ impl BackgroundHangMonitorRegister for HangMonitorRegister {
         );
 
         bhm_chan.send(MonitoredComponentMsg::Register(
-            SamplerImpl::new_boxed(),
+            SamplerImpl::default(),
             thread::current().name().map(str::to_owned),
             transient_hang_timeout,
             permanent_hang_timeout,
@@ -96,7 +96,7 @@ impl BackgroundHangMonitorClone for HangMonitorRegister {
 enum MonitoredComponentMsg {
     /// Register component for monitoring,
     Register(
-        Box<dyn Sampler>,
+        SamplerImpl,
         Option<String>,
         Duration,
         Duration,
@@ -159,7 +159,7 @@ impl BackgroundHangMonitor for BackgroundHangMonitorChan {
 }
 
 struct MonitoredComponent {
-    sampler: Box<dyn Sampler>,
+    sampler: SamplerImpl,
     last_activity: Instant,
     last_annotation: Option<HangAnnotation>,
     transient_hang_timeout: Duration,

--- a/components/background_hang_monitor/lib.rs
+++ b/components/background_hang_monitor/lib.rs
@@ -37,7 +37,7 @@ pub use self::background_hang_monitor::*;
         )
     ),
 ))]
-pub use crate::sampler::DummySampler as SamplerImpl;
+pub(crate) use crate::sampler::DummySampler as SamplerImpl;
 #[cfg(all(
     feature = "sampler",
     target_os = "linux",
@@ -48,14 +48,14 @@ pub use crate::sampler::DummySampler as SamplerImpl;
         target_env = "musl"
     ))
 ))]
-pub use crate::sampler_linux::LinuxSampler as SamplerImpl;
+pub(crate) use crate::sampler_linux::LinuxSampler as SamplerImpl;
 #[cfg(all(feature = "sampler", target_os = "android"))]
-pub use crate::sampler_linux::LinuxSampler as SamplerImpl;
+pub(crate) use crate::sampler_linux::LinuxSampler as SamplerImpl;
 #[cfg(all(feature = "sampler", target_os = "macos"))]
-pub use crate::sampler_mac::MacOsSampler as SamplerImpl;
+pub(crate) use crate::sampler_mac::MacOsSampler as SamplerImpl;
 #[cfg(all(
     feature = "sampler",
     target_os = "windows",
     any(target_arch = "x86_64", target_arch = "x86")
 ))]
-pub use crate::sampler_windows::WindowsSampler as SamplerImpl;
+pub(crate) use crate::sampler_windows::WindowsSampler as SamplerImpl;

--- a/components/background_hang_monitor/sampler.rs
+++ b/components/background_hang_monitor/sampler.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::marker::PhantomData;
 use std::ptr;
 
 use background_hang_monitor_api::{HangProfile, HangProfileSymbol};
@@ -12,33 +13,13 @@ pub trait Sampler: Send {
     fn suspend_and_sample_thread(&self) -> Result<NativeStack, ()>;
 }
 
-pub struct DummySampler;
-
-impl DummySampler {
-    #[expect(dead_code)]
-    pub fn new_boxed() -> Box<dyn Sampler> {
-        Box::new(DummySampler)
-    }
-}
+// Implementing this type on `PhantomData` allows avoiding dead code warnings.
+pub(crate) type DummySampler = PhantomData<()>;
 
 impl Sampler for DummySampler {
     fn suspend_and_sample_thread(&self) -> Result<NativeStack, ()> {
         Err(())
     }
-}
-
-// Several types in this file are currently not used in a Linux or Windows build.
-pub type Address = *const u8;
-
-/// The registers used for stack unwinding
-#[expect(dead_code)]
-pub struct Registers {
-    /// Instruction pointer.
-    pub instruction_ptr: Address,
-    /// Stack pointer.
-    pub stack_ptr: Address,
-    /// Frame pointer.
-    pub frame_ptr: Address,
 }
 
 pub struct NativeStack {

--- a/components/background_hang_monitor/sampler_mac.rs
+++ b/components/background_hang_monitor/sampler_mac.rs
@@ -4,19 +4,32 @@
 
 use std::{panic, process};
 
-use crate::sampler::{Address, NativeStack, Registers, Sampler};
+use crate::sampler::{NativeStack, Sampler};
 
 type MonitoredThreadId = mach2::mach_types::thread_act_t;
+
+// Several types in this file are currently not used in a Linux or Windows build.
+type Address = *const u8;
+
+/// The registers used for stack unwinding
+struct Registers {
+    /// Instruction pointer.
+    pub instruction_ptr: Address,
+    /// Stack pointer.
+    pub stack_ptr: Address,
+    /// Frame pointer.
+    pub frame_ptr: Address,
+}
 
 pub struct MacOsSampler {
     thread_id: MonitoredThreadId,
 }
 
-impl MacOsSampler {
+impl Default for MacOsSampler {
     #[expect(unsafe_code)]
-    pub fn new_boxed() -> Box<dyn Sampler> {
+    fn default() -> Self {
         let thread_id = unsafe { mach2::mach_init::mach_thread_self() };
-        Box::new(MacOsSampler { thread_id })
+        Self { thread_id }
     }
 }
 

--- a/components/background_hang_monitor/sampler_windows.rs
+++ b/components/background_hang_monitor/sampler_windows.rs
@@ -11,10 +11,10 @@ pub struct WindowsSampler {
     thread_id: MonitoredThreadId,
 }
 
-impl WindowsSampler {
-    pub(super) fn new_boxed() -> Box<dyn Sampler> {
+impl Default for WindowsSampler {
+    fn default() -> Self {
         let thread_id = 0; // TODO: use windows::Win32::System::Threading::GetThreadId
-        Box::new(WindowsSampler { thread_id })
+        Self { thread_id }
     }
 }
 


### PR DESCRIPTION
- Move `Registers` to `sampler_macos.rs` where it is used.
- Reimplement `DummySampler` so that it does not produce dead code warnings on platforms that do not use it.

Testing: This change fixes a build warning, so should not need tests.
