### PR TITLE
config: Add `SERVO_DIAGNOSTICS` environment variable for diagnostic options

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 #[cfg(any(target_os = "android", target_env = "ohos"))]
 use std::sync::OnceLock;
-use std::{env, fmt, process};
+use std::{env, fmt};
 
 use bpaf::*;
 use euclid::Size2D;
@@ -625,15 +625,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         },
     };
 
-    if cmd_args
-        .debug
-        .iter()
-        .any(|debug_option| debug_option.contains("help"))
-    {
-        print_debug_options_usage("servo");
-        return ArgumentParsingResult::Exit;
-    }
-
     // If this is the content process, we'll receive the real options over IPC. So fill in some dummy options for now.
     if let Some(content_process) = cmd_args.content_process {
         return ArgumentParsingResult::ContentProcess(content_process);
@@ -697,11 +688,12 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
         ..Default::default()
     };
 
-    let mut debug_options = DiagnosticsLogging::default();
+    let mut debug_options = DiagnosticsLogging::new();
+
+    // Parse -Z command-line flags.
     for debug_string in cmd_args.debug {
-        let result = debug_options.extend(debug_string);
-        if let Err(error) = result {
-            println!("error: unrecognized debug option: {}", error);
+        if let Err(error) = debug_options.extend_from_string(&debug_string) {
+            eprintln!("Could not parse debug logging option: {error}");
             return ArgumentParsingResult::ErrorParsing;
         }
     }
@@ -736,56 +728,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
     };
 
     ArgumentParsingResult::ChromeProcess(opts, preferences, servoshell_preferences)
-}
-
-fn print_debug_options_usage(app: &str) {
-    fn print_option(name: &str, description: &str) {
-        println!("\t{:<35} {}", name, description);
-    }
-
-    println!(
-        "Usage: {} debug option,[options,...]\n\twhere options include\n\nOptions:",
-        app
-    );
-    print_option(
-        "disable-share-style-cache",
-        "Disable the style sharing cache.",
-    );
-    print_option(
-        "dump-stacking-context-tree",
-        "Print the stacking context tree after each layout.",
-    );
-    print_option(
-        "dump-display-list",
-        "Print the display list after each layout.",
-    );
-    print_option(
-        "dump-flow-tree",
-        "Print the fragment tree after each layout.",
-    );
-    print_option(
-        "dump-rule-tree",
-        "Print the style rule tree after each layout.",
-    );
-    print_option(
-        "dump-style-tree",
-        "Print the DOM with computed styles after each restyle.",
-    );
-    print_option("dump-style-stats", "Print style statistics each restyle.");
-    print_option("dump-scroll-tree", "Print scroll tree after each layout.");
-    print_option("gc-profile", "Log GC passes and their durations.");
-    print_option(
-        "profile-script-events",
-        "Enable profiling of script-related events.",
-    );
-    print_option(
-        "relayout-event",
-        "Print notifications when there is a relayout.",
-    );
-
-    println!();
-
-    process::exit(0)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
With this change can now configure diagnostic logging via the `SERVO_DIAGNOSTICS` environment variable in addition to the existing -Z command-line flag.

The environment variable accepts the same comma-separated options as -Z (e.g., `SERVO_DIAGNOSTICS=style-tree,display-list`). The help option works from both sources and will display all available diagnostic flags.

Environment variable parsing is disabled in production builds

Testing: Tested locally for release, debug and production build to make sure it is disabled for production
Fixes: Part of https://github.com/servo/servo/issues/40863
