### PR TITLE
Allow llvm-coverage to write file on webdriver exit

### DIFF
--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -42,6 +42,8 @@ gamepad = ["libservo/gamepad"]
 jitspew = ["libservo/jitspew"]
 js_backtrace = ["libservo/js_backtrace"]
 js_jit = ["libservo/js_jit"]
+# Allow llvm-coverage functions for writing files
+llvm-coverage = []
 max_log_level = ["log/release_max_level_info"]
 media-gstreamer = ["libservo/media-gstreamer"]
 native-bluetooth = ["libservo/native-bluetooth"]

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -42,8 +42,6 @@ gamepad = ["libservo/gamepad"]
 jitspew = ["libservo/jitspew"]
 js_backtrace = ["libservo/js_backtrace"]
 js_jit = ["libservo/js_jit"]
-# Allow llvm-coverage functions for writing files
-llvm-coverage = []
 max_log_level = ["log/release_max_level_info"]
 media-gstreamer = ["libservo/media-gstreamer"]
 native-bluetooth = ["libservo/native-bluetooth"]

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -18,6 +18,10 @@ name = "servo"
 path = "main.rs"
 bench = false
 
+[lints.rust]
+# These are not official flags but still used for testing and pgo.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)', 'cfg(llvm_pgo)'] }
+
 # Some of these dependencies are only needed for a specific target OS, but
 # since build-scripts can't detect the Cargo target OS at build-time, we
 # must unconditionally add these dependencies. See https://github.com/rust-lang/cargo/issues/4932

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -32,6 +32,11 @@ use crate::prefs::{EXPERIMENTAL_PREFS, ServoShellPreferences};
 use crate::webdriver::WebDriverEmbedderControls;
 use crate::window::{PlatformWindow, ServoShellWindow, ServoShellWindowId};
 
+#[cfg(feature = "llvm-coverage")]
+unsafe extern "C" {
+    fn __llvm_profile_write_file();
+}
+
 #[derive(Default)]
 pub struct WebViewCollection {
     /// List of top-level browsing contexts.
@@ -303,6 +308,11 @@ impl RunningAppState {
         // to run wpt test using servodriver.
         self.servoshell_preferences.webdriver_port.set(None);
         self.exit_scheduled.set(true);
+
+        #[cfg(feature = "llvm-coverage")]
+        unsafe {
+            __llvm_profile_write_file()
+        }
     }
 
     #[cfg_attr(any(target_os = "android", target_env = "ohos"), expect(dead_code))]

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -129,6 +129,7 @@ class MachCommands(CommandBase):
 
         if self.enable_code_coverage:
             print("Building with code coverage instrumentation...")
+            opts += ["-F", "llvm-coverage"]
             # We don't want coverage for build-scripts and proc macros.
             kwargs["target_override"] = target_triple
             this_dir = pathlib.Path(os.path.dirname(__file__))

--- a/python/servo/build_commands.py
+++ b/python/servo/build_commands.py
@@ -129,7 +129,6 @@ class MachCommands(CommandBase):
 
         if self.enable_code_coverage:
             print("Building with code coverage instrumentation...")
-            opts += ["-F", "llvm-coverage"]
             # We don't want coverage for build-scripts and proc macros.
             kwargs["target_override"] = target_triple
             this_dir = pathlib.Path(os.path.dirname(__file__))


### PR DESCRIPTION
This adds a `cfg` to servo that uses the llvm profile-runtime function for writing the coverage file to disk.

When the webdriver shuts down we should make sure to write the llvm_coverage file. This is only required on platforms like android or ohos, where there is no real exiting of the process, so we need to manually dump the profile to disk.

See also https://clang.llvm.org/docs/SourceBasedCodeCoverage.html

Testing: Tested '/mach build -r --coverage && ./mach test-wpt -r --coverage' and there do not seem any parsing errors anymore.
Fixes: https://github.com/servo/servo/issues/40942
