### PR TITLE
script: Implement import key operation of RSA-PSS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5054,6 +5054,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -5828,6 +5831,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5860,6 +5880,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -6723,6 +6754,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7357,6 +7399,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rsa"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha1",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7633,6 +7697,7 @@ dependencies = [
  "net_traits",
  "nom 8.0.0",
  "nom-rfc8288",
+ "num-bigint-dig",
  "num-traits",
  "num_cpus",
  "p256",
@@ -7647,6 +7712,7 @@ dependencies = [
  "rand 0.9.2",
  "range",
  "regex",
+ "rsa",
  "rustc-hash 2.1.1",
  "script_bindings",
  "script_traits",
@@ -8548,6 +8614,12 @@ name = "speexdsp-resampler"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72d540d5c565dbe1f891d7e21ceb21d2649508306782f1066989fccb0b363d3"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spirv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ net_traits = { path = "components/shared/net" }
 nix = "0.30"
 nom = "8.0.0"
 nom-rfc8288 = "0.4.0"
+num-bigint-dig = "0.8"
 num-traits = "0.2"
 num_cpus = "1.17.0"
 openxr = "0.19"
@@ -135,6 +136,7 @@ rayon = "1"
 read-fonts = "0.35.0"
 regex = "1.12"
 resvg = "0.45.0"
+rsa = { version = "0.9.9", features = ["sha1", "sha2"] }
 rustc-hash = "2.1.1"
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
 rustls-pki-types = "1.13"

--- a/components/script/Cargo.toml
+++ b/components/script/Cargo.toml
@@ -102,6 +102,7 @@ mime_guess = { workspace = true }
 net_traits = { workspace = true }
 nom = { workspace = true }
 nom-rfc8288 = { workspace = true }
+num-bigint-dig = { workspace = true }
 num-traits = { workspace = true }
 num_cpus = { workspace = true }
 p256 = { workspace = true }
@@ -116,6 +117,7 @@ profile_traits = { workspace = true }
 rand = { workspace = true }
 range = { path = "../range" }
 regex = { workspace = true }
+rsa = { workspace = true }
 rustc-hash = { workspace = true }
 script_bindings = { path = "../script_bindings" }
 script_traits = { workspace = true }

--- a/components/script/dom/cryptokey.rs
+++ b/components/script/dom/cryptokey.rs
@@ -27,6 +27,8 @@ pub(crate) enum CryptoKeyOrCryptoKeyPair {
 
 /// The underlying cryptographic data this key represents
 pub(crate) enum Handle {
+    RsaPrivateKey(rsa::RsaPrivateKey),
+    RsaPublicKey(rsa::RsaPublicKey),
     P256PrivateKey(p256::SecretKey),
     P384PrivateKey(p384::SecretKey),
     P521PrivateKey(p521::SecretKey),
@@ -214,6 +216,8 @@ impl Handle {
 impl MallocSizeOf for Handle {
     fn size_of(&self, ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
         match self {
+            Handle::RsaPrivateKey(private_key) => private_key.size_of(ops),
+            Handle::RsaPublicKey(public_key) => public_key.size_of(ops),
             Handle::P256PrivateKey(private_key) => private_key.size_of(ops),
             Handle::P384PrivateKey(private_key) => private_key.size_of(ops),
             Handle::P521PrivateKey(private_key) => private_key.size_of(ops),

--- a/components/script/dom/subtlecrypto/rsa_pss_operation.rs
+++ b/components/script/dom/subtlecrypto/rsa_pss_operation.rs
@@ -1,0 +1,466 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use base64ct::{Base64UrlUnpadded, Encoding};
+use pkcs8::der::asn1::BitString;
+use pkcs8::der::{AnyRef, Decode};
+use pkcs8::{PrivateKeyInfo, SubjectPublicKeyInfo};
+use rsa::pkcs1::{self, DecodeRsaPrivateKey};
+use rsa::traits::PublicKeyParts;
+use rsa::{BigUint, RsaPrivateKey, RsaPublicKey};
+
+use crate::dom::bindings::codegen::Bindings::CryptoKeyBinding::{KeyType, KeyUsage};
+use crate::dom::bindings::codegen::Bindings::SubtleCryptoBinding::{
+    AlgorithmIdentifier, JsonWebKey, KeyFormat,
+};
+use crate::dom::bindings::error::Error;
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::bindings::str::DOMString;
+use crate::dom::cryptokey::{CryptoKey, Handle};
+use crate::dom::globalscope::GlobalScope;
+use crate::dom::subtlecrypto::{
+    ALG_RSA_PSS, ALG_SHA1, ALG_SHA256, ALG_SHA384, ALG_SHA512, JsonWebKeyExt,
+    KeyAlgorithmAndDerivatives, Operation, SubtleRsaHashedImportParams,
+    SubtleRsaHashedKeyAlgorithm, normalize_algorithm,
+};
+use crate::script_runtime::CanGc;
+
+/// <https://w3c.github.io/webcrypto/#rsa-pss-operations-import-key>
+pub(crate) fn import_key(
+    global: &GlobalScope,
+    normalized_algorithm: &SubtleRsaHashedImportParams,
+    format: KeyFormat,
+    key_data: &[u8],
+    extractable: bool,
+    usages: Vec<KeyUsage>,
+    can_gc: CanGc,
+) -> Result<DomRoot<CryptoKey>, Error> {
+    // Step 1. Let keyData be the key data to be imported.
+
+    // Step 2.
+    let (key_handle, key_type) = match format {
+        // If format is "spki":
+        KeyFormat::Spki => {
+            // Step 2.1. If usages contains an entry which is not "verify" then throw a
+            // SyntaxError.
+            if usages.iter().any(|usage| *usage != KeyUsage::Verify) {
+                return Err(Error::Syntax(Some(
+                    "Usages contains an entry which is not \"verify\"".to_string(),
+                )));
+            }
+
+            // Step 2.2. Let spki be the result of running the parse a subjectPublicKeyInfo
+            // algorithm over keyData.
+            // Step 2.3. If an error occurred while parsing, then throw a DataError.
+            let spki =
+                SubjectPublicKeyInfo::<AnyRef, BitString>::from_der(key_data).map_err(|_| {
+                    Error::Data(Some(
+                        "Fail to parse SubjectPublicKeyInfo over keyData".to_string(),
+                    ))
+                })?;
+
+            // Step 2.4. If the algorithm object identifier field of the algorithm
+            // AlgorithmIdentifier field of spki is not equal to the rsaEncryption object
+            // identifier defined in [RFC3447], then throw a DataError.
+            if spki.algorithm.oid != pkcs1::ALGORITHM_OID {
+                return Err(Error::Data(Some(
+                    "Algorithm object identifier of spki is not an rsaEncryption".to_string(),
+                )));
+            }
+
+            // Step 2.5. Let publicKey be the result of performing the parse an ASN.1 structure
+            // algorithm, with data as the subjectPublicKeyInfo field of spki, structure as the
+            // RSAPublicKey structure specified in Section A.1.1 of [RFC3447], and exactData set to
+            // true.
+            // Step 2.6. If an error occurred while parsing, or it can be determined that publicKey
+            // is not a valid public key according to [RFC3447], then throw a DataError.
+            let pkcs1_bytes = spki.subject_public_key.as_bytes().ok_or(Error::Data(Some(
+                "Fail to parse byte sequence over SubjectPublicKey field of spki".to_string(),
+            )))?;
+            let rsa_public_key_structure =
+                pkcs1::RsaPublicKey::try_from(pkcs1_bytes).map_err(|_| {
+                    Error::Data(Some(
+                        "SubjectPublicKey field of spki is not an RSAPublicKey structure"
+                            .to_string(),
+                    ))
+                })?;
+            let n = BigUint::from_bytes_be(rsa_public_key_structure.modulus.as_bytes());
+            let e = BigUint::from_bytes_be(rsa_public_key_structure.public_exponent.as_bytes());
+            let public_key = RsaPublicKey::new(n, e).map_err(|_| {
+                Error::Data(Some(
+                    "Fail to construct RSA public key from modulus and public exponent".to_string(),
+                ))
+            })?;
+
+            // Step 2.7. Let key be a new CryptoKey that represents the RSA public key identified
+            // by publicKey.
+            // Step 2.8. Set the [[type]] internal slot of key to "public"
+            // NOTE: Done in Step 3-8.
+            let key_handle = Handle::RsaPublicKey(public_key);
+            let key_type = KeyType::Public;
+            (key_handle, key_type)
+        },
+        // If format is "pkcs8":
+        KeyFormat::Pkcs8 => {
+            // Step 2.1. If usages contains an entry which is not "sign" then throw a SyntaxError.
+            if usages.iter().any(|usage| *usage != KeyUsage::Sign) {
+                return Err(Error::Syntax(Some(
+                    "Usages contains an entry which is not \"sign\"".to_string(),
+                )));
+            }
+
+            // Step 2.2. Let privateKeyInfo be the result of running the parse a privateKeyInfo
+            // algorithm over keyData.
+            // Step 2.3. If an error occurred while parsing, then throw a DataError.
+            let private_key_info = PrivateKeyInfo::from_der(key_data).map_err(|_| {
+                Error::Data(Some(
+                    "Fail to parse PrivateKeyInfo over keyData".to_string(),
+                ))
+            })?;
+
+            // Step 2.4. If the algorithm object identifier field of the privateKeyAlgorithm
+            // PrivateKeyAlgorithm field of privateKeyInfo is not equal to the rsaEncryption object
+            // identifier defined in [RFC3447], then throw a DataError.
+            if private_key_info.algorithm.oid != pkcs1::ALGORITHM_OID {
+                return Err(Error::Data(Some(
+                    "Algorithm object identifier of PrivateKeyInfo is not an rsaEncryption"
+                        .to_string(),
+                )));
+            }
+
+            // Step 2.5. Let rsaPrivateKey be the result of performing the parse an ASN.1 structure
+            // algorithm, with data as the privateKey field of privateKeyInfo, structure as the
+            // RSAPrivateKey structure specified in Section A.1.2 of [RFC3447], and exactData set
+            // to true.
+            // Step 2.6. If an error occurred while parsing, or if rsaPrivateKey is not a valid RSA
+            // private key according to [RFC3447], then throw a DataError.
+            let rsa_private_key = RsaPrivateKey::from_pkcs1_der(private_key_info.private_key)
+                .map_err(|_| {
+                    Error::Data(Some(
+                        "PrivateKey field of PrivateKeyInfo is not an RSAPrivateKey structure"
+                            .to_string(),
+                    ))
+                })?;
+
+            // Step 2.7. Let key be a new CryptoKey that represents the RSA private key identified
+            // by rsaPrivateKey.
+            // Step 2.8. Set the [[type]] internal slot of key to "private"
+            // NOTE: Done in Step 3-8.
+            let key_handle = Handle::RsaPrivateKey(rsa_private_key);
+            let key_type = KeyType::Private;
+            (key_handle, key_type)
+        },
+        // If format is "jwk":
+        KeyFormat::Jwk => {
+            // Step 2.1.
+            // If keyData is a JsonWebKey dictionary:
+            //     Let jwk equal keyData.
+            // Otherwise:
+            //     Throw a DataError.
+            let cx = GlobalScope::get_cx();
+            let jwk = JsonWebKey::parse(cx, key_data)?;
+
+            // Step 2.2. If the d field of jwk is present and usages contains an entry which is not
+            // "sign", or, if the d field of jwk is not present and usages contains an entry which
+            // is not "verify" then throw a SyntaxError.
+            if jwk.d.is_some() && usages.iter().any(|usage| *usage != KeyUsage::Sign) {
+                return Err(Error::Syntax(Some(
+                    "The d field of jwk is present and usages contains an entry which is not \"sign\""
+                        .to_string()
+                )));
+            }
+            if jwk.d.is_none() && usages.iter().any(|usage| *usage != KeyUsage::Verify) {
+                return Err(Error::Syntax(Some(
+                    "The d field of jwk is not present and usages contains an entry which is not \"verify\""
+                        .to_string()
+                )));
+            }
+
+            // Step 2.3. If the kty field of jwk is not a case-sensitive string match to "RSA",
+            // then throw a DataError.
+            if jwk.kty.as_ref().is_none_or(|kty| kty != "RSA") {
+                return Err(Error::Data(Some(
+                    "The kty field of jwk is not a case-sensitive string match to \"RSA\""
+                        .to_string(),
+                )));
+            }
+
+            // Step 2.4. If usages is non-empty and the use field of jwk is present and is not a
+            // case-sensitive string match to "sig", then throw a DataError.
+            if !usages.is_empty() && jwk.use_.as_ref().is_some_and(|use_| use_ != "sig") {
+                return Err(Error::Data(Some(
+                    "Usages is non-empty and the use field of jwk is present and \
+                    is not a case-sensitive string match to \"sig\""
+                        .to_string(),
+                )));
+            }
+
+            // Step 2.5. If the key_ops field of jwk is present, and is invalid according to the
+            // requirements of JSON Web Key [JWK] or does not contain all of the specified usages
+            // values, then throw a DataError.
+            jwk.check_key_ops(&usages)?;
+
+            // Step 2.6. If the ext field of jwk is present and has the value false and extractable
+            // is true, then throw a DataError.
+            if jwk.ext.is_some_and(|ext| !ext) && extractable {
+                return Err(Error::Data(Some(
+                    "The ext field of jwk is present and \
+                    has the value false and extractable is true"
+                        .to_string(),
+                )));
+            }
+
+            // Step 2.7.
+            // If the alg field of jwk is not present:
+            //     Let hash be undefined.
+            // If the alg field is equal to the string "PS1":
+            //     Let hash be the string "SHA-1".
+            // If the alg field is equal to the string "PS256":
+            //     Let hash be the string "SHA-256".
+            // If the alg field is equal to the string "PS384":
+            //     Let hash be the string "SHA-384".
+            // If the alg field is equal to the string "PS512":
+            //     Let hash be the string "SHA-512".
+            // Otherwise:
+            //     Perform any key import steps defined by other applicable specifications, passing
+            //     format, jwk and obtaining hash.
+            //     If an error occurred or there are no applicable specifications, throw a DataError.
+            let hash = match jwk.alg {
+                None => None,
+                Some(alg) => match &*alg.str() {
+                    "PS1" => Some(ALG_SHA1),
+                    "PS256" => Some(ALG_SHA256),
+                    "PS384" => Some(ALG_SHA384),
+                    "PS512" => Some(ALG_SHA512),
+                    _ => None,
+                },
+            };
+
+            // Step 2.8. If hash is not undefined:
+            if let Some(hash) = hash {
+                // Step 2.8.1. Let normalizedHash be the result of normalize an algorithm with alg
+                // set to hash and op set to digest.
+                let normalized_hash = normalize_algorithm(
+                    cx,
+                    &Operation::Digest,
+                    &AlgorithmIdentifier::String(DOMString::from(hash)),
+                    can_gc,
+                )?;
+
+                // Step 2.8.2. If normalizedHash is not equal to the hash member of
+                // normalizedAlgorithm, throw a DataError.
+                if normalized_hash.name() != normalized_algorithm.hash.name() {
+                    return Err(Error::Data(Some(
+                        "The normalizedHash is not equal to the hash member of normalizedAlgorithm"
+                            .to_string(),
+                    )));
+                }
+            }
+
+            // Step 2.9.
+            match jwk.d {
+                // If the d field of jwk is present:
+                Some(d) => {
+                    // Step 2.9.1. If jwk does not meet the requirements of Section 6.3.2 of JSON
+                    // Web Algorithms [JWA], then throw a DataError.
+                    let n = Base64UrlUnpadded::decode_vec(
+                        &jwk.n
+                            .ok_or(Error::Data(Some(
+                                "The n field does not exist in jwk".to_string(),
+                            )))?
+                            .str(),
+                    )
+                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
+                    let e = Base64UrlUnpadded::decode_vec(
+                        &jwk.e
+                            .ok_or(Error::Data(Some(
+                                "The e field does not exist in jwk".to_string(),
+                            )))?
+                            .str(),
+                    )
+                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
+                    let d = Base64UrlUnpadded::decode_vec(&d.str()).map_err(|_| {
+                        Error::Data(Some("Fail to decode d field of jwk".to_string()))
+                    })?;
+                    let p = jwk
+                        .p
+                        .map(|p| Base64UrlUnpadded::decode_vec(&p.str()))
+                        .transpose()
+                        .map_err(|_| {
+                            Error::Data(Some("Fail to decode p field of jwk".to_string()))
+                        })?;
+                    let q = jwk
+                        .q
+                        .map(|q| Base64UrlUnpadded::decode_vec(&q.str()))
+                        .transpose()
+                        .map_err(|_| {
+                            Error::Data(Some("Fail to decode q field of jwk".to_string()))
+                        })?;
+                    let dp = jwk
+                        .dp
+                        .map(|dp| Base64UrlUnpadded::decode_vec(&dp.str()))
+                        .transpose()
+                        .map_err(|_| {
+                            Error::Data(Some("Fail to decode dp field of jwk".to_string()))
+                        })?;
+                    let dq = jwk
+                        .dq
+                        .map(|dq| Base64UrlUnpadded::decode_vec(&dq.str()))
+                        .transpose()
+                        .map_err(|_| {
+                            Error::Data(Some("Fail to decode dq field of jwk".to_string()))
+                        })?;
+                    let qi = jwk
+                        .qi
+                        .map(|qi| Base64UrlUnpadded::decode_vec(&qi.str()))
+                        .transpose()
+                        .map_err(|_| {
+                            Error::Data(Some("Fail to decode qi field of jwk".to_string()))
+                        })?;
+                    let mut primes = match (p, q, dp, dq, qi) {
+                        (Some(p), Some(q), Some(_dp), Some(_dq), Some(_qi)) => vec![p, q],
+                        (None, None, None, None, None) => Vec::new(),
+                        _ => return Err(Error::Data(Some(
+                            "The p, q, dp, dq, qi fields of jwk must be either all-present or all-absent"
+                                .to_string()
+                        ))),
+                    };
+                    if let Some(oth) = jwk.oth {
+                        if primes.is_empty() {
+                            return Err(Error::Data(Some(
+                                "The oth field exists in jwk but one of p, q, dp, dq, qi is missing".to_string()
+                            )));
+                        }
+                        for other_prime in oth {
+                            let r = Base64UrlUnpadded::decode_vec(
+                                &other_prime
+                                    .r
+                                    .ok_or(Error::Data(Some(
+                                        "The e field does not exist in oth field of jwk"
+                                            .to_string(),
+                                    )))?
+                                    .str(),
+                            )
+                            .map_err(|_| {
+                                Error::Data(Some(
+                                    "Fail to decode r field of oth field of jwk".to_string(),
+                                ))
+                            })?;
+                            primes.push(r);
+                        }
+                    }
+
+                    // Step 2.9.2. Let privateKey represents the RSA private key identified by
+                    // interpreting jwk according to Section 6.3.2 of JSON Web Algorithms [JWA].
+                    // Step 2.9.3. If privateKey is not a valid RSA private key according to
+                    // [RFC3447], then throw a DataError.
+                    let private_key = RsaPrivateKey::from_components(
+                        BigUint::from_bytes_be(&n),
+                        BigUint::from_bytes_be(&e),
+                        BigUint::from_bytes_be(&d),
+                        primes
+                            .into_iter()
+                            .map(|prime| BigUint::from_bytes_be(&prime))
+                            .collect(),
+                    )
+                    .map_err(|_| {
+                        Error::Data(Some(
+                            "Fail to construct RSA private key from values in jwk".to_string(),
+                        ))
+                    })?;
+
+                    // Step 2.9.4. Let key be a new CryptoKey object that represents privateKey.
+                    // Step 2.9.5. Set the [[type]] internal slot of key to "private"
+                    // NOTE: Done in Step 3-8.
+                    let key_handle = Handle::RsaPrivateKey(private_key);
+                    let key_type = KeyType::Private;
+                    (key_handle, key_type)
+                },
+                // Otherwise:
+                None => {
+                    // Step 2.9.1. If jwk does not meet the requirements of Section 6.3.1 of JSON
+                    // Web Algorithms [JWA], then throw a DataError.
+                    let n = Base64UrlUnpadded::decode_vec(
+                        &jwk.n
+                            .ok_or(Error::Data(Some(
+                                "The n field does not exist in jwk".to_string(),
+                            )))?
+                            .str(),
+                    )
+                    .map_err(|_| Error::Data(Some("Fail to decode n field of jwk".to_string())))?;
+                    let e = Base64UrlUnpadded::decode_vec(
+                        &jwk.e
+                            .ok_or(Error::Data(Some(
+                                "The e field does not exist in jwk".to_string(),
+                            )))?
+                            .str(),
+                    )
+                    .map_err(|_| Error::Data(Some("Fail to decode e field of jwk".to_string())))?;
+
+                    // Step 2.9.2. Let publicKey represent the RSA public key identified by
+                    // interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
+                    // Step 2.9.3. If publicKey can be determined to not be a valid RSA public key
+                    // according to [RFC3447], then throw a DataError.
+                    let public_key =
+                        RsaPublicKey::new(BigUint::from_bytes_be(&n), BigUint::from_bytes_be(&e))
+                            .map_err(|_| {
+                            Error::Data(Some(
+                                "Fail to construct RSA public key from values in jwk".to_string(),
+                            ))
+                        })?;
+
+                    // Step 2.9.4. Let key be a new CryptoKey representing publicKey.
+                    // Step 2.9.5. Set the [[type]] internal slot of key to "public"
+                    // NOTE: Done in Step 3-8.
+                    let key_handle = Handle::RsaPublicKey(public_key);
+                    let key_type = KeyType::Public;
+                    (key_handle, key_type)
+                },
+            }
+        },
+        // Otherwise:
+        _ => {
+            // throw a NotSupportedError.
+            return Err(Error::NotSupported(Some(
+                "Unsupported import key format for RSA key".to_string(),
+            )));
+        },
+    };
+
+    // Step 3. Let algorithm be a new RsaHashedKeyAlgorithm dictionary.
+    // Step 4. Set the name attribute of algorithm to "RSA-PSS"
+    // Step 5. Set the modulusLength attribute of algorithm to the length, in bits, of the RSA
+    // public modulus.
+    // Step 6. Set the publicExponent attribute of algorithm to the BigInteger representation of
+    // the RSA public exponent.
+    // Step 7. Set the hash attribute of algorithm to the hash member of normalizedAlgorithm.
+    // Step 8. Set the [[algorithm]] internal slot of key to algorithm
+    let (modulus_length, public_exponent) = match &key_handle {
+        Handle::RsaPrivateKey(private_key) => {
+            (private_key.size() as u32 * 8, private_key.e().to_bytes_be())
+        },
+        Handle::RsaPublicKey(public_key) => {
+            (public_key.size() as u32 * 8, public_key.e().to_bytes_be())
+        },
+        _ => unreachable!(),
+    };
+    let algorithm = SubtleRsaHashedKeyAlgorithm {
+        name: ALG_RSA_PSS.to_string(),
+        modulus_length,
+        public_exponent,
+        hash: normalized_algorithm.hash.clone(),
+    };
+    let key = CryptoKey::new(
+        global,
+        key_type,
+        extractable,
+        KeyAlgorithmAndDerivatives::RsaHashedKeyAlgorithm(algorithm),
+        usages,
+        key_handle,
+        can_gc,
+    );
+
+    // Step 9. Return key.
+    Ok(key)
+}

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -20,7 +20,10 @@ pub(crate) mod base {
     #[allow(unused_imports)]
     pub(crate) use js::realm::{AutoRealm, CurrentRealm};
     pub(crate) use js::rust::wrappers::Call;
-    pub(crate) use js::rust::{HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
+    pub(crate) use js::rust::{
+        CustomTrace, HandleObject, HandleValue, MutableHandleObject, MutableHandleValue,
+    };
+    pub(crate) use js::typedarray;
     pub(crate) use js::typedarray::{
         ArrayBuffer, ArrayBufferView, Float32Array, Float64Array, Uint8Array, Uint8ClampedArray,
     };

--- a/components/script_bindings/webidls/SubtleCrypto.webidl
+++ b/components/script_bindings/webidls/SubtleCrypto.webidl
@@ -56,6 +56,10 @@ interface SubtleCrypto {
                          sequence<KeyUsage> keyUsages );
 };
 
+// https://w3c.github.io/webcrypto/#big-integer
+
+typedef Uint8Array BigInteger;
+
 // https://w3c.github.io/webcrypto/#algorithm-dictionary
 
 typedef (object or DOMString) AlgorithmIdentifier;
@@ -70,6 +74,25 @@ dictionary Algorithm {
 
 dictionary KeyAlgorithm {
   required DOMString name;
+};
+
+// https://w3c.github.io/webcrypto/#RsaKeyAlgorithm-dictionary
+
+dictionary RsaKeyAlgorithm : KeyAlgorithm {
+  required unsigned long modulusLength;
+  required BigInteger publicExponent;
+};
+
+// https://w3c.github.io/webcrypto/#RsaHashedKeyAlgorithm-dictionary
+
+dictionary RsaHashedKeyAlgorithm : RsaKeyAlgorithm {
+  required KeyAlgorithm hash;
+};
+
+// https://w3c.github.io/webcrypto/#RsaHashedImportParams-dictionary
+
+dictionary RsaHashedImportParams : Algorithm {
+  required HashAlgorithmIdentifier hash;
 };
 
 // https://w3c.github.io/webcrypto/#EcdsaParams-dictionary

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,10 @@ ignore = [
     "RUSTSEC-2025-0098",
     # The crate `unic-ucd-ident` is unmaintained.
     "RUSTSEC-2025-0100",
+    # The crate `rsa` is vulnerable to Marvin Attack that leaks
+    # cryptographic secret via side channel. Wait for a patch in stable
+    # release version from upstream.
+    "RUSTSEC-2023-0071",
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/tests/wpt/meta/WebCryptoAPI/import_export/rsa_importKey.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/import_export/rsa_importKey.https.any.js.ini
@@ -875,18 +875,6 @@
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
     expected: FAIL
 
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
     expected: FAIL
 
@@ -897,18 +885,6 @@
     expected: FAIL
 
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
     expected: FAIL
 
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
@@ -923,18 +899,6 @@
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
     expected: FAIL
 
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
     expected: FAIL
 
@@ -945,18 +909,6 @@
     expected: FAIL
 
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
     expected: FAIL
 
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
@@ -971,18 +923,6 @@
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
     expected: FAIL
 
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
     expected: FAIL
 
@@ -993,18 +933,6 @@
     expected: FAIL
 
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
     expected: FAIL
 
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
@@ -1019,18 +947,6 @@
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
     expected: FAIL
 
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
     expected: FAIL
 
@@ -1041,18 +957,6 @@
     expected: FAIL
 
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
     expected: FAIL
 
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
@@ -1067,18 +971,6 @@
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
     expected: FAIL
 
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
     expected: FAIL
 
@@ -1089,18 +981,6 @@
     expected: FAIL
 
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
     expected: FAIL
 
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
@@ -1115,18 +995,6 @@
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
     expected: FAIL
 
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
     expected: FAIL
 
@@ -1137,18 +1005,6 @@
     expected: FAIL
 
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
     expected: FAIL
 
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
@@ -1581,150 +1437,6 @@
     expected: FAIL
 
   [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-OAEP}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, false, [\])]
     expected: FAIL
 
   [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [\])]
@@ -2321,24 +2033,6 @@
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign, sign\])]
     expected: FAIL
 
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, true, [\])]
     expected: FAIL
 
@@ -2355,24 +2049,6 @@
     expected: FAIL
 
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign, sign\])]
     expected: FAIL
 
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, true, [\])]
@@ -2393,24 +2069,6 @@
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign, sign\])]
     expected: FAIL
 
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, true, [\])]
     expected: FAIL
 
@@ -2427,24 +2085,6 @@
     expected: FAIL
 
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign, sign\])]
     expected: FAIL
 
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, true, [\])]
@@ -2465,24 +2105,6 @@
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign, sign\])]
     expected: FAIL
 
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, true, [\])]
     expected: FAIL
 
@@ -2499,24 +2121,6 @@
     expected: FAIL
 
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign, sign\])]
     expected: FAIL
 
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, true, [\])]
@@ -2537,24 +2141,6 @@
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign, sign\])]
     expected: FAIL
 
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, true, [\])]
     expected: FAIL
 
@@ -2571,24 +2157,6 @@
     expected: FAIL
 
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign, sign\])]
     expected: FAIL
 
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, true, [\])]
@@ -2609,24 +2177,6 @@
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign, sign\])]
     expected: FAIL
 
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, true, [\])]
     expected: FAIL
 
@@ -2643,24 +2193,6 @@
     expected: FAIL
 
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign, sign\])]
     expected: FAIL
 
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, true, [\])]
@@ -2681,24 +2213,6 @@
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign, sign\])]
     expected: FAIL
 
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, true, [\])]
     expected: FAIL
 
@@ -2715,24 +2229,6 @@
     expected: FAIL
 
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign, sign\])]
     expected: FAIL
 
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [\])]
@@ -4045,18 +3541,6 @@
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
     expected: FAIL
 
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
     expected: FAIL
 
@@ -4067,18 +3551,6 @@
     expected: FAIL
 
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
     expected: FAIL
 
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
@@ -4093,18 +3565,6 @@
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
     expected: FAIL
 
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
     expected: FAIL
 
@@ -4115,18 +3575,6 @@
     expected: FAIL
 
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
     expected: FAIL
 
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
@@ -4141,18 +3589,6 @@
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
     expected: FAIL
 
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
     expected: FAIL
 
@@ -4163,18 +3599,6 @@
     expected: FAIL
 
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
     expected: FAIL
 
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
@@ -4189,18 +3613,6 @@
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
     expected: FAIL
 
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
     expected: FAIL
 
@@ -4211,18 +3623,6 @@
     expected: FAIL
 
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
     expected: FAIL
 
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, true, [verify\])]
@@ -4237,18 +3637,6 @@
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign\])]
     expected: FAIL
 
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, true, [verify\])]
     expected: FAIL
 
@@ -4259,18 +3647,6 @@
     expected: FAIL
 
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign\])]
     expected: FAIL
 
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, true, [verify\])]
@@ -4285,18 +3661,6 @@
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign\])]
     expected: FAIL
 
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, true, [verify\])]
     expected: FAIL
 
@@ -4307,18 +3671,6 @@
     expected: FAIL
 
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign\])]
     expected: FAIL
 
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [verify\])]
@@ -4751,150 +4103,6 @@
     expected: FAIL
 
   [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-OAEP}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 1024 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 2048 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, true, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Empty Usages: 4096 bits (jwk, object(spki, pkcs8, jwk), {hash: SHA-512, name: RSA-PSS}, false, [\])]
     expected: FAIL
 
   [Empty Usages: 1024 bits (pkcs8, object(spki, pkcs8, jwk), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [\])]
@@ -5491,24 +4699,6 @@
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign, sign\])]
     expected: FAIL
 
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-1, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, true, [\])]
     expected: FAIL
 
@@ -5525,24 +4715,6 @@
     expected: FAIL
 
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-256, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-256, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign, sign\])]
     expected: FAIL
 
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, true, [\])]
@@ -5563,24 +4735,6 @@
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign, sign\])]
     expected: FAIL
 
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-384, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-384, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, true, [\])]
     expected: FAIL
 
@@ -5597,24 +4751,6 @@
     expected: FAIL
 
   [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-512, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (pkcs8, buffer(636), {hash: SHA-512, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 1024 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign, sign\])]
     expected: FAIL
 
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, true, [\])]
@@ -5635,24 +4771,6 @@
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign, sign\])]
     expected: FAIL
 
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-1, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-1, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, true, [\])]
     expected: FAIL
 
@@ -5669,24 +4787,6 @@
     expected: FAIL
 
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-256, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-256, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign, sign\])]
     expected: FAIL
 
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, true, [\])]
@@ -5707,24 +4807,6 @@
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign, sign\])]
     expected: FAIL
 
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-384, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-384, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
   [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, true, [\])]
     expected: FAIL
 
@@ -5741,24 +4823,6 @@
     expected: FAIL
 
   [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (spki, buffer(294), {hash: SHA-512, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (pkcs8, buffer(1218), {hash: SHA-512, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 2048 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign, sign\])]
     expected: FAIL
 
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, true, [\])]
@@ -5779,24 +4843,6 @@
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, true, [sign, sign\])]
     expected: FAIL
 
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-1, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-1, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-1, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-1, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, true, [\])]
     expected: FAIL
 
@@ -5813,24 +4859,6 @@
     expected: FAIL
 
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, true, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-256, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-256, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-256, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-256, name: RSA-PSS}, false, [sign, sign\])]
     expected: FAIL
 
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, true, [\])]
@@ -5851,24 +4879,6 @@
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, true, [sign, sign\])]
     expected: FAIL
 
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-384, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-384, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-384, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-384, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
   [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, true, [\])]
     expected: FAIL
 
@@ -5885,24 +4895,6 @@
     expected: FAIL
 
   [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, true, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (spki, buffer(550), {hash: SHA-512, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e), {hash: SHA-512, name: RSA-PSS}, false, [verify, verify\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (pkcs8, buffer(2376), {hash: SHA-512, name: RSA-PSS}, false, [sign, sign\])]
-    expected: FAIL
-
-  [Good parameters: 4096 bits (jwk, object(kty, n, e, d, p, q, dp, dq, qi), {hash: SHA-512, name: RSA-PSS}, false, [sign, sign\])]
     expected: FAIL
 
   [Good parameters: 1024 bits (spki, buffer(162), {hash: SHA-1, name: RSASSA-PKCS1-v1_5}, true, [\])]

--- a/tests/wpt/meta/WebCryptoAPI/sign_verify/rsa_pkcs.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/sign_verify/rsa_pkcs.https.any.js.ini
@@ -131,6 +131,30 @@
   [importVectorKeys step: RSASSA-PKCS1-v1_5 with SHA-512 verification failure with altered plaintext]
     expected: FAIL
 
+  [RSASSA-PKCS1-v1_5 with SHA-1 signing with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-256 signing with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-384 signing with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-512 signing with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-1 verification with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-256 verification with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-384 verification with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-512 verification with wrong algorithm name]
+    expected: FAIL
+
 
 [rsa_pkcs.https.any.html]
   [importVectorKeys step: RSASSA-PKCS1-v1_5 with SHA-1 verification]
@@ -263,4 +287,28 @@
     expected: FAIL
 
   [importVectorKeys step: RSASSA-PKCS1-v1_5 with SHA-512 verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-1 signing with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-256 signing with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-384 signing with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-512 signing with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-1 verification with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-256 verification with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-384 verification with wrong algorithm name]
+    expected: FAIL
+
+  [RSASSA-PKCS1-v1_5 with SHA-512 verification with wrong algorithm name]
     expected: FAIL

--- a/tests/wpt/meta/WebCryptoAPI/sign_verify/rsa_pss.https.any.js.ini
+++ b/tests/wpt/meta/WebCryptoAPI/sign_verify/rsa_pss.https.any.js.ini
@@ -287,6 +287,246 @@
   [importVectorKeys step: RSA-PSS with SHA-512, salted verification failure with altered plaintext]
     expected: FAIL
 
+  [RSA-PSS with SHA-1 and no salt verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted verification failure with altered plaintext]
+    expected: FAIL
+
 
 [rsa_pss.https.any.html]
   [importVectorKeys step: RSA-PSS with SHA-1 and no salt verification]
@@ -575,4 +815,244 @@
     expected: FAIL
 
   [importVectorKeys step: RSA-PSS with SHA-512, salted verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted verification]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted verification with altered signature after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted with altered plaintext after call]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted using privateKey to verify]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted using publicKey to sign]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted no verify usage]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted round trip]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted verification failure with altered signature]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted verification failure with wrong saltLength]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1 and no salt verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256 and no salt verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384 and no salt verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512 and no salt verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-1, salted verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-256, salted verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-384, salted verification failure with altered plaintext]
+    expected: FAIL
+
+  [RSA-PSS with SHA-512, salted verification failure with altered plaintext]
     expected: FAIL


### PR DESCRIPTION
Start adding RSA-PSS support to WebCrypto API.

This patch implements import key operation of RSA-PSS, with `rsa` crate.

Testing:
- Pass some WPT tests that were expected to fail.
- Some new FAIL expectations are added. They were skipped by WPT when the import key operation of RSA-PSS had not been implemented, and requires other not-yet-implemented operations to pass.

Fixes: #34362, and part of #41113