### PR TITLE
libservo: Trigger shutdown internally from `Servo`'s `Drop` impl

### DIFF
--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -30,15 +30,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build()
         .expect("Failed to create EventLoop");
     let mut app = App::new(&event_loop);
-    event_loop.run_app(&mut app)?;
-
-    if let App::Running(state) = app {
-        if let Some(state) = Rc::into_inner(state) {
-            state.servo.deinit();
-        }
-    }
-
-    Ok(())
+    Ok(event_loop.run_app(&mut app)?)
 }
 
 struct AppState {

--- a/components/servo/servo_delegate.rs
+++ b/components/servo/servo_delegate.rs
@@ -4,7 +4,6 @@
 use base::generic_channel;
 use embedder_traits::Notification;
 
-use crate::Servo;
 use crate::webview_delegate::{AllowOrDenyRequest, WebResourceLoad};
 
 #[derive(Debug)]
@@ -21,13 +20,13 @@ pub enum ServoError {
 
 pub trait ServoDelegate {
     /// Notification that Servo has received a major error.
-    fn notify_error(&self, _servo: &Servo, _error: ServoError) {}
+    fn notify_error(&self, _error: ServoError) {}
     /// Report that the DevTools server has started on the given `port`. The `token` that
     /// be used to bypass the permission prompt from the DevTools client.
-    fn notify_devtools_server_started(&self, _servo: &Servo, _port: u16, _token: String) {}
+    fn notify_devtools_server_started(&self, _port: u16, _token: String) {}
     /// Request a DevTools connection from a DevTools client. Typically an embedder application
     /// will show a permissions prompt when this happens to confirm a connection is allowed.
-    fn request_devtools_connection(&self, _servo: &Servo, _request: AllowOrDenyRequest) {}
+    fn request_devtools_connection(&self, _request: AllowOrDenyRequest) {}
     /// Triggered when Servo will load a web (HTTP/HTTPS) resource. The load may be
     /// intercepted and alternate contents can be loaded by the client by calling
     /// [`WebResourceLoad::intercept`]. If not handled, the load will continue as normal.

--- a/components/servo/tests/servo.rs
+++ b/components/servo/tests/servo.rs
@@ -16,7 +16,7 @@ use common::ServoTest;
 
 #[test]
 fn test_simple_start_and_stop_servo() {
-    let servo_test = ServoTest::new();
-    servo_test.servo().start_shutting_down();
-    while servo_test.servo().spin_event_loop() {}
+    // The drop implementation of `Servo` will trigger the shutdown processs and also spin the
+    // event loop until shutdown is complete.
+    ServoTest::new();
 }

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -298,7 +298,7 @@ fn test_cursor_change() {
 fn test_negative_resize_to_request() {
     let servo_test = ServoTest::new();
     struct WebViewResizeTestDelegate {
-        servo: Rc<Servo>,
+        servo: Servo,
         rendering_context: Rc<dyn RenderingContext>,
         popup: RefCell<Option<WebView>>,
         resize_request: Cell<Option<DeviceIntSize>>,

--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -243,26 +243,6 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_setExperimentalMode<'local>(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn Java_org_servo_servoview_JNIServo_requestShutdown<'local>(
-    mut env: JNIEnv<'local>,
-    _class: JClass<'local>,
-) {
-    debug!("requestShutdown");
-    call(&mut env, |s| s.request_shutdown());
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn Java_org_servo_servoview_JNIServo_deinit<'local>(
-    _env: JNIEnv<'local>,
-    _class: JClass<'local>,
-) {
-    debug!("deinit");
-    APP.with(|app| {
-        *app.borrow_mut() = None;
-    });
-}
-
-#[unsafe(no_mangle)]
 pub extern "C" fn Java_org_servo_servoview_JNIServo_resize<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
@@ -655,9 +635,6 @@ impl HostTrait for HostCallbacks {
 
     fn on_shutdown_complete(&self) {
         debug!("on_shutdown_complete");
-        let mut env = self.jvm.get_env().unwrap();
-        env.call_method(self.callbacks.as_obj(), "onShutdownComplete", "()V", &[])
-            .unwrap();
     }
 
     fn on_title_changed(&self, title: Option<String>) {

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -328,12 +328,6 @@ impl App {
         self.state.window_for_webview_id(id).activate_webview(id);
     }
 
-    /// Request shutdown. Will call on_shutdown_complete.
-    pub fn request_shutdown(&self) {
-        self.state.schedule_exit();
-        self.spin_event_loop();
-    }
-
     /// This is the Servo heartbeat. This needs to be called
     /// everytime wakeup is called or when embedder wants Servo
     /// to act on its pending events.

--- a/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
+++ b/support/android/apk/servoview/src/main/java/org/servo/servoview/JNIServo.java
@@ -110,8 +110,6 @@ public class JNIServo {
 
         void onHistoryChanged(boolean canGoBack, boolean canGoForward);
 
-        void onShutdownComplete();
-
         void onImeShow();
         void onImeHide();
 


### PR DESCRIPTION
Remove the public API to trigger shutdown and instead trigger the process from `Servo`'s implementation of `Drop` trait.

This makes it hard to create issues involving the order of destruction of `Servo` and `WebView`s. It will also allow us to implement asynchronous shutdown in the future.

Testing: Should be covered by existing unit tests.
