### PR TITLE
build(deps): Bump mozangle to 0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,24 +815,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.1",
- "shlex",
- "syn",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -5431,11 +5413,11 @@ dependencies = [
 
 [[package]]
 name = "mozangle"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab823731ea6297e7280dade983df955d1a8209d2deb44f505932b8873168992"
+checksum = "97f4fcc47005b28e642cc098f2048a236fd8c531fc7a11b8b8bf14fb1230f122"
 dependencies = [
- "bindgen 0.71.1",
+ "bindgen",
  "cc",
  "gl_generator",
  "libz-sys",
@@ -5447,7 +5429,7 @@ name = "mozjs"
 version = "0.14.2"
 source = "git+https://github.com/servo/mozjs#e1f9c3a3e5e2ebd78bbff7ed8ce4f2d9ee991b46"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cc",
  "encoding_rs",
  "libc",
@@ -5460,7 +5442,7 @@ name = "mozjs_sys"
 version = "0.140.5-3"
 source = "git+https://github.com/servo/mozjs#e1f9c3a3e5e2ebd78bbff7ed8ce4f2d9ee991b46"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cc",
  "encoding_c",
  "encoding_c_mem",

--- a/deny.toml
+++ b/deny.toml
@@ -89,9 +89,6 @@ skip = [
     "futures",
     "redox_syscall",
 
-    # Duplicated by aws-lc-rs
-    "bindgen",
-
     # New versions of these dependencies is pulled in by GStreamer / GLib.
     "itertools",
 


### PR DESCRIPTION
This allows removing a duplicate bindgen version.

Testing: Regular dependency bump testing

