### PR TITLE
script: Update `media` to include fix for `AudioBufferSourceNode.loop`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7988,7 +7988,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
+source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -8001,7 +8001,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
+source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -8022,7 +8022,7 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
+source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8032,7 +8032,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
+source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -8046,7 +8046,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
+source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -8079,7 +8079,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
+source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -8089,7 +8089,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
+source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8103,7 +8103,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
+source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8118,7 +8118,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
+source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -8130,7 +8130,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
+source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
 dependencies = [
  "uuid",
 ]
@@ -8138,12 +8138,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
+source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
+source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
 dependencies = [
  "log",
  "servo-media-streams",

--- a/tests/wpt/tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/looped-constant-buffer.html
+++ b/tests/wpt/tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/looped-constant-buffer.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Looped AudioBufferSourceNode Keeps Rendering</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/webaudio/resources/audit-util.js"></script>
+  </head>
+  <body>
+    <script>
+      promise_test(async () => {
+        const sampleRate = 44100;
+        const renderFrames = 2048;
+        const loopFrames = 64;
+
+        const context = new OfflineAudioContext(1, renderFrames, sampleRate);
+        const loopDuration = loopFrames / sampleRate;
+
+        const src = new AudioBufferSourceNode(context, {
+          buffer: createConstantBuffer(context, loopFrames, 1),
+          loop: true,
+          loopStart: 0,
+          loopEnd: loopDuration,
+        });
+
+        src.connect(context.destination);
+        src.start();
+
+        const resultBuffer = await context.startRendering();
+        const result = resultBuffer.getChannelData(0);
+        const expected = new Float32Array(result.length).fill(1);
+
+        // WebAudio §1.9.5 requires that a looped region keeps playing until it is
+        // stopped, so the rendered output should remain constant 1 even after
+        // multiple loop passes.
+        assert_array_equals(
+          result,
+          expected,
+          'looped buffer should continue emitting ones even after first loop'
+        );
+      }, 'looped-constant-buffer-keeps-rendering');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Fix in https://github.com/servo/media/pull/476:

Previously:
the moment we set bufferSource.loop = true, the node hit the early “extreme edge case” check, decided “I refuse to output”, triggered onended, and returned silence. So the loop never got a chance to run.

Now:

Early bailout is removed(no idea why was there in first place).
The per tick offset is guaranteed to be a sensible value with respect to the loop range (wrapped if extreme).
The normal mixing code runs, updating pos each tick and respecting the loop region

Testing: I tested this manually, it would be nice to add a test for it, and I’m surprised there isn’t one yet.
Fixes: #41073 