### PR TITLE
build(deps): Use crates.io release of mozjs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5482,7 +5482,8 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.2"
-source = "git+https://github.com/servo/mozjs#256cc579e514bc3159d987c0cdf167e8c2820235"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34bf8b52709b8527798f16a83fbda66e4a1df86627f15d1c9df90fc8363ef1c4"
 dependencies = [
  "bindgen",
  "cc",
@@ -5494,8 +5495,9 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.140.5-5"
-source = "git+https://github.com/servo/mozjs#256cc579e514bc3159d987c0cdf167e8c2820235"
+version = "0.140.5-6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec814a703a34e6f940cba08ba56ca7b0c95d31fa9191858888265ce353e6540e"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ imsz = "0.4"
 indexmap = { version = "2.11.4", features = ["std"] }
 ipc-channel = "0.20.2"
 itertools = "0.14"
-js = { package = "mozjs", git = "https://github.com/servo/mozjs", default-features = false, features = ["libz-sys", "intl"] }
+js = { package = "mozjs", version = "0.14.2", default-features = false, features = ["libz-sys", "intl"] }
 keyboard-types = { version = "0.8.3", features = ["serde", "webdriver"] }
 kurbo = { version = "0.12", features = ["euclid"] }
 layout_api = { path = "components/shared/layout" }


### PR DESCRIPTION
Using mozjs from crates.io should improve the clean build speed, since the initial download from crates.io is much smaller than cloning the whole mozjs git repository.

Testing: This is a normal dependency update
