### PR TITLE
CI: Add retries for unit-tests with code-coverage

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -283,8 +283,7 @@ jobs:
         run: |
           cargo +${{ steps.msrv.outputs.rust_version }} build -p libservo --locked --all-targets
 
-  # Runs the underlying job (“workload”) on a self-hosted runner if available,
-  # with the help of a `runner-select` job and a `runner-timeout` job.
+  # Runs the underlying job (“workload”) on a self-hosted runner if available.
   runner-select-coverage:
     if: inputs.coverage
     runs-on: ubuntu-24.04
@@ -356,12 +355,10 @@ jobs:
             CARGO_PROFILE=coverage
           fi
           echo "cargo_profile=${CARGO_PROFILE}" | tee $GITHUB_OUTPUT
-      # We can remove this after upgrading to Rust 1.90, but for now
-      # installing lld is the easiest way to get it in path.
-      - name: install lld
-        run: sudo apt-get install -y lld
       - name: Run unit-tests with coverage
         shell: bash
+        env:
+          NEXTEST_RETRIES: 2 # https://github.com/servo/servo/issues/30683
         run: |
           ./mach test-unit --code-coverage \
               --profile=${{ steps.options.outputs.cargo_profile }} \


### PR DESCRIPTION
Some unit-tests are flaky, so we rerun them normally. We didn't do this until now when measuring coverage, which has been a source of failures for the coverage job.
Additionally, we can also remove the install lld step, since we are now using a newer version of Rust, where we can just use lld out of the box.

Testing: [mach try linux-coverage](https://github.com/servo/servo/actions/runs/19704473261)

