### PR TITLE
script: Don't dirty with ContentOrHeritage damage when changing state

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -5183,9 +5183,6 @@ impl Element {
             }
         }
 
-        // Dirty the node so that it is laid out again if necessary.
-        self.upcast::<Node>().dirty(NodeDamage::ContentOrHeritage);
-
         self.state.set(state);
     }
 


### PR DESCRIPTION
When for example changing the hover state of an element, we were dirtying it with ContentOrHeritage damage, which forced it to be laid out again.

This was added in #39102 in order to fix #38989, but for the most part it's no longer needed.

However, we will now dirty when a `<textarea>` or `<input>` which can be selected gets or loses focus. This is to ensure that the caret or selections get correctly updated.

Testing: Manually tested that #38989 is not regressing
