### PR TITLE
script_bindings: Disallow manual Drop implementations for DOM interfaces.

### DIFF
--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -205,7 +205,6 @@
 #[macro_use]
 pub(crate) mod macros;
 
-#[expect(unused_imports)]
 pub(crate) mod types {
     include!(concat!(env!("OUT_DIR"), "/InterfaceTypes.rs"));
 }

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -103,7 +103,8 @@ DOMInterfaces = {
 },
 
 'CookieStore': {
-    'canGc': ['Set', 'Set_', 'Get', 'Get_', 'GetAll', 'GetAll_', 'Delete', 'Delete_']
+    'canGc': ['Set', 'Set_', 'Get', 'Get_', 'GetAll', 'GetAll_', 'Delete', 'Delete_'],
+    'allowDropImpl': True,
 },
 
 'CountQueuingStrategy': {
@@ -302,19 +303,42 @@ DOMInterfaces = {
 'GPUAdapter': {
     'inRealms': ['RequestDevice'],
     'canGc': ['RequestDevice'],
+    'allowDropImpl': True,
+},
+
+'GPUBindGroup': {
+    'allowDropImpl': True,
+},
+
+'GPUBindGroupLayout': {
+    'allowDropImpl': True,
 },
 
 'GPUBuffer': {
     'inRealms': ['MapAsync'],
     'canGc': ['GetMappedRange', 'MapAsync'],
+    'allowDropImpl': True,
 },
 
 'GPUCanvasContext': {
     'weakReferenceable': True,
+    'allowDropImpl': True,
+},
+
+'GPUCommandBuffer': {
+    'allowDropImpl': True,
 },
 
 'GPUCompilationInfo': {
     'canGc': ['Messages'],
+},
+
+'GPUComputePassEncoder': {
+    'allowDropImpl': True,
+},
+
+'GPUComputePipeline': {
+    'allowDropImpl': True,
 },
 
 'GPUDevice': {
@@ -330,11 +354,44 @@ DOMInterfaces = {
         'CreateShaderModule',
         'PopErrorScope'
     ],
+    'allowDropImpl': True,
     'weakReferenceable': True, # for usage in GlobalScope https://github.com/servo/servo/issues/32519
+},
+
+'GPUPipelineLayout': {
+    'allowDropImpl': True,
 },
 
 'GPUQueue': {
     'canGc': ['OnSubmittedWorkDone'],
+},
+
+'GPURenderBundle': {
+    'allowDropImpl': True,
+},
+
+'GPURenderPassEncoder': {
+    'allowDropImpl': True,
+},
+
+'GPURenderPipeline': {
+    'allowDropImpl': True,
+},
+
+'GPUSampler': {
+    'allowDropImpl': True,
+},
+
+'GPUShaderModule': {
+    'allowDropImpl': True,
+},
+
+'GPUTexture': {
+    'allowDropImpl': True,
+},
+
+'GPUTextureView': {
+    'allowDropImpl': True,
 },
 
 'History': {
@@ -579,7 +636,8 @@ DOMInterfaces = {
 
 'Promise': {
     'spiderMonkeyInterface': True,
-    'additionalTraits': ["js::conversions::FromJSValConvertibleRc"]
+    'additionalTraits': ["js::conversions::FromJSValConvertibleRc"],
+    'allowDropImpl': True,
 },
 
 'RadioNodeList': {
@@ -681,11 +739,44 @@ DOMInterfaces = {
 'WebGLRenderingContext': {
     'canGc': ['MakeXRCompatible'],
     'weakReferenceable': True,
+    'allowDropImpl': True,
 },
 
 'WebGL2RenderingContext': {
     'canGc': ['MakeXRCompatible'],
     'additionalTraits': ['crate::interfaces::WebGL2RenderingContextHelpers'],
+},
+
+'WebGLProgram': {
+    'allowDropImpl': True,
+},
+
+'WebGLQuery': {
+    'allowDropImpl': True,
+},
+
+'WebGLRenderbuffer': {
+    'allowDropImpl': True,
+},
+
+'WebGLSampler': {
+    'allowDropImpl': True,
+},
+
+'WebGLShader': {
+    'allowDropImpl': True,
+},
+
+'WebGLSync': {
+    'allowDropImpl': True,
+},
+
+'WebGLTexture': {
+    'allowDropImpl': True,
+},
+
+'WebGLTransformFeedback': {
+    'allowDropImpl': True,
 },
 
 'Window': {

--- a/components/script_bindings/codegen/configuration.py
+++ b/components/script_bindings/codegen/configuration.py
@@ -300,6 +300,7 @@ class Descriptor(DescriptorProvider):
         self.proxy = False
         self.weakReferenceable = desc.get('weakReferenceable', False)
         self.useSystemCompartment = desc.get('useSystemCompartment', False)
+        self.allowDropImpl = desc.get('allowDropImpl', False)
 
         # If we're concrete, we need to crawl our ancestor interfaces and mark
         # them as having a concrete descendant.


### PR DESCRIPTION
This implements the solution from #26488 that prevents implementing Drop manually for DOM interfaces, which is very easy to write in a way that can cause memory safety errors during JS runtime teardown. Since we have a bunch of pre-existing implementations that we are working on removing, this PR adds an opt-out mechanism that those interfaces use.

Testing: Compile-time code generation; not possible to test.
Fixes: part of #26488
