### PR TITLE
libservo: Remove `WebViewInner::rect`

### DIFF
--- a/components/servo/examples/winit_minimal.rs
+++ b/components/servo/examples/winit_minimal.rs
@@ -156,8 +156,6 @@ impl ApplicationHandler<WakerEvent> for App {
             WindowEvent::Resized(new_size) => {
                 if let Self::Running(state) = self {
                     if let Some(webview) = state.webviews.borrow().last() {
-                        let mut rect = webview.rect();
-                        rect.set_size(winit_size_to_euclid_size(new_size).to_f32());
                         webview.resize(new_size);
                     }
                 }

--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -15,7 +15,7 @@ use egui::{
 };
 use egui_glow::{CallbackFn, EguiGlow};
 use egui_winit::EventResponse;
-use euclid::{Box2D, Length, Point2D, Rect, Scale, Size2D};
+use euclid::{Length, Point2D, Rect, Scale, Size2D};
 use log::warn;
 use servo::{
     DeviceIndependentPixel, DevicePixel, Image, LoadStatus, OffscreenRenderingContext, PixelFormat,
@@ -491,9 +491,8 @@ impl Gui {
             // the size of its RenderingContext.
             let rect = ctx.available_rect();
             let size = Size2D::new(rect.width(), rect.height()) * scale;
-            let rect = Box2D::from_origin_and_size(Point2D::origin(), size);
             if let Some(webview) = window.active_webview() &&
-                rect != webview.rect()
+                size != webview.size()
             {
                 // `rect` is sized to just the WebView viewport, which is required by
                 // `OffscreenRenderingContext` See:

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -13,7 +13,7 @@ use std::env;
 use std::rc::Rc;
 use std::time::Duration;
 
-use euclid::{Angle, Length, Point2D, Rotation3D, Scale, Size2D, UnknownUnit, Vector3D};
+use euclid::{Angle, Length, Point2D, Rect, Rotation3D, Scale, Size2D, UnknownUnit, Vector3D};
 use keyboard_types::ShortcutMatcher;
 use log::{debug, info};
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle, RawWindowHandle};
@@ -254,7 +254,8 @@ impl Window {
     ) {
         // `point` can be outside viewport, such as at toolbar with negative y-coordinate.
         let point = self.webview_relative_mouse_point.get();
-        if !webview.rect().contains(point) {
+        let webview_rect: Rect<_, _> = webview.size().into();
+        if !webview_rect.contains(point) {
             return;
         }
 
@@ -298,8 +299,9 @@ impl Window {
         let previous_point = self.webview_relative_mouse_point.get();
         self.webview_relative_mouse_point.set(point);
 
-        if !webview.rect().contains(point) {
-            if webview.rect().contains(previous_point) {
+        let webview_rect: Rect<_, _> = webview.size().into();
+        if !webview_rect.contains(point) {
+            if webview_rect.contains(previous_point) {
                 webview.notify_input_event(InputEvent::MouseLeftViewport(
                     MouseLeftViewportEvent::default(),
                 ));
@@ -685,10 +687,8 @@ impl PlatformWindow for Window {
                         self.handle_mouse_move_event(&webview, position);
                     },
                     WindowEvent::CursorLeft { .. } => {
-                        if webview
-                            .rect()
-                            .contains(self.webview_relative_mouse_point.get())
-                        {
+                        let webview_rect: Rect<_, _> = webview.size().into();
+                        if webview_rect.contains(self.webview_relative_mouse_point.get()) {
                             webview.notify_input_event(InputEvent::MouseLeftViewport(
                                 MouseLeftViewportEvent::default(),
                             ));


### PR DESCRIPTION
With the removal of the MDI support, a `WebView` is now always as big as
the `RenderingContext` onto which it renders. This change removes the
remnant of the MDI support which is the `rect` property. This was
problematic because it could get out of sync with the size of the
`RenderingContext`.

This change also adds a test for the case where these could get out of
sync.

Testing: There is a unit test for this change.
Closes: #41148.
Fixes: #41116.
