### PR TITLE
servoshell: Prepare November release (0.0.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8198,7 +8198,7 @@ dependencies = [
 
 [[package]]
 name = "servoshell"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "android_logger",
  "backtrace",

--- a/Info.plist
+++ b/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.2</string>
+	<string>0.0.3</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>NSPrincipalClass</key>

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "servoshell"
 build = "build.rs"
-version = "0.0.2"
+version = "0.0.3"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true

--- a/resources/resource_protocol/license.html
+++ b/resources/resource_protocol/license.html
@@ -2882,8 +2882,8 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.27</a></li>
-                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.27</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.31</a></li>
+                        <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.31</a></li>
                     </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3722,6 +3722,215 @@ Software.
             </li>
             <li class="license">
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/krisprice/ipnet ">ipnet 2.11.0</a>
+                    </p>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;{}&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 Juniper Networks, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/openharmony-rs/hilog ">hilog 0.2.2</a></li>
@@ -3938,11 +4147,11 @@ Software.
                         <li><a href=" https://github.com/rust-ammonia/rust-content-security-policy ">content-security-policy 0.5.4</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.21</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.7</a></li>
-                        <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.4</a></li>
-                        <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.10</a></li>
+                        <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
+                        <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.11</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.13</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.51</a></li>
-                        <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.51</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.53</a></li>
+                        <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.53</a></li>
                         <li><a href=" https://github.com/clap-rs/clap ">clap_lex 0.7.6</a></li>
                         <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.4</a></li>
                         <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.0</a></li>
@@ -5013,7 +5222,7 @@ limitations under the License.
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/hyperium/http ">http 0.2.12</a></li>
-                        <li><a href=" https://github.com/hyperium/http ">http 1.3.1</a></li>
+                        <li><a href=" https://github.com/hyperium/http ">http 1.4.0</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7110,7 +7319,7 @@ limitations under the License.
                         <li><a href=" https://github.com/dcchut/async-recursion ">async-recursion 1.1.1</a></li>
                         <li><a href=" https://github.com/image-rs/image-gif ">gif 0.13.3</a></li>
                         <li><a href=" https://github.com/rust-windowing/keyboard-types ">keyboard-types 0.8.3</a></li>
-                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.0-rc.17</a></li>
+                        <li><a href=" https://github.com/SeaQL/sea-query ">sea-query 1.0.0-rc.22</a></li>
                         <li><a href=" https://github.com/image-rs/weezl ">weezl 0.1.12</a></li>
                     </ul>
                 <pre class="license-text">                              Apache License
@@ -7350,7 +7559,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/pacak/bpaf ">bpaf_derive 0.5.17</a></li>
                         <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.19.0</a></li>
                         <li><a href=" https://github.com/japaric/cast.rs ">cast 0.3.0</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.45</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.48</a></li>
                         <li><a href=" https://github.com/jethrogb/rust-cexpr ">cexpr 0.6.0</a></li>
                         <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
                         <li><a href=" https://github.com/servo/cgl-rs ">cgl 0.3.2</a></li>
@@ -7381,7 +7590,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/smol-rs/event-listener ">event-listener 5.4.1</a></li>
                         <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
                         <li><a href=" https://github.com/alexcrichton/filetime ">filetime 0.2.26</a></li>
-                        <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.4</a></li>
+                        <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.5</a></li>
                         <li><a href=" https://github.com/bluss/fixedbitset ">fixedbitset 0.1.9</a></li>
                         <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.5</a></li>
                         <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
@@ -7418,7 +7627,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/timothee-haudebourg/khronos-egl ">khronos-egl 6.0.0</a></li>
                         <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
                         <li><a href=" https://github.com/rust-fuzz/libfuzzer ">libfuzzer-sys 0.4.10</a></li>
-                        <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.22</a></li>
+                        <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.23</a></li>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.11.0</a></li>
                         <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.4.15</a></li>
                         <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
@@ -7464,7 +7673,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls 1.0.1</a></li>
                         <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                         <li><a href=" https://github.com/adjivas/sig ">sig 1.0.0</a></li>
-                        <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.6</a></li>
+                        <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.7</a></li>
                         <li><a href=" https://github.com/linebender/simplecss ">simplecss 0.2.2</a></li>
                         <li><a href=" https://github.com/servo/smallbitvec ">smallbitvec 2.6.0</a></li>
                         <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
@@ -7474,7 +7683,7 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
                         <li><a href=" https://github.com/servo/string-cache ">string_cache 0.9.0</a></li>
                         <li><a href=" https://github.com/servo/string-cache ">string_cache_codegen 0.6.1</a></li>
-                        <li><a href=" https://github.com/servo/surfman ">surfman 0.10.0</a></li>
+                        <li><a href=" https://github.com/servo/surfman ">surfman 0.11.0</a></li>
                         <li><a href=" https://github.com/linebender/svgtypes ">svgtypes 0.15.3</a></li>
                         <li><a href=" https://github.com/gdesmott/system-deps ">system-deps 6.2.2</a></li>
                         <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.44</a></li>
@@ -8559,16 +8768,20 @@ limitations under the License.</pre>
                     <ul class="license-used-by">
                         <li><a href=" https://github.com/RustCrypto/AEADs ">aes-gcm 0.10.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/block-ciphers ">aes 0.8.4</a></li>
+                        <li><a href=" https://github.com/RustCrypto/password-hashes/tree/master/argon2 ">argon2 0.5.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats/tree/master/base16ct ">base16ct 0.2.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats ">base64ct 1.8.0</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hashes ">blake2 0.10.6</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">block-padding 0.3.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/block-modes ">cbc 0.1.2</a></li>
+                        <li><a href=" https://github.com/RustCrypto/stream-ciphers ">chacha20 0.9.1</a></li>
+                        <li><a href=" https://github.com/RustCrypto/AEADs/tree/master/chacha20poly1305 ">chacha20poly1305 0.10.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">cipher 0.4.4</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats/tree/master/const-oid ">const-oid 0.9.6</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.17</a></li>
                         <li><a href=" https://github.com/RustCrypto/crypto-bigint ">crypto-bigint 0.5.5</a></li>
-                        <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.6</a></li>
+                        <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.7</a></li>
                         <li><a href=" https://github.com/RustCrypto/block-modes ">ctr 0.9.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats/tree/master/der ">der 0.7.10</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">digest 0.10.7</a></li>
@@ -8576,17 +8789,21 @@ limitations under the License.</pre>
                         <li><a href=" https://github.com/RustCrypto/universal-hashes ">ghash 0.5.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.12.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">inout 0.1.4</a></li>
+                        <li><a href=" https://github.com/RustCrypto/sponges/tree/master/keccak ">keccak 0.1.5</a></li>
                         <li><a href=" https://github.com/RustCrypto/utils ">opaque-debug 0.3.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p256 ">p256 0.13.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p384 ">p384 0.13.1</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p521 ">p521 0.13.3</a></li>
+                        <li><a href=" https://github.com/RustCrypto/traits/tree/master/password-hash ">password-hash 0.5.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats/tree/master/pem-rfc7468 ">pem-rfc7468 0.7.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats/tree/master/pkcs8 ">pkcs8 0.10.2</a></li>
+                        <li><a href=" https://github.com/RustCrypto/universal-hashes ">poly1305 0.8.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/universal-hashes ">polyval 0.6.2</a></li>
                         <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/primeorder ">primeorder 0.13.6</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats/tree/master/sec1 ">sec1 0.7.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/hashes ">sha1 0.10.6</a></li>
                         <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.10.9</a></li>
+                        <li><a href=" https://github.com/RustCrypto/hashes ">sha3 0.10.8</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits/tree/master/signature ">signature 2.2.0</a></li>
                         <li><a href=" https://github.com/RustCrypto/formats/tree/master/spki ">spki 0.7.3</a></li>
                         <li><a href=" https://github.com/RustCrypto/traits ">universal-hash 0.5.1</a></li>
@@ -12110,27 +12327,27 @@ limitations under the License.
                         <li><a href=" https://github.com/zrzka/anes-rs ">anes 0.1.6</a></li>
                         <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.100</a></li>
                         <li><a href=" https://github.com/1Password/arboard ">arboard 3.6.1</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.33</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.34</a></li>
                         <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
                         <li><a href=" https://github.com/odilia-app/atspi ">atspi-proxies 0.9.0</a></li>
                         <li><a href=" https://github.com/jrmuizel/build-parallel ">build-parallel 0.1.2</a></li>
                         <li><a href=" https://github.com/emk/cesu8-rs ">cesu8 1.1.0</a></li>
                         <li><a href=" https://github.com/linebender/color ">color 0.3.2</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.32</a></li>
-                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.30</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.33</a></li>
+                        <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.31</a></li>
                         <li><a href=" https://github.com/soc/directories-rs ">directories 6.0.0</a></li>
                         <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.5.0</a></li>
                         <li><a href=" https://github.com/soc/dirs-rs ">dirs 6.0.0</a></li>
                         <li><a href=" https://github.com/slint-ui/document-features ">document-features 0.2.12</a></li>
                         <li><a href=" https://github.com/dtolnay/dtoa ">dtoa 1.0.10</a></li>
                         <li><a href=" https://gitlab.com/kornelski/dunce ">dunce 1.0.5</a></li>
-                        <li><a href=" https://github.com/emilk/egui ">ecolor 0.33.0</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui-winit ">egui-winit 0.33.0</a></li>
-                        <li><a href=" https://github.com/emilk/egui ">egui 0.33.0</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui_glow ">egui_glow 0.33.0</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/emath ">emath 0.33.0</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint ">epaint 0.33.0</a></li>
-                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.0</a></li>
+                        <li><a href=" https://github.com/emilk/egui ">ecolor 0.33.2</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui-winit ">egui-winit 0.33.2</a></li>
+                        <li><a href=" https://github.com/emilk/egui ">egui 0.33.2</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/egui_glow ">egui_glow 0.33.2</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/emath ">emath 0.33.2</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint ">epaint 0.33.2</a></li>
+                        <li><a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.2</a></li>
                         <li><a href=" https://github.com/nical/etagere ">etagere 0.2.15</a></li>
                         <li><a href=" https://github.com/image-rs/fdeflate ">fdeflate 0.3.7</a></li>
                         <li><a href=" https://github.com/linebender/fearless_simd ">fearless_simd 0.3.0</a></li>
@@ -12218,7 +12435,8 @@ limitations under the License.
                         <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher 1.0.1</a></li>
                         <li><a href=" https://github.com/gfx-rs/rspirv ">spirv 0.3.0+sdk-1.3.268.0</a></li>
                         <li><a href=" https://github.com/nical/rust_debug ">svg_fmt 0.4.5</a></li>
-                        <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.110</a></li>
+                        <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.111</a></li>
+                        <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
                         <li><a href=" https://github.com/gankra/thin-vec ">thin-vec 0.2.14</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 1.0.69</a></li>
                         <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.17</a></li>
@@ -12748,7 +12966,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozangle ">mozangle 0.5.3</a>
+                            <a href=" https://github.com/servo/mozangle ">mozangle 0.5.4</a>
                     </p>
                 <pre class="license-text">// Copyright (C) 2002-2013 The ANGLE Project Authors. 
 // All rights reserved.
@@ -12786,11 +13004,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             </li>
             <li class="license">
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
-                    <h4>Used by:</h4>
-                    <ul class="license-used-by">
-                        <li><a href=" https://github.com/rust-lang/rust-bindgen ">bindgen 0.71.1</a></li>
-                        <li><a href=" https://github.com/rust-lang/rust-bindgen ">bindgen 0.72.1</a></li>
-                    </ul>
+                    <p>
+                        Used by
+                            <a href=" https://github.com/rust-lang/rust-bindgen ">bindgen 0.72.1</a>
+                    </p>
                 <pre class="license-text">BSD 3-Clause License
 
 Copyright (c) 2013, Jyun-Yan You
@@ -13447,7 +13664,7 @@ insights.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.32.3</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.34.0</a>
                     </p>
                 <pre class="license-text">/* Copyright (c) 2018, Google Inc.
  *
@@ -13588,7 +13805,7 @@ third-party/chromium/LICENSE.
                 <h3 id="ISC">ISC License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.14.1</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.15.1</a>
                     </p>
                 <pre class="license-text">ISC License:
 
@@ -13944,7 +14161,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hyperium/hyper ">hyper 1.8.0</a>
+                            <a href=" https://github.com/hyperium/hyper ">hyper 1.8.1</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2014-2025 Sean McArthur
 
@@ -14269,7 +14486,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/tokio-rs/bytes ">bytes 1.10.1</a>
+                            <a href=" https://github.com/tokio-rs/bytes ">bytes 1.11.0</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2018 Carl Lerche
 
@@ -14533,9 +14750,9 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/tokio-rs/tracing ">tracing-attributes 0.1.30</a></li>
-                        <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.34</a></li>
-                        <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.41</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tracing ">tracing-attributes 0.1.31</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.35</a></li>
+                        <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.43</a></li>
                     </ul>
                 <pre class="license-text">Copyright (c) 2019 Tokio Contributors
 
@@ -14566,10 +14783,12 @@ DEALINGS IN THE SOFTWARE.
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
-                    <p>
-                        Used by
-                            <a href=" https://github.com/tower-rs/tower ">tower-service 0.3.3</a>
-                    </p>
+                    <h4>Used by:</h4>
+                    <ul class="license-used-by">
+                        <li><a href=" https://github.com/tower-rs/tower ">tower-layer 0.3.3</a></li>
+                        <li><a href=" https://github.com/tower-rs/tower ">tower-service 0.3.3</a></li>
+                        <li><a href=" https://github.com/tower-rs/tower ">tower 0.5.2</a></li>
+                    </ul>
                 <pre class="license-text">Copyright (c) 2019 Tower Contributors
 
 Permission is hereby granted, free of charge, to any
@@ -14775,7 +14994,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.17</a>
+                            <a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.18</a>
                     </p>
                 <pre class="license-text">Copyright (c) 2023-2025 Sean McArthur
 
@@ -15604,7 +15823,7 @@ SOFTWARE.</pre>
                         <li><a href=" https://github.com/plotters-rs/plotters.git ">plotters-svg 0.3.7</a></li>
                         <li><a href=" https://github.com/plotters-rs/plotters ">plotters 0.3.7</a></li>
                         <li><a href=" https://github.com/lu-zero/simd_helpers ">simd_helpers 0.1.0</a></li>
-                        <li><a href=" https://github.com/DioxusLabs/taffy ">taffy 0.9.1</a></li>
+                        <li><a href=" https://github.com/DioxusLabs/taffy ">taffy 0.9.2</a></li>
                         <li><a href=" https://github.com/reem/rust-void.git ">void 1.0.2</a></li>
                     </ul>
                 <pre class="license-text">MIT License
@@ -15750,7 +15969,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/becheran/grid ">grid 0.18.0</a>
+                            <a href=" https://github.com/becheran/grid ">grid 1.0.0</a>
                     </p>
                 <pre class="license-text">MIT License
 
@@ -15808,11 +16027,11 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <h4>Used by:</h4>
                     <ul class="license-used-by">
-                        <li><a href=" https://github.com/zeenix/endi ">endi 1.1.0</a></li>
+                        <li><a href=" https://github.com/zeenix/endi ">endi 1.1.1</a></li>
                         <li><a href=" https://github.com/sunfishcode/is-terminal ">is-terminal 0.4.17</a></li>
                         <li><a href=" https://github.com/AltF02/x11-rs.git ">x11-dl 2.21.0</a></li>
                         <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep-macros 0.5.1</a></li>
-                        <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep 0.5.1</a></li>
+                        <li><a href=" https://github.com/luukvanderduim/zbus-lockstep ">zbus-lockstep 0.5.2</a></li>
                         <li><a href=" https://github.com/dbus2/zbus/ ">zvariant_utils 3.2.1</a></li>
                     </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any
@@ -15844,7 +16063,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.13</a>
+                            <a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.14</a>
                     </p>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -16264,7 +16483,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/sdroege/bytes-num-slice-cast ">byte-slice-cast 0.2.0</a>
+                            <a href=" https://github.com/sdroege/bytes-num-slice-cast ">byte-slice-cast 1.2.3</a>
                     </p>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -18542,7 +18761,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/servo-media-traits ">servo-media-traits 0.1.0</a></li>
                         <li><a href=" https://crates.io/crates/servo-media-webrtc ">servo-media-webrtc 0.1.0</a></li>
                         <li><a href=" https://crates.io/crates/servo-media ">servo-media 0.1.0</a></li>
-                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.5-0</a></li>
+                        <li><a href=" https://github.com/servo/mozjs/ ">mozjs_sys 0.140.5-5</a></li>
                         <li><a href=" https://github.com/servo/stylo ">stylo 0.9.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">selectors 0.33.0</a></li>
                         <li><a href=" https://github.com/servo/stylo ">stylo_atoms 0.9.0</a></li>
@@ -18607,7 +18826,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                         <li><a href=" https://crates.io/crates/webgpu ">webgpu 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/webxr ">webxr 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/xpath ">xpath 0.0.1</a></li>
-                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.0.2</a></li>
+                        <li><a href=" https://crates.io/crates/servoshell ">servoshell 0.0.3</a></li>
                         <li><a href=" https://crates.io/crates/task_info ">task_info 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/deny_public_fields_tests ">deny_public_fields_tests 0.0.1</a></li>
                         <li><a href=" https://crates.io/crates/malloc_size_of_tests ">malloc_size_of_tests 0.0.1</a></li>
@@ -18998,7 +19217,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.14.1</a>
+                            <a href=" https://github.com/servo/mozjs/ ">mozjs 0.14.2</a>
                     </p>
                 <pre class="license-text">Mozilla Public License Version 2.0
 &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
@@ -19403,7 +19622,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="OFL-1.1">SIL Open Font License 1.1</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.0</a>
+                            <a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.2</a>
                     </p>
                 <pre class="license-text">This Font Software is licensed under the SIL Open Font License,
 Version 1.1.
@@ -19503,7 +19722,7 @@ OTHER DEALINGS IN THE FONT SOFTWARE.
                 <h3 id="OpenSSL">OpenSSL License</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.32.3</a>
+                            <a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.34.0</a>
                     </p>
                 <pre class="license-text">/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
  * All rights reserved.
@@ -19677,7 +19896,7 @@ int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
                 <h3 id="Ubuntu-font-1.0">Ubuntu Font Licence v1.0</h3>
                     <p>
                         Used by
-                            <a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.0</a>
+                            <a href=" https://github.com/emilk/egui/tree/main/crates/epaint_default_fonts ">epaint_default_fonts 0.33.2</a>
                     </p>
                 <pre class="license-text">-------------------------------
 UBUNTU FONT LICENCE Version 1.0

--- a/support/android/apk/servoapp/build.gradle.kts
+++ b/support/android/apk/servoapp/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         minSdk = 30
         targetSdk = 33
         versionCode = generatedVersionCode
-        versionName = "0.0.2"
+        versionName = "0.0.3"
     }
 
     compileOptions {

--- a/support/openharmony/entry/oh-package.json5
+++ b/support/openharmony/entry/oh-package.json5
@@ -5,7 +5,7 @@
   "name": "servoshell",
   "description": "Please describe the basic information.",
   "main": "",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "dependencies": {
     "libservoshell.so": "file:./src/main/cpp/types/libentry"
   }

--- a/support/openharmony/oh-package.json5
+++ b/support/openharmony/oh-package.json5
@@ -8,6 +8,6 @@
   "name": "servoshell",
   "description": "Servo browser shell",
   "main": "",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "dependencies": {}
 }

--- a/support/windows/Servo.wxs.mako
+++ b/support/windows/Servo.wxs.mako
@@ -6,7 +6,7 @@
            UpgradeCode="060cd15d-eab1-4614-b438-3988e3efdcf1"
            Language="1033"
            Codepage="1252"
-           Version="0.0.2">
+           Version="0.0.3">
     <Package Id="*"
              Keywords="Installer"
              Description="Servo Tech Demo Installer"


### PR DESCRIPTION
As discussed in the tsc-channel, prepare for the next release by cutting a version on the last day of the month.

Note: The actual release would happen ~ 2 weeks from now, when the blog post for november is ready. 

This commit was produced by running `./mach release 0.0.3`.

Testing: Not required. Additional pre-release testing will happen after the version bump and before the release, with potential patches being cherry-picked to a release branch. 
