### PR TITLE
compositing: Drop `Painter`s when they have no `WebView`s

### DIFF
--- a/components/compositing/largest_contentful_paint_calculator.rs
+++ b/components/compositing/largest_contentful_paint_calculator.rs
@@ -56,13 +56,12 @@ impl LargestContentfulPaintCalculator {
             .and_then(|container| container.calculate_largest_contentful_paint(paint_time))
     }
 
-    pub(crate) fn add_to_disabled_lcp_webviews(&mut self, webview_id: WebViewId) {
+    pub(crate) fn disable_for_webview(&mut self, webview_id: WebViewId) {
         self.disabled_lcp_for_webviews.insert(webview_id);
     }
 
-    pub(crate) fn clear(&mut self) {
-        self.lcp_containers.clear();
-        self.disabled_lcp_for_webviews.clear();
+    pub(crate) fn note_webview_removed(&mut self, webview_id: WebViewId) {
+        self.disabled_lcp_for_webviews.remove(&webview_id);
     }
 }
 

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -32,7 +32,6 @@ mod from_constellation {
             match self {
                 Self::ChangeRunningAnimationsState(..) => target!("ChangeRunningAnimationsState"),
                 Self::SetFrameTreeForWebView(..) => target!("SetFrameTreeForWebView"),
-                Self::RemoveWebView(..) => target!("RemoveWebView"),
                 Self::SetThrottled(..) => target!("SetThrottled"),
                 Self::NewWebRenderFrameReady(..) => target!("NewWebRenderFrameReady"),
                 Self::PipelineExited(..) => target!("PipelineExited"),

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3065,8 +3065,6 @@ where
         let browsing_context =
             self.close_browsing_context(browsing_context_id, ExitPipelineMode::Normal);
         self.webviews.remove(&webview_id);
-        self.compositor_proxy
-            .send(CompositorMsg::RemoveWebView(webview_id));
         self.embedder_proxy
             .send(EmbedderMsg::WebViewClosed(webview_id));
 

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -636,7 +636,6 @@ impl Drop for ServoInner {
         while self.spin_event_loop() {
             std::thread::sleep(Duration::from_micros(500));
         }
-        self.compositor.borrow_mut().deinit();
     }
 }
 

--- a/components/servo/webview.rs
+++ b/components/servo/webview.rs
@@ -106,6 +106,7 @@ impl Drop for WebViewInner {
         self.servo
             .constellation_proxy()
             .send(EmbedderToConstellationMessage::CloseWebView(self.id));
+        self.servo.compositor_mut().remove_webview(self.id);
     }
 }
 

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -88,8 +88,6 @@ pub enum CompositorMsg {
     ChangeRunningAnimationsState(WebViewId, PipelineId, AnimationState),
     /// Updates the frame tree for the given webview.
     SetFrameTreeForWebView(WebViewId, SendableFrameTree),
-    /// Remove a webview.
-    RemoveWebView(WebViewId),
     /// Set whether to use less resources by stopping animations.
     SetThrottled(WebViewId, PipelineId, bool),
     /// WebRender has produced a new frame. This message informs the compositor that
@@ -531,10 +529,16 @@ impl PainterSurfmanDetailsMap {
         map.get(&painter_id).cloned()
     }
 
-    pub fn insert(&mut self, painter_id: PainterId, details: PainterSurfmanDetails) {
+    pub fn insert(&self, painter_id: PainterId, details: PainterSurfmanDetails) {
         let mut map = self.0.lock().expect("poisoned");
         let existing = map.insert(painter_id, details);
         assert!(existing.is_none())
+    }
+
+    pub fn remove(&self, painter_id: PainterId) {
+        let mut map = self.0.lock().expect("poisoned");
+        let details = map.remove(&painter_id);
+        assert!(details.is_some());
     }
 }
 


### PR DESCRIPTION
Remove `Painter`s from the `Compositor` when their final `WebView` is
dropped. This ensures that their resources are properly released and
deinitialized, such as the WebRender instance and all of its resources.
Without this change, these things leak.

This change requires the ability to handle inexistant `Painter`s during
message handling, as messages from other parts of the `Constellation`
for a `Painter` can arrive after it has been released. We don't really
need to do this for `Compositor` API calls because they are triggered
via the `WebView`. When a `WebView` is alive its `Painter` should always
also be alive, so the `expect()` call still makes sense in that case.

Part of this also involves removing the redundant `RemoveWebView`
message to the `Compositor`. This is handled now in the `WebView` `Drop`
implementation for both simplicity and necessity.

Testing: This should not change observable behavior, but does fix a memory leak
while closing windows.
