### PR TITLE
script: Expose a single interface to run js code on globalscope

### DIFF
--- a/components/script/dom/debuggerglobalscope.rs
+++ b/components/script/dom/debuggerglobalscope.rs
@@ -36,7 +36,6 @@ use crate::dom::types::{DebuggerAddDebuggeeEvent, DebuggerGetPossibleBreakpoints
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::realms::enter_realm;
-use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{CanGc, IntroductionType, JSContext};
 
 #[dom_struct]
@@ -129,14 +128,8 @@ impl DebuggerGlobalScope {
         can_gc: CanGc,
     ) -> Result<(), JavaScriptEvaluationError> {
         rooted!(in (*Self::get_cx()) let mut rval = UndefinedValue());
-        self.global_scope.evaluate_js_on_global_with_result(
-            script,
-            rval.handle_mut(),
-            ScriptFetchOptions::default_classic_script(&self.global_scope),
-            self.global_scope.api_base_url(),
-            can_gc,
-            None,
-        )
+        self.global_scope
+            .evaluate_js_on_global(script, "", None, rval.handle_mut(), can_gc)
     }
 
     pub(crate) fn execute(&self, can_gc: CanGc) {

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -2878,23 +2878,23 @@ impl GlobalScope {
     }
 
     /// Evaluate JS code on this global scope.
-    pub(crate) fn evaluate_js_on_global_with_result(
+    pub(crate) fn evaluate_js_on_global(
         &self,
         code: Cow<'_, str>,
-        rval: MutableHandleValue,
-        fetch_options: ScriptFetchOptions,
-        script_base_url: ServoUrl,
-        can_gc: CanGc,
+        filename: &str,
         introduction_type: Option<&'static CStr>,
+        rval: MutableHandleValue,
+        can_gc: CanGc,
     ) -> Result<(), JavaScriptEvaluationError> {
         let source_code = SourceCode::Text(Rc::new(DOMString::from_string(code.into_owned())));
+        let fetch_options = ScriptFetchOptions::default_classic_script(self);
         self.evaluate_script_on_global_with_result(
             &source_code,
-            "",
+            filename,
             rval,
             1,
             fetch_options,
-            script_base_url,
+            self.api_base_url(),
             can_gc,
             introduction_type,
         )
@@ -2903,7 +2903,7 @@ impl GlobalScope {
     /// Evaluate a JS script on this global scope.
     #[expect(unsafe_code)]
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn evaluate_script_on_global_with_result(
+    fn evaluate_script_on_global_with_result(
         &self,
         code: &SourceCode,
         filename: &str,

--- a/components/script/dom/workletglobalscope.rs
+++ b/components/script/dom/workletglobalscope.rs
@@ -36,7 +36,6 @@ use crate::dom::webgpu::identityhub::IdentityHub;
 use crate::dom::worklet::WorkletExecutor;
 use crate::messaging::MainThreadScriptMsg;
 use crate::realms::enter_realm;
-use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{CanGc, IntroductionType, JSContext};
 
 #[dom_struct]
@@ -142,13 +141,12 @@ impl WorkletGlobalScope {
     ) -> Result<(), JavaScriptEvaluationError> {
         debug!("Evaluating Dom in a worklet.");
         rooted!(in (*GlobalScope::get_cx()) let mut rval = UndefinedValue());
-        self.globalscope.evaluate_js_on_global_with_result(
+        self.globalscope.evaluate_js_on_global(
             script,
-            rval.handle_mut(),
-            ScriptFetchOptions::default_classic_script(&self.globalscope),
-            self.globalscope.api_base_url(),
-            can_gc,
+            "",
             Some(IntroductionType::WORKLET),
+            rval.handle_mut(),
+            can_gc,
         )
     }
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -149,7 +149,6 @@ use crate::mime::{APPLICATION, MimeExt, TEXT, XML};
 use crate::navigation::{InProgressLoad, NavigationListener};
 use crate::network_listener::FetchResponseListener;
 use crate::realms::enter_realm;
-use crate::script_module::ScriptFetchOptions;
 use crate::script_mutation_observers::ScriptMutationObservers;
 use crate::script_runtime::{
     CanGc, IntroductionType, JSContext, JSContextHelper, Runtime, ScriptThreadEventCategory,
@@ -3460,13 +3459,12 @@ impl ScriptThread {
         // Script source is ready to be evaluated (11.)
         let _ac = enter_realm(global_scope);
         rooted!(in(*GlobalScope::get_cx()) let mut jsval = UndefinedValue());
-        _ = global_scope.evaluate_js_on_global_with_result(
+        _ = global_scope.evaluate_js_on_global(
             script_source,
-            jsval.handle_mut(),
-            ScriptFetchOptions::default_classic_script(global_scope),
-            global_scope.api_base_url(),
-            can_gc,
+            "",
             Some(IntroductionType::JAVASCRIPT_URL),
+            jsval.handle_mut(),
+            can_gc,
         );
 
         load_data.js_eval_result = if jsval.get().is_string() {
@@ -3844,13 +3842,12 @@ impl ScriptThread {
         let context = window.get_cx();
 
         rooted!(in(*context) let mut return_value = UndefinedValue());
-        if let Err(err) = global_scope.evaluate_js_on_global_with_result(
+        if let Err(err) = global_scope.evaluate_js_on_global(
             script.into(),
-            return_value.handle_mut(),
-            ScriptFetchOptions::default_classic_script(global_scope),
-            global_scope.api_base_url(),
-            can_gc,
+            "",
             None, // No known `introductionType` for JS code from embedder
+            return_value.handle_mut(),
+            can_gc,
         ) {
             _ = self.senders.pipeline_to_constellation_sender.send((
                 webview_id,

--- a/components/script/timers.rs
+++ b/components/script/timers.rs
@@ -38,7 +38,6 @@ use crate::dom::testbinding::TestBindingCallback;
 use crate::dom::trustedscript::TrustedScript;
 use crate::dom::types::{Window, WorkerGlobalScope};
 use crate::dom::xmlhttprequest::XHRTimeoutCallback;
-use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{CanGc, IntroductionType};
 use crate::script_thread::ScriptThread;
 use crate::task_source::SendableTaskSource;
@@ -800,15 +799,12 @@ impl JsTimerTask {
                 // Step 9.6.9. Run the classic script script.
                 //
                 // FIXME(cybai): Use base url properly by saving private reference for timers (#27260)
-                _ = global.evaluate_js_on_global_with_result(
+                _ = global.evaluate_js_on_global(
                     (*code_str.str()).into(),
-                    rval.handle_mut(),
-                    ScriptFetchOptions::default_classic_script(&global),
-                    // Step 9.6. Let base URL be settings object's API base URL.
-                    // Step 9.7.2. Set base URL to initiating script's base URL.
-                    global.api_base_url(),
-                    can_gc,
+                    "",
                     Some(IntroductionType::DOM_TIMER),
+                    rval.handle_mut(),
+                    can_gc,
                 );
             },
             // Step 9.5. If handler is a Function, then invoke handler given arguments and

--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -90,7 +90,6 @@ use crate::dom::validitystate::ValidationFlags;
 use crate::dom::window::Window;
 use crate::dom::xmlserializer::XMLSerializer;
 use crate::realms::{AlreadyInRealm, InRealm, enter_realm};
-use crate::script_module::ScriptFetchOptions;
 use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
 use crate::script_thread::ScriptThread;
 
@@ -637,13 +636,12 @@ pub(crate) fn handle_execute_script(
 
             rooted!(in(*cx) let mut rval = UndefinedValue());
             let global = window.as_global_scope();
-            let evaluation_result = global.evaluate_js_on_global_with_result(
+            let evaluation_result = global.evaluate_js_on_global(
                 eval.into(),
-                rval.handle_mut(),
-                ScriptFetchOptions::default_classic_script(global),
-                global.api_base_url(),
-                can_gc,
+                "",
                 None, // No known `introductionType` for JS code from WebDriver
+                rval.handle_mut(),
+                can_gc,
             );
 
             let result = evaluation_result
@@ -675,13 +673,12 @@ pub(crate) fn handle_execute_async_script(
             rooted!(in(*cx) let mut rval = UndefinedValue());
 
             let global_scope = window.as_global_scope();
-            if let Err(error) = global_scope.evaluate_js_on_global_with_result(
+            if let Err(error) = global_scope.evaluate_js_on_global(
                 eval.into(),
-                rval.handle_mut(),
-                ScriptFetchOptions::default_classic_script(global_scope),
-                global_scope.api_base_url(),
-                can_gc,
+                "",
                 None, // No known `introductionType` for JS code from WebDriver
+                rval.handle_mut(),
+                can_gc,
             ) {
                 reply_sender.send(Err(error)).unwrap_or_else(|error| {
                     error!("ExecuteAsyncScript Failed to send reply: {error}");


### PR DESCRIPTION
Small cleanup, avoid repeating some code, since in these cases we use the defaults provided by `GlobalScope`

Testing: Covered by existing tests, no behaviour change.
