### PR TITLE
ci: Run WPT jobs on self-hosted runners

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
+        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: ubuntu-22.04
@@ -77,7 +77,7 @@ jobs:
     name: Bencher (${{ inputs.target }}) [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@3fde8fcc735354a1b17223c80b7d4170af7a8551
+      - uses: servo/ci-runners/actions/checkout@4422139e238c3699ba62d452839cd9cf46c374b6
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-${{ inputs.target }}

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
+        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: ubuntu-22.04
@@ -77,7 +77,7 @@ jobs:
     name: Bencher (${{ inputs.target }}) [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
+      - uses: servo/ci-runners/actions/checkout@3fde8fcc735354a1b17223c80b7d4170af7a8551
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-${{ inputs.target }}

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+        uses: servo/ci-runners/actions/runner-select@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: ubuntu-22.04
@@ -77,7 +77,7 @@ jobs:
     name: Bencher (${{ inputs.target }}) [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+      - uses: servo/ci-runners/actions/checkout@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-${{ inputs.target }}

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
+        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: ubuntu-22.04
@@ -77,7 +77,7 @@ jobs:
     name: Bencher (${{ inputs.target }}) [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@4422139e238c3699ba62d452839cd9cf46c374b6
+      - uses: servo/ci-runners/actions/checkout@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.profile }}-binary-${{ inputs.target }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
+        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -42,7 +42,7 @@ jobs:
     name: Lint [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@3fde8fcc735354a1b17223c80b7d4170af7a8551
+      - uses: servo/ci-runners/actions/checkout@4422139e238c3699ba62d452839cd9cf46c374b6
         with:
           fetch-depth: 2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
+        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -42,7 +42,7 @@ jobs:
     name: Lint [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
+      - uses: servo/ci-runners/actions/checkout@3fde8fcc735354a1b17223c80b7d4170af7a8551
         with:
           fetch-depth: 2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
+        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -42,7 +42,7 @@ jobs:
     name: Lint [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@4422139e238c3699ba62d452839cd9cf46c374b6
+      - uses: servo/ci-runners/actions/checkout@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
         with:
           fetch-depth: 2
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+        uses: servo/ci-runners/actions/runner-select@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -42,7 +42,7 @@ jobs:
     name: Lint [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+      - uses: servo/ci-runners/actions/checkout@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
         with:
           fetch-depth: 2
 

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -35,50 +35,39 @@ jobs:
     outputs:
       unique-id: ${{ steps.select.outputs.unique-id }}
       selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
+      selected-runner-count: ${{ steps.select.outputs.selected-runner-count }}
+      selected-runner-indices: ${{ steps.select.outputs.selected-runner-indices }}
       runner-type-label: ${{ steps.select.outputs.runner-type-label }}
       is-self-hosted: ${{ steps.select.outputs.is-self-hosted }}
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
+        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
           # that the system has a glibc version that is compatible with the one
           # used by the wpt.fyi runners.
           github-hosted-runner-label: ubuntu-22.04
+          github-hosted-runner-count: ${{ inputs.number-of-wpt-chunks }}
           self-hosted-image-name: servo-ubuntu2204-wpt
           self-hosted-runner-count: 2
+          first-runner-index: 1
           # You can disable self-hosted runners globally by creating a repository variable named
           # NO_SELF_HOSTED_RUNNERS with any non-empty value.
           # <https://github.com/servo/servo/settings/variables/actions>
           NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
           # Any other boolean conditions that disable self-hosted runners go here.
           force-github-hosted-runner: ${{ inputs.upload || inputs.force-github-hosted-runner }}
-  chunks:
-    needs:
-      - runner-select
-    name: Generate chunks array
-    runs-on: ubuntu-22.04
-    outputs:
-      chunks-array: ${{ steps.generate-chunks-array.outputs.result }}
-      number-of-chunks: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && 2 || inputs.number-of-wpt-chunks }}
-    steps:
-      - uses: actions/github-script@v7
-        id: generate-chunks-array
-        with:
-          script: |
-            return Array.from({length: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && 2 || inputs.number-of-wpt-chunks }}}, (_, i) => i + 1)
   linux-wpt:
     needs:
       - runner-select
-      - chunks
     name: WPT [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     strategy:
       fail-fast: false
       matrix:
-        chunk_id: ${{ fromJson(needs.chunks.outputs.chunks-array) }}
+        chunk_id: ${{ fromJSON(needs.runner-select.outputs.selected-runner-indices) }}
     steps:
       - uses: actions/checkout@v5
         if: github.event_name != 'pull_request_target'
@@ -120,7 +109,7 @@ jobs:
           ./mach test-wpt \
             $WPT_ALWAYS_SUCCEED_ARG \
             --profile ${{ inputs.profile }} --processes $((nproc * 4)) --timeout-multiplier 2 \
-            --total-chunks ${{ needs.chunks.outputs.number-of-chunks }} --this-chunk ${{ matrix.chunk_id }} \
+            --total-chunks ${{ needs.runner-select.outputs.selected-runner-count }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/linux/raw/${{ matrix.chunk_id }}.log \
             --log-wptreport wpt-full-logs/linux/wptreport/${{ matrix.chunk_id }}.json \
             --log-raw-stable-unexpected wpt-filtered-logs/linux/${{ matrix.chunk_id }}.log \

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -28,21 +28,53 @@ env:
   WPT_ALWAYS_SUCCEED_ARG: "${{ inputs.wpt-sync-from-upstream && '--always-succeed' || '' }}"
 
 jobs:
+  # Runs the underlying job (“workload”) on a self-hosted runner if available,
+  # with the help of a `runner-select` job and a `runner-timeout` job.
+  runner-select:
+    runs-on: ubuntu-24.04
+    outputs:
+      unique-id: ${{ steps.select.outputs.unique-id }}
+      selected-runner-label: ${{ steps.select.outputs.selected-runner-label }}
+      runner-type-label: ${{ steps.select.outputs.runner-type-label }}
+      is-self-hosted: ${{ steps.select.outputs.is-self-hosted }}
+    steps:
+      - name: Runner select
+        id: select
+        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          # Before updating the GH action runner image for the nightly job, ensure
+          # that the system has a glibc version that is compatible with the one
+          # used by the wpt.fyi runners.
+          github-hosted-runner-label: ubuntu-22.04
+          self-hosted-image-name: servo-ubuntu2204-wpt
+          self-hosted-runner-count: 2
+          # You can disable self-hosted runners globally by creating a repository variable named
+          # NO_SELF_HOSTED_RUNNERS with any non-empty value.
+          # <https://github.com/servo/servo/settings/variables/actions>
+          NO_SELF_HOSTED_RUNNERS: ${{ vars.NO_SELF_HOSTED_RUNNERS }}
+          # Any other boolean conditions that disable self-hosted runners go here.
+          force-github-hosted-runner: ${{ inputs.upload || inputs.force-github-hosted-runner }}
   chunks:
+    needs:
+      - runner-select
     name: Generate chunks array
     runs-on: ubuntu-22.04
     outputs:
       chunks-array: ${{ steps.generate-chunks-array.outputs.result }}
+      number-of-chunks: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && 2 || inputs.number-of-wpt-chunks }}
     steps:
       - uses: actions/github-script@v7
         id: generate-chunks-array
         with:
           script: |
-            return Array.from({length: ${{ inputs.number-of-wpt-chunks }}}, (_, i) => i + 1)
+            return Array.from({length: ${{ fromJSON(needs.runner-select.outputs.is-self-hosted) && 2 || inputs.number-of-wpt-chunks }}}, (_, i) => i + 1)
   linux-wpt:
-    name: WPT
-    runs-on: ubuntu-22.04
-    needs: chunks
+    needs:
+      - runner-select
+      - chunks
+    name: WPT [${{ needs.runner-select.outputs.unique-id }}]
+    runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     strategy:
       fail-fast: false
       matrix:
@@ -63,8 +95,10 @@ jobs:
       - name: unPackage binary
         run: tar -xzf ${{ inputs.profile }}-binary-linux/target.tar.gz
       - name: Setup Python
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: ./.github/actions/setup-python
       - name: Change Mirror Priorities
+        if: ${{ runner.environment != 'self-hosted' }}
         uses: ./.github/actions/apt-mirrors
       - name: Bootstrap dependencies
         run: |
@@ -75,14 +109,18 @@ jobs:
         if: ${{ inputs.wpt-sync-from-upstream }}
         run: |
           ./mach update-wpt --sync --patch
+      - run: |
+          apt purge -y fonts-droid-fallback
+          apt install -y fonts-dejavu-extra
       - name: Run tests
         run: |
           mkdir -p wpt-filtered-logs/linux
           mkdir -p wpt-full-logs/linux
+          nproc=$(nproc)
           ./mach test-wpt \
             $WPT_ALWAYS_SUCCEED_ARG \
-            --profile ${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
-            --total-chunks ${{ inputs.number-of-wpt-chunks }} --this-chunk ${{ matrix.chunk_id }} \
+            --profile ${{ inputs.profile }} --processes $((nproc * 4)) --timeout-multiplier 2 \
+            --total-chunks ${{ needs.chunks.outputs.number-of-chunks }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/linux/raw/${{ matrix.chunk_id }}.log \
             --log-wptreport wpt-full-logs/linux/wptreport/${{ matrix.chunk_id }}.json \
             --log-raw-stable-unexpected wpt-filtered-logs/linux/${{ matrix.chunk_id }}.log \

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -92,15 +92,16 @@ jobs:
       - name: Bootstrap dependencies
         run: |
           sudo apt update
-          sudo apt install -qy --no-install-recommends mesa-vulkan-drivers fonts-noto-cjk
           ./mach bootstrap --skip-lints --skip-nextest
+          # FIXME #41043, #41044
+          sudo apt install -qy --no-install-recommends mesa-vulkan-drivers fonts-noto-cjk fonts-dejavu-extra
+          # FIXME #35029
+          sudo apt purge -y fonts-droid-fallback
       - name: Sync from upstream WPT
         if: ${{ inputs.wpt-sync-from-upstream }}
         run: |
           ./mach update-wpt --sync --patch
       - run: |
-          apt purge -y fonts-droid-fallback
-          apt install -y fonts-dejavu-extra
       - name: Run tests
         run: |
           mkdir -p wpt-filtered-logs/linux

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -108,7 +108,7 @@ jobs:
           nproc=$(nproc)
           ./mach test-wpt \
             $WPT_ALWAYS_SUCCEED_ARG \
-            --profile ${{ inputs.profile }} --processes $((nproc * ${{ inputs.wpt-args == '' && 2 || 1 }})) --timeout-multiplier 2 \
+            --profile ${{ inputs.profile }} --processes $((nproc * ${{ runner.environment == 'self-hosted' && 2 || 1 }})) --timeout-multiplier 2 \
             --total-chunks ${{ needs.runner-select.outputs.selected-runner-count }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/linux/raw/${{ matrix.chunk_id }}.log \
             --log-wptreport wpt-full-logs/linux/wptreport/${{ matrix.chunk_id }}.json \

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -51,7 +51,7 @@ jobs:
           github-hosted-runner-label: ubuntu-22.04
           github-hosted-runner-count: ${{ inputs.number-of-wpt-chunks }}
           self-hosted-image-name: servo-ubuntu2204-wpt
-          self-hosted-runner-count: 2
+          self-hosted-runner-count: 3
           first-runner-index: 1
           # You can disable self-hosted runners globally by creating a repository variable named
           # NO_SELF_HOSTED_RUNNERS with any non-empty value.

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
+        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+        uses: servo/ci-runners/actions/runner-select@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -52,7 +52,6 @@ jobs:
           github-hosted-runner-count: ${{ inputs.number-of-wpt-chunks }}
           self-hosted-image-name: servo-ubuntu2204-wpt
           self-hosted-runner-count: 3
-          first-runner-index: 1
           # You can disable self-hosted runners globally by creating a repository variable named
           # NO_SELF_HOSTED_RUNNERS with any non-empty value.
           # <https://github.com/servo/servo/settings/variables/actions>

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -109,7 +109,7 @@ jobs:
           nproc=$(nproc)
           ./mach test-wpt \
             $WPT_ALWAYS_SUCCEED_ARG \
-            --profile ${{ inputs.profile }} --processes $((nproc * 4)) --timeout-multiplier 2 \
+            --profile ${{ inputs.profile }} --processes $((nproc * ${{ inputs.wpt-args == '' && 2 || 1 }})) --timeout-multiplier 2 \
             --total-chunks ${{ needs.runner-select.outputs.selected-runner-count }} --this-chunk ${{ matrix.chunk_id }} \
             --log-raw wpt-full-logs/linux/raw/${{ matrix.chunk_id }}.log \
             --log-wptreport wpt-full-logs/linux/wptreport/${{ matrix.chunk_id }}.json \

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -100,7 +100,6 @@ jobs:
         if: ${{ inputs.wpt-sync-from-upstream }}
         run: |
           ./mach update-wpt --sync --patch
-      - run: |
       - name: Run tests
         run: |
           mkdir -p wpt-filtered-logs/linux

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+        uses: servo/ci-runners/actions/runner-select@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -133,7 +133,7 @@ jobs:
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+      - uses: servo/ci-runners/actions/checkout@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}
@@ -298,7 +298,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+        uses: servo/ci-runners/actions/runner-select@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -320,7 +320,7 @@ jobs:
     runs-on: ${{ needs.runner-select-coverage.outputs.selected-runner-label }}
     continue-on-error: true
     steps:
-      - uses: servo/ci-runners/actions/checkout@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+      - uses: servo/ci-runners/actions/checkout@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
+        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -133,7 +133,7 @@ jobs:
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
+      - uses: servo/ci-runners/actions/checkout@3fde8fcc735354a1b17223c80b7d4170af7a8551
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}
@@ -298,7 +298,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
+        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -320,7 +320,7 @@ jobs:
     runs-on: ${{ needs.runner-select-coverage.outputs.selected-runner-label }}
     continue-on-error: true
     steps:
-      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
+      - uses: servo/ci-runners/actions/checkout@3fde8fcc735354a1b17223c80b7d4170af7a8551
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
+        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -133,7 +133,7 @@ jobs:
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@4422139e238c3699ba62d452839cd9cf46c374b6
+      - uses: servo/ci-runners/actions/checkout@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}
@@ -298,7 +298,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
+        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -320,7 +320,7 @@ jobs:
     runs-on: ${{ needs.runner-select-coverage.outputs.selected-runner-label }}
     continue-on-error: true
     steps:
-      - uses: servo/ci-runners/actions/checkout@4422139e238c3699ba62d452839cd9cf46c374b6
+      - uses: servo/ci-runners/actions/checkout@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
+        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -133,7 +133,7 @@ jobs:
     name: Linux Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@3fde8fcc735354a1b17223c80b7d4170af7a8551
+      - uses: servo/ci-runners/actions/checkout@4422139e238c3699ba62d452839cd9cf46c374b6
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}
@@ -298,7 +298,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
+        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
         with:
           GITHUB_TOKEN: ${{ github.token }}
           # Before updating the GH action runner image for the nightly job, ensure
@@ -320,7 +320,7 @@ jobs:
     runs-on: ${{ needs.runner-select-coverage.outputs.selected-runner-label }}
     continue-on-error: true
     steps:
-      - uses: servo/ci-runners/actions/checkout@3fde8fcc735354a1b17223c80b7d4170af7a8551
+      - uses: servo/ci-runners/actions/checkout@4422139e238c3699ba62d452839cd9cf46c374b6
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         if: ${{ runner.environment != 'self-hosted' }}

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
+        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: macos-15-intel
@@ -119,7 +119,7 @@ jobs:
       - name: Kill XProtectBehaviorService
         run: |
           echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
-      - uses: servo/ci-runners/actions/checkout@3fde8fcc735354a1b17223c80b7d4170af7a8551
+      - uses: servo/ci-runners/actions/checkout@4422139e238c3699ba62d452839cd9cf46c374b6
 
       - if: runner.environment != 'self-hosted'
         name: Setup Python

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
+        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: macos-15-intel
@@ -119,7 +119,7 @@ jobs:
       - name: Kill XProtectBehaviorService
         run: |
           echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
-      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
+      - uses: servo/ci-runners/actions/checkout@3fde8fcc735354a1b17223c80b7d4170af7a8551
 
       - if: runner.environment != 'self-hosted'
         name: Setup Python

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
+        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: macos-15-intel
@@ -119,7 +119,7 @@ jobs:
       - name: Kill XProtectBehaviorService
         run: |
           echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
-      - uses: servo/ci-runners/actions/checkout@4422139e238c3699ba62d452839cd9cf46c374b6
+      - uses: servo/ci-runners/actions/checkout@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
 
       - if: runner.environment != 'self-hosted'
         name: Setup Python

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+        uses: servo/ci-runners/actions/runner-select@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: macos-15-intel
@@ -119,7 +119,7 @@ jobs:
       - name: Kill XProtectBehaviorService
         run: |
           echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
-      - uses: servo/ci-runners/actions/checkout@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+      - uses: servo/ci-runners/actions/checkout@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
 
       - if: runner.environment != 'self-hosted'
         name: Setup Python

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
+        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: windows-2022
@@ -103,7 +103,7 @@ jobs:
     name: Windows Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@3fde8fcc735354a1b17223c80b7d4170af7a8551
+      - uses: servo/ci-runners/actions/checkout@4422139e238c3699ba62d452839cd9cf46c374b6
 
       - name: ccache
         # FIXME: “Error: Restoring cache failed: Error: Unable to locate executable file: sh.”

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@44317e3cd86c5ff2ef0b08878b90da246bc237da
+        uses: servo/ci-runners/actions/runner-select@3fde8fcc735354a1b17223c80b7d4170af7a8551
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: windows-2022
@@ -103,7 +103,7 @@ jobs:
     name: Windows Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
+      - uses: servo/ci-runners/actions/checkout@3fde8fcc735354a1b17223c80b7d4170af7a8551
 
       - name: ccache
         # FIXME: “Error: Restoring cache failed: Error: Unable to locate executable file: sh.”

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+        uses: servo/ci-runners/actions/runner-select@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: windows-2022
@@ -103,7 +103,7 @@ jobs:
     name: Windows Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
+      - uses: servo/ci-runners/actions/checkout@6d88b19dda997f1ce2a11e4c1c34717c2bbcafba
 
       - name: ccache
         # FIXME: “Error: Restoring cache failed: Error: Unable to locate executable file: sh.”

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: Runner select
         id: select
-        uses: servo/ci-runners/actions/runner-select@4422139e238c3699ba62d452839cd9cf46c374b6
+        uses: servo/ci-runners/actions/runner-select@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
         with:
           GITHUB_TOKEN: ${{ github.token }}
           github-hosted-runner-label: windows-2022
@@ -103,7 +103,7 @@ jobs:
     name: Windows Build [${{ needs.runner-select.outputs.unique-id }}]
     runs-on: ${{ needs.runner-select.outputs.selected-runner-label }}
     steps:
-      - uses: servo/ci-runners/actions/checkout@4422139e238c3699ba62d452839cd9cf46c374b6
+      - uses: servo/ci-runners/actions/checkout@8c9da53d1cdd63b32fcc58d03aa614313c4c3057
 
       - name: ccache
         # FIXME: “Error: Restoring cache failed: Error: Unable to locate executable file: sh.”


### PR DESCRIPTION
this patch enables WPT runs to use self-hosted runners, using the changes in servo/ci-runners#90, servo/ci-runners#91, servo/ci-runners#92, and servo/ci-runners#93 (see servo/ci-runners#21 for more details).

fallback to GitHub-hosted runners is included for now, but we can use three self-hosted runners to do what required twenty GitHub-hosted runners in the same amount of time (20 minutes). in the future, we may be able to run WPT faster than that by decreasing --timeout-multiplier or further increasing --processes, if we fix the flakes.

Testing:
- <https://github.com/servo/servo/actions/runs/19951033498> (18 **22** 18min, 0 stable unexpected)
- <https://github.com/servo/servo/actions/runs/19952863638> (18 **19** **19**min, 0 stable unexpected)
- <https://github.com/servo/servo/actions/runs/19952882829> (16 **24** 16min, 0 stable unexpected)
- <https://github.com/servo/servo/actions/runs/19952885991> (15 **20** **20**min, 0 stable unexpected)
- <https://github.com/servo/servo/actions/runs/19953672646> (16 **20** 18min, 0 stable unexpected)
- <https://github.com/servo/servo/actions/runs/19953675013> (**18** 17 **18**min, 0 stable unexpected)
- <https://github.com/servo/servo/actions/runs/21129181925> (16 **19** 18min, 0 stable unexpected)

Fixes: part of #38141