### PR TITLE
Base: Implement GenericOneshot channels

### DIFF
--- a/components/script/webdriver_handlers.rs
+++ b/components/script/webdriver_handlers.rs
@@ -7,7 +7,7 @@ use std::ffi::CString;
 use std::ptr::NonNull;
 
 use base::IpcSend;
-use base::generic_channel::GenericSender;
+use base::generic_channel::{GenericOneshotSender, GenericSender};
 use base::id::{BrowsingContextId, PipelineId};
 use cookie::Cookie;
 use embedder_traits::{
@@ -799,7 +799,7 @@ pub(crate) fn handle_get_element_in_view_center_point(
     documents: &DocumentCollection,
     pipeline: PipelineId,
     element_id: String,
-    reply: IpcSender<Result<Option<(i64, i64)>, ErrorStatus>>,
+    reply: GenericOneshotSender<Result<Option<(i64, i64)>, ErrorStatus>>,
     can_gc: CanGc,
 ) {
     reply

--- a/components/shared/base/generic_channel/oneshot.rs
+++ b/components/shared/base/generic_channel/oneshot.rs
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::fmt;
+use std::marker::PhantomData;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::generic_channel::{
+    GenericReceiverVariants, GenericSenderVariants, GenericSenderVisitor, ReceiveResult, SendError,
+    SendResult, serialize_generic_sender_variants,
+};
+
+/// The oneshot sender struct
+pub struct GenericOneshotSender<T: Serialize>(GenericSenderVariants<T>);
+
+impl<T: Serialize> GenericOneshotSender<T> {
+    #[inline]
+    /// Send a message across the channel
+    pub fn send(self, msg: T) -> SendResult {
+        match self.0 {
+            GenericSenderVariants::Ipc(ref sender) => sender
+                .send(msg)
+                .map_err(|e| SendError::SerializationError(format!("{e}"))),
+            GenericSenderVariants::Crossbeam(ref sender) => {
+                sender.send(Ok(msg)).map_err(|_| SendError::Disconnected)
+            },
+        }
+    }
+}
+
+impl<T> GenericOneshotReceiver<T>
+where
+    T: for<'de> Deserialize<'de> + Serialize,
+{
+    #[inline]
+    /// Receive a message across the channel
+    pub fn recv(self) -> ReceiveResult<T> {
+        match self.0 {
+            GenericReceiverVariants::Ipc(ref receiver) => Ok(receiver.recv()?),
+            GenericReceiverVariants::Crossbeam(ref receiver) => {
+                // `recv()` returns an error if the channel is disconnected
+                let msg = receiver.recv()?;
+                // `msg` must be `ok` because the corresponding [`GenericSender::Crossbeam`] will
+                // unconditionally send an `Ok(T)`
+                Ok(msg.expect("Infallible"))
+            },
+        }
+    }
+}
+
+/// The oneshot receiver struct
+pub struct GenericOneshotReceiver<T: Serialize + for<'de> Deserialize<'de>>(
+    GenericReceiverVariants<T>,
+);
+
+/// Creates a oneshot generic channel. This channel allows only a fixed capacity and might have other optimizations.
+/// The send and receive methods will consume the Sender/Receiver.
+/// We will automatically select ipc or crossbeam channels.
+pub fn oneshot<T>() -> Option<(GenericOneshotSender<T>, GenericOneshotReceiver<T>)>
+where
+    T: for<'de> Deserialize<'de> + Serialize,
+{
+    if servo_config::opts::get().multiprocess || servo_config::opts::get().force_ipc {
+        ipc_channel::ipc::channel()
+            .map(|(tx, rx)| {
+                (
+                    GenericOneshotSender(GenericSenderVariants::Ipc(tx)),
+                    GenericOneshotReceiver(GenericReceiverVariants::Ipc(rx)),
+                )
+            })
+            .ok()
+    } else {
+        let (rx, tx) = crossbeam_channel::bounded(1);
+        Some((
+            GenericOneshotSender(GenericSenderVariants::Crossbeam(rx)),
+            GenericOneshotReceiver(GenericReceiverVariants::Crossbeam(tx)),
+        ))
+    }
+}
+
+impl<T: Serialize> Serialize for GenericOneshotSender<T> {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        serialize_generic_sender_variants(&self.0, s)
+    }
+}
+
+impl<'a, T: Serialize + Deserialize<'a>> Deserialize<'a> for GenericOneshotSender<T> {
+    fn deserialize<D>(d: D) -> Result<GenericOneshotSender<T>, D::Error>
+    where
+        D: Deserializer<'a>,
+    {
+        d.deserialize_enum(
+            "GenericSender",
+            &["Ipc", "Crossbeam"],
+            GenericSenderVisitor {
+                marker: PhantomData,
+            },
+        )
+        .map(|variant| GenericOneshotSender(variant))
+    }
+}
+
+impl<T: Serialize> fmt::Debug for GenericOneshotSender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Sender(..)")
+    }
+}

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 
-use base::generic_channel::GenericSender;
+use base::generic_channel::{GenericOneshotSender, GenericSender};
 use base::id::{BrowsingContextId, WebViewId};
 use cookie::Cookie;
 use crossbeam_channel::Sender;
@@ -83,9 +83,9 @@ pub enum CustomHandlersAutomationMode {
 #[derive(Debug)]
 pub enum WebDriverCommandMsg {
     /// Get the window rectangle.
-    GetWindowRect(WebViewId, IpcSender<DeviceIndependentIntRect>),
+    GetWindowRect(WebViewId, GenericOneshotSender<DeviceIndependentIntRect>),
     /// Get the viewport size.
-    GetViewportSize(WebViewId, IpcSender<Size2D<u32, DevicePixel>>),
+    GetViewportSize(WebViewId, GenericOneshotSender<Size2D<u32, DevicePixel>>),
     /// Load a URL in the top-level browsing context with the given ID.
     LoadUrl(WebViewId, Url, GenericSender<WebDriverLoadStatus>),
     /// Refresh the top-level browsing context with the given ID.
@@ -105,10 +105,10 @@ pub enum WebDriverCommandMsg {
     SetWindowRect(
         WebViewId,
         DeviceIndependentIntRect,
-        IpcSender<DeviceIndependentIntRect>,
+        GenericOneshotSender<DeviceIndependentIntRect>,
     ),
     /// Maximize the window. Send back result window rectangle.
-    MaximizeWebView(WebViewId, IpcSender<DeviceIndependentIntRect>),
+    MaximizeWebView(WebViewId, GenericOneshotSender<DeviceIndependentIntRect>),
     /// Take a screenshot of the viewport.
     TakeScreenshot(
         WebViewId,
@@ -119,28 +119,28 @@ pub enum WebDriverCommandMsg {
     /// the provided channels to return the top level browsing context id
     /// associated with the new webview, and sets a "load status sender" if provided.
     NewWebView(
-        IpcSender<WebViewId>,
+        GenericOneshotSender<WebViewId>,
         Option<GenericSender<WebDriverLoadStatus>>,
     ),
     /// Close the webview associated with the provided id.
-    CloseWebView(WebViewId, IpcSender<()>),
+    CloseWebView(WebViewId, GenericOneshotSender<()>),
     /// Focus the webview associated with the provided id.
     FocusWebView(WebViewId),
     /// Get focused webview. For now, this is only used when start new session.
-    GetFocusedWebView(IpcSender<Option<WebViewId>>),
+    GetFocusedWebView(GenericOneshotSender<Option<WebViewId>>),
     /// Get webviews state
-    GetAllWebViews(IpcSender<Vec<WebViewId>>),
+    GetAllWebViews(GenericOneshotSender<Vec<WebViewId>>),
     /// Check whether top-level browsing context is open.
-    IsWebViewOpen(WebViewId, IpcSender<bool>),
+    IsWebViewOpen(WebViewId, GenericOneshotSender<bool>),
     /// Check whether browsing context is open.
-    IsBrowsingContextOpen(BrowsingContextId, IpcSender<bool>),
-    CurrentUserPrompt(WebViewId, IpcSender<Option<WebDriverUserPrompt>>),
+    IsBrowsingContextOpen(BrowsingContextId, GenericOneshotSender<bool>),
+    CurrentUserPrompt(WebViewId, GenericOneshotSender<Option<WebDriverUserPrompt>>),
     HandleUserPrompt(
         WebViewId,
         WebDriverUserPromptAction,
-        IpcSender<Result<String, ()>>,
+        GenericOneshotSender<Result<String, ()>>,
     ),
-    GetAlertText(WebViewId, IpcSender<Result<String, ()>>),
+    GetAlertText(WebViewId, GenericOneshotSender<Result<String, ()>>),
     SendAlertText(WebViewId, String),
     FocusBrowsingContext(BrowsingContextId),
     Shutdown,
@@ -206,7 +206,10 @@ pub enum WebDriverScriptCommand {
     GetElementRect(String, IpcSender<Result<UntypedRect<f64>, ErrorStatus>>),
     GetElementTagName(String, IpcSender<Result<String, ErrorStatus>>),
     GetElementText(String, IpcSender<Result<String, ErrorStatus>>),
-    GetElementInViewCenterPoint(String, IpcSender<Result<Option<(i64, i64)>, ErrorStatus>>),
+    GetElementInViewCenterPoint(
+        String,
+        GenericOneshotSender<Result<Option<(i64, i64)>, ErrorStatus>>,
+    ),
     ScrollAndGetBoundingClientRect(String, IpcSender<Result<UntypedRect<f32>, ErrorStatus>>),
     GetBrowsingContextId(
         WebDriverFrameId,

--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use base::generic_channel;
 use base::id::BrowsingContextId;
 use crossbeam_channel::Select;
 use embedder_traits::{
@@ -14,7 +15,6 @@ use embedder_traits::{
     WheelEvent, WheelMode,
 };
 use euclid::Point2D;
-use ipc_channel::ipc;
 use keyboard_types::webdriver::KeyInputState;
 use log::info;
 use rustc_hash::FxHashSet;
@@ -26,7 +26,7 @@ use webdriver::actions::{
 };
 use webdriver::error::{ErrorStatus, WebDriverError};
 
-use crate::{Handler, VerifyBrowsingContextIsOpen, WebElement, wait_for_ipc_response};
+use crate::{Handler, VerifyBrowsingContextIsOpen, WebElement, wait_for_oneshot_response};
 
 // Interval between wheelScroll and pointerMove increments in ms, based on common vsync
 static POINTERMOVE_INTERVAL: u64 = 17;
@@ -751,12 +751,12 @@ impl Handler {
         if x < 0.0 || y < 0.0 {
             return Err(ErrorStatus::MoveTargetOutOfBounds);
         }
-        let (sender, receiver) = ipc::channel().unwrap();
+        let (sender, receiver) = generic_channel::oneshot().unwrap();
         let cmd_msg = WebDriverCommandMsg::GetViewportSize(self.verified_webview_id(), sender);
         self.send_message_to_embedder(cmd_msg)
             .map_err(|_| ErrorStatus::UnknownError)?;
 
-        let viewport_size = match wait_for_ipc_response(receiver) {
+        let viewport_size = match wait_for_oneshot_response(receiver) {
             Ok(response) => response,
             Err(WebDriverError { error, .. }) => return Err(error),
         };
@@ -801,7 +801,7 @@ impl Handler {
         &self,
         web_element: &WebElement,
     ) -> Result<(i64, i64), ErrorStatus> {
-        let (sender, receiver) = ipc::channel().unwrap();
+        let (sender, receiver) = generic_channel::oneshot().unwrap();
         // Step 1. Let element be the result of trying to run actions options'
         // get element origin steps with origin and browsing context.
         self.browsing_context_script_command(
@@ -811,7 +811,7 @@ impl Handler {
         .unwrap();
 
         // Step 2. If element is null, return error with error code no such element.
-        let response = match wait_for_ipc_response(receiver) {
+        let response = match wait_for_oneshot_response(receiver) {
             Ok(response) => response,
             Err(WebDriverError { error, .. }) => return Err(error),
         };


### PR DESCRIPTION
This implements a GenericOneshot channel. The size in the crossbeam channel is restricted while in the Ipc case we use the same IpcChannel(for now).

We also use these channels in WebDriver to prove they work.

Testing: Unit Tests and compilation still works.
Fixes: https://github.com/servo/servo/issues/39019
