### PR TITLE
script: Add error messages to operations of ChaCha20-Poly1305

### DIFF
--- a/components/script/dom/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/subtlecrypto/chacha20_poly1305_operation.rs
@@ -215,7 +215,11 @@ pub(crate) fn import_key(
             KeyUsage::Encrypt | KeyUsage::Decrypt | KeyUsage::WrapKey | KeyUsage::UnwrapKey
         )
     }) {
-        return Err(Error::Syntax(None));
+        return Err(Error::Syntax(Some(
+            "Usages contains an entry which is not one of \"encrypt\", \"decrypt\", \"wrapKey\" \
+            or \"unwrapKey\""
+                .to_string(),
+        )));
     }
 
     // Step 3.
@@ -228,7 +232,9 @@ pub(crate) fn import_key(
 
             // Step 3.2. If the length in bits of data is not 256 then throw a DataError.
             if data.len() != 32 {
-                return Err(Error::Data(None));
+                return Err(Error::Data(Some(
+                    "The length in bits of data is not 256".to_string(),
+                )));
             }
         },
         // If format is "jwk":
@@ -242,28 +248,41 @@ pub(crate) fn import_key(
 
             // Step 3.2. If the kty field of jwk is not "oct", then throw a DataError.
             if jwk.kty.as_ref().is_none_or(|kty| kty != "oct") {
-                return Err(Error::Data(None));
+                return Err(Error::Data(Some(
+                    "The kty field of jwk is not \"oct\"".to_string(),
+                )));
             }
 
             // Step 3.3. If jwk does not meet the requirements of Section 6.4 of JSON Web
             // Algorithms [JWA], then throw a DataError.
             let Some(k) = jwk.k.as_ref() else {
-                return Err(Error::Data(None));
+                return Err(Error::Data(Some(
+                    "jwk does not meet the requirements of JWA".to_string(),
+                )));
             };
 
             // Step 3.4. Let data be the byte sequence obtained by decoding the k field of jwk.
-            data = Base64UrlUnpadded::decode_vec(&k.str()).map_err(|_| Error::Data(None))?;
+            data = Base64UrlUnpadded::decode_vec(&k.str()).map_err(|_| {
+                Error::Data(Some(
+                    "Fail to obtain byte sequence by decoding the k field of jwk".to_string(),
+                ))
+            })?;
 
             // Step 3.5. If the alg field of jwk is present, and is not "C20P", then throw a
             // DataError.
             if jwk.alg.as_ref().is_some_and(|alg| alg != "C20P") {
-                return Err(Error::Data(None));
+                return Err(Error::Data(Some(
+                    "The alg field of jwk is present, and is not \"C20P\"".to_string(),
+                )));
             }
 
             // Step 3.6. If usages is non-empty and the use field of jwk is present and is not
             // "enc", then throw a DataError.
             if !usages.is_empty() && jwk.use_.as_ref().is_some_and(|use_| use_ != "enc") {
-                return Err(Error::Data(None));
+                return Err(Error::Data(Some(
+                    "Usages is non-empty and the use field of jwk is present and is not \"enc\""
+                        .to_string(),
+                )));
             }
 
             // Step 3.7. If the key_ops field of jwk is present, and is invalid according to the
@@ -274,13 +293,19 @@ pub(crate) fn import_key(
             // Step 3.8. If the ext field of jwk is present and has the value false and extractable
             // is true, then throw a DataError.
             if jwk.ext.is_some_and(|ext| !ext) && extractable {
-                return Err(Error::Data(None));
+                return Err(Error::Data(Some(
+                    "The ext field of jwk is present and has the value false and \
+                    extractable is true"
+                        .to_string(),
+                )));
             }
         },
         // Otherwise:
         _ => {
             // throw a NotSupportedError.
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "ChaCha20-Poly1305 does not support this import key format".to_string(),
+            )));
         },
     }
 
@@ -288,6 +313,9 @@ pub(crate) fn import_key(
     // Step 5. Let algorithm be a new KeyAlgorithm.
     // Step 6. Set the name attribute of algorithm to "ChaCha20-Poly1305".
     // Step 7. Set the [[algorithm]] internal slot of key to algorithm.
+    let handle = Handle::ChaCha20Poly1305Key(Key::from_exact_iter(data).ok_or(Error::Data(
+        Some("ChaCha20-Poly1305 fails to create key from data".to_string()),
+    ))?);
     let algorithm = SubtleKeyAlgorithm {
         name: ALG_CHACHA20_POLY1305.to_string(),
     };
@@ -297,7 +325,7 @@ pub(crate) fn import_key(
         extractable,
         KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
         usages,
-        Handle::ChaCha20Poly1305Key(Key::from_exact_iter(data).ok_or(Error::Data(None))?),
+        handle,
         can_gc,
     );
 
@@ -310,7 +338,11 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
     // Step 1. If the underlying cryptographic key material represented by the [[handle]] internal
     // slot of key cannot be accessed, then throw an OperationError.
     let Handle::ChaCha20Poly1305Key(key_handle) = key.handle() else {
-        return Err(Error::Operation(None));
+        return Err(Error::Operation(Some(
+            "The underlying cryptographic key material represented by the [[handle]] internal \
+            slot of key cannot be accessed"
+                .to_string(),
+        )));
     };
 
     // Step 2.
@@ -357,7 +389,9 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
         // Otherwise:
         _ => {
             // throw a NotSupportedError.
-            return Err(Error::NotSupported(None));
+            return Err(Error::NotSupported(Some(
+                "ChaCha20-Poly1305 does not support this import key format".to_string(),
+            )));
         },
     };
 


### PR DESCRIPTION
Error messages in the import/export key operations of ChaCha20-Poly1305 are missing. This patch adds those error messages.

Testing: No behavioral change. Existing tests suffice.