### PR TITLE
Block and report CSP violations for javascript: URLs in window.open

### DIFF
--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -624,9 +624,8 @@ impl ScriptThread {
     }
 
     /// <https://html.spec.whatwg.org/multipage/#navigate-to-a-javascript:-url>
-    pub(crate) fn navigate_to_javascript_url(
+    pub(crate) fn can_navigate_to_javascript_url(
         global: &GlobalScope,
-        containing_global: &GlobalScope,
         load_data: &mut LoadData,
         container: Option<&Element>,
         can_gc: CanGc,
@@ -644,6 +643,20 @@ impl ScriptThread {
             .get_csp_list()
             .should_navigation_request_be_blocked(global, load_data, container, can_gc)
         {
+            return false;
+        }
+
+        true
+    }
+
+    pub(crate) fn navigate_to_javascript_url(
+        global: &GlobalScope,
+        containing_global: &GlobalScope,
+        load_data: &mut LoadData,
+        container: Option<&Element>,
+        can_gc: CanGc,
+    ) -> bool {
+        if !Self::can_navigate_to_javascript_url(global, load_data, container, can_gc) {
             return false;
         }
 

--- a/tests/wpt/meta/content-security-policy/script-src/javascript-window-open-blocked.html.ini
+++ b/tests/wpt/meta/content-security-policy/script-src/javascript-window-open-blocked.html.ini
@@ -1,4 +1,0 @@
-[javascript-window-open-blocked.html]
-  expected: TIMEOUT
-  [Check that a securitypolicyviolation event is fired]
-    expected: NOTRUN

--- a/tests/wpt/meta/content-security-policy/unsafe-hashes/javascript_src_denied_missing_unsafe_hashes-window_open.html.ini
+++ b/tests/wpt/meta/content-security-policy/unsafe-hashes/javascript_src_denied_missing_unsafe_hashes-window_open.html.ini
@@ -1,3 +1,0 @@
-[javascript_src_denied_missing_unsafe_hashes-window_open.html]
-  [Test that the javascript: src is not allowed to run]
-    expected: FAIL

--- a/tests/wpt/meta/content-security-policy/unsafe-hashes/javascript_src_denied_wrong_hash-window_open.html.ini
+++ b/tests/wpt/meta/content-security-policy/unsafe-hashes/javascript_src_denied_wrong_hash-window_open.html.ini
@@ -1,3 +1,0 @@
-[javascript_src_denied_wrong_hash-window_open.html]
-  [Test that the javascript: src is not allowed to run]
-    expected: FAIL


### PR DESCRIPTION
Previously, when window.open() was called with a javascript: URL, the script would execute unconditionally without any CSP enforcement. The CSP list was not propagated from the opener to the newly opened document.

This commit fixes two issues:

1. Propagate CSP from opener to new document The CSP list from the existing (opener) document is now copied to the target document before navigation, ensuring CSP policies are enforced.

2. Report CSP violations to the correct window Per the CSP spec, violations should be reported to the navigation request's client (the opener window), not the target window. To achieve this, we check CSP early in window.open() while both windows are accessible, before entering the normal navigation flow where only the target window is available.


Testing: new wpt successes:
- `content-security-policy/script-src/javascript-window-open-blocked.html`
- `content-security-policy/unsafe-hashes/javascript_src_denied_missing_unsafe_hashes-window_open.html`
- `content-security-policy/unsafe-hashes/javascript_src_denied_wrong_hash-window_open.html`


Fixes: part of #36437
