### PR TITLE
Fix CSP nonce validation and violation reporting for external scripts

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -2626,10 +2626,10 @@ impl Element {
     }
 
     /// <https://www.w3.org/TR/CSP/#is-element-nonceable>
-    pub(crate) fn nonce_value_if_nonceable(&self) -> Option<String> {
+    pub(crate) fn is_nonceable(&self) -> bool {
         // Step 1: If element does not have an attribute named "nonce", return "Not Nonceable".
         if !self.has_attribute(&local_name!("nonce")) {
-            return None;
+            return false;
         }
         // Step 2: If element is a script element, then for each attribute of element’s attribute list:
         if self.downcast::<HTMLScriptElement>().is_some() {
@@ -2638,13 +2638,13 @@ impl Element {
                 // for "<script" or "<style", return "Not Nonceable".
                 let attr_name = attr.name().to_ascii_lowercase();
                 if attr_name.contains("<script") || attr_name.contains("<style") {
-                    return None;
+                    return false;
                 }
                 // Step 2.2: If attribute’s value contains an ASCII case-insensitive match
                 // for "<script" or "<style", return "Not Nonceable".
                 let attr_value = attr.value().to_ascii_lowercase();
                 if attr_value.contains("<script") || attr_value.contains("<style") {
-                    return None;
+                    return false;
                 }
             }
         }
@@ -2652,7 +2652,7 @@ impl Element {
         // TODO(https://github.com/servo/servo/issues/4577 and https://github.com/whatwg/html/issues/3257):
         // Figure out how to retrieve this information from the parser
         // Step 4: Return "Nonceable".
-        Some(self.nonce_value().trim().to_owned())
+        true
     }
 
     // https://dom.spec.whatwg.org/#insert-adjacent

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -225,10 +225,6 @@ impl HTMLLinkElement {
         }
         self.cssom_stylesheet.set(None);
     }
-
-    pub(crate) fn line_number(&self) -> u32 {
-        self.line_number as u32
-    }
 }
 
 fn get_attr(element: &Element, local_name: &LocalName) -> Option<String> {
@@ -1138,11 +1134,7 @@ impl FetchResponseListener for FaviconFetchContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        let link = self.link.root();
-        let source_position = link
-            .upcast::<Element>()
-            .compute_source_position(link.line_number as u32);
-        global.report_csp_violations(violations, None, Some(source_position));
+        global.report_csp_violations(violations, None, None);
     }
 }
 

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -725,7 +725,15 @@ impl HTMLScriptElement {
         };
 
         // Step 24. Let cryptographic nonce be el's [[CryptographicNonce]] internal slot's value.
-        let cryptographic_nonce = self.upcast::<Element>().nonce_value();
+        // If the element has a nonce content attribute but is not nonceable strip the nonce to prevent injection attacks.
+        // Elements without a nonce content attribute (e.g. JS-created with .nonce = "abc")
+        // use the internal slot directly — the nonceable check only applies to parser-created elements.
+        let el = self.upcast::<Element>();
+        let cryptographic_nonce = if el.is_nonceable() || !el.has_attribute(&local_name!("nonce")) {
+            el.nonce_value().trim().to_owned()
+        } else {
+            String::new()
+        };
 
         // Step 25. If el has an integrity attribute, then let integrity metadata be that attribute's value.
         // Otherwise, let integrity metadata be the empty string.

--- a/components/script/dom/html/htmlscriptelement.rs
+++ b/components/script/dom/html/htmlscriptelement.rs
@@ -472,10 +472,7 @@ impl FetchResponseListener for ClassicContext {
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
         let elem = self.elem.root();
-        let source_position = elem
-            .upcast::<Element>()
-            .compute_source_position(elem.line_number as u32);
-        global.report_csp_violations(violations, Some(elem.upcast()), Some(source_position));
+        global.report_csp_violations(violations, Some(elem.upcast()), None);
     }
 }
 

--- a/components/script/dom/processingoptions.rs
+++ b/components/script/dom/processingoptions.rs
@@ -25,13 +25,11 @@ use nom_rfc8288::complete::link_lenient as parse_link_header;
 use servo_url::{ImmutableOrigin, ServoUrl};
 use strum::IntoStaticStr;
 
-use crate::dom::bindings::inheritance::Castable;
 use crate::dom::bindings::refcounted::Trusted;
 use crate::dom::bindings::reflector::DomGlobal;
 use crate::dom::bindings::root::DomRoot;
 use crate::dom::csp::{GlobalCspReporting, Violation};
 use crate::dom::document::Document;
-use crate::dom::element::Element;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::medialist::MediaList;
 use crate::dom::node::NodeTraits;
@@ -537,12 +535,7 @@ impl FetchResponseListener for LinkFetchContext {
 
     fn process_csp_violations(&mut self, _request_id: RequestId, violations: Vec<Violation>) {
         let global = &self.resource_timing_global();
-        let source_position = self.link.as_ref().map(|link| {
-            let link = link.root();
-            link.upcast::<Element>()
-                .compute_source_position(link.line_number())
-        });
-        global.report_csp_violations(violations, None, source_position);
+        global.report_csp_violations(violations, None, None);
     }
 }
 

--- a/components/script/dom/security/csp.rs
+++ b/components/script/dom/security/csp.rs
@@ -286,13 +286,17 @@ pub(crate) trait GlobalCspReporting {
 
 #[expect(unsafe_code)]
 fn compute_scripted_caller_source_position() -> SourcePosition {
-    let scripted_caller =
-        unsafe { describe_scripted_caller(*GlobalScope::get_cx()) }.unwrap_or_default();
-
-    SourcePosition {
-        source_file: scripted_caller.filename,
-        line_number: scripted_caller.line,
-        column_number: scripted_caller.col + 1,
+    match unsafe { describe_scripted_caller(*GlobalScope::get_cx()) } {
+        Ok(scripted_caller) => SourcePosition {
+            source_file: scripted_caller.filename,
+            line_number: scripted_caller.line,
+            column_number: scripted_caller.col + 1,
+        },
+        Err(()) => SourcePosition {
+            source_file: String::new(),
+            line_number: 0,
+            column_number: 0,
+        },
     }
 }
 

--- a/components/script/dom/security/csp.rs
+++ b/components/script/dom/security/csp.rs
@@ -167,7 +167,11 @@ impl CspReporting for Option<CspList> {
             return false;
         };
         let element = CspElement {
-            nonce: el.nonce_value_if_nonceable().map(Cow::Owned),
+            nonce: if el.is_nonceable() {
+                Some(Cow::Owned(el.nonce_value().trim().to_owned()))
+            } else {
+                None
+            },
         };
         let (result, violations) =
             csp_list.should_elements_inline_type_behavior_be_blocked(&element, type_, source);

--- a/components/script/dom/security/csppolicyviolationreport.rs
+++ b/components/script/dom/security/csppolicyviolationreport.rs
@@ -82,6 +82,15 @@ impl Convert<SecurityPolicyViolationEventInit> for SecurityPolicyViolationReport
 
 impl Convert<CSPViolationReportBody> for SecurityPolicyViolationReport {
     fn convert(self) -> CSPViolationReportBody {
+        let (source_file, line_number, column_number) = if !self.source_file.is_empty() {
+            (
+                Some(self.source_file.into()),
+                Some(self.line_number),
+                Some(self.column_number),
+            )
+        } else {
+            (None, None, None)
+        };
         CSPViolationReportBody {
             sample: self.sample.map(|s| s.into()),
             blockedURL: Some(self.blocked_url.into()),
@@ -91,10 +100,10 @@ impl Convert<CSPViolationReportBody> for SecurityPolicyViolationReport {
             referrer: Some("".to_owned().into()),
             statusCode: self.status_code,
             documentURL: self.document_url.into(),
-            sourceFile: Some(self.source_file.into()),
+            sourceFile: source_file,
             effectiveDirective: self.effective_directive.into(),
-            lineNumber: Some(self.line_number),
-            columnNumber: Some(self.column_number),
+            lineNumber: line_number,
+            columnNumber: column_number,
             originalPolicy: self.original_policy.into(),
             disposition: self.disposition,
             parent: ReportBody::empty(),

--- a/tests/wpt/meta/trusted-types/navigate-to-javascript-url-001.html.ini
+++ b/tests/wpt/meta/trusted-types/navigate-to-javascript-url-001.html.ini
@@ -1,3 +1,0 @@
-[navigate-to-javascript-url-001.html]
-  [Setting window.location to a javascript: URL without a default policy should report a CSP violation instead of executing the JavaScript code.]
-    expected: FAIL

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -10802,6 +10802,14 @@
       []
      ]
     },
+    "csp": {
+     "support": {
+      "nonce-should-be-blocked.js": [
+       "501f7a92088ec4dfd5197c5378e207d9007abe2f",
+       []
+      ]
+     }
+    },
     "details_ui_closed_ref.html": [
      "b7db1ce810c09c9169142db4333f2648ed098239",
      []
@@ -13442,6 +13450,15 @@
      ],
      "cross-origin-postMessage.html": [
       "143240c97aa60b52c8d2e0067c25e4509bf6481d",
+      [
+       null,
+       {}
+      ]
+     ]
+    },
+    "csp": {
+     "nonce-external-script-malformed-blocked.html": [
+      "845a7d7aba109769add506290aac1ce42eff2699",
       [
        null,
        {}

--- a/tests/wpt/mozilla/tests/mozilla/csp/nonce-external-script-malformed-blocked.html
+++ b/tests/wpt/mozilla/tests/mozilla/csp/nonce-external-script-malformed-blocked.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<meta http-equiv="Content-Security-Policy" content="script-src 'nonce-abc'">
+<script src="/resources/testharness.js" nonce="abc"></script>
+<script src="/resources/testharnessreport.js" nonce="abc"></script>
+<!--
+    This is a subset of content-security-policy/script-src/nonce-enforce-blocked.html
+    covering only the cases Servo can currently enforce without html5ever changes.
+
+    The remaining failures are blocked by required changes in the HTML parser:
+    - SVG script support (https://github.com/servo/html5ever/issues/118)
+    - Duplicate attribute detection (https://github.com/servo/html5ever/pull/695)
+-->
+<script nonce="abc">
+    var t = async_test("Unnonced scripts generate reports.");
+    var events = 0;
+    var firstLine = 51;
+    var expectations = {}
+    expectations[firstLine] = true;
+    expectations[firstLine + 3] = true;
+    expectations[firstLine + 6] = true;
+    expectations[firstLine + 9] = true;
+    expectations[firstLine + 12] = true;
+    expectations[firstLine + 15] = true;
+    expectations[firstLine + 18] = true;
+    // expectations[firstLine + 21] = true;
+    // expectations[firstLine + 24] = true;
+    // expectations[firstLine + 28] = true;
+    expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?1"] = true;
+    expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?2"] = true;
+    expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?3"] = true;
+    expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?4"] = true;
+    // expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?5"] = true;
+    expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?6"] = true;
+    expectations["/_mozilla/mozilla/csp/support/nonce-should-be-blocked.js?7"] = true;
+
+    document.addEventListener('securitypolicyviolation', t.step_func(e => {
+        if (e.lineNumber) {
+            // Verify that the line is expected, then clear the expectation:
+            assert_true(expectations[e.lineNumber], "Line number: " + e.lineNumber);
+            assert_equals(e.blockedURI, "inline");
+        } else {
+            // Otherwise, verify that the URL is expected, then clear the expectation:
+            var url = new URL(e.blockedURI);
+            assert_true(expectations[url.pathname + url.search], "URL: " + e.blockedURI);
+        }
+        events++;
+        if (events == Object.keys(expectations).length)
+          t.done();
+    }));
+</script>
+<script>
+    t.unreached_func("No nonce, no execution.")();
+</script>
+<script nonce="xyz">
+    t.unreached_func("Bad nonce, no execution.")();
+</script>
+<script <script nonce="abc">
+    t.unreached_func("'<script' attribute, no execution.")();
+</script>
+<script attribute<script nonce="abc">
+    t.unreached_func("'attribute<script', no execution.")();
+</script>
+<script attribute<style="value" nonce="abc">
+    t.unreached_func("'attribute<style' attribute, no execution.")();
+</script>
+<script attribute=<script nonce="abc">
+    t.unreached_func("'<script' value, no execution.")();
+</script>
+<script attribute=value<script nonce="abc">
+    t.unreached_func("'value<script', no execution.")();
+</script>
+<!-- Blocked on html5ever duplicate-attribute detection (https://github.com/servo/html5ever/pull/695) <script attribute attribute nonce="abc">
+    t.unreached_func("Duplicate attribute, no execution.")();
+</script>
+<script attribute attribute=<style nonce="abc">
+    t.unreached_func("2# Duplicate attribute, no execution.")();
+</script> -->
+<!-- Blocked on html5ever SVG script support (https://github.com/servo/html5ever/issues/118) <svg xmlns="http://www.w3.org/2000/svg">
+<script attribute attribute nonce="abc">
+    t.unreached_func("Duplicate attribute in SVG, no execution.")();
+</script>
+</svg> -->
+<script src="support/nonce-should-be-blocked.js?1" <script nonce="abc"></script>
+<script src="support/nonce-should-be-blocked.js?2" attribute=<script nonce="abc"></script>
+<script src="support/nonce-should-be-blocked.js?3" <style nonce="abc"></script>
+<script src="support/nonce-should-be-blocked.js?4" attribute=<style nonce="abc"></script>
+<!-- Blocked on html5ever duplicate-attribute detection (https://github.com/servo/html5ever/pull/695) <script src="support/nonce-should-be-blocked.js?5" attribute attribute nonce="abc"></script> -->
+<script src="support/nonce-should-be-blocked.js?6" attribute<script nonce="abc"></script>
+<script src="support/nonce-should-be-blocked.js?7" attribute=value<script nonce="abc"></script>

--- a/tests/wpt/mozilla/tests/mozilla/csp/support/nonce-should-be-blocked.js
+++ b/tests/wpt/mozilla/tests/mozilla/csp/support/nonce-should-be-blocked.js
@@ -1,0 +1,1 @@
+t.unreached_func(document.currentScript.getAttribute('src') + " should not execute.")();


### PR DESCRIPTION
This PR fixes two related issues with Content Security Policy (CSP) nonce validation for external scripts:

1. Missing nonce validation for external scripts with malformed attributes
2. Incorrect violation event reporting for blocked external resources


This makes servo closer to passing the `nonce-enforce-blocked` wpt test.

The remaining failures are blocked by required changes in the html parser.

1. Svg script support (https://github.com/servo/html5ever/issues/118)
```html
<svg xmlns="http://www.w3.org/2000/svg">
<script attribute attribute nonce="abc">
    t.unreached_func("Duplicate attribute in SVG, no execution.")();
</script>
</svg>
```

2. Duplicate attrs check
the html parser needs to provide this flag, as mentioned on the original commit message (https://github.com/servo/servo/commit/4821bc0ab01e1ed0bb27e86c2df545019bd3856a)

```html
<script attribute attribute nonce="abc">
    t.unreached_func("Duplicate attribute, no execution.")();
</script>
<script attribute attribute=<style nonce="abc">
    t.unreached_func("2# Duplicate attribute, no execution.")();
</script>

[...]

<script src="../support/nonce-should-be-blocked.js?5" attribute attribute nonce="abc"></script>
```

I've also created a PR to implement the duplicate attrs flag on html5ever https://github.com/servo/html5ever/pull/695

Testing: doesn't fixes the aforementioned wpt test yet.
Fixes: part of #36437 
