### PR TITLE
libservo: Finish the `SimpleDialog` API

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -39,7 +39,7 @@ use dom_struct::dom_struct;
 use embedder_traits::user_content_manager::{UserContentManager, UserScript};
 use embedder_traits::{
     AlertResponse, ConfirmResponse, EmbedderMsg, JavaScriptEvaluationError, PromptResponse,
-    ScriptToEmbedderChan, SimpleDialog, Theme, UntrustedNodeAddress, ViewportDetails,
+    ScriptToEmbedderChan, SimpleDialogRequest, Theme, UntrustedNodeAddress, ViewportDetails,
     WebDriverJSResult, WebDriverLoadStatus,
 };
 use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect};
@@ -1014,7 +1014,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
         let (sender, receiver) =
             ProfiledGenericChannel::channel(self.global().time_profiler_chan().clone()).unwrap();
-        let dialog = SimpleDialog::Alert {
+        let dialog = SimpleDialogRequest::Alert {
             id: self.Document().embedder_controls().next_control_id(),
             message: message.to_string(),
             response_sender: sender,
@@ -1047,7 +1047,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         // the user to respond with a positive or negative response.
         let (sender, receiver) =
             ProfiledGenericChannel::channel(self.global().time_profiler_chan().clone()).unwrap();
-        let dialog = SimpleDialog::Confirm {
+        let dialog = SimpleDialogRequest::Confirm {
             id: self.Document().embedder_controls().next_control_id(),
             message: message.to_string(),
             response_sender: sender,
@@ -1098,7 +1098,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         // defaulted to the value given by default.
         let (sender, receiver) =
             ProfiledGenericChannel::channel(self.global().time_profiler_chan().clone()).unwrap();
-        let dialog = SimpleDialog::Prompt {
+        let dialog = SimpleDialogRequest::Prompt {
             id: self.Document().embedder_controls().next_control_id(),
             message: message.to_string(),
             default: default.to_string(),

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -62,9 +62,9 @@ pub use crate::servo::{Servo, ServoBuilder, run_content_process};
 pub use crate::servo_delegate::{ServoDelegate, ServoError};
 pub use crate::webview::{WebView, WebViewBuilder};
 pub use crate::webview_delegate::{
-    AllowOrDenyRequest, AuthenticationRequest, ColorPicker, ContextMenu, EmbedderControl,
-    FilePicker, InputMethodControl, NavigationRequest, PermissionRequest, SelectElement,
-    WebResourceLoad, WebViewDelegate,
+    AlertDialog, AllowOrDenyRequest, AuthenticationRequest, ColorPicker, ConfirmDialog,
+    ContextMenu, EmbedderControl, FilePicker, InputMethodControl, NavigationRequest,
+    PermissionRequest, PromptDialog, SelectElement, SimpleDialog, WebResourceLoad, WebViewDelegate,
 };
 
 // Since WebXR is guarded by conditional compilation it is exported via submodule.

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -468,7 +468,7 @@ impl Servo {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     webview.delegate().show_embedder_control(
                         webview,
-                        EmbedderControl::SimpleDialog(simple_dialog),
+                        EmbedderControl::SimpleDialog(simple_dialog.into()),
                     );
                 }
             },

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -518,7 +518,7 @@ fn test_show_and_hide_ime() {
 #[test]
 fn test_alert_dialog() {
     test_simple_dialog("window.alert('Alert');", |dialog| {
-        let SimpleDialog::Alert { .. } = dialog else {
+        let SimpleDialog::Alert(..) = dialog else {
             unreachable!("Expected dialog to be a SimpleDialog::Alert");
         };
         assert_eq!(dialog.message(), "Alert");
@@ -528,7 +528,7 @@ fn test_alert_dialog() {
 #[test]
 fn test_prompt_dialog() {
     test_simple_dialog("window.prompt('Prompt');", |dialog| {
-        let SimpleDialog::Prompt { .. } = dialog else {
+        let SimpleDialog::Prompt(..) = dialog else {
             unreachable!("Expected dialog to be a SimpleDialog::Prompt");
         };
         assert_eq!(dialog.message(), "Prompt");
@@ -538,7 +538,7 @@ fn test_prompt_dialog() {
 #[test]
 fn test_confirm_dialog() {
     test_simple_dialog("window.confirm('Confirm');", |dialog| {
-        let SimpleDialog::Confirm { .. } = dialog else {
+        let SimpleDialog::Confirm(..) = dialog else {
             unreachable!("Expected dialog to be a SimpleDialog::Confirm");
         };
         assert_eq!(dialog.message(), "Confirm");

--- a/components/shared/embedder/embedder_controls.rs
+++ b/components/shared/embedder/embedder_controls.rs
@@ -1,0 +1,208 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use base::Epoch;
+use base::generic_channel::GenericSender;
+use base::id::{PipelineId, WebViewId};
+use bitflags::bitflags;
+use serde::{Deserialize, Serialize};
+use url::Url;
+use uuid::Uuid;
+
+use crate::{InputMethodType, RgbColor};
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+pub struct EmbedderControlId {
+    pub webview_id: WebViewId,
+    pub pipeline_id: PipelineId,
+    pub index: Epoch,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum EmbedderControlRequest {
+    /// Indicates that the user has activated a `<select>` element.
+    SelectElement(Vec<SelectElementOptionOrOptgroup>, Option<usize>),
+    /// Indicates that the user has activated a `<input type=color>` element.
+    ColorPicker(RgbColor),
+    /// Indicates that the user has activated a `<input type=file>` element.
+    FilePicker(FilePickerRequest),
+    /// Indicates that the the user has activated a text or input control that should show
+    /// an IME.
+    InputMethod(InputMethodRequest),
+    /// Indicates that the the user has triggered the display of a context menu.
+    ContextMenu(ContextMenuRequest),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SelectElementOption {
+    /// A unique identifier for the option that can be used to select it.
+    pub id: usize,
+    /// The label that should be used to display the option to the user.
+    pub label: String,
+    /// Whether or not the option is selectable
+    pub is_disabled: bool,
+}
+
+/// Represents the contents of either an `<option>` or an `<optgroup>` element
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum SelectElementOptionOrOptgroup {
+    Option(SelectElementOption),
+    Optgroup {
+        label: String,
+        options: Vec<SelectElementOption>,
+    },
+}
+
+/// Request to present a context menu to the user. This is triggered by things like
+/// right-clicking on web content.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ContextMenuRequest {
+    pub element_info: ContextMenuElementInformation,
+    pub items: Vec<ContextMenuItem>,
+}
+
+/// An item in a context menu.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ContextMenuItem {
+    Item {
+        label: String,
+        action: ContextMenuAction,
+        enabled: bool,
+    },
+    Separator,
+}
+
+/// A particular action associated with a [`ContextMenuItem`]. These actions are
+/// context-sensitive, which means that some of them are available only for some
+/// page elements.
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub enum ContextMenuAction {
+    GoBack,
+    GoForward,
+    Reload,
+
+    CopyLink,
+    OpenLinkInNewWebView,
+
+    CopyImageLink,
+    OpenImageInNewView,
+
+    Cut,
+    Copy,
+    Paste,
+    SelectAll,
+}
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
+    pub struct ContextMenuElementInformationFlags: u8 {
+        /// Whether or not the element this context menu was activated for was a link.
+        const Link = 1 << 1;
+        /// Whether or not the element this context menu was activated for was an image.
+        const Image = 1 << 2;
+        /// Whether or not the element this context menu was activated for was editable
+        /// text.
+        const EditableText = 1 << 3;
+        /// Whether or not the element this context menu was activated for was covered by
+        /// a selection.
+        const Selection = 1 << 4;
+    }
+}
+
+/// Information about the element that a context menu was activated for. values which
+/// do not apply to this element will be `None`.
+///
+/// Note that an element might be both an image and a link, if the element is an `<img>`
+/// tag nested inside of a `<a>` tag.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct ContextMenuElementInformation {
+    pub flags: ContextMenuElementInformationFlags,
+    pub link_url: Option<Url>,
+    pub image_url: Option<Url>,
+}
+
+/// Request to present an IME to the user when an editable element is focused. If `type` is
+/// [`InputMethodType::Text`], then the `text` parameter specifies the pre-existing text content and
+/// `insertion_point` the zero-based index into the string of the insertion point.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InputMethodRequest {
+    pub input_method_type: InputMethodType,
+    pub text: String,
+    pub insertion_point: Option<u32>,
+    pub multiline: bool,
+}
+
+/// Filter for file selection;
+/// the `String` content is expected to be extension (e.g, "doc", without the prefixing ".")
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct FilterPattern(pub String);
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FilePickerRequest {
+    pub origin: String,
+    pub current_paths: Vec<PathBuf>,
+    pub filter_patterns: Vec<FilterPattern>,
+    pub allow_select_multiple: bool,
+    pub accept_current_paths_for_testing: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum EmbedderControlResponse {
+    SelectElement(Option<usize>),
+    ColorPicker(Option<RgbColor>),
+    FilePicker(Option<Vec<SelectedFile>>),
+    ContextMenu(Option<ContextMenuAction>),
+}
+
+/// Response to file selection request
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SelectedFile {
+    pub id: Uuid,
+    pub filename: PathBuf,
+    pub modified: SystemTime,
+    pub size: u64,
+    // https://w3c.github.io/FileAPI/#dfn-type
+    pub type_string: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub enum SimpleDialogRequest {
+    Alert {
+        id: EmbedderControlId,
+        message: String,
+        response_sender: GenericSender<AlertResponse>,
+    },
+    Confirm {
+        id: EmbedderControlId,
+        message: String,
+        response_sender: GenericSender<ConfirmResponse>,
+    },
+    Prompt {
+        id: EmbedderControlId,
+        message: String,
+        default: String,
+        response_sender: GenericSender<PromptResponse>,
+    },
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+pub enum AlertResponse {
+    Ok,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+pub enum ConfirmResponse {
+    Ok,
+    Cancel,
+}
+
+#[derive(Deserialize, PartialEq, Serialize)]
+pub enum PromptResponse {
+    Ok(String),
+    Cancel,
+}

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -172,24 +172,11 @@ impl PlatformWindow for EmbeddedPlatformWindow {
                 self.host.on_ime_show(input_method_control);
             },
             EmbedderControl::SimpleDialog(simple_dialog) => match simple_dialog {
-                SimpleDialog::Alert {
-                    message,
-                    response_sender,
-                    ..
-                } => {
-                    self.host.show_alert(message);
-                    let _ = response_sender.send(AlertResponse::Ok);
+                SimpleDialog::Alert(alert_dialog) => {
+                    self.host.show_alert(alert_dialog.message().into());
+                    alert_dialog.confirm();
                 },
-                SimpleDialog::Confirm {
-                    response_sender, ..
-                } => {
-                    let _ = response_sender.send(Default::default());
-                },
-                SimpleDialog::Prompt {
-                    response_sender, ..
-                } => {
-                    let _ = response_sender.send(Default::default());
-                },
+                _ => {}, // The drop implementation will send the default response.
             },
             _ => {},
         }

--- a/tests/wpt/meta/webdriver/tests/classic/send_alert_text/send.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/send_alert_text/send.py.ini
@@ -2,17 +2,5 @@
   [test_chained_alert_element_not_interactable[alert\]]
     expected: [PASS, FAIL]
 
-  [test_send_alert_text[\]]
-    expected: FAIL
-
-  [test_send_alert_text[Federer\]]
-    expected: FAIL
-
-  [test_send_alert_text[ Fed erer \]]
-    expected: FAIL
-
-  [test_send_alert_text[Fed\\terer\]]
-    expected: FAIL
-
   [test_chained_alert_element_not_interactable[confirm\]]
     expected: [PASS, FAIL]


### PR DESCRIPTION
Finish exposing the `SimpleDialog` API in libservo, abstracting away the
response senders into structures with methods. In addition, add a
default behavior so that embedders do not have to explicitly send a
reponse when dialogs are ignored. This makes the API much harder to
misuse.

Finally, the WebDriver API for setting the prompt dialog entry
field is corrected to actually set that value rather than the message.
This makes sense as part of this change as the type safety of the
structures makes setting the message (the old, wrong behavior) harder
 to implement.

Testing: This causes a WebDriver conformance test to start passing.
