### PR TITLE
devtools: Default implementation for `handle_message`

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -56,7 +56,10 @@ pub(crate) trait Actor: Any + ActorAsAny {
         msg_type: &str,
         msg: &Map<String, Value>,
         stream_id: StreamId,
-    ) -> Result<(), ActorError>;
+    ) -> Result<(), ActorError> {
+        let _ = (request, registry, msg_type, msg, stream_id);
+        Err(ActorError::UnrecognizedPacketType)
+    }
     fn name(&self) -> String;
     fn cleanup(&self, _id: StreamId) {}
 }

--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -5,10 +5,8 @@
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorRegistry};
 use crate::actors::object::ObjectActorMsg;
-use crate::protocol::ClientRequest;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -67,18 +65,6 @@ pub struct EnvironmentActor {
 impl Actor for EnvironmentActor {
     fn name(&self) -> String {
         self.name.clone()
-    }
-
-    fn handle_message(
-        &self,
-        _request: ClientRequest,
-        _registry: &ActorRegistry,
-        _msg_type: &str,
-        _msg: &Map<String, Value>,
-        _id: StreamId,
-    ) -> Result<(), ActorError> {
-        // TODO: Handle messages.
-        Err(ActorError::UnrecognizedPacketType)
     }
 }
 

--- a/components/devtools/actors/framerate.rs
+++ b/components/devtools/actors/framerate.rs
@@ -7,12 +7,9 @@ use std::mem;
 use base::id::PipelineId;
 use devtools_traits::DevtoolScriptControlMsg;
 use ipc_channel::ipc::IpcSender;
-use serde_json::{Map, Value};
 
-use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorRegistry};
 use crate::actors::timeline::HighResolutionStamp;
-use crate::protocol::ClientRequest;
 
 pub struct FramerateActor {
     name: String,
@@ -25,17 +22,6 @@ pub struct FramerateActor {
 impl Actor for FramerateActor {
     fn name(&self) -> String {
         self.name.clone()
-    }
-
-    fn handle_message(
-        &self,
-        _request: ClientRequest,
-        _registry: &ActorRegistry,
-        _msg_type: &str,
-        _msg: &Map<String, Value>,
-        _id: StreamId,
-    ) -> Result<(), ActorError> {
-        Err(ActorError::UnrecognizedPacketType)
     }
 }
 

--- a/components/devtools/actors/memory.rs
+++ b/components/devtools/actors/memory.rs
@@ -3,11 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use serde::Serialize;
-use serde_json::{Map, Value};
 
-use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
-use crate::protocol::ClientRequest;
+use crate::actor::{Actor, ActorRegistry};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -31,17 +28,6 @@ pub struct MemoryActor {
 impl Actor for MemoryActor {
     fn name(&self) -> String {
         self.name.clone()
-    }
-
-    fn handle_message(
-        &self,
-        _request: ClientRequest,
-        _registry: &ActorRegistry,
-        _msg_type: &str,
-        _msg: &Map<String, Value>,
-        _id: StreamId,
-    ) -> Result<(), ActorError> {
-        Err(ActorError::UnrecognizedPacketType)
     }
 }
 

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -3,11 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use serde::Serialize;
-use serde_json::{Map, Value};
 
-use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
-use crate::protocol::ClientRequest;
+use crate::actor::{Actor, ActorRegistry};
 
 #[derive(Serialize)]
 pub struct ObjectPreview {
@@ -39,17 +36,9 @@ impl Actor for ObjectActor {
     fn name(&self) -> String {
         self.name.clone()
     }
-    fn handle_message(
-        &self,
-        _request: ClientRequest,
-        _: &ActorRegistry,
-        _: &str,
-        _: &Map<String, Value>,
-        _: StreamId,
-    ) -> Result<(), ActorError> {
-        // TODO: Handle enumSymbols for console object inspection
-        Err(ActorError::UnrecognizedPacketType)
-    }
+
+    // TODO: Handle messages
+    // https://searchfox.org/firefox-main/source/devtools/shared/specs/object.js
 }
 
 impl ObjectActor {

--- a/components/devtools/actors/pause.rs
+++ b/components/devtools/actors/pause.rs
@@ -2,11 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use serde_json::{Map, Value};
-
-use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
-use crate::protocol::ClientRequest;
+use crate::actor::Actor;
 
 // TODO: Remove once the actor is used.
 #[allow(dead_code)]
@@ -19,17 +15,5 @@ pub struct PauseActor {
 impl Actor for PauseActor {
     fn name(&self) -> String {
         self.name.clone()
-    }
-
-    fn handle_message(
-        &self,
-        _request: ClientRequest,
-        _registry: &ActorRegistry,
-        _msg_type: &str,
-        _msg: &Map<String, Value>,
-        _id: StreamId,
-    ) -> Result<(), ActorError> {
-        // TODO: Handle messages.
-        Err(ActorError::UnrecognizedPacketType)
     }
 }


### PR DESCRIPTION
Some cleanup to avoid having to specify an empty `handle_message` method if it is not implemented or not necessary. Removed the TODOs from Environment and Pause since they don't respond to any message.

Testing: This patch doesn't change behaviour.
