### PR TITLE
readablestream: respect abort ordering during pipeTo shutdown

### DIFF
--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -357,6 +357,7 @@ impl Callback for PipeTo {
 }
 
 impl PipeTo {
+    #[allow(clippy::too_many_arguments)]
     fn delay_cancel_until_abort(
         &self,
         cx: SafeJSContext,

--- a/tests/wpt/meta/streams/piping/abort.any.js.ini
+++ b/tests/wpt/meta/streams/piping/abort.any.js.ini
@@ -5,9 +5,6 @@
   expected: ERROR
 
 [abort.any.html]
-  [a rejection from underlyingSink.abort() should be preferred to one from underlyingSource.cancel()]
-    expected: FAIL
-
 
 [abort.any.shadowrealm-in-dedicatedworker.html]
   expected: ERROR
@@ -22,9 +19,6 @@
   expected: ERROR
 
 [abort.any.worker.html]
-  [a rejection from underlyingSink.abort() should be preferred to one from underlyingSource.cancel()]
-    expected: FAIL
-
 
 [abort.https.any.shadowrealm-in-audioworklet.html]
   expected: ERROR


### PR DESCRIPTION
readablestream: respect abort ordering during pipeTo shutdown

Testing: `a rejection from underlyingSink.abort() should be preferred to one from underlyingSource.cancel()` test is passing now.