### PR TITLE
layout: Ensure that `background-repeat: round` size calculation rounds to nearest natural number

### DIFF
--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -294,8 +294,18 @@ fn layout_1d(
     positioning_area_size: f32,
 ) -> Layout1DResult {
     // https://drafts.csswg.org/css-backgrounds/#background-repeat
+    // > If background-repeat is round for one (or both) dimensions, there is a second step.
+    // > The UA must scale the image in that dimension (or both dimensions) so that it fits
+    // > a whole number of times in the background positioning area. In the case of the
+    // > width (height is analogous):
+    // >
+    // > | If X ≠ 0 is the width of the image after step one and W is the width of the
+    // > | background positioning area, then the rounded width X' = W / round(W / X) where
+    // > | round() is a function that returns the nearest natural number (integer greater than
+    // > | zero).
     if let Repeat::Round = repeat {
-        *tile_size = positioning_area_size / (positioning_area_size / *tile_size).round();
+        let round = |number: f32| number.round().max(1.0);
+        *tile_size = positioning_area_size / round(positioning_area_size / *tile_size);
     }
     // https://drafts.csswg.org/css-backgrounds/#background-position
     let mut position = position

--- a/tests/wpt/tests/css/css-backgrounds/background-repeat/background-repeat-image-larger-than-positioning-area-crash.html
+++ b/tests/wpt/tests/css/css-backgrounds/background-repeat/background-repeat-image-larger-than-positioning-area-crash.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="help" href="https://github.com/servo/servo/issues/41130">
+<style>
+  #span {background-repeat: round; background-image: url("../../support/60x60-green.png") }
+</style>
+<span id="span">A</span>


### PR DESCRIPTION
The previous code was just rounding to the nearest integrer, while the
specification says to round to the nearest natural number. The prevents
`inf` and `NaN` values from creeping to the results. This was leading to
a crash in WebRender.

Testing: This change adds a crash test.
Fixes: #41130.
