### PR TITLE
script: Decouple ownership of the media element from IPC router callback

### DIFF
--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy.https.sub.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy.https.sub.html.ini
@@ -1,0 +1,7 @@
+[autoplay-allowed-by-feature-policy.https.sub.html]
+  expected: TIMEOUT
+  [Feature-Policy header: autoplay * allows the top-level document.]
+    expected: TIMEOUT
+
+  [Feature-Policy header: autoplay * allows same-origin iframes.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-default-feature-policy.https.sub.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-default-feature-policy.https.sub.html.ini
@@ -1,3 +1,10 @@
 [autoplay-default-feature-policy.https.sub.html]
+  expected: TIMEOUT
   [Default "autoplay" feature policy ["self"\] disallows cross-origin iframes.]
     expected: FAIL
+
+  [Default "autoplay" feature policy ["self"\] allows the top-level document.]
+    expected: TIMEOUT
+
+  [Default "autoplay" feature policy ["self"\] allows same-origin iframes.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-disabled-by-feature-policy.https.sub.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-disabled-by-feature-policy.https.sub.html.ini
@@ -1,6 +1,10 @@
 [autoplay-disabled-by-feature-policy.https.sub.html]
+  expected: TIMEOUT
   [Feature-Policy header: autoplay "none" disallows same-origin iframes.]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Feature-Policy header: autoplay "none" disallows cross-origin iframes.]
     expected: FAIL
+
+  [Feature-Policy header: autoplay "none" has no effect on the top level document.]
+    expected: TIMEOUT


### PR DESCRIPTION
Added new invocation struct `HTMLMediaElementEventHandler` that allows to decouple ownership of the `HTMLMediaElement` from the IPC router callback (break cyclic reference dependency) by replacing a `Trusted` wrapper with more suitable `WeakRef`.
Note that `WeakRef` is not thread-safe and MUST be rooted and/or deleted on the script thread.
    
Testing: Regressions in the following tests caused by overly aggressive GC on document activity change to `Inactive` and will be follow up in https://github.com/servo/servo/issues/41138
- html/semantics/embedded-content/media-elements/autoplay-allowed-by-feature-policy.https.sub.html
- html/semantics/embedded-content/media-elements/autoplay-default-feature-policy.https.sub.html
- html/semantics/embedded-content/media-elements/autoplay-disabled-by-feature-policy.https.sub.html

Fixes: https://github.com/servo/servo/issues/40243