### PR TITLE
script: Fire the video `resize` event in the expected order

### DIFF
--- a/tests/wpt/tests/html/semantics/embedded-content/media-elements/event_order_durationchange_resize_loadedmetadata.html
+++ b/tests/wpt/tests/html/semantics/embedded-content/media-elements/event_order_durationchange_resize_loadedmetadata.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+ <head>
+  <title>{audio,video} events - durationchange, resize (only video), then loadedmetadata</title>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script src="/common/media.js"></script>
+ </head>
+ <body>
+  <p><a href="https://html.spec.whatwg.org/multipage/#mediaevents">spec reference</a></p>
+  <audio id="a" autoplay controls>
+  </audio>
+  <video id="v" autoplay controls>
+  </video>
+  <div id="log"></div>
+  <script>
+test(function() {
+  var t = async_test("setting src attribute on autoplay audio should trigger durationchange then loadedmetadata event");
+  var a = document.getElementById("a");
+  var found_durationchange = false;
+  a.addEventListener("error", t.unreached_func());
+  a.addEventListener("durationchange", t.step_func(function() {
+    found_durationchange = true;
+  }));
+  a.addEventListener("loadedmetadata", t.step_func(function() {
+    assert_true(found_durationchange);
+    t.done();
+    a.pause();
+  }), false);
+  a.src = getAudioURI("/media/sound_5") + "?" + new Date() + Math.random();
+}, "audio events - durationchange, then loadedmetadata");
+
+test(function() {
+  var t = async_test("setting src attribute on autoplay video should trigger durationchange, resize then loadedmetadata event");
+  var v = document.getElementById("v");
+  var found_durationchange = false;
+  var found_resize = false;
+  v.addEventListener("error", t.unreached_func());
+  v.addEventListener("durationchange", t.step_func(function() {
+    found_durationchange = true;
+  }));
+  v.addEventListener("resize", t.step_func(function() {
+    found_resize = true;
+  }));
+  v.addEventListener("loadedmetadata", t.step_func(function() {
+    assert_true(found_durationchange);
+    assert_true(found_resize);
+    t.done();
+    v.pause();
+  }), false);
+  v.src = getVideoURI("/media/movie_5") + "?" + new Date() + Math.random();
+}, "video events - durationchange, resize then loadeddata");
+ </script>
+ </body>
+</html>


### PR DESCRIPTION
Queuing a media element task given the media element to fire an event named `resize` at the media element shoud be done:
- upon the initial `metadata` event from the media engine
https://html.spec.whatwg.org/multipage/#loading-the-media-resource:event-media-resize
- whenever the video dimensions are changed (readyState is not `HAVE_NOTHING`)
https://html.spec.whatwg.org/multipage/#the-video-element:event-media-resize

See https://html.spec.whatwg.org/multipage/#event-media-resize

Testing: Added new test to confirm `resize` event ordering
- html/semantics/embedded-content/media-elements/event_order_durationchange_resize_loadedmetadata.html