### PR TITLE
script: Break the `ScriptThread` dependency on the initial `Pipeline`

### DIFF
--- a/components/background_hang_monitor/background_hang_monitor.rs
+++ b/components/background_hang_monitor/background_hang_monitor.rs
@@ -237,13 +237,11 @@ impl BackgroundHangMonitorWorker {
                 None => "null".to_string(),
             };
             let json = format!(
-                "{}{{ \"name\": {}, \"namespace\": {}, \"index\": {}, \"type\": \"{:?}\", \
+                "{}{{ \"name\": {}, \"event loop id\": \"{:?}\", \
                  \"time\": {}, \"frames\": {} }}",
                 if !first { ",\n" } else { "" },
                 name,
-                id.0.namespace_id.0,
-                id.0.index.0.get(),
-                id.1,
+                id,
                 (instant - self.sampling_baseline).as_millis(),
                 serde_json::to_string(&profile.backtrace).unwrap(),
             );

--- a/components/background_hang_monitor/tests/hang_monitor_tests.rs
+++ b/components/background_hang_monitor/tests/hang_monitor_tests.rs
@@ -15,7 +15,7 @@ use background_hang_monitor_api::{
     HangMonitorAlert, MonitoredComponentId, MonitoredComponentType, ScriptHangAnnotation,
 };
 use base::generic_channel;
-use base::id::TEST_PIPELINE_ID;
+use base::id::TEST_SCRIPT_EVENT_LOOP_ID;
 use ipc_channel::ipc;
 
 static SERIAL: Mutex<()> = Mutex::new(());
@@ -39,7 +39,7 @@ fn test_hang_monitoring() {
     }
 
     let background_hang_monitor = background_hang_monitor_register.register_component(
-        MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script),
+        MonitoredComponentId(TEST_SCRIPT_EVENT_LOOP_ID, MonitoredComponentType::Script),
         Duration::from_millis(10),
         Duration::from_millis(1000),
         Box::new(BHMExitSignal),
@@ -55,7 +55,8 @@ fn test_hang_monitoring() {
     // Check for a transient hang alert.
     match background_hang_monitor_receiver.recv().unwrap() {
         HangMonitorAlert::Hang(HangAlert::Transient(component_id, _annotation)) => {
-            let expected = MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script);
+            let expected =
+                MonitoredComponentId(TEST_SCRIPT_EVENT_LOOP_ID, MonitoredComponentType::Script);
             assert_eq!(expected, component_id);
         },
         _ => unreachable!(),
@@ -67,7 +68,8 @@ fn test_hang_monitoring() {
     // Check for a permanent hang alert.
     match background_hang_monitor_receiver.recv().unwrap() {
         HangMonitorAlert::Hang(HangAlert::Permanent(component_id, _annotation, _profile)) => {
-            let expected = MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script);
+            let expected =
+                MonitoredComponentId(TEST_SCRIPT_EVENT_LOOP_ID, MonitoredComponentType::Script);
             assert_eq!(expected, component_id);
         },
         _ => unreachable!(),
@@ -83,7 +85,8 @@ fn test_hang_monitoring() {
     // Check for a transient hang alert.
     match background_hang_monitor_receiver.recv().unwrap() {
         HangMonitorAlert::Hang(HangAlert::Transient(component_id, _annotation)) => {
-            let expected = MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script);
+            let expected =
+                MonitoredComponentId(TEST_SCRIPT_EVENT_LOOP_ID, MonitoredComponentType::Script);
             assert_eq!(expected, component_id);
         },
         _ => unreachable!(),
@@ -107,7 +110,8 @@ fn test_hang_monitoring() {
     // We're getting new hang alerts for the latest task.
     match background_hang_monitor_receiver.recv().unwrap() {
         HangMonitorAlert::Hang(HangAlert::Transient(component_id, _annotation)) => {
-            let expected = MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script);
+            let expected =
+                MonitoredComponentId(TEST_SCRIPT_EVENT_LOOP_ID, MonitoredComponentType::Script);
             assert_eq!(expected, component_id);
         },
         _ => unreachable!(),
@@ -153,7 +157,7 @@ fn test_hang_monitoring_unregister() {
     }
 
     let background_hang_monitor = background_hang_monitor_register.register_component(
-        MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script),
+        MonitoredComponentId(TEST_SCRIPT_EVENT_LOOP_ID, MonitoredComponentType::Script),
         Duration::from_millis(10),
         Duration::from_millis(1000),
         Box::new(BHMExitSignal),
@@ -253,7 +257,7 @@ fn test_hang_monitoring_exit_signal_inner(op_order: fn(&mut dyn FnMut(), &mut dy
         &mut || {
             // Register a component.
             background_hang_monitor = Some(background_hang_monitor_register.register_component(
-                MonitoredComponentId(TEST_PIPELINE_ID, MonitoredComponentType::Script),
+                MonitoredComponentId(TEST_SCRIPT_EVENT_LOOP_ID, MonitoredComponentType::Script),
                 Duration::from_millis(10),
                 Duration::from_millis(1000),
                 signal.take().unwrap(),

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -9,10 +9,10 @@
 use std::hash::Hash;
 use std::marker::PhantomData;
 use std::rc::Rc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use background_hang_monitor_api::{BackgroundHangMonitorControlMsg, HangMonitorAlert};
 use base::generic_channel::{GenericReceiver, GenericSender};
+use base::id::ScriptEventLoopId;
 use ipc_channel::Error;
 use ipc_channel::ipc::IpcSender;
 use script_traits::{InitialScriptState, NewPipelineInfo, ScriptThreadMessage};
@@ -20,13 +20,11 @@ use serde::{Deserialize, Serialize};
 use servo_config::opts::Opts;
 use servo_config::prefs::Preferences;
 
-static CURRENT_EVENT_LOOP_ID: AtomicUsize = AtomicUsize::new(0);
-
 /// <https://html.spec.whatwg.org/multipage/#event-loop>
 pub struct EventLoop {
     script_chan: GenericSender<ScriptThreadMessage>,
     dont_send_or_sync: PhantomData<Rc<()>>,
-    id: usize,
+    id: ScriptEventLoopId,
 }
 
 impl PartialEq for EventLoop {
@@ -52,12 +50,15 @@ impl Drop for EventLoop {
 impl EventLoop {
     /// Create a new event loop from the channel to its script thread.
     pub fn new(script_chan: GenericSender<ScriptThreadMessage>) -> Rc<EventLoop> {
-        let id = CURRENT_EVENT_LOOP_ID.fetch_add(1, Ordering::Relaxed);
         Rc::new(EventLoop {
             script_chan,
             dont_send_or_sync: PhantomData,
-            id,
+            id: ScriptEventLoopId::new(),
         })
+    }
+
+    pub(crate) fn id(&self) -> ScriptEventLoopId {
+        self.id
     }
 
     /// Send a message to the event loop.

--- a/components/constellation/pipeline.rs
+++ b/components/constellation/pipeline.rs
@@ -269,7 +269,9 @@ impl Pipeline {
                         script_to_devtools_ipc_sender
                     });
 
+                let event_loop = EventLoop::new(script_chan.clone());
                 let initial_script_state = InitialScriptState {
+                    id: event_loop.id(),
                     pipeline_to_constellation_sender: state.script_to_constellation_chan.clone(),
                     script_to_embedder_sender: state.script_to_embedder_chan,
                     namespace_request_sender: state.namespace_request_sender,
@@ -281,7 +283,7 @@ impl Pipeline {
                     storage_threads: state.storage_threads,
                     time_profiler_sender: state.time_profiler_chan,
                     memory_profiler_sender: state.mem_profiler_chan,
-                    constellation_to_script_sender: script_chan.clone(),
+                    constellation_to_script_sender: script_chan,
                     constellation_to_script_receiver: script_port,
                     pipeline_namespace_id: state.pipeline_namespace_id,
                     cross_process_compositor_api: state
@@ -339,7 +341,7 @@ impl Pipeline {
                     (None, None, Some(join_handle))
                 };
 
-                (EventLoop::new(script_chan), multiprocess_data)
+                (event_loop, multiprocess_data)
             },
         };
 

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -747,13 +747,13 @@ impl GlobalScope {
     /// workers that are not currently handling a message.
     pub(crate) fn webview_id(&self) -> Option<WebViewId> {
         if let Some(window) = self.downcast::<Window>() {
-            Some(window.webview_id())
-        } else if let Some(dedicated) = self.downcast::<DedicatedWorkerGlobalScope>() {
-            dedicated.webview_id()
-        } else {
-            // ServiceWorkerGlobalScope, PaintWorklet, or DissimilarOriginWindow
-            None
+            return Some(window.webview_id());
         }
+        // If this is a worker only DedicatedWorkerGlobalScope will have a WebViewId, the other are
+        // ServiceWorkerGlobalScope, PaintWorklet, or DissimilarOriginWindow.
+        // TODO: This should only return None for ServiceWorkerGlobalScope.
+        self.downcast::<DedicatedWorkerGlobalScope>()
+            .map(DedicatedWorkerGlobalScope::webview_id)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/components/script/dom/workers/worker.rs
+++ b/components/script/dom/workers/worker.rs
@@ -196,8 +196,9 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
             pipeline_id: global.pipeline_id(),
         };
 
-        let webview_id = global.webview_id().expect("global must have a webview id");
-
+        let webview_id = global
+            .webview_id()
+            .expect("Global object must have a WebViewId");
         let browsing_context = global
             .downcast::<Window>()
             .map(|w| w.window_proxy().browsing_context_id())
@@ -236,6 +237,7 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
             .expect("Tried to create a worker in a worker while not handling a message?");
         let join_handle = DedicatedWorkerGlobalScope::run_worker_scope(
             init,
+            webview_id,
             worker_url,
             devtools_receiver,
             worker_ref,

--- a/components/shared/background_hang_monitor/lib.rs
+++ b/components/shared/background_hang_monitor/lib.rs
@@ -9,7 +9,7 @@
 use std::time::Duration;
 use std::{fmt, mem};
 
-use base::id::PipelineId;
+use base::id::ScriptEventLoopId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
@@ -158,7 +158,7 @@ pub enum MonitoredComponentType {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct MonitoredComponentId(pub PipelineId, pub MonitoredComponentType);
+pub struct MonitoredComponentId(pub ScriptEventLoopId, pub MonitoredComponentType);
 
 /// A handle to register components for hang monitoring,
 /// and to receive a means to communicate with the underlying hang monitor worker.

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -10,7 +10,8 @@ use base::Epoch;
 use base::generic_channel::{GenericCallback, GenericReceiver, GenericSender, SendResult};
 use base::id::{
     BroadcastChannelRouterId, BrowsingContextId, HistoryStateId, MessagePortId,
-    MessagePortRouterId, PipelineId, ServiceWorkerId, ServiceWorkerRegistrationId, WebViewId,
+    MessagePortRouterId, PipelineId, ScriptEventLoopId, ServiceWorkerId,
+    ServiceWorkerRegistrationId, WebViewId,
 };
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
 use compositing_traits::CrossProcessCompositorApi;
@@ -670,7 +671,7 @@ pub enum ScriptToConstellationMessage {
     /// Update the pipeline Url, which can change after redirections.
     SetFinalUrl(ServoUrl),
     /// A log entry, with the top-level browsing context id and thread name
-    LogEntry(Option<String>, LogEntry),
+    LogEntry(Option<ScriptEventLoopId>, Option<String>, LogEntry),
     /// Discard the document.
     DiscardDocument,
     /// Discard the browsing context.

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -16,7 +16,7 @@ use std::fmt;
 use std::time::Duration;
 
 use base::cross_process_instant::CrossProcessInstant;
-use base::id::{MessagePortId, PipelineId, WebViewId};
+use base::id::{MessagePortId, PipelineId, ScriptEventLoopId, WebViewId};
 use compositing_traits::largest_contentful_paint_candidate::LargestContentfulPaintType;
 use embedder_traits::{
     CompositorHitTestResult, EmbedderControlId, EmbedderControlResponse, InputEventAndId,
@@ -66,7 +66,7 @@ pub enum EmbedderToConstellationMessage {
     /// Reload a top-level browsing context.
     Reload(WebViewId),
     /// A log entry, with the top-level browsing context id and thread name
-    LogEntry(Option<WebViewId>, Option<String>, LogEntry),
+    LogEntry(Option<ScriptEventLoopId>, Option<String>, LogEntry),
     /// Create a new top level browsing context.
     NewWebView(ServoUrl, WebViewId, ViewportDetails),
     /// Close a top level browsing context.

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -15,7 +15,7 @@ use base::cross_process_instant::CrossProcessInstant;
 use base::generic_channel::{GenericReceiver, GenericSender};
 use base::id::{
     BrowsingContextId, HistoryStateId, PipelineId, PipelineNamespaceId, PipelineNamespaceRequest,
-    WebViewId,
+    ScriptEventLoopId, WebViewId,
 };
 #[cfg(feature = "bluetooth")]
 use bluetooth_traits::BluetoothRequest;
@@ -333,6 +333,9 @@ pub struct ConstellationInputEvent {
 /// do! Use IPC senders and receivers instead.
 #[derive(Deserialize, Serialize)]
 pub struct InitialScriptState {
+    /// The id of the script event loop that this state will start. This is used to uniquely
+    /// identify an event loop.
+    pub id: ScriptEventLoopId,
     /// The sender to use to install the `Pipeline` namespace into this process (if necessary).
     pub namespace_request_sender: GenericSender<PipelineNamespaceRequest>,
     /// A channel with which messages can be sent to us (the script thread).


### PR DESCRIPTION
`ScriptThread`s start with an initial `Pipeline`, but that `Pipeline`
should not be used for any `ScriptThread` global data as a
`ScriptThread` can have any number of `Pipeline`s that come and go.
There's no architectural reason why a `ScriptThread` should be
associated with only a single `WebView`.

This change makes it so that the `ScriptThread` no longer uses the
`PipelineId` and the `WebViewId` of the initial `Pipeline` to initialize
itself. Instead a `ScriptEventLoopId` is used to uniquely identify every
`ScriptThread` in both the `ScriptThread` and the `Constellation`.
The remaining use was for crash reporting. Now when a crash happens, it
launches the sad tab in all `WebView`s that depeneded on that
`ScriptThread`.

This is a change which should allow simplifying the way that
`EventLoop`s/`ScriptThread`s are started in the `Constellation`, which
will be handled in a followup.

Testing: This shouldn't change behavior except in the case where a
`ScriptThread` is used in more than a single `WebView`, which should work
properly now. I tested this change manually by running servoshell in
multiprocess mode while causing a panic to happen due to a null pointer
dereference. The sad tab appeared after this change, so things seem to work
properly still. Testing crashes is tricky with the way we test servo now.
