### PR TITLE
Base: Implement GenericReceiverSet

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -105,7 +105,7 @@ use base::id::{
     PainterId, PipelineId, PipelineNamespace, PipelineNamespaceId, PipelineNamespaceRequest,
     ScriptEventLoopId, WebViewId,
 };
-use base::{Epoch, IpcSend, generic_channel};
+use base::{Epoch, generic_channel};
 #[cfg(feature = "bluetooth")]
 use bluetooth_traits::BluetoothRequest;
 use canvas::canvas_paint_thread::CanvasPaintThread;

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -14,6 +14,7 @@ mod font_context {
     use std::thread;
 
     use app_units::Au;
+    use base::generic_channel;
     use compositing_traits::CrossProcessPaintApi;
     use fonts::platform::font::PlatformFont;
     use fonts::{
@@ -48,7 +49,7 @@ mod font_context {
     impl TestContext {
         fn new() -> TestContext {
             let (system_font_service, system_font_service_proxy) = MockSystemFontService::spawn();
-            let (core_sender, _) = ipc::channel().unwrap();
+            let (core_sender, _) = generic_channel::channel().unwrap();
             let mock_resource_threads = ResourceThreads::new(core_sender);
             let mock_paint_api = CrossProcessPaintApi::dummy();
 

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -256,7 +256,7 @@ impl ResourceChannelManager {
         let reporter_id = rx_set.add(memory_reporter);
 
         loop {
-            for received in rx_set.select().unwrap().into_iter() {
+            for received in rx_set.select().into_iter() {
                 // Handles case where profiler thread shuts down before resource thread.
                 match received {
                     GenericSelectionResult::ChannelClosed(_) => continue,

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -260,7 +260,9 @@ impl ResourceChannelManager {
                 // Handles case where profiler thread shuts down before resource thread.
                 match received {
                     GenericSelectionResult::ChannelClosed(_) => continue,
-                    GenericSelectionResult::Error => log::error!("Found selection error"),
+                    GenericSelectionResult::Error(error) => {
+                        log::error!("Found selection error: {error}")
+                    },
                     GenericSelectionResult::MessageReceived(id, msg) => {
                         if id == reporter_id {
                             if let CoreResourceMsg::CollectMemoryReport(report_chan) = msg {

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -277,7 +277,6 @@ impl ResourceChannelManager {
                             let group = if id == private_id {
                                 &private_http_state
                             } else {
-                                println!("IDS {private_id}, {public_id}");
                                 assert_eq!(id, public_id);
                                 &public_http_state
                             };

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -277,6 +277,7 @@ impl ResourceChannelManager {
                             let group = if id == private_id {
                                 &private_http_state
                             } else {
+                                println!("IDS {private_id}, {public_id}");
                                 assert_eq!(id, public_id);
                                 &public_http_state
                             };

--- a/components/script/dom/cookiestore.rs
+++ b/components/script/dom/cookiestore.rs
@@ -6,13 +6,12 @@ use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
-use base::IpcSend;
+use base::generic_channel::{GenericSend, GenericSender};
 use base::id::CookieStoreId;
 use cookie::{Cookie, SameSite};
 use dom_struct::dom_struct;
 use hyper_serde::Serde;
 use ipc_channel::ipc;
-use ipc_channel::ipc::IpcSender;
 use ipc_channel::router::ROUTER;
 use itertools::Itertools;
 use js::jsval::NullValue;
@@ -50,7 +49,7 @@ pub(crate) struct CookieStore {
     store_id: CookieStoreId,
     #[ignore_malloc_size_of = "Channels are hard"]
     #[no_trace]
-    unregister_channel: IpcSender<CoreResourceMsg>,
+    unregister_channel: GenericSender<CoreResourceMsg>,
 }
 
 struct CookieListener {
@@ -97,7 +96,7 @@ impl CookieListener {
 }
 
 impl CookieStore {
-    fn new_inherited(unregister_channel: IpcSender<CoreResourceMsg>) -> CookieStore {
+    fn new_inherited(unregister_channel: GenericSender<CoreResourceMsg>) -> CookieStore {
         CookieStore {
             eventtarget: EventTarget::new_inherited(),
             in_flight: Default::default(),

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -13,8 +13,9 @@ use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
 use base::cross_process_instant::CrossProcessInstant;
+use base::generic_channel::GenericSend;
 use base::id::WebViewId;
-use base::{Epoch, IpcSend, generic_channel};
+use base::{Epoch, generic_channel};
 use bitflags::bitflags;
 use chrono::Local;
 use constellation_traits::{NavigationHistoryBehavior, ScriptToConstellationMessage};

--- a/components/script/dom/document_embedder_controls.rs
+++ b/components/script/dom/document_embedder_controls.rs
@@ -4,7 +4,8 @@
 
 use std::cell::Cell;
 
-use base::{Epoch, IpcSend};
+use base::Epoch;
+use base::generic_channel::GenericSend;
 use constellation_traits::{LoadData, NavigationHistoryBehavior};
 use embedder_traits::{
     ContextMenuAction, ContextMenuElementInformation, ContextMenuElementInformationFlags,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -16,8 +16,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use base::generic_channel::GenericCallback;
-use base::generic_channel::GenericSend;
+use base::generic_channel::{GenericCallback, GenericSend};
 use base::id::{
     BlobId, BroadcastChannelRouterId, MessagePortId, MessagePortRouterId, PipelineId,
     ServiceWorkerId, ServiceWorkerRegistrationId, WebViewId,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -21,7 +21,7 @@ use base::id::{
     BlobId, BroadcastChannelRouterId, MessagePortId, MessagePortRouterId, PipelineId,
     ServiceWorkerId, ServiceWorkerRegistrationId, WebViewId,
 };
-use base::{IpcSend, generic_channel};
+use base::generic_channel;
 use constellation_traits::{
     BlobData, BlobImpl, BroadcastChannelMsg, FileBlob, MessagePortImpl, MessagePortMsg,
     PortMessageTask, ScriptToConstellationChan, ScriptToConstellationMessage,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -17,6 +17,7 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use base::generic_channel::GenericCallback;
+use base::generic_channel::GenericSend;
 use base::id::{
     BlobId, BroadcastChannelRouterId, MessagePortId, MessagePortRouterId, PipelineId,
     ServiceWorkerId, ServiceWorkerRegistrationId, WebViewId,

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -16,12 +16,12 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use base::generic_channel;
 use base::generic_channel::{GenericCallback, GenericSend};
 use base::id::{
     BlobId, BroadcastChannelRouterId, MessagePortId, MessagePortRouterId, PipelineId,
     ServiceWorkerId, ServiceWorkerRegistrationId, WebViewId,
 };
-use base::generic_channel;
 use constellation_traits::{
     BlobData, BlobImpl, BroadcastChannelMsg, FileBlob, MessagePortImpl, MessagePortMsg,
     PortMessageTask, ScriptToConstellationChan, ScriptToConstellationMessage,

--- a/components/script/dom/history.rs
+++ b/components/script/dom/history.rs
@@ -5,7 +5,7 @@
 use std::cell::Cell;
 use std::cmp::Ordering;
 
-use base::IpcSend;
+use base::generic_channel::GenericSend;
 use base::id::HistoryStateId;
 use constellation_traits::{
     ScriptToConstellationMessage, StructuredSerializedData, TraversalDirection,

--- a/components/script/dom/servoparser/prefetch.rs
+++ b/components/script/dom/servoparser/prefetch.rs
@@ -5,7 +5,7 @@
 use std::cell::{Cell, RefCell};
 use std::ops::Deref;
 
-use base::IpcSend;
+use base::generic_channel::GenericSend;
 use base::id::{PipelineId, WebViewId};
 use html5ever::buffer_queue::BufferQueue;
 use html5ever::tokenizer::states::RawKind;

--- a/components/script/dom/url.rs
+++ b/components/script/dom/url.rs
@@ -4,7 +4,7 @@
 
 use std::default::Default;
 
-use base::IpcSend;
+use base::generic_channel::GenericSend;
 use dom_struct::dom_struct;
 use js::rust::HandleObject;
 use net_traits::CoreResourceMsg;

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -6,8 +6,6 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
-
-use base::IpcSend;
 use base::generic_channel::{GenericReceiver, GenericSender, RoutedReceiver};
 use base::id::PipelineId;
 use constellation_traits::{

--- a/components/script/dom/workers/serviceworkerglobalscope.rs
+++ b/components/script/dom/workers/serviceworkerglobalscope.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
-use base::generic_channel::{GenericReceiver, GenericSender, RoutedReceiver};
+
+use base::generic_channel::{GenericReceiver, GenericSend, GenericSender, RoutedReceiver};
 use base::id::PipelineId;
 use constellation_traits::{
     ScopeThings, ServiceWorkerMsg, WorkerGlobalScopeInit, WorkerScriptLoadOrigin,

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -10,8 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use base::cross_process_instant::CrossProcessInstant;
-use base::generic_channel::{GenericSender, RoutedReceiver};
-use base::generic_channel::GenericSend;
+use base::generic_channel::{GenericSend, GenericSender, RoutedReceiver};
 use base::id::{PipelineId, PipelineNamespace};
 use constellation_traits::WorkerGlobalScopeInit;
 use content_security_policy::CspList;

--- a/components/script/dom/workers/workerglobalscope.rs
+++ b/components/script/dom/workers/workerglobalscope.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
-use base::IpcSend;
 use base::cross_process_instant::CrossProcessInstant;
 use base::generic_channel::{GenericSender, RoutedReceiver};
+use base::generic_channel::GenericSend;
 use base::id::{PipelineId, PipelineNamespace};
 use constellation_traits::WorkerGlobalScopeInit;
 use content_security_policy::CspList;

--- a/components/script/dom/worklet.rs
+++ b/components/script/dom/worklet.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicIsize, Ordering};
 use std::thread;
 
-use base::IpcSend;
+use base::generic_channel::GenericSend;
 use base::id::{PipelineId, WebViewId};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use dom_struct::dom_struct;

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -5,9 +5,8 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::CString;
 use std::ptr::NonNull;
-
-use base::IpcSend;
 use base::generic_channel::{GenericOneshotSender, GenericSender};
+use base::generic_channel::{GenericSend, GenericSender};
 use base::id::{BrowsingContextId, PipelineId};
 use cookie::Cookie;
 use embedder_traits::{

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::CString;
 use std::ptr::NonNull;
 
-use base::generic_channel::{GenericOneshotSender, GenericSend, GenericSender, GenericSender};
+use base::generic_channel::{GenericOneshotSender, GenericSend, GenericSender};
 use base::id::{BrowsingContextId, PipelineId};
 use cookie::Cookie;
 use embedder_traits::{

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -5,8 +5,8 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::CString;
 use std::ptr::NonNull;
-use base::generic_channel::{GenericOneshotSender, GenericSender};
-use base::generic_channel::{GenericSend, GenericSender};
+
+use base::generic_channel::{GenericOneshotSender, GenericSend, GenericSender, GenericSender};
 use base::id::{BrowsingContextId, PipelineId};
 use cookie::Cookie;
 use embedder_traits::{

--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -24,6 +24,8 @@ mod oneshot;
 /// 'GenericSharedMemory' is, however, still useful so we reexport it under a different name for future optimization.
 pub use ipc_channel::ipc::IpcSharedMemory as GenericSharedMemory;
 pub use oneshot::{GenericOneshotReceiver, GenericOneshotSender, oneshot};
+mod generic_channelset;
+pub use generic_channelset::{GenericReceiverSet, GenericSelectionResult};
 
 /// Abstraction of the ability to send a particular type of message cross-process.
 /// This can be used to ease the use of GenericSender sub-fields.
@@ -246,6 +248,11 @@ impl fmt::Display for ReceiveError {
             ReceiveError::Io(ref error) => write!(fmt, "io error: {error}"),
             ReceiveError::Disconnected => write!(fmt, "disconnected"),
         }
+    }
+}
+impl From<std::io::Error> for ReceiveError {
+    fn from(value: std::io::Error) -> Self {
+        ReceiveError::Io(value)
     }
 }
 
@@ -641,5 +648,155 @@ mod single_process_channel_tests {
         });
         let received = rx.try_recv_timeout(timeout_duration);
         assert!(received.is_ok());
+    }
+}
+
+/// This tests need to be in here because they use the 'new_generic_channel_..' methods
+#[cfg(test)]
+mod generic_receiversets_tests {
+    use std::time::Duration;
+
+    use crate::generic_channel::generic_channelset::{
+        GenericSelectionResult, create_crossbeam_receiver_set, create_ipc_receiver_set,
+    };
+    use crate::generic_channel::{new_generic_channel_crossbeam, new_generic_channel_ipc};
+
+    #[test]
+    fn test_ipc_side1() {
+        let (snd1, recv1) = new_generic_channel_ipc().unwrap();
+        let (snd2, recv2) = new_generic_channel_ipc().unwrap();
+
+        // We keep the senders alive till all threads are done
+        let snd1_c = snd1.clone();
+        let snd2_c = snd2.clone();
+        let mut set = create_ipc_receiver_set();
+        set.add(recv1);
+        set.add(recv2);
+
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_secs(1));
+            snd1_c.send(10).unwrap();
+        });
+        std::thread::spawn(move || {
+            snd2_c.send(20).unwrap();
+        });
+
+        let select_result = set.select().unwrap();
+        let channel_result = select_result.first().unwrap();
+        assert_eq!(
+            *channel_result,
+            GenericSelectionResult::MessageReceived(1, 20)
+        );
+    }
+
+    #[test]
+    fn test_ipc_side2() {
+        let (snd1, recv1) = new_generic_channel_ipc().unwrap();
+        let (snd2, recv2) = new_generic_channel_ipc().unwrap();
+
+        // We keep the senders alive till all threads are done
+        let snd1_c = snd1.clone();
+        let snd2_c = snd2.clone();
+        let mut set = create_ipc_receiver_set();
+        set.add(recv1);
+        set.add(recv2);
+
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_secs(2));
+            snd1_c.send(10).unwrap();
+        });
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_secs(1));
+            snd2_c.send(20).unwrap();
+        });
+
+        let select_result = set.select().unwrap();
+        let channel_result = select_result.first().unwrap();
+        assert_eq!(
+            *channel_result,
+            GenericSelectionResult::MessageReceived(1, 20)
+        );
+    }
+
+    #[test]
+    fn test_ipc_side_multiple() {
+        let (snd1, recv1) = new_generic_channel_ipc().unwrap();
+        let (snd2, recv2) = new_generic_channel_ipc().unwrap();
+
+        // We keep the senders alive till all threads are done
+        let snd1_c = snd1.clone();
+        let snd2_c = snd2.clone();
+        let mut set = create_ipc_receiver_set();
+        set.add(recv1);
+        set.add(recv2);
+
+        std::thread::spawn(move || {
+            snd1_c.send(10).unwrap();
+        });
+        std::thread::spawn(move || {
+            snd2_c.send(20).unwrap();
+        });
+        std::thread::sleep(Duration::from_secs(1));
+
+        let select_result = set.select().unwrap();
+        assert_eq!(select_result.len(), 2);
+        assert!(select_result.contains(&GenericSelectionResult::MessageReceived(1, 20)));
+        assert!(select_result.contains(&GenericSelectionResult::MessageReceived(0, 10)));
+    }
+
+    #[test]
+    fn test_crossbeam_side1() {
+        let (snd1, recv1) = new_generic_channel_crossbeam();
+        let (snd2, recv2) = new_generic_channel_crossbeam();
+
+        // We keep the senders alive till all threads are done
+        let snd1_c = snd1.clone();
+        let snd2_c = snd2.clone();
+        let mut set = create_crossbeam_receiver_set();
+        set.add(recv1);
+        set.add(recv2);
+
+        std::thread::spawn(move || {
+            snd1_c.send(10).unwrap();
+        });
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_secs(2));
+            snd2_c.send(20).unwrap();
+        });
+
+        let select_result = set.select().unwrap();
+        let channel_result = select_result.first().unwrap();
+        assert_eq!(
+            *channel_result,
+            GenericSelectionResult::MessageReceived(0, 10)
+        );
+    }
+
+    #[test]
+    fn test_crossbeam_side2() {
+        let (snd1, recv1) = new_generic_channel_crossbeam();
+        let (snd2, recv2) = new_generic_channel_crossbeam();
+
+        // We keep the senders alive till all threads are done
+        let snd1_c = snd1.clone();
+        let snd2_c = snd2.clone();
+        let mut set = create_crossbeam_receiver_set();
+        set.add(recv1);
+        set.add(recv2);
+
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_secs(2));
+            snd1_c.send(10).unwrap();
+        });
+        std::thread::spawn(move || {
+            snd2_c.send(20).unwrap();
+        });
+
+        let select_result = set.select().unwrap();
+        let channel_result = select_result.first().unwrap();
+        assert_eq!(
+            *channel_result,
+            GenericSelectionResult::MessageReceived(1, 20)
+        );
     }
 }

--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -674,10 +674,10 @@ mod generic_receiversets_tests {
         set.add(recv2);
 
         std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_secs(1));
             snd1_c.send(10).unwrap();
         });
         std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_secs(1));
             snd2_c.send(20).unwrap();
         });
 
@@ -685,7 +685,7 @@ mod generic_receiversets_tests {
         let channel_result = select_result.first().unwrap();
         assert_eq!(
             *channel_result,
-            GenericSelectionResult::MessageReceived(1, 20)
+            GenericSelectionResult::MessageReceived(0, 10)
         );
     }
 
@@ -702,11 +702,10 @@ mod generic_receiversets_tests {
         set.add(recv2);
 
         std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_secs(2));
+            std::thread::sleep(Duration::from_secs(1));
             snd1_c.send(10).unwrap();
         });
         std::thread::spawn(move || {
-            std::thread::sleep(Duration::from_secs(1));
             snd2_c.send(20).unwrap();
         });
 
@@ -803,6 +802,7 @@ mod generic_receiversets_tests {
     #[test]
     fn test_ipc_no_crash_on_disconnect() {
         // Test that we do not crash if a channel gets disconnected.
+        // Channel 2 gets disconnected because snd2 gets moved into the thread and then falls out of scope
         let (snd1, recv1) = new_generic_channel_ipc().unwrap();
         let (snd2, recv2) = new_generic_channel_ipc().unwrap();
 
@@ -819,7 +819,7 @@ mod generic_receiversets_tests {
         std::thread::spawn(move || {
             snd2.send(20).unwrap();
         });
-
+        std::thread::sleep(Duration::from_secs(1));
         let select_result = set.select();
         let channel_result = select_result.first().unwrap();
         assert_eq!(
@@ -830,6 +830,7 @@ mod generic_receiversets_tests {
 
     #[test]
     fn test_crossbeam_no_crash_on_disconnect() {
+        // Channel 2 gets disconnected because snd2 gets moved into the thread and then falls out of scope
         let (snd1, recv1) = new_generic_channel_crossbeam();
         let (snd2, recv2) = new_generic_channel_crossbeam();
 
@@ -846,7 +847,7 @@ mod generic_receiversets_tests {
         std::thread::spawn(move || {
             snd2.send(20).unwrap();
         });
-
+        std::thread::sleep(Duration::from_secs(1));
         let select_result = set.select();
         let channel_result = select_result.first().unwrap();
         assert_eq!(

--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -670,8 +670,8 @@ mod generic_receiversets_tests {
         let snd1_c = snd1.clone();
         let snd2_c = snd2.clone();
         let mut set = create_ipc_receiver_set();
-        set.add(recv1);
-        set.add(recv2);
+        let recv1_select_index = set.add(recv1);
+        let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             snd1_c.send(10).unwrap();
@@ -685,7 +685,7 @@ mod generic_receiversets_tests {
         let channel_result = select_result.first().unwrap();
         assert_eq!(
             *channel_result,
-            GenericSelectionResult::MessageReceived(0, 10)
+            GenericSelectionResult::MessageReceived(recv1_select_index, 10)
         );
     }
 
@@ -698,8 +698,8 @@ mod generic_receiversets_tests {
         let snd1_c = snd1.clone();
         let snd2_c = snd2.clone();
         let mut set = create_ipc_receiver_set();
-        set.add(recv1);
-        set.add(recv2);
+        let recv1_select_index = set.add(recv1);
+        let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(1));
@@ -713,7 +713,7 @@ mod generic_receiversets_tests {
         let channel_result = select_result.first().unwrap();
         assert_eq!(
             *channel_result,
-            GenericSelectionResult::MessageReceived(1, 20)
+            GenericSelectionResult::MessageReceived(recv2_select_index, 20)
         );
     }
 
@@ -726,8 +726,8 @@ mod generic_receiversets_tests {
         let snd1_c = snd1.clone();
         let snd2_c = snd2.clone();
         let mut set = create_ipc_receiver_set();
-        set.add(recv1);
-        set.add(recv2);
+        let recv1_select_index = set.add(recv1);
+        let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             snd1_c.send(10).unwrap();
@@ -739,8 +739,18 @@ mod generic_receiversets_tests {
 
         let select_result = set.select();
         assert_eq!(select_result.len(), 2);
-        assert!(select_result.contains(&GenericSelectionResult::MessageReceived(1, 20)));
-        assert!(select_result.contains(&GenericSelectionResult::MessageReceived(0, 10)));
+        assert!(
+            select_result.contains(&GenericSelectionResult::MessageReceived(
+                recv2_select_index,
+                20
+            ))
+        );
+        assert!(
+            select_result.contains(&GenericSelectionResult::MessageReceived(
+                recv1_select_index,
+                10
+            ))
+        );
     }
 
     #[test]
@@ -752,8 +762,8 @@ mod generic_receiversets_tests {
         let snd1_c = snd1.clone();
         let snd2_c = snd2.clone();
         let mut set = create_crossbeam_receiver_set();
-        set.add(recv1);
-        set.add(recv2);
+        let recv1_select_index = set.add(recv1);
+        let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             snd1_c.send(10).unwrap();
@@ -767,7 +777,7 @@ mod generic_receiversets_tests {
         let channel_result = select_result.first().unwrap();
         assert_eq!(
             *channel_result,
-            GenericSelectionResult::MessageReceived(0, 10)
+            GenericSelectionResult::MessageReceived(recv1_select_index, 10)
         );
     }
 
@@ -780,8 +790,8 @@ mod generic_receiversets_tests {
         let snd1_c = snd1.clone();
         let snd2_c = snd2.clone();
         let mut set = create_crossbeam_receiver_set();
-        set.add(recv1);
-        set.add(recv2);
+        let recv1_select_index = set.add(recv1);
+        let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(2));
@@ -795,7 +805,7 @@ mod generic_receiversets_tests {
         let channel_result = select_result.first().unwrap();
         assert_eq!(
             *channel_result,
-            GenericSelectionResult::MessageReceived(1, 20)
+            GenericSelectionResult::MessageReceived(recv2_select_index, 20)
         );
     }
 
@@ -809,8 +819,8 @@ mod generic_receiversets_tests {
         // We keep the senders alive till all threads are done
         let snd1_c = snd1.clone();
         let mut set = create_ipc_receiver_set();
-        set.add(recv1);
-        set.add(recv2);
+        let recv1_select_index = set.add(recv1);
+        let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(2));
@@ -824,7 +834,7 @@ mod generic_receiversets_tests {
         let channel_result = select_result.first().unwrap();
         assert_eq!(
             *channel_result,
-            GenericSelectionResult::MessageReceived(1, 20)
+            GenericSelectionResult::MessageReceived(recv2_select_index, 20)
         );
     }
 
@@ -837,8 +847,8 @@ mod generic_receiversets_tests {
         // We keep the senders alive till all threads are done
         let snd1_c = snd1.clone();
         let mut set = create_crossbeam_receiver_set();
-        set.add(recv1);
-        set.add(recv2);
+        let recv1_select_index = set.add(recv1);
+        let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(2));
@@ -852,7 +862,7 @@ mod generic_receiversets_tests {
         let channel_result = select_result.first().unwrap();
         assert_eq!(
             *channel_result,
-            GenericSelectionResult::MessageReceived(1, 20)
+            GenericSelectionResult::MessageReceived(recv2_select_index, 20)
         );
     }
 
@@ -865,8 +875,8 @@ mod generic_receiversets_tests {
         // We keep the senders alive till all threads are done
         let snd1_c = snd1.clone();
         let mut set = create_ipc_receiver_set();
-        set.add(recv1);
-        set.add(recv2);
+        let recv1_select_index = set.add(recv1);
+        let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(2));
@@ -878,7 +888,10 @@ mod generic_receiversets_tests {
 
         let select_result = set.select();
         let channel_result = select_result.first().unwrap();
-        assert_eq!(*channel_result, GenericSelectionResult::ChannelClosed(1));
+        assert_eq!(
+            *channel_result,
+            GenericSelectionResult::ChannelClosed(recv2_select_index)
+        );
     }
 
     #[test]
@@ -889,8 +902,8 @@ mod generic_receiversets_tests {
         // We keep the senders alive till all threads are done
         let snd1_c = snd1.clone();
         let mut set = create_crossbeam_receiver_set();
-        set.add(recv1);
-        set.add(recv2);
+        let recv1_select_index = set.add(recv1);
+        let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(2));
@@ -902,6 +915,9 @@ mod generic_receiversets_tests {
 
         let select_result = set.select();
         let channel_result = select_result.first().unwrap();
-        assert_eq!(*channel_result, GenericSelectionResult::ChannelClosed(1));
+        assert_eq!(
+            *channel_result,
+            GenericSelectionResult::ChannelClosed(recv2_select_index)
+        );
     }
 }

--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -671,14 +671,14 @@ mod generic_receiversets_tests {
         let snd2_c = snd2.clone();
         let mut set = create_ipc_receiver_set();
         let recv1_select_index = set.add(recv1);
-        let recv2_select_index = set.add(recv2);
+        let _recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             snd1_c.send(10).unwrap();
         });
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(1));
-            snd2_c.send(20).unwrap();
+            let _ = snd2_c.send(20); // this might error with closed channel
         });
 
         let select_result = set.select();
@@ -698,12 +698,12 @@ mod generic_receiversets_tests {
         let snd1_c = snd1.clone();
         let snd2_c = snd2.clone();
         let mut set = create_ipc_receiver_set();
-        let recv1_select_index = set.add(recv1);
+        let _recv1_select_index = set.add(recv1);
         let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(1));
-            snd1_c.send(10).unwrap();
+            let _ = snd1_c.send(10);
         });
         std::thread::spawn(move || {
             snd2_c.send(20).unwrap();
@@ -718,42 +718,6 @@ mod generic_receiversets_tests {
     }
 
     #[test]
-    fn test_ipc_side_multiple() {
-        let (snd1, recv1) = new_generic_channel_ipc().unwrap();
-        let (snd2, recv2) = new_generic_channel_ipc().unwrap();
-
-        // We keep the senders alive till all threads are done
-        let snd1_c = snd1.clone();
-        let snd2_c = snd2.clone();
-        let mut set = create_ipc_receiver_set();
-        let recv1_select_index = set.add(recv1);
-        let recv2_select_index = set.add(recv2);
-
-        std::thread::spawn(move || {
-            snd1_c.send(10).unwrap();
-        });
-        std::thread::spawn(move || {
-            snd2_c.send(20).unwrap();
-        });
-        std::thread::sleep(Duration::from_secs(1));
-
-        let select_result = set.select();
-        assert_eq!(select_result.len(), 2);
-        assert!(
-            select_result.contains(&GenericSelectionResult::MessageReceived(
-                recv2_select_index,
-                20
-            ))
-        );
-        assert!(
-            select_result.contains(&GenericSelectionResult::MessageReceived(
-                recv1_select_index,
-                10
-            ))
-        );
-    }
-
-    #[test]
     fn test_crossbeam_side1() {
         let (snd1, recv1) = new_generic_channel_crossbeam();
         let (snd2, recv2) = new_generic_channel_crossbeam();
@@ -763,14 +727,14 @@ mod generic_receiversets_tests {
         let snd2_c = snd2.clone();
         let mut set = create_crossbeam_receiver_set();
         let recv1_select_index = set.add(recv1);
-        let recv2_select_index = set.add(recv2);
+        let _recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             snd1_c.send(10).unwrap();
         });
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(2));
-            snd2_c.send(20).unwrap();
+            let _ = snd2_c.send(20);
         });
 
         let select_result = set.select();
@@ -790,12 +754,12 @@ mod generic_receiversets_tests {
         let snd1_c = snd1.clone();
         let snd2_c = snd2.clone();
         let mut set = create_crossbeam_receiver_set();
-        let recv1_select_index = set.add(recv1);
+        let _recv1_select_index = set.add(recv1);
         let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(2));
-            snd1_c.send(10).unwrap();
+            let _ = snd1_c.send(10);
         });
         std::thread::spawn(move || {
             snd2_c.send(20).unwrap();
@@ -819,12 +783,12 @@ mod generic_receiversets_tests {
         // We keep the senders alive till all threads are done
         let snd1_c = snd1.clone();
         let mut set = create_ipc_receiver_set();
-        let recv1_select_index = set.add(recv1);
+        let _recv1_select_index = set.add(recv1);
         let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(2));
-            snd1_c.send(10).unwrap();
+            let _ = snd1_c.send(10);
         });
         std::thread::spawn(move || {
             snd2.send(20).unwrap();
@@ -847,12 +811,12 @@ mod generic_receiversets_tests {
         // We keep the senders alive till all threads are done
         let snd1_c = snd1.clone();
         let mut set = create_crossbeam_receiver_set();
-        let recv1_select_index = set.add(recv1);
+        let _recv1_select_index = set.add(recv1);
         let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(2));
-            snd1_c.send(10).unwrap();
+            let _ = snd1_c.send(10);
         });
         std::thread::spawn(move || {
             snd2.send(20).unwrap();
@@ -875,12 +839,12 @@ mod generic_receiversets_tests {
         // We keep the senders alive till all threads are done
         let snd1_c = snd1.clone();
         let mut set = create_ipc_receiver_set();
-        let recv1_select_index = set.add(recv1);
+        let _recv1_select_index = set.add(recv1);
         let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(2));
-            snd1_c.send(10).unwrap();
+            let _ = snd1_c.send(10);
         });
         std::thread::spawn(move || {
             drop(snd2);
@@ -902,12 +866,12 @@ mod generic_receiversets_tests {
         // We keep the senders alive till all threads are done
         let snd1_c = snd1.clone();
         let mut set = create_crossbeam_receiver_set();
-        let recv1_select_index = set.add(recv1);
+        let _recv1_select_index = set.add(recv1);
         let recv2_select_index = set.add(recv2);
 
         std::thread::spawn(move || {
             std::thread::sleep(Duration::from_secs(2));
-            snd1_c.send(10).unwrap();
+            let _ = snd1_c.send(10);
         });
         std::thread::spawn(move || {
             drop(snd2);

--- a/components/shared/base/generic_channel/generic_channelset.rs
+++ b/components/shared/base/generic_channel/generic_channelset.rs
@@ -114,8 +114,9 @@ impl<T: Serialize + for<'de> Deserialize<'de>> GenericReceiverSet<T> {
                 GenericReceiverSetVariants::Crossbeam(receivers),
                 GenericReceiverVariants::Crossbeam(receiver),
             ) => {
+                let index = receivers.len() as u64;
                 receivers.push(receiver);
-                receivers.len().checked_sub(1).unwrap() as u64
+                index
             },
         }
     }

--- a/components/shared/base/generic_channel/generic_channelset.rs
+++ b/components/shared/base/generic_channel/generic_channelset.rs
@@ -115,7 +115,7 @@ impl<T: Serialize + for<'de> Deserialize<'de>> GenericReceiverSet<T> {
                 GenericReceiverVariants::Crossbeam(receiver),
             ) => {
                 receivers.push(receiver);
-                receivers.len() as u64
+                receivers.len().checked_sub(1).unwrap() as u64
             },
         }
     }

--- a/components/shared/base/generic_channel/generic_channelset.rs
+++ b/components/shared/base/generic_channel/generic_channelset.rs
@@ -1,0 +1,155 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use ipc_channel::ipc::{IpcReceiverSet, IpcSelectionResult};
+use serde::{Deserialize, Serialize};
+
+use crate::generic_channel::{GenericReceiver, GenericReceiverVariants, ReceiveError};
+
+/// A GenericReceiverSet. Allows you to wait on multiple GenericReceivers.
+/// Automatically selects either Ipc or crossbeam depending on multiprocess mode.
+/// # Examples
+/// ```
+/// # let mut rx_set = GenericReceiverSet::new();
+/// # let private_channel = generic_channel::channel().unwrap();
+/// # let public_channel = generic_channel::channel().unwrap();
+/// # let reporter_channel = generic_channel::channel().unwrap();
+/// # let private_id = rx_set.add(private_receiver);
+/// # let public_id = rx_set.add(public_receiver);
+/// # let reporter_id = rx_set.add(memory_reporter);
+/// # for received in rx_set.select().unwrap().into_iter() {
+/// #     match received {
+/// #         GenericSelectionResult::ChannelClosed(_) => continue,
+/// #         GenericSelectionResult::Error => println!("Found selection error"),
+/// #         GenericSelectionResult::MessageReceived(id, msg) => {
+/// #     }
+/// # }
+/// ```
+pub struct GenericReceiverSet<T: Serialize + for<'de> Deserialize<'de>>(
+    GenericReceiverSetVariants<T>,
+);
+
+impl<T: Serialize + for<'de> Deserialize<'de>> Default for GenericReceiverSet<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+enum GenericReceiverSetVariants<T: for<'de> Deserialize<'de>> {
+    Ipc(ipc_channel::ipc::IpcReceiverSet),
+    Crossbeam(Vec<crossbeam_channel::Receiver<Result<T, ipc_channel::Error>>>),
+}
+
+#[cfg(test)]
+pub fn create_ipc_receiver_set<T: Serialize + for<'de> serde::Deserialize<'de>>()
+-> GenericReceiverSet<T> {
+    GenericReceiverSet(GenericReceiverSetVariants::Ipc(
+        IpcReceiverSet::new().expect("Could not create ipc receiver"),
+    ))
+}
+
+#[cfg(test)]
+pub fn create_crossbeam_receiver_set<T: Serialize + for<'de> serde::Deserialize<'de>>()
+-> GenericReceiverSet<T> {
+    GenericReceiverSet(GenericReceiverSetVariants::Crossbeam(vec![]))
+}
+
+/// Result for readable events returned from [GenericReceiverSet::select].
+#[derive(Debug, PartialEq)]
+pub enum GenericSelectionResult<T> {
+    /// A message received from the [`GenericReceiver`],
+    /// identified by the `u64` value and Deserialized into a 'T'.
+    MessageReceived(u64, T),
+    /// The channel has been closed for the [GenericReceiver] identified by the `u64` value.
+    ChannelClosed(u64),
+    /// An error occured decoding the message.
+    Error,
+}
+
+impl<T: Serialize + for<'de> serde::Deserialize<'de>> From<IpcSelectionResult>
+    for GenericSelectionResult<T>
+{
+    fn from(value: IpcSelectionResult) -> Self {
+        match value {
+            IpcSelectionResult::MessageReceived(channel_id, ipc_message) => {
+                match ipc_message.to() {
+                    Ok(value) => GenericSelectionResult::MessageReceived(channel_id, value),
+                    Err(_) => GenericSelectionResult::Error,
+                }
+            },
+            IpcSelectionResult::ChannelClosed(channel_id) => {
+                GenericSelectionResult::ChannelClosed(channel_id)
+            },
+        }
+    }
+}
+
+impl<T: Serialize + for<'de> Deserialize<'de>> GenericReceiverSet<T> {
+    /// Create a new ReceiverSet.
+    pub fn new() -> GenericReceiverSet<T> {
+        if servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc {
+            GenericReceiverSet(GenericReceiverSetVariants::Ipc(
+                IpcReceiverSet::new().expect("Could not create ipc receiver"),
+            ))
+        } else {
+            GenericReceiverSet(GenericReceiverSetVariants::Crossbeam(vec![]))
+        }
+    }
+
+    /// Add a receiver to the set.
+    pub fn add(&mut self, receiver: GenericReceiver<T>) -> u64 {
+        match (&mut self.0, receiver.0) {
+            (
+                GenericReceiverSetVariants::Ipc(ipc_receiver_set),
+                GenericReceiverVariants::Ipc(ipc_receiver),
+            ) => ipc_receiver_set
+                .add(ipc_receiver)
+                .expect("Could not add channel"),
+            (GenericReceiverSetVariants::Ipc(_), GenericReceiverVariants::Crossbeam(_)) => {
+                unreachable!()
+            },
+            (GenericReceiverSetVariants::Crossbeam(_), GenericReceiverVariants::Ipc(_)) => {
+                unreachable!()
+            },
+            (
+                GenericReceiverSetVariants::Crossbeam(receivers),
+                GenericReceiverVariants::Crossbeam(receiver),
+            ) => {
+                receivers.push(receiver);
+                receivers.len() as u64
+            },
+        }
+    }
+
+    /// Block until at least one of the Receivers receives a message and return a vector of the received messages.
+    pub fn select(&mut self) -> Result<Vec<GenericSelectionResult<T>>, ReceiveError> {
+        match &mut self.0 {
+            GenericReceiverSetVariants::Ipc(ipc_receiver_set) => ipc_receiver_set
+                .select()
+                .map(|result_value| {
+                    result_value
+                        .into_iter()
+                        .map(|selection_result| selection_result.into())
+                        .collect()
+                })
+                .map_err(|e| e.into()),
+            GenericReceiverSetVariants::Crossbeam(receivers) => {
+                let mut sel = crossbeam_channel::Select::new();
+                // we need to add all the receivers to the set
+                let _selected_receivers = receivers
+                    .iter()
+                    .map(|receiver| sel.recv(receiver))
+                    .collect::<Vec<usize>>();
+                let selector = sel.select();
+                let index = selector.index();
+                let Some(receiver) = receivers.get(index) else {
+                    return Err(ReceiveError::Disconnected);
+                };
+                let result = selector.recv(receiver)?;
+                Ok(vec![GenericSelectionResult::MessageReceived(
+                    index.try_into().unwrap(),
+                    result.unwrap(),
+                )])
+            },
+        }
+    }
+}

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -11,7 +11,7 @@ use std::thread::{self, JoinHandle};
 use base::cross_process_instant::CrossProcessInstant;
 use base::generic_channel::{self, GenericSender};
 use base::id::{CookieStoreId, HistoryStateId, PipelineId};
-use base::{IpcSend, IpcSendResult};
+use base::generic_channel::{GenericSend, GenericSender, SendResult};
 use content_security_policy::{self as csp};
 use cookie::Cookie;
 use crossbeam_channel::{Receiver, Sender, unbounded};
@@ -19,11 +19,12 @@ use headers::{ContentType, HeaderMapExt, ReferrerPolicy as ReferrerPolicyHeader}
 use http::{Error as HttpError, HeaderMap, HeaderValue, StatusCode, header};
 use hyper_serde::Serde;
 use hyper_util::client::legacy::Error as HyperError;
-use ipc_channel::ipc::{self, IpcError, IpcReceiver, IpcSender};
+use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
 use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
 use mime::Mime;
+use profile_traits::mem::ReportsChan;
 use rand::{RngCore, rng};
 use request::RequestId;
 use rustc_hash::FxHashMap;
@@ -487,7 +488,7 @@ pub trait AsyncRuntime: Send {
 }
 
 /// Handle to a resource thread
-pub type CoreResourceThread = IpcSender<CoreResourceMsg>;
+pub type CoreResourceThread = GenericSender<CoreResourceMsg>;
 
 // FIXME: Originally we will construct an Arc<ResourceThread> from ResourceThread
 // in script_thread to avoid some performance pitfall. Now we decide to deal with
@@ -550,12 +551,12 @@ impl ResourceThreads {
     }
 }
 
-impl IpcSend<CoreResourceMsg> for ResourceThreads {
-    fn send(&self, msg: CoreResourceMsg) -> IpcSendResult {
-        self.core_thread.send(msg).map_err(IpcError::Bincode)
+impl GenericSend<CoreResourceMsg> for ResourceThreads {
+    fn send(&self, msg: CoreResourceMsg) -> SendResult {
+        self.core_thread.send(msg)
     }
 
-    fn sender(&self) -> IpcSender<CoreResourceMsg> {
+    fn sender(&self) -> GenericSender<CoreResourceMsg> {
         self.core_thread.clone()
     }
 }
@@ -655,6 +656,7 @@ pub enum CoreResourceMsg {
     /// Break the load handler loop, send a reply when done cleaning up local resources
     /// and exit
     Exit(IpcSender<()>),
+    CollectMemoryReport(ReportsChan),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -9,9 +9,8 @@ use std::sync::{LazyLock, OnceLock};
 use std::thread::{self, JoinHandle};
 
 use base::cross_process_instant::CrossProcessInstant;
-use base::generic_channel::{self, GenericSender};
 use base::id::{CookieStoreId, HistoryStateId, PipelineId};
-use base::generic_channel::{GenericSend, GenericSender, SendResult};
+use base::generic_channel::{self, GenericSend, GenericSender, SendResult};
 use content_security_policy::{self as csp};
 use cookie::Cookie;
 use crossbeam_channel::{Receiver, Sender, unbounded};

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -9,8 +9,8 @@ use std::sync::{LazyLock, OnceLock};
 use std::thread::{self, JoinHandle};
 
 use base::cross_process_instant::CrossProcessInstant;
-use base::id::{CookieStoreId, HistoryStateId, PipelineId};
 use base::generic_channel::{self, GenericSend, GenericSender, SendResult};
+use base::id::{CookieStoreId, HistoryStateId, PipelineId};
 use content_security_policy::{self as csp};
 use cookie::Cookie;
 use crossbeam_channel::{Receiver, Sender, unbounded};

--- a/tests/wpt/meta/cookiestore/cookieStore_delete_arguments.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_delete_arguments.https.any.js.ini
@@ -1,5 +1,4 @@
 [cookieStore_delete_arguments.https.any.html]
-  expected: TIMEOUT
   [cookieStore.delete domain starts with "."]
     expected: FAIL
 
@@ -18,20 +17,8 @@
   [cookieStore.delete with path that does not start with /]
     expected: FAIL
 
-  [cookieStore.delete with positional empty name]
-    expected: TIMEOUT
-
-  [cookieStore.delete with empty name in options]
-    expected: NOTRUN
-
-  [cookieStore.delete with maximum cookie name size]
-    expected: NOTRUN
-
   [cookieStore.delete with a __Host- prefix should not have a domain]
-    expected: NOTRUN
-
-  [cookieStore.delete with whitespace]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [cookieStore_delete_arguments.https.any.serviceworker.html]

--- a/tests/wpt/meta/cookiestore/cookieStore_set_arguments.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_set_arguments.https.any.js.ini
@@ -2,7 +2,7 @@
   expected: ERROR
 
 [cookieStore_set_arguments.https.any.html]
-  expected: TIMEOUT
+  expected: CRASH
   [cookieStore.set fails with empty name and empty value]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/cookiestore/cookieStore_special_names.https.any.js.ini
+++ b/tests/wpt/meta/cookiestore/cookieStore_special_names.https.any.js.ini
@@ -1,5 +1,4 @@
 [cookieStore_special_names.https.any.html]
-  expected: TIMEOUT
   [cookieStore.set with __Host- prefix and a domain option]
     expected: FAIL
 
@@ -40,34 +39,34 @@
     expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have __Host- prefix]
-    expected: TIMEOUT
+    expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have __Secure- prefix]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have __Http- prefix]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have __HostHttp- prefix]
     expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have  __Host- prefix]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have \t__Host- prefix]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have  __Secure- prefix]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have \t__Secure- prefix]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have  __Http- prefix]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have \t__Http- prefix]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have  __HostHttp- prefix]
     expected: FAIL
@@ -88,13 +87,13 @@
     expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have __Host-Http- prefix]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have  __Host-Http- prefix]
-    expected: NOTRUN
+    expected: FAIL
 
   [cookieStore.set a nameless cookie cannot have \t__Host-Http- prefix]
-    expected: NOTRUN
+    expected: FAIL
 
 
 [cookieStore_special_names.https.any.serviceworker.html]


### PR DESCRIPTION
This implements GenericReceiverSet similar to IpcReceiverSet. This allows us to wait on a group of channels.

IpcReceiverSet was allowed to use IpcReceivers of different type, i.e., `IpcReceiver<Foo>` and `IpcReceiver<Bar>` in the same select query. This changes with GenericReceiverSet to only allow one type, i.e., `GenericReceiver<Foo>`. As this functionality was only used in the CoreResourceThread, we changed the setup slightly for the memory reporter.

With this we also change the implementation of CoreResourceThread to now use the GenericReceiverSet.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: New testcases were added to GenericReceiverSet and browsing works normally.
