### PR TITLE
ohos / android: Fix missing error message for cli parsing errors

### DIFF
--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -623,7 +623,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
                 {
                     let mut builder = hilog::Builder::new();
                     builder.set_domain(hilog::LogDomain::new(0xE0C3));
-                    //let logger: &'static hilog::Logger = &LOGGER;
                     log::error!("{}", error.clone().unwrap_stderr());
                 }
                 #[cfg(target_os = "android")]

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -623,7 +623,6 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
                 {
                     let mut builder = hilog::Builder::new();
                     builder.set_domain(hilog::LogDomain::new(0xE0C3));
-                    log::error!("{}", error.clone().unwrap_stderr());
                 }
                 #[cfg(target_os = "android")]
                 {
@@ -633,6 +632,11 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
                             .with_filter(filter_builder.build())
                             .with_tag("servoshell"),
                     )
+                }
+                match &error {
+                    ParseFailure::Stdout(_, _) => unreachable!("Should never happen"),
+                    ParseFailure::Completion(_) => unreachable!("Should never happen"),
+                    ParseFailure::Stderr(doc) => log::error!("{doc}"),
                 }
             } else {
                 error.print_message(80);

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -619,23 +619,11 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
             // Because this is very early in startup stdout/stderr forward
             // facilities might not be available yet
             if cfg!(target_os = "android") || cfg!(target_env = "ohos") {
-                #[cfg(target_env = "ohos")]
-                {
-                    let mut builder = hilog::Builder::new();
-                    builder.set_domain(hilog::LogDomain::new(0xE0C3));
-                }
-                #[cfg(target_os = "android")]
-                {
-                    android_logger::init_once(
-                        Config::default()
-                            .with_max_level(log::LevelFilter::Debug)
-                            .with_filter(filter_builder.build())
-                            .with_tag("servoshell"),
-                    )
-                }
                 match &error {
                     ParseFailure::Stderr(doc) => log::error!("{doc}"),
-                    _ => log::error!("This should never happen."),
+                    // '--help' will be parsed by the next one.
+                    ParseFailure::Stdout(doc, _) => log::error!("{doc}"),
+                    ParseFailure::Completion(_) => log::error!("Not supported on these platforms"),
                 }
             } else {
                 error.print_message(80);

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -634,9 +634,8 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
                     )
                 }
                 match &error {
-                    ParseFailure::Stdout(_, _) => unreachable!("Should never happen"),
-                    ParseFailure::Completion(_) => unreachable!("Should never happen"),
                     ParseFailure::Stderr(doc) => log::error!("{doc}"),
+                    _ => log::error!("This should never happen."),
                 }
             } else {
                 error.print_message(80);

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -616,8 +616,8 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
     let cmd_args = match cmd_args {
         Ok(cmd_args) => cmd_args,
         Err(error) => {
-            // Because this is very early in startup stdout/stderr forward
-            // facilities might not be available yet
+            // Servo will exit after printing the parsing error, which makes the stdout / stderr
+            // redirection via a seperate thread racy, so we log directly to the system logger.
             if cfg!(target_os = "android") || cfg!(target_env = "ohos") {
                 match &error {
                     ParseFailure::Stderr(doc) => log::error!("{doc}"),


### PR DESCRIPTION
On ohos/android the early redirect from stderr/stdout is not yet setup when we parse commandline arguments.
This redirects these error on the standard logging facilities.

Testing: Tested on OHOS device with correct and incorrect arguments and on linux desktop.
