### PR TITLE
Add wpt code coverage job to CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -494,6 +494,9 @@ jobs:
       - name: Bootstrap dependencies
         if: ${{ runner.environment != 'self-hosted' }}
         run: ./mach bootstrap --skip-lints --skip-nextest
+      - name: Set LIBCLANG_PATH env # needed for bindgen in mozangle
+        if: ${{ runner.environment != 'self-hosted' }}
+        run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
       - name: Build servo with coverage instrumentation
         run: ./mach build --locked --profile real-release --coverage
       - name: Build package for target

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -456,7 +456,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
+        uses: servo/ci-runners/actions/runner-select@f0b81b95522256c64ee207b4236ec71fc23b99a1
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -518,7 +518,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
+        uses: servo/ci-runners/actions/runner-select@f0b81b95522256c64ee207b4236ec71fc23b99a1
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -498,9 +498,9 @@ jobs:
         if: ${{ runner.environment != 'self-hosted' }}
         run: echo "LIBCLANG_PATH=/usr/lib/llvm-14/lib" >> $GITHUB_ENV
       - name: Build servo with coverage instrumentation
-        run: ./mach build --locked --profile real-release --coverage
+        run: ./mach build --locked --profile release --coverage
       - name: Build package for target
-        run: tar -czf target.tar.gz target/x86_64-unknown-linux-gnu/real-release/servo resources
+        run: tar -czf target.tar.gz target/x86_64-unknown-linux-gnu/release/servo resources
       - name: Upload artifact for target
         uses: actions/upload-artifact@v5
         with:
@@ -573,7 +573,7 @@ jobs:
         run: |
           mkdir -p wpt-filtered-logs/linux
           mkdir -p wpt-full-logs/linux
-          ./mach test-wpt --profile real-release --coverage --timeout-multiplier 2 \
+          ./mach test-wpt --profile release --coverage --timeout-multiplier 2 \
               --log-raw wpt-full-logs/linux/raw.log \
               --log-wptreport wpt-full-logs/linux/wptreport.json \
               --log-raw-stable-unexpected wpt-filtered-logs/linux.log \
@@ -585,11 +585,11 @@ jobs:
         with:
           name: wpt-code-coverage-raw-linux
           path: |
-            target/x86_64-unknown-linux-gnu/real-release/servo
+            target/x86_64-unknown-linux-gnu/release/servo
             target/*.profraw
       - name: Generate report
         run: |
-          ./mach coverage-report --profile real-release --codecov --output-path=codecov.json
+          ./mach coverage-report --profile release --codecov --output-path=codecov.json
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -456,7 +456,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
+        uses: servo/ci-runners/actions/runner-select@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -477,7 +477,7 @@ jobs:
     continue-on-error: true
     needs: [runner-select-coverage-build]
     steps:
-      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
+      - uses: servo/ci-runners/actions/checkout@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}
@@ -518,7 +518,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
+        uses: servo/ci-runners/actions/runner-select@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -539,7 +539,7 @@ jobs:
     continue-on-error: true
     needs: [runner-select-wpt-coverage]
     steps:
-      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
+      - uses: servo/ci-runners/actions/checkout@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -444,3 +444,165 @@ jobs:
       - name: Run Examples
         run: |
           ls components/media/examples/examples/*.rs | xargs -I{} basename  {} .rs  | grep -v params_connect | RUST_BACKTRACE=1 GST_DEBUG=3 xargs -I{} cargo run -p servo-media-examples --example {}
+
+  # Runs the underlying job (“workload”) on a self-hosted runner if available.
+  runner-select-coverage-build:
+    if: inputs.coverage
+    runs-on: ubuntu-24.04
+    outputs:
+      unique-id: ${{ steps.select.outputs.unique-id }}
+      selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
+      is-self-hosted: ${{ steps.select.outputs.is-self-hosted }}
+    steps:
+      - name: Runner select
+        id: select
+        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          # Before updating the GH action runner image for the nightly job, ensure
+          # that the system has a glibc version that is compatible with the one
+          # used by the wpt.fyi runners.
+          github-hosted-runner-label: ubuntu-22.04
+          self-hosted-image-name: servo-ubuntu2204
+          # You can disable self-hosted runners globally by creating a repository variable named
+          # NO_SELF_HOSTED_RUNNERS with any non-empty value.
+          # <https://github.com/servo/servo/settings/variables/actions>
+          NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
+          # Any other boolean conditions that disable self-hosted runners go here.
+          force-github-hosted-runner: ${{ inputs.force-github-hosted-runner }}
+
+  coverage-build:
+    name: Build for code coverage [${{ needs.runner-select-coverage-build.outputs.unique-id }}]
+    runs-on: ${{ needs.runner-select-coverage-build.outputs.selected-runner-label }}
+    continue-on-error: true
+    needs: [runner-select-coverage-build]
+    steps:
+      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        if: ${{ runner.environment != 'self-hosted' }}
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
+      - name: Setup Python
+        if: ${{ runner.environment != 'self-hosted' }}
+        uses: ./.github/actions/setup-python
+      - name: Change Mirror Priorities
+        if: ${{ runner.environment != 'self-hosted' }}
+        uses: ./.github/actions/apt-mirrors
+      - name: Bootstrap dependencies
+        if: ${{ runner.environment != 'self-hosted' }}
+        run: ./mach bootstrap --skip-lints --skip-nextest
+      - name: Build servo with coverage instrumentation
+        run: ./mach build --locked --profile real-release --coverage
+      - name: Build package for target
+        run: tar -czf target.tar.gz target/x86_64-unknown-linux-gnu/real-release/servo resources
+      - name: Upload artifact for target
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-binary-linux
+          path: target.tar.gz
+
+  # Runs the underlying job (“workload”) on a self-hosted runner if available.
+  runner-select-wpt-coverage:
+    runs-on: ubuntu-24.04
+    needs: coverage-build
+    outputs:
+      unique-id: ${{ steps.select.outputs.unique-id }}
+      selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
+      is-self-hosted: ${{ steps.select.outputs.is-self-hosted }}
+    steps:
+      - name: Runner select
+        id: select
+        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          # Before updating the GH action runner image for the nightly job, ensure
+          # that the system has a glibc version that is compatible with the one
+          # used by the wpt.fyi runners.
+          github-hosted-runner-label: ubuntu-22.04
+          self-hosted-image-name: servo-ubuntu2204
+          # You can disable self-hosted runners globally by creating a repository variable named
+          # NO_SELF_HOSTED_RUNNERS with any non-empty value.
+          # <https://github.com/servo/servo/settings/variables/actions>
+          NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
+          # Any other boolean conditions that disable self-hosted runners go here.
+          force-github-hosted-runner: ${{ inputs.force-github-hosted-runner }}
+
+  wpt-test-coverage:
+    name: WPT Test Coverage [${{ needs.runner-select-wpt-coverage.outputs.unique-id }}]
+    runs-on: ${{ needs.runner-select-wpt-coverage.outputs.selected-runner-label }}
+    continue-on-error: true
+    needs: [runner-select-wpt-coverage]
+    steps:
+      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        if: ${{ runner.environment != 'self-hosted' }}
+        with:
+          tool-cache: false
+          large-packages: false
+          swap-storage: false
+      - name: Setup Python
+        if: ${{ runner.environment != 'self-hosted' }}
+        uses: ./.github/actions/setup-python
+      - name: Change Mirror Priorities
+        if: ${{ runner.environment != 'self-hosted' }}
+        uses: ./.github/actions/apt-mirrors
+      - name: Bootstrap dependencies
+        if: ${{ runner.environment != 'self-hosted' }}
+        run: |
+          sudo apt update
+          sudo apt install -qy --no-install-recommends mesa-vulkan-drivers fonts-noto-cjk
+          ./mach bootstrap --skip-lints --skip-nextest
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - uses: actions/download-artifact@v5
+        with:
+          name: coverage-binary-linux
+          path: coverage-binary-linux
+      - name: unPackage binary
+        run: tar -xzf coverage-binary-linux/target.tar.gz
+      - name: Run wpt tests with code coverage
+        run: |
+          mkdir -p wpt-filtered-logs/linux
+          mkdir -p wpt-full-logs/linux
+          ./mach test-wpt --profile real-release --coverage --timeout-multiplier 2 \
+              --log-raw wpt-full-logs/linux/raw.log \
+              --log-wptreport wpt-full-logs/linux/wptreport.json \
+              --log-raw-stable-unexpected wpt-filtered-logs/linux.log \
+              --filter-intermittents wpt-filtered-logs/linux.json \
+              || echo "Unexpected wpt results. This may cause code-coverage to be inaccurate."
+      - name: Archive raw profile data
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: wpt-code-coverage-raw-linux
+          path: |
+            target/x86_64-unknown-linux-gnu/real-release/servo
+            target/*.profraw
+      - name: Generate report
+        run: |
+          ./mach coverage-report --profile real-release --codecov --output-path=codecov.json
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov.json
+          fail_ci_if_error: true
+          flags: wpt,wpt-linux
+      - name: Archive results (filtered)
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: wpt-filtered-logs-linux-${{ matrix.chunk_id }}
+          path: wpt-filtered-logs/*/
+      - name: Archive results (full)
+        uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: wpt-full-logs-linux-${{ matrix.chunk_id }}
+          path: wpt-full-logs/*/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,6 +326,10 @@ inherits = "release"
 debug-assertions = true
 overflow-checks = true
 
+[profile.real-release]
+inherits = "release"
+debug-assertions = false
+
 # Disk-space is limited in CI, so we disabled features that are not needed for code coverage.
 # Locally using the default `dev` profile is perfectly fine.
 [profile.coverage]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,10 +326,6 @@ inherits = "release"
 debug-assertions = true
 overflow-checks = true
 
-[profile.real-release]
-inherits = "release"
-debug-assertions = false
-
 # Disk-space is limited in CI, so we disabled features that are not needed for code coverage.
 # Locally using the default `dev` profile is perfectly fine.
 [profile.coverage]

--- a/python/servo/command_base.py
+++ b/python/servo/command_base.py
@@ -598,7 +598,7 @@ class CommandBase(object):
                         target_dir = get_target_dir()
                         # See `cargo llvm-cov show-env`. We only need the profile file environment variable
                         # The other variables are only required when creating a coverage report.
-                        os.environ["LLVM_PROFILE_FILE"] = f"{target_dir}/servo-%p-%14m.profraw"
+                        os.environ["LLVM_PROFILE_FILE"] = f"{target_dir}/servo-%p.profraw"
 
                 if binary_selection:
                     if "servo_binary" not in kwargs:

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -207,7 +207,7 @@ class PostBuildCommands(CommandBase):
         os.environ["CARGO_LLVM_COV_TARGET_DIR"] = target_dir
         profraw_files = [pathlib.Path(target_dir).joinpath(f) for f in os.listdir(target_dir) if f.endswith(".profraw")]
         zero_size_profraw_files = [f for f in profraw_files if os.path.getsize(f) == 0]
-        suspicously_small_files = [f for f in profraw_files if 0 < os.path.getsize(f) < 8000000 ]
+        suspicously_small_files = [f for f in profraw_files if 0 < os.path.getsize(f) < 8000000]
         filtered_profraw_files = [f for f in profraw_files if os.path.getsize(f) > 0]
         if len(zero_size_profraw_files) > 0:
             print(f"Warning found {len(zero_size_profraw_files)} zero-sized profraw files: {zero_size_profraw_files}")

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -10,6 +10,7 @@
 import json
 import os
 import os.path as path
+import pathlib
 import subprocess
 from subprocess import CompletedProcess
 from shutil import copy2
@@ -204,6 +205,20 @@ class PostBuildCommands(CommandBase):
         os.environ["CARGO_LLVM_COV"] = "1"
         os.environ["CARGO_LLVM_COV_SHOW_ENV"] = "1"
         os.environ["CARGO_LLVM_COV_TARGET_DIR"] = target_dir
+        profraw_files = [pathlib.Path(target_dir).joinpath(f) for f in os.listdir(target_dir) if f.endswith(".profraw")]
+        zero_size_profraw_files = [f for f in profraw_files if os.path.getsize(f) == 0]
+        suspicously_small_files = [f for f in profraw_files if 0 < os.path.getsize(f) < 8000000 ]
+        filtered_profraw_files = [f for f in profraw_files if os.path.getsize(f) > 0]
+        if len(zero_size_profraw_files) > 0:
+            print(f"Warning found {len(zero_size_profraw_files)} zero-sized profraw files: {zero_size_profraw_files}")
+            print(f"Removing {len(zero_size_profraw_files)} files, keeping {len(filtered_profraw_files)} files.")
+            for file in zero_size_profraw_files:
+                os.remove(file)
+        if len(suspicously_small_files) > 0:
+            print(f"Warning found {len(suspicously_small_files)} files with size < 8MB: {suspicously_small_files}")
+            for file in suspicously_small_files:
+                print(f"Removing {file}")
+                os.rename(file, str(file) + ".broken")
         try:
             cargo_llvm_cov_cmd = ["cargo", "llvm-cov", "report", "--target", self.target.triple()]
             cargo_llvm_cov_cmd.extend(build_type.as_cargo_arg())


### PR DESCRIPTION
This adds a job which can compute wpt code coverage on a self-hosted runner. 

Open issues: 

- Currently, around 10% of the profile files are either 0 size or corrupted and need to be filtered out.
Presumably this is due to servo not shutting down properly (e.g. could be crashing during a test). 
 Perhaps we could try dumping the coverage in the panic-handler, or running tests where the expectation is crash in a dedicated process to begin with.
- It takes around an hour on a self-hosted runner, but much longer on github-hosted runners (without chunking).
  Either we would need a way to force using a self-hosted runner, or add chunking support.

Testing: [try run](https://github.com/servo/servo/actions/runs/19890487861/job/57026388185), [codecov report from try run](https://app.codecov.io/github/servo/servo/commit/19fa9037554f3ce025395b8b2f8fa70372b99f9d/tree?dropdown=coverage)

