### PR TITLE
html: Track the script/UA initiated media `seek` request

### DIFF
--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/preserves-pitch.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/preserves-pitch.html.ini
@@ -1,4 +1,5 @@
 [preserves-pitch.html]
+  expected: TIMEOUT
   [Test that preservesPitch is present and unprefixed.]
     expected: FAIL
 
@@ -6,13 +7,16 @@
     expected: FAIL
 
   [Speed-ups should change the pitch when preservesPitch=false]
-    expected: FAIL
+    expected: NOTRUN
 
   [Slow-downs should change the pitch when preservesPitch=false]
-    expected: FAIL
+    expected: NOTRUN
 
   [The default playbackRate should not affect pitch, even with preservesPitch=false]
-    expected: FAIL
+    expected: TIMEOUT
+
+  [Speed-ups should not change the pitch when preservesPitch=true]
+    expected: NOTRUN
 
   [Slow-downs should not change the pitch when preservesPitch=true]
-    expected: FAIL
+    expected: NOTRUN


### PR DESCRIPTION
The low-level media `seek` request could be initiated by script (DOM method call or setting of an IDL attribute), by the user agent (seeking data) or by the media engine itself (e.g. gst_play_set_rate()).
And to distinguish between them we will use the latest seek position (in seconds) to be able abort processing the `seek` algorithm steps (13-17) for a `seek` request initiated by the media engine.

See https://html.spec.whatwg.org/multipage/#dom-media-seek

If the `seeking` is in progress, any callback which affects the current playback position (`position changed`, `end of the playback`) shouldn't be processed (event marshalling over IPC router is non-state conditional).

Testing: Regression in the following test causes by gstreamer issue when the `gst_play_set_rate()` overrides the latest seek requested position unconditionally and the user agent receives the `seek completion` event with the unexpected seek position (0.5+ instead of 0.0).
- html/semantics/embedded-content/media-elements/preserves-pitch.html

See https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4762

Fixes: https://github.com/servo/servo/issues/37057