### PR TITLE
dom: Avoid crashing on empty favicon `href` attribute

### DIFF
--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -257,7 +257,7 @@ impl VirtualMethods for HTMLLinkElement {
                 }
 
                 if self.relations.get().contains(LinkRelations::ICON) {
-                    self.handle_favicon_url();
+                    self.handle_favicon_url(&attr.value());
                 }
 
                 // https://html.spec.whatwg.org/multipage/#link-type-prefetch
@@ -275,7 +275,7 @@ impl VirtualMethods for HTMLLinkElement {
                 }
             },
             local_name!("sizes") if self.relations.get().contains(LinkRelations::ICON) => {
-                self.handle_favicon_url();
+                self.handle_favicon_url(&attr.value());
             },
             local_name!("crossorigin") => {
                 // https://html.spec.whatwg.org/multipage/#link-type-prefetch
@@ -378,7 +378,7 @@ impl VirtualMethods for HTMLLinkElement {
                 }
 
                 if relations.contains(LinkRelations::ICON) {
-                    self.handle_favicon_url();
+                    self.handle_favicon_url(&href);
                 }
 
                 if relations.contains(LinkRelations::PREFETCH) {
@@ -616,7 +616,12 @@ impl HTMLLinkElement {
         }
     }
 
-    fn handle_favicon_url(&self) {
+    fn handle_favicon_url(&self, href: &str) {
+        // If el's href attribute's value is the empty string, then return.
+        if href.is_empty() {
+            return;
+        }
+
         // The spec does not specify this, but we don't fetch favicons for iframes, as
         // they won't be displayed anyways.
         let window = self.owner_window();

--- a/tests/wpt/tests/html/links/icon/empty-href-crash.html
+++ b/tests/wpt/tests/html/links/icon/empty-href-crash.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Test for #41047: Panic when the href attribute of a link is empty.</title>
+<link rel="icon" href="">


### PR DESCRIPTION
Add a check to handle_favicon_url() similar to the ones done in similar functions: handle_stylesheet_url() and fetch_and_process_prefetch_link()

Testing: Check that loading http://chiptune.com/  doesn't crash anymore.
Fixes: https://github.com/servo/servo/issues/41047
