### PR TITLE
Fix crash when creating an AudioNode from a closed AudioContext

### DIFF
--- a/components/script/dom/audio/audiodestinationnode.rs
+++ b/components/script/dom/audio/audiodestinationnode.rs
@@ -29,7 +29,7 @@ impl AudioDestinationNode {
             options.unwrap_or(2, ChannelCountMode::Max, ChannelInterpretation::Speakers);
         AudioDestinationNode {
             node: AudioNode::new_inherited_for_id(
-                context.destination_node(),
+                Some(context.destination_node()),
                 context,
                 node_options,
                 1,

--- a/components/script/dom/audio/audiolistener.rs
+++ b/components/script/dom/audio/audiolistener.rs
@@ -42,7 +42,7 @@ impl AudioListener {
         let position_x = AudioParam::new(
             window,
             context,
-            node,
+            Some(node),
             AudioNodeType::AudioListenerNode,
             ParamType::Position(ParamDir::X),
             AutomationRate::A_rate,
@@ -54,7 +54,7 @@ impl AudioListener {
         let position_y = AudioParam::new(
             window,
             context,
-            node,
+            Some(node),
             AudioNodeType::AudioListenerNode,
             ParamType::Position(ParamDir::Y),
             AutomationRate::A_rate,
@@ -66,7 +66,7 @@ impl AudioListener {
         let position_z = AudioParam::new(
             window,
             context,
-            node,
+            Some(node),
             AudioNodeType::AudioListenerNode,
             ParamType::Position(ParamDir::Z),
             AutomationRate::A_rate,
@@ -78,7 +78,7 @@ impl AudioListener {
         let forward_x = AudioParam::new(
             window,
             context,
-            node,
+            Some(node),
             AudioNodeType::AudioListenerNode,
             ParamType::Forward(ParamDir::X),
             AutomationRate::A_rate,
@@ -90,7 +90,7 @@ impl AudioListener {
         let forward_y = AudioParam::new(
             window,
             context,
-            node,
+            Some(node),
             AudioNodeType::AudioListenerNode,
             ParamType::Forward(ParamDir::Y),
             AutomationRate::A_rate,
@@ -102,7 +102,7 @@ impl AudioListener {
         let forward_z = AudioParam::new(
             window,
             context,
-            node,
+            Some(node),
             AudioNodeType::AudioListenerNode,
             ParamType::Forward(ParamDir::Z),
             AutomationRate::A_rate,
@@ -114,7 +114,7 @@ impl AudioListener {
         let up_x = AudioParam::new(
             window,
             context,
-            node,
+            Some(node),
             AudioNodeType::AudioListenerNode,
             ParamType::Up(ParamDir::X),
             AutomationRate::A_rate,
@@ -126,7 +126,7 @@ impl AudioListener {
         let up_y = AudioParam::new(
             window,
             context,
-            node,
+            Some(node),
             AudioNodeType::AudioListenerNode,
             ParamType::Up(ParamDir::Y),
             AutomationRate::A_rate,
@@ -138,7 +138,7 @@ impl AudioListener {
         let up_z = AudioParam::new(
             window,
             context,
-            node,
+            Some(node),
             AudioNodeType::AudioListenerNode,
             ParamType::Up(ParamDir::Z),
             AutomationRate::A_rate,

--- a/tests/wpt/tests/webaudio/the-audio-api/the-mediastreamaudiodestinationnode-interface/closed-audiocontext-construction.html
+++ b/tests/wpt/tests/webaudio/the-audio-api/the-mediastreamaudiodestinationnode-interface/closed-audiocontext-construction.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>MediaStreamAudioDestinationNode after closing AudioContext</title>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+  const context = new AudioContext();
+  await context.close();
+  assert_equals(context.state, "closed", "The AudioContext should report a closed state");
+
+  let audioNode;
+  try {
+    audioNode = new MediaStreamAudioDestinationNode(context);
+  } catch (err) {
+    assert_unreached(`Constructing MediaStreamAudioDestinationNode should not throw when the context is closed. Threw: ${err}`);
+  }
+
+  assert_true(audioNode instanceof MediaStreamAudioDestinationNode, "The created node should be a MediaStreamAudioDestinationNode");
+}, "Constructing MediaStreamAudioDestinationNode on a closed AudioContext succeeds");
+</script>


### PR DESCRIPTION
Fix crash when creating an AudioNode from a closed AudioContext

Testing: added crash test.
Fixes: #36856
