### PR TITLE
devtools: Update to Firefox 145

### DIFF
--- a/components/devtools/actor.rs
+++ b/components/devtools/actor.rs
@@ -166,7 +166,6 @@ impl ActorRegistry {
 
     pub fn actor_to_script(&self, actor: String) -> String {
         for (key, value) in &*self.script_actors.borrow() {
-            debug!("checking {}", value);
             if *value == actor {
                 return key.to_owned();
             }

--- a/components/devtools/actors/device.rs
+++ b/components/devtools/actors/device.rs
@@ -58,7 +58,7 @@ impl Actor for DeviceActor {
                         apptype: "servo".to_string(),
                         version: env!("CARGO_PKG_VERSION").to_string(),
                         appbuildid: BUILD_ID.to_string(),
-                        platformversion: "133.0".to_string(),
+                        platformversion: "145.0".to_string(),
                         brand_name: "Servo".to_string(),
                     },
                 };

--- a/components/devtools/actors/watcher.rs
+++ b/components/devtools/actors/watcher.rs
@@ -81,7 +81,7 @@ impl SessionContext {
                 ("platform-message", false),
                 ("network-event", true),
                 ("network-event-stacktrace", false),
-                ("reflow", false),
+                ("reflow", true),
                 ("stylesheet", false),
                 ("source", true),
                 ("thread-state", false),

--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -36,12 +36,8 @@ use serde::Serialize;
 use crate::actor::{Actor, ActorRegistry};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::console::{ConsoleActor, Root};
-use crate::actors::device::DeviceActor;
 use crate::actors::framerate::FramerateActor;
 use crate::actors::network_event::NetworkEventActor;
-use crate::actors::performance::PerformanceActor;
-use crate::actors::preference::PreferenceActor;
-use crate::actors::process::ProcessActor;
 use crate::actors::root::RootActor;
 use crate::actors::source::SourceActor;
 use crate::actors::thread::ThreadActor;
@@ -161,26 +157,8 @@ impl DevtoolsInstance {
 
         // Create basic actors
         let mut registry = ActorRegistry::new();
-        let performance = PerformanceActor::new(registry.new_name("performance"));
-        let device = DeviceActor::new(registry.new_name("device"));
-        let preference = PreferenceActor::new(registry.new_name("preference"));
-        let process = ProcessActor::new(registry.new_name("process"));
-        let root = RootActor {
-            tabs: vec![],
-            workers: vec![],
-            device: device.name(),
-            performance: performance.name(),
-            preference: preference.name(),
-            process: process.name(),
-            active_tab: None.into(),
-        };
 
-        registry.register(root);
-        registry.register(performance);
-        registry.register(device);
-        registry.register(preference);
-        registry.register(process);
-        registry.find::<RootActor>("root");
+        RootActor::register(&mut registry);
 
         let actors = registry.create_shareable();
 


### PR DESCRIPTION
Update the target spec version from 133 to 145. Solves a few issues with incorrect or outdated messages, such as an error with `reflow`.

The only meaningful change I could find is that the performance actor is now called "perf" instead of "performance". It is part of a set of global actors that the root handles. I made it more explicit and moved the global actor registration inside of the root actor, it makes more sense to have it there.

Finally, I ordered the message handling alphabetically. The only changed entry is `getRoot` because of the global actors.

Testing: I manually tested the functionalities and checked the logs.
