### PR TITLE
fonts: Replace deprecated `xml-rs` with `xml@1.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2877,7 +2877,7 @@ dependencies = [
  "url",
  "webrender_api",
  "winapi",
- "xml-rs",
+ "xml",
  "yeslogic-fontconfig-sys",
 ]
 
@@ -7473,7 +7473,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11199,6 +11199,12 @@ name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2df5825faced2427b2da74d9100f1e2e93c533fff063506a81ede1cf517b2e7e"
 
 [[package]]
 name = "xml-rs"

--- a/components/fonts/Cargo.toml
+++ b/components/fonts/Cargo.toml
@@ -70,7 +70,7 @@ servo_allocator = { path = "../allocator" }
 fontconfig_sys = { package = "yeslogic-fontconfig-sys", version = "6" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-xml-rs = "0.8"
+xml = "1.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 dwrote = { workspace = true }

--- a/components/fonts/platform/freetype/android/xml.rs
+++ b/components/fonts/platform/freetype/android/xml.rs
@@ -41,7 +41,7 @@ pub(super) fn parse(bytes: &[u8]) -> xml::reader::Result<Vec<Node>> {
                     nodes.push(Node::Text(s))
                 }
             },
-            StartDocument { .. } | EndDocument | ProcessingInstruction { .. } | Comment(..) => {},
+            StartDocument { .. } | EndDocument | ProcessingInstruction { .. } | Comment(..) => {}, _=> {},
         }
     }
     assert!(stack.is_empty());

--- a/components/fonts/platform/freetype/android/xml.rs
+++ b/components/fonts/platform/freetype/android/xml.rs
@@ -41,7 +41,7 @@ pub(super) fn parse(bytes: &[u8]) -> xml::reader::Result<Vec<Node>> {
                     nodes.push(Node::Text(s))
                 }
             },
-            StartDocument { .. } | EndDocument | ProcessingInstruction { .. } | Comment(..) => {}, _=> {},
+            StartDocument { .. } | EndDocument | ProcessingInstruction { .. } | Comment(..) => {}, _ => {},
         }
     }
     assert!(stack.is_empty());

--- a/components/fonts/platform/freetype/android/xml.rs
+++ b/components/fonts/platform/freetype/android/xml.rs
@@ -41,7 +41,8 @@ pub(super) fn parse(bytes: &[u8]) -> xml::reader::Result<Vec<Node>> {
                     nodes.push(Node::Text(s))
                 }
             },
-            StartDocument { .. } | EndDocument | ProcessingInstruction { .. } | Comment(..) => {}, Doctype => {},
+            StartDocument { .. } | EndDocument | ProcessingInstruction { .. } | Comment(..) => {},
+            Doctype => {},
         }
     }
     assert!(stack.is_empty());

--- a/components/fonts/platform/freetype/android/xml.rs
+++ b/components/fonts/platform/freetype/android/xml.rs
@@ -41,7 +41,7 @@ pub(super) fn parse(bytes: &[u8]) -> xml::reader::Result<Vec<Node>> {
                     nodes.push(Node::Text(s))
                 }
             },
-            StartDocument { .. } | EndDocument | ProcessingInstruction { .. } | Comment(..) => {}, _ => {},
+            StartDocument { .. } | EndDocument | ProcessingInstruction { .. } | Comment(..) => {}, Doctype => {},
         }
     }
     assert!(stack.is_empty());


### PR DESCRIPTION
This PR updates `xml-rs` crate. On the official crate site it is mentioned to change the name of the crate with `xml` and update it.It is also explicitly mentioned that their won't be any code changes so I think their isn't any major API changes. 

Reference:- https://crates.io/crates/xml-rs/0.8.28

Testing: It doesn't require testing because this is just the change in the crate's name
