### PR TITLE
layout: Handle stacking context tree outlines during display list building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7788,7 +7788,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.33.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8095,7 +8095,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8634,7 +8634,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8691,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8700,12 +8700,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
 
 [[package]]
 name = "stylo_derive"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8717,7 +8717,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8726,7 +8726,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8743,12 +8743,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
 
 [[package]]
 name = "stylo_traits"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9162,7 +9162,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9175,7 +9175,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#ae78004b3056c90b66dbba4d92edc0edbc24bc49"
+source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
Instead of eagerly adding outlines to their own stacking context tree
section, handle them as part of display list building. This means that
the stacking context tree does not need to be rebuilt when outlines on
the page change.

Testing: This is a speculative performance fix, behavior is covered by
existing tests.
Fixes: #40957.
