### PR TITLE
webdriver: Enable testdriver tests for Touch by always dispatching embedder `MouseMove`

### DIFF
--- a/components/webdriver_server/actions.rs
+++ b/components/webdriver_server/actions.rs
@@ -530,8 +530,6 @@ impl Handler {
             let PointerInputState {
                 x: current_x,
                 y: current_y,
-                subtype,
-                pointer_id,
                 ..
             } = *self.get_pointer_input_state(source_id);
 
@@ -542,14 +540,7 @@ impl Handler {
                 // Step 7.2. Perform implementation-specific action dispatch steps
                 let point = WebViewPoint::Page(Point2D::new(x as f32, y as f32));
 
-                let input_event = match subtype {
-                    PointerType::Mouse => InputEvent::MouseMove(MouseMoveEvent::new(point)),
-                    PointerType::Pen | PointerType::Touch => InputEvent::Touch(TouchEvent::new(
-                        TouchEventType::Move,
-                        TouchId(pointer_id as i32),
-                        point,
-                    )),
-                };
+                let input_event = InputEvent::MouseMove(MouseMoveEvent::new(point));
                 if last {
                     self.send_blocking_input_event_to_embedder(input_event);
                 } else {

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-body.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-body.html.ini
@@ -1,4 +1,3 @@
 [non-passive-touchmove-event-listener-on-body.html]
-  expected: CRASH
   [non-passive touchmove event listener on body]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-div.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-div.html.ini
@@ -1,4 +1,3 @@
 [non-passive-touchmove-event-listener-on-div.html]
-  expected: CRASH
   [non-passive touchmove event listener on div]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-document.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-document.html.ini
@@ -1,4 +1,3 @@
 [non-passive-touchmove-event-listener-on-document.html]
-  expected: CRASH
   [non-passive touchmove event listener on document]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-root.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-root.html.ini
@@ -1,4 +1,3 @@
 [non-passive-touchmove-event-listener-on-root.html]
-  expected: CRASH
   [non-passive touchmove event listener on root]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-window.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchmove-event-listener-on-window.html.ini
@@ -1,4 +1,0 @@
-[non-passive-touchmove-event-listener-on-window.html]
-  expected: CRASH
-  [non-passive-touchmove-event-listener-on-window]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-body.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-body.html.ini
@@ -1,4 +1,0 @@
-[non-passive-touchstart-event-listener-on-body.html]
-  expected: CRASH
-  [non-passive touchstart event listener on body]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-div.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-div.html.ini
@@ -1,4 +1,0 @@
-[non-passive-touchstart-event-listener-on-div.html]
-  expected: CRASH
-  [non-passive touchstart event listener on div]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-document.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-document.html.ini
@@ -1,4 +1,0 @@
-[non-passive-touchstart-event-listener-on-document.html]
-  expected: CRASH
-  [non-passive touchstart event listener on document]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-root.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-root.html.ini
@@ -1,4 +1,0 @@
-[non-passive-touchstart-event-listener-on-root.html]
-  expected: CRASH
-  [non-passive touchstart event listener on root]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-window.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/non-passive-touchstart-event-listener-on-window.html.ini
@@ -1,4 +1,0 @@
-[non-passive-touchstart-event-listener-on-window.html]
-  expected: CRASH
-  [non-passive touchstart event listener on window]
-    expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-body.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-body.html.ini
@@ -1,4 +1,3 @@
 [passive-touchmove-event-listener-on-body.html]
-  expected: CRASH
   [passive touchmove event listener on body]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-div.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-div.html.ini
@@ -1,4 +1,3 @@
 [passive-touchmove-event-listener-on-div.html]
-  expected: CRASH
   [passive touchmove event listener on div]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-document.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-document.html.ini
@@ -1,4 +1,3 @@
 [passive-touchmove-event-listener-on-document.html]
-  expected: CRASH
   [passive touchmove event listener on document]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-root.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-root.html.ini
@@ -1,4 +1,3 @@
 [passive-touchmove-event-listener-on-root.html]
-  expected: CRASH
   [passive touchmove event listener on root]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-window.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchmove-event-listener-on-window.html.ini
@@ -1,4 +1,3 @@
 [passive-touchmove-event-listener-on-window.html]
-  expected: CRASH
   [passive touchmove event listener on window]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-body.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-body.html.ini
@@ -1,4 +1,3 @@
 [passive-touchstart-event-listener-on-body.html]
-  expected: CRASH
   [passive touchstart event listener on body]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-div.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-div.html.ini
@@ -1,4 +1,3 @@
 [passive-touchstart-event-listener-on-div.html]
-  expected: CRASH
   [passive touchstart event listener on div]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-document.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-document.html.ini
@@ -1,4 +1,3 @@
 [passive-touchstart-event-listener-on-document.html]
-  expected: CRASH
   [passive touchstart event listener on document]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-root.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-root.html.ini
@@ -1,4 +1,3 @@
 [passive-touchstart-event-listener-on-root.html]
-  expected: CRASH
   [passive touchstart event listener on root]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-window.html.ini
+++ b/tests/wpt/meta/dom/events/non-cancelable-when-passive/passive-touchstart-event-listener-on-window.html.ini
@@ -1,4 +1,3 @@
 [passive-touchstart-event-listener-on-window.html]
-  expected: CRASH
   [passive touchstart event listener on window]
     expected: FAIL

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-document.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-document.tentative.html.ini
@@ -1,4 +1,4 @@
 [overscroll-event-fired-to-document.tentative.html]
-  expected: CRASH
+  expected: TIMEOUT
   [Tests that the document gets overscroll event when no element scrolls after touch scrolling.]
     expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-element-with-overscroll-behavior.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-element-with-overscroll-behavior.tentative.html.ini
@@ -1,4 +1,4 @@
 [overscroll-event-fired-to-element-with-overscroll-behavior.tentative.html]
-  expected: CRASH
+  expected: TIMEOUT
   [Tests that the last element in the cut scroll chain gets overscroll event when no element scrolls by touch.]
     expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-scrolled-element.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-scrolled-element.tentative.html.ini
@@ -1,4 +1,4 @@
 [overscroll-event-fired-to-scrolled-element.tentative.html]
-  expected: CRASH
+  expected: TIMEOUT
   [Tests that the scrolled element gets overscroll event after fully scrolling by touch.]
     expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-window.tentative.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/overscroll-event-fired-to-window.tentative.html.ini
@@ -1,4 +1,4 @@
 [overscroll-event-fired-to-window.tentative.html]
-  expected: CRASH
+  expected: TIMEOUT
   [Tests that the window gets overscroll event when no element scrollsafter touch scrolling.]
     expected: TIMEOUT

--- a/tests/wpt/meta/dom/events/scrolling/scrollend-event-fired-after-snap.html.ini
+++ b/tests/wpt/meta/dom/events/scrolling/scrollend-event-fired-after-snap.html.ini
@@ -1,5 +1,5 @@
 [scrollend-event-fired-after-snap.html]
-  expected: CRASH
+  expected: TIMEOUT
   [Tests that scrollend is fired after scroll snap animation completion.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/html/semantics/interestfor/interestfor-pseudo-element.tentative.html.ini
+++ b/tests/wpt/meta/html/semantics/interestfor/interestfor-pseudo-element.tentative.html.ini
@@ -1,5 +1,4 @@
 [interestfor-pseudo-element.tentative.html]
-  expected: CRASH
   [pseudo element should work for Button]
     expected: FAIL
 

--- a/tests/wpt/meta/html/semantics/popovers/popover-self-invoke.html.ini
+++ b/tests/wpt/meta/html/semantics/popovers/popover-self-invoke.html.ini
@@ -1,5 +1,4 @@
 [popover-self-invoke.html]
-  expected: CRASH
   [mouse on a popover button that is its own target should open it.]
     expected: FAIL
 

--- a/tests/wpt/meta/html/user-activation/activation-trigger-pointerevent.html.ini
+++ b/tests/wpt/meta/html/user-activation/activation-trigger-pointerevent.html.ini
@@ -5,12 +5,12 @@
 
 
 [activation-trigger-pointerevent.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [Activation through touch pointerevent click]
     expected: TIMEOUT
 
 
 [activation-trigger-pointerevent.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [Activation through pen pointerevent click]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html.ini
+++ b/tests/wpt/meta/pointerevents/capturing_boundary_event_handler_at_ua_shadowdom.html.ini
@@ -10,7 +10,6 @@
 
 
 [capturing_boundary_event_handler_at_ua_shadowdom.html?pen]
-  expected: CRASH
   [Capturing boundary event handler at DIV]
     expected: FAIL
 
@@ -22,7 +21,6 @@
 
 
 [capturing_boundary_event_handler_at_ua_shadowdom.html?touch]
-  expected: CRASH
   [Capturing boundary event handler at DIV]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/coalesced_events_attributes.https.html.ini
+++ b/tests/wpt/meta/pointerevents/coalesced_events_attributes.https.html.ini
@@ -1,5 +1,5 @@
 [coalesced_events_attributes.https.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [Coalesced list in boundary events]
     expected: TIMEOUT
 
@@ -14,7 +14,7 @@
 
 
 [coalesced_events_attributes.https.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [Coalesced list in boundary events]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/coalesced_events_attributes_on_redispatch.https.html.ini
+++ b/tests/wpt/meta/pointerevents/coalesced_events_attributes_on_redispatch.https.html.ini
@@ -5,12 +5,12 @@
 
 
 [coalesced_events_attributes_on_redispatch.https.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [Coalesced list in pointerdown/move/up events]
     expected: TIMEOUT
 
 
 [coalesced_events_attributes_on_redispatch.https.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [Coalesced list in pointerdown/move/up events]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/coalesced_events_attributes_under_load.https.optional.html.ini
+++ b/tests/wpt/meta/pointerevents/coalesced_events_attributes_under_load.https.optional.html.ini
@@ -5,12 +5,12 @@
 
 
 [coalesced_events_attributes_under_load.https.optional.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [Coalesced pointermoves under load]
     expected: TIMEOUT
 
 
 [coalesced_events_attributes_under_load.https.optional.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [Coalesced pointermoves under load]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/compat/pointerevent_touch_target_after_pointerdown_target_removed.tentative.html.ini
+++ b/tests/wpt/meta/pointerevents/compat/pointerevent_touch_target_after_pointerdown_target_removed.tentative.html.ini
@@ -1,5 +1,4 @@
 [pointerevent_touch_target_after_pointerdown_target_removed.tentative.html]
-  expected: CRASH
   [After a pointerdown listener removes its target, touch events should be fired on the touchstart target even though an orphan and pointer events should be fired on the parent]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_after_target_appended.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_after_target_appended.html.ini
@@ -1,5 +1,4 @@
 [pointerevent_after_target_appended.html?touch]
-  expected: CRASH
   [pointer events from touch received before/after child attached at pointerdown]
     expected: FAIL
 
@@ -52,7 +51,6 @@
 
 
 [pointerevent_after_target_appended.html?pen]
-  expected: CRASH
   [pointer events from pen received before/after child attached at pointerdown]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_after_target_appended_interleaved.tentative.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_after_target_appended_interleaved.tentative.html.ini
@@ -1,5 +1,4 @@
 [pointerevent_after_target_appended_interleaved.tentative.html?touch]
-  expected: CRASH
   [mouse events from touch received before/after child attached at pointerdown]
     expected: FAIL
 
@@ -14,7 +13,6 @@
 
 
 [pointerevent_after_target_appended_interleaved.tentative.html?pen]
-  expected: CRASH
   [mouse events from pen received before/after child attached at pointerdown]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_after_target_removed.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_after_target_removed.html.ini
@@ -1,5 +1,4 @@
 [pointerevent_after_target_removed.html?pen]
-  expected: CRASH
   [pointer events from pen received before/after child removal at pointerdown]
     expected: FAIL
 
@@ -14,7 +13,6 @@
 
 
 [pointerevent_after_target_removed.html?touch]
-  expected: CRASH
   [pointer events from touch received before/after child removal at pointerdown]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_after_target_removed_interleaved.tentative.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_after_target_removed_interleaved.tentative.html.ini
@@ -1,5 +1,4 @@
 [pointerevent_after_target_removed_interleaved.tentative.html?touch]
-  expected: CRASH
   [mouse events from touch received before/after child removal at pointerdown]
     expected: FAIL
 
@@ -16,7 +15,6 @@
 
 
 [pointerevent_after_target_removed_interleaved.tentative.html?pen]
-  expected: CRASH
   [mouse events from pen received before/after child removal at pointerdown]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_attributes.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_attributes.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_attributes.html?pen-nonstandard]
-  expected: CRASH
+  expected: ERROR
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -8,7 +8,7 @@
 
 
 [pointerevent_attributes.html?pen-right-nonstandard]
-  expected: CRASH
+  expected: ERROR
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -17,7 +17,7 @@
 
 
 [pointerevent_attributes.html?touch]
-  expected: CRASH
+  expected: ERROR
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -26,7 +26,7 @@
 
 
 [pointerevent_attributes.html?pen-right]
-  expected: CRASH
+  expected: ERROR
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -35,7 +35,7 @@
 
 
 [pointerevent_attributes.html?mouse-right-nonstandard]
-  expected: CRASH
+  expected: ERROR
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -44,7 +44,7 @@
 
 
 [pointerevent_attributes.html?pen]
-  expected: CRASH
+  expected: ERROR
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -53,7 +53,7 @@
 
 
 [pointerevent_attributes.html?mouse-right]
-  expected: CRASH
+  expected: ERROR
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -62,7 +62,7 @@
 
 
 [pointerevent_attributes.html?mouse-nonstandard]
-  expected: CRASH
+  expected: ERROR
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -71,7 +71,7 @@
 
 
 [pointerevent_attributes.html?mouse]
-  expected: CRASH
+  expected: ERROR
   [Test pointer events in the main document]
     expected: FAIL
 
@@ -80,7 +80,7 @@
 
 
 [pointerevent_attributes.html?touch-nonstandard]
-  expected: CRASH
+  expected: ERROR
   [Test pointer events in the main document]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_auxclick_is_a_pointerevent.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_auxclick_is_a_pointerevent.html.ini
@@ -8,7 +8,7 @@
 
 
 [pointerevent_auxclick_is_a_pointerevent.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [auxclick using pen is a PointerEvent with correct properties]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/pointerevent_boundary_events_in_capturing.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_boundary_events_in_capturing.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_boundary_events_in_capturing.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [Boundary events around pointer capture and release]
     expected: TIMEOUT
 
@@ -11,6 +11,6 @@
 
 
 [pointerevent_boundary_events_in_capturing.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [Boundary events around pointer capture and release]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_capture_touch_and_release_at_got_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_capture_touch_and_release_at_got_capture.html.ini
@@ -1,4 +1,3 @@
 [pointerevent_capture_touch_and_release_at_got_capture.html]
-  expected: CRASH
   [A pointerout should be fired on the capturing element after losing the capture]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_change-touch-action-onpointerdown_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_change-touch-action-onpointerdown_touch.html.ini
@@ -1,4 +1,3 @@
 [pointerevent_change-touch-action-onpointerdown_touch.html]
-  expected: CRASH
   [scroll should be received before the test finishes]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_click_during_parent_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_click_during_parent_capture.html.ini
@@ -1,5 +1,4 @@
 [pointerevent_click_during_parent_capture.html?pointerType=touch&preventDefault=pointerdown]
-  expected: CRASH
   [Test in the topmost document: all expected events should be fired]
     expected: FAIL
 
@@ -11,7 +10,6 @@
 
 
 [pointerevent_click_during_parent_capture.html?pointerType=touch&preventDefault=touchstart]
-  expected: CRASH
   [Test in the topmost document: all expected events should be fired]
     expected: FAIL
 
@@ -20,7 +18,6 @@
 
 
 [pointerevent_click_during_parent_capture.html?pointerType=touch&preventDefault=]
-  expected: CRASH
   [Test in the topmost document: all expected events should be fired]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_click_is_a_pointerevent.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_click_is_a_pointerevent.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_click_is_a_pointerevent.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [click using pen is a PointerEvent with correct properties]
     expected: TIMEOUT
 
@@ -11,7 +11,7 @@
 
 
 [pointerevent_click_is_a_pointerevent.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [click using touch is a PointerEvent with correct properties]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/pointerevent_click_is_a_pointerevent_multiple_clicks.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_click_is_a_pointerevent_multiple_clicks.html.ini
@@ -1,5 +1,4 @@
 [pointerevent_click_is_a_pointerevent_multiple_clicks.html?touch]
-  expected: CRASH
   [click using touch is a PointerEvent]
     expected: FAIL
 
@@ -10,6 +9,5 @@
 
 
 [pointerevent_click_is_a_pointerevent_multiple_clicks.html?pen]
-  expected: CRASH
   [click using pen is a PointerEvent]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_contextmenu_is_a_pointerevent.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_contextmenu_is_a_pointerevent.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_contextmenu_is_a_pointerevent.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [contextmenu using touch is a PointerEvent with correct properties]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/pointerevent_disabled_form_control.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_disabled_form_control.html.ini
@@ -1,11 +1,11 @@
 [pointerevent_disabled_form_control.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [pen pointerevent attributes]
     expected: NOTRUN
 
 
 [pointerevent_disabled_form_control.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [touch pointerevent attributes]
     expected: NOTRUN
 

--- a/tests/wpt/meta/pointerevents/pointerevent_element_haspointercapture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_element_haspointercapture.html.ini
@@ -1,11 +1,11 @@
 [pointerevent_element_haspointercapture.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [hasPointerCapture]
     expected: NOTRUN
 
 
 [pointerevent_element_haspointercapture.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [hasPointerCapture]
     expected: NOTRUN
 

--- a/tests/wpt/meta/pointerevents/pointerevent_element_haspointercapture_release_pending_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_element_haspointercapture_release_pending_capture.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_element_haspointercapture_release_pending_capture.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [hasPointerCapture test after the pending pointer capture element releases pointer capture]
     expected: NOTRUN
 
@@ -11,6 +11,6 @@
 
 
 [pointerevent_element_haspointercapture_release_pending_capture.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [hasPointerCapture test after the pending pointer capture element releases pointer capture]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_fractional_coordinates.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_fractional_coordinates.html.ini
@@ -1,5 +1,4 @@
 [pointerevent_fractional_coordinates.html?touch]
-  expected: CRASH
   [touch]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_iframe-touch-action-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_iframe-touch-action-none_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_iframe-touch-action-none_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [touch iframe received pointercancel]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_movementxy.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_movementxy.html.ini
@@ -5,12 +5,12 @@
 
 
 [pointerevent_movementxy.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [touch pointerevent attributes]
     expected: NOTRUN
 
 
 [pointerevent_movementxy.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [pen pointerevent attributes]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointercancel_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [pointercancel event received]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointercapture_in_frame.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointercapture_in_frame.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_pointercapture_in_frame.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [Test touchpointer capture in same-origin frame: Pointer down at inner frame and set pointer capture.]
     expected: TIMEOUT
 
@@ -41,7 +41,7 @@
 
 
 [pointerevent_pointercapture_in_frame.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [Test penpointer capture in same-origin frame: Pointer down at inner frame and set pointer capture.]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerleave_after_pointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointerleave_after_pointercancel_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [pointerleave event received]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointermove_isprimary_same_as_pointerdown.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointermove_isprimary_same_as_pointerdown.html.ini
@@ -5,6 +5,6 @@
 
 
 [pointerevent_pointermove_isprimary_same_as_pointerdown.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [pointermove has same isPrimary as last pointerdown]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerout_after_pointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointerout_after_pointercancel_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [pointerout event received]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerout_pen.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerout_pen.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_pointerout_pen.html]
-  expected: CRASH
+  expected: TIMEOUT
   [pointerout event received]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_pointerrawupdate_coalesced_events_attributes.https.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_pointerrawupdate_coalesced_events_attributes.https.html.ini
@@ -5,12 +5,12 @@
 
 
 [pointerevent_pointerrawupdate_coalesced_events_attributes.https.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [Simple test for getCoalescedEvents() of `pointerrawupdate`]
     expected: TIMEOUT
 
 
 [pointerevent_pointerrawupdate_coalesced_events_attributes.https.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [Simple test for getCoalescedEvents() of `pointerrawupdate`]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_events_to_original_target.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_events_to_original_target.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_releasepointercapture_events_to_original_target.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [pen got/lost pointercapture: subsequent events to target]
     expected: NOTRUN
 
@@ -11,6 +11,6 @@
 
 
 [pointerevent_releasepointercapture_events_to_original_target.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [touch got/lost pointercapture: subsequent events to target]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_onpointercancel_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_onpointercancel_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_releasepointercapture_onpointercancel_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [pointer capture is released on pointercancel]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_pointerup_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_pointerup_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_releasepointercapture_pointerup_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [releasePointerCapture on pointerup]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_release_right_after_capture.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_releasepointercapture_release_right_after_capture.html.ini
@@ -1,11 +1,11 @@
 [pointerevent_releasepointercapture_release_right_after_capture.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [Release pointer capture right after setpointercapture]
     expected: NOTRUN
 
 
 [pointerevent_releasepointercapture_release_right_after_capture.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [Release pointer capture right after setpointercapture]
     expected: NOTRUN
 

--- a/tests/wpt/meta/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_sequence_at_implicit_release_on_click.html.ini
@@ -1,11 +1,9 @@
 [pointerevent_sequence_at_implicit_release_on_click.html?touch]
-  expected: CRASH
   [touch Boundary events are emitted after lostpointercapture]
     expected: FAIL
 
 
 [pointerevent_sequence_at_implicit_release_on_click.html?pen]
-  expected: CRASH
   [pen Boundary events are emitted after lostpointercapture]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_sequence_at_implicit_release_on_drag.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_sequence_at_implicit_release_on_drag.html.ini
@@ -1,4 +1,3 @@
 [pointerevent_sequence_at_implicit_release_on_drag.html]
-  expected: CRASH
   [touch Event sequence at implicit release on drag]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_override_pending_capture_element.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_override_pending_capture_element.html.ini
@@ -5,12 +5,12 @@
 
 
 [pointerevent_setpointercapture_override_pending_capture_element.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [setPointerCapture: override the pending pointer capture element]
     expected: NOTRUN
 
 
 [pointerevent_setpointercapture_override_pending_capture_element.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [setPointerCapture: override the pending pointer capture element]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_pointerup_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_pointerup_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_setpointercapture_pointerup_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [setPointerCapture on pointerup]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_to_same_element_twice.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_setpointercapture_to_same_element_twice.html.ini
@@ -1,5 +1,4 @@
 [pointerevent_setpointercapture_to_same_element_twice.html?pen]
-  expected: CRASH
   [A repeated setPointerCapture call does not redispatch capture events]
     expected: FAIL
 
@@ -16,7 +15,6 @@
 
 
 [pointerevent_setpointercapture_to_same_element_twice.html?touch]
-  expected: CRASH
   [A repeated setPointerCapture call does not redispatch capture events]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_to_slotted_target.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_to_slotted_target.html.ini
@@ -1,11 +1,9 @@
 [pointerevent_to_slotted_target.html?touch]
-  expected: CRASH
   [Pointer events from touch to slotted element and shadow-host]
     expected: FAIL
 
 
 [pointerevent_to_slotted_target.html?pen]
-  expected: CRASH
   [Pointer events from pen to slotted element and shadow-host]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-auto-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-auto-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-auto-css_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-button-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-button-none-test_touch.html.ini
@@ -1,2 +1,0 @@
-[pointerevent_touch-action-button-none-test_touch.html]
-  expected: CRASH

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-auto-child-none_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_child-auto-child-none_touch.html]
-  expected: CRASH
+  expected: ERROR
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-none_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_child-none_touch.html]
-  expected: CRASH
+  expected: ERROR
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_child-pan-x-child-pan-x_touch.html]
-  expected: CRASH
+  expected: ERROR
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_child-pan-x-child-pan-y_touch.html]
-  expected: CRASH
+  expected: ERROR
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_highest-parent-none_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-inherit_highest-parent-none_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-inherit_highest-parent-none_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-modified_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-modified_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-modified_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [No scrolling after deleting touch-action:none after pointerdown]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-none-css_touch.html]
-  expected: CRASH
+  expected: ERROR
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html.ini
@@ -1,2 +1,0 @@
-[pointerevent_touch-action-none-on-body-when-style-propagates-to-viewport_touch.html]
-  expected: CRASH

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-down-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-down-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-down-css_touch.html]
-  expected: CRASH
+  expected: ERROR
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-left-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-left-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-left-css_touch.html]
-  expected: CRASH
+  expected: ERROR
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-right-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-right-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-right-css_touch.html]
-  expected: CRASH
+  expected: ERROR
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-up-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-up-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-up-css_touch.html]
-  expected: CRASH
+  expected: ERROR
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-x-css_touch.html]
-  expected: CRASH
+  expected: ERROR
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y-pan-y_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-x-pan-y-pan-y_touch.html]
-  expected: CRASH
+  expected: ERROR
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-x-pan-y_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-x-pan-y_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-y-css_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-pan-y-css_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-action-pan-y-css_touch.html]
-  expected: CRASH
+  expected: ERROR
   [touch-action attribute test]
     expected: NOTRUN

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-span-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-span-none-test_touch.html.ini
@@ -1,4 +1,3 @@
 [pointerevent_touch-action-span-none-test_touch.html]
-  expected: CRASH
   [touch-action attribute test in element]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-action-table-none-test_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-action-table-none-test_touch.html.ini
@@ -1,5 +1,5 @@
 [pointerevent_touch-action-table-none-test_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [touch-action attribute test on the cell]
     expected: FAIL
 

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-adjustment_click_target.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-adjustment_click_target.html.ini
@@ -1,2 +1,0 @@
-[pointerevent_touch-adjustment_click_target.html]
-  expected: CRASH

--- a/tests/wpt/meta/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_touch-propagates-when-target-is-video_touch.html.ini
@@ -1,4 +1,4 @@
 [pointerevent_touch-propagates-when-target-is-video_touch.html]
-  expected: CRASH
+  expected: TIMEOUT
   [Touch-generated events should propagate to the parent when a video element is the target]
     expected: TIMEOUT

--- a/tests/wpt/meta/pointerevents/pointerup_after_pointerdown_target_removed.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerup_after_pointerdown_target_removed.html.ini
@@ -4,12 +4,10 @@
 
 
 [pointerup_after_pointerdown_target_removed.html?pen]
-  expected: CRASH
   [pointerup event from pen fired after pointerdown target is removed]
     expected: FAIL
 
 
 [pointerup_after_pointerdown_target_removed.html?touch]
-  expected: CRASH
   [pointerup event from touch fired after pointerdown target is removed]
     expected: FAIL

--- a/tests/wpt/meta/pointerevents/predicted_events_attributes.html.ini
+++ b/tests/wpt/meta/pointerevents/predicted_events_attributes.html.ini
@@ -1,5 +1,5 @@
 [predicted_events_attributes.html?pen]
-  expected: CRASH
+  expected: TIMEOUT
   [Predicted list in boundary events]
     expected: TIMEOUT
 
@@ -29,7 +29,7 @@
 
 
 [predicted_events_attributes.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [Predicted list in boundary events]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/pointerevents/touch-action-with-swipe-dir-change.html.ini
+++ b/tests/wpt/meta/pointerevents/touch-action-with-swipe-dir-change.html.ini
@@ -1,5 +1,5 @@
 [touch-action-with-swipe-dir-change.html?touch]
-  expected: CRASH
+  expected: TIMEOUT
   [touch-action:auto with right,down swipe]
     expected: TIMEOUT
 

--- a/tests/wpt/meta/touch-events/mouseevents-after-touchend.tentative.html.ini
+++ b/tests/wpt/meta/touch-events/mouseevents-after-touchend.tentative.html.ini
@@ -1,5 +1,4 @@
 [mouseevents-after-touchend.tentative.html]
-  expected: CRASH
   [Single tap should cause a click]
     expected: FAIL
 

--- a/tests/wpt/meta/touch-events/multi-touch-interactions.html.ini
+++ b/tests/wpt/meta/touch-events/multi-touch-interactions.html.ini
@@ -1,13 +1,19 @@
 [multi-touch-interactions.html]
-  expected: CRASH
-  [touchstart event received]
-    expected: NOTRUN
-
+  expected: TIMEOUT
   [touchmove event received]
     expected: NOTRUN
 
-  [touchend event received]
-    expected: NOTRUN
+  [touchend #1: change in targetTouches.length is valid]
+    expected: FAIL
 
-  [Interaction with mouse events]
+  [touchend #1: event dispatched to correct element<br>]
+    expected: FAIL
+
+  [touchend #2: change in targetTouches.length is valid]
+    expected: FAIL
+
+  [touchend #2: event dispatched to correct element<br>]
+    expected: FAIL
+
+  [touchstart #3: change in targetTouches.length is valid]
     expected: FAIL

--- a/tests/wpt/meta/touch-events/multi-touch-interfaces.html.ini
+++ b/tests/wpt/meta/touch-events/multi-touch-interfaces.html.ini
@@ -1,13 +1,7 @@
 [multi-touch-interfaces.html]
-  expected: CRASH
-  [touchstart event received]
-    expected: NOTRUN
-
+  expected: TIMEOUT
   [touchmove event received]
     expected: NOTRUN
 
   [touchend event received]
-    expected: NOTRUN
-
-  [Interaction with mouse events]
     expected: FAIL

--- a/tests/wpt/meta/touch-events/single-tap-when-touchend-listener-use-sync-xhr.html.ini
+++ b/tests/wpt/meta/touch-events/single-tap-when-touchend-listener-use-sync-xhr.html.ini
@@ -1,4 +1,3 @@
 [single-tap-when-touchend-listener-use-sync-xhr.html]
-  expected: CRASH
   [Click event should be fired when touchend opens synchronous XHR]
     expected: TIMEOUT

--- a/tests/wpt/meta/touch-events/single-tap-when-touchend-listener-use-sync-xhr.html.ini
+++ b/tests/wpt/meta/touch-events/single-tap-when-touchend-listener-use-sync-xhr.html.ini
@@ -1,3 +1,3 @@
 [single-tap-when-touchend-listener-use-sync-xhr.html]
   [Click event should be fired when touchend opens synchronous XHR]
-    expected: TIMEOUT
+    expected: FAIL

--- a/tests/wpt/meta/touch-events/single-touch-vertical-rl.html.ini
+++ b/tests/wpt/meta/touch-events/single-touch-vertical-rl.html.ini
@@ -1,4 +1,0 @@
-[single-touch-vertical-rl.html]
-  expected: CRASH
-  [touch & click events in vertical-rl mode have correct coordinates]
-    expected: TIMEOUT

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_pen.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_pen.py.ini
@@ -1,5 +1,4 @@
 [pointer_pen.py]
-  expected: TIMEOUT
   [test_no_browsing_context]
     expected: FAIL
 

--- a/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_touch.py.ini
+++ b/tests/wpt/meta/webdriver/tests/classic/perform_actions/pointer_touch.py.ini
@@ -1,5 +1,4 @@
 [pointer_touch.py]
-  expected: TIMEOUT
   [test_no_browsing_context]
     expected: FAIL
 


### PR DESCRIPTION
Back in #41067, we added webdriver touch support for all platforms. All touch-related testdriver tests which faked to work has been CRASH instead, as we assume that touch down event always happens before touch move and touch up.

But the assumption above is not wrong, as I observed embedder events dispatched from OHOS/Android when interacting as human. It is just that the tests are flawed: almost all of them have pointermove first even for touch, and spec didn't consider touch/pen support well enough: #41042.

Luckily, our embedder `MouseMove` event would also update the webdriver pointer status, which effectively allow touch down/touch up to happen at right point. It **doesn't matter** whether the website has mouse listener or not.

Testing: Tested manually on a touch-event-only complicated website. Also, tests no longer crash, also with expectations different from before https://github.com/servo/servo/pull/41067, e.g. [this](https://github.com/servo/servo/pull/41067/files#diff-db149f4025dab43bd5a3c8a412ea2ac9e521f4745c0f982925b4d15b236ff955) had been failing but now passes.