### PR TITLE
script: Reverse retargeting algorithm for ShadowRoot.element[s]FromPoint.

### DIFF
--- a/components/script/dom/shadowroot.rs
+++ b/components/script/dom/shadowroot.rs
@@ -391,9 +391,7 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
             self.document.has_browsing_context(),
         ) {
             Some(e) => {
-                let retargeted_node = self
-                    .upcast::<EventTarget>()
-                    .retarget(e.upcast::<EventTarget>());
+                let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
                 retargeted_node.downcast::<Element>().map(DomRoot::from_ref)
             },
             None => None,
@@ -410,9 +408,7 @@ impl ShadowRootMethods<crate::DomTypeHolder> for ShadowRoot {
             .elements_from_point(x, y, None, self.document.has_browsing_context())
             .iter()
         {
-            let retargeted_node = self
-                .upcast::<EventTarget>()
-                .retarget(e.upcast::<EventTarget>());
+            let retargeted_node = e.upcast::<EventTarget>().retarget(self.upcast());
             if let Some(element) = retargeted_node.downcast::<Element>().map(DomRoot::from_ref) {
                 elements.push(element);
             }

--- a/tests/wpt/meta/css/cssom-view/elementsFromPoint-shadowroot.html.ini
+++ b/tests/wpt/meta/css/cssom-view/elementsFromPoint-shadowroot.html.ini
@@ -1,6 +1,3 @@
 [elementsFromPoint-shadowroot.html]
   [elementsFromPoint on the document root should not return elements in shadow trees]
     expected: FAIL
-
-  [elementsFromPoint on a shadow root should include elements in that shadow tree]
-    expected: FAIL

--- a/tests/wpt/meta/shadow-dom/DocumentOrShadowRoot-prototype-elementFromPoint.html.ini
+++ b/tests/wpt/meta/shadow-dom/DocumentOrShadowRoot-prototype-elementFromPoint.html.ini
@@ -1,10 +1,4 @@
 [DocumentOrShadowRoot-prototype-elementFromPoint.html]
-  [document.elementFromPoint and shadowRoot.elementFromPoint must return the element assigned to a slot when hit-tested text node under an element is assigned to a slot in the shadow tree and the shadow host of the slot has display: block]
-    expected: FAIL
-
-  [document.elementFromPoint and shadowRoot.elementFromPoint must return the element assigned to a slot when hit-tested text node under an element is assigned to a slot in the shadow tree and the shadow host of the slot has display: inline-block]
-    expected: FAIL
-
   [document.elementFromPoint must return the shadow host of the hit-tested element under a shadow root and shadowRoot.elementFromPoint must return the element parent of the hit-tested text node under the point when the shadow host has display: inline]
     expected: FAIL
 
@@ -23,24 +17,6 @@
   [document.elementFromPoint must return the shadow host and shadowRoot.elementFromPoint must return the slot parent of the fallback text when the hit-tested text node is a fallback content and the host has display: inline-block]
     expected: FAIL
 
-  [document.elementFromPoint, shadowRoot.elementFromPoint, innerShadow.elementFromPoint must return a child element assigned to a slot when the hit-tested text node is assigned to a slot in the shadow tree of the child element and the outer shadow host has display: inline]
-    expected: FAIL
-
-  [document.elementFromPoint, shadowRoot.elementFromPoint, innerShadow.elementFromPoint must return a child element assigned to a slot when the hit-tested text node is assigned to a slot in the shadow tree of the child element and the outer shadow host has display: block]
-    expected: FAIL
-
-  [document.elementFromPoint, shadowRoot.elementFromPoint, innerShadow.elementFromPoint must return a child element assigned to a slot when the hit-tested text node is assigned to a slot in the shadow tree of the child element and the outer shadow host has display: inline-block]
-    expected: FAIL
-
-  [document.elementFromPoint, shadowRoot.elementFromPoint, innerShadow.elementFromPoint must return a child element with its own shadow tree assigned to a slot when the hit-tested text node is its direct child and the outer shadow host has display: inline]
-    expected: FAIL
-
-  [document.elementFromPoint, shadowRoot.elementFromPoint, innerShadow.elementFromPoint must return a child element with its own shadow tree assigned to a slot when the hit-tested text node is its direct child and the outer shadow host has display: block]
-    expected: FAIL
-
-  [document.elementFromPoint, shadowRoot.elementFromPoint, innerShadow.elementFromPoint must return a child element with its own shadow tree assigned to a slot when the hit-tested text node is its direct child and the outer shadow host has display: inline-block]
-    expected: FAIL
-
   [document.elementFromPoint, shadowRoot.elementFromPoint must return a child element with its own shadow tree assigned to a slot when the hit-tested text node is a child of another element and innerShadow.elementFromPoint must return the parent element of the hit-tested text node under it when the outer shadow host has display: inline]
     expected: FAIL
 
@@ -48,24 +24,6 @@
     expected: FAIL
 
   [document.elementFromPoint, shadowRoot.elementFromPoint must return a child element with its own shadow tree assigned to a slot when the hit-tested text node is a child of another element and innerShadow.elementFromPoint must return the parent element of the hit-tested text node under it when the outer shadow host has display: inline-block]
-    expected: FAIL
-
-  [document.elementsFromPoint and shadow.elementsFromPoint must return the shadow host and its ancestors of the hit-tested text node when the hit-tested text node is a direct child of the root and the host has display: inline]
-    expected: FAIL
-
-  [document.elementsFromPoint and shadow.elementsFromPoint must return the shadow host and its ancestors of the hit-tested text node when the hit-tested text node is a direct child of the root and the host has display: block]
-    expected: FAIL
-
-  [document.elementsFromPoint and shadow.elementsFromPoint must return the shadow host and its ancestors of the hit-tested text node when the hit-tested text node is a direct child of the root and the host has display: inline-block]
-    expected: FAIL
-
-  [document.elementsFromPoint and shadowRoot.elementsFromPoint must return the shadow host and its ancestors when the hit-tested text node is assigned to a slot and the host has display: inline]
-    expected: FAIL
-
-  [document.elementsFromPoint and shadowRoot.elementsFromPoint must return the shadow host and its ancestors when the hit-tested text node is assigned to a slot and the host has display: block]
-    expected: FAIL
-
-  [document.elementsFromPoint and shadowRoot.elementsFromPoint must return the shadow host and its ancestors when the hit-tested text node is assigned to a slot and the host has display: inline-block]
     expected: FAIL
 
   [document.elementsFromPoint and shadowRoot.elementsFromPoint must return the element assigned to a slot and its non-shadow ancestors when hit-tested text node under an element is assigned to a slot in the shadow tree and the shadow host of the slot has display: inline]
@@ -93,13 +51,4 @@
     expected: FAIL
 
   [document.elementsFromPoint must return the shadow host and its ancestors and shadowRoot.elementsFromPoint must return the slot parent of the fallback text and its non-shadow ancestors when the hit-tested text node is a fallback content and the host has display: inline-block]
-    expected: FAIL
-
-  [shadowRoot.elementsFromPoint must behave the same with document.elementsFromPoint regarding HTML element]
-    expected: FAIL
-
-  [elementsFromPoint should return all elements under a point, even when context object is not connected]
-    expected: FAIL
-
-  [document.elementFromPoint and shadowRoot.elementFromPoint must return the element assigned to a slot when hit-tested text node under an element is assigned to a slot in the shadow tree and the shadow host of the slot has display: inline]
     expected: FAIL


### PR DESCRIPTION
This implementation is not actually specified (see #40973 and https://github.com/w3c/csswg-drafts/issues/556), but the implementation that we have is backwards. Other retargeting uses that describe "retarget _something_ against _another thing_" map to `something.retarget(another_thing)`, but what the current code was doing for element[s]FromPoint was the equivalent of "retarget _this_ against each element", which is obviously wrong.

Testing: Newly-passing tests.