### PR TITLE
servoshell: Fix stdout / stderr output in windows production builds

### DIFF
--- a/ports/servoshell/main.rs
+++ b/ports/servoshell/main.rs
@@ -16,11 +16,24 @@
 
 // Normally, rust uses the "Console" Windows subsystem, which pops up a console
 // when running an application. Switching to the "Windows" subsystem prevents
-// this, but also hides debugging output. Use the "Windows" console unless debug
-// mode is turned on.
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+// this, but also hides debugging output. We mitigate this by attempting to
+// attach to the console of the parent process.
+#![windows_subsystem = "windows"]
+
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::System::Console;
 
 fn main() {
+    #[cfg(target_os = "windows")]
+    // SAFETY: No safety related side effects or requirements.
+    unsafe {
+        // When servo is started from the commandline, we still want output
+        // to be printed. Due to us using the `windows` subsystem, this doesn't
+        // work out-of-the-box, and we need to manually attempt to attach to
+        // the console of the parent process. If servo was not started from
+        // the commandline, then the call will fail, which we can ignore.
+        let _result = Console::AttachConsole(Console::ATTACH_PARENT_PROCESS);
+    }
     cfg_if::cfg_if! {
         if #[cfg(not(any(target_os = "android", target_env = "ohos")))] {
             servoshell::main()


### PR DESCRIPTION
When servo is started from the command line, we still want output to be printed. On windows, due to us using the `windows` subsystem (as opposed to the default `console` subsystem), this doesn't work out-of-the-box, and we need to manually attempt to attach to the console of the parent process. If servo was not started from the command line, then the call will fail, which we can ignore.
Since we can now have the best of both worlds (i.e  no popping up console window, and preserve stdout / stderr when started from a console), we can now unconditionally use the `windows` subsystem. (On non-windows platforms, `windows-subsystem` does nothing)

Testing: Manually tested. The original issue does not reproduce when redirecting stdout / stderr, so I don't see a way to write an automated test.
Fixes: #40211
