### PR TITLE
dom: add a pseudo-iterator that doesn't root and unroot

### DIFF
--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -159,7 +159,7 @@ use crate::dom::mutationobserver::{Mutation, MutationObserver};
 use crate::dom::namednodemap::NamedNodeMap;
 use crate::dom::node::{
     BindContext, ChildrenMutation, CloneChildrenFlag, IsShadowTree, LayoutNodeHelpers, Node,
-    NodeDamage, NodeFlags, NodeTraits, ShadowIncluding, UnbindContext,
+    NodeDamage, NodeFlags, NodeTraits, ShadowIncluding, UnbindContext, UnrootedIterator,
 };
 use crate::dom::nodelist::NodeList;
 use crate::dom::promise::Promise;
@@ -4764,7 +4764,7 @@ impl SelectorsElement for SelectorWrapper<'_> {
     }
 
     fn is_empty(&self) -> bool {
-        self.node.children().all(|node| {
+        self.node.unrooted_children().all(|node| {
             !node.is::<Element>() &&
                 match node.downcast::<Text>() {
                     None => true,
@@ -5299,7 +5299,10 @@ impl Element {
             }
             if let Some(ref legend) = ancestor.children().find(|n| n.is::<HTMLLegendElement>()) {
                 // XXXabinader: should we save previous ancestor to avoid this iteration?
-                if node.ancestors().any(|ancestor| ancestor == *legend) {
+                if node
+                    .unrooted_ancestors()
+                    .any(|ancestor| *ancestor == **legend)
+                {
                     continue;
                 }
             }

--- a/components/script/dom/html/htmlbuttonelement.rs
+++ b/components/script/dom/html/htmlbuttonelement.rs
@@ -26,7 +26,7 @@ use crate::dom::html::htmlformelement::{
     FormControl, FormDatum, FormDatumValue, FormSubmitterElement, HTMLFormElement, ResetFrom,
     SubmittedFrom,
 };
-use crate::dom::node::{BindContext, Node, NodeTraits, UnbindContext};
+use crate::dom::node::{BindContext, Node, NodeTraits, UnbindContext, UnrootedIterator};
 use crate::dom::nodelist::NodeList;
 use crate::dom::validation::{Validatable, is_barred_by_datalist_ancestor};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
@@ -303,7 +303,7 @@ impl VirtualMethods for HTMLButtonElement {
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();
         if node
-            .ancestors()
+            .unrooted_ancestors()
             .any(|ancestor| ancestor.is::<HTMLFieldSetElement>())
         {
             el.check_ancestors_disabled_state_for_form_control();

--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -75,7 +75,8 @@ use crate::dom::html::htmloutputelement::HTMLOutputElement;
 use crate::dom::html::htmlselectelement::HTMLSelectElement;
 use crate::dom::html::htmltextareaelement::HTMLTextAreaElement;
 use crate::dom::node::{
-    BindContext, Node, NodeFlags, NodeTraits, UnbindContext, VecPreOrderInsertionHelper,
+    BindContext, Node, NodeFlags, NodeTraits, UnbindContext, UnrootedIterator,
+    VecPreOrderInsertionHelper,
 };
 use crate::dom::nodelist::{NodeList, RadioListMode};
 use crate::dom::radionodelist::RadioNodeList;
@@ -1216,7 +1217,10 @@ impl HTMLFormElement {
             let child = child.upcast::<Node>();
 
             // Step 5.1: The field element has a datalist element ancestor.
-            if child.ancestors().any(|a| a.is::<HTMLDataListElement>()) {
+            if child
+                .unrooted_ancestors()
+                .any(|a| a.is::<HTMLDataListElement>())
+            {
                 continue;
             }
             if let NodeTypeId::Element(ElementTypeId::HTMLElement(element)) = child.type_id() {

--- a/components/script/dom/html/htmlinputelement.rs
+++ b/components/script/dom/html/htmlinputelement.rs
@@ -78,6 +78,7 @@ use crate::dom::keyboardevent::KeyboardEvent;
 use crate::dom::mouseevent::MouseEvent;
 use crate::dom::node::{
     BindContext, CloneChildrenFlag, Node, NodeDamage, NodeTraits, ShadowIncluding, UnbindContext,
+    UnrootedIterator,
 };
 use crate::dom::nodelist::NodeList;
 use crate::dom::shadowroot::ShadowRoot;
@@ -3195,7 +3196,7 @@ impl VirtualMethods for HTMLInputElement {
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();
         if node
-            .ancestors()
+            .unrooted_ancestors()
             .any(|ancestor| ancestor.is::<HTMLFieldSetElement>())
         {
             el.check_ancestors_disabled_state_for_form_control();

--- a/components/script/dom/html/htmllegendelement.rs
+++ b/components/script/dom/html/htmllegendelement.rs
@@ -15,7 +15,7 @@ use crate::dom::element::Element;
 use crate::dom::html::htmlelement::HTMLElement;
 use crate::dom::html::htmlfieldsetelement::HTMLFieldSetElement;
 use crate::dom::html::htmlformelement::{FormControl, HTMLFormElement};
-use crate::dom::node::{BindContext, Node, UnbindContext};
+use crate::dom::node::{BindContext, Node, UnbindContext, UnrootedIterator};
 use crate::dom::virtualmethods::VirtualMethods;
 use crate::script_runtime::CanGc;
 
@@ -76,7 +76,7 @@ impl VirtualMethods for HTMLLegendElement {
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();
         if node
-            .ancestors()
+            .unrooted_ancestors()
             .any(|ancestor| ancestor.is::<HTMLFieldSetElement>())
         {
             el.check_ancestors_disabled_state_for_form_control();

--- a/components/script/dom/html/htmlselectelement.rs
+++ b/components/script/dom/html/htmlselectelement.rs
@@ -4,7 +4,7 @@
 
 use std::default::Default;
 use std::iter;
-
+use crate::dom::node::UnrootedIterator;
 use dom_struct::dom_struct;
 use embedder_traits::EmbedderControlRequest;
 use embedder_traits::{SelectElementOption, SelectElementOptionOrOptgroup};
@@ -715,7 +715,7 @@ impl VirtualMethods for HTMLSelectElement {
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();
         if node
-            .ancestors()
+            .unrooted_ancestors()
             .any(|ancestor| ancestor.is::<HTMLFieldSetElement>())
         {
             el.check_ancestors_disabled_state_for_form_control();

--- a/components/script/dom/html/htmltextareaelement.rs
+++ b/components/script/dom/html/htmltextareaelement.rs
@@ -37,6 +37,7 @@ use crate::dom::html::htmlinputelement::HTMLInputElement;
 use crate::dom::keyboardevent::KeyboardEvent;
 use crate::dom::node::{
     BindContext, ChildrenMutation, CloneChildrenFlag, Node, NodeDamage, NodeTraits, UnbindContext,
+    UnrootedIterator,
 };
 use crate::dom::nodelist::NodeList;
 use crate::dom::textcontrol::{TextControlElement, TextControlSelection};
@@ -657,7 +658,7 @@ impl VirtualMethods for HTMLTextAreaElement {
         let node = self.upcast::<Node>();
         let el = self.upcast::<Element>();
         if node
-            .ancestors()
+            .unrooted_ancestors()
             .any(|ancestor| ancestor.is::<HTMLFieldSetElement>())
         {
             el.check_ancestors_disabled_state_for_form_control();

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -1239,6 +1239,13 @@ impl Node {
         }
     }
 
+    pub(crate) fn unrooted_ancestors(&self) -> impl UnrootedIterator {
+        UnrootedNodeIterator {
+            start: &self.parent_node,
+            next_node: |n| &n.parent_node,
+        }
+    }
+
     /// <https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-ancestor>
     pub(crate) fn inclusive_ancestors(
         &self,
@@ -1289,6 +1296,13 @@ impl Node {
         SimpleNodeIterator {
             current: self.GetFirstChild(),
             next_node: |n| n.GetNextSibling(),
+        }
+    }
+
+    pub(crate) fn unrooted_children(&self) -> impl UnrootedIterator {
+        UnrootedNodeIterator {
+            start: &self.first_child,
+            next_node: |n| &n.next_sibling,
         }
     }
 
@@ -2158,6 +2172,89 @@ where
     }
 }
 
+/// An iterator that doesn't root items and exposes a subset of the
+/// regular `Iterator` trait that are safe with no rooting.
+pub(crate) trait UnrootedIterator {
+    fn any<F>(&self, closure: F) -> bool
+    where
+        F: Fn(&Node) -> bool;
+
+    fn all<F>(&self, closure: F) -> bool
+    where
+        F: Fn(&Node) -> bool;
+
+    fn is_empty(&self) -> bool;
+}
+
+struct UnrootedNodeIterator<'a, I>
+where
+    I: Fn(&Node) -> &MutNullableDom<Node>,
+{
+    start: &'a MutNullableDom<Node>,
+    next_node: I,
+}
+
+impl<'a, I> UnrootedNodeIterator<'a, I>
+where
+    I: Fn(&Node) -> &MutNullableDom<Node>,
+{
+    fn any_all_common<F>(&self, closure: F, expected: bool) -> bool
+    where
+        F: Fn(&Node) -> bool,
+    {
+        let mut current = self.start;
+        let mut done = false;
+        let mut result = !expected;
+
+        while let Some(node) = current.if_is_some(|p| {
+            // Update the state based on the closure result.
+            if closure(p) == expected {
+                done = true;
+                result = expected;
+            }
+
+            // Move the iterator along.
+            (self.next_node)(p)
+        }) {
+            if done {
+                break;
+            }
+            current = node
+        }
+
+        result
+    }
+}
+
+impl<'a, I> UnrootedIterator for UnrootedNodeIterator<'a, I>
+where
+    I: Fn(&Node) -> &MutNullableDom<Node>,
+{
+    fn any<F>(&self, closure: F) -> bool
+    where
+        F: Fn(&Node) -> bool,
+    {
+        self.any_all_common(closure, true)
+    }
+
+    fn all<F>(&self, closure: F) -> bool
+    where
+        F: Fn(&Node) -> bool,
+    {
+        self.any_all_common(closure, false)
+    }
+
+    fn is_empty(&self) -> bool {
+        let mut empty = true;
+        self.start.if_is_some(|_| {
+            empty = false;
+            &None::<Node>
+        });
+
+        empty
+    }
+}
+
 /// Whether a tree traversal should pass shadow tree boundaries.
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) enum ShadowIncluding {
@@ -2419,7 +2516,7 @@ impl Node {
                 // Step 6.1
                 NodeTypeId::DocumentFragment(_) => {
                     // Step 6.1.1(b)
-                    if node.children().any(|c| c.is::<Text>()) {
+                    if node.unrooted_children().any(|c| c.is::<Text>()) {
                         return Err(Error::HierarchyRequest(None));
                     }
                     match node.child_elements().count() {
@@ -2458,7 +2555,7 @@ impl Node {
                 },
                 // Step 6.3
                 NodeTypeId::DocumentType => {
-                    if parent.children().any(|c| c.is_doctype()) {
+                    if parent.unrooted_children().any(|c| c.is_doctype()) {
                         return Err(Error::HierarchyRequest(None));
                     }
                     match child {
@@ -3571,7 +3668,7 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                 // Step 6.1
                 NodeTypeId::DocumentFragment(_) => {
                     // Step 6.1.1(b)
-                    if node.children().any(|c| c.is::<Text>()) {
+                    if node.unrooted_children().any(|c| c.is::<Text>()) {
                         return Err(Error::HierarchyRequest(None));
                     }
                     match node.child_elements().count() {
@@ -3600,7 +3697,10 @@ impl NodeMethods<crate::DomTypeHolder> for Node {
                 },
                 // Step 6.3
                 NodeTypeId::DocumentType => {
-                    if self.children().any(|c| c.is_doctype() && &*c != child) {
+                    if self
+                        .unrooted_children()
+                        .any(|c| c.is_doctype() && c != child)
+                    {
                         return Err(Error::HierarchyRequest(None));
                     }
                     if self

--- a/components/script/dom/validation.rs
+++ b/components/script/dom/validation.rs
@@ -10,7 +10,7 @@ use crate::dom::element::Element;
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::html::htmldatalistelement::HTMLDataListElement;
 use crate::dom::html::htmlelement::HTMLElement;
-use crate::dom::node::Node;
+use crate::dom::node::{Node, UnrootedIterator};
 use crate::dom::validitystate::{ValidationFlags, ValidityState};
 use crate::script_runtime::CanGc;
 
@@ -100,7 +100,7 @@ pub(crate) trait Validatable {
 /// <https://html.spec.whatwg.org/multipage/#the-datalist-element%3Abarred-from-constraint-validation>
 pub(crate) fn is_barred_by_datalist_ancestor(elem: &Node) -> bool {
     elem.upcast::<Node>()
-        .ancestors()
+        .unrooted_ancestors()
         .any(|node| node.is::<HTMLDataListElement>())
 }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -62,7 +62,7 @@ use crate::dom::event::{Event, EventBubbles, EventCancelable};
 use crate::dom::eventtarget::EventTarget;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::headers::is_forbidden_request_header;
-use crate::dom::node::Node;
+use crate::dom::node::{Node, UnrootedIterator};
 use crate::dom::performance::performanceresourcetiming::InitiatorType;
 use crate::dom::progressevent::ProgressEvent;
 use crate::dom::readablestream::ReadableStream;
@@ -1418,7 +1418,7 @@ impl XMLHttpRequest {
             // Not sure it the parser should throw an error for this case
             // The specification does not indicates this test,
             // but for now we check the document has no child nodes
-            let has_no_child_nodes = temp_doc.upcast::<Node>().children().next().is_none();
+            let has_no_child_nodes = temp_doc.upcast::<Node>().unrooted_children().is_empty();
             if has_no_child_nodes {
                 return None;
             }


### PR DESCRIPTION
This adds a trait and struct implementing that trait to expose safe methods to use on node sets without rooting and unrooting items. For now the trait exposes `any()`, `all()`  and `is_empty()`, and the `children()` and `ancestors()` iterators have an unrooted version.

Testing: Covered by existing WPT.
Fixes: Related to https://github.com/servo/servo/issues/40713 but not a full fix.
