### PR TITLE
script: Fix IIRFilter crash on silent blocks and add crash test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7984,7 +7984,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#b0d3b744b0114fb66a05dcb80c209c0f7b94ac8e"
+source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -7997,7 +7997,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#b0d3b744b0114fb66a05dcb80c209c0f7b94ac8e"
+source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -8018,7 +8018,7 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#b0d3b744b0114fb66a05dcb80c209c0f7b94ac8e"
+source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8028,7 +8028,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#b0d3b744b0114fb66a05dcb80c209c0f7b94ac8e"
+source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -8042,7 +8042,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#b0d3b744b0114fb66a05dcb80c209c0f7b94ac8e"
+source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -8075,7 +8075,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#b0d3b744b0114fb66a05dcb80c209c0f7b94ac8e"
+source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -8085,7 +8085,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#b0d3b744b0114fb66a05dcb80c209c0f7b94ac8e"
+source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8099,7 +8099,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#b0d3b744b0114fb66a05dcb80c209c0f7b94ac8e"
+source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8114,7 +8114,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#b0d3b744b0114fb66a05dcb80c209c0f7b94ac8e"
+source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -8126,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#b0d3b744b0114fb66a05dcb80c209c0f7b94ac8e"
+source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
 dependencies = [
  "uuid",
 ]
@@ -8134,12 +8134,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#b0d3b744b0114fb66a05dcb80c209c0f7b94ac8e"
+source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#b0d3b744b0114fb66a05dcb80c209c0f7b94ac8e"
+source = "git+https://github.com/servo/media#06be48523c18de62bbea7ffbc373f5aba1372953"
 dependencies = [
  "log",
  "servo-media-streams",

--- a/tests/wpt/tests/webaudio/the-audio-api/the-iirfilternode-interface/iir-filter-silent-block-crash.html
+++ b/tests/wpt/tests/webaudio/the-audio-api/the-iirfilternode-interface/iir-filter-silent-block-crash.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Regression test for IIRFilter destination crash</title>
+<script>
+  var audioContext = new AudioContext();
+  var destination = audioContext.destination;
+  var filter = destination.context.createIIRFilter([1],[1]);
+  filter.connect(destination);
+</script>


### PR DESCRIPTION
Fix IIRFilter crash on silent blocks and add crash test.

Before fix: `let blocks: SmallVec<[Block; 1]> = SmallVec::new();` followed by `blocks.as_slice().iter().map(.)`, Because blocks was empty, the iterator never produced anything, so the resulting Chunk had zero blocks and caused:

```
panic: index out of bounds: the len is 0 but the index is 0 (thread AudioRenderThread, at /home/runner/.cargo/git/checkouts/media-9074def3f0bdf023/b0d3b74/audio/iir_filter_node.rs:173)
```

Now: we still use SmallVec<[Block; 1]>, but we actually push a block into it before returning: create Block::default(), call explicit_silence() on it, blocks.push(block), then Chunk { blocks }. This ensures the chunk contains one explicit silent block, which is what downstream code expects.

Actual fix is in:
https://github.com/servo/media/pull/477

This PR uses the new media version containing fix and added crash test.


Testing: added crash test.
Fixes: https://github.com/servo/servo/issues/41085

