### PR TITLE
ci: Add timeout to ohos-speedometer

### DIFF
--- a/.github/workflows/ohos.yml
+++ b/.github/workflows/ohos.yml
@@ -293,6 +293,7 @@ jobs:
       - name: Run speedometer
         id: BencherRun
         run: uv run ./etc/ci/scenario/servo_speedometer.py ${{ inputs.profile }}
+        timeout-minutes: 10
         continue-on-error: true
       - name: Handle failed speedometer
         if: ${{ steps.BencherRun.outcome == 'failure' }}


### PR DESCRIPTION
The script seems to get sometimes stuck, so add a timeout that prevents needing to wait until the default timeout is hit.
The timeouts might be related to the script change from https://github.com/servo/servo/pull/40798.

Testing: Not needed. 

