### PR TITLE
Don't override `opsz` from `font-variation-settings` when `font-optical-sizing` is `auto`

### DIFF
--- a/tests/wpt/meta/css/css-fonts/font-variation-settings-descriptor-03.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-variation-settings-descriptor-03.html.ini
@@ -1,2 +1,0 @@
-[font-variation-settings-descriptor-03.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-fonts/font-variation-settings-descriptor-04.html.ini
+++ b/tests/wpt/meta/css/css-fonts/font-variation-settings-descriptor-04.html.ini
@@ -1,2 +1,0 @@
-[font-variation-settings-descriptor-04.html]
-  expected: FAIL


### PR DESCRIPTION
`font-optical-sizing:auto` is UA-defined, and other browsers only set `opsz` when other variation sources don't already set it.

Gecko code for reference: https://searchfox.org/firefox-main/source/gfx/src/nsFont.cpp#277.

Testing: New tests start to pass

