### PR TITLE
indexeddb: move database open and upgrade transaction to in parallel.

### DIFF
--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -121,6 +121,7 @@ use crate::dom::eventsource::EventSource;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::file::File;
 use crate::dom::html::htmlscriptelement::ScriptId;
+use crate::dom::idbfactory::IDBFactory;
 use crate::dom::messageport::MessagePort;
 use crate::dom::paintworkletglobalscope::PaintWorkletGlobalScope;
 use crate::dom::performance::performance::Performance;
@@ -2999,6 +3000,17 @@ impl GlobalScope {
 
         // TODO: plug worklets into this.
         true
+    }
+
+    /// Returns the idb factory for this global.
+    /// TODO: move the idb to the global itself.
+    pub(crate) fn get_indexeddb(&self) -> DomRoot<IDBFactory> {
+        if let Some(window) = self.downcast::<Window>() {
+            return window.IndexedDB();
+        } else if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
+            return worker.IndexedDB();
+        }
+        unreachable!("IndexedDB not available in this scope");
     }
 
     /// Perform a microtask checkpoint.

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3010,7 +3010,7 @@ impl GlobalScope {
         } else if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
             return worker.IndexedDB();
         }
-        unreachable!("IndexedDB not available in this scope");
+        unreachable!("IndexedDB is only exposed on Window and WorkerGlobalScope.");
     }
 
     /// Perform a microtask checkpoint.

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -5,36 +5,56 @@ use dom_struct::dom_struct;
 use js::rust::HandleValue;
 use servo_url::origin::ImmutableOrigin;
 
+use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::IDBFactoryBinding::IDBFactoryMethods;
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::import::base::SafeJSContext;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
-use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::root::{Dom, DomRoot};
 use crate::dom::bindings::str::DOMString;
+use crate::dom::bindings::trace::HashMapTracedValues;
 use crate::dom::globalscope::GlobalScope;
+use crate::dom::indexeddb::idbdatabase::IDBDatabase;
 use crate::dom::indexeddb::idbopendbrequest::IDBOpenDBRequest;
 use crate::indexeddb::convert_value_to_key;
 use crate::script_runtime::CanGc;
 
+/// A non-jstraceable string wrapper for use in `HashMapTracedValues`.
+#[derive(Clone, Eq, Hash, MallocSizeOf, PartialEq)]
+pub(crate) struct DBName(pub(crate) String);
+
 #[dom_struct]
 pub struct IDBFactory {
     reflector_: Reflector,
+    /// <https://www.w3.org/TR/IndexedDB-2/#connection>
+    connections: DomRefCell<HashMapTracedValues<DBName, Dom<IDBDatabase>>>,
 }
 
 impl IDBFactory {
     pub fn new_inherited() -> IDBFactory {
         IDBFactory {
             reflector_: Reflector::new(),
+            connections: Default::default(),
         }
     }
 
     pub fn new(global: &GlobalScope, can_gc: CanGc) -> DomRoot<IDBFactory> {
         reflect_dom_object(Box::new(IDBFactory::new_inherited()), global, can_gc)
     }
+
+    pub(crate) fn note_connection(&self, name: DBName, connection: &IDBDatabase) {
+        self.connections
+            .borrow_mut()
+            .insert(name, Dom::from_ref(connection));
+    }
+
+    pub(crate) fn get_connection(&self, name: &DBName) -> Option<DomRoot<IDBDatabase>> {
+        self.connections.borrow().get(name).map(|db| db.as_rooted())
+    }
 }
 
 impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbfactory-open>
+    /// <https://w3c.github.io/IndexedDB/#dom-idbfactory-open>
     fn Open(&self, name: DOMString, version: Option<u64>) -> Fallible<DomRoot<IDBOpenDBRequest>> {
         // Step 1: If version is 0 (zero), throw a TypeError.
         if version == Some(0) {
@@ -45,11 +65,15 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
 
         // Step 2: Let origin be the origin of the global scope used to
         // access this IDBFactory.
+        // TODO: update to 3.0 spec.
+        // Let environment be this’s relevant settings object.
         let global = self.global();
         let origin = global.origin();
 
         // Step 3: if origin is an opaque origin,
         // throw a "SecurityError" DOMException and abort these steps.
+        // TODO: update to 3.0 spec.
+        // Let storageKey be the result of running obtain a storage key given environment.
         if let ImmutableOrigin::Opaque(_) = origin.immutable() {
             return Err(Error::Security(None));
         }
@@ -62,7 +86,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
             return Err(Error::Operation(None));
         }
 
-        // Step 6
+        // Step 6: Return a new IDBOpenDBRequest object for request.
         Ok(request)
     }
 

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -217,7 +217,9 @@ impl IDBOpenDBRequest {
             Some(version),
             CanGc::note(),
         );
-        let _did_throw = event.upcast::<Event>().fire(self.upcast(), CanGc::note());
+
+        // TODO: use as part of step 10.6.2
+        let _did_throw = event.upcast::<Event>().fire(self.upcast(), can_gc);
 
         // Step 10.6: If transaction’s state is active, then:
         if transaction.is_active() {

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -70,6 +70,7 @@ impl OpenRequestListener {
             },
             OpenDatabaseResult::Upgrade {
                 version,
+                old_version,
                 transaction,
             } => {
                 // TODO: link with backend connection concept.
@@ -83,7 +84,7 @@ impl OpenRequestListener {
                     idb_factory.note_connection(name.clone(), &connection);
                     connection
                 });
-                request.upgrade_db_version(&connection, version, transaction, can_gc);
+                request.upgrade_db_version(&connection, old_version, version, transaction, can_gc);
                 return;
             },
         };
@@ -168,6 +169,7 @@ impl IDBOpenDBRequest {
     fn upgrade_db_version(
         &self,
         connection: &IDBDatabase,
+        old_version: u64,
         version: u64,
         transaction: u64,
         can_gc: CanGc,
@@ -206,7 +208,6 @@ impl IDBOpenDBRequest {
         // Step 10.5: Let didThrow be the result of
         // firing a version change event named upgradeneeded
         // at request with old version and version.
-        let old_version = connection.version();
         let event = IDBVersionChangeEvent::new(
             &global,
             Atom::from("upgradeneeded"),

--- a/components/script/dom/indexeddb/idbtransaction.rs
+++ b/components/script/dom/indexeddb/idbtransaction.rs
@@ -130,6 +130,7 @@ impl IDBTransaction {
     }
 
     // Runs the transaction and waits for it to finish
+    // TODO: run in-parallel.
     pub fn wait(&self) {
         // Start the transaction
         let (sender, receiver) = channel(self.global().time_profiler_chan().clone()).unwrap();

--- a/components/shared/storage/indexeddb.rs
+++ b/components/shared/storage/indexeddb.rs
@@ -316,6 +316,27 @@ pub enum CreateObjectResult {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+/// Result of <https://w3c.github.io/IndexedDB/#open-a-database-connection>
+/// `Upgrade` is an optional first message,
+/// followed by the ultimate result.
+/// TODO: refactor messaging into a coherent whole
+/// and with a persistent communication mechanism.
+pub enum OpenDatabaseResult {
+    VersionError,
+    AbortError,
+    /// A connection with a version, updgraded or not.
+    Connection {
+        version: u64,
+        upgraded: bool,
+    },
+    /// An upgrade transaction for a version started.
+    Upgrade {
+        version: u64,
+        transaction: u64,
+    },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub enum SyncOperation {
     /// Upgrades the version of the database
     UpgradeVersion(
@@ -394,7 +415,7 @@ pub enum SyncOperation {
     ),
 
     OpenDatabase(
-        GenericCallback<u64>, // Returns the version
+        GenericCallback<OpenDatabaseResult>, // Returns the result
         ImmutableOrigin,
         String,      // Database
         Option<u64>, // Eventual version
@@ -447,6 +468,10 @@ pub enum IndexedDBThreadMsg {
         IndexedDBTxnMode,
         AsyncOperation,
     ),
+    OpenTransactionInactive {
+        name: String,
+        transaction: u64,
+    },
 }
 
 #[cfg(test)]

--- a/components/shared/storage/indexeddb.rs
+++ b/components/shared/storage/indexeddb.rs
@@ -332,6 +332,7 @@ pub enum OpenDatabaseResult {
     /// An upgrade transaction for a version started.
     Upgrade {
         version: u64,
+        old_version: u64,
         transaction: u64,
     },
 }

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -75,17 +75,21 @@ impl SqliteEngine {
         base_dir: &Path,
         db_info: &IndexedDBDescription,
         pool: Arc<ThreadPool>,
-    ) -> Result<Self, Error> {
+    ) -> Result<(Self, bool), Error> {
         let mut db_path = PathBuf::new();
         db_path.push(base_dir);
         db_path.push(db_info.as_path());
         let db_parent = db_path.clone();
         db_path.push("db.sqlite");
 
-        if !db_path.exists() {
+        let created_db_path = if !db_path.exists() {
             std::fs::create_dir_all(db_parent).unwrap();
             std::fs::File::create(&db_path).unwrap();
-        }
+            true
+        } else {
+            false
+        };
+
         let connection = Self::init_db(&db_path, db_info)?;
 
         for stmt in DB_PRAGMAS {
@@ -93,12 +97,15 @@ impl SqliteEngine {
             let _ = connection.execute(stmt, ());
         }
 
-        Ok(Self {
-            connection,
-            db_path,
-            read_pool: pool.clone(),
-            write_pool: pool,
-        })
+        Ok((
+            Self {
+                connection,
+                db_path,
+                read_pool: pool.clone(),
+                write_pool: pool,
+            },
+            created_db_path,
+        ))
     }
 
     fn init_db(path: &Path, db_info: &IndexedDBDescription) -> Result<Connection, Error> {

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -67,6 +67,7 @@ pub struct SqliteEngine {
     connection: Connection,
     read_pool: Arc<ThreadPool>,
     write_pool: Arc<ThreadPool>,
+    created_db_path: bool,
 }
 
 impl SqliteEngine {
@@ -75,7 +76,7 @@ impl SqliteEngine {
         base_dir: &Path,
         db_info: &IndexedDBDescription,
         pool: Arc<ThreadPool>,
-    ) -> Result<(Self, bool), Error> {
+    ) -> Result<Self, Error> {
         let mut db_path = PathBuf::new();
         db_path.push(base_dir);
         db_path.push(db_info.as_path());
@@ -97,15 +98,18 @@ impl SqliteEngine {
             let _ = connection.execute(stmt, ());
         }
 
-        Ok((
-            Self {
-                connection,
-                db_path,
-                read_pool: pool.clone(),
-                write_pool: pool,
-            },
+        Ok(Self {
+            connection,
+            db_path,
+            read_pool: pool.clone(),
+            write_pool: pool,
             created_db_path,
-        ))
+        })
+    }
+
+    /// Returns whether the physical db was created as part of `new`.
+    pub(crate) fn created_db_path(&self) -> bool {
+        self.created_db_path
     }
 
     fn init_db(path: &Path, db_info: &IndexedDBDescription) -> Result<Connection, Error> {

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -354,7 +354,7 @@ impl IndexedDBManager {
         // TODO: implement transactions and their lifecyle.
 
         // Step 7: Let old version be db’s version.
-        // Note: done in script.
+        let old_version = db.version().expect("DB should have a version.");
 
         // Step 8: Set db’s version to version.
         // This change is considered part of the transaction,
@@ -370,6 +370,7 @@ impl IndexedDBManager {
         if sender
             .send(OpenDatabaseResult::Upgrade {
                 version: new_version,
+                old_version,
                 transaction: transaction_id,
             })
             .is_err()

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -609,7 +609,10 @@ impl IndexedDBManager {
                     let _ = sender.send(Err(BackendError::DbNotFound));
                 }
             },
-            SyncOperation::RegisterNewTxn(sender, origin, db_name) => {
+            SyncOperation::RegisterNewTxn(sender, _origin, _db_name) => {
+                // Note: ignoring origin and name for now, 
+                // but those could be used again when implementing 
+                // lifecycle.
                 let transaction_id = self.serial_number_counter;
                 self.serial_number_counter += 1;
                 let _ = sender.send(transaction_id);

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -420,9 +420,10 @@ impl IndexedDBManager {
                 // If this fails for any reason, return an appropriate error
                 // (e.g. a "QuotaExceededError" or "UnknownError" DOMException).
                 // TODO: return error.
-                let (engine, created_db_path) =
+                let engine =
                     SqliteEngine::new(idb_base_dir, &idb_description, self.thread_pool.clone())
                         .expect("Failed to create sqlite engine");
+                let created_db_path = engine.created_db_path();
                 let db = IndexedDBEnvironment::new(engine);
                 let db_version = db.version().expect("DB should have a version.");
 

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -424,15 +424,16 @@ impl IndexedDBManager {
                     SqliteEngine::new(idb_base_dir, &idb_description, self.thread_pool.clone())
                         .expect("Failed to create sqlite engine");
                 let db = IndexedDBEnvironment::new(engine);
+                let db_version = db.version().expect("DB should have a version.");
 
                 let version = if created_db_path {
                     version.unwrap_or(1)
                 } else {
-                    version.unwrap_or_else(|| db.version().expect("DB should have a version."))
+                    version.unwrap_or(db_version)
                 };
 
                 e.insert(db);
-                (0, version)
+                (db_version, version)
             },
             Entry::Occupied(db) => {
                 let db_version = db.get().version().expect("Db should have a version.");

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -610,8 +610,8 @@ impl IndexedDBManager {
                 }
             },
             SyncOperation::RegisterNewTxn(sender, _origin, _db_name) => {
-                // Note: ignoring origin and name for now, 
-                // but those could be used again when implementing 
+                // Note: ignoring origin and name for now,
+                // but those could be used again when implementing
                 // lifecycle.
                 let transaction_id = self.serial_number_counter;
                 self.serial_number_counter += 1;

--- a/tests/wpt/meta/IndexedDB/delete-request-queue.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/delete-request-queue.any.js.ini
@@ -1,9 +1,14 @@
 [delete-request-queue.any.html]
+  [Deletes are processed as a FIFO queue]
+    expected: FAIL
+
 
 [delete-request-queue.any.serviceworker.html]
   expected: ERROR
 
-[delete-request-queue.any.worker.html]
-
 [delete-request-queue.any.sharedworker.html]
   expected: ERROR
+
+[delete-request-queue.any.worker.html]
+  [Deletes are processed as a FIFO queue]
+    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbdatabase-createObjectStore-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbdatabase-createObjectStore-exception-order.any.js.ini
@@ -2,9 +2,6 @@
   [IDBDatabase.createObjectStore exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
-  [IDBDatabase.createObjectStore exception order: TransactionInactiveError vs. SyntaxError]
-    expected: FAIL
-
 
 [idbdatabase-createObjectStore-exception-order.any.sharedworker.html]
   expected: ERROR
@@ -14,7 +11,4 @@
 
 [idbdatabase-createObjectStore-exception-order.any.html]
   [IDBDatabase.createObjectStore exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBDatabase.createObjectStore exception order: TransactionInactiveError vs. SyntaxError]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbdatabase-deleteObjectStore-exception-order.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbdatabase-deleteObjectStore-exception-order.any.js.ini
@@ -2,18 +2,12 @@
   [IDBDatabase.deleteObjectStore exception order: InvalidStateError vs. TransactionInactiveError]
     expected: FAIL
 
-  [IDBDatabase.deleteObjectStore exception order: TransactionInactiveError vs. NotFoundError]
-    expected: FAIL
-
 
 [idbdatabase-deleteObjectStore-exception-order.any.sharedworker.html]
   expected: ERROR
 
 [idbdatabase-deleteObjectStore-exception-order.any.worker.html]
   [IDBDatabase.deleteObjectStore exception order: InvalidStateError vs. TransactionInactiveError]
-    expected: FAIL
-
-  [IDBDatabase.deleteObjectStore exception order: TransactionInactiveError vs. NotFoundError]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
@@ -1,5 +1,4 @@
 [idbfactory_open.any.worker.html]
-  expected: TIMEOUT
   [IDBFactory.open() - error in version change transaction aborts open]
     expected: FAIL
 
@@ -16,12 +15,6 @@
     expected: FAIL
 
   [Calling open() with version argument 1.5 should not throw.]
-    expected: TIMEOUT
-
-  [IDBFactory.open() - no version opens current database]
-    expected: FAIL
-
-  [IDBFactory.open() - upgradeneeded gets VersionChangeEvent]
     expected: FAIL
 
 
@@ -32,7 +25,6 @@
   expected: ERROR
 
 [idbfactory_open.any.html]
-  expected: TIMEOUT
   [IDBFactory.open() - error in version change transaction aborts open]
     expected: FAIL
 
@@ -48,11 +40,5 @@
   [Calling open() with version argument 9007199254740991 should not throw.]
     expected: FAIL
 
-  [IDBFactory.open() - no version opens current database]
-    expected: FAIL
-
   [Calling open() with version argument 1.5 should not throw.]
-    expected: TIMEOUT
-
-  [IDBFactory.open() - upgradeneeded gets VersionChangeEvent]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
@@ -1,4 +1,5 @@
 [idbfactory_open.any.worker.html]
+  expected: TIMEOUT
   [IDBFactory.open() - error in version change transaction aborts open]
     expected: FAIL
 
@@ -15,6 +16,12 @@
     expected: FAIL
 
   [Calling open() with version argument 1.5 should not throw.]
+    expected: TIMEOUT
+
+  [IDBFactory.open() - no version opens current database]
+    expected: FAIL
+
+  [IDBFactory.open() - upgradeneeded gets VersionChangeEvent]
     expected: FAIL
 
 

--- a/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory_open.any.js.ini
@@ -25,6 +25,7 @@
   expected: ERROR
 
 [idbfactory_open.any.html]
+  expected: TIMEOUT
   [IDBFactory.open() - error in version change transaction aborts open]
     expected: FAIL
 
@@ -38,4 +39,13 @@
     expected: FAIL
 
   [Calling open() with version argument 9007199254740991 should not throw.]
+    expected: FAIL
+
+  [IDBFactory.open() - no version opens current database]
+    expected: FAIL
+
+  [Calling open() with version argument 1.5 should not throw.]
+    expected: TIMEOUT
+
+  [IDBFactory.open() - upgradeneeded gets VersionChangeEvent]
     expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_delete.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_delete.any.js.ini
@@ -7,9 +7,6 @@
   expected: ERROR
 
 [idbobjectstore_delete.any.html]
-  [delete() key doesn't match any records]
-    expected: FAIL
-
 
 [idbobjectstore_delete.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_get.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_get.any.js.ini
@@ -5,9 +5,6 @@
   [When an invalid key is used, throw DataError]
     expected: FAIL
 
-  [Attempts to retrieve a record that doesn't exist]
-    expected: FAIL
-
 
 [idbobjectstore_get.any.serviceworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idbobjectstore_get.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbobjectstore_get.any.js.ini
@@ -12,6 +12,3 @@
 [idbobjectstore_get.any.worker.html]
   [When an invalid key is used, throw DataError]
     expected: FAIL
-
-  [Attempts to retrieve a record that doesn't exist]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbtransaction-oncomplete.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbtransaction-oncomplete.any.js.ini
@@ -1,8 +1,3 @@
-[idbtransaction-oncomplete.any.html]
-  [IDBTransaction - complete event]
-    expected: FAIL
-
-
 [idbtransaction-oncomplete.any.sharedworker.html]
   expected: ERROR
 
@@ -10,5 +5,3 @@
   expected: ERROR
 
 [idbtransaction-oncomplete.any.worker.html]
-  [IDBTransaction - complete event]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/open-request-queue.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/open-request-queue.any.js.ini
@@ -1,5 +1,8 @@
 [open-request-queue.any.worker.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [IndexedDB: open and delete requests are processed as a FIFO queue]
+    expected: TIMEOUT
+
 
 [open-request-queue.any.serviceworker.html]
   expected: ERROR
@@ -8,4 +11,6 @@
   expected: ERROR
 
 [open-request-queue.any.html]
-  expected: CRASH
+  expected: TIMEOUT
+  [IndexedDB: open and delete requests are processed as a FIFO queue]
+    expected: TIMEOUT

--- a/tests/wpt/meta/IndexedDB/worker-termination-aborts-upgrade.window.js.ini
+++ b/tests/wpt/meta/IndexedDB/worker-termination-aborts-upgrade.window.js.ini
@@ -1,0 +1,3 @@
+[worker-termination-aborts-upgrade.window.html]
+  [Worker Termination Aborts a Pending Upgrade]
+    expected: FAIL


### PR DESCRIPTION
The spec concept of [opening a database](https://www.w3.org/TR/IndexedDB-2/#open-a-database), and the conditional [upgrade of a database](https://w3c.github.io/IndexedDB/#upgrade-a-database), should be run in-parallel, meaning on the backend indexeddb thread, and not on the script-thread. 

This implements the move, but retains a blocking wait on the upgrade transaction finish. It is the first step towards a larger refactoring(see https://github.com/servo/servo/issues/40983), which will see concepts like transaction lifecyle and connection queues be implemented on the indexeddb thread, and which will make any waiting non-blocking as well. 

Other smaller changes to support the above are: 
- returning whether a physical db was created when instantiating the db engine.
- using a global counter to produce transaction ids.

Testing: New failures on WPT tests: to be fixed as part of several follow-ups.
Fixes: The parts of https://github.com/servo/servo/issues/38942#issuecomment-3270223903 that were not addressed when the issue was closed.
