### PR TITLE
servoshell: Add support for opening new windows on desktop

### DIFF
--- a/ports/servoshell/desktop/event_loop.rs
+++ b/ports/servoshell/desktop/event_loop.rs
@@ -131,7 +131,7 @@ impl HeadlessEventLoop {
 
         loop {
             self.sleep();
-            if !app.pump_servo_event_loop() {
+            if !app.pump_servo_event_loop(None) {
                 break;
             }
             *self.guard.lock().unwrap() = false;

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -10,9 +10,9 @@ use keyboard_types::{CompositionEvent, CompositionState, Key, KeyState, NamedKey
 use log::{info, warn};
 use raw_window_handle::{RawWindowHandle, WindowHandle};
 use servo::{
-    AlertResponse, DeviceIndependentIntRect, DeviceIndependentPixel, DeviceIntSize, DevicePixel,
-    DevicePoint, DeviceVector2D, EmbedderControl, EmbedderControlId, EventLoopWaker, ImeEvent,
-    InputEvent, KeyboardEvent, LoadStatus, MediaSessionActionType, MediaSessionEvent, MouseButton,
+    DeviceIndependentIntRect, DeviceIndependentPixel, DeviceIntSize, DevicePixel, DevicePoint,
+    DeviceVector2D, EmbedderControl, EmbedderControlId, EventLoopWaker, ImeEvent, InputEvent,
+    KeyboardEvent, LoadStatus, MediaSessionActionType, MediaSessionEvent, MouseButton,
     MouseButtonAction, MouseButtonEvent, MouseMoveEvent, Opts, Preferences, RefreshDriver,
     RenderingContext, ScreenGeometry, Scroll, Servo, ServoBuilder, SimpleDialog, TouchEvent,
     TouchEventType, TouchId, WebView, WebViewId, WindowRenderingContext, convert_rect_to_css_pixel,
@@ -297,7 +297,7 @@ impl App {
             current_can_go_forward: Default::default(),
             current_load_status: Default::default(),
         });
-        state.create_window(platform_window.clone(), initial_url);
+        state.open_window(platform_window.clone(), initial_url);
 
         Rc::new(Self {
             state,

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -85,7 +85,7 @@ pub(crate) struct ServoShellPreferences {
     /// remote WebDriver commands.
     pub webdriver_port: Cell<Option<u16>>,
     /// Whether the CLI option to enable experimental prefs was present at startup.
-    pub experimental_prefs_enabled: bool,
+    pub experimental_preferences_enabled: bool,
     /// Log filter given in the `log_filter` spec as a String, if any.
     /// If a filter is passed, the logger should adjust accordingly.
     #[cfg(target_env = "ohos")]
@@ -117,7 +117,7 @@ impl Default for ServoShellPreferences {
             log_filter: None,
             #[cfg(target_env = "ohos")]
             log_to_file: false,
-            experimental_prefs_enabled: false,
+            experimental_preferences_enabled: false,
         }
     }
 }
@@ -687,7 +687,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         output_image_path: cmd_args.output.map(|p| p.to_string_lossy().into_owned()),
         exit_after_stable_image: cmd_args.exit,
         userscripts_directory: cmd_args.userscripts,
-        experimental_prefs_enabled: cmd_args.enable_experimental_web_platform_features,
+        experimental_preferences_enabled: cmd_args.enable_experimental_web_platform_features,
         #[cfg(target_env = "ohos")]
         log_filter: cmd_args.log_filter.or_else(|| {
             (!preferences.log_filter.is_empty()).then(|| preferences.log_filter.clone())

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -14,7 +14,7 @@ use servo::{
 };
 use url::Url;
 
-use crate::running_app_state::{RunningAppState, WebViewCollection};
+use crate::running_app_state::{RunningAppState, UserInterfaceCommand, WebViewCollection};
 
 // This should vary by zoom level and maybe actual text size (focused or under cursor)
 #[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(dead_code))]
@@ -100,7 +100,7 @@ impl ServoShellWindow {
         self.platform_window()
             .rendering_context()
             .make_current()
-            .unwrap();
+            .expect("Could not make PlatformWindow RenderingContext current");
         webview.paint();
         self.platform_window().rendering_context().present();
     }
@@ -126,6 +126,7 @@ impl ServoShellWindow {
         self.needs_repaint.set(true)
     }
 
+    #[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(dead_code))]
     pub(crate) fn schedule_close(&self) {
         self.close_scheduled.set(true)
     }
@@ -281,6 +282,7 @@ pub(crate) trait PlatformWindow {
     /// Request that the `Window` rebuild its user interface, if it has one. This should
     /// not repaint, but should prepare the user interface for painting when it is
     /// actually requested.
+    #[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(dead_code))]
     fn rebuild_user_interface(&self, _: &RunningAppState, _: &ServoShellWindow) {}
     /// Inform the `Window` that the state of a `WebView` has changed and that it should
     /// do an incremental update of user interface state. Returns `true` if the user
@@ -307,12 +309,9 @@ pub(crate) trait PlatformWindow {
     /// TODO: This should be handled internally in the winit window if possible so that it
     /// makes more sense when we are mixing headed and headless windows.
     #[cfg(not(any(target_os = "android", target_env = "ohos")))]
-    fn handle_winit_app_event(
-        &self,
-        _: Rc<RunningAppState>,
-        _: &ServoShellWindow,
-        _: crate::desktop::event_loop::AppEvent,
-    ) {
+    fn handle_winit_app_event(&self, _: crate::desktop::event_loop::AppEvent) {}
+    fn take_user_interface_commands(&self) -> Vec<UserInterfaceCommand> {
+        Default::default()
     }
     /// Request that the window redraw itself. It is up to the window to do this
     /// once the windowing system is ready. If this is a headless window, the redraw


### PR DESCRIPTION
This change finishes adding support for opening new windows in the
desktop version of servoshell. A new button is added to the tab bar
which opens a new window (this can be adjusted later, if necessary).
User interface commands now need to be processed in the context of the
`App` as we need access to a reference to the `ActiveEventLoop` to
create a new window.

Testing: servoshell is mainly untested, though a future change will add new
unit tests for multi-window functionality.
Fixes: #13997.
