### PR TITLE
IndexedDB: Use GenericSender, GenericReceiver and GenericCallback for IndexedDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8513,7 +8513,6 @@ version = "0.0.1"
 dependencies = [
  "base",
  "bincode",
- "ipc-channel",
  "log",
  "malloc_size_of_derive",
  "profile",
@@ -8542,7 +8541,6 @@ name = "storage_traits"
 version = "0.0.1"
 dependencies = [
  "base",
- "ipc-channel",
  "malloc_size_of_derive",
  "profile_traits",
  "serde",

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -99,7 +99,7 @@ use background_hang_monitor::HangMonitorRegister;
 use background_hang_monitor_api::{
     BackgroundHangMonitorControlMsg, BackgroundHangMonitorRegister, HangMonitorAlert,
 };
-use base::generic_channel::{GenericSender, RoutedReceiver};
+use base::generic_channel::{GenericSend, GenericSender, RoutedReceiver};
 use base::id::{
     BrowsingContextGroupId, BrowsingContextId, HistoryStateId, MessagePortId, MessagePortRouterId,
     PainterId, PipelineId, PipelineNamespace, PipelineNamespaceId, PipelineNamespaceRequest,
@@ -2601,7 +2601,7 @@ where
         let (client_storage_generic_sender, client_storage_generic_receiver) =
             generic_channel::channel().expect("Failed to create generic channel!");
         let (indexeddb_ipc_sender, indexeddb_ipc_receiver) =
-            ipc::channel().expect("Failed to create IPC channel!");
+            generic_channel::channel().expect("Failed to create generic channel!");
         let (web_storage_generic_sender, web_storage_generic_receiver) =
             generic_channel::channel().expect("Failed to create generic channel!");
 

--- a/components/script/dom/indexeddb/idbdatabase.rs
+++ b/components/script/dom/indexeddb/idbdatabase.rs
@@ -4,10 +4,9 @@
 
 use std::cell::Cell;
 
-use base::IpcSend;
+use base::generic_channel::{GenericSend, GenericSender};
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
-use profile_traits::ipc;
+use profile_traits::generic_channel::channel;
 use storage_traits::indexeddb::{IndexedDBThreadMsg, KeyPath, SyncOperation};
 use stylo_atoms::Atom;
 
@@ -76,7 +75,7 @@ impl IDBDatabase {
         )
     }
 
-    fn get_idb_thread(&self) -> IpcSender<IndexedDBThreadMsg> {
+    fn get_idb_thread(&self) -> GenericSender<IndexedDBThreadMsg> {
         self.global().storage_threads().sender()
     }
 
@@ -100,7 +99,7 @@ impl IDBDatabase {
     }
 
     pub fn version(&self) -> u64 {
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let (sender, receiver) = channel(self.global().time_profiler_chan().clone()).unwrap();
         let operation = SyncOperation::Version(
             sender,
             self.global().origin().immutable().clone(),
@@ -249,7 +248,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
             &upgrade_transaction,
         );
 
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let (sender, receiver) = channel(self.global().time_profiler_chan().clone()).unwrap();
 
         let key_paths = key_path.map(|p| match p {
             StringOrStringSequence::String(s) => KeyPath::String(s.to_string()),
@@ -311,7 +310,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
         // FIXME:(arihant2math) Remove from index set ...
 
         // Step 7
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let (sender, receiver) = channel(self.global().time_profiler_chan().clone()).unwrap();
 
         let operation = SyncOperation::DeleteObjectStore(
             sender,
@@ -365,7 +364,7 @@ impl IDBDatabaseMethods<crate::DomTypeHolder> for IDBDatabase {
         // Step 3: Wait for all transactions by this db to finish
         // FIXME:(arihant2math)
         // Step 4: If force flag is set, fire a close event
-        let (sender, receiver) = ipc::channel(self.global().time_profiler_chan().clone()).unwrap();
+        let (sender, receiver) = channel(self.global().time_profiler_chan().clone()).unwrap();
         let operation = SyncOperation::CloseDatabase(
             sender,
             self.global().origin().immutable().clone(),

--- a/components/script/indexeddb.rs
+++ b/components/script/indexeddb.rs
@@ -5,7 +5,6 @@
 use std::ffi::CString;
 use std::ptr;
 
-use ipc_channel::ipc::IpcSender;
 use itertools::Itertools;
 use js::conversions::jsstr_to_string;
 use js::jsapi::{
@@ -16,11 +15,8 @@ use js::jsapi::{
 use js::jsval::{DoubleValue, JSVal, UndefinedValue};
 use js::rust::wrappers::{IsArrayObject, JS_GetProperty, JS_HasOwnProperty, JS_IsIdentifier};
 use js::rust::{HandleValue, IntoHandle, IntoMutableHandle, MutableHandleValue};
-use profile_traits::ipc;
-use profile_traits::ipc::IpcReceiver;
 use script_bindings::script_runtime::CanGc;
-use serde::{Deserialize, Serialize};
-use storage_traits::indexeddb::{BackendResult, IndexedDBKeyRange, IndexedDBKeyType};
+use storage_traits::indexeddb::{IndexedDBKeyRange, IndexedDBKeyType};
 
 use crate::dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
 use crate::dom::bindings::codegen::Bindings::FileBinding::FileMethods;
@@ -30,7 +26,6 @@ use crate::dom::bindings::conversions::{
 };
 use crate::dom::bindings::error::Error;
 use crate::dom::bindings::import::module::SafeJSContext;
-use crate::dom::bindings::root::DomRoot;
 use crate::dom::bindings::str::DOMString;
 use crate::dom::bindings::structuredclone;
 use crate::dom::bindings::utils::set_dictionary_property;
@@ -39,15 +34,6 @@ use crate::dom::file::File;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::idbkeyrange::IDBKeyRange;
 use crate::dom::idbobjectstore::KeyPath;
-
-pub fn create_channel<T>(
-    global: DomRoot<GlobalScope>,
-) -> (IpcSender<BackendResult<T>>, IpcReceiver<BackendResult<T>>)
-where
-    T: for<'a> Deserialize<'a> + Serialize,
-{
-    ipc::channel::<BackendResult<T>>(global.time_profiler_chan().clone()).unwrap()
-}
 
 // https://www.w3.org/TR/IndexedDB-2/#convert-key-to-value
 #[expect(unsafe_code)]

--- a/components/shared/profile/generic_callback.rs
+++ b/components/shared/profile/generic_callback.rs
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use base::generic_channel::SendResult;
+use serde::{Deserialize, Serialize};
+
+use crate::time::{ProfilerCategory, ProfilerChan};
+use crate::time_profile;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GenericCallback<T>
+where
+    T: Serialize + Send + 'static,
+{
+    callback: base::generic_channel::GenericCallback<T>,
+    time_profiler_chan: ProfilerChan,
+}
+
+impl<T> GenericCallback<T>
+where
+    T: for<'de> Deserialize<'de> + Serialize + Send + 'static,
+{
+    pub fn new<F: FnMut(Result<T, ipc_channel::Error>) + Send + 'static>(
+        time_profiler_chan: ProfilerChan,
+        callback: F,
+    ) -> Result<Self, ipc_channel::Error> {
+        Ok(GenericCallback {
+            callback: base::generic_channel::GenericCallback::new(callback)?,
+            time_profiler_chan,
+        })
+    }
+
+    pub fn send(&self, value: T) -> SendResult {
+        time_profile!(
+            ProfilerCategory::IpcReceiver,
+            None,
+            self.time_profiler_chan.clone(),
+            move || self.callback.send(value)
+        )
+    }
+}

--- a/components/shared/profile/lib.rs
+++ b/components/shared/profile/lib.rs
@@ -8,6 +8,7 @@
 
 #![deny(unsafe_code)]
 
+pub mod generic_callback;
 pub mod generic_channel;
 pub mod ipc;
 pub mod mem;

--- a/components/shared/storage/Cargo.toml
+++ b/components/shared/storage/Cargo.toml
@@ -13,7 +13,6 @@ path = "lib.rs"
 
 [dependencies]
 base = { workspace = true }
-ipc-channel = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 profile_traits = { path = "../profile" }

--- a/components/shared/storage/lib.rs
+++ b/components/shared/storage/lib.rs
@@ -3,8 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use base::generic_channel::{GenericSend, GenericSender, SendResult};
-use base::{IpcSend, IpcSendResult};
-use ipc_channel::ipc::{IpcError, IpcSender};
 use malloc_size_of::malloc_size_of_is_0;
 use serde::{Deserialize, Serialize};
 
@@ -19,14 +17,14 @@ pub mod webstorage_thread;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StorageThreads {
     client_storage_thread: GenericSender<ClientStorageThreadMessage>,
-    idb_thread: IpcSender<IndexedDBThreadMsg>,
+    idb_thread: GenericSender<IndexedDBThreadMsg>,
     web_storage_thread: GenericSender<WebStorageThreadMsg>,
 }
 
 impl StorageThreads {
     pub fn new(
         client_storage_thread: GenericSender<ClientStorageThreadMessage>,
-        idb_thread: IpcSender<IndexedDBThreadMsg>,
+        idb_thread: GenericSender<IndexedDBThreadMsg>,
         web_storage_thread: GenericSender<WebStorageThreadMsg>,
     ) -> StorageThreads {
         StorageThreads {
@@ -47,12 +45,12 @@ impl GenericSend<ClientStorageThreadMessage> for StorageThreads {
     }
 }
 
-impl IpcSend<IndexedDBThreadMsg> for StorageThreads {
-    fn send(&self, msg: IndexedDBThreadMsg) -> IpcSendResult {
-        self.idb_thread.send(msg).map_err(IpcError::Bincode)
+impl GenericSend<IndexedDBThreadMsg> for StorageThreads {
+    fn send(&self, msg: IndexedDBThreadMsg) -> SendResult {
+        self.idb_thread.send(msg)
     }
 
-    fn sender(&self) -> IpcSender<IndexedDBThreadMsg> {
+    fn sender(&self) -> GenericSender<IndexedDBThreadMsg> {
         self.idb_thread.clone()
     }
 }

--- a/components/storage/Cargo.toml
+++ b/components/storage/Cargo.toml
@@ -15,7 +15,6 @@ path = "lib.rs"
 [dependencies]
 base = { workspace = true }
 bincode = { workspace = true }
-ipc-channel = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 log = { workspace = true }

--- a/components/storage/indexeddb/engines/sqlite.rs
+++ b/components/storage/indexeddb/engines/sqlite.rs
@@ -5,12 +5,12 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use base::threadpool::ThreadPool;
-use ipc_channel::ipc::IpcSender;
 use log::{error, info};
+use profile_traits::generic_callback::GenericCallback;
 use rusqlite::{Connection, Error, OptionalExtension, params};
 use sea_query::{Condition, Expr, ExprTrait, IntoCondition, SqliteQueryBuilder};
 use sea_query_rusqlite::RusqliteBinder;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use storage_traits::indexeddb::{
     AsyncOperation, AsyncReadOnlyOperation, AsyncReadWriteOperation, BackendError, BackendResult,
     CreateObjectResult, IndexedDBKeyRange, IndexedDBKeyType, IndexedDBRecord, IndexedDBTxnMode,
@@ -388,21 +388,18 @@ impl KvsEngine for SqliteEngine {
                         })
                         .optional()
                     });
-                fn process_object_store<T>(
+                fn process_object_store<T: Send + Serialize + for<'de> Deserialize<'de>>(
                     object_store: Result<Option<object_store_model::Model>, Error>,
-                    sender: &IpcSender<BackendResult<T>>,
-                ) -> Result<object_store_model::Model, ()>
-                where
-                    T: Serialize,
-                {
+                    callback: &GenericCallback<BackendResult<T>>,
+                ) -> Result<object_store_model::Model, ()> {
                     match object_store {
                         Ok(Some(store)) => Ok(store),
                         Ok(None) => {
-                            let _ = sender.send(Err(BackendError::StoreNotFound));
+                            let _ = callback.send(Err(BackendError::StoreNotFound));
                             Err(())
                         },
                         Err(e) => {
-                            let _ = sender.send(Err(BackendError::DbErr(format!("{:?}", e))));
+                            let _ = callback.send(Err(BackendError::DbErr(format!("{:?}", e))));
                             Err(())
                         },
                     }
@@ -410,12 +407,12 @@ impl KvsEngine for SqliteEngine {
 
                 match request.operation {
                     AsyncOperation::ReadWrite(AsyncReadWriteOperation::PutItem {
-                        sender,
+                        callback,
                         key,
                         value,
                         should_overwrite,
                     }) => {
-                        let Ok(object_store) = process_object_store(object_store, &sender) else {
+                        let Ok(object_store) = process_object_store(object_store, &callback) else {
                             continue;
                         };
                         let key = match key
@@ -424,12 +421,12 @@ impl KvsEngine for SqliteEngine {
                         {
                             Ok(key) => key,
                             Err(e) => {
-                                let _ = sender.send(Err(BackendError::DbErr(format!("{:?}", e))));
+                                let _ = callback.send(Err(BackendError::DbErr(format!("{:?}", e))));
                                 continue;
                             },
                         };
                         let serialized_key: Vec<u8> = bincode::serialize(&key).unwrap();
-                        let _ = sender.send(
+                        let _ = callback.send(
                             Self::put_item(
                                 &connection,
                                 object_store,
@@ -441,26 +438,26 @@ impl KvsEngine for SqliteEngine {
                         );
                     },
                     AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetItem {
-                        sender,
+                        callback,
                         key_range,
                     }) => {
-                        let Ok(object_store) = process_object_store(object_store, &sender) else {
+                        let Ok(object_store) = process_object_store(object_store, &callback) else {
                             continue;
                         };
-                        let _ = sender.send(
+                        let _ = callback.send(
                             Self::get_item(&connection, object_store, key_range)
                                 .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
                         );
                     },
                     AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetAllKeys {
-                        sender,
+                        callback,
                         key_range,
                         count,
                     }) => {
-                        let Ok(object_store) = process_object_store(object_store, &sender) else {
+                        let Ok(object_store) = process_object_store(object_store, &callback) else {
                             continue;
                         };
-                        let _ = sender.send(
+                        let _ = callback.send(
                             Self::get_all_keys(&connection, object_store, key_range, count)
                                 .map(|keys| {
                                     keys.into_iter()
@@ -471,51 +468,51 @@ impl KvsEngine for SqliteEngine {
                         );
                     },
                     AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetAllItems {
-                        sender,
+                        callback,
                         key_range,
                         count,
                     }) => {
-                        let Ok(object_store) = process_object_store(object_store, &sender) else {
+                        let Ok(object_store) = process_object_store(object_store, &callback) else {
                             continue;
                         };
-                        let _ = sender.send(
+                        let _ = callback.send(
                             Self::get_all_items(&connection, object_store, key_range, count)
                                 .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
                         );
                     },
                     AsyncOperation::ReadWrite(AsyncReadWriteOperation::RemoveItem {
-                        sender,
+                        callback,
                         key_range,
                     }) => {
-                        let Ok(object_store) = process_object_store(object_store, &sender) else {
+                        let Ok(object_store) = process_object_store(object_store, &callback) else {
                             continue;
                         };
-                        let _ = sender.send(
+                        let _ = callback.send(
                             Self::delete_item(&connection, object_store, key_range)
                                 .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
                         );
                     },
                     AsyncOperation::ReadOnly(AsyncReadOnlyOperation::Count {
-                        sender,
+                        callback,
                         key_range,
                     }) => {
-                        let Ok(object_store) = process_object_store(object_store, &sender) else {
+                        let Ok(object_store) = process_object_store(object_store, &callback) else {
                             continue;
                         };
-                        let _ = sender.send(
+                        let _ = callback.send(
                             Self::count(&connection, object_store, key_range)
                                 .map(|r| r as u64)
                                 .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
                         );
                     },
                     AsyncOperation::ReadOnly(AsyncReadOnlyOperation::Iterate {
-                        sender,
+                        callback,
                         key_range,
                     }) => {
-                        let Ok(object_store) = process_object_store(object_store, &sender) else {
+                        let Ok(object_store) = process_object_store(object_store, &callback) else {
                             continue;
                         };
-                        let _ = sender.send(
+                        let _ = callback.send(
                             Self::get_all_records(&connection, object_store, key_range)
                                 .map(|records| {
                                     records
@@ -540,13 +537,13 @@ impl KvsEngine for SqliteEngine {
                         );
                     },
                     AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetKey {
-                        sender,
+                        callback,
                         key_range,
                     }) => {
-                        let Ok(object_store) = process_object_store(object_store, &sender) else {
+                        let Ok(object_store) = process_object_store(object_store, &callback) else {
                             continue;
                         };
-                        let _ = sender.send(
+                        let _ = callback.send(
                             Self::get_key(&connection, object_store, key_range)
                                 .map(|key| key.map(|k| bincode::deserialize(&k).unwrap()))
                                 .map_err(|e| BackendError::DbErr(format!("{:?}", e))),
@@ -890,7 +887,7 @@ mod tests {
                 KvsOperation {
                     store_name: store_name.to_owned(),
                     operation: AsyncOperation::ReadWrite(AsyncReadWriteOperation::PutItem {
-                        sender: put.0,
+                        callback: put.0,
                         key: Some(IndexedDBKeyType::Number(1.0)),
                         value: vec![1, 2, 3],
                         should_overwrite: false,
@@ -899,7 +896,7 @@ mod tests {
                 KvsOperation {
                     store_name: store_name.to_owned(),
                     operation: AsyncOperation::ReadWrite(AsyncReadWriteOperation::PutItem {
-                        sender: put2.0,
+                        callback: put2.0,
                         key: Some(IndexedDBKeyType::String("2.0".to_string())),
                         value: vec![4, 5, 6],
                         should_overwrite: false,
@@ -908,7 +905,7 @@ mod tests {
                 KvsOperation {
                     store_name: store_name.to_owned(),
                     operation: AsyncOperation::ReadWrite(AsyncReadWriteOperation::PutItem {
-                        sender: put3.0,
+                        callback: put3.0,
                         key: Some(IndexedDBKeyType::Array(vec![
                             IndexedDBKeyType::String("3".to_string()),
                             IndexedDBKeyType::Number(0.0),
@@ -921,7 +918,7 @@ mod tests {
                 KvsOperation {
                     store_name: store_name.to_owned(),
                     operation: AsyncOperation::ReadWrite(AsyncReadWriteOperation::PutItem {
-                        sender: put_dup.0,
+                        callback: put_dup.0,
                         key: Some(IndexedDBKeyType::Number(1.0)),
                         value: vec![10, 11, 12],
                         should_overwrite: false,
@@ -930,21 +927,21 @@ mod tests {
                 KvsOperation {
                     store_name: store_name.to_owned(),
                     operation: AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetItem {
-                        sender: get_item_some.0,
+                        callback: get_item_some.0,
                         key_range: IndexedDBKeyRange::only(IndexedDBKeyType::Number(1.0)),
                     }),
                 },
                 KvsOperation {
                     store_name: store_name.to_owned(),
                     operation: AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetItem {
-                        sender: get_item_none.0,
+                        callback: get_item_none.0,
                         key_range: IndexedDBKeyRange::only(IndexedDBKeyType::Number(5.0)),
                     }),
                 },
                 KvsOperation {
                     store_name: store_name.to_owned(),
                     operation: AsyncOperation::ReadOnly(AsyncReadOnlyOperation::GetAllItems {
-                        sender: get_all_items.0,
+                        callback: get_all_items.0,
                         key_range: IndexedDBKeyRange::lower_bound(
                             IndexedDBKeyType::Number(0.0),
                             false,
@@ -955,14 +952,14 @@ mod tests {
                 KvsOperation {
                     store_name: store_name.to_owned(),
                     operation: AsyncOperation::ReadOnly(AsyncReadOnlyOperation::Count {
-                        sender: count.0,
+                        callback: count.0,
                         key_range: IndexedDBKeyRange::only(IndexedDBKeyType::Number(1.0)),
                     }),
                 },
                 KvsOperation {
                     store_name: store_name.to_owned(),
                     operation: AsyncOperation::ReadWrite(AsyncReadWriteOperation::RemoveItem {
-                        sender: remove.0,
+                        callback: remove.0,
                         key_range: IndexedDBKeyRange::only(IndexedDBKeyType::Number(1.0)),
                     }),
                 },

--- a/components/storage/storage_thread.rs
+++ b/components/storage/storage_thread.rs
@@ -5,7 +5,6 @@
 use std::path::PathBuf;
 
 use base::generic_channel::GenericSender;
-use ipc_channel::ipc::IpcSender;
 use profile_traits::mem::ProfilerChan as MemProfilerChan;
 use storage_traits::StorageThreads;
 use storage_traits::client_storage::ClientStorageThreadMessage;
@@ -21,7 +20,7 @@ pub fn new_storage_threads(
 ) -> (StorageThreads, StorageThreads) {
     let client_storage: GenericSender<ClientStorageThreadMessage> =
         ClientStorageThreadFactory::new(config_dir.clone());
-    let idb: IpcSender<IndexedDBThreadMsg> = IndexedDBThreadFactory::new(config_dir.clone());
+    let idb: GenericSender<IndexedDBThreadMsg> = IndexedDBThreadFactory::new(config_dir.clone());
     let web_storage: GenericSender<WebStorageThreadMsg> =
         WebStorageThreadFactory::new(config_dir, mem_profiler_chan);
     (


### PR DESCRIPTION
Moving IndexedDB to use the generic channel methods.

Of note is the change in 'IDBRequest::execute_async'. This method previously added a channel that was constructed from the callsite in put into the AsyncOperation. Now we do not take a function but take a 'FnOnce(GenericCallback<BackendResult<T>>) -> AsyncOperation'. With this the callsite can construct the AsyncOperation to give in the 'IndexedDBThreadMsg::Async'.

The rest are mostly just type changes.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: WPT tests on the IndexedDB subset still pass.
