### PR TITLE
net: Remove use of deprecated crate `rustls-pemfile`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5673,7 +5673,6 @@ dependencies = [
  "resvg",
  "rustc-hash 2.1.1",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -7445,15 +7444,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,6 @@ regex = "1.12"
 resvg = "0.45.0"
 rustc-hash = "2.1.1"
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
-rustls-pemfile = "2.0"
 rustls-pki-types = "1.13"
 rustls-platform-verifier = "0.6.2"
 script_traits = { path = "components/shared/script" }

--- a/components/net/Cargo.toml
+++ b/components/net/Cargo.toml
@@ -61,7 +61,6 @@ rayon = { workspace = true }
 resvg = { workspace = true }
 rustc-hash = { workspace = true }
 rustls = { workspace = true }
-rustls-pemfile = { workspace = true }
 rustls-pki-types = { workspace = true }
 rustls-platform-verifier = { workspace = true }
 serde = { workspace = true }

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -41,6 +41,7 @@ use profile_traits::path;
 use profile_traits::time::ProfilerChan;
 use rustc_hash::FxHashMap;
 use rustls_pki_types::CertificateDer;
+use rustls_pki_types::pem::PemObject;
 use serde::{Deserialize, Serialize};
 use servo_arc::Arc as ServoArc;
 use servo_config::pref;
@@ -67,7 +68,7 @@ use crate::websocket_loader::create_handshake_request;
 fn load_root_cert_store_from_file(file_path: String) -> io::Result<Vec<CertificateDer<'static>>> {
     let mut pem = BufReader::new(File::open(file_path)?);
 
-    let certs = rustls_pemfile::certs(&mut pem)
+    let certs = CertificateDer::pem_reader_iter(&mut pem)
         .filter_map(|cert| {
             cert.inspect_err(|e| log::error!("Could not load certificate ({e}). Ignoring it."))
                 .ok()


### PR DESCRIPTION
Switch the last remaining uses of the deprecated `rustls-pemfile` crate
to the `rustls-pki-types` crate.

Fixes #41090.

Testing: Should be covered by exiting tests.
