### PR TITLE
Guard MediaElementAudioSourceNode against closed contexts and add crash test

### DIFF
--- a/components/script/dom/audio/mediaelementaudiosourcenode.rs
+++ b/components/script/dom/audio/mediaelementaudiosourcenode.rs
@@ -45,8 +45,8 @@ impl MediaElementAudioSourceNode {
         node.message(AudioNodeMessage::MediaElementSourceNode(
             MediaElementSourceNodeMessage::GetAudioRenderer(sender),
         ));
-        let audio_renderer = receiver.recv().unwrap();
-        media_element.set_audio_renderer(audio_renderer, can_gc);
+        let audio_renderer = receiver.recv();
+        media_element.set_audio_renderer(audio_renderer.ok(), can_gc);
         let media_element = Dom::from_ref(media_element);
         Ok(MediaElementAudioSourceNode {
             node,

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -2900,10 +2900,10 @@ impl HTMLMediaElement {
     /// renderer.
     pub(crate) fn set_audio_renderer(
         &self,
-        audio_renderer: Arc<Mutex<dyn AudioRenderer>>,
+        audio_renderer: Option<Arc<Mutex<dyn AudioRenderer>>>,
         can_gc: CanGc,
     ) {
-        *self.audio_renderer.borrow_mut() = Some(audio_renderer);
+        *self.audio_renderer.borrow_mut() = audio_renderer;
 
         let had_player = {
             if let Some(ref player) = *self.player.borrow() {

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -10730,6 +10730,10 @@
      "192c7235d061b439ef2b57d4b01b170b7412dcdc",
      []
     ],
+    "mediaElementAudioSource_closed_context_crash.html": [
+     "c56ea161d116e4308b08daf0c122981cc9a832bd",
+     []
+    ],
     "nested_asap_script.js": [
      "59562a8c9c39130cad411815059513c4ce0a7c04",
      []

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -10730,10 +10730,6 @@
      "192c7235d061b439ef2b57d4b01b170b7412dcdc",
      []
     ],
-    "mediaElementAudioSource_closed_context_crash.html": [
-     "c56ea161d116e4308b08daf0c122981cc9a832bd",
-     []
-    ],
     "nested_asap_script.js": [
      "59562a8c9c39130cad411815059513c4ce0a7c04",
      []

--- a/tests/wpt/mozilla/tests/mozilla/mediaElementAudioSource_closed_context_crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/mediaElementAudioSource_closed_context_crash.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Regression for MediaElementAudioSourceNode constructor crash after closing AudioContext</title>
+<script>
+  var audioContext = new AudioContext();
+  audioContext.close();
+  new MediaElementAudioSourceNode(audioContext, {mediaElement:video});
+</script>

--- a/tests/wpt/tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSource_closed_context-crash.html
+++ b/tests/wpt/tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/mediaElementAudioSource_closed_context-crash.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>Regression for MediaElementAudioSourceNode constructor crash after closing AudioContext</title>
+<video id="video"></video>
 <script>
   var audioContext = new AudioContext();
   audioContext.close();


### PR DESCRIPTION
Guard MediaElementAudioSourceNode against closed contexts and add crash test

Testing: Added crash test.
Fixes: #41083