### PR TITLE
Use 'GenericSender' and 'GenericReceiver' for bluetooth main component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,6 @@ dependencies = [
  "blurmock",
  "blurz",
  "embedder_traits",
- "ipc-channel",
  "log",
  "rand 0.9.2",
  "servo_config",

--- a/components/bluetooth/Cargo.toml
+++ b/components/bluetooth/Cargo.toml
@@ -17,7 +17,6 @@ bitflags = { workspace = true }
 bluetooth_traits = { workspace = true }
 blurmock = { version = "0.1.2", optional = true }
 embedder_traits = { workspace = true }
-ipc-channel = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 servo_config = { path = "../config" }

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -362,7 +362,7 @@ pub struct Constellation<STF, SWF> {
     /// An IPC channel for the constellation to send messages to the
     /// bluetooth thread.
     #[cfg(feature = "bluetooth")]
-    pub(crate) bluetooth_ipc_sender: IpcSender<BluetoothRequest>,
+    pub(crate) bluetooth_ipc_sender: GenericSender<BluetoothRequest>,
 
     /// A map of origin to sender to a Service worker manager.
     sw_managers: HashMap<ImmutableOrigin, GenericSender<ServiceWorkerMsg>>,
@@ -518,7 +518,7 @@ pub struct InitialConstellationState {
 
     /// A channel to the bluetooth thread.
     #[cfg(feature = "bluetooth")]
-    pub bluetooth_thread: IpcSender<BluetoothRequest>,
+    pub bluetooth_thread: GenericSender<BluetoothRequest>,
 
     /// A proxy to the `SystemFontService` which manages the list of system fonts.
     pub system_font_service: Arc<SystemFontServiceProxy>,

--- a/components/script/dom/bluetooth/bluetooth.rs
+++ b/components/script/dom/bluetooth/bluetooth.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::{BluetoothError, BluetoothRequest, GATTType};
 use bluetooth_traits::{BluetoothResponse, BluetoothResponseResult};
 use bluetooth_traits::blocklist::{Blocklist, uuid_is_blocklisted};
@@ -154,7 +155,7 @@ impl Bluetooth {
         reflect_dom_object(Box::new(Bluetooth::new_inherited()), global, can_gc)
     }
 
-    fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetooth/bluetoothdevice.rs
+++ b/components/script/dom/bluetooth/bluetoothdevice.rs
@@ -6,12 +6,12 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::{
     BluetoothCharacteristicMsg, BluetoothDescriptorMsg, BluetoothRequest, BluetoothResponse,
     BluetoothServiceMsg,
 };
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
 use profile_traits::ipc;
 
 use crate::conversions::Convert;
@@ -197,7 +197,7 @@ impl BluetoothDevice {
         bt_descriptor
     }
 
-    fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetooth/bluetoothpermissionresult.rs
+++ b/components/script/dom/bluetooth/bluetoothpermissionresult.rs
@@ -4,9 +4,9 @@
 
 use std::rc::Rc;
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse};
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothPermissionResultBinding::BluetoothPermissionResultMethods;
@@ -61,7 +61,7 @@ impl BluetoothPermissionResult {
         self.global().as_window().Navigator().Bluetooth()
     }
 
-    pub(crate) fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    pub(crate) fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattcharacteristic.rs
@@ -4,10 +4,10 @@
 
 use std::rc::Rc;
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::blocklist::{Blocklist, uuid_is_blocklisted};
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse, GATTType};
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothCharacteristicPropertiesBinding::BluetoothCharacteristicPropertiesMethods;
@@ -84,7 +84,7 @@ impl BluetoothRemoteGATTCharacteristic {
         )
     }
 
-    fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattdescriptor.rs
@@ -4,10 +4,10 @@
 
 use std::rc::Rc;
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::blocklist::{Blocklist, uuid_is_blocklisted};
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse};
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTCharacteristicBinding::BluetoothRemoteGATTCharacteristicMethods;
@@ -71,7 +71,7 @@ impl BluetoothRemoteGATTDescriptor {
         )
     }
 
-    fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetooth/bluetoothremotegattserver.rs
+++ b/components/script/dom/bluetooth/bluetoothremotegattserver.rs
@@ -5,9 +5,9 @@
 use std::cell::Cell;
 use std::rc::Rc;
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::{BluetoothRequest, BluetoothResponse, GATTType};
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
 
 use crate::dom::bindings::codegen::Bindings::BluetoothDeviceBinding::BluetoothDeviceMethods;
 use crate::dom::bindings::codegen::Bindings::BluetoothRemoteGATTServerBinding::BluetoothRemoteGATTServerMethods;
@@ -51,7 +51,7 @@ impl BluetoothRemoteGATTServer {
         )
     }
 
-    fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 

--- a/components/script/dom/bluetooth/testrunner.rs
+++ b/components/script/dom/bluetooth/testrunner.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::generic_channel::GenericSender;
 use bluetooth_traits::BluetoothRequest;
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
 use profile_traits::ipc;
 
 use crate::conversions::Convert;
@@ -33,7 +33,7 @@ impl TestRunner {
         reflect_dom_object(Box::new(TestRunner::new_inherited()), global, can_gc)
     }
 
-    fn get_bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    fn get_bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.global().as_window().bluetooth_thread()
     }
 }

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -332,7 +332,7 @@ pub(crate) struct Window {
     /// A handle for communicating messages to the bluetooth thread.
     #[no_trace]
     #[cfg(feature = "bluetooth")]
-    bluetooth_thread: IpcSender<BluetoothRequest>,
+    bluetooth_thread: GenericSender<BluetoothRequest>,
 
     #[cfg(feature = "bluetooth")]
     bluetooth_extra_permission_data: BluetoothExtraPermissionData,
@@ -627,7 +627,7 @@ impl Window {
     }
 
     #[cfg(feature = "bluetooth")]
-    pub(crate) fn bluetooth_thread(&self) -> IpcSender<BluetoothRequest> {
+    pub(crate) fn bluetooth_thread(&self) -> GenericSender<BluetoothRequest> {
         self.bluetooth_thread.clone()
     }
 
@@ -3420,7 +3420,7 @@ impl Window {
         image_cache: Arc<dyn ImageCache>,
         resource_threads: ResourceThreads,
         storage_threads: StorageThreads,
-        #[cfg(feature = "bluetooth")] bluetooth_thread: IpcSender<BluetoothRequest>,
+        #[cfg(feature = "bluetooth")] bluetooth_thread: GenericSender<BluetoothRequest>,
         mem_profiler_chan: MemProfilerChan,
         time_profiler_chan: TimeProfilerChan,
         devtools_chan: Option<IpcSender<ScriptToDevtoolsControlMsg>>,

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -342,7 +342,7 @@ pub(crate) struct ScriptThreadSenders {
     /// A handle to the bluetooth thread.
     #[no_trace]
     #[cfg(feature = "bluetooth")]
-    pub(crate) bluetooth_sender: IpcSender<BluetoothRequest>,
+    pub(crate) bluetooth_sender: GenericSender<BluetoothRequest>,
 
     /// A [`Sender`] that sends messages to the `Constellation`.
     #[no_trace]

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -9,7 +9,7 @@ use std::rc::{Rc, Weak};
 use std::sync::Arc;
 
 use background_hang_monitor::HangMonitorRegister;
-use base::generic_channel::{GenericCallback, RoutedReceiver};
+use base::generic_channel::{GenericCallback, GenericSender, RoutedReceiver};
 pub use base::id::WebViewId;
 use base::id::{PipelineNamespace, PipelineNamespaceId};
 #[cfg(feature = "bluetooth")]
@@ -900,7 +900,7 @@ fn create_constellation(
     let opts = opts::get();
 
     #[cfg(feature = "bluetooth")]
-    let bluetooth_thread: IpcSender<BluetoothRequest> =
+    let bluetooth_thread: GenericSender<BluetoothRequest> =
         BluetoothThreadFactory::new(embedder_proxy.clone());
 
     let privileged_urls = protocols.privileged_urls();

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -355,7 +355,7 @@ pub struct InitialScriptState {
     pub storage_threads: StorageThreads,
     /// A channel to the bluetooth thread.
     #[cfg(feature = "bluetooth")]
-    pub bluetooth_sender: IpcSender<BluetoothRequest>,
+    pub bluetooth_sender: GenericSender<BluetoothRequest>,
     /// A channel to the time profiler thread.
     pub time_profiler_sender: profile_traits::time::ProfilerChan,
     /// A channel to the memory profiler thread.


### PR DESCRIPTION
Using generic channel for bluetooth module.
Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: This should not change functionality.
