### PR TITLE
Remove unused `ipc-channel` dependency in `layout` and `background_hang_monitor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,7 +736,6 @@ dependencies = [
  "backtrace",
  "base",
  "crossbeam-channel",
- "ipc-channel",
  "libc",
  "log",
  "mach2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,6 @@ name = "background_hang_monitor_api"
 version = "0.0.1"
 dependencies = [
  "base",
- "ipc-channel",
  "serde",
 ]
 
@@ -5033,7 +5032,6 @@ dependencies = [
  "fonts",
  "fonts_traits",
  "html5ever",
- "ipc-channel",
  "libc",
  "malloc_size_of_derive",
  "net_traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4980,7 +4980,6 @@ dependencies = [
  "html5ever",
  "icu_locid",
  "icu_segmenter",
- "ipc-channel",
  "itertools 0.14.0",
  "kurbo 0.12.0",
  "layout_api",

--- a/components/background_hang_monitor/Cargo.toml
+++ b/components/background_hang_monitor/Cargo.toml
@@ -18,7 +18,6 @@ background_hang_monitor_api = { workspace = true }
 backtrace = { workspace = true }
 base = { workspace = true }
 crossbeam-channel = { workspace = true }
-ipc-channel = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 rustc-demangle = { version = "0.1", optional = true }

--- a/components/background_hang_monitor/tests/hang_monitor_tests.rs
+++ b/components/background_hang_monitor/tests/hang_monitor_tests.rs
@@ -16,7 +16,6 @@ use background_hang_monitor_api::{
 };
 use base::generic_channel;
 use base::id::TEST_SCRIPT_EVENT_LOOP_ID;
-use ipc_channel::ipc;
 
 static SERIAL: Mutex<()> = Mutex::new(());
 

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -31,7 +31,6 @@ fonts_traits = { workspace = true }
 html5ever = { workspace = true }
 icu_locid = { workspace = true }
 icu_segmenter = { workspace = true }
-ipc-channel = { workspace = true }
 itertools = { workspace = true }
 kurbo = { workspace = true }
 layout_api = { workspace = true }

--- a/components/shared/background_hang_monitor/Cargo.toml
+++ b/components/shared/background_hang_monitor/Cargo.toml
@@ -15,5 +15,4 @@ doctest = false
 
 [dependencies]
 base = { workspace = true }
-ipc-channel = { workspace = true }
 serde = { workspace = true }

--- a/components/shared/layout/Cargo.toml
+++ b/components/shared/layout/Cargo.toml
@@ -25,7 +25,6 @@ euclid = { workspace = true }
 fonts = { path = "../../fonts" }
 fonts_traits = { workspace = true }
 html5ever = { workspace = true }
-ipc-channel = { workspace = true }
 libc = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }


### PR DESCRIPTION
`layout` and `background_hang_monitor` do not need `ipc-channel` anymore.

Testing: It compiles.
