### PR TITLE
devtools: Box the actor inside register

### DIFF
--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -273,14 +273,14 @@ impl BrowsingContextActor {
             watcher: watcher.name(),
         };
 
-        actors.register(Box::new(accessibility));
-        actors.register(Box::new(css_properties));
-        actors.register(Box::new(inspector));
-        actors.register(Box::new(reflow));
-        actors.register(Box::new(style_sheets));
-        actors.register(Box::new(tabdesc));
-        actors.register(Box::new(thread));
-        actors.register(Box::new(watcher));
+        actors.register(accessibility);
+        actors.register(css_properties);
+        actors.register(inspector);
+        actors.register(reflow);
+        actors.register(style_sheets);
+        actors.register(tabdesc);
+        actors.register(thread);
+        actors.register(watcher);
 
         target
     }

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -81,7 +81,7 @@ impl Actor for FrameActor {
                     from: self.name(),
                     environment: environment.encode(registry),
                 };
-                registry.register_later(Box::new(environment));
+                registry.register_later(environment);
                 request.reply_final(&msg)?
             },
             _ => return Err(ActorError::UnrecognizedPacketType),

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -56,7 +56,7 @@ impl FramerateActor {
         };
 
         actor.start_recording();
-        registry.register_later(Box::new(actor));
+        registry.register_later(actor);
         actor_name
     }
 

--- a/components/devtools/actors/inspector.rs
+++ b/components/devtools/actors/inspector.rs
@@ -105,7 +105,7 @@ impl Actor for InspectorActor {
                     };
                     let mut walker_name = self.walker.borrow_mut();
                     *walker_name = Some(walker.name());
-                    registry.register_later(Box::new(walker));
+                    registry.register_later(walker);
                 }
 
                 let msg = GetWalkerReply {
@@ -127,7 +127,7 @@ impl Actor for InspectorActor {
                     };
                     let mut page_style = self.page_style.borrow_mut();
                     *page_style = Some(style.name());
-                    registry.register_later(Box::new(style));
+                    registry.register_later(style);
                 }
 
                 let msg = GetPageStyleReply {
@@ -162,7 +162,7 @@ impl Actor for InspectorActor {
                     };
                     let mut highlighter = self.highlighter.borrow_mut();
                     *highlighter = Some(highlighter_actor.name());
-                    registry.register_later(Box::new(highlighter_actor));
+                    registry.register_later(highlighter_actor);
                 }
 
                 let msg = GetHighlighterReply {

--- a/components/devtools/actors/inspector/node.rs
+++ b/components/devtools/actors/inspector/node.rs
@@ -240,7 +240,7 @@ impl NodeInfoToProtocol for NodeInfo {
                     walker: walker.clone(),
                     style_rules: RefCell::new(HashMap::new()),
                 };
-                actors.register_later(Box::new(node_actor));
+                actors.register_later(node_actor);
                 name
             } else {
                 actors.script_to_actor(id.to_string())

--- a/components/devtools/actors/inspector/page_style.rs
+++ b/components/devtools/actors/inspector/page_style.rs
@@ -189,7 +189,7 @@ impl PageStyleActor {
                             );
                             let rule = actor.applied(registry)?;
 
-                            registry.register_later(Box::new(actor));
+                            registry.register_later(actor);
                             e.insert(name);
                             rule
                         },
@@ -240,7 +240,7 @@ impl PageStyleActor {
                 let name = registry.new_name("style-rule");
                 let actor = StyleRuleActor::new(name.clone(), target.into(), None);
                 let computed = actor.computed(registry)?;
-                registry.register_later(Box::new(actor));
+                registry.register_later(actor);
                 e.insert(name);
                 Some(computed)
             },

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -196,7 +196,7 @@ impl Actor for WalkerActor {
                 // TODO: Create actual layout inspector actor
                 let layout = LayoutInspectorActor::new(registry.new_name("layout"));
                 let actor = layout.encodable();
-                registry.register_later(Box::new(layout));
+                registry.register_later(layout);
 
                 let msg = GetLayoutInspectorReply {
                     from: self.name(),

--- a/components/devtools/actors/memory.rs
+++ b/components/devtools/actors/memory.rs
@@ -53,7 +53,7 @@ impl MemoryActor {
             name: actor_name.clone(),
         };
 
-        registry.register_later(Box::new(actor));
+        registry.register_later(actor);
         actor_name
     }
 

--- a/components/devtools/actors/network_event.rs
+++ b/components/devtools/actors/network_event.rs
@@ -369,7 +369,7 @@ impl Actor for NetworkEventActor {
                         // Queue a LongStringActor for this body
                         let long_string_actor = LongStringActor::new(registry, full_str);
                         let long_string_obj = long_string_actor.long_string_obj();
-                        registry.register_later(Box::new(long_string_actor));
+                        registry.register_later(long_string_actor);
 
                         ResponseContentObj {
                             mime_type,

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -62,7 +62,7 @@ impl ObjectActor {
             };
 
             registry.register_script_actor(uuid, name.clone());
-            registry.register_later(Box::new(actor));
+            registry.register_later(actor);
 
             name
         } else {

--- a/components/devtools/actors/source.rs
+++ b/components/devtools/actors/source.rs
@@ -158,7 +158,7 @@ impl SourceActor {
             introduction_type,
             script_sender,
         );
-        actors.register(Box::new(source_actor));
+        actors.register(source_actor);
         actors.register_source_actor(pipeline_id, &source_actor_name);
 
         actors.find(&source_actor_name)

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -414,10 +414,10 @@ impl WatcherActor {
             session_context,
         };
 
-        actors.register(Box::new(network_parent));
-        actors.register(Box::new(target_configuration));
-        actors.register(Box::new(thread_configuration));
-        actors.register(Box::new(breakpoint_list));
+        actors.register(network_parent);
+        actors.register(target_configuration);
+        actors.register(thread_configuration);
+        actors.register(breakpoint_list);
 
         watcher
     }

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -161,7 +161,7 @@ impl DevtoolsInstance {
         let device = DeviceActor::new(registry.new_name("device"));
         let preference = PreferenceActor::new(registry.new_name("preference"));
         let process = ProcessActor::new(registry.new_name("process"));
-        let root = Box::new(RootActor {
+        let root = RootActor {
             tabs: vec![],
             workers: vec![],
             device: device.name(),
@@ -169,13 +169,13 @@ impl DevtoolsInstance {
             preference: preference.name(),
             process: process.name(),
             active_tab: None.into(),
-        });
+        };
 
         registry.register(root);
-        registry.register(Box::new(performance));
-        registry.register(Box::new(device));
-        registry.register(Box::new(preference));
-        registry.register(Box::new(process));
+        registry.register(performance);
+        registry.register(device);
+        registry.register(preference);
+        registry.register(process);
         registry.find::<RootActor>("root");
 
         let actors = registry.create_shareable();
@@ -360,7 +360,7 @@ impl DevtoolsInstance {
 
             let thread = ThreadActor::new(actors.new_name("thread"));
             let thread_name = thread.name();
-            actors.register(Box::new(thread));
+            actors.register(thread);
 
             let worker_name = actors.new_name("worker");
             let worker = WorkerActor {
@@ -377,7 +377,7 @@ impl DevtoolsInstance {
             root.workers.push(worker.name.clone());
 
             self.actor_workers.insert(id, worker_name.clone());
-            actors.register(Box::new(worker));
+            actors.register(worker);
 
             Root::DedicatedWorker(worker_name)
         } else {
@@ -397,7 +397,7 @@ impl DevtoolsInstance {
                         &mut actors,
                     );
                     let name = browsing_context_actor.name();
-                    actors.register(Box::new(browsing_context_actor));
+                    actors.register(browsing_context_actor);
                     name
                 });
 
@@ -417,7 +417,7 @@ impl DevtoolsInstance {
             root: parent_actor,
         };
 
-        actors.register(Box::new(console));
+        actors.register(console);
     }
 
     fn handle_title_changed(&self, pipeline_id: PipelineId, title: String) {
@@ -538,7 +538,7 @@ impl DevtoolsInstance {
         let actor = NetworkEventActor::new(actor_name.clone(), resource_id, watcher_name);
 
         self.actor_requests.insert(request_id, actor_name.clone());
-        actors.register(Box::new(actor));
+        actors.register(actor);
 
         actor_name
     }


### PR DESCRIPTION
Small refactor to reduce verbosity when creating actors. Since they always need to be boxed, do that in `register{_later}` instead. I also added the `Send` trait to `Actor` directly since it is always needed.

Testing: This patch doesn't change behaviour.
