### PR TITLE
webgl: Unconditionally decrement busy count of WebGL contexts.

### DIFF
--- a/tests/wpt/tests/webgl/basic-unused-context-crash.html
+++ b/tests/wpt/tests/webgl/basic-unused-context-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>WebGL context that is created but not used should not cause a crash</title>
+<link rel="author" title="Frédéric Wang" href="mailto:fwang@igalia.com">
+<link rel="author" title="Mukilan Thiyagarajan" href="mailto:mukilan@igalia.com" />
+<link rel="issue" href="https://github.com/servo/servo/issues/41082" />
+
+<p>Test passes if it doesn't crash.</p>
+
+<canvas id="canvas"></canvas>
+<script>
+  canvas.getContext("webgl");
+</script>


### PR DESCRIPTION
The current logic returns early without decrementing the busy count if the swap chain doesn't have a front surface. This happens if the context was created but never used for rendering, as seen in the linked issue. Since the count is always incremented when locking, this causes the count to never reach zero, causing the cleanup logic in `remove_webgl_context` to skip freeing the context and associated resources.

Fixes #41082.

Testing: A new crash test is added.
