### PR TITLE
CI: Set default timeouts for ohos ci webdriver interactions

### DIFF
--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -82,7 +82,7 @@ def create_driver(timeout: int = 10) -> webdriver.Remote:
     options = ArgOptions()
     options.set_capability("browserName", "servo")
     # Wait at most 10 minutes for a script to execute and 5 minutes and 1.3 minutes for element finding
-    options.timeouts = {"script": 36000, "pageLoad": 18000, "implicit": 5000}
+    options.timeouts = {"script": 600, "pageLoad": 600, "implicit": 600}
     driver = None
     start_time = time.time()
     while driver is None and time.time() - start_time < timeout:

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -81,6 +81,8 @@ def create_driver(timeout: int = 10) -> webdriver.Remote:
     print("Trying to create driver")
     options = ArgOptions()
     options.set_capability("browserName", "servo")
+    # Wait at most 10 minutes for a script to execute and 5 minutes and 1.3 minutes for element finding
+    options.timeouts = {"script": 36000, "pageLoad": 18000, "implicit": 5000}
     driver = None
     start_time = time.time()
     while driver is None and time.time() - start_time < timeout:


### PR DESCRIPTION
The default timeouts seem to be quite large for things such as script
execution. We set a common timeout to hopefully fix the CI problems.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: This just sets timeouts and the default ones should be large enough to allow all the scripts to still execute.
