### PR TITLE
servoshell: Unset `webdriver_port` when scheduling shutdown

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use core::panic;
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::fs::{self, File, read_to_string};
 use std::io::Read;
@@ -81,7 +82,7 @@ pub(crate) struct ServoShellPreferences {
     pub userscripts_directory: Option<PathBuf>,
     /// `None` to disable WebDriver or `Some` with a port number to start a server to listen to
     /// remote WebDriver commands.
-    pub webdriver_port: Option<u16>,
+    pub webdriver_port: Cell<Option<u16>>,
     /// Whether the CLI option to enable experimental prefs was present at startup.
     pub experimental_prefs_enabled: bool,
     /// Log filter given in the `log_filter` spec as a String, if any.
@@ -110,7 +111,7 @@ impl Default for ServoShellPreferences {
             output_image_path: None,
             exit_after_stable_image: false,
             userscripts_directory: None,
-            webdriver_port: None,
+            webdriver_port: Cell::new(None),
             #[cfg(target_env = "ohos")]
             log_filter: None,
             #[cfg(target_env = "ohos")]
@@ -681,7 +682,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         initial_window_size: cmd_args.window_size.unwrap_or(default_window_size),
         screen_size_override: cmd_args.screen_size_override,
         simulate_touch_events: cmd_args.simulate_touch_events,
-        webdriver_port: cmd_args.webdriver_port,
+        webdriver_port: Cell::new(cmd_args.webdriver_port),
         output_image_path: cmd_args.output.map(|p| p.to_string_lossy().into_owned()),
         exit_after_stable_image: cmd_args.exit,
         userscripts_directory: cmd_args.userscripts,


### PR DESCRIPTION
This is the minimal possible changes after I've tried several approaches. The original problem is tricky after multi-window support, as we want to shutdown normally while not panic after no window is open to support Servodriver.

Testing: 
1. We no longer panic on https://github.com/servo/servo/blob/f0ed7506cd28701107239241154ae40b738effe4/tests/wpt/tests/webdriver/tests/classic/close_window/close.py#L87
2. Wpt can end normally instead of always **"Max retry exceeded to normally shut down. Killing instead."**

Fixes: https://github.com/servo/servo/issues/40972#issuecomment-3594308162
