### PR TITLE
constellation: Break the `EventLoop` dependency on the initial `Pipeline`

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -423,7 +423,6 @@ impl Drop for ScriptMemoryFailsafe<'_> {
 impl ScriptThreadFactory for ScriptThread {
     fn create(
         state: InitialScriptState,
-        new_pipeline_info: NewPipelineInfo,
         layout_factory: Arc<dyn LayoutFactory>,
         image_cache_factory: Arc<dyn ImageCacheFactory>,
         background_hang_monitor_register: Box<dyn BackgroundHangMonitorRegister>,
@@ -453,9 +452,6 @@ impl ScriptThreadFactory for ScriptThread {
                 });
 
                 let mut failsafe = ScriptMemoryFailsafe::new(&script_thread);
-
-                // TODO: Eventually this should happen as a separate message to this new `ScriptThread`.
-                script_thread.spawn_pipeline(new_pipeline_info);
 
                 memory_profiler_sender.run_with_memory_reporting(
                     || script_thread.start(CanGc::note()),
@@ -892,7 +888,7 @@ impl ScriptThread {
             #[cfg(feature = "bluetooth")]
             bluetooth_sender: state.bluetooth_sender,
             constellation_sender: state.constellation_to_script_sender,
-            pipeline_to_constellation_sender: state.pipeline_to_constellation_sender.sender.clone(),
+            pipeline_to_constellation_sender: state.script_to_constellation_sender,
             pipeline_to_embedder_sender: state.script_to_embedder_sender.clone(),
             image_cache_sender,
             time_profiler_sender: state.time_profiler_sender,

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -32,7 +32,7 @@ use constellation::{
     Constellation, FromEmbedderLogger, FromScriptLogger, InitialConstellationState,
     NewScriptEventLoopProcessInfo, UnprivilegedContent,
 };
-use constellation_traits::{EmbedderToConstellationMessage, ScriptToConstellationChan};
+use constellation_traits::{EmbedderToConstellationMessage, ScriptToConstellationSender};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use embedder_traits::user_content_manager::UserContentManager;
 pub use embedder_traits::*;
@@ -976,8 +976,8 @@ where
     }
 }
 
-fn set_logger(script_to_constellation_chan: ScriptToConstellationChan) {
-    let con_logger = FromScriptLogger::new(script_to_constellation_chan);
+fn set_logger(script_to_constellation_sender: ScriptToConstellationSender) {
+    let con_logger = FromScriptLogger::new(script_to_constellation_sender);
     let env = env_logger::Env::default();
     let env_logger = EnvLoggerBuilder::from_env(env).build();
 
@@ -1019,7 +1019,7 @@ pub fn run_content_process(token: String) {
             set_logger(
                 new_event_loop_info
                     .initial_script_state
-                    .pipeline_to_constellation_sender
+                    .script_to_constellation_sender
                     .clone(),
             );
 
@@ -1035,7 +1035,6 @@ pub fn run_content_process(token: String) {
             let layout_factory = Arc::new(LayoutFactoryImpl());
             let script_join_handle = script::ScriptThread::create(
                 new_event_loop_info.initial_script_state,
-                new_event_loop_info.new_pipeline_info,
                 layout_factory,
                 Arc::new(ImageCacheFactoryImpl::new(
                     new_event_loop_info.broken_image_icon_data,

--- a/components/shared/background_hang_monitor/lib.rs
+++ b/components/shared/background_hang_monitor/lib.rs
@@ -204,7 +204,7 @@ pub trait BackgroundHangMonitorExitSignal: Send {
 }
 
 /// Messages to control the sampling profiler.
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum BackgroundHangMonitorControlMsg {
     /// Toggle the sampler, with a given sampling rate and max total sampling duration.
     ToggleSampler(Duration, Duration),

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -45,11 +45,14 @@ use crate::{
     LogEntry, MessagePortMsg, PortMessageTask, PortTransferInfo, TraversalDirection, WindowSizeType,
 };
 
+pub type ScriptToConstellationSender =
+    GenericSender<(WebViewId, PipelineId, ScriptToConstellationMessage)>;
+
 /// A Script to Constellation channel.
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct ScriptToConstellationChan {
     /// Sender for communicating with constellation thread.
-    pub sender: GenericSender<(WebViewId, PipelineId, ScriptToConstellationMessage)>,
+    pub sender: ScriptToConstellationSender,
     /// Used to identify the origin `WebView` of the message.
     pub webview_id: WebViewId,
     /// Used to identify the origin `Pipeline` of the message.

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -39,7 +39,7 @@ use pixels::RasterImage;
 use profile_traits::mem::Report;
 use profile_traits::time;
 use rustc_hash::FxHashMap;
-use script_traits::{InitialScriptState, NewPipelineInfo, Painter, ScriptThreadMessage};
+use script_traits::{InitialScriptState, Painter, ScriptThreadMessage};
 use serde::{Deserialize, Serialize};
 use servo_arc::Arc as ServoArc;
 use servo_url::{ImmutableOrigin, ServoUrl};
@@ -367,7 +367,6 @@ pub trait ScriptThreadFactory {
     /// Create a `ScriptThread`.
     fn create(
         state: InitialScriptState,
-        new_pipeline_info: NewPipelineInfo,
         layout_factory: Arc<dyn LayoutFactory>,
         image_cache_factory: Arc<dyn ImageCacheFactory>,
         background_hang_monitor_register: Box<dyn BackgroundHangMonitorRegister>,

--- a/components/shared/net/pub_domains.rs
+++ b/components/shared/net/pub_domains.rs
@@ -145,7 +145,7 @@ pub fn is_reg_domain(domain: &str) -> bool {
 /// Returns None if the URL has no host name.
 /// Returns the registered suffix for the host name if it is a domain.
 /// Leaves the host name alone if it is an IP address.
-pub fn reg_host(url: &ServoUrl) -> Option<Host> {
+pub fn registered_domain_name(url: &ServoUrl) -> Option<Host> {
     match url.origin() {
         ImmutableOrigin::Tuple(_, Host::Domain(domain), _) => {
             Some(Host::Domain(String::from(reg_suffix(&domain))))

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -23,7 +23,7 @@ use canvas_traits::webgl::WebGLPipeline;
 use compositing_traits::CrossProcessCompositorApi;
 use compositing_traits::largest_contentful_paint_candidate::LargestContentfulPaintType;
 use constellation_traits::{
-    KeyboardScroll, LoadData, NavigationHistoryBehavior, ScriptToConstellationChan,
+    KeyboardScroll, LoadData, NavigationHistoryBehavior, ScriptToConstellationSender,
     StructuredSerializedData, WindowSizeType,
 };
 use crossbeam_channel::RecvTimeoutError;
@@ -58,7 +58,7 @@ use webrender_api::units::{DevicePixel, LayoutVector2D};
 use webrender_api::{ExternalScrollId, ImageKey};
 
 /// The initial data required to create a new `Pipeline` attached to an existing `ScriptThread`.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NewPipelineInfo {
     /// The ID of the parent pipeline and frame type, if any.
     /// If `None`, this is a root pipeline.
@@ -343,7 +343,7 @@ pub struct InitialScriptState {
     /// A port on which messages sent by the constellation to script can be received.
     pub constellation_to_script_receiver: GenericReceiver<ScriptThreadMessage>,
     /// A channel on which messages can be sent to the constellation from script.
-    pub pipeline_to_constellation_sender: ScriptToConstellationChan,
+    pub script_to_constellation_sender: ScriptToConstellationSender,
     /// A channel which allows script to send messages directly to the Embedder
     /// This will pump the embedder event loop.
     pub script_to_embedder_sender: ScriptToEmbedderChan,


### PR DESCRIPTION
Currently starting a script `EventLoop` depends on sending data about
the initial `Pipeline`. This change breaks this dependency. The goal
here is to:

1. Allow `ScriptThread`s to be shared between `WebView`s. This will
   allow more flexiblity with the way that `ScriptThread`s are created,
   which should allow us to perserve system resources by allowing them
   to be shared between `WebView`s. With this change, we can do away
   with the `InitialPipelineState` entirely, which was gather
   information necessary for both a new `EventLoop` and a new
   `Pipeline`. We no longer have to do many clones when reusing an
   existing even loop.
1. Simplify the way that `EventLoop`s and `Pipeline`s are spawned. Now
   `Pipeline`s are spawned in the same way no matter what.

Now the general order of operations when starting a pipeline is:

1. Get or create an event loop for the pipeline:
    - If the event loop needs to be spawn, spawned it in a new thread or
      process.
2. Send the spawn pipeline message to the event loop (kept alive via an
   `Rc`.

Testing: This should not change behavior in a way that is observable, so should
be covered by existing tests.
