### PR TITLE
Move `disable_share_style_cache` to `prefs`

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -117,9 +117,6 @@ pub struct DebugOptions {
     /// Periodically print out on which events script threads spend their processing time.
     pub profile_script_events: bool,
 
-    /// Disable the style sharing cache.
-    pub disable_share_style_cache: bool,
-
     /// Whether to show in stdout style sharing cache stats after a restyle.
     pub dump_style_statistics: bool,
 
@@ -132,7 +129,6 @@ impl DebugOptions {
         for option in debug_string.split(',') {
             match option {
                 "help" => self.help = true,
-                "disable-share-style-cache" => self.disable_share_style_cache = true,
                 "dump-display-list" => self.dump_display_list = true,
                 "dump-stacking-context-tree" => self.dump_stacking_context_tree = true,
                 "dump-flow-tree" => self.dump_flow_tree = true,

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -233,6 +233,7 @@ pub struct Preferences {
     pub layout_container_queries_enabled: bool,
     pub layout_css_transition_behavior_enabled: bool,
     pub layout_flexbox_enabled: bool,
+    pub layout_style_sharing_cache_enabled: bool,
     pub layout_threads: i64,
     pub layout_unimplemented: bool,
     pub layout_variable_fonts_enabled: bool,
@@ -416,6 +417,7 @@ impl Preferences {
             layout_css_transition_behavior_enabled: true,
             layout_flexbox_enabled: true,
             layout_grid_enabled: false,
+            layout_style_sharing_cache_enabled: true,
             // TODO(mrobinson): This should likely be based on the number of processors.
             layout_threads: 3,
             layout_unimplemented: false,

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -180,8 +180,10 @@ impl Servo {
 
         use std::sync::atomic::Ordering;
 
-        style::context::DEFAULT_DISABLE_STYLE_SHARING_CACHE
-            .store(opts.debug.disable_share_style_cache, Ordering::Relaxed);
+        style::context::DEFAULT_DISABLE_STYLE_SHARING_CACHE.store(
+            !pref!(layout_style_sharing_cache_enabled),
+            Ordering::Relaxed,
+        );
         style::context::DEFAULT_DUMP_STYLE_STATISTICS
             .store(opts.debug.dump_style_statistics, Ordering::Relaxed);
         style::traversal::IS_SERVO_NONINCREMENTAL_LAYOUT


### PR DESCRIPTION
This change move `DebugOpts::disable_share_style_cache` to `Prefs::layout_style_sharing_cache_enabled` and ensure it is enabled by default. We also inverted the usage.

Testing: 
Fixes: Part of https://github.com/servo/servo/issues/40863
