### PR TITLE
layout: Preserve cached intrinsic inline sizes in more cases

### DIFF
--- a/components/layout/flow/mod.rs
+++ b/components/layout/flow/mod.rs
@@ -511,6 +511,7 @@ fn compute_inline_content_sizes_for_block_level_boxes(
             },
             BlockLevelBox::SameFormattingContextBlock { base, contents, .. } => {
                 let inline_content_sizes_result = sizing::outer_inline(
+                    base,
                     &contents.layout_style(base),
                     containing_block,
                     &LogicalVec2::zero(),

--- a/components/layout/formatting_contexts.rs
+++ b/components/layout/formatting_contexts.rs
@@ -223,6 +223,7 @@ impl IndependentFormattingContext {
         auto_block_size_stretches_to_containing_block: bool,
     ) -> InlineContentSizesResult {
         sizing::outer_inline(
+            &self.base,
             &self.layout_style(),
             containing_block,
             auto_minimum,

--- a/components/layout/layout_box_base.rs
+++ b/components/layout/layout_box_base.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::fmt::{Debug, Formatter};
+use std::sync::atomic::AtomicBool;
 
 use app_units::Au;
 use atomic_refcell::AtomicRefCell;
@@ -29,6 +30,7 @@ pub(crate) struct LayoutBoxBase {
     pub style: Arc<ComputedValues>,
     pub cached_inline_content_size:
         AtomicRefCell<Option<Box<(SizeConstraint, InlineContentSizesResult)>>>,
+    pub outer_inline_content_sizes_depend_on_content: AtomicBool,
     pub cached_layout_result: AtomicRefCell<Option<Box<CacheableLayoutResultAndInputs>>>,
     pub fragments: AtomicRefCell<Vec<Fragment>>,
 }
@@ -39,6 +41,7 @@ impl LayoutBoxBase {
             base_fragment_info,
             style,
             cached_inline_content_size: AtomicRefCell::default(),
+            outer_inline_content_sizes_depend_on_content: AtomicBool::new(true),
             cached_layout_result: AtomicRefCell::default(),
             fragments: AtomicRefCell::default(),
         }
@@ -83,14 +86,6 @@ impl LayoutBoxBase {
 
     pub(crate) fn clear_fragments(&self) {
         self.fragments.borrow_mut().clear();
-    }
-
-    /// Clear cached data accumulated during fragment tree layout, either fragments and
-    /// the cached inline content size, or just fragments.
-    pub(crate) fn clear_fragments_and_layout_cache(&self) {
-        self.fragments.borrow_mut().clear();
-        *self.cached_layout_result.borrow_mut() = None;
-        *self.cached_inline_content_size.borrow_mut() = None;
     }
 
     pub(crate) fn repair_style(&mut self, new_style: &Arc<ComputedValues>) {

--- a/components/shared/layout/layout_damage.rs
+++ b/components/shared/layout/layout_damage.rs
@@ -13,8 +13,10 @@ bitflags! {
         /// Recollect the box children for this element, because some of the them will be
         /// rebuilt.
         const RECOLLECT_BOX_TREE_CHILDREN = 0b0111_1111_1111 << 4;
+        /// Clear the cached inline content sizes and recompute them during the next layout.
+        const RECOMPUTE_INLINE_CONTENT_SIZES = 0b1000_0000_0000 << 4;
         /// Rebuild the entire box for this element, which means that every part of layout
-        /// needs to happena again.
+        /// needs to happen again.
         const REBUILD_BOX = 0b1111_1111_1111 << 4;
     }
 }
@@ -22,6 +24,10 @@ bitflags! {
 impl LayoutDamage {
     pub fn recollect_box_tree_children() -> RestyleDamage {
         RestyleDamage::from_bits_retain(LayoutDamage::RECOLLECT_BOX_TREE_CHILDREN.bits())
+    }
+
+    pub fn recompute_inline_content_sizes() -> RestyleDamage {
+        RestyleDamage::from_bits_retain(LayoutDamage::RECOMPUTE_INLINE_CONTENT_SIZES.bits())
     }
 
     pub fn rebuild_box_tree() -> RestyleDamage {


### PR DESCRIPTION
If a box has layout damage, but the intrinsic contribution of some ancestor doesn't depend on its contents, then we don't need to clear the cached intrinsic sizes of further ancestors.

Testing: No behavior change, just an optimization. It would be good to have unit tests that check we don't do unnecessary work, but leaving this for the future.
