### PR TITLE
compositor: Allow touch up to not panic when its touch sequence not found

### DIFF
--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -521,7 +521,10 @@ impl TouchHandler {
     }
 
     pub fn on_touch_up(&mut self, id: TouchId, point: Point2D<f32, DevicePixel>) {
-        let touch_sequence = self.get_current_touch_sequence_mut();
+        let Some(touch_sequence) = self.try_get_current_touch_sequence_mut() else {
+            warn!("Current touch sequence not found");
+            return;
+        };
         let old = match touch_sequence
             .active_touch_points
             .iter()


### PR DESCRIPTION
It's possible that the touch sequence start (meaning the `touchdown` happens) on different webview from the `touchup` event. This PR prevent panic when such case happen.