### PR TITLE
touch: Stop flinging if no scroll happened

### DIFF
--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -383,12 +383,7 @@ impl TouchHandler {
         };
 
         if velocity.length().abs() < FLING_MIN_SCREEN_PX {
-            let _span = profile_traits::info_span!("TouchHandler::FlingEnd").entered();
-            touch_sequence.state = Finished;
-            // If we were flinging previously, there could still be a touch_up event result
-            // coming in after we stopped flinging
-            self.try_remove_touch_sequence(self.current_sequence_id);
-            self.observing_frames_for_fling.set(false);
+            self.stop_fling_if_needed();
             None
         } else {
             // TODO: Probably we should multiply with the current refresh rate (and divide on each frame)
@@ -405,6 +400,23 @@ impl TouchHandler {
                 cursor: *cursor,
             })
         }
+    }
+
+    pub(crate) fn stop_fling_if_needed(&mut self) {
+        let touch_sequence = self.get_current_touch_sequence_mut();
+        let Flinging { .. } = touch_sequence.state else {
+            return;
+        };
+        let _span = profile_traits::info_span!("TouchHandler::FlingEnd").entered();
+        debug!(
+            "Stopping fling in touch sequence {:?}",
+            self.current_sequence_id
+        );
+        touch_sequence.state = Finished;
+        // If we were flinging previously, there could still be a touch_up event result
+        // coming in after we stopped flinging
+        self.try_remove_touch_sequence(self.current_sequence_id);
+        self.observing_frames_for_fling.set(false);
     }
 
     pub fn on_touch_move(

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -403,19 +403,17 @@ impl TouchHandler {
     }
 
     pub(crate) fn stop_fling_if_needed(&mut self) {
+        let current_sequence_id = self.current_sequence_id;
         let touch_sequence = self.get_current_touch_sequence_mut();
         let Flinging { .. } = touch_sequence.state else {
             return;
         };
         let _span = profile_traits::info_span!("TouchHandler::FlingEnd").entered();
-        debug!(
-            "Stopping fling in touch sequence {:?}",
-            self.current_sequence_id
-        );
+        debug!("Stopping fling in touch sequence {current_sequence_id:?}");
         touch_sequence.state = Finished;
         // If we were flinging previously, there could still be a touch_up event result
         // coming in after we stopped flinging
-        self.try_remove_touch_sequence(self.current_sequence_id);
+        self.try_remove_touch_sequence(current_sequence_id);
         self.observing_frames_for_fling.set(false);
     }
 

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -785,6 +785,9 @@ impl WebViewRenderer {
                 scroll_result.external_scroll_id,
                 scroll_result.hit_test_result.clone(),
             );
+        } else {
+            // No scroll happened, so if we were flinging, stop the fling.
+            self.touch_handler.stop_fling_if_needed();
         }
 
         (self.set_pinch_zoom(new_pinch_zoom), scroll_result)

--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -786,7 +786,6 @@ impl WebViewRenderer {
                 scroll_result.hit_test_result.clone(),
             );
         } else {
-            // No scroll happened, so if we were flinging, stop the fling.
             self.touch_handler.stop_fling_if_needed();
         }
 


### PR DESCRIPTION
If no scroll happened, we would stop flinging if there is any.
Extract the functionality to `fn stop_fling_if_needed`.
Testing: There are currently no related test cases for the modifications made to fling.
Fixes: #41026
