### PR TITLE
Documentation: Add documentation for EmbedderMsg to clarify

### DIFF
--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -385,6 +385,7 @@ impl Image {
     }
 }
 
+/// Messages towards the embedder.
 #[derive(Deserialize, IntoStaticStr, Serialize)]
 pub enum EmbedderMsg {
     /// A status message to be displayed by the browser chrome.


### PR DESCRIPTION
EmbedderMsg go towards the Embedder. We clarify this.

Testing: Just a doc comment.
