### PR TITLE
net: Allow servo to use a http proxy without authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4120,6 +4120,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4127,7 +4128,9 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.1",
  "tokio",
@@ -4752,6 +4755,12 @@ dependencies = [
  "uuid",
  "windows 0.61.3",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-terminal"
@@ -5680,7 +5689,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tokio-util",
- "tower-service",
+ "tower",
  "tungstenite",
  "url",
  "uuid",
@@ -5720,6 +5729,7 @@ dependencies = [
  "servo_arc",
  "servo_malloc_size_of",
  "servo_url",
+ "tower",
  "url",
  "uuid",
  "webrender_api",
@@ -8836,6 +8846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9320,6 +9336,26 @@ name = "topological-sort"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa7c7f42dea4b1b99439786f5633aeb9c14c1b53f75e282803c2ec2ad545873c"
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ http = "1.4"
 http-body-util = "0.1"
 hyper = "1.8"
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "logging", "tls12", "webpki-tokio"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "http2", "tokio"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "http2", "tokio", "client-proxy"] }
 hyper_serde = { path = "components/hyper_serde" }
 icu_locid = "1.5.0"
 icu_segmenter = "1.5.0"
@@ -174,7 +174,7 @@ tikv-jemallocator = "0.6.1"
 time = { package = "time", version = "0.3", features = ["large-dates", "local-offset", "serde"] }
 tokio = "1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging"] }
-tower-service = "0.3"
+tower = { version = "0.5", default-features = false, features = ["util"] }
 tracing = "0.1.43"
 tracing-perfetto = "0.1.5"
 tracing-subscriber = "0.3.20"

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -245,6 +245,9 @@ pub struct Preferences {
     pub network_enforce_tls_localhost: bool,
     pub network_enforce_tls_onion: bool,
     pub network_http_cache_disabled: bool,
+    pub network_http_proxy_enable: bool,
+    /// A url for a http proxy
+    pub network_http_proxy_uri: String,
     pub network_local_directory_listing_enabled: bool,
     pub network_mime_sniff: bool,
     pub session_history_max_length: i64,
@@ -427,6 +430,8 @@ impl Preferences {
             network_enforce_tls_localhost: false,
             network_enforce_tls_onion: false,
             network_http_cache_disabled: false,
+            network_http_proxy_enable: false,
+            network_http_proxy_uri: String::new(),
             network_local_directory_listing_enabled: true,
             network_mime_sniff: false,
             session_history_max_length: 20,

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -245,8 +245,7 @@ pub struct Preferences {
     pub network_enforce_tls_localhost: bool,
     pub network_enforce_tls_onion: bool,
     pub network_http_cache_disabled: bool,
-    pub network_http_proxy_enable: bool,
-    /// A url for a http proxy
+    /// A url for a http proxy. We treat an empty string as no proxy.
     pub network_http_proxy_uri: String,
     pub network_local_directory_listing_enabled: bool,
     pub network_mime_sniff: bool,
@@ -430,7 +429,6 @@ impl Preferences {
             network_enforce_tls_localhost: false,
             network_enforce_tls_onion: false,
             network_http_cache_disabled: false,
-            network_http_proxy_enable: false,
             network_http_proxy_uri: String::new(),
             network_local_directory_listing_enabled: true,
             network_mime_sniff: false,

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -74,7 +74,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 tokio-rustls = { workspace = true }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7.12", default-features = false, features = ["codec", "io"] }
-tower-service = { workspace = true }
+tower = { workspace = true }
 tungstenite = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -6,8 +6,8 @@ use std::collections::hash_map::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-use futures::Future;
 use futures::task::{Context, Poll};
+use futures::{Future, TryFutureExt};
 use http::uri::{Authority, Uri as Destination};
 use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
@@ -15,12 +15,15 @@ use hyper::rt::Executor;
 use hyper_rustls::HttpsConnector as HyperRustlsHttpsConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::client::legacy::connect::HttpConnector as HyperHttpConnector;
+use hyper_util::client::legacy::connect::proxy::Tunnel;
+use hyper_util::rt::TokioIo;
 use log::warn;
 use parking_lot::Mutex;
 use rustls::client::WebPkiServerVerifier;
 use rustls::{ClientConfig, RootCertStore};
 use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
-use tower_service::Service;
+use tokio::net::TcpStream;
+use tower::Service;
 
 use crate::async_runtime::spawn_task;
 use crate::hosts::replace_host;
@@ -42,9 +45,10 @@ impl ServoHttpConnector {
 }
 
 impl Service<Destination> for ServoHttpConnector {
-    type Response = <HyperHttpConnector as Service<Destination>>::Response;
-    type Error = <HyperHttpConnector as Service<Destination>>::Error;
-    type Future = <HyperHttpConnector as Service<Destination>>::Future;
+    type Response = TokioIo<TcpStream>;
+    type Error = ConnectionError;
+    type Future =
+        std::pin::Pin<Box<dyn Future<Output = Result<TokioIo<TcpStream>, ConnectionError>> + Send>>;
 
     fn call(&mut self, dest: Destination) -> Self::Future {
         // Perform host replacement when making the actual TCP connection.
@@ -69,7 +73,11 @@ impl Service<Destination> for ServoHttpConnector {
             }
         }
 
-        self.inner.call(new_dest)
+        Box::pin(
+            self.inner
+                .call(new_dest)
+                .map_err(|e| ConnectionError::HttpError(format!("{e}"))),
+        )
     }
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -267,13 +275,76 @@ impl rustls::client::danger::ServerCertVerifier for CertificateVerificationOverr
 
 pub type BoxedBody = BoxBody<Bytes, hyper::Error>;
 
-pub fn create_http_client(tls_config: TlsConfig) -> Client<Connector, BoxedBody> {
+fn create_maybe_proxy_connector() -> MaybeProxyConnector {
+    if servo_config::pref!(network_http_proxy_enable) {
+        if let Ok(http_proxy_uri) = servo_config::pref!(network_http_proxy_uri).parse() {
+            log::info!("Using proxy specified via {:?}", http_proxy_uri);
+            return MaybeProxyConnector::Right(TunnelErrorMasker(Tunnel::new(
+                http_proxy_uri,
+                ServoHttpConnector::new(),
+            )));
+        }
+    }
+
+    MaybeProxyConnector::Left(ServoHttpConnector::new())
+}
+
+/// Either a proxy tunnel or the ServoHttpConnector
+pub type MaybeProxyConnector = tower::util::Either<ServoHttpConnector, TunnelErrorMasker>;
+
+#[derive(Debug)]
+#[allow(unused)]
+/// The error type for the MaybeProxyConnector
+pub enum ConnectionError {
+    HttpError(String),
+    // It looks like currently the type is not exported.
+    ProxyError(String),
+}
+
+impl std::fmt::Display for ConnectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl std::error::Error for ConnectionError {}
+
+#[derive(Clone)]
+/// This is just used to give us control over the error types 'Tunnel<>' returns.
+pub struct TunnelErrorMasker(Tunnel<ServoHttpConnector>);
+
+// Just forward everything to the inner type except that we modify the errors returned.
+impl Service<Destination> for TunnelErrorMasker {
+    type Response = TokioIo<TcpStream>;
+    type Error = ConnectionError;
+    type Future =
+        std::pin::Pin<Box<dyn Future<Output = Result<TokioIo<TcpStream>, ConnectionError>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.0
+            .poll_ready(cx)
+            .map_err(|e| ConnectionError::ProxyError(format!("{e}")))
+    }
+
+    fn call(&mut self, req: Destination) -> Self::Future {
+        Box::pin(
+            self.0
+                .call(req)
+                .map_err(|e| ConnectionError::ProxyError(format!("{e}"))),
+        )
+    }
+}
+
+pub type ServoClient = Client<hyper_rustls::HttpsConnector<MaybeProxyConnector>, BoxedBody>;
+
+pub fn create_http_client(tls_config: TlsConfig) -> ServoClient {
+    let maybe_proxy_connector = create_maybe_proxy_connector();
     let connector = hyper_rustls::HttpsConnectorBuilder::new()
         .with_tls_config(tls_config)
         .https_or_http()
         .enable_http1()
         .enable_http2()
-        .wrap_connector(ServoHttpConnector::new());
+        .wrap_connector(maybe_proxy_connector);
 
     Client::builder(TokioExecutor {})
         .http1_title_case_headers(true)

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -276,8 +276,9 @@ impl rustls::client::danger::ServerCertVerifier for CertificateVerificationOverr
 pub type BoxedBody = BoxBody<Bytes, hyper::Error>;
 
 fn create_maybe_proxy_connector() -> MaybeProxyConnector {
-    if servo_config::pref!(network_http_proxy_enable) {
-        if let Ok(http_proxy_uri) = servo_config::pref!(network_http_proxy_uri).parse() {
+    let network_http_proxy_uri = servo_config::pref!(network_http_proxy_uri);
+    if !network_http_proxy_uri.is_empty() {
+        if let Ok(http_proxy_uri) = network_http_proxy_uri.parse() {
             log::info!("Using proxy specified via {:?}", http_proxy_uri);
             return MaybeProxyConnector::Right(TunnelErrorMasker(Tunnel::new(
                 http_proxy_uri,
@@ -293,7 +294,6 @@ fn create_maybe_proxy_connector() -> MaybeProxyConnector {
 pub type MaybeProxyConnector = tower::util::Either<ServoHttpConnector, TunnelErrorMasker>;
 
 #[derive(Debug)]
-#[allow(unused)]
 /// The error type for the MaybeProxyConnector
 pub enum ConnectionError {
     HttpError(String),

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -37,7 +37,6 @@ use hyper::body::{Bytes, Frame};
 use hyper::ext::ReasonPhrase;
 use hyper::header::{HeaderName, TRANSFER_ENCODING};
 use hyper_serde::Serde;
-use hyper_util::client::legacy::Client;
 use ipc_channel::ipc::{self, IpcSender, IpcSharedMemory};
 use ipc_channel::router::ROUTER;
 use log::{debug, error, info, log_enabled, warn};
@@ -72,7 +71,7 @@ use tokio::sync::mpsc::{
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::async_runtime::spawn_task;
-use crate::connector::{CertificateErrorOverrideManager, Connector, create_tls_config};
+use crate::connector::{CertificateErrorOverrideManager, ServoClient, create_tls_config};
 use crate::cookie::ServoCookie;
 use crate::cookie_storage::CookieStorage;
 use crate::decoder::Decoder;
@@ -108,7 +107,7 @@ pub struct HttpState {
     pub http_cache_state: HttpCacheState,
     pub auth_cache: RwLock<AuthCache>,
     pub history_states: RwLock<FxHashMap<HistoryStateId, Vec<u8>>>,
-    pub client: Client<Connector, crate::connector::BoxedBody>,
+    pub client: ServoClient,
     pub override_manager: CertificateErrorOverrideManager,
     pub embedder_proxy: Mutex<EmbedderProxy>,
 }
@@ -620,7 +619,7 @@ impl BodySink {
 
 #[allow(clippy::too_many_arguments)]
 async fn obtain_response(
-    client: &Client<Connector, crate::connector::BoxedBody>,
+    client: &ServoClient,
     url: &ServoUrl,
     method: &Method,
     request_headers: &mut HeaderMap,

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -42,6 +42,7 @@ rustls-pki-types = { workspace = true }
 serde = { workspace = true }
 servo_arc = { workspace = true }
 servo_url = { path = "../../url" }
+tower = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 webrender_api = { workspace = true }


### PR DESCRIPTION
Servo can now use a http proxy to connect to the internet. This currently only supports using all connections through the proxy.

This uses the already used hyper_util crate which had the functionality in it already.
We also switch from tower_service to tower with only util feature flag. This might increase the binary size slightly.

Testing: Tested on a local machine which is behind a proxy with and without the flag and it works correctly.
