### PR TITLE
script_bindings: Remove Drop impl exception for WebGLProgram.

### DIFF
--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -747,10 +747,6 @@ DOMInterfaces = {
     'additionalTraits': ['crate::interfaces::WebGL2RenderingContextHelpers'],
 },
 
-'WebGLProgram': {
-    'allowDropImpl': True,
-},
-
 'WebGLQuery': {
     'allowDropImpl': True,
 },


### PR DESCRIPTION
The handwritten Drop implementation was removed in #37622, so we can now remove the exception for it.

Testing: Compile-time generated code can't be meaningfully tested.
Fixes: part of #26488
