### PR TITLE
selectors::Element::parent() shouldn't cross shadow tree boundary

### DIFF
--- a/components/script/layout_dom/element.rs
+++ b/components/script/layout_dom/element.rs
@@ -133,10 +133,7 @@ impl<'dom> ServoLayoutElement<'dom> {
 
     /// Returns the parent element of this element, if it has one.
     fn parent_element(&self) -> Option<Self> {
-        self.element
-            .upcast()
-            .composed_parent_node_ref()
-            .and_then(|node| node.downcast().map(ServoLayoutElement::from_layout_js))
+        self.as_node().parent_element()
     }
 
     fn is_root(&self) -> bool {
@@ -218,9 +215,7 @@ impl<'dom> style::dom::TElement for ServoLayoutElement<'dom> {
             return self.pseudo_element_originating_element();
         }
 
-        // FIXME: By default the inheritance parent would be the Self::parent_element
-        //        but probably we should use the flattened tree parent.
-        self.parent_element()
+        self.traversal_parent()
     }
 
     fn is_html_element(&self) -> bool {

--- a/tests/wpt/meta/css/css-lists/counter-list-item-slot-order.html.ini
+++ b/tests/wpt/meta/css/css-lists/counter-list-item-slot-order.html.ini
@@ -1,2 +1,0 @@
-[counter-list-item-slot-order.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/css-nesting/host-nesting-003.html.ini
+++ b/tests/wpt/meta/css/css-nesting/host-nesting-003.html.ini
@@ -1,2 +1,0 @@
-[host-nesting-003.html]
-  expected: FAIL

--- a/tests/wpt/meta/css/selectors/is-where-shadow.html.ini
+++ b/tests/wpt/meta/css/selectors/is-where-shadow.html.ini
@@ -1,6 +1,3 @@
 [is-where-shadow.html]
   [:is() inside :host-context()]
     expected: FAIL
-
-  [:is() inside ::slotted()]
-    expected: FAIL

--- a/tests/wpt/meta/html/rendering/the-details-element/details-blockification.html.ini
+++ b/tests/wpt/meta/html/rendering/the-details-element/details-blockification.html.ini
@@ -1,0 +1,3 @@
+[details-blockification.html]
+  [Summary and content should have display:block computed value]
+    expected: FAIL


### PR DESCRIPTION
ServoLayoutElement::parent_element() method shouldn't cross shadow tree boundary.
`inheritance_parent` uses `traversal_parent`

Testing: 
`tests/wpt/meta/css/css-lists/counter-list-item-slot-order.html.ini`
`tests/wpt/meta/css/css-nesting/host-nesting-003.html.ini`
`tests/wpt/meta/css/selectors/is-where-shadow.html.ini`
and manual test in the below issue
The regression in `tests/wpt/meta/html/rendering/the-details-element/details-blockification.html.ini` has 1 more cause https://github.com/servo/servo/pull/40977#issuecomment-3608471378

Fixes: [#40896](https://github.com/servo/servo/issues/40896)

cc: @xiaochengh 