### PR TITLE
Implement preference for mail handler

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -238,6 +238,8 @@ pub struct Preferences {
     pub layout_unimplemented: bool,
     pub layout_variable_fonts_enabled: bool,
     pub layout_writing_mode_enabled: bool,
+    /// Handler used to handle `mailto:` links
+    pub mailto_handler: String,
     /// Enable hardware acceleration for video playback.
     pub media_glvideo_enabled: bool,
     /// Enable a non-standard event handler for verifying behavior of media elements during tests.
@@ -427,6 +429,7 @@ impl Preferences {
             layout_unimplemented: false,
             layout_variable_fonts_enabled: false,
             layout_writing_mode_enabled: false,
+            mailto_handler: String::new(),
             media_glvideo_enabled: false,
             media_testing_enabled: false,
             network_enforce_tls_enabled: false,

--- a/components/net/protocols/mod.rs
+++ b/components/net/protocols/mod.rs
@@ -216,8 +216,8 @@ impl ProtocolHandler for WebPageContentProtocolHandler {
                 NetworkError::Internal("Failed to parse substituted protocol handler url".into()),
             )));
         };
-        // Ensure we did a proper substitution with a HTTP result
-        assert!(matches!(result_url.scheme(), "http" | "https"));
+        // Ensure we did a proper substitution with a HTTP result or internal Servo link
+        assert!(matches!(result_url.scheme(), "http" | "https" | "servo"));
         // Step 9. Navigate an appropriate navigable to resultURL.
         request.url_list.push(result_url);
         let request2 = request.clone();

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -12,7 +12,8 @@ use std::{env, fs};
 use log::warn;
 use servo::protocol_handler::ProtocolRegistry;
 use servo::{
-    EventLoopWaker, Opts, Preferences, ServoBuilder, ServoUrl, UserContentManager, UserScript,
+    EventLoopWaker, Opts, PrefValue, Preferences, ServoBuilder, ServoUrl, UserContentManager,
+    UserScript,
 };
 use url::Url;
 use winit::application::ApplicationHandler;
@@ -96,6 +97,10 @@ impl App {
             "resource",
             protocols::resource::ResourceProtocolHandler::default(),
         );
+        if let PrefValue::Str(mailto_handler) = self.preferences.get_value("mailto_handler") {
+            let _ = protocol_registry
+                .register_page_content_handler("mailto".to_owned(), mailto_handler);
+        }
 
         let servo_builder = ServoBuilder::default()
             .opts(self.opts.clone())

--- a/ports/servoshell/desktop/protocols/resource.rs
+++ b/ports/servoshell/desktop/protocols/resource.rs
@@ -20,10 +20,10 @@ use servo::protocol_handler::{
 use tokio::sync::mpsc::unbounded_channel;
 
 #[derive(Default)]
-pub struct ResourceProtocolHandler {}
+pub(crate) struct ResourceProtocolHandler {}
 
 impl ResourceProtocolHandler {
-    pub fn response_for_path(
+    pub(crate) fn response_for_path(
         request: &mut Request,
         done_chan: &mut DoneChannel,
         context: &FetchContext,

--- a/ports/servoshell/prefs.rs
+++ b/ports/servoshell/prefs.rs
@@ -457,6 +457,10 @@ struct CmdArgs {
     #[bpaf(long)]
     log_to_file: bool,
 
+    /// Handler used to handle `mailto:` links
+    #[bpaf(long)]
+    mailto_handler: Option<String>,
+
     /// Run in multiprocess mode.
     #[bpaf(short('M'), long)]
     multiprocess: bool,
@@ -566,7 +570,7 @@ struct CmdArgs {
     url: String,
 }
 
-fn update_preferences_from_command_line_arguemnts(
+fn update_preferences_from_command_line_arguments(
     preferences: &mut Preferences,
     cmd_args: &CmdArgs,
 ) {
@@ -600,6 +604,11 @@ fn update_preferences_from_command_line_arguemnts(
     if let Some(user_agent) = cmd_args.user_agent.clone() {
         preferences.user_agent = user_agent;
     }
+
+    preferences.mailto_handler = cmd_args
+        .mailto_handler
+        .clone()
+        .unwrap_or("servo:preferences?mail_handler=%s".to_owned());
 
     if cmd_args.webdriver_port.is_some() {
         preferences.dom_testing_html_input_element_select_files_enabled = true;
@@ -647,7 +656,7 @@ pub(crate) fn parse_command_line_arguments(args: Vec<String>) -> ArgumentParsing
 
     let mut preferences = get_preferences(&cmd_args.prefs_file, &config_dir);
 
-    update_preferences_from_command_line_arguemnts(&mut preferences, &cmd_args);
+    update_preferences_from_command_line_arguments(&mut preferences, &cmd_args);
 
     // FIXME: enable JIT compilation on 32-bit Android after the startup crash issue (#31134) is fixed.
     if cfg!(target_os = "android") && cfg!(target_pointer_width = "32") {

--- a/resources/resource_protocol/preferences.html
+++ b/resources/resource_protocol/preferences.html
@@ -15,6 +15,9 @@
       .hidden {
           display: none;
       }
+      .error {
+        color: red;
+      }
     </style>
   </head>
   <body>
@@ -32,6 +35,11 @@
         <li>
           <input type="checkbox" class="bool-preference" id="http-cache">
           <label for="http-cache">Disable HTTP cache</label>
+        </li>
+        <li>
+          <div class="error hidden" id="mailto-handler-error">Configure a mail handler to be able to handle `mailto:` links</div>
+          <input class="string-preference" id="mailto-handler" size=50>
+          <label for="mailto-handler">Mailto handler</label>
         </li>
         <li>
           <div>
@@ -54,6 +62,7 @@
           "http-cache": ["network_http_cache_disabled"],
           "more-experimental": ["dom_abort_controller_enabled", "dom_indexeddb_enabled"],
           "user-agent": ["user_agent"],
+          "mailto-handler": ["mailto_handler"],
       };
 
       const userAgents = {
@@ -87,6 +96,12 @@
               const prefValue = navigator.servo.getStringPreference(prefs[pref.id][0]);
               pref.value = prefValue;
               pref.oninput = (ev) => updateStringPreference(ev.target);
+          }
+
+          const searchParams = new URLSearchParams(window.location.search);
+
+          if (searchParams.get("mail_handler")) {
+              document.getElementById("mailto-handler-error").classList.remove("hidden");
           }
       }
 

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -10803,6 +10803,10 @@
       "c7f68081044c6686812921752d5e8b1f8b342ee6",
       []
      ],
+     "mailto.html": [
+      "618308052c97336424f94c13f1d8ea9dbef69f8b",
+      []
+     ],
      "no_mime_type.py": [
       "980eeee18f993f20a9df033f337a52ec93155ec4",
       []

--- a/tests/wpt/mozilla/tests/mozilla/resources/mailto.html
+++ b/tests/wpt/mozilla/tests/mozilla/resources/mailto.html
@@ -1,0 +1,3 @@
+<body>
+    <a href="mailto:info@servo.org" target="__blank">Mail to Servo</a>
+</body>


### PR DESCRIPTION
To avoid configuring a default mail handler for all Servoshell users, this now becomes a preference.
The preference can be set on the command line to
specify a custom value:

```
./mach run tests/wpt/mozilla/tests/mozilla/resources/mailto.html --mailto-handler="<handler>"
```

It is also shown on the preferences.html page, which shows an error if the query parameter is set. That query parameter is set by default as a handler, so that the user gets shown the error that no handler was configured.

Unfortunately updating the handler in the preferences doesn't have any effect, since protocols can only be registered on startup. Therefore, if we want to support updating the preferences value, we would need to persist the Servo preferences.

All in all, this allows me to continue testing the protocol handlers, while also showing embedders how they can hook up such handlers.

Part of #40615
