### PR TITLE
webdriver: Add touch support for all platforms

### DIFF
--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -2342,7 +2342,7 @@ impl Handler {
         };
 
         // Step 8.16. Dispatch a list of actions with session's current browsing context
-        let actions_by_tick = self.actions_by_tick_from_sequence(vec![action_sequence]);
+        let actions_by_tick = self.extract_an_action_sequence(vec![action_sequence]);
         if let Err(e) = self.dispatch_actions(actions_by_tick, self.browsing_context_id()?) {
             log::error!("handle_element_click: dispatch_actions failed: {:?}", e);
         }

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -51,10 +51,12 @@ use servo_url::ServoUrl;
 use style_traits::CSSPixel;
 use time::OffsetDateTime;
 use uuid::Uuid;
+#[cfg(not(any(target_env = "ohos", target_os = "android")))]
+use webdriver::actions::PointerMoveAction;
 use webdriver::actions::{
     ActionSequence, ActionsType, KeyAction, KeyActionItem, KeyDownAction, KeyUpAction,
-    PointerAction, PointerActionItem, PointerActionParameters, PointerDownAction,
-    PointerMoveAction, PointerOrigin, PointerType, PointerUpAction,
+    PointerAction, PointerActionItem, PointerActionParameters, PointerDownAction, PointerOrigin,
+    PointerType, PointerUpAction,
 };
 use webdriver::capabilities::CapabilitiesMatching;
 use webdriver::command::{
@@ -2281,6 +2283,79 @@ impl Handler {
 
     /// <https://w3c.github.io/webdriver/#element-click>
     /// Step 8 for elements other than <option>
+    /// There is currently no spec for touchscreen webdriver support.
+    /// There is an ongoing discussion in W3C:
+    /// <https://github.com/w3c/webdriver/issues/1925>
+    #[cfg(any(target_env = "ohos", target_os = "android"))]
+    fn perform_element_click(&mut self, element: String) -> WebDriverResult<WebDriverResponse> {
+        // Step 8.1 - 8.4: Create UUID, create input source "pointer".
+        let id = Uuid::new_v4().to_string();
+
+        let pointer_ids = self.session()?.pointer_ids();
+        let (x, y) = self
+            .get_origin_relative_coordinates(
+                &PointerOrigin::Element(WebElement(element.clone())),
+                0.0,
+                0.0,
+                &id,
+            )
+            .map_err(|err| WebDriverError::new(err, ""))?;
+
+        // Difference with Desktop: Create an input source with coordinates directly at the
+        // element centre.
+        self.session_mut()?.input_state_table.insert(
+            id.clone(),
+            InputSourceState::Pointer(PointerInputState::new(
+                PointerType::Touch,
+                pointer_ids,
+                x,
+                y,
+            )),
+        );
+
+        // Step 8.11. Construct pointer down action.
+        // Step 8.12. Set a property button to 0 on pointer down action.
+        let pointer_down_action = PointerDownAction {
+            button: i16::from(MouseButton::Left) as u64,
+            ..Default::default()
+        };
+
+        // Step 8.13. Construct pointer up action.
+        // Step 8.14. Set a property button to 0 on pointer up action.
+        let pointer_up_action = PointerUpAction {
+            button: i16::from(MouseButton::Left) as u64,
+            ..Default::default()
+        };
+
+        // Difference with Desktop: We only need pointerdown and pointerup for touchscreen.
+        let action_sequence = ActionSequence {
+            id: id.clone(),
+            actions: ActionsType::Pointer {
+                parameters: PointerActionParameters {
+                    pointer_type: PointerType::Touch,
+                },
+                actions: vec![
+                    PointerActionItem::Pointer(PointerAction::Down(pointer_down_action)),
+                    PointerActionItem::Pointer(PointerAction::Up(pointer_up_action)),
+                ],
+            },
+        };
+
+        // Step 8.16. Dispatch a list of actions with session's current browsing context
+        let actions_by_tick = self.actions_by_tick_from_sequence(vec![action_sequence]);
+        if let Err(e) = self.dispatch_actions(actions_by_tick, self.browsing_context_id()?) {
+            log::error!("handle_element_click: dispatch_actions failed: {:?}", e);
+        }
+
+        // Step 8.17 Remove an input source with input state and input id.
+        self.session_mut()?.input_state_table.remove(&id);
+
+        Ok(WebDriverResponse::Void)
+    }
+
+    /// <https://w3c.github.io/webdriver/#element-click>
+    /// Step 8 for elements other than <option>,
+    #[cfg(not(any(target_env = "ohos", target_os = "android")))]
     fn perform_element_click(&mut self, element: String) -> WebDriverResult<WebDriverResponse> {
         // Step 8.1 - 8.4: Create UUID, create input source "pointer".
         let id = Uuid::new_v4().to_string();
@@ -2288,7 +2363,12 @@ impl Handler {
         let pointer_ids = self.session()?.pointer_ids();
         self.session_mut()?.input_state_table.insert(
             id.clone(),
-            InputSourceState::Pointer(PointerInputState::new(PointerType::Mouse, pointer_ids)),
+            InputSourceState::Pointer(PointerInputState::new(
+                PointerType::Mouse,
+                pointer_ids,
+                0.0,
+                0.0,
+            )),
         );
 
         // Step 8.7. Construct a pointer move action.

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-body.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-body.html.ini
@@ -1,3 +1,4 @@
 [non-passive-touchmove-event-listener-on-body.html]
+  expected: CRASH
   [non-passive touchmove event listener on body]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-div.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-div.html.ini
@@ -1,3 +1,4 @@
 [non-passive-touchmove-event-listener-on-div.html]
+  expected: CRASH
   [non-passive touchmove event listener on div]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-document.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-document.html.ini
@@ -1,3 +1,4 @@
 [non-passive-touchmove-event-listener-on-document.html]
+  expected: CRASH
   [non-passive touchmove event listener on document]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-root.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-root.html.ini
@@ -1,3 +1,4 @@
 [non-passive-touchmove-event-listener-on-root.html]
+  expected: CRASH
   [non-passive touchmove event listener on root]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-window.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-window.html.ini
@@ -1,3 +1,4 @@
 [non-passive-touchmove-event-listener-on-window.html]
+  expected: CRASH
   [non-passive-touchmove-event-listener-on-window]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-body.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-body.html.ini
@@ -1,3 +1,4 @@
 [non-passive-touchstart-event-listener-on-body.html]
+  expected: CRASH
   [non-passive touchstart event listener on body]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-div.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-div.html.ini
@@ -1,3 +1,4 @@
 [non-passive-touchstart-event-listener-on-div.html]
+  expected: CRASH
   [non-passive touchstart event listener on div]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-document.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-document.html.ini
@@ -1,3 +1,4 @@
 [non-passive-touchstart-event-listener-on-document.html]
+  expected: CRASH
   [non-passive touchstart event listener on document]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-root.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-root.html.ini
@@ -1,3 +1,4 @@
 [non-passive-touchstart-event-listener-on-root.html]
+  expected: CRASH
   [non-passive touchstart event listener on root]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-window.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-window.html.ini
@@ -1,3 +1,4 @@
 [non-passive-touchstart-event-listener-on-window.html]
+  expected: CRASH
   [non-passive touchstart event listener on window]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-body.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-body.html.ini
@@ -1,3 +1,4 @@
 [passive-touchmove-event-listener-on-body.html]
+  expected: CRASH
   [passive touchmove event listener on body]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-div.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-div.html.ini
@@ -1,3 +1,4 @@
 [passive-touchmove-event-listener-on-div.html]
+  expected: CRASH
   [passive touchmove event listener on div]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-document.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-document.html.ini
@@ -1,3 +1,4 @@
 [passive-touchmove-event-listener-on-document.html]
+  expected: CRASH
   [passive touchmove event listener on document]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-root.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-root.html.ini
@@ -1,3 +1,4 @@
 [passive-touchmove-event-listener-on-root.html]
+  expected: CRASH
   [passive touchmove event listener on root]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-window.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-window.html.ini
@@ -1,3 +1,4 @@
 [passive-touchmove-event-listener-on-window.html]
+  expected: CRASH
   [passive touchmove event listener on window]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-body.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-body.html.ini
@@ -1,3 +1,4 @@
 [passive-touchstart-event-listener-on-body.html]
+  expected: CRASH
   [passive touchstart event listener on body]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-div.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-div.html.ini
@@ -1,3 +1,4 @@
 [passive-touchstart-event-listener-on-div.html]
+  expected: CRASH
   [passive touchstart event listener on div]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-document.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-document.html.ini
@@ -1,3 +1,4 @@
 [passive-touchstart-event-listener-on-document.html]
+  expected: CRASH
   [passive touchstart event listener on document]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-root.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-root.html.ini
@@ -1,3 +1,4 @@
 [passive-touchstart-event-listener-on-root.html]
+  expected: CRASH
   [passive touchstart event listener on root]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-window.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-window.html.ini
@@ -1,3 +1,4 @@
 [passive-touchstart-event-listener-on-window.html]
+  expected: CRASH
   [passive touchstart event listener on window]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-document.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-document.tentative.html.ini
@@ -1,4 +1,4 @@
 [overscroll-event-fired-to-document.tentative.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Tests that the document gets overscroll event when no element scrolls after touch scrolling.]
     expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-element-with-overscroll-behavior.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-element-with-overscroll-behavior.tentative.html.ini
@@ -1,4 +1,4 @@
 [overscroll-event-fired-to-element-with-overscroll-behavior.tentative.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Tests that the last element in the cut scroll chain gets overscroll event when no element scrolls by touch.]
     expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-scrolled-element.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-scrolled-element.tentative.html.ini
@@ -1,4 +1,4 @@
 [overscroll-event-fired-to-scrolled-element.tentative.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Tests that the scrolled element gets overscroll event after fully scrolling by touch.]
     expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-window.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-window.tentative.html.ini
@@ -1,4 +1,4 @@
 [overscroll-event-fired-to-window.tentative.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Tests that the window gets overscroll event when no element scrollsafter touch scrolling.]
     expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/scrollend-event-fired-after-snap.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/scrollend-event-fired-after-snap.html.ini
@@ -1,5 +1,5 @@
 [scrollend-event-fired-after-snap.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Tests that scrollend is fired after scroll snap animation completion.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/html/semantics/interestfor/interestfor-pseudo-element.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/interestfor/interestfor-pseudo-element.tentative.html.ini
@@ -1,4 +1,5 @@
 [interestfor-pseudo-element.tentative.html]
+  expected: CRASH
   [pseudo element should work for Button]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/popovers/popover-self-invoke.html.ini
+++ b/tests/wpt/meta/html/semantics/popovers/popover-self-invoke.html.ini
@@ -1,4 +1,5 @@
 [popover-self-invoke.html]
+  expected: CRASH
   [mouse on a popover button that is its own target should open it.]
     expected: FAIL
 

--- a/tests/wpt/meta/html/user-activation/activation-trigger-pointerevent.html.ini
+++ b/tests/wpt/meta/html/user-activation/activation-trigger-pointerevent.html.ini
@@ -5,12 +5,12 @@
 
 
 [activation-trigger-pointerevent.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Activation through touch pointerevent click]
     expected: TIMEOUT
 
 
 [activation-trigger-pointerevent.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Activation through pen pointerevent click]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html.ini
+++ b/tests/wpt/meta/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html.ini
@@ -10,6 +10,7 @@
 
 
 [capturing_boundary_event_handler_at_ua_shadowdom.html?pen]
+  expected: CRASH
   [Capturing boundary event handler at DIV]
     expected: FAIL
 
@@ -21,6 +22,7 @@
 
 
 [capturing_boundary_event_handler_at_ua_shadowdom.html?touch]
+  expected: CRASH
   [Capturing boundary event handler at DIV]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/coalesced_events_attributes.https.html.ini
+++ b/tests/wpt/meta/pointerevents/coalesced_events_attributes.https.html.ini
@@ -1,5 +1,5 @@
 [coalesced_events_attributes.https.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Coalesced list in boundary events]
     expected: TIMEOUT
 
@@ -14,7 +14,7 @@
 
 
 [coalesced_events_attributes.https.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Coalesced list in boundary events]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/coalesced_events_attributes_on_redispatch.https.html.ini
+++ b/tests/wpt/meta/pointerevents/coalesced_events_attributes_on_redispatch.https.html.ini
@@ -5,12 +5,12 @@
 
 
 [coalesced_events_attributes_on_redispatch.https.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Coalesced list in pointerdown/move/up events]
     expected: TIMEOUT
 
 
 [coalesced_events_attributes_on_redispatch.https.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Coalesced list in pointerdown/move/up events]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/coalesced_events_attributes_under_load.https.optional.html.ini
+++ b/tests/wpt/meta/pointerevents/coalesced_events_attributes_under_load.https.optional.html.ini
@@ -5,12 +5,12 @@
 
 
 [coalesced_events_attributes_under_load.https.optional.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Coalesced pointermoves under load]
     expected: TIMEOUT
 
 
 [coalesced_events_attributes_under_load.https.optional.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Coalesced pointermoves under load]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/compat/pointerevent_touch_target_after_pointerdown_target_removed.tentative.html.ini
+++ b/tests/wpt/meta/pointerevents/compat/pointerevent_touch_target_after_pointerdown_target_removed.tentative.html.ini
@@ -1,4 +1,5 @@
 [pointerevent_touch_target_after_pointerdown_target_removed.tentative.html]
+  expected: CRASH
   [After a pointerdown listener removes its target, touch events should be fired on the touchstart target even though an orphan and pointer events should be fired on the parent]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_after_target_appended.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_after_target_appended.html.ini
@@ -1,4 +1,5 @@
 [pointerevent_after_target_appended.html?touch]
+  expected: CRASH
   [pointer events from touch received before/after child attached at pointerdown]
     expected: FAIL
 
@@ -51,6 +52,7 @@
 
 
 [pointerevent_after_target_appended.html?pen]
+  expected: CRASH
   [pointer events from pen received before/after child attached at pointerdown]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_after_target_appended_interleaved.tentative.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_after_target_appended_interleaved.tentative.html.ini
@@ -1,4 +1,5 @@
 [pointerevent_after_target_appended_interleaved.tentative.html?touch]
+  expected: CRASH
   [mouse events from touch received before/after child attached at pointerdown]
     expected: FAIL
 
@@ -13,6 +14,7 @@
 
 
 [pointerevent_after_target_appended_interleaved.tentative.html?pen]
+  expected: CRASH
   [mouse events from pen received before/after child attached at pointerdown]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_after_target_removed.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_after_target_removed.html.ini
@@ -1,4 +1,5 @@
 [pointerevent_after_target_removed.html?pen]
+  expected: CRASH
   [pointer events from pen received before/after child removal at pointerdown]
     expected: FAIL
 
@@ -13,6 +14,7 @@
 
 
 [pointerevent_after_target_removed.html?touch]
+  expected: CRASH
   [pointer events from touch received before/after child removal at pointerdown]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_after_target_removed_interleaved.tentative.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_after_target_removed_interleaved.tentative.html.ini
@@ -1,4 +1,5 @@
 [pointerevent_after_target_removed_interleaved.tentative.html?touch]
+  expected: CRASH
   [mouse events from touch received before/after child removal at pointerdown]
     expected: FAIL
 
@@ -15,6 +16,7 @@
 
 
 [pointerevent_after_target_removed_interleaved.tentative.html?pen]
+  expected: CRASH
   [mouse events from pen received before/after child removal at pointerdown]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_attributes.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_attributes.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_attributes.html?pen-nonstandard]
-  expected: ERROR
+  expected: CRASH
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -8,7 +8,7 @@
 
 
 [pointerevent_attributes.html?pen-right-nonstandard]
-  expected: ERROR
+  expected: CRASH
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -17,7 +17,7 @@
 
 
 [pointerevent_attributes.html?touch]
-  expected: ERROR
+  expected: CRASH
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -26,7 +26,7 @@
 
 
 [pointerevent_attributes.html?pen-right]
-  expected: ERROR
+  expected: CRASH
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -35,7 +35,7 @@
 
 
 [pointerevent_attributes.html?mouse-right-nonstandard]
-  expected: ERROR
+  expected: CRASH
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -44,7 +44,7 @@
 
 
 [pointerevent_attributes.html?pen]
-  expected: ERROR
+  expected: CRASH
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -53,7 +53,7 @@
 
 
 [pointerevent_attributes.html?mouse-right]
-  expected: ERROR
+  expected: CRASH
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -62,7 +62,7 @@
 
 
 [pointerevent_attributes.html?mouse-nonstandard]
-  expected: ERROR
+  expected: CRASH
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -71,7 +71,7 @@
 
 
 [pointerevent_attributes.html?mouse]
-  expected: ERROR
+  expected: CRASH
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -80,7 +80,7 @@
 
 
 [pointerevent_attributes.html?touch-nonstandard]
-  expected: ERROR
+  expected: CRASH
   [Test pointer events in the main document]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_auxclick_is_a_pointerevent.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_auxclick_is_a_pointerevent.html.ini
@@ -8,7 +8,7 @@
 
 
 [pointerevent_auxclick_is_a_pointerevent.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [auxclick using pen is a PointerEvent with correct properties]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/pointerevent_boundary_events_in_capturing.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_boundary_events_in_capturing.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_boundary_events_in_capturing.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Boundary events around pointer capture and release]
     expected: TIMEOUT
 
@@ -11,6 +11,6 @@
 
 
 [pointerevent_boundary_events_in_capturing.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Boundary events around pointer capture and release]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_capture_touch_and_release_at_got_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_capture_touch_and_release_at_got_capture.html.ini
@@ -1,3 +1,4 @@
 [pointerevent_capture_touch_and_release_at_got_capture.html]
+  expected: CRASH
   [A pointerout should be fired on the capturing element after losing the capture]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_change-touch-action-onpointerdown_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_change-touch-action-onpointerdown_touch.html.ini
@@ -1,3 +1,4 @@
 [pointerevent_change-touch-action-onpointerdown_touch.html]
+  expected: CRASH
   [scroll should be received before the test finishes]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_click_during_parent_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_click_during_parent_capture.html.ini
@@ -1,4 +1,5 @@
 [pointerevent_click_during_parent_capture.html?pointerType=touch&preventDefault=pointerdown]
+  expected: CRASH
   [Test in the topmost document: all expected events should be fired]
     expected: FAIL
 
@@ -10,6 +11,7 @@
 
 
 [pointerevent_click_during_parent_capture.html?pointerType=touch&preventDefault=touchstart]
+  expected: CRASH
   [Test in the topmost document: all expected events should be fired]
     expected: FAIL
 
@@ -18,6 +20,7 @@
 
 
 [pointerevent_click_during_parent_capture.html?pointerType=touch&preventDefault=]
+  expected: CRASH
   [Test in the topmost document: all expected events should be fired]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_click_is_a_pointerevent.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_click_is_a_pointerevent.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_click_is_a_pointerevent.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [click using pen is a PointerEvent with correct properties]
     expected: TIMEOUT
 
@@ -11,7 +11,7 @@
 
 
 [pointerevent_click_is_a_pointerevent.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [click using touch is a PointerEvent with correct properties]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/pointerevent_click_is_a_pointerevent_multiple_clicks.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_click_is_a_pointerevent_multiple_clicks.html.ini
@@ -1,4 +1,5 @@
 [pointerevent_click_is_a_pointerevent_multiple_clicks.html?touch]
+  expected: CRASH
   [click using touch is a PointerEvent]
     expected: FAIL
 
@@ -9,5 +10,6 @@
 
 
 [pointerevent_click_is_a_pointerevent_multiple_clicks.html?pen]
+  expected: CRASH
   [click using pen is a PointerEvent]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_contextmenu_is_a_pointerevent.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_contextmenu_is_a_pointerevent.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_contextmenu_is_a_pointerevent.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [contextmenu using touch is a PointerEvent with correct properties]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/pointerevent_disabled_form_control.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_disabled_form_control.html.ini
@@ -1,11 +1,11 @@
 [pointerevent_disabled_form_control.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [pen pointerevent attributes]
     expected: NOTRUN
 
 
 [pointerevent_disabled_form_control.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [touch pointerevent attributes]
     expected: NOTRUN
 

--- a/tests/wpt/meta/pointerevents/pointerevent_element_haspointercapture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_element_haspointercapture.html.ini
@@ -1,11 +1,11 @@
 [pointerevent_element_haspointercapture.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [hasPointerCapture]
     expected: NOTRUN
 
 
 [pointerevent_element_haspointercapture.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [hasPointerCapture]
     expected: NOTRUN
 

--- a/tests/wpt/meta/pointerevents/pointerevent_element_haspointercapture_release_pending_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_element_haspointercapture_release_pending_capture.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_element_haspointercapture_release_pending_capture.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [hasPointerCapture test after the pending pointer capture element releases pointer capture]
     expected: NOTRUN
 
@@ -11,6 +11,6 @@
 
 
 [pointerevent_element_haspointercapture_release_pending_capture.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [hasPointerCapture test after the pending pointer capture element releases pointer capture]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_fractional_coordinates.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_fractional_coordinates.html.ini
@@ -1,4 +1,5 @@
 [pointerevent_fractional_coordinates.html?touch]
+  expected: CRASH
   [touch]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_iframe-touch-action-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_iframe-touch-action-none_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_iframe-touch-action-none_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touch iframe received pointercancel]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_movementxy.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_movementxy.html.ini
@@ -5,12 +5,12 @@
 
 
 [pointerevent_movementxy.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [touch pointerevent attributes]
     expected: NOTRUN
 
 
 [pointerevent_movementxy.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [pen pointerevent attributes]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointercancel_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [pointercancel event received]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointercapture_in_frame.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointercapture_in_frame.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_pointercapture_in_frame.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Test touchpointer capture in same-origin frame: Pointer down at inner frame and set pointer capture.]
     expected: TIMEOUT
 
@@ -41,7 +41,7 @@
 
 
 [pointerevent_pointercapture_in_frame.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Test penpointer capture in same-origin frame: Pointer down at inner frame and set pointer capture.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointerleave_after_pointercancel_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [pointerleave event received]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointermove_isprimary_same_as_pointerdown.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointermove_isprimary_same_as_pointerdown.html.ini
@@ -5,6 +5,6 @@
 
 
 [pointerevent_pointermove_isprimary_same_as_pointerdown.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [pointermove has same isPrimary as last pointerdown]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointerout_after_pointercancel_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [pointerout event received]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerout_pen.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerout_pen.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointerout_pen.html]
-  expected: TIMEOUT
+  expected: CRASH
   [pointerout event received]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerrawupdate_coalesced_events_attributes.https.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerrawupdate_coalesced_events_attributes.https.html.ini
@@ -5,12 +5,12 @@
 
 
 [pointerevent_pointerrawupdate_coalesced_events_attributes.https.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Simple test for getCoalescedEvents() of `pointerrawupdate`]
     expected: TIMEOUT
 
 
 [pointerevent_pointerrawupdate_coalesced_events_attributes.https.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Simple test for getCoalescedEvents() of `pointerrawupdate`]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_events_to_original_target.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_events_to_original_target.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_releasepointercapture_events_to_original_target.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [pen got/lost pointercapture: subsequent events to target]
     expected: NOTRUN
 
@@ -11,6 +11,6 @@
 
 
 [pointerevent_releasepointercapture_events_to_original_target.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [touch got/lost pointercapture: subsequent events to target]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_onpointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_onpointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_releasepointercapture_onpointercancel_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [pointer capture is released on pointercancel]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_pointerup_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_pointerup_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_releasepointercapture_pointerup_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [releasePointerCapture on pointerup]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_release_right_after_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_release_right_after_capture.html.ini
@@ -1,11 +1,11 @@
 [pointerevent_releasepointercapture_release_right_after_capture.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Release pointer capture right after setpointercapture]
     expected: NOTRUN
 
 
 [pointerevent_releasepointercapture_release_right_after_capture.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Release pointer capture right after setpointercapture]
     expected: NOTRUN
 

--- a/tests/wpt/meta/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html.ini
@@ -1,9 +1,11 @@
 [pointerevent_sequence_at_implicit_release_on_click.html?touch]
+  expected: CRASH
   [touch Boundary events are emitted after lostpointercapture]
     expected: FAIL
 
 
 [pointerevent_sequence_at_implicit_release_on_click.html?pen]
+  expected: CRASH
   [pen Boundary events are emitted after lostpointercapture]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_sequence_at_implicit_release_on_drag.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_sequence_at_implicit_release_on_drag.html.ini
@@ -1,3 +1,4 @@
 [pointerevent_sequence_at_implicit_release_on_drag.html]
+  expected: CRASH
   [touch Event sequence at implicit release on drag]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_override_pending_capture_element.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_override_pending_capture_element.html.ini
@@ -5,12 +5,12 @@
 
 
 [pointerevent_setpointercapture_override_pending_capture_element.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [setPointerCapture: override the pending pointer capture element]
     expected: NOTRUN
 
 
 [pointerevent_setpointercapture_override_pending_capture_element.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [setPointerCapture: override the pending pointer capture element]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_pointerup_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_pointerup_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_setpointercapture_pointerup_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [setPointerCapture on pointerup]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_to_same_element_twice.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_to_same_element_twice.html.ini
@@ -1,4 +1,5 @@
 [pointerevent_setpointercapture_to_same_element_twice.html?pen]
+  expected: CRASH
   [A repeated setPointerCapture call does not redispatch capture events]
     expected: FAIL
 
@@ -15,6 +16,7 @@
 
 
 [pointerevent_setpointercapture_to_same_element_twice.html?touch]
+  expected: CRASH
   [A repeated setPointerCapture call does not redispatch capture events]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_to_slotted_target.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_to_slotted_target.html.ini
@@ -1,9 +1,11 @@
 [pointerevent_to_slotted_target.html?touch]
+  expected: CRASH
   [Pointer events from touch to slotted element and shadow-host]
     expected: FAIL
 
 
 [pointerevent_to_slotted_target.html?pen]
+  expected: CRASH
   [Pointer events from pen to slotted element and shadow-host]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-auto-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-auto-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-auto-css_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-button-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-button-none-test_touch.html.ini
@@ -1,0 +1,2 @@
+[pointerevent_touch-action-button-none-test_touch.html]
+  expected: CRASH

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_child-auto-child-none_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_child-none_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_highest-parent-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_highest-parent-none_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_highest-parent-none_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-modified_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-modified_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-modified_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [No scrolling after deleting touch-action:none after pointerdown]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-none-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html.ini
@@ -1,0 +1,2 @@
+[pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html]
+  expected: CRASH

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-down-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-down-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-down-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-left-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-left-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-left-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-right-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-right-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-right-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-up-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-up-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-up-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-x-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y-pan-y_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-x-pan-y-pan-y_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-x-pan-y_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-y-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-y-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-y-css_touch.html]
-  expected: ERROR
+  expected: CRASH
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-span-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-span-none-test_touch.html.ini
@@ -1,3 +1,4 @@
 [pointerevent_touch-action-span-none-test_touch.html]
+  expected: CRASH
   [touch-action attribute test in element]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-table-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-table-none-test_touch.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_touch-action-table-none-test_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touch-action attribute test on the cell]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-adjustment_click_target.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-adjustment_click_target.html.ini
@@ -1,0 +1,2 @@
+[pointerevent_touch-adjustment_click_target.html]
+  expected: CRASH

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-propagates-when-target-is-video_touch.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Touch-generated events should propagate to the parent when a video element is the target]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerup_after_pointerdown_target_removed.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerup_after_pointerdown_target_removed.html.ini
@@ -4,10 +4,12 @@
 
 
 [pointerup_after_pointerdown_target_removed.html?pen]
+  expected: CRASH
   [pointerup event from pen fired after pointerdown target is removed]
     expected: FAIL
 
 
 [pointerup_after_pointerdown_target_removed.html?touch]
+  expected: CRASH
   [pointerup event from touch fired after pointerdown target is removed]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/predicted_events_attributes.html.ini
+++ b/tests/wpt/meta/pointerevents/predicted_events_attributes.html.ini
@@ -1,5 +1,5 @@
 [predicted_events_attributes.html?pen]
-  expected: TIMEOUT
+  expected: CRASH
   [Predicted list in boundary events]
     expected: TIMEOUT
 
@@ -29,7 +29,7 @@
 
 
 [predicted_events_attributes.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [Predicted list in boundary events]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/touch-action-with-swipe-dir-change.html.ini
+++ b/tests/wpt/meta/pointerevents/touch-action-with-swipe-dir-change.html.ini
@@ -1,5 +1,5 @@
 [touch-action-with-swipe-dir-change.html?touch]
-  expected: TIMEOUT
+  expected: CRASH
   [touch-action:auto with right,down swipe]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/touch-events/mouseevents-after-touchend.tentative.html.ini
+++ b/tests/wpt/meta/touch-events/mouseevents-after-touchend.tentative.html.ini
@@ -1,4 +1,5 @@
 [mouseevents-after-touchend.tentative.html]
+  expected: CRASH
   [Single tap should cause a click]
     expected: FAIL
 

--- a/tests/wpt/meta/touch-events/multi-touch-interactions.html.ini
+++ b/tests/wpt/meta/touch-events/multi-touch-interactions.html.ini
@@ -1,5 +1,5 @@
 [multi-touch-interactions.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touchstart event received]
     expected: NOTRUN
 

--- a/tests/wpt/meta/touch-events/multi-touch-interfaces.html.ini
+++ b/tests/wpt/meta/touch-events/multi-touch-interfaces.html.ini
@@ -1,5 +1,5 @@
 [multi-touch-interfaces.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touchstart event received]
     expected: NOTRUN
 

--- a/tests/wpt/meta/touch-events/single-tap-when-touchend-listener-use-sync-xhr.html.ini
+++ b/tests/wpt/meta/touch-events/single-tap-when-touchend-listener-use-sync-xhr.html.ini
@@ -1,4 +1,4 @@
 [single-tap-when-touchend-listener-use-sync-xhr.html]
-  expected: TIMEOUT
+  expected: CRASH
   [Click event should be fired when touchend opens synchronous XHR]
     expected: TIMEOUT

--- a/tests/wpt/meta/touch-events/single-touch-vertical-rl.html.ini
+++ b/tests/wpt/meta/touch-events/single-touch-vertical-rl.html.ini
@@ -1,4 +1,4 @@
 [single-touch-vertical-rl.html]
-  expected: TIMEOUT
+  expected: CRASH
   [touch & click events in vertical-rl mode have correct coordinates]
     expected: TIMEOUT

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_pen.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_pen.py.ini
@@ -1,4 +1,5 @@
 [pointer_pen.py]
+  expected: TIMEOUT
   [test_no_browsing_context]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_touch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_touch.py.ini
@@ -1,4 +1,5 @@
 [pointer_touch.py]
+  expected: TIMEOUT
   [test_no_browsing_context]
     expected: FAIL
 


### PR DESCRIPTION
Some mobile websites only have touch event listeners, but not any for mouse events. We add native touch support for "element click", for Android/OHOS. We are finally utilizing `subtype` and can remove the `dead_code` macro for it: we dispatch action based on the subtype given, which has impact for [Perform Actions](https://w3c.github.io/webdriver/#dfn-actions) **on all platforms**.

Testing: 
1. Tested on OHOS for a normal webpage, plus a special webpage that only has touch event listener.
2. Desktop: Previously, we always ignore the requested of pointer subtype and dispatch the mouse. All 138 stable unexpected test actually never worked, and now crash due to "Got a touchmove event for a non-active touch point" since we can dispatch touch now. I plan to improve this and make it work soon!

Fixes: The step 4 of #41042. We still need to fix some bugs of spec, and wait for resolution.

TODO later: When we have touch simulation for Desktop, "Element click" should also dispatch pointer touch.