### PR TITLE
script: Stop assuming that previous dirty root is still connected

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -719,14 +719,14 @@ impl Document {
         };
 
         let dirty_root = match self.dirty_root.get() {
-            None => {
+            Some(root) if root.is_connected() => root,
+            _ => {
                 element
                     .upcast::<Node>()
                     .set_flag(NodeFlags::HAS_DIRTY_DESCENDANTS, true);
                 self.dirty_root.set(Some(element));
                 return;
             },
-            Some(root) => root,
         };
 
         for ancestor in element.upcast::<Node>().inclusive_ancestors_in_flat_tree() {

--- a/tests/wpt/meta/css/cssom/caretRangeFromPoint-replace-document.tentative.html.ini
+++ b/tests/wpt/meta/css/cssom/caretRangeFromPoint-replace-document.tentative.html.ini
@@ -1,2 +1,3 @@
 [caretRangeFromPoint-replace-document.tentative.html]
-  expected: CRASH
+  [document.caretRangeFromPoint(0, 0)]
+    expected: FAIL

--- a/tests/wpt/tests/dom/nodes/crashtests/document-replaceChild-input-documentElement.html
+++ b/tests/wpt/tests/dom/nodes/crashtests/document-replaceChild-input-documentElement.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<title>Node.replaceChild()</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-node-replacechild">
+<link rel="help" href="https://github.com/servo/servo/issues/40920">
+<script>
+document.replaceChild(document.createElement("input"), document.documentElement);
+</script>


### PR DESCRIPTION
We were trying to update the dirty root to be the common ancestor of the old dirty root and the element noted with dirty descendants. But that would panic if when the old dirty root had been disconnected.

In that case, just set the dirty root to be the element, as if the old dirty root was None.

Testing: Adding a crashtest, and one existing test now fails instead of crashing
Fixes: #40920
