### PR TITLE
Expose window.clientInformation as a navigator alias

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1383,6 +1383,11 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
             .or_init(|| Navigator::new(self, CanGc::note()))
     }
 
+    /// <https://html.spec.whatwg.org/multipage/#dom-clientinformation>
+    fn ClientInformation(&self) -> DomRoot<Navigator> {
+        self.Navigator()
+    }
+
     /// <https://html.spec.whatwg.org/multipage/#dom-settimeout>
     fn SetTimeout(
         &self,

--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -48,6 +48,7 @@
 
   // the user agent
   readonly attribute Navigator navigator;
+  [Replaceable] readonly attribute Navigator clientInformation;
   //[Replaceable] readonly attribute External external;
   //readonly attribute ApplicationCache applicationCache;
 

--- a/tests/wpt/meta/html/dom/idlharness.https.html.ini
+++ b/tests/wpt/meta/html/dom/idlharness.https.html.ini
@@ -1909,13 +1909,7 @@
   [Window interface: attribute originAgentCluster]
     expected: FAIL
 
-  [Window interface: attribute clientInformation]
-    expected: FAIL
-
   [Window interface: operation reportError(any)]
-    expected: FAIL
-
-  [Window interface: window must inherit property "clientInformation" with the proper type]
     expected: FAIL
 
   [Window interface: window must inherit property "reportError(any)" with the proper type]

--- a/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/clientinformation.window.js.ini
+++ b/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/clientinformation.window.js.ini
@@ -1,3 +1,0 @@
-[clientinformation.window.html]
-  [window.clientInformation exists and equals window.navigator]
-    expected: FAIL

--- a/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/per-global.window.js.ini
+++ b/tests/wpt/meta/html/webappapis/system-state-and-capabilities/the-navigator-object/per-global.window.js.ini
@@ -2,14 +2,8 @@
   [Navigating from the initial about:blank must not replace window.navigator]
     expected: FAIL
 
-  [Discarding the browsing context must not change window.clientInformation]
-    expected: FAIL
-
   [Navigating from the initial about:blank must not replace window.clientInformation]
     expected: FAIL
 
   [document.open() must replace window.clientInformation]
-    expected: FAIL
-
-  [document.open() must not replace window.clientInformation]
     expected: FAIL


### PR DESCRIPTION
Expose window.clientInformation as a navigator alias.

Testing: clientInformation test expectations are updated. 
Fixes: https://github.com/servo/servo/issues/41089
