### PR TITLE
servoshell: Always exit via `RunningAppState::schedule_exit`

### DIFF
--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -349,7 +349,7 @@ impl App {
 
     /// Request shutdown. Will call on_shutdown_complete.
     pub fn request_shutdown(&self) {
-        self.state.servo.start_shutting_down();
+        self.state.schedule_exit();
         self.spin_event_loop();
     }
 

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -297,7 +297,7 @@ impl RunningAppState {
         }
 
         if self.servoshell_preferences.exit_after_stable_image && self.achieved_stable_image.get() {
-            self.servo.start_shutting_down();
+            self.schedule_exit();
         }
 
         // When a ServoShellWindow has no more WebViews, close it. When no more windows are open, exit

--- a/ports/servoshell/webdriver.rs
+++ b/ports/servoshell/webdriver.rs
@@ -142,7 +142,7 @@ impl RunningAppState {
                     let _ = sender.send(());
                 },
                 WebDriverCommandMsg::Shutdown => {
-                    self.servo().start_shutting_down();
+                    self.schedule_exit();
                 },
                 WebDriverCommandMsg::IsWebViewOpen(webview_id, sender) => {
                     let context = self.webview_by_id(webview_id);


### PR DESCRIPTION
This prevents crashes when exiting servoshell in different situations.
For instance, this fixes a crash when running WPT tests on some systems.

Testing: This fixes an issue when running WPT tests locally.
