### PR TITLE
Webgpu error handling

### DIFF
--- a/python/wpt/exporter/__init__.py
+++ b/python/wpt/exporter/__init__.py
@@ -169,7 +169,7 @@ class WPTSync:
             return True
 
         pull_data = payload["pull_request"]
-        if NO_SYNC_SIGNAL in pull_data.get("body", ""):
+        if NO_SYNC_SIGNAL in (pull_data.get("body") or ""):
             return True
 
         # Only look for an existing remote PR if the action is appropriate.
@@ -218,7 +218,7 @@ class WPTSync:
         logging.info("  → PR is upstreamable: '%s'", is_upstreamable)
 
         title = pull_data["title"]
-        body = pull_data["body"]
+        body = pull_data["body"] or ""
         if run.upstream_pr.has_value():
             if is_upstreamable:
                 # In case this is adding new upstreamable changes to a PR that was closed


### PR DESCRIPTION
### Summary
This PR implements missing error handling for WebGPU `ComputePass` and `RenderPass` encoders and fixes a CI failure in the WPT export script.

### WebGPU Changes
* **Enable Error Reporting:** Uncommented `maybe_dispatch_wgpu_error` in `BeginComputePass` and `BeginRenderPass` to correctly report errors during pass creation.
* **End Pass Validation:** Updated `EndComputePass` and `EndRenderPass` to capture the result of the end operations and dispatch any errors using `maybe_dispatch_wgpu_error`.
* **Fix Compilation:** Resolved a compilation error by correctly binding `device_id` in the match patterns.

### CI Fix
* **WPT Export Script:** Fixed a `TypeError` in `python/wpt/exporter/__init__.py` that occurred when a Pull Request body was `None`. The script now safely defaults to an empty string.

### Testing
* [x] Verified compilation with `./mach build`.
* [x] Passed `./mach test-tidy`.
* [x] Verified the CI fix with a reproduction script.

Fixes #<ISSUE_NUMBER>