### PR TITLE
serviceworker-next

### DIFF
--- a/components/script/dom/windowclient.rs
+++ b/components/script/dom/windowclient.rs
@@ -4,18 +4,47 @@
 
 use std::rc::Rc;
 
+use base::id::PipelineId;
 use dom_struct::dom_struct;
 use script_bindings::codegen::GenericBindings::WindowClientBinding::WindowClientMethods;
+use script_bindings::root::DomRoot;
 use script_bindings::script_runtime::CanGc;
 use script_bindings::str::USVString;
 
-use crate::dom::bindings::reflector::DomGlobal;
+use crate::dom::bindings::reflector::{DomGlobal, reflect_dom_object};
 use crate::dom::client::Client;
+use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 
 #[dom_struct]
 pub(crate) struct WindowClient {
     client: Client,
+    #[no_trace]
+    pipeline_id: PipelineId,
+}
+
+impl WindowClient {
+    pub(crate) fn new_inherited(client: Client, pipeline_id: PipelineId) -> WindowClient {
+        WindowClient {
+            client,
+            pipeline_id,
+        }
+    }
+
+    pub(crate) fn new(
+        global: &GlobalScope,
+        pipeline_id: PipelineId,
+        can_gc: CanGc,
+    ) -> DomRoot<WindowClient> {
+        reflect_dom_object(
+            Box::new(WindowClient::new_inherited(
+                Client::new_inherited(global.get_url()),
+                pipeline_id,
+            )),
+            global,
+            can_gc,
+        )
+    }
 }
 
 impl WindowClientMethods<crate::DomTypeHolder> for WindowClient {

--- a/components/script/dom/workers/serviceworkercontainer.rs
+++ b/components/script/dom/workers/serviceworkercontainer.rs
@@ -51,7 +51,7 @@ impl ServiceWorkerContainer {
 
     #[cfg_attr(crown, allow(crown::unrooted_must_root))]
     pub(crate) fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<ServiceWorkerContainer> {
-        let client = Client::new(global.as_window(), can_gc);
+        let client = Client::new(global, can_gc);
         let container = ServiceWorkerContainer::new_inherited(&client);
         reflect_dom_object(Box::new(container), global, can_gc)
     }

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -47,10 +47,11 @@ use crate::dom::dedicatedworkerglobalscope::AutoWorkerReset;
 use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::extendableevent::ExtendableEvent;
-use crate::dom::extendablemessageevent::ExtendableMessageEvent;
+use crate::dom::extendablemessageevent::{ExtendableMessageEvent, MessageSource};
 use crate::dom::globalscope::GlobalScope;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
+use crate::dom::windowclient::WindowClient;
 use crate::dom::worker::TrustedWorkerAddress;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::fetch::{CspViolationsProcessor, load_whole_resource};
@@ -465,11 +466,15 @@ impl ServiceWorkerGlobalScope {
                 if let Ok(ports) =
                     structuredclone::read(scope.upcast(), *msg.data, message.handle_mut(), can_gc)
                 {
+                    // TODO: incorrect when dealing with non-windows
+                    let source = Some(MessageSource::Client(DomRoot::from_ref(
+                        WindowClient::new(self.upcast(), msg.pipeline_id, can_gc).upcast(),
+                    )));
                     ExtendableMessageEvent::dispatch_jsval(
                         target,
                         scope.upcast(),
                         message.handle(),
-                        None,
+                        source,
                         ports,
                         can_gc,
                     );

--- a/components/script_bindings/webidls/Client.webidl
+++ b/components/script_bindings/webidls/Client.webidl
@@ -9,8 +9,8 @@ interface Client {
   readonly attribute USVString url;
   readonly attribute FrameType frameType;
   readonly attribute DOMString id;
-  // undefined postMessage(any message, sequence<object> transfer);
-  // undefined postMessage(any message, optional StructuredSerializeOptions options = {});
+  [Throws] undefined postMessage(any message, sequence<object> transfer);
+  [Throws] undefined postMessage(any message, optional StructuredSerializeOptions options = {});
 };
 
 enum FrameType {


### PR DESCRIPTION
Expose `WindowClient` as source. This isn't correct if the message comes from something other than a window, but that can be fixed later. The next thing to fix is sending messages in the other direction via client.

Testing: WPT
Fixes: Partially #40781 
