### PR TITLE
compositing: Re-enable LCP calculation on WebViews after they have been reloaded/navigated

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -3750,6 +3750,8 @@ where
                     new_browsing_context_info: None,
                     viewport_details,
                 });
+                self.paint_proxy
+                    .send(PaintMessage::EnableLCPCalculation(webview_id));
                 Some(new_pipeline_id)
             },
         }
@@ -4209,6 +4211,8 @@ where
             ScriptThreadMessage::Reload(pipeline_id),
             "Got reload event after closure",
         );
+        self.paint_proxy
+            .send(PaintMessage::EnableLCPCalculation(webview_id));
     }
 
     /// <https://html.spec.whatwg.org/multipage/#window-post-message-steps>

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -539,6 +539,11 @@ impl Paint {
                     painter.append_lcp_candidate(lcp_candidate, webview_id, pipeline_id, epoch);
                 }
             },
+            PaintMessage::EnableLCPCalculation(webview_id) => {
+                if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
+                    painter.enable_lcp_calculation(&webview_id);
+                }
+            },
         }
     }
 

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -819,7 +819,7 @@ impl Painter {
             webview_renderer.pipeline_exited(pipeline_id, pipeline_exit_source);
         }
         self.lcp_calculator
-            .remove_lcp_candidates_for_pipeline(pipeline_id.into());
+            .remove_lcp_candidates_for_pipeline(&pipeline_id.into());
     }
 
     pub(crate) fn send_initial_pipeline_transaction(
@@ -1197,7 +1197,7 @@ impl Painter {
         };
 
         self.send_root_pipeline_display_list();
-        self.lcp_calculator.note_webview_removed(webview_id);
+        self.lcp_calculator.enable_for_webview(&webview_id);
     }
 
     pub(crate) fn is_empty(&mut self) -> bool {
@@ -1309,6 +1309,14 @@ impl Painter {
         }
         // Disable LCP calculation on any scroll event.
         self.lcp_calculator.disable_for_webview(webview_id);
+    }
+
+    pub(crate) fn enable_lcp_calculation(&mut self, webview_id: &WebViewId) {
+        self.lcp_calculator.enable_for_webview(webview_id);
+    }
+
+    pub(crate) fn lcp_calculation_enabled_for_webview(&self, webview_id: &WebViewId) -> bool {
+        self.lcp_calculator.enabled_for_webview(webview_id)
     }
 
     pub(crate) fn pinch_zoom(
@@ -1436,10 +1444,12 @@ impl Painter {
         pipeline_id: PipelineId,
         epoch: Epoch,
     ) {
-        if self
-            .lcp_calculator
-            .append_lcp_candidate(webview_id, pipeline_id.into(), lcp_candidate)
-        {
+        if self.lcp_calculation_enabled_for_webview(&webview_id) {
+            self.lcp_calculator.append_lcp_candidate(
+                lcp_candidate,
+                pipeline_id.into(),
+                &webview_id,
+            );
             if let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) {
                 webview_renderer
                     .ensure_pipeline_details(pipeline_id)

--- a/components/paint/tracing.rs
+++ b/components/paint/tracing.rs
@@ -54,6 +54,7 @@ mod from_constellation {
                 Self::DelayNewFrameForCanvas(..) => target!("DelayFramesForCanvas"),
                 Self::ScreenshotReadinessReponse(..) => target!("ScreenshotReadinessResponse"),
                 Self::SendLCPCandidate(..) => target!("SendLCPCandidate"),
+                Self::EnableLCPCalculation(..) => target!("EnableLCPCalculation"),
             }
         }
     }

--- a/components/servo/tests/common/mod.rs
+++ b/components/servo/tests/common/mod.rs
@@ -12,9 +12,11 @@ use dpi::PhysicalSize;
 use embedder_traits::EventLoopWaker;
 use paint_api::rendering_context::{RenderingContext, SoftwareRenderingContext};
 use servo::{
-    EmbedderControl, JSValue, JavaScriptEvaluationError, LoadStatus, Preferences, Servo,
-    ServoBuilder, SimpleDialog, WebView, WebViewDelegate,
+    EmbedderControl, InputEvent, JSValue, JavaScriptEvaluationError, LoadStatus, MouseButton,
+    MouseButtonAction, MouseButtonEvent, MouseMoveEvent, Preferences, Servo, ServoBuilder,
+    SimpleDialog, WebView, WebViewDelegate,
 };
+use webrender_api::units::DevicePoint;
 
 pub struct ServoTest {
     pub servo: Servo,
@@ -145,6 +147,24 @@ impl WebViewDelegate for WebViewDelegateImpl {
         self.number_of_controls_hidden
             .set(self.number_of_controls_hidden.get() + 1);
     }
+}
+
+// Used by some unit tests only. Since they compile into different binaries,
+// it will be flagged as unused for certain unit tests.
+#[allow(dead_code)]
+pub(crate) fn click_at_point(webview: &WebView, point: DevicePoint) {
+    let point = point.into();
+    webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point)));
+    webview.notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
+        MouseButtonAction::Down,
+        MouseButton::Left,
+        point,
+    )));
+    webview.notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
+        MouseButtonAction::Up,
+        MouseButton::Left,
+        point,
+    )));
 }
 
 // Used by some unit tests only. Since they compile into different binaries,

--- a/components/servo/tests/largest_contentful_paint.rs
+++ b/components/servo/tests/largest_contentful_paint.rs
@@ -7,13 +7,14 @@ mod common;
 
 use std::rc::Rc;
 
+use euclid::Point2D;
 use servo::{InputEvent, JSValue, MouseMoveEvent, WebViewBuilder};
 use servo_config::prefs::Preferences;
 use url::Url;
 use webrender_api::units::DevicePoint;
 
 use crate::common::{
-    ServoTest, WebViewDelegateImpl, evaluate_javascript,
+    ServoTest, WebViewDelegateImpl, click_at_point, evaluate_javascript,
     show_webview_and_wait_for_rendering_to_be_ready,
 };
 
@@ -111,7 +112,62 @@ fn test_largest_contentful_paint_js_api_with_mouse_move() {
     if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), lcp_script) {
         panic!("Failed to evaluate LCP setup script: {:?}", err);
     }
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
+    // Read from a global variable used to store the result since evaluate_javascript doesn't handle Promises
+    let lcp = evaluate_javascript(&servo_test, webview.clone(), "window.lcp;");
+    assert_eq!(lcp, Ok(JSValue::Object(std::collections::HashMap::new())));
+}
+
+#[test]
+fn test_largest_contentful_paint_js_api_with_mouse_click_and_reload() {
+    let servo_test = ServoTest::new_with_builder(|builder| {
+        let mut preferences = Preferences::default();
+        preferences.largest_contentful_paint_enabled = true;
+        builder.preferences(preferences)
+    });
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(
+            Url::parse(
+                "data:text/html,<!DOCTYPE html>\
+                <a href=\"https://servo.org\"><div style=\"width: 50px; height: 50px;\">Link</div></a> \
+                <div><img src=\"data:image/svg+xml,<svg width='50' height='50'><circle cx='25' cy='25' r='20' fill='green'/></svg>\"\
+                style=\"width: 50px; height: 50px;\"></div>"
+            )
+            .unwrap(),
+        )
+        .build();
+
+    // Simulate a user interaction to disable LCP calculation for the WebView.
+    click_at_point(&webview, Point2D::new(1., 1.));
+
+    let lcp_script = "(async () => {
+        window.lcp = await new Promise(resolve => {
+            (new PerformanceObserver(entryList => {
+                resolve(entryList.getEntries()[0]);
+            }))
+            .observe({type: 'largest-contentful-paint', buffered: true});
+        })
+    })();";
+
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), lcp_script) {
+        panic!("Failed to evaluate LCP setup script: {:?}", err);
+    }
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+
+    // Read from a global variable used to store the result since evaluate_javascript doesn't handle Promises
+    let lcp = evaluate_javascript(&servo_test, webview.clone(), "window.lcp;");
+    assert_eq!(lcp, Ok(JSValue::Undefined));
+
+    // Reloading the WebView should re-enable LCP calculation.
+    webview.reload();
+
+    if let Err(err) = evaluate_javascript(&servo_test, webview.clone(), lcp_script) {
+        panic!("Failed to evaluate LCP setup script: {:?}", err);
+    }
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
     // Read from a global variable used to store the result since evaluate_javascript doesn't handle Promises

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -29,7 +29,7 @@ use url::Url;
 use webrender_api::units::{DeviceIntSize, DevicePoint};
 
 use crate::common::{
-    ServoTest, WebViewDelegateImpl, evaluate_javascript,
+    ServoTest, WebViewDelegateImpl, click_at_point, evaluate_javascript,
     show_webview_and_wait_for_rendering_to_be_ready,
 };
 
@@ -44,21 +44,6 @@ fn wait_for_webview_scene_to_be_up_to_date(servo_test: &ServoTest, webview: &Web
         callback_waiting.set(false);
     });
     servo_test.spin(move || waiting.get());
-}
-
-fn click_at_point(webview: &WebView, point: DevicePoint) {
-    let point = point.into();
-    webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(point)));
-    webview.notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
-        MouseButtonAction::Down,
-        MouseButton::Left,
-        point,
-    )));
-    webview.notify_input_event(InputEvent::MouseButton(MouseButtonEvent::new(
-        MouseButtonAction::Up,
-        MouseButton::Left,
-        point,
-    )));
 }
 
 fn open_context_menu_at_point(webview: &WebView, point: DevicePoint) {

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -187,6 +187,8 @@ pub enum PaintMessage {
     ScreenshotReadinessReponse(WebViewId, FxHashMap<PipelineId, Epoch>),
     /// The candidate of largest-contentful-paint
     SendLCPCandidate(LCPCandidate, WebViewId, PipelineId, Epoch),
+    /// Enable LCP calculation for the given WebView.
+    EnableLCPCalculation(WebViewId),
 }
 
 impl Debug for PaintMessage {


### PR DESCRIPTION
Re-enable LCP calculation on WebViews after they have been reloaded/navigated.

Scenario: LCP calculation is stopped when user interaction is detected. When page is reloaded. No, LCP is observed. So, can't develop the performance or benchmark tools.

Motivation: No explicit specs found for this, but this was missed during implementation from my side. And also observed inconsistent with Chrome. 
 
Testing: `components/servo/tests/largest_contentful_paint.rs`

Fixes: #42533
