### PR TITLE
servoshell: Explicitly add the  `Win32_System_Console` feature to `windows-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ webxr-api = { path = "components/shared/webxr" }
 wgpu-core = "26"
 wgpu-types = "26"
 winapi = "0.3"
-windows-sys = "0.61"
+windows-sys = { version = "0.61", features = ["Win32_System_Console"] }
 winit = "0.30.12"
 wio = "0.2"
 wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.68" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ webxr-api = { path = "components/shared/webxr" }
 wgpu-core = "26"
 wgpu-types = "26"
 winapi = "0.3"
-windows-sys = { version = "0.61", features = ["Win32_System_Console"] }
+windows-sys = "0.61"
 winit = "0.30.12"
 wio = "0.2"
 wr_malloc_size_of = { git = "https://github.com/servo/webrender", branch = "0.68" }

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -126,7 +126,7 @@ sig = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 libservo = { path = "../../components/servo", features = ["no-wgl"] }
-windows-sys = { workspace = true, features = ["Win32_Graphics_Gdi"] }
+windows-sys = { workspace = true, features = ["Win32_Graphics_Gdi", "Win32_System_Console"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-app-kit = { version = "0.3.2", default-features = false, features = [


### PR DESCRIPTION
In #40961, we start to use `windows_sys::Win32::System::Console;`. This is gated behind `Win32_System_Console` feature. We didn't have the problem merging that one, because it was luckily enabled by some other dependencies. But @dependabot can act weird: #40979, which would break the build from time to time.

See https://github.com/servo/servo/actions/runs/19816434323/job/56768628158.

Fixes: Treacherous bug that is only revealed when other crates's `windows-sys` is downgraded.
