### PR TITLE
devtools: ActorEncode trait

### DIFF
--- a/components/devtools/actors/breakpoint.rs
+++ b/components/devtools/actors/breakpoint.rs
@@ -2,16 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use serde::Serialize;
-
-use crate::EmptyReplyMsg;
-use crate::actor::{Actor, ActorError};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
-
-#[derive(Serialize)]
-pub struct BreakpointListActorMsg {
-    actor: String,
-}
+use crate::{ActorMsg, EmptyReplyMsg};
 
 pub struct BreakpointListActor {
     name: String,
@@ -56,8 +49,10 @@ impl BreakpointListActor {
     pub fn new(name: String) -> Self {
         Self { name }
     }
+}
 
-    pub fn encodable(&self) -> BreakpointListActorMsg {
-        BreakpointListActorMsg { actor: self.name() }
+impl ActorEncode<ActorMsg> for BreakpointListActor {
+    fn encode(&self, _: &ActorRegistry) -> ActorMsg {
+        ActorMsg { actor: self.name() }
     }
 }

--- a/components/devtools/actors/browsing_context.rs
+++ b/components/devtools/actors/browsing_context.rs
@@ -20,7 +20,7 @@ use embedder_traits::Theme;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::inspector::InspectorActor;
 use crate::actors::inspector::accessibility::AccessibilityActor;
 use crate::actors::inspector::css_properties::CssPropertiesActor;
@@ -285,34 +285,6 @@ impl BrowsingContextActor {
         target
     }
 
-    pub fn encodable(&self) -> BrowsingContextActorMsg {
-        BrowsingContextActorMsg {
-            actor: self.name(),
-            traits: BrowsingContextTraits {
-                is_browsing_context: true,
-                frames: true,
-                log_in_page: false,
-                navigation: true,
-                supports_top_level_target_flag: true,
-                watchpoints: true,
-            },
-            title: self.title.borrow().clone(),
-            url: self.url.borrow().clone(),
-            browser_id: self.browser_id.value(),
-            browsing_context_id: self.browsing_context_id.value(),
-            outer_window_id: self.active_outer_window_id.get().value(),
-            is_top_level_target: true,
-            accessibility_actor: self.accessibility.clone(),
-            console_actor: self.console.clone(),
-            css_properties_actor: self.css_properties.clone(),
-            inspector_actor: self.inspector.clone(),
-            reflow_actor: self.reflow.clone(),
-            style_sheets_actor: self.style_sheets.clone(),
-            thread_actor: self.thread.clone(),
-            target_type: TargetType::Frame,
-        }
-    }
-
     pub(crate) fn navigate(&self, state: NavigationState, id_map: &mut IdMap) {
         let (pipeline_id, title, url, state) = match state {
             NavigationState::Start(url) => (None, None, url, "start"),
@@ -369,5 +341,35 @@ impl BrowsingContextActor {
         self.script_chan
             .send(SimulateColorScheme(self.active_pipeline_id.get(), theme))
             .map_err(|_| ())
+    }
+}
+
+impl ActorEncode<BrowsingContextActorMsg> for BrowsingContextActor {
+    fn encode(&self, _: &ActorRegistry) -> BrowsingContextActorMsg {
+        BrowsingContextActorMsg {
+            actor: self.name(),
+            traits: BrowsingContextTraits {
+                is_browsing_context: true,
+                frames: true,
+                log_in_page: false,
+                navigation: true,
+                supports_top_level_target_flag: true,
+                watchpoints: true,
+            },
+            title: self.title.borrow().clone(),
+            url: self.url.borrow().clone(),
+            browser_id: self.browser_id.value(),
+            browsing_context_id: self.browsing_context_id.value(),
+            outer_window_id: self.active_outer_window_id.get().value(),
+            is_top_level_target: true,
+            accessibility_actor: self.accessibility.clone(),
+            console_actor: self.console.clone(),
+            css_properties_actor: self.css_properties.clone(),
+            inspector_actor: self.inspector.clone(),
+            reflow_actor: self.reflow.clone(),
+            style_sheets_actor: self.style_sheets.clone(),
+            thread_actor: self.thread.clone(),
+            target_type: TargetType::Frame,
+        }
     }
 }

--- a/components/devtools/actors/environment.rs
+++ b/components/devtools/actors/environment.rs
@@ -5,7 +5,7 @@
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use crate::actor::{Actor, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorRegistry};
 use crate::actors::object::ObjectActorMsg;
 
 #[derive(Serialize)]
@@ -68,17 +68,13 @@ impl Actor for EnvironmentActor {
     }
 }
 
-pub trait EnvironmentToProtocol {
-    fn encode(&self, actors: &ActorRegistry) -> EnvironmentActorMsg;
-}
-
-impl EnvironmentToProtocol for EnvironmentActor {
-    fn encode(&self, actors: &ActorRegistry) -> EnvironmentActorMsg {
+impl ActorEncode<EnvironmentActorMsg> for EnvironmentActor {
+    fn encode(&self, registry: &ActorRegistry) -> EnvironmentActorMsg {
         let parent = self
             .parent
             .as_ref()
-            .map(|p| actors.find::<EnvironmentActor>(p))
-            .map(|p| Box::new(p.encode(actors)));
+            .map(|p| registry.find::<EnvironmentActor>(p))
+            .map(|p| Box::new(p.encode(registry)));
         // TODO: Change hardcoded values.
         EnvironmentActorMsg {
             actor: self.name(),

--- a/components/devtools/actors/frame.rs
+++ b/components/devtools/actors/frame.rs
@@ -9,8 +9,8 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
-use crate::actors::environment::{EnvironmentActor, EnvironmentActorMsg, EnvironmentToProtocol};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actors::environment::{EnvironmentActor, EnvironmentActorMsg};
 use crate::protocol::ClientRequest;
 
 #[derive(Serialize)]
@@ -90,12 +90,8 @@ impl Actor for FrameActor {
     }
 }
 
-pub trait FrameToProtocol {
-    fn encode(self) -> FrameActorMsg;
-}
-
-impl FrameToProtocol for FrameActor {
-    fn encode(self) -> FrameActorMsg {
+impl ActorEncode<FrameActorMsg> for FrameActor {
+    fn encode(&self, _: &ActorRegistry) -> FrameActorMsg {
         // TODO: Handle other states
         let state = FrameState::OnStack;
         let async_cause = if let FrameState::OnStack = state {
@@ -104,7 +100,7 @@ impl FrameToProtocol for FrameActor {
             Some("await".into())
         };
         FrameActorMsg {
-            actor: self.name,
+            actor: self.name(),
             type_: "call".into(),
             arguments: vec![],
             async_cause,
@@ -112,7 +108,7 @@ impl FrameToProtocol for FrameActor {
             oldest: true,
             state,
             where_: FrameWhere {
-                actor: self.source_actor,
+                actor: self.source_actor.clone(),
                 line: 1, // TODO: get from breakpoint?
                 column: 1,
             },

--- a/components/devtools/actors/inspector/layout.rs
+++ b/components/devtools/actors/inspector/layout.rs
@@ -8,14 +8,9 @@
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
-
-#[derive(Serialize)]
-pub struct LayoutInspectorActorMsg {
-    actor: String,
-}
+use crate::{ActorMsg, StreamId};
 
 pub struct LayoutInspectorActor {
     name: String,
@@ -80,8 +75,10 @@ impl LayoutInspectorActor {
     pub fn new(name: String) -> Self {
         Self { name }
     }
+}
 
-    pub fn encodable(&self) -> LayoutInspectorActorMsg {
-        LayoutInspectorActorMsg { actor: self.name() }
+impl ActorEncode<ActorMsg> for LayoutInspectorActor {
+    fn encode(&self, _: &ActorRegistry) -> ActorMsg {
+        ActorMsg { actor: self.name() }
     }
 }

--- a/components/devtools/actors/inspector/style_rule.rs
+++ b/components/devtools/actors/inspector/style_rule.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::inspector::node::NodeActor;
 use crate::actors::inspector::walker::WalkerActor;
 use crate::protocol::ClientRequest;
@@ -130,7 +130,7 @@ impl Actor for StyleRuleActor {
                     ))
                     .map_err(|_| ActorError::Internal)?;
 
-                request.reply_final(&self.encodable(registry))?
+                request.reply_final(&self.encode(registry))?
             },
             _ => return Err(ActorError::UnrecognizedPacketType),
         };
@@ -245,8 +245,10 @@ impl StyleRuleActor {
                 .collect(),
         )
     }
+}
 
-    pub fn encodable(&self, registry: &ActorRegistry) -> StyleRuleActorMsg {
+impl ActorEncode<StyleRuleActorMsg> for StyleRuleActor {
+    fn encode(&self, registry: &ActorRegistry) -> StyleRuleActorMsg {
         StyleRuleActorMsg {
             from: self.name(),
             rule: self.applied(registry),

--- a/components/devtools/actors/inspector/walker.rs
+++ b/components/devtools/actors/inspector/walker.rs
@@ -13,11 +13,11 @@ use devtools_traits::{AttrModification, DevtoolScriptControlMsg};
 use serde::Serialize;
 use serde_json::{self, Map, Value};
 
-use crate::actor::{Actor, ActorError, ActorRegistry};
-use crate::actors::inspector::layout::{LayoutInspectorActor, LayoutInspectorActorMsg};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
+use crate::actors::inspector::layout::LayoutInspectorActor;
 use crate::actors::inspector::node::{NodeActorMsg, NodeInfoToProtocol};
 use crate::protocol::{ClientRequest, JsonPacketStream};
-use crate::{EmptyReplyMsg, StreamId};
+use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
 #[derive(Serialize)]
 pub struct WalkerMsg {
@@ -58,8 +58,8 @@ struct ChildrenReply {
 
 #[derive(Serialize)]
 struct GetLayoutInspectorReply {
-    actor: LayoutInspectorActorMsg,
     from: String,
+    actor: ActorMsg,
 }
 
 #[derive(Serialize)]
@@ -199,7 +199,7 @@ impl Actor for WalkerActor {
             "getLayoutInspector" => {
                 // TODO: Create actual layout inspector actor
                 let layout = LayoutInspectorActor::new(registry.new_name("layout"));
-                let actor = layout.encodable();
+                let actor = layout.encode(registry);
                 registry.register_later(layout);
 
                 let msg = GetLayoutInspectorReply {

--- a/components/devtools/actors/object.rs
+++ b/components/devtools/actors/object.rs
@@ -4,7 +4,7 @@
 
 use serde::Serialize;
 
-use crate::actor::{Actor, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorRegistry};
 
 #[derive(Serialize)]
 pub struct ObjectPreview {
@@ -60,17 +60,11 @@ impl ObjectActor {
     }
 }
 
-// TODO: Remove once the message is used.
-#[allow(dead_code)]
-pub trait ObjectToProtocol {
-    fn encode(self) -> ObjectActorMsg;
-}
-
-impl ObjectToProtocol for ObjectActor {
-    fn encode(self) -> ObjectActorMsg {
+impl ActorEncode<ObjectActorMsg> for ObjectActor {
+    fn encode(&self, _: &ActorRegistry) -> ObjectActorMsg {
         // TODO: Review hardcoded values here
         ObjectActorMsg {
-            actor: self.name,
+            actor: self.name(),
             type_: "object".into(),
             class: "Window".into(),
             own_property_length: 0,

--- a/components/devtools/actors/process.rs
+++ b/components/devtools/actors/process.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::StreamId;
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::root::DescriptorTraits;
 use crate::protocol::ClientRequest;
 
@@ -69,8 +69,10 @@ impl ProcessActor {
     pub fn new(name: String) -> Self {
         Self { name }
     }
+}
 
-    pub fn encodable(&self) -> ProcessActorMsg {
+impl ActorEncode<ProcessActorMsg> for ProcessActor {
+    fn encode(&self, _: &ActorRegistry) -> ProcessActorMsg {
         ProcessActorMsg {
             actor: self.name(),
             id: 0,

--- a/components/devtools/actors/watcher/network_parent.rs
+++ b/components/devtools/actors/watcher/network_parent.rs
@@ -2,17 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use serde::Serialize;
 use serde_json::{Map, Value};
 
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
-use crate::{EmptyReplyMsg, StreamId};
-
-#[derive(Serialize)]
-pub struct NetworkParentActorMsg {
-    actor: String,
-}
+use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
 pub struct NetworkParentActor {
     name: String,
@@ -49,8 +43,10 @@ impl NetworkParentActor {
     pub fn new(name: String) -> Self {
         Self { name }
     }
+}
 
-    pub fn encodable(&self) -> NetworkParentActorMsg {
-        NetworkParentActorMsg { actor: self.name() }
+impl ActorEncode<ActorMsg> for NetworkParentActor {
+    fn encode(&self, _: &ActorRegistry) -> ActorMsg {
+        ActorMsg { actor: self.name() }
     }
 }

--- a/components/devtools/actors/watcher/target_configuration.rs
+++ b/components/devtools/actors/watcher/target_configuration.rs
@@ -12,7 +12,7 @@ use log::warn;
 use serde::Serialize;
 use serde_json::{Map, Value};
 
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::actors::browsing_context::BrowsingContextActor;
 use crate::actors::tab::TabDescriptorActor;
 use crate::protocol::ClientRequest;
@@ -114,8 +114,10 @@ impl TargetConfigurationActor {
             ]),
         }
     }
+}
 
-    pub fn encodable(&self) -> TargetConfigurationActorMsg {
+impl ActorEncode<TargetConfigurationActorMsg> for TargetConfigurationActor {
+    fn encode(&self, _: &ActorRegistry) -> TargetConfigurationActorMsg {
         TargetConfigurationActorMsg {
             actor: self.name(),
             configuration: self.configuration.clone(),

--- a/components/devtools/actors/watcher/thread_configuration.rs
+++ b/components/devtools/actors/watcher/thread_configuration.rs
@@ -7,17 +7,11 @@
 
 use std::collections::HashMap;
 
-use serde::Serialize;
 use serde_json::{Map, Value};
 
-use crate::actor::{Actor, ActorError, ActorRegistry};
+use crate::actor::{Actor, ActorEncode, ActorError, ActorRegistry};
 use crate::protocol::ClientRequest;
-use crate::{EmptyReplyMsg, StreamId};
-
-#[derive(Serialize)]
-pub struct ThreadConfigurationActorMsg {
-    actor: String,
-}
+use crate::{ActorMsg, EmptyReplyMsg, StreamId};
 
 pub struct ThreadConfigurationActor {
     name: String,
@@ -59,8 +53,10 @@ impl ThreadConfigurationActor {
             _configuration: HashMap::new(),
         }
     }
+}
 
-    pub fn encodable(&self) -> ThreadConfigurationActorMsg {
-        ThreadConfigurationActorMsg { actor: self.name() }
+impl ActorEncode<ActorMsg> for ThreadConfigurationActor {
+    fn encode(&self, _: &ActorRegistry) -> ActorMsg {
+        ActorMsg { actor: self.name() }
     }
 }


### PR DESCRIPTION
Unify various `encodable` and `encode` methods from actors in an `ActorEncode` trait, making it more consistent.

Add an `ActorRegistry::encode` method that finds an actor by name and then returns its serialized version.

Add an `ActorMsg` struct to avoid creating repeated structs for simple serializations.

There are two exceptions: `EncodableConsoleMessage` and `NodeInfo`. These also have an `encode` method, but they are not actors, so including them in this trait doesn't make much sense. Besides, they have special requirements so it is better to keep them separate.

Testing: Manual testing in `about:debugging`.
