### PR TITLE
serviceworker-next: Pass `PipelineId` as parameter to communicate which source is being used

### DIFF
--- a/components/script/dom/workers/abstractworker.rs
+++ b/components/script/dom/workers/abstractworker.rs
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
+use base::id::PipelineId;
 use constellation_traits::StructuredSerializedData;
 use servo_url::ImmutableOrigin;
 
@@ -21,6 +21,7 @@ pub(crate) enum WorkerScriptMsg {
 pub(crate) struct MessageData {
     pub origin: ImmutableOrigin,
     pub data: Box<StructuredSerializedData>,
+    pub pipeline_id: PipelineId,
 }
 
 pub(crate) struct SimpleWorkerErrorHandler<T: DomObject> {

--- a/components/script/dom/workers/serviceworker.rs
+++ b/components/script/dom/workers/serviceworker.rs
@@ -105,8 +105,10 @@ impl ServiceWorker {
         // Step 7
         let data = structuredclone::write(cx, message, Some(transfer))?;
         let incumbent = GlobalScope::incumbent().expect("no incumbent global?");
+        let pipeline_id = incumbent.pipeline_id();
         let msg_vec = DOMMessage {
             origin: incumbent.origin().immutable().clone(),
+            pipeline_id,
             data,
         };
         let _ = self.global().script_to_constellation_chan().send(

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -149,6 +149,7 @@ impl Worker {
             address,
             WorkerScriptMsg::DOMMessage(MessageData {
                 origin: self.global().origin().immutable().clone(),
+                pipeline_id: self.global().pipeline_id(),
                 data: Box::new(data),
             }),
         ));

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -64,10 +64,15 @@ impl ServiceWorker {
 
     /// Forward a DOM message to the running service worker scope.
     fn forward_dom_message(&self, msg: DOMMessage) {
-        let DOMMessage { origin, data } = msg;
+        let DOMMessage {
+            origin,
+            data,
+            pipeline_id,
+        } = msg;
         let _ = self.sender.send(ServiceWorkerScriptMsg::CommonWorker(
             WorkerScriptMsg::DOMMessage(MessageData {
                 origin,
+                pipeline_id,
                 data: Box::new(data),
             }),
         ));

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -221,6 +221,7 @@ pub struct ScopeThings {
 pub struct DOMMessage {
     /// The origin of the message
     pub origin: ImmutableOrigin,
+    pub pipeline_id: PipelineId,
     /// The payload of the message
     pub data: StructuredSerializedData,
 }


### PR DESCRIPTION
**Targets `serviceworker-next`**

I'm still working on how to convert this to a `WindowClient`.

Testing: WPT
Fixes: Partially #40781 