### PR TITLE
net: use system certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5675,6 +5675,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "servo_arc",
@@ -6367,6 +6368,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openxr"
@@ -7429,6 +7436,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7445,6 +7464,33 @@ checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -7495,6 +7541,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7791,6 +7846,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -10199,6 +10277,15 @@ dependencies = [
  "webrender_api",
  "wgpu-core",
  "wgpu-types",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3e3b5f5e80bc89f30ce8d0343bf4e5f12341c51f3e26cbeecbc7c85443e85b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ rustc-hash = "2.1.1"
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
 rustls-pemfile = "2.0"
 rustls-pki-types = "1.13"
+rustls-platform-verifier = "0.6.2"
 script_traits = { path = "components/shared/script" }
 sec1 = "0.7"
 selectors = { git = "https://github.com/servo/stylo", branch = "2025-11-01" }

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -250,6 +250,8 @@ pub struct Preferences {
     pub network_http_proxy_uri: String,
     pub network_local_directory_listing_enabled: bool,
     pub network_mime_sniff: bool,
+    /// Use the webpki roots if no root store path is given.
+    pub network_webpki_roots: bool,
     pub session_history_max_length: i64,
     /// The background color of shell's viewport. This will be used by OpenGL's `glClearColor`.
     pub shell_background_color_rgba: [f64; 4],
@@ -434,6 +436,7 @@ impl Preferences {
             network_http_proxy_uri: String::new(),
             network_local_directory_listing_enabled: true,
             network_mime_sniff: false,
+            network_webpki_roots: false,
             session_history_max_length: 20,
             shell_background_color_rgba: [1.0, 1.0, 1.0, 1.0],
             threadpools_async_runtime_workers_max: 6,

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -63,6 +63,7 @@ rustc-hash = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
 rustls-pki-types = { workspace = true }
+rustls-platform-verifier = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 servo_arc = { workspace = true }

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -21,6 +21,7 @@ use log::warn;
 use parking_lot::Mutex;
 use rustls::ClientConfig;
 use rustls::client::danger::ServerCertVerifier;
+use rustls::crypto::aws_lc_rs;
 use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
 use tokio::net::TcpStream;
 use tower::Service;
@@ -193,7 +194,7 @@ impl CertificateVerificationOverrideVerifier {
         override_manager: CertificateErrorOverrideManager,
     ) -> Self {
         let crypto_provider = rustls::crypto::CryptoProvider::get_default()
-            .expect("Could not get a crypto provider. ")
+            .unwrap_or(&Arc::new(aws_lc_rs::default_provider()))
             .clone();
         let main_verifier = match ca_certficates {
             #[cfg(not(target_os = "android"))]

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -91,7 +91,7 @@ pub struct FetchContext {
     pub timing: ServoArc<Mutex<ResourceFetchTiming>>,
     pub protocols: Arc<ProtocolRegistry>,
     pub websocket_chan: Option<Arc<Mutex<WebSocketChannel>>>,
-    pub ca_certificates: CACertificates,
+    pub ca_certificates: CACertificates<'static>,
     pub ignore_certificate_errors: bool,
 }
 

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -68,12 +68,8 @@ fn load_root_cert_store_from_file(file_path: String) -> io::Result<Vec<Certifica
 
     let certs = rustls_pemfile::certs(&mut pem)
         .filter_map(|cert| {
-            if let Err(e) = cert {
-                log::error!("Could not load certificate ({e}). Ignoring it.");
-                None
-            } else {
-                Some(cert.unwrap())
-            }
+            cert.inspect_err(|e| log::error!("Could not load certificate ({e}). Ignoring it."))
+                .ok()
         })
         .collect();
     Ok(certs)

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -40,7 +40,7 @@ use profile_traits::mem::{
 use profile_traits::path;
 use profile_traits::time::ProfilerChan;
 use rustc_hash::FxHashMap;
-use rustls::RootCertStore;
+use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
 use servo_arc::Arc as ServoArc;
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -63,13 +63,20 @@ use crate::request_interceptor::RequestInterceptor;
 use crate::websocket_loader::create_handshake_request;
 
 /// Load a file with CA certificate and produce a RootCertStore with the results.
-fn load_root_cert_store_from_file(file_path: String) -> io::Result<RootCertStore> {
-    let mut root_cert_store = RootCertStore::empty();
-
+fn load_root_cert_store_from_file(file_path: String) -> io::Result<Vec<CertificateDer<'static>>> {
     let mut pem = BufReader::new(File::open(file_path)?);
-    let certs: Result<Vec<_>, _> = rustls_pemfile::certs(&mut pem).collect();
-    root_cert_store.add_parsable_certificates(certs?);
-    Ok(root_cert_store)
+
+    let certs = rustls_pemfile::certs(&mut pem)
+        .filter_map(|cert| {
+            if let Err(e) = cert {
+                log::error!("Could not load certificate ({e}). Ignoring it.");
+                None
+            } else {
+                Some(cert.unwrap())
+            }
+        })
+        .collect();
+    Ok(certs)
 }
 
 /// Returns a tuple of (public, private) senders to the new threads.
@@ -123,7 +130,7 @@ pub fn new_core_resource_thread(
     mem_profiler_chan: MemProfilerChan,
     embedder_proxy: EmbedderProxy,
     config_dir: Option<PathBuf>,
-    ca_certificates: CACertificates,
+    ca_certificates: CACertificates<'static>,
     ignore_certificate_errors: bool,
     protocols: Arc<ProtocolRegistry>,
 ) -> (CoreResourceThread, CoreResourceThread) {
@@ -173,7 +180,7 @@ pub fn new_core_resource_thread(
 struct ResourceChannelManager {
     resource_manager: CoreResourceManager,
     config_dir: Option<PathBuf>,
-    ca_certificates: CACertificates,
+    ca_certificates: CACertificates<'static>,
     ignore_certificate_errors: bool,
     cancellation_listeners: FxHashMap<RequestId, Weak<CancellationListener>>,
     cookie_listeners: FxHashMap<CookieStoreId, IpcSender<CookieAsyncResponse>>,
@@ -181,7 +188,7 @@ struct ResourceChannelManager {
 
 fn create_http_states(
     config_dir: Option<&Path>,
-    ca_certificates: CACertificates,
+    ca_certificates: CACertificates<'static>,
     ignore_certificate_errors: bool,
     embedder_proxy: EmbedderProxy,
 ) -> (Arc<HttpState>, Arc<HttpState>) {
@@ -571,7 +578,7 @@ pub struct CoreResourceManager {
     filemanager: FileManager,
     request_interceptor: RequestInterceptor,
     thread_pool: Arc<ThreadPool>,
-    ca_certificates: CACertificates,
+    ca_certificates: CACertificates<'static>,
     ignore_certificate_errors: bool,
 }
 
@@ -580,7 +587,7 @@ impl CoreResourceManager {
         devtools_sender: Option<Sender<DevtoolsControlMsg>>,
         _profiler_chan: ProfilerChan,
         embedder_proxy: EmbedderProxy,
-        ca_certificates: CACertificates,
+        ca_certificates: CACertificates<'static>,
         ignore_certificate_errors: bool,
     ) -> CoreResourceManager {
         let num_threads = thread::available_parallelism()

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -768,7 +768,7 @@ fn test_fetch_with_hsts() {
         ))),
         protocols: Arc::new(ProtocolRegistry::default()),
         websocket_chan: None,
-        ca_certificates: CACertificates::Default,
+        ca_certificates: CACertificates::PlatformVerifier,
         ignore_certificate_errors: false,
     };
 
@@ -832,7 +832,7 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
         ))),
         protocols: Arc::new(ProtocolRegistry::default()),
         websocket_chan: None,
-        ca_certificates: CACertificates::Default,
+        ca_certificates: CACertificates::PlatformVerifier,
         ignore_certificate_errors: false,
     };
 
@@ -901,7 +901,7 @@ fn test_fetch_self_signed() {
         ))),
         protocols: Arc::new(ProtocolRegistry::default()),
         websocket_chan: None,
-        ca_certificates: CACertificates::Default,
+        ca_certificates: CACertificates::PlatformVerifier,
         ignore_certificate_errors: false,
     };
 
@@ -1552,7 +1552,7 @@ fn test_fetch_request_intercepted() {
         ))),
         protocols: Arc::new(ProtocolRegistry::default()),
         websocket_chan: None,
-        ca_certificates: CACertificates::Default,
+        ca_certificates: CACertificates::PlatformVerifier,
         ignore_certificate_errors: false,
     };
 

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -107,7 +107,7 @@ fn create_http_state(fc: Option<EmbedderProxy>) -> HttpState {
         http_cache: RwLock::new(net::http_cache::HttpCache::default()),
         http_cache_state: Mutex::new(HashMap::new()),
         client: create_http_client(create_tls_config(
-            net::connector::CACertificates::Default,
+            net::connector::CACertificates::PlatformVerifier,
             false, /* ignore_certificate_errors */
             override_manager.clone(),
         )),
@@ -139,7 +139,7 @@ fn new_fetch_context(
         ))),
         protocols: Arc::new(ProtocolRegistry::with_internal_protocols()),
         websocket_chan: None,
-        ca_certificates: CACertificates::Default,
+        ca_certificates: CACertificates::PlatformVerifier,
         ignore_certificate_errors: false,
     }
 }

--- a/components/net/tests/resource_thread.rs
+++ b/components/net/tests/resource_thread.rs
@@ -30,7 +30,7 @@ fn test_exit() {
         MemProfilerChan(mtx),
         create_embedder_proxy(),
         None,
-        CACertificates::Default,
+        CACertificates::PlatformVerifier,
         false, /* ignore_certificate_errors */
         std::sync::Arc::new(ProtocolRegistry::default()),
     );


### PR DESCRIPTION
This changes the certificate verifier to use rustls_platform_verifier under the hood.

**Note**: The rustls-platform-verifier has specific instructions for android and currently we fall back to the webpki roots for this platform.

Testing: This was tested on linux, macos and ohos and the rest in the CI.
Fixes: Should fix https://github.com/servo/servo/issues/32903 and partially https://github.com/servo/servo/issues/35227
