### PR TITLE
html: Add new media tracks when receiving the initial media `metadata` event

### DIFF
--- a/tests/wpt/meta/html/semantics/embedded-content/the-video-element/video_size_preserved_after_ended.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-video-element/video_size_preserved_after_ended.html.ini
@@ -1,3 +1,0 @@
-[video_size_preserved_after_ended.html]
-  [Video dimensions are preserved at the end of the video.]
-    expected: FAIL


### PR DESCRIPTION
The new audio/video tracks should be added to the media element from the initial `metadata` event from the media engine because there are possibility of the multiple `metadata` events without any associated `media track` state changes and previously the application added new tracks into lists unconditionally.

The registered issue to handle possible dynamic `media track` state changes from the media engine gracefully.
https://github.com/servo/servo/issues/43386

Testing: Improvements in the following tests
- html/semantics/embedded-content/the-video-element/video_size_preserved_after_ended.html

Fixes: https://github.com/servo/servo/issues/32623