### PR TITLE
script: Bring creating and running classic scripts closer to spec

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3782,17 +3782,22 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
 }
 
 /// <https://html.spec.whatwg.org/multipage/#classic-script>
+#[derive(JSTraceable, MallocSizeOf)]
 pub struct ClassicScript {
     /// On script parsing success this will be <https://html.spec.whatwg.org/multipage/#concept-script-record>
     /// On failure <https://html.spec.whatwg.org/multipage/#concept-script-error-to-rethrow>
+    #[no_trace]
+    #[ignore_malloc_size_of = "mozjs"]
     pub record: Result<NonNull<JSScript>, RethrowError>,
     /// <https://html.spec.whatwg.org/multipage/#concept-script-script-fetch-options>
     fetch_options: ScriptFetchOptions,
     /// <https://html.spec.whatwg.org/multipage/#concept-script-base-url>
+    #[no_trace]
     url: ServoUrl,
     /// <https://html.spec.whatwg.org/multipage/#muted-errors>
     muted_errors: bool,
     /// used for unminify_js
+    #[conditional_malloc_size_of]
     source: Rc<DOMString>,
     unminified_dir: Option<String>,
     external: bool,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3785,7 +3785,7 @@ impl GlobalScopeHelpers<crate::DomTypeHolder> for GlobalScope {
 pub struct ClassicScript {
     /// On script parsing success this will be <https://html.spec.whatwg.org/multipage/#concept-script-record>
     /// On failure <https://html.spec.whatwg.org/multipage/#concept-script-error-to-rethrow>
-    record: Result<NonNull<JSScript>, RethrowError>,
+    pub record: Result<NonNull<JSScript>, RethrowError>,
     /// <https://html.spec.whatwg.org/multipage/#concept-script-script-fetch-options>
     fetch_options: ScriptFetchOptions,
     /// <https://html.spec.whatwg.org/multipage/#concept-script-base-url>

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3480,6 +3480,7 @@ impl GlobalScope {
 
     /// <https://html.spec.whatwg.org/multipage/#creating-a-classic-script>
     #[expect(unsafe_code)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn create_a_classic_script(
         &self,
         source: Cow<'_, str>,

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -1064,12 +1064,13 @@ impl HTMLScriptElement {
                     (*script.text().str()).into(),
                     script.url,
                     script.fetch_options,
+                    false,
                     Some(introduction_type),
                     line_number,
                     script.external,
                 );
                 // Step 6."classic".3. Run the classic script given by el's result.
-                _ = global.run_a_classic_script(script, can_gc);
+                _ = global.run_a_classic_script(script, false, can_gc);
 
                 // Step 6."classic".4. Set document's currentScript attribute to oldCurrentScript.
                 document.set_current_script(old_script.as_deref());

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -21,7 +21,6 @@ use net_traits::request::{
     RequestBuilder, RequestId,
 };
 use net_traits::{FetchMetadata, Metadata, NetworkError, ResourceFetchTiming};
-use script_bindings::domstring::BytesView;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use style::attr::AttrValue;
 use style::str::{HTML_SPACE_CHARACTERS, StaticStringVec};
@@ -68,34 +67,6 @@ use crate::script_module::{
     fetch_inline_module_script, parse_an_import_map_string, register_import_map,
 };
 use crate::script_runtime::{CanGc, IntroductionType};
-use crate::unminify::ScriptSource;
-
-impl ScriptSource for ScriptOrigin {
-    fn unminified_dir(&self) -> Option<String> {
-        self.unminified_dir.clone()
-    }
-
-    fn extract_bytes(&self) -> BytesView<'_> {
-        match &self.code {
-            SourceCode::Text(text) => text.as_bytes(),
-            SourceCode::Compiled(compiled_source_code) => {
-                compiled_source_code.original_text.as_bytes()
-            },
-        }
-    }
-
-    fn rewrite_source(&mut self, source: Rc<DOMString>) {
-        self.code = SourceCode::Text(source);
-    }
-
-    fn url(&self) -> ServoUrl {
-        self.url.clone()
-    }
-
-    fn is_external(&self) -> bool {
-        self.external
-    }
-}
 
 /// An unique id for script element.
 #[derive(Clone, Copy, Debug, Eq, Hash, JSTraceable, PartialEq)]
@@ -327,6 +298,7 @@ pub(crate) type ScriptResult = Result<Script, NoTrace<NetworkError>>;
 
 // TODO merge classic and module scripts
 #[derive(JSTraceable, MallocSizeOf)]
+#[expect(clippy::large_enum_variant)]
 pub(crate) enum Script {
     Classic(ClassicScript),
     Other(ScriptOrigin),

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -382,7 +382,7 @@ impl ServiceWorkerGlobalScope {
                         worker_scope.clear_js_runtime();
                         return;
                     },
-                    Ok((metadata, bytes)) => (metadata.final_url, bytes),
+                    Ok((metadata, bytes, _)) => (metadata.final_url, bytes),
                 };
 
                 unsafe {

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -48,7 +48,7 @@ use crate::dom::event::Event;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::extendableevent::ExtendableEvent;
 use crate::dom::extendablemessageevent::ExtendableMessageEvent;
-use crate::dom::globalscope::GlobalScope;
+use crate::dom::globalscope::{ErrorReporting, GlobalScope, RethrowErrors};
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::worker::TrustedWorkerAddress;
@@ -406,12 +406,12 @@ impl ServiceWorkerGlobalScope {
                         String::from_utf8_lossy(&source),
                         url,
                         ScriptFetchOptions::default_classic_script(global_scope),
-                        false,
+                        ErrorReporting::Unmuted,
                         Some(IntroductionType::WORKER),
                         1,
                         true,
                     );
-                    _ = global_scope.run_a_classic_script(script, false, CanGc::note());
+                    _ = global_scope.run_a_classic_script(script, RethrowErrors::No, CanGc::note());
                     global.dispatch_activate(CanGc::note(), InRealm::entered(&realm));
                 }
 

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::borrow::Cow;
 use std::cell::{RefCell, RefMut};
 use std::default::Default;
 use std::rc::Rc;
@@ -989,21 +988,6 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
 }
 
 impl WorkerGlobalScope {
-    pub(crate) fn execute_script(&self, source: Cow<'_, str>, can_gc: CanGc) {
-        let global = self.upcast::<GlobalScope>();
-        let script = global.create_a_classic_script(
-            source,
-            self.worker_url.borrow().clone(),
-            ScriptFetchOptions::default_classic_script(global),
-            false,
-            Some(IntroductionType::WORKER),
-            1,
-            true,
-        );
-
-        _ = global.run_a_classic_script(script, false, can_gc);
-    }
-
     pub(crate) fn new_script_pair(&self) -> (ScriptEventLoopSender, ScriptEventLoopReceiver) {
         let dedicated = self.downcast::<DedicatedWorkerGlobalScope>();
         if let Some(dedicated) = dedicated {

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -980,12 +980,13 @@ impl WorkerGlobalScope {
             source,
             self.worker_url.borrow().clone(),
             ScriptFetchOptions::default_classic_script(global),
+            false,
             Some(IntroductionType::WORKER),
             1,
             true,
         );
 
-        _ = global.run_a_classic_script(script, can_gc);
+        _ = global.run_a_classic_script(script, false, can_gc);
     }
 
     pub(crate) fn new_script_pair(&self) -> (ScriptEventLoopSender, ScriptEventLoopReceiver) {

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -697,7 +697,7 @@ impl WorkletThread {
             can_gc,
         )
         .ok()
-        .and_then(|(_, bytes)| String::from_utf8(bytes).ok());
+        .and_then(|(_, bytes, _)| String::from_utf8(bytes).ok());
 
         // Step 4.
         // NOTE: the spec parses and executes the script in separate steps,

--- a/components/script/script_module.rs
+++ b/components/script/script_module.rs
@@ -64,7 +64,7 @@ use crate::dom::dynamicmoduleowner::{DynamicModuleId, DynamicModuleOwner};
 use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::html::htmlscriptelement::{
-    HTMLScriptElement, SCRIPT_JS_MIMES, ScriptId, ScriptOrigin, ScriptType,
+    HTMLScriptElement, SCRIPT_JS_MIMES, Script, ScriptId, ScriptOrigin, ScriptType,
 };
 use crate::dom::node::NodeTraits;
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
@@ -1073,21 +1073,25 @@ impl ModuleOwner {
                     match network_error.as_ref() {
                         Some(network_error) => Err(network_error.clone().into()),
                         None => match module_identity {
-                            ModuleIdentity::ModuleUrl(script_src) => Ok(ScriptOrigin::external(
-                                Rc::clone(&module_tree.get_text().borrow()),
-                                script_src.clone(),
-                                fetch_options,
-                                ScriptType::Module,
-                                global.unminified_js_dir(),
-                            )),
-                            ModuleIdentity::ScriptId(_) => Ok(ScriptOrigin::internal(
-                                Rc::clone(&module_tree.get_text().borrow()),
-                                document.base_url().clone(),
-                                fetch_options,
-                                ScriptType::Module,
-                                global.unminified_js_dir(),
-                                Err(Error::NotFound(None)),
-                            )),
+                            ModuleIdentity::ModuleUrl(script_src) => {
+                                Ok(Script::Other(ScriptOrigin::external(
+                                    Rc::clone(&module_tree.get_text().borrow()),
+                                    script_src.clone(),
+                                    fetch_options,
+                                    ScriptType::Module,
+                                    global.unminified_js_dir(),
+                                )))
+                            },
+                            ModuleIdentity::ScriptId(_) => {
+                                Ok(Script::Other(ScriptOrigin::internal(
+                                    Rc::clone(&module_tree.get_text().borrow()),
+                                    document.base_url().clone(),
+                                    fetch_options,
+                                    ScriptType::Module,
+                                    global.unminified_js_dir(),
+                                    Err(Error::NotFound(None)),
+                                )))
+                            },
                         },
                     }
                 };

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -792,7 +792,7 @@ impl JsTimerTask {
 
                 // Step 9.6.6. Let base URL be settings object's API base URL.
                 let base_url = global.api_base_url();
-                
+
                 // TODO Step 9.6.7. If initiating script is not null, then:
                 // Step 9.6.7.1. Set fetch options to a script fetch options whose cryptographic nonce
                 // is initiating script's fetch options's cryptographic nonce,
@@ -801,7 +801,7 @@ impl JsTimerTask {
                 // referrer policy is initiating script's fetch options's referrer policy,
                 // and fetch priority is "auto".
                 // Step 9.6.7.2. Set base URL to initiating script's base URL.
-                
+
                 // Step 9.6.8. Let script be the result of creating a classic script given handler,
                 // settings object, base URL, and fetch options.
                 let script = global.create_a_classic_script(

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -32,7 +32,7 @@ use crate::dom::bindings::str::DOMString;
 use crate::dom::csp::CspReporting;
 use crate::dom::document::RefreshRedirectDue;
 use crate::dom::eventsource::EventSourceTimeoutCallback;
-use crate::dom::globalscope::GlobalScope;
+use crate::dom::globalscope::{ErrorReporting, GlobalScope, RethrowErrors};
 #[cfg(feature = "testbinding")]
 use crate::dom::testbinding::TestBindingCallback;
 use crate::dom::trustedscript::TrustedScript;
@@ -808,16 +808,14 @@ impl JsTimerTask {
                     (*code_str.str()).into(),
                     base_url,
                     fetch_options,
-                    false,
+                    ErrorReporting::Unmuted,
                     Some(IntroductionType::DOM_TIMER),
                     1,
                     false,
                 );
 
                 // Step 9.6.9. Run the classic script script.
-                //
-                // FIXME(cybai): Use base url properly by saving private reference for timers (#27260)
-                _ = global.run_a_classic_script(script, false, can_gc);
+                _ = global.run_a_classic_script(script, RethrowErrors::No, can_gc);
             },
             // Step 9.5. If handler is a Function, then invoke handler given arguments and
             // "report", and with callback this value set to thisArg.

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -335,6 +335,18 @@ impl FetchMetadata {
             Self::Filtered { unsafe_, .. } => unsafe_,
         }
     }
+
+    /// <https://html.spec.whatwg.org/multipage/#cors-cross-origin>
+    pub fn is_cors_cross_origin(&self) -> bool {
+        if let Self::Filtered { filtered, .. } = self {
+            match filtered {
+                FilteredMetadata::Basic(_) | FilteredMetadata::Cors(_) => false,
+                FilteredMetadata::Opaque | FilteredMetadata::OpaqueRedirect(_) => true,
+            }
+        } else {
+            false
+        }
+    }
 }
 
 impl FetchTaskTarget for IpcSender<FetchResponseMsg> {

--- a/tests/wpt/meta/html/browsers/sandboxing/window-open-blank-from-different-initiator.html.ini
+++ b/tests/wpt/meta/html/browsers/sandboxing/window-open-blank-from-different-initiator.html.ini
@@ -5,4 +5,3 @@
 
   [One pending navigation]
     expected: TIMEOUT
-

--- a/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/alpha/base-url-worker-importScripts.html.ini
+++ b/tests/wpt/meta/html/semantics/scripting-1/the-script-element/module/dynamic-import/alpha/base-url-worker-importScripts.html.ini
@@ -1,7 +1,3 @@
 [base-url-worker-importScripts.html]
-  [Relative URL-like from same-origin importScripts()]
-    expected: FAIL
-
   [Relative URL-like from cross-origin importScripts()]
     expected: FAIL
-

--- a/tests/wpt/meta/html/webappapis/scripting/processing-model-2/compile-error-in-setInterval.html.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/processing-model-2/compile-error-in-setInterval.html.ini
@@ -1,3 +1,0 @@
-[compile-error-in-setInterval.html]
-  [window.onerror - compile error in setInterval]
-    expected: FAIL

--- a/tests/wpt/meta/html/webappapis/scripting/processing-model-2/compile-error-in-setTimeout.html.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/processing-model-2/compile-error-in-setTimeout.html.ini
@@ -1,3 +1,0 @@
-[compile-error-in-setTimeout.html]
-  [window.onerror - compile error in setTimeout]
-    expected: FAIL

--- a/tests/wpt/meta/html/webappapis/scripting/processing-model-2/runtime-error-in-setInterval.html.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/processing-model-2/runtime-error-in-setInterval.html.ini
@@ -1,3 +1,0 @@
-[runtime-error-in-setInterval.html]
-  [window.onerror - runtime error in setInterval]
-    expected: FAIL

--- a/tests/wpt/meta/html/webappapis/scripting/processing-model-2/runtime-error-in-setTimeout.html.ini
+++ b/tests/wpt/meta/html/webappapis/scripting/processing-model-2/runtime-error-in-setTimeout.html.ini
@@ -1,3 +1,0 @@
-[runtime-error-in-setTimeout.html]
-  [window.onerror - runtime error in setTimeout]
-    expected: FAIL

--- a/tests/wpt/meta/notifications/permissions-non-secure.html.ini
+++ b/tests/wpt/meta/notifications/permissions-non-secure.html.ini
@@ -1,4 +1,4 @@
 [permissions-non-secure.html]
-  expected: ERROR
+  expected: TIMEOUT
   [Notification.permission must be called from a secure worker]
     expected: TIMEOUT

--- a/tests/wpt/meta/wasm/webapi/esm-integration/worker-import-source-phase.tentative.html.ini
+++ b/tests/wpt/meta/wasm/webapi/esm-integration/worker-import-source-phase.tentative.html.ini
@@ -1,3 +1,4 @@
 [worker-import-source-phase.tentative.html]
+  expected: TIMEOUT
   [Testing import of WebAssembly source phase from JavaScript worker]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/wasm/webapi/esm-integration/worker-import.tentative.html.ini
+++ b/tests/wpt/meta/wasm/webapi/esm-integration/worker-import.tentative.html.ini
@@ -1,3 +1,4 @@
 [worker-import.tentative.html]
+  expected: TIMEOUT
   [Testing import of WebAssembly from JavaScript worker]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/workers/dedicated-worker-parse-error-failure.html.ini
+++ b/tests/wpt/meta/workers/dedicated-worker-parse-error-failure.html.ini
@@ -1,7 +1,0 @@
-[dedicated-worker-parse-error-failure.html]
-  [Static import on classic worker should dispatch an event named error.]
-    expected: FAIL
-
-  [Classic worker construction for script with syntax error should dispatch an event named error.]
-    expected: FAIL
-

--- a/tests/wpt/meta/workers/interfaces/WorkerUtils/importScripts/catch.sub.any.js.ini
+++ b/tests/wpt/meta/workers/interfaces/WorkerUtils/importScripts/catch.sub.any.js.ini
@@ -1,16 +1,4 @@
 [catch.sub.any.worker.html]
-  [Redirect-to-Cross-origin throw]
-    expected: FAIL
-
-  [Cross-origin syntax error]
-    expected: FAIL
-
-  [Cross-origin throw]
-    expected: FAIL
-
-  [Redirect-to-cross-origin syntax error]
-    expected: FAIL
-
 
 [catch.sub.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/workers/interfaces/WorkerUtils/importScripts/report-error-cross-origin.sub.any.js.ini
+++ b/tests/wpt/meta/workers/interfaces/WorkerUtils/importScripts/report-error-cross-origin.sub.any.js.ini
@@ -5,9 +5,5 @@
   [WorkerGlobalScope error event: lineno]
     expected: FAIL
 
-  [WorkerGlobalScope error event: error]
-    expected: FAIL
-
   [WorkerGlobalScope error event: filename]
     expected: FAIL
-

--- a/tests/wpt/meta/workers/interfaces/WorkerUtils/importScripts/report-error-redirect-to-cross-origin.sub.any.js.ini
+++ b/tests/wpt/meta/workers/interfaces/WorkerUtils/importScripts/report-error-redirect-to-cross-origin.sub.any.js.ini
@@ -5,9 +5,5 @@
   [WorkerGlobalScope error event: lineno]
     expected: FAIL
 
-  [WorkerGlobalScope error event: error]
-    expected: FAIL
-
   [WorkerGlobalScope error event: filename]
     expected: FAIL
-

--- a/tests/wpt/meta/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-cross-origin.sub.any.js.ini
+++ b/tests/wpt/meta/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-cross-origin.sub.any.js.ini
@@ -2,9 +2,6 @@
   [WorkerGlobalScope error event: lineno]
     expected: FAIL
 
-  [WorkerGlobalScope error event: error]
-    expected: FAIL
-
   [WorkerGlobalScope error event: filename]
     expected: FAIL
 

--- a/tests/wpt/meta/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-redirect-to-cross-origin.sub.any.js.ini
+++ b/tests/wpt/meta/workers/interfaces/WorkerUtils/importScripts/report-error-setTimeout-redirect-to-cross-origin.sub.any.js.ini
@@ -2,9 +2,6 @@
   [WorkerGlobalScope error event: lineno]
     expected: FAIL
 
-  [WorkerGlobalScope error event: error]
-    expected: FAIL
-
   [WorkerGlobalScope error event: filename]
     expected: FAIL
 


### PR DESCRIPTION
Use the algorithms introduced in #41109 in more places.
Follow more closely the spec when executing classic scripts, introducing the concepts of rethrowing and muting errors.
Muting errors is not actually implemented, and will be done in a followup.

Testing: More tests start passing 
Fixes #34199
Fixes #27260
Fixes #15188
