### PR TITLE
allocator: Write untracked allocations to log file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8094,6 +8094,7 @@ version = "0.0.1"
 dependencies = [
  "backtrace",
  "libc",
+ "log",
  "rustc-hash 2.1.1",
  "tikv-jemalloc-sys",
  "tikv-jemallocator",

--- a/components/allocator/Cargo.toml
+++ b/components/allocator/Cargo.toml
@@ -11,11 +11,12 @@ rust-version.workspace = true
 path = "lib.rs"
 
 [features]
-allocation-tracking = ["backtrace", "dep:rustc-hash"]
+allocation-tracking = ["backtrace", "dep:rustc-hash", "log"]
 use-system-allocator = ["libc"]
 
 [dependencies]
 backtrace = { workspace = true, optional = true }
+log = { workspace = true, optional = true }
 rustc-hash = { workspace = true, optional = true }
 
 [target.'cfg(not(any(windows, target_env = "ohos")))'.dependencies]

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -19,9 +19,9 @@ static ALLOC: crate::tracking::AccountingAlloc<Allocator> =
 #[cfg(feature = "allocation-tracking")]
 mod tracking;
 
-pub fn dump_unmeasured() {
+pub fn dump_unmeasured(_writer: impl std::io::Write) {
     #[cfg(feature = "allocation-tracking")]
-    ALLOC.dump_unmeasured_allocations();
+    ALLOC.dump_unmeasured_allocations(_writer);
 }
 
 pub use crate::platform::*;

--- a/components/allocator/lib.rs
+++ b/components/allocator/lib.rs
@@ -19,6 +19,10 @@ static ALLOC: crate::tracking::AccountingAlloc<Allocator> =
 #[cfg(feature = "allocation-tracking")]
 mod tracking;
 
+pub fn is_tracking_unmeasured() -> bool {
+    cfg!(feature = "allocation-tracking")
+}
+
 pub fn dump_unmeasured(_writer: impl std::io::Write) {
     #[cfg(feature = "allocation-tracking")]
     ALLOC.dump_unmeasured_allocations(_writer);


### PR DESCRIPTION
The output is very large, so moving it away from stdout makes it easier to write tools to process it.

Testing: No automated testing for optional low-level feature.