### PR TITLE
Fixes ByteLengthQueuingStrategy.size WPTs that were previously marked as TIMEOUT/CRASH

### DIFF
--- a/tests/wpt/meta/streams/queuing-strategies.any.js.ini
+++ b/tests/wpt/meta/streams/queuing-strategies.any.js.ini
@@ -1,0 +1,23 @@
+[queuing-strategies.any.shadowrealm-in-shadowrealm.html]
+  expected: ERROR
+
+[queuing-strategies.any.shadowrealm-in-sharedworker.html]
+  expected: ERROR
+
+[queuing-strategies.https.any.shadowrealm-in-serviceworker.html]
+  expected: ERROR
+
+[queuing-strategies.any.sharedworker.html]
+  expected: ERROR
+
+[queuing-strategies.https.any.shadowrealm-in-audioworklet.html]
+  expected: ERROR
+
+[queuing-strategies.any.shadowrealm-in-window.html]
+  expected: ERROR
+
+[queuing-strategies.any.serviceworker.html]
+  expected: ERROR
+
+[queuing-strategies.any.shadowrealm-in-dedicatedworker.html]
+  expected: ERROR


### PR DESCRIPTION
I got trigged by this:

<img width="1589" height="919" alt="image" src="https://github.com/user-attachments/assets/ad827309-551a-452a-9af3-b857b71dc4cd" />



Servo is the only one TIMEOUT on this test, but we don't have a `tests/wpt/meta/streams/queuing-strategies.any.js.ini`, when I run it locally I get one test TIMEOUT and another one CRASH, this should fix it.


Before this fix:
```
[queuing-strategies.any.worker.html]
  expected: CRASH

[queuing-strategies.any.html]
  expected: TIMEOUT
  [ByteLengthQueuingStrategy: size behaves as expected with strange arguments]
    expected: TIMEOUT

```