### PR TITLE
script: Implement `<input type=range>` widget's layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7796,7 +7796,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.33.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
+source = "git+https://github.com/rayguo17/stylo?branch=slide-bar#15bca7974398f54cf331a3334d4c8c753d49a0f1"
 dependencies = [
  "bitflags 2.10.0",
  "cssparser",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.3"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
+source = "git+https://github.com/rayguo17/stylo?branch=slide-bar#15bca7974398f54cf331a3334d4c8c753d49a0f1"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
+source = "git+https://github.com/rayguo17/stylo?branch=slide-bar#15bca7974398f54cf331a3334d4c8c753d49a0f1"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -8699,7 +8699,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
+source = "git+https://github.com/rayguo17/stylo?branch=slide-bar#15bca7974398f54cf331a3334d4c8c753d49a0f1"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -8708,12 +8708,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
+source = "git+https://github.com/rayguo17/stylo?branch=slide-bar#15bca7974398f54cf331a3334d4c8c753d49a0f1"
 
 [[package]]
 name = "stylo_derive"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
+source = "git+https://github.com/rayguo17/stylo?branch=slide-bar#15bca7974398f54cf331a3334d4c8c753d49a0f1"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -8725,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
+source = "git+https://github.com/rayguo17/stylo?branch=slide-bar#15bca7974398f54cf331a3334d4c8c753d49a0f1"
 dependencies = [
  "bitflags 2.10.0",
  "stylo_malloc_size_of",
@@ -8734,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
+source = "git+https://github.com/rayguo17/stylo?branch=slide-bar#15bca7974398f54cf331a3334d4c8c753d49a0f1"
 dependencies = [
  "app_units",
  "cssparser",
@@ -8751,12 +8751,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
+source = "git+https://github.com/rayguo17/stylo?branch=slide-bar#15bca7974398f54cf331a3334d4c8c753d49a0f1"
 
 [[package]]
 name = "stylo_traits"
 version = "0.9.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
+source = "git+https://github.com/rayguo17/stylo?branch=slide-bar#15bca7974398f54cf331a3334d4c8c753d49a0f1"
 dependencies = [
  "app_units",
  "bitflags 2.10.0",
@@ -9176,7 +9176,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.3.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
+source = "git+https://github.com/rayguo17/stylo?branch=slide-bar#15bca7974398f54cf331a3334d4c8c753d49a0f1"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -9189,7 +9189,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-11-01#41e2bdee7cc2501273216bb6d6a16e523acc8c3e"
+source = "git+https://github.com/rayguo17/stylo?branch=slide-bar#15bca7974398f54cf331a3334d4c8c753d49a0f1"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,15 +265,15 @@ codegen-units = 1
 #
 # Or for Stylo:
 #
-# [patch."https://github.com/servo/stylo"]
-# selectors = { path = "../stylo/selectors" }
-# servo_arc = { path = "../stylo/servo_arc" }
-# stylo = { path = "../stylo/style" }
-# stylo_atoms = { path = "../stylo/stylo_atoms" }
-# stylo_config = { path = "../stylo/stylo_config" }
-# stylo_dom = { path = "../stylo/stylo_dom" }
-# stylo_malloc_size_of = { path = "../stylo/malloc_size_of" }
-# stylo_traits = { path = "../stylo/style_traits" }
+[patch."https://github.com/servo/stylo"]
+selectors = { git = "https://github.com/rayguo17/stylo", branch = "slide-bar" }
+servo_arc = { git = "https://github.com/rayguo17/stylo", branch = "slide-bar" }
+stylo = { git = "https://github.com/rayguo17/stylo", branch = "slide-bar" }
+stylo_atoms = { git = "https://github.com/rayguo17/stylo", branch = "slide-bar" }
+stylo_config = { git = "https://github.com/rayguo17/stylo", branch = "slide-bar" }
+stylo_dom = { git = "https://github.com/rayguo17/stylo", branch = "slide-bar" }
+stylo_malloc_size_of = { git = "https://github.com/rayguo17/stylo", branch = "slide-bar" }
+stylo_traits = { git = "https://github.com/rayguo17/stylo", branch = "slide-bar" }
 #
 # Or for WebRender:
 #

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -1,5 +1,5 @@
 button {
-    cursor: default;
+  cursor: default;
 }
 
 button,
@@ -135,6 +135,49 @@ input[type="color"] {
   border-radius: 2px;
   background: lightgrey;
   border: 1px solid gray;
+}
+
+input[type="range"] {
+  width: 100px;
+  height: 16px;
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  background: none;
+  border: none;
+}
+
+input[type="range"]::-servo-range-track {
+  width: 100%;
+  height: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: #ddd;
+  border-radius: 5px;
+  position: absolute;
+  cursor: pointer;
+}
+
+input[type="range"]::-servo-range-progress {
+  height: 8px;
+  background-color: #7a3;
+  border-radius: 5px;
+  position: absolute;
+  cursor: pointer;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+input[type="range"]::-servo-range-thumb {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: gray;
+  border: 2px solid white;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
 }
 
 td[align="left"]    { text-align: left; }

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -141,7 +141,6 @@ input[type="range"] {
   width: 100px;
   height: 16px;
   position: relative;
-  display: inline-block;
   cursor: pointer;
   background: none;
   border: none;

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3627,6 +3627,10 @@ impl Document {
             task.run_box();
         }
     }
+    /// Returns whether there are any active script or layout blockers.
+    pub(crate) fn has_script_or_layout_blocker(&self) -> bool {
+        self.script_and_layout_blockers.get() > 0
+    }
 
     /// Enqueue a task to run as soon as any JS and layout blockers are removed.
     pub(crate) fn add_delayed_task<T: 'static + NonSendTaskBox>(&self, task: T) {

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -3627,7 +3627,7 @@ impl Document {
             task.run_box();
         }
     }
-    /// Returns whether there are any active script or layout blockers.
+
     pub(crate) fn has_script_or_layout_blocker(&self) -> bool {
         self.script_and_layout_blockers.get() > 0
     }

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -1552,7 +1552,13 @@ impl HTMLInputElement {
         };
         let range_shadow_tree: Ref<'_, InputTypeRangeShadowTree> = self.range_shadow_tree(can_gc);
 
-        let track_rect_width = range_shadow_tree.range_track.upcast::<Node>().client_rect().width() as f64;
+        let track_rect_width = range_shadow_tree
+            .range_track
+            .upcast::<Node>()
+            .padding_box()
+            .unwrap_or_default()
+            .width()
+            .to_f64_px();
         let thumb_rect_width = range_shadow_tree
             .range_thumb
             .upcast::<Node>()
@@ -1562,8 +1568,7 @@ impl HTMLInputElement {
             .to_f64_px();
         let thumb_style = format!(
             "left: {}px",
-            percent / 100.0 * (track_rect_width - thumb_rect_width) +
-                thumb_rect_width / 2.0
+            percent / 100.0 * (track_rect_width - thumb_rect_width) + thumb_rect_width / 2.0
         );
         let progress_style = format!("width: {percent}%;");
         range_shadow_tree.range_thumb.set_string_attribute(

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -1544,13 +1544,7 @@ impl HTMLInputElement {
         let min = self.minimum().unwrap_or(0.0);
         let max = self.maximum().unwrap_or(100.0);
         let value_num = self.convert_string_to_number(&value.str()).unwrap_or(0.0);
-        let clamped_value = if value_num < min {
-            min
-        } else if value_num > max {
-            max
-        } else {
-            value_num
-        };
+        let clamped_value = value_num.clamp(min, max);
         let percent = if (max - min).abs() < f64::EPSILON {
             0.0
         } else {
@@ -1596,7 +1590,6 @@ impl HTMLInputElement {
     fn may_have_embedder_control(&self) -> bool {
         let el = self.upcast::<Element>();
         self.input_type() == InputType::Color && !el.disabled_state()
-        // TODO: Add embedder control for slider
     }
 
     fn handle_key_reaction(&self, action: KeyReaction, event: &Event, can_gc: CanGc) {

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1912,7 +1912,9 @@ impl<'dom> LayoutNodeHelpers<'dom> for LayoutDom<'dom, Node> {
         {
             let input = self.unsafe_get().downcast::<HTMLInputElement>().unwrap();
 
-            !input.is_textual_widget() && input.input_type() != InputType::Color
+            !input.is_textual_widget() &&
+                input.input_type() != InputType::Color &&
+                input.input_type() != InputType::Range
         } else {
             type_id ==
                 NodeTypeId::Element(ElementTypeId::HTMLElement(

--- a/tests/wpt/meta/css/css-flexbox/flexitem-stretch-range.html.ini
+++ b/tests/wpt/meta/css/css-flexbox/flexitem-stretch-range.html.ini
@@ -1,0 +1,2 @@
+[flexitem-stretch-range.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-grid/alignment/grid-self-alignment-stretch-input-range.html.ini
+++ b/tests/wpt/meta/css/css-grid/alignment/grid-self-alignment-stretch-input-range.html.ini
@@ -1,0 +1,2 @@
+[grid-self-alignment-stretch-input-range.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/range-percent-intrinsic-size-2.html.ini
+++ b/tests/wpt/meta/css/css-sizing/range-percent-intrinsic-size-2.html.ini
@@ -1,0 +1,2 @@
+[range-percent-intrinsic-size-2.html]
+  expected: FAIL

--- a/tests/wpt/meta/css/css-sizing/range-percent-intrinsic-size-2a.html.ini
+++ b/tests/wpt/meta/css/css-sizing/range-percent-intrinsic-size-2a.html.ini
@@ -1,0 +1,2 @@
+[range-percent-intrinsic-size-2a.html]
+  expected: FAIL

--- a/tests/wpt/meta/html/semantics/forms/the-input-element/range-tick-marks-02.html.ini
+++ b/tests/wpt/meta/html/semantics/forms/the-input-element/range-tick-marks-02.html.ini
@@ -1,0 +1,2 @@
+[range-tick-marks-02.html]
+  expected: FAIL


### PR DESCRIPTION
Implement the layout of `<input type="range">`. Support automatically calculating the position of thumb based on the current input value, and the size of `range-track` and `range-thumb`. Added a `document.has_script_or_layout_blocker` function to detect whether it is possible to run `box_area_query` during `bind_to_tree`, add `delay_task` if there are blocker.

Testing: Since the layout of the widget is up to the implementation, there has no WPT test testing the layout, and it should not affect any WPT test.
Fixes: https://github.com/servo/servo/issues/22728

Parellel Stylo PR: https://github.com/servo/stylo/pull/276

The layout for this widget looks like this:
<img width="166" height="39" alt="image" src="https://github.com/user-attachments/assets/e617c94d-8eb6-4c91-8af7-b201418e4bb5" />
Feel free to suggest any style :)
cc @xiaochengh 