### PR TITLE
config: Rename `DebugOpts` to `DiagnosticsLogging` and get rid of `dump` terminology

### DIFF
--- a/components/config/opts.rs
+++ b/components/config/opts.rs
@@ -37,7 +37,7 @@ pub struct Opts {
 
     /// Debug options that are used by developers to control Servo
     /// behavior for debugging purposes.
-    pub debug: DebugOptions,
+    pub debug: DiagnosticsLogging,
 
     /// Whether we're running in multiprocess mode.
     pub multiprocess: bool,
@@ -89,53 +89,57 @@ pub struct Opts {
 
 /// Debug options for Servo, currently set on the command line with -Z
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct DebugOptions {
+pub struct DiagnosticsLogging {
     /// List all the debug options.
     pub help: bool,
 
     /// Print the DOM after each restyle.
-    pub dump_style_tree: bool,
+    pub style_tree: bool,
 
-    /// Dumps the rule tree.
-    pub dump_rule_tree: bool,
+    /// Log the rule tree.
+    pub rule_tree: bool,
 
-    /// Print the fragment tree after each layout.
-    pub dump_flow_tree: bool,
+    /// Log the fragment tree after each layout.
+    pub flow_tree: bool,
 
-    /// Print the stacking context tree after each layout.
-    pub dump_stacking_context_tree: bool,
+    /// Log the stacking context tree after each layout.
+    pub stacking_context_tree: bool,
 
-    /// Print the scroll tree after each layout.
-    pub dump_scroll_tree: bool,
+    /// Log the scroll tree after each layout.
+    ///
+    /// Displays the hierarchy of scrollable areas and their properties.
+    pub scroll_tree: bool,
 
-    /// Print the display list after each layout.
-    pub dump_display_list: bool,
+    /// Log the display list after each layout.
+    pub display_list: bool,
 
-    /// Print notifications when there is a relayout.
+    /// Log notifications when a relayout occurs.
     pub relayout_event: bool,
 
-    /// Periodically print out on which events script threads spend their processing time.
+    /// Periodically log on which events script threads spend their processing time.
     pub profile_script_events: bool,
 
-    /// Whether to show in stdout style sharing cache stats after a restyle.
-    pub dump_style_statistics: bool,
+    /// Log style sharing cache statistics to after each restyle.
+    ///
+    /// Shows hit/miss statistics for the style sharing cache
+    pub style_statistics: bool,
 
-    /// Log GC passes and their durations.
+    /// Log garbage collection passes and their durations.
     pub gc_profile: bool,
 }
 
-impl DebugOptions {
+impl DiagnosticsLogging {
     pub fn extend(&mut self, debug_string: String) -> Result<(), String> {
         for option in debug_string.split(',') {
             match option {
                 "help" => self.help = true,
-                "dump-display-list" => self.dump_display_list = true,
-                "dump-stacking-context-tree" => self.dump_stacking_context_tree = true,
-                "dump-flow-tree" => self.dump_flow_tree = true,
-                "dump-rule-tree" => self.dump_rule_tree = true,
-                "dump-style-tree" => self.dump_style_tree = true,
-                "dump-style-stats" => self.dump_style_statistics = true,
-                "dump-scroll-tree" => self.dump_scroll_tree = true,
+                "display-list" => self.display_list = true,
+                "stacking-context-tree" => self.stacking_context_tree = true,
+                "flow-tree" => self.flow_tree = true,
+                "rule-tree" => self.rule_tree = true,
+                "style-tree" => self.style_tree = true,
+                "style-stats" => self.style_statistics = true,
+                "scroll-tree" => self.scroll_tree = true,
                 "gc-profile" => self.gc_profile = true,
                 "profile-script-events" => self.profile_script_events = true,
                 "relayout-event" => self.relayout_event = true,

--- a/components/layout/display_list/mod.rs
+++ b/components/layout/display_list/mod.rs
@@ -18,7 +18,7 @@ use gradient::WebRenderGradient;
 use net_traits::image_cache::Image as CachedImage;
 use range::Range as ServoRange;
 use servo_arc::Arc as ServoArc;
-use servo_config::opts::DebugOptions;
+use servo_config::opts::DiagnosticsLogging;
 use servo_geometry::MaxRect;
 use style::Zero;
 use style::color::{AbsoluteColor, ColorSpace};
@@ -172,7 +172,7 @@ impl DisplayListBuilder<'_> {
         image_resolver: Arc<ImageResolver>,
         device_pixel_ratio: Scale<f32, StyloCSSPixel, StyloDevicePixel>,
         highlighted_dom_node: Option<OpaqueNode>,
-        debug: &DebugOptions,
+        debug: &DiagnosticsLogging,
         lcp_candidate_collector: Option<&mut LargestContentfulPaintCandidateCollector>,
     ) -> BuiltDisplayList {
         // Build the rest of the display list which inclues all of the WebRender primitives.
@@ -186,7 +186,7 @@ impl DisplayListBuilder<'_> {
         // the display list for printing the serialized version when `finalize()` is called.
         // We need to call this before adding any display items so that they are printed
         // during `finalize()`.
-        if debug.dump_display_list {
+        if debug.display_list {
             webrender_display_list_builder.dump_serialized_display_list();
         }
 

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -19,7 +19,7 @@ use euclid::SideOffsets2D;
 use euclid::default::{Point2D, Rect, Size2D};
 use log::warn;
 use malloc_size_of_derive::MallocSizeOf;
-use servo_config::opts::DebugOptions;
+use servo_config::opts::DiagnosticsLogging;
 use style::Zero;
 use style::color::AbsoluteColor;
 use style::computed_values::float::T as ComputedFloat;
@@ -126,7 +126,7 @@ impl StackingContextTree {
         viewport_details: ViewportDetails,
         pipeline_id: wr::PipelineId,
         first_reflow: bool,
-        debug: &DebugOptions,
+        debug: &DiagnosticsLogging,
     ) -> Self {
         let scrollable_overflow = fragment_tree.scrollable_overflow();
         let scrollable_overflow = LayoutSize::from_untyped(Size2D::new(
@@ -191,7 +191,7 @@ impl StackingContextTree {
         }
         root_stacking_context.sort();
 
-        if debug.dump_stacking_context_tree {
+        if debug.stacking_context_tree {
             root_stacking_context.debug_print();
         }
 
@@ -446,7 +446,7 @@ impl StackingContext {
         }
     }
 
-    fn create_root(root_scroll_node_id: ScrollTreeNodeId, debug: &DebugOptions) -> Self {
+    fn create_root(root_scroll_node_id: ScrollTreeNodeId, debug: &DiagnosticsLogging) -> Self {
         Self {
             scroll_tree_node_id: root_scroll_node_id,
             clip_id: None,
@@ -456,7 +456,7 @@ impl StackingContext {
             real_stacking_contexts_and_positioned_stacking_containers: vec![],
             float_stacking_containers: vec![],
             atomic_inline_stacking_containers: vec![],
-            debug_print_items: debug.dump_stacking_context_tree.then(|| vec![].into()),
+            debug_print_items: debug.stacking_context_tree.then(|| vec![].into()),
         }
     }
 

--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -43,7 +43,7 @@ use rustc_hash::FxHashMap;
 use script::layout_dom::{ServoLayoutDocument, ServoLayoutElement, ServoLayoutNode};
 use script_traits::{DrawAPaintImageResult, PaintWorkletError, Painter, ScriptThreadMessage};
 use servo_arc::Arc as ServoArc;
-use servo_config::opts::{self, DebugOptions};
+use servo_config::opts::{self, DiagnosticsLogging};
 use servo_config::pref;
 use servo_url::ServoUrl;
 use style::animation::DocumentAnimationSet;
@@ -197,7 +197,7 @@ pub struct LayoutThread {
 
     /// Debug options, copied from configuration to this `LayoutThread` in order
     /// to avoid having to constantly access the thread-safe global options.
-    debug: DebugOptions,
+    debug: DiagnosticsLogging,
 
     /// Tracks the node that was highlighted by the devtools during the last reflow.
     ///
@@ -1155,13 +1155,13 @@ impl LayoutThread {
 
         *self.fragment_tree.borrow_mut() = Some(fragment_tree);
 
-        if self.debug.dump_style_tree {
+        if self.debug.style_tree {
             println!(
                 "{:?}",
                 ShowSubtreeDataAndPrimaryValues(root_element.as_node())
             );
         }
-        if self.debug.dump_rule_tree {
+        if self.debug.rule_tree {
             recalc_style_traversal
                 .context()
                 .style_context
@@ -1188,7 +1188,7 @@ impl LayoutThread {
 
         if let Some(fragment_tree) = &*self.fragment_tree.borrow() {
             fragment_tree.calculate_scrollable_overflow();
-            if self.debug.dump_flow_tree {
+            if self.debug.flow_tree {
                 fragment_tree.print();
             }
         }
@@ -1245,7 +1245,7 @@ impl LayoutThread {
                 .set_all_scroll_offsets(&old_scroll_offsets);
         }
 
-        if self.debug.dump_scroll_tree {
+        if self.debug.scroll_tree {
             new_stacking_context_tree
                 .compositor_info
                 .scroll_tree

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -45,7 +45,7 @@ pub use net_traits::pub_domains::is_reg_domain;
 // This should be replaced with an API on ServoBuilder.
 // See <https://github.com/servo/servo/issues/40950>.
 pub use resources;
-pub use servo_config::opts::{DebugOptions, Opts, OutputOptions};
+pub use servo_config::opts::{DiagnosticsLogging, Opts, OutputOptions};
 pub use servo_config::prefs::{PrefValue, Preferences, UserAgentPlatform};
 pub use servo_config::{opts, pref, prefs};
 pub use servo_geometry::{

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -185,7 +185,7 @@ impl Servo {
             Ordering::Relaxed,
         );
         style::context::DEFAULT_DUMP_STYLE_STATISTICS
-            .store(opts.debug.dump_style_statistics, Ordering::Relaxed);
+            .store(opts.debug.style_statistics, Ordering::Relaxed);
         style::traversal::IS_SERVO_NONINCREMENTAL_LAYOUT
             .store(opts.nonincremental_layout, Ordering::Relaxed);
 

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -18,7 +18,8 @@ use euclid::Size2D;
 use log::warn;
 use serde_json::Value;
 use servo::{
-    DebugOptions, DeviceIndependentPixel, Opts, OutputOptions, PrefValue, Preferences, ServoUrl,
+    DeviceIndependentPixel, DiagnosticsLogging, Opts, OutputOptions, PrefValue, Preferences,
+    ServoUrl,
 };
 use url::Url;
 
@@ -696,7 +697,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         ..Default::default()
     };
 
-    let mut debug_options = DebugOptions::default();
+    let mut debug_options = DiagnosticsLogging::default();
     for debug_string in cmd_args.debug {
         let result = debug_options.extend(debug_string);
         if let Err(error) = result {


### PR DESCRIPTION
In this PR, we rename `DebugOpts` to `DiagnosticsLogging`, add some
documentation and rename variables to get rid of dump terminology.

Testing: 
Fixes: part of https://github.com/servo/servo/issues/40863
