### PR TITLE
Rename `IOCompositor` to `Paint`

### DIFF
--- a/components/compositing/lib.rs
+++ b/components/compositing/lib.rs
@@ -8,7 +8,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use base::generic_channel::RoutedReceiver;
-use compositing_traits::{CompositorMsg, CompositorProxy};
+use compositing_traits::{PaintMessage, PaintProxy};
 use constellation_traits::EmbedderToConstellationMessage;
 use crossbeam_channel::Sender;
 use embedder_traits::{EventLoopWaker, ShutdownState};
@@ -16,13 +16,13 @@ use profile_traits::{mem, time};
 #[cfg(feature = "webxr")]
 use webxr::WebXrRegistry;
 
-pub use crate::compositor::{IOCompositor, WebRenderDebugOption};
+pub use crate::paint::{Paint, WebRenderDebugOption};
 
 #[macro_use]
 mod tracing;
 
-mod compositor;
 mod largest_contentful_paint_calculator;
+mod paint;
 mod painter;
 mod pinch_zoom;
 mod pipeline_details;
@@ -33,12 +33,12 @@ mod touch;
 mod webrender_external_images;
 mod webview_renderer;
 
-/// Data used to construct a compositor.
-pub struct InitialCompositorState {
-    /// A channel to the compositor.
-    pub compositor_proxy: CompositorProxy,
-    /// A port on which messages inbound to the compositor can be received.
-    pub receiver: RoutedReceiver<CompositorMsg>,
+/// Data used to initialize the `Paint` subsystem.
+pub struct InitialPaintState {
+    /// A channel to `Paint`.
+    pub paint_proxy: PaintProxy,
+    /// A port on which messages inbound to `Paint` can be received.
+    pub receiver: RoutedReceiver<PaintMessage>,
     /// A channel to the constellation.
     pub embedder_to_constellation_sender: Sender<EmbedderToConstellationMessage>,
     /// A channel to the time profiler thread.

--- a/components/compositing/paint.rs
+++ b/components/compositing/paint.rs
@@ -70,7 +70,7 @@ pub enum WebRenderDebugOption {
 ///    Once the frame is ready the [`Painter`] for the WebRender instance will ask libservo
 ///    to inform the embedder that a new frame is ready so that it can trigger a paint.
 /// 3. Drive animation and animation callback updates. Animation updates should ideally be
-///    coordinated with the system vscync signal, so the `RefreshDriver` is exposed in the
+///    coordinated with the system vsync signal, so the `RefreshDriver` is exposed in the
 ///    API to allow the embedder to do this. The [`Painter`] then asks its `WebView`s to
 ///    update their rendering, which triggers layouts.
 /// 4. Eagerly handle scrolling and touch events. In order to avoid latency when handling

--- a/components/compositing/paint.rs
+++ b/components/compositing/paint.rs
@@ -15,7 +15,7 @@ use bitflags::bitflags;
 use canvas_traits::webgl::{WebGLContextId, WebGLThreads};
 use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::{
-    CompositorMsg, CompositorProxy, PainterSurfmanDetails, PainterSurfmanDetailsMap,
+    PaintMessage, PaintProxy, PainterSurfmanDetails, PainterSurfmanDetailsMap,
     WebRenderExternalImageIdManager, WebViewTrait,
 };
 use constellation_traits::EmbedderToConstellationMessage;
@@ -47,7 +47,7 @@ use webrender::{CaptureBits, MemoryReport};
 use webrender_api::units::{DevicePixel, DevicePoint};
 use webrender_api::{FontInstanceKey, FontKey, ImageKey};
 
-use crate::InitialCompositorState;
+use crate::InitialPaintState;
 use crate::painter::Painter;
 use crate::webview_renderer::UnknownWebView;
 
@@ -59,26 +59,46 @@ pub enum WebRenderDebugOption {
     RenderTargetDebug,
 }
 
-/// NB: Never block on the constellation, because sometimes the constellation blocks on us.
-pub struct IOCompositor {
-    /// All of the [`Painters`] for this [`IOCompositor`]. Each [`Painter`] handles painting to
+/// [`Paint`] is Servo's rendering subsystem. It has a few responsibilities:
+///
+/// 1. Maintain a WebRender instance for each [`RenderingContext`] that Servo knows about.
+///    [`RenderingContext`]s are per-`WebView`, but more than one `WebView` can use the same
+///    [`RenderingContext`]. This allows multiple `WebView`s to share the same WebRender
+///    instance which is more efficient. This is useful for tabbed web browsers.
+/// 2. Receive display lists from the layout of all of the currently active `Pipeline`s
+///    (frames). These display lists are sent to WebRender, and new frames are generated.
+///    Once the frame is ready the [`Painter`] for the WebRender instance will ask libservo
+///    to inform the embedder that a new frame is ready so that it can trigger a paint.
+/// 3. Drive animation and animation callback updates. Animation updates should ideally be
+///    coordinated with the system vscync signal, so the `RefreshDriver` is exposed in the
+///    API to allow the embedder to do this. The [`Painter`] then asks its `WebView`s to
+///    update their rendering, which triggers layouts.
+/// 4. Eagerly handle scrolling and touch events. In order to avoid latency when handling
+///    these kind of actions, each [`Painter`] will eagerly process touch events and
+///    perform panning and zooming operations on their WebRender contents -- informing the
+///    WebView contents asynchronously.
+///
+/// `Paint` and all of its contained structs should **never** block on the Constellation,
+/// because sometimes the Constellation blocks on us.
+pub struct Paint {
+    /// All of the [`Painters`] for this [`Paint`]. Each [`Painter`] handles painting to
     /// a single [`RenderingContext`].
     painters: Vec<Rc<RefCell<Painter>>>,
 
-    /// A [`CompositorProxy`] which can be used to allow other parts of Servo to communicate
-    /// with this [`IOCompositor`].
-    pub(crate) compositor_proxy: CompositorProxy,
+    /// A [`PaintProxy`] which can be used to allow other parts of Servo to communicate
+    /// with this [`Paint`].
+    pub(crate) paint_proxy: PaintProxy,
 
     /// An [`EventLoopWaker`] used to wake up the main embedder event loop when the renderer needs
     /// to run.
     pub(crate) event_loop_waker: Box<dyn EventLoopWaker>,
 
-    /// Tracks whether we are in the process of shutting down, or have shut down and should close
-    /// the compositor. This is shared with the `Servo` instance.
+    /// Tracks whether we are in the process of shutting down, or have shut down and
+    /// should shut down `Paint`. This is shared with the `Servo` instance.
     shutdown_state: Rc<Cell<ShutdownState>>,
 
     /// The port on which we receive messages.
-    compositor_receiver: RoutedReceiver<CompositorMsg>,
+    paint_receiver: RoutedReceiver<PaintMessage>,
 
     /// The channel on which messages can be sent to the constellation.
     pub(crate) embedder_to_constellation_sender: Sender<EmbedderToConstellationMessage>,
@@ -136,12 +156,12 @@ bitflags! {
     }
 }
 
-impl IOCompositor {
-    pub fn new(state: InitialCompositorState) -> Rc<RefCell<Self>> {
+impl Paint {
+    pub fn new(state: InitialPaintState) -> Rc<RefCell<Self>> {
         let registration = state.mem_profiler_chan.prepare_memory_reporting(
-            "compositor".into(),
-            state.compositor_proxy.clone(),
-            CompositorMsg::CollectMemoryReport,
+            "paint".into(),
+            state.paint_proxy.clone(),
+            PaintMessage::CollectMemoryReport,
         );
 
         let webrender_external_image_id_manager = WebRenderExternalImageIdManager::default();
@@ -153,7 +173,7 @@ impl IOCompositor {
             #[cfg(feature = "webxr")]
             webxr_layer_grand_manager,
         } = WebGLComm::new(
-            state.compositor_proxy.cross_process_compositor_api.clone(),
+            state.paint_proxy.cross_process_paint_api.clone(),
             webrender_external_image_id_manager.clone(),
             painter_surfman_details_map.clone(),
         );
@@ -174,12 +194,12 @@ impl IOCompositor {
             webxr_main_thread
         };
 
-        Rc::new(RefCell::new(IOCompositor {
+        Rc::new(RefCell::new(Paint {
             painters: Default::default(),
-            compositor_proxy: state.compositor_proxy,
+            paint_proxy: state.paint_proxy,
             event_loop_waker: state.event_loop_waker,
             shutdown_state: state.shutdown_state,
-            compositor_receiver: state.receiver,
+            paint_receiver: state.receiver,
             embedder_to_constellation_sender: state.embedder_to_constellation_sender.clone(),
             webrender_external_image_id_manager,
             webgl_threads,
@@ -308,9 +328,9 @@ impl IOCompositor {
     }
 
     pub fn finish_shutting_down(&self) {
-        // Drain compositor port, sometimes messages contain channels that are blocking
+        // Drain paint port, sometimes messages contain channels that are blocking
         // another thread from finishing (i.e. SetFrameTree).
-        while self.compositor_receiver.try_recv().is_ok() {}
+        while self.paint_receiver.try_recv().is_ok() {}
 
         let (webgl_exit_sender, webgl_exit_receiver) =
             ipc::channel().expect("Failed to create IPC channel!");
@@ -330,7 +350,7 @@ impl IOCompositor {
         }
     }
 
-    fn handle_browser_message(&self, msg: CompositorMsg) {
+    fn handle_browser_message(&self, msg: PaintMessage) {
         trace_msg_from_constellation!(msg, "{msg:?}");
 
         match self.shutdown_state() {
@@ -340,16 +360,16 @@ impl IOCompositor {
                 return;
             },
             ShutdownState::FinishedShuttingDown => {
-                // Messages to the compositor are ignored after shutdown is complete.
+                // Messages to Paint are ignored after shutdown is complete.
                 return;
             },
         }
 
         match msg {
-            CompositorMsg::CollectMemoryReport(sender) => {
+            PaintMessage::CollectMemoryReport(sender) => {
                 self.collect_memory_report(sender);
             },
-            CompositorMsg::ChangeRunningAnimationsState(
+            PaintMessage::ChangeRunningAnimationsState(
                 webview_id,
                 pipeline_id,
                 animation_state,
@@ -362,30 +382,30 @@ impl IOCompositor {
                     );
                 }
             },
-            CompositorMsg::SetFrameTreeForWebView(webview_id, frame_tree) => {
+            PaintMessage::SetFrameTreeForWebView(webview_id, frame_tree) => {
                 if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
                     painter.set_frame_tree_for_webview(&frame_tree);
                 }
             },
-            CompositorMsg::SetThrottled(webview_id, pipeline_id, throttled) => {
+            PaintMessage::SetThrottled(webview_id, pipeline_id, throttled) => {
                 if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
                     painter.set_throttled(webview_id, pipeline_id, throttled);
                 }
             },
-            CompositorMsg::PipelineExited(webview_id, pipeline_id, pipeline_exit_source) => {
+            PaintMessage::PipelineExited(webview_id, pipeline_id, pipeline_exit_source) => {
                 if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
                     painter.notify_pipeline_exited(webview_id, pipeline_id, pipeline_exit_source);
                 }
             },
-            CompositorMsg::NewWebRenderFrameReady(..) => {
+            PaintMessage::NewWebRenderFrameReady(..) => {
                 unreachable!("New WebRender frames should be handled in the caller.");
             },
-            CompositorMsg::SendInitialTransaction(webview_id, pipeline_id) => {
+            PaintMessage::SendInitialTransaction(webview_id, pipeline_id) => {
                 if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
                     painter.send_initial_pipeline_transaction(webview_id, pipeline_id);
                 }
             },
-            CompositorMsg::ScrollNodeByDelta(
+            PaintMessage::ScrollNodeByDelta(
                 webview_id,
                 pipeline_id,
                 offset,
@@ -400,12 +420,12 @@ impl IOCompositor {
                     );
                 }
             },
-            CompositorMsg::ScrollViewportByDelta(webview_id, delta) => {
+            PaintMessage::ScrollViewportByDelta(webview_id, delta) => {
                 if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
                     painter.scroll_viewport_by_delta(webview_id, delta);
                 }
             },
-            CompositorMsg::UpdateEpoch {
+            PaintMessage::UpdateEpoch {
                 webview_id,
                 pipeline_id,
                 epoch,
@@ -414,7 +434,7 @@ impl IOCompositor {
                     painter.update_epoch(webview_id, pipeline_id, epoch);
                 }
             },
-            CompositorMsg::SendDisplayList {
+            PaintMessage::SendDisplayList {
                 webview_id,
                 display_list_descriptor,
                 display_list_receiver,
@@ -427,25 +447,25 @@ impl IOCompositor {
                     );
                 }
             },
-            CompositorMsg::GenerateFrame(painter_ids) => {
+            PaintMessage::GenerateFrame(painter_ids) => {
                 for painter_id in painter_ids {
                     if let Some(mut painter) = self.maybe_painter_mut(painter_id) {
                         painter.generate_frame_for_script();
                     }
                 }
             },
-            CompositorMsg::GenerateImageKey(webview_id, result_sender) => {
+            PaintMessage::GenerateImageKey(webview_id, result_sender) => {
                 self.handle_generate_image_key(webview_id, result_sender);
             },
-            CompositorMsg::GenerateImageKeysForPipeline(webview_id, pipeline_id) => {
+            PaintMessage::GenerateImageKeysForPipeline(webview_id, pipeline_id) => {
                 self.handle_generate_image_keys_for_pipeline(webview_id, pipeline_id);
             },
-            CompositorMsg::UpdateImages(painter_id, updates) => {
+            PaintMessage::UpdateImages(painter_id, updates) => {
                 if let Some(mut painter) = self.maybe_painter_mut(painter_id) {
                     painter.update_images(updates);
                 }
             },
-            CompositorMsg::DelayNewFrameForCanvas(
+            PaintMessage::DelayNewFrameForCanvas(
                 webview_id,
                 pipeline_id,
                 canvas_epoch,
@@ -455,21 +475,21 @@ impl IOCompositor {
                     painter.delay_new_frames_for_canvas(pipeline_id, canvas_epoch, image_keys);
                 }
             },
-            CompositorMsg::AddFont(painter_id, font_key, data, index) => {
+            PaintMessage::AddFont(painter_id, font_key, data, index) => {
                 debug_assert!(painter_id == font_key.into());
 
                 if let Some(mut painter) = self.maybe_painter_mut(painter_id) {
                     painter.add_font(font_key, data, index);
                 }
             },
-            CompositorMsg::AddSystemFont(painter_id, font_key, native_handle) => {
+            PaintMessage::AddSystemFont(painter_id, font_key, native_handle) => {
                 debug_assert!(painter_id == font_key.into());
 
                 if let Some(mut painter) = self.maybe_painter_mut(painter_id) {
                     painter.add_system_font(font_key, native_handle);
                 }
             },
-            CompositorMsg::AddFontInstance(
+            PaintMessage::AddFontInstance(
                 painter_id,
                 font_instance_key,
                 font_key,
@@ -484,12 +504,12 @@ impl IOCompositor {
                     painter.add_font_instance(font_instance_key, font_key, size, flags, variations);
                 }
             },
-            CompositorMsg::RemoveFonts(painter_id, keys, instance_keys) => {
+            PaintMessage::RemoveFonts(painter_id, keys, instance_keys) => {
                 if let Some(mut painter) = self.maybe_painter_mut(painter_id) {
                     painter.remove_fonts(keys, instance_keys);
                 }
             },
-            CompositorMsg::GenerateFontKeys(
+            PaintMessage::GenerateFontKeys(
                 number_of_font_keys,
                 number_of_font_instance_keys,
                 result_sender,
@@ -502,17 +522,17 @@ impl IOCompositor {
                     painter_id,
                 );
             },
-            CompositorMsg::Viewport(webview_id, viewport_description) => {
+            PaintMessage::Viewport(webview_id, viewport_description) => {
                 if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
                     painter.set_viewport_description(webview_id, viewport_description);
                 }
             },
-            CompositorMsg::ScreenshotReadinessReponse(webview_id, pipelines_and_epochs) => {
+            PaintMessage::ScreenshotReadinessReponse(webview_id, pipelines_and_epochs) => {
                 if let Some(painter) = self.maybe_painter(webview_id.into()) {
                     painter.handle_screenshot_readiness_reply(webview_id, pipelines_and_epochs);
                 }
             },
-            CompositorMsg::SendLCPCandidate(lcp_candidate, webview_id, pipeline_id, epoch) => {
+            PaintMessage::SendLCPCandidate(lcp_candidate, webview_id, pipeline_id, epoch) => {
                 if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
                     painter.append_lcp_candidate(lcp_candidate, webview_id, pipeline_id, epoch);
                 }
@@ -565,7 +585,7 @@ impl IOCompositor {
                 .map(|painter| painter.borrow().scroll_trees_memory_usage(ops))
                 .sum();
             reports.push(Report {
-                path: path!["compositor", "scroll-tree"],
+                path: path!["paint", "scroll-tree"],
                 kind: ReportKind::ExplicitJemallocHeapSize,
                 size: scroll_trees_memory_usage,
             });
@@ -574,29 +594,29 @@ impl IOCompositor {
         sender.send(ProcessReports::new(reports));
     }
 
-    /// Handle messages sent to the compositor during the shutdown process. In general,
-    /// the things the compositor can do in this state are limited. It's very important to
+    /// Handle messages sent to `Paint` during the shutdown process. In general,
+    /// the things `Paint` can do in this state are limited. It's very important to
     /// answer any synchronous messages though as other threads might be waiting on the
     /// results to finish their own shut down process. We try to do as little as possible
     /// during this time.
     ///
     /// When that involves generating WebRender ids, our approach here is to simply
-    /// generate them, but assume they will never be used, since once shutting down the
-    /// compositor no longer does any WebRender frame generation.
-    fn handle_browser_message_while_shutting_down(&self, msg: CompositorMsg) {
+    /// generate them, but assume they will never be used, since once shutting down
+    /// `Paint` no longer does any WebRender frame generation.
+    fn handle_browser_message_while_shutting_down(&self, msg: PaintMessage) {
         match msg {
-            CompositorMsg::PipelineExited(webview_id, pipeline_id, pipeline_exit_source) => {
+            PaintMessage::PipelineExited(webview_id, pipeline_id, pipeline_exit_source) => {
                 if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
                     painter.notify_pipeline_exited(webview_id, pipeline_id, pipeline_exit_source);
                 }
             },
-            CompositorMsg::GenerateImageKey(webview_id, result_sender) => {
+            PaintMessage::GenerateImageKey(webview_id, result_sender) => {
                 self.handle_generate_image_key(webview_id, result_sender);
             },
-            CompositorMsg::GenerateImageKeysForPipeline(webview_id, pipeline_id) => {
+            PaintMessage::GenerateImageKeysForPipeline(webview_id, pipeline_id) => {
                 self.handle_generate_image_keys_for_pipeline(webview_id, pipeline_id);
             },
-            CompositorMsg::GenerateFontKeys(
+            PaintMessage::GenerateFontKeys(
                 number_of_font_keys,
                 number_of_font_instance_keys,
                 result_sender,
@@ -668,20 +688,20 @@ impl IOCompositor {
             .render(&self.time_profiler_chan);
     }
 
-    /// Get the message receiver for this [`IOCompositor`].
-    pub fn receiver(&self) -> &RoutedReceiver<CompositorMsg> {
-        &self.compositor_receiver
+    /// Get the message receiver for this [`Paint`].
+    pub fn receiver(&self) -> &RoutedReceiver<PaintMessage> {
+        &self.paint_receiver
     }
 
     #[servo_tracing::instrument(skip_all)]
-    pub fn handle_messages(&self, mut messages: Vec<CompositorMsg>) {
+    pub fn handle_messages(&self, mut messages: Vec<PaintMessage>) {
         // Pull out the `NewWebRenderFrameReady` messages from the list of messages and handle them
         // at the end of this function. This prevents overdraw when more than a single message of
         // this type of received. In addition, if any of these frames need a repaint, that reflected
         // when calling `handle_new_webrender_frame_ready`.
         let mut saw_webrender_frame_ready_for_painter = HashMap::new();
         messages.retain(|message| match message {
-            CompositorMsg::NewWebRenderFrameReady(painter_id, _document_id, need_repaint) => {
+            PaintMessage::NewWebRenderFrameReady(painter_id, _document_id, need_repaint) => {
                 if let Some(painter) = self.maybe_painter(*painter_id) {
                     painter.decrement_pending_frames();
                     *saw_webrender_frame_ready_for_painter

--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -383,7 +383,7 @@ impl Painter {
         self.rendering_context.prepare_for_rendering();
 
         time_profile!(
-            ProfilerCategory::Compositing,
+            ProfilerCategory::Painting,
             None,
             time_profiler_channel.clone(),
             || {
@@ -957,7 +957,7 @@ impl Painter {
             },
             display_list_descriptor,
         );
-        let _span = profile_traits::trace_span!("PaintMessage::BuiltDisplayList",).entered();
+        let _span = profile_traits::trace_span!("PaintMessage::SendDisplayList",).entered();
         let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) else {
             return warn!("Could not find WebView for incoming display list");
         };

--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{PainterId, PipelineId, WebViewId};
-use compositing_traits::display_list::{CompositorDisplayListInfo, ScrollType};
+use compositing_traits::display_list::{PaintDisplayListInfo, ScrollType};
 use compositing_traits::largest_contentful_paint_candidate::LCPCandidate;
 use compositing_traits::rendering_context::RenderingContext;
 use compositing_traits::viewport_description::ViewportDescription;
@@ -22,7 +22,7 @@ use constellation_traits::{EmbedderToConstellationMessage, PaintMetricEvent};
 use crossbeam_channel::Sender;
 use dpi::PhysicalSize;
 use embedder_traits::{
-    CompositorHitTestResult, InputEvent, InputEventAndId, InputEventId, InputEventResult,
+    InputEvent, InputEventAndId, InputEventId, InputEventResult, PaintHitTestResult,
     ScreenshotCaptureError, Scroll, ViewportDetails, WebViewPoint, WebViewRect,
 };
 use euclid::{Point2D, Rect, Scale, Size2D};
@@ -54,9 +54,9 @@ use webrender_api::{
 };
 use wr_malloc_size_of::MallocSizeOfOps;
 
-use crate::IOCompositor;
-use crate::compositor::{RepaintReason, WebRenderDebugOption};
+use crate::Paint;
 use crate::largest_contentful_paint_calculator::LargestContentfulPaintCalculator;
+use crate::paint::{RepaintReason, WebRenderDebugOption};
 use crate::refresh_driver::{AnimationRefreshDriverObserver, BaseRefreshDriver};
 use crate::render_notifier::RenderNotifier;
 use crate::screenshot::ScreenshotTaker;
@@ -141,10 +141,7 @@ impl Drop for Painter {
 }
 
 impl Painter {
-    pub(crate) fn new(
-        rendering_context: Rc<dyn RenderingContext>,
-        compositor: &IOCompositor,
-    ) -> Self {
+    pub(crate) fn new(rendering_context: Rc<dyn RenderingContext>, paint: &Paint) -> Self {
         let webrender_gl = rendering_context.gleam_gl_api();
 
         // Make sure the gl context is made current.
@@ -153,31 +150,29 @@ impl Painter {
         }
         debug_assert_eq!(webrender_gl.get_error(), gleam::gl::NO_ERROR,);
 
-        let id_manager = compositor.webrender_external_image_id_manager();
+        let id_manager = paint.webrender_external_image_id_manager();
         let mut external_image_handlers = Box::new(WebRenderExternalImageHandlers::new(id_manager));
 
         // Set WebRender external image handler for WebGL textures.
         let image_handler = Box::new(WebGLExternalImages::new(
-            compositor.webgl_threads(),
+            paint.webgl_threads(),
             rendering_context.clone(),
-            compositor.swap_chains.clone(),
-            compositor.busy_webgl_contexts_map.clone(),
+            paint.swap_chains.clone(),
+            paint.busy_webgl_contexts_map.clone(),
         ));
         external_image_handlers.set_handler(image_handler, WebRenderImageHandlerType::WebGl);
 
         #[cfg(feature = "webgpu")]
         external_image_handlers.set_handler(
-            Box::new(webgpu::WebGpuExternalImages::new(
-                compositor.webgpu_image_map(),
-            )),
+            Box::new(webgpu::WebGpuExternalImages::new(paint.webgpu_image_map())),
             WebRenderImageHandlerType::WebGpu,
         );
 
         WindowGLContext::initialize_image_handler(&mut external_image_handlers);
 
-        let embedder_to_constellation_sender = compositor.embedder_to_constellation_sender.clone();
+        let embedder_to_constellation_sender = paint.embedder_to_constellation_sender.clone();
         let refresh_driver = Rc::new(BaseRefreshDriver::new(
-            compositor.event_loop_waker.clone_box(),
+            paint.event_loop_waker.clone_box(),
             rendering_context.refresh_driver(),
         ));
         let animation_refresh_driver_observer = Rc::new(AnimationRefreshDriverObserver::new(
@@ -215,10 +210,7 @@ impl Painter {
         let painter_id = PainterId::next();
         let (mut webrender, webrender_api_sender) = webrender::create_webrender_instance(
             webrender_gl.clone(),
-            Box::new(RenderNotifier::new(
-                painter_id,
-                compositor.compositor_proxy.clone(),
-            )),
+            Box::new(RenderNotifier::new(painter_id, paint.paint_proxy.clone())),
             webrender::WebRenderOptions {
                 // We force the use of optimized shaders here because rendering is broken
                 // on Android emulators with unoptimized shaders. This is due to a known
@@ -454,7 +446,7 @@ impl Painter {
 
                 match pipeline.first_paint_metric.get() {
                     // We need to check whether the current epoch is later, because
-                    // CrossProcessCompositorMessage::SendInitialTransaction sends an
+                    // CrossProcessPaintMessage::SendInitialTransaction sends an
                     // empty display list to WebRender which can happen before we receive
                     // the first "real" display list.
                     PaintMetricState::Seen(epoch, first_reflow) if epoch <= current_epoch => {
@@ -545,7 +537,7 @@ impl Painter {
         webrender_api: &RenderApi,
         webrender_document: DocumentId,
         point: DevicePoint,
-    ) -> Vec<CompositorHitTestResult> {
+    ) -> Vec<PaintHitTestResult> {
         // DevicePoint and WorldPoint are the same for us.
         let world_point = WorldPoint::from_untyped(point.to_untyped());
         let results = webrender_api.hit_test(webrender_document, world_point);
@@ -556,7 +548,7 @@ impl Painter {
             .map(|item| {
                 let pipeline_id = item.pipeline.into();
                 let external_scroll_id = ExternalScrollId(item.tag.0, item.pipeline);
-                CompositorHitTestResult {
+                PaintHitTestResult {
                     pipeline_id,
                     point_in_viewport: Point2D::from_untyped(item.point_in_viewport.to_untyped()),
                     external_scroll_id,
@@ -819,7 +811,7 @@ impl Painter {
         pipeline_id: PipelineId,
         pipeline_exit_source: PipelineExitSource,
     ) {
-        debug!("Compositor got pipeline exited: {webview_id:?} {pipeline_id:?}",);
+        debug!("Paint got pipeline exited: {webview_id:?} {pipeline_id:?}",);
         if let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) {
             webview_renderer.pipeline_exited(pipeline_id, pipeline_exit_source);
         }
@@ -932,13 +924,13 @@ impl Painter {
                 return warn!("Could not receive display list info: {error}");
             },
         };
-        let display_list_info: CompositorDisplayListInfo =
-            match bincode::deserialize(&display_list_info) {
-                Ok(display_list_info) => display_list_info,
-                Err(error) => {
-                    return warn!("Could not deserialize display list info: {error}");
-                },
-            };
+        let display_list_info: PaintDisplayListInfo = match bincode::deserialize(&display_list_info)
+        {
+            Ok(display_list_info) => display_list_info,
+            Err(error) => {
+                return warn!("Could not deserialize display list info: {error}");
+            },
+        };
         let items_data = match display_list_receiver.recv() {
             Ok(display_list_data) => display_list_data,
             Err(error) => {
@@ -965,8 +957,7 @@ impl Painter {
             },
             display_list_descriptor,
         );
-        let _span =
-            profile_traits::trace_span!("ScriptToCompositorMsg::BuiltDisplayList",).entered();
+        let _span = profile_traits::trace_span!("PaintMessage::BuiltDisplayList",).entered();
         let Some(webview_renderer) = self.webview_renderers.get_mut(&webview_id) else {
             return warn!("Could not find WebView for incoming display list");
         };

--- a/components/compositing/pipeline_details.rs
+++ b/components/compositing/pipeline_details.rs
@@ -30,8 +30,8 @@ pub(crate) struct PipelineDetails {
     /// Whether to use less resources by stopping animations.
     pub throttled: bool,
 
-    /// The compositor-side [ScrollTree]. This is used to allow finding and scrolling
-    /// nodes in the compositor before forwarding new offsets to WebRender.
+    /// The `Paint`-side [ScrollTree]. This is used to allow finding and scrolling
+    /// nodes in `Paint` before forwarding new offsets to WebRender.
     pub scroll_tree: ScrollTree,
 
     /// The paint metric status of the first paint.

--- a/components/compositing/refresh_driver.rs
+++ b/components/compositing/refresh_driver.rs
@@ -202,7 +202,7 @@ impl Default for TimerRefreshDriver {
     fn default() -> Self {
         let (sender, receiver) = crossbeam_channel::unbounded::<TimerThreadMessage>();
         let join_handle = thread::Builder::new()
-            .name(String::from("CompositorTimerThread"))
+            .name(String::from("PaintTimerThread"))
             .spawn(move || {
                 let mut scheduler = TimerScheduler::default();
 

--- a/components/compositing/render_notifier.rs
+++ b/components/compositing/render_notifier.rs
@@ -3,20 +3,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use base::id::PainterId;
-use compositing_traits::{CompositorMsg, CompositorProxy};
+use compositing_traits::{PaintMessage, PaintProxy};
 use webrender_api::{DocumentId, FramePublishId, FrameReadyParams};
 
 #[derive(Clone)]
 pub(crate) struct RenderNotifier {
     painter_id: PainterId,
-    compositor_proxy: CompositorProxy,
+    paint_proxy: PaintProxy,
 }
 
 impl RenderNotifier {
-    pub(crate) fn new(painter_id: PainterId, compositor_proxy: CompositorProxy) -> RenderNotifier {
+    pub(crate) fn new(painter_id: PainterId, paint_proxy: PaintProxy) -> RenderNotifier {
         RenderNotifier {
             painter_id,
-            compositor_proxy,
+            paint_proxy,
         }
     }
 }
@@ -25,7 +25,7 @@ impl webrender_api::RenderNotifier for RenderNotifier {
     fn clone(&self) -> Box<dyn webrender_api::RenderNotifier> {
         Box::new(RenderNotifier::new(
             self.painter_id,
-            self.compositor_proxy.clone(),
+            self.paint_proxy.clone(),
         ))
     }
 
@@ -37,11 +37,10 @@ impl webrender_api::RenderNotifier for RenderNotifier {
         _: FramePublishId,
         frame_ready_params: &FrameReadyParams,
     ) {
-        self.compositor_proxy
-            .send(CompositorMsg::NewWebRenderFrameReady(
-                self.painter_id,
-                document_id,
-                frame_ready_params.render,
-            ));
+        self.paint_proxy.send(PaintMessage::NewWebRenderFrameReady(
+            self.painter_id,
+            document_id,
+            frame_ready_params.render,
+        ));
     }
 }

--- a/components/compositing/screenshot.rs
+++ b/components/compositing/screenshot.rs
@@ -13,7 +13,7 @@ use image::RgbaImage;
 use rustc_hash::FxHashMap;
 use webrender_api::units::{DeviceIntRect, DeviceRect};
 
-use crate::compositor::RepaintReason;
+use crate::paint::RepaintReason;
 use crate::painter::Painter;
 
 pub(crate) struct ScreenshotRequest {

--- a/components/compositing/touch.rs
+++ b/components/compositing/touch.rs
@@ -6,7 +6,7 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use base::id::WebViewId;
-use embedder_traits::{CompositorHitTestResult, InputEventId, Scroll, TouchEventType, TouchId};
+use embedder_traits::{InputEventId, PaintHitTestResult, Scroll, TouchEventType, TouchId};
 use euclid::{Point2D, Scale, Vector2D};
 use log::{debug, error, warn};
 use rustc_hash::FxHashMap;
@@ -14,7 +14,7 @@ use style_traits::CSSPixel;
 use webrender_api::units::{DevicePixel, DevicePoint, DeviceVector2D};
 
 use self::TouchSequenceState::*;
-use crate::compositor::RepaintReason;
+use crate::paint::RepaintReason;
 use crate::painter::Painter;
 use crate::refresh_driver::{BaseRefreshDriver, RefreshDriverObserver};
 use crate::webview_renderer::{ScrollEvent, ScrollZoomEvent, WebViewRenderer};
@@ -76,11 +76,11 @@ pub enum TouchMoveAllowed {
     Pending,
 }
 
-/// A cached [`CompositorHitTestResult`] to use during a touch sequence. This
+/// A cached [`PaintHitTestResult`] to use during a touch sequence. This
 /// is kept so that the renderer doesn't have to constantly keep making hit tests
 /// while during panning and flinging actions.
 struct HitTestResultCache {
-    value: CompositorHitTestResult,
+    value: PaintHitTestResult,
     device_pixels_per_page: Scale<f32, CSSPixel, DevicePixel>,
 }
 
@@ -627,7 +627,7 @@ impl TouchHandler {
         }
     }
 
-    pub(crate) fn get_hit_test_result_cache_value(&self) -> Option<CompositorHitTestResult> {
+    pub(crate) fn get_hit_test_result_cache_value(&self) -> Option<PaintHitTestResult> {
         let sequence = self.touch_sequence_map.get(&self.current_sequence_id)?;
         if sequence.state == Finished {
             return None;
@@ -640,7 +640,7 @@ impl TouchHandler {
 
     pub(crate) fn set_hit_test_result_cache_value(
         &mut self,
-        value: CompositorHitTestResult,
+        value: PaintHitTestResult,
         device_pixels_per_page: Scale<f32, CSSPixel, DevicePixel>,
     ) {
         if let Some(sequence) = self.touch_sequence_map.get_mut(&self.current_sequence_id) {

--- a/components/compositing/tracing.rs
+++ b/components/compositing/tracing.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /// Log an event from constellation at trace level.
-/// - To disable tracing: RUST_LOG='compositor<constellation@=off'
-/// - To enable tracing: RUST_LOG='compositor<constellation@'
+/// - To disable tracing: RUST_LOG='paint<constellation@=off'
+/// - To enable tracing: RUST_LOG='paint<constellation@'
 macro_rules! trace_msg_from_constellation {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
@@ -23,11 +23,11 @@ mod from_constellation {
 
     macro_rules! target {
         ($($name:literal)+) => {
-            concat!("compositor<constellation@", $($name),+)
+            concat!("paint<constellation@", $($name),+)
         };
     }
 
-    impl LogTarget for compositing_traits::CompositorMsg {
+    impl LogTarget for compositing_traits::PaintMessage {
         fn log_target(&self) -> &'static str {
             match self {
                 Self::ChangeRunningAnimationsState(..) => target!("ChangeRunningAnimationsState"),

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -45,7 +45,7 @@
 //! The constellation also maintains channels to other parts of Servo, including:
 //!
 //! * The script thread.
-//! * The `Paint` subsystem, which runs in the embedder main thread.
+//! * The `Paint` subsystem, which runs in the same thread as the `Servo` instance.
 //! * The font cache, image cache, and resource manager, which load
 //!   and cache shared fonts, images, or other resources.
 //! * The service worker manager.
@@ -2447,7 +2447,7 @@ where
                     resource_threads: self.public_resource_threads.clone(),
                     own_sender: own_sender.clone(),
                     receiver,
-                    paint_aip: self.paint_proxy.cross_process_paint_api.clone(),
+                    paint_api: self.paint_proxy.cross_process_paint_api.clone(),
                     system_font_service_sender: self.system_font_service.to_sender(),
                 };
 

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -104,10 +104,7 @@ impl EventLoop {
             constellation_to_script_sender: script_chan,
             constellation_to_script_receiver: script_port,
             pipeline_namespace_id: constellation.next_pipeline_namespace_id(),
-            cross_process_compositor_api: constellation
-                .compositor_proxy
-                .cross_process_compositor_api
-                .clone(),
+            cross_process_paint_api: constellation.paint_proxy.cross_process_paint_api.clone(),
             webgl_chan: constellation
                 .webgl_threads
                 .as_ref()

--- a/components/constellation/logging.rs
+++ b/components/constellation/logging.rs
@@ -73,7 +73,7 @@ impl Log for FromScriptLogger {
     fn flush(&self) {}
 }
 
-/// A logger directed at the constellation from the compositor
+/// A logger directed at the constellation from `Paint`.
 #[derive(Clone)]
 pub struct FromEmbedderLogger {
     /// A channel to the constellation

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/// Log an event from compositor at trace level.
-/// - To disable tracing: RUST_LOG='constellation<compositor@=off'
-/// - To enable tracing: RUST_LOG='constellation<compositor@'
+/// Log an event from embedder at trace level.
+/// - To disable tracing: RUST_LOG='constellation<embedder@=off'
+/// - To enable tracing: RUST_LOG='constellation<embedder@'
 /// - Recommended filters when tracing is enabled:
-///   - constellation<compositor@ForwardEvent(MouseMoveEvent)=off
-///   - constellation<compositor@LogEntry=off
-///   - constellation<compositor@ReadyToPresent=off
-macro_rules! trace_msg_from_compositor {
+///   - constellation<embedder@ForwardEvent(MouseMoveEvent)=off
+///   - constellation<embedder@LogEntry=off
+///   - constellation<embedder@ReadyToPresent=off
+macro_rules! trace_msg_from_embedder {
     // This macro only exists to put the docs in the same file as the target prefix,
     // so the macro definition is always the same.
     ($event:expr, $($rest:tt)+) => {
@@ -35,14 +35,14 @@ pub(crate) trait LogTarget {
     fn log_target(&self) -> &'static str;
 }
 
-mod from_compositor {
+mod from_embedder {
     use embedder_traits::{InputEvent, InputEventAndId};
 
     use super::LogTarget;
 
     macro_rules! target {
         ($($name:literal)+) => {
-            concat!("constellation<compositor@", $($name),+)
+            concat!("constellation<embedder@", $($name),+)
         };
     }
 

--- a/components/fonts/tests/font_context.rs
+++ b/components/fonts/tests/font_context.rs
@@ -14,7 +14,7 @@ mod font_context {
     use std::thread;
 
     use app_units::Au;
-    use compositing_traits::CrossProcessCompositorApi;
+    use compositing_traits::CrossProcessPaintApi;
     use fonts::platform::font::PlatformFont;
     use fonts::{
         FallbackFontSelectionOptions, FontContext, FontDescriptor, FontFamilyDescriptor,
@@ -50,14 +50,14 @@ mod font_context {
             let (system_font_service, system_font_service_proxy) = MockSystemFontService::spawn();
             let (core_sender, _) = ipc::channel().unwrap();
             let mock_resource_threads = ResourceThreads::new(core_sender);
-            let mock_compositor_api = CrossProcessCompositorApi::dummy();
+            let mock_paint_api = CrossProcessPaintApi::dummy();
 
             let proxy_clone = Arc::new(system_font_service_proxy.to_sender().to_proxy());
             INIT.call_once(|| {
                 start_fetch_thread();
             });
             Self {
-                context: FontContext::new(proxy_clone, mock_compositor_api, mock_resource_threads),
+                context: FontContext::new(proxy_clone, mock_paint_api, mock_resource_threads),
                 system_font_service,
                 system_font_service_proxy,
             }

--- a/components/layout/display_list/background.rs
+++ b/components/layout/display_list/background.rs
@@ -65,11 +65,7 @@ impl<'a> BackgroundPainter<'a> {
         if &BackgroundAttachment::Fixed ==
             get_cyclic(&background.background_attachment.0, layer_index)
         {
-            return builder
-                .compositor_info
-                .viewport_details
-                .layout_size()
-                .into();
+            return builder.paint_info.viewport_details.layout_size().into();
         }
 
         match get_cyclic(&background.background_clip.0, layer_index) {
@@ -153,11 +149,7 @@ impl<'a> BackgroundPainter<'a> {
                 Origin::PaddingBox => *fragment_builder.padding_rect(),
                 Origin::BorderBox => fragment_builder.border_rect,
             },
-            BackgroundAttachment::Fixed => builder
-                .compositor_info
-                .viewport_details
-                .layout_size()
-                .into(),
+            BackgroundAttachment::Fixed => builder.paint_info.viewport_details.layout_size().into(),
         }
     }
 }

--- a/components/layout/display_list/hit_test.rs
+++ b/components/layout/display_list/hit_test.rs
@@ -101,7 +101,7 @@ impl<'a> HitTest<'a> {
 
         let transform = self
             .stacking_context_tree
-            .compositor_info
+            .paint_info
             .scroll_tree
             .cumulative_root_to_node_transform(scroll_tree_node_id)?;
 
@@ -268,7 +268,7 @@ impl Fragment {
                 if is_root_element {
                     let viewport_size = hit_test
                         .stacking_context_tree
-                        .compositor_info
+                        .paint_info
                         .viewport_details
                         .size;
                     let viewport_rect = LayoutRect::from_origin_and_size(

--- a/components/layout/display_list/largest_contenful_paint_candidate_collector.rs
+++ b/components/layout/display_list/largest_contenful_paint_candidate_collector.rs
@@ -17,7 +17,7 @@ pub(crate) struct LargestContentfulPaintCandidateCollector {
     /// The rect of viewport.
     pub viewport_rect: LayoutRect,
     /// Flag to indicate if there is an update to LCP candidate.
-    /// This is used to avoid sending duplicate LCP candidates to the compositor.
+    /// This is used to avoid sending duplicate LCP candidates to `Paint`.
     pub did_lcp_candidate_update: bool,
 }
 

--- a/components/layout/display_list/stacking_context.rs
+++ b/components/layout/display_list/stacking_context.rs
@@ -11,7 +11,7 @@ use app_units::Au;
 use base::id::ScrollTreeNodeId;
 use base::print_tree::PrintTree;
 use compositing_traits::display_list::{
-    AxesScrollSensitivity, CompositorDisplayListInfo, ReferenceFrameNodeInfo, ScrollableNodeInfo,
+    AxesScrollSensitivity, PaintDisplayListInfo, ReferenceFrameNodeInfo, ScrollableNodeInfo,
     SpatialTreeNodeInfo, StickyNodeInfo,
 };
 use embedder_traits::ViewportDetails;
@@ -106,11 +106,11 @@ pub(crate) struct StackingContextTree {
     /// The root stacking context of this [`StackingContextTree`].
     pub root_stacking_context: StackingContext,
 
-    /// The information about the WebRender display list that the compositor
+    /// The information about the WebRender display list that `Paint`
     /// consumes. This curerntly contains the out-of-band hit testing information
-    /// data structure that the compositor uses to map hit tests to information
+    /// data structure that `Paint` uses to map hit tests to information
     /// about the item hit.
-    pub compositor_info: CompositorDisplayListInfo,
+    pub paint_info: PaintDisplayListInfo,
 
     /// All of the clips collected for this [`StackingContextTree`]. These are added
     /// for things like `overflow`. More clips may be created later during WebRender
@@ -135,7 +135,7 @@ impl StackingContextTree {
         ));
 
         let viewport_size = viewport_details.layout_size();
-        let compositor_info = CompositorDisplayListInfo::new(
+        let paint_info = PaintDisplayListInfo::new(
             viewport_details,
             scrollable_overflow,
             pipeline_id,
@@ -145,7 +145,7 @@ impl StackingContextTree {
             first_reflow,
         );
 
-        let root_scroll_node_id = compositor_info.root_scroll_node_id;
+        let root_scroll_node_id = paint_info.root_scroll_node_id;
         let cb_for_non_fixed_descendants = ContainingBlock::new(
             fragment_tree.initial_containing_block,
             root_scroll_node_id,
@@ -154,7 +154,7 @@ impl StackingContextTree {
         );
         let cb_for_fixed_descendants = ContainingBlock::new(
             fragment_tree.initial_containing_block,
-            compositor_info.root_reference_frame_id,
+            paint_info.root_reference_frame_id,
             None,
             ClipId::INVALID,
         );
@@ -174,7 +174,7 @@ impl StackingContextTree {
         let mut stacking_context_tree = Self {
             // This is just a temporary value that will be replaced once we have finished building the tree.
             root_stacking_context: StackingContext::create_root(root_scroll_node_id, debug),
-            compositor_info,
+            paint_info,
             clip_store: Default::default(),
         };
 
@@ -209,7 +209,7 @@ impl StackingContextTree {
         transform: LayoutTransform,
         kind: wr::ReferenceFrameKind,
     ) -> ScrollTreeNodeId {
-        self.compositor_info.scroll_tree.add_scroll_tree_node(
+        self.paint_info.scroll_tree.add_scroll_tree_node(
             Some(parent_scroll_node_id),
             SpatialTreeNodeInfo::ReferenceFrame(ReferenceFrameNodeInfo {
                 origin,
@@ -229,7 +229,7 @@ impl StackingContextTree {
         clip_rect: LayoutRect,
         scroll_sensitivity: AxesScrollSensitivity,
     ) -> ScrollTreeNodeId {
-        self.compositor_info.scroll_tree.add_scroll_tree_node(
+        self.paint_info.scroll_tree.add_scroll_tree_node(
             Some(parent_scroll_node_id),
             SpatialTreeNodeInfo::Scroll(ScrollableNodeInfo {
                 external_id,
@@ -250,7 +250,7 @@ impl StackingContextTree {
         vertical_offset_bounds: StickyOffsetBounds,
         horizontal_offset_bounds: StickyOffsetBounds,
     ) -> ScrollTreeNodeId {
-        self.compositor_info.scroll_tree.add_scroll_tree_node(
+        self.paint_info.scroll_tree.add_scroll_tree_node(
             Some(parent_scroll_node_id),
             SpatialTreeNodeInfo::Sticky(StickyNodeInfo {
                 frame_rect,
@@ -1505,7 +1505,7 @@ impl BoxFragment {
         let tag = self.base.tag?;
         let external_scroll_id = wr::ExternalScrollId(
             tag.to_display_list_fragment_id(),
-            stacking_context_tree.compositor_info.pipeline_id,
+            stacking_context_tree.paint_info.pipeline_id,
         );
 
         let sensitivity = AxesScrollSensitivity {
@@ -1546,7 +1546,7 @@ impl BoxFragment {
             None => {
                 // This is a direct descendant of a reference frame.
                 &stacking_context_tree
-                    .compositor_info
+                    .paint_info
                     .viewport_details
                     .layout_size()
             },

--- a/components/layout/query.rs
+++ b/components/layout/query.rs
@@ -116,7 +116,7 @@ pub(crate) fn process_box_area_request(
     }
 
     let Some(transform) =
-        root_transform_for_layout_node(&stacking_context_tree.compositor_info.scroll_tree, node)
+        root_transform_for_layout_node(&stacking_context_tree.paint_info.scroll_tree, node)
     else {
         return Some(Rect::new(rect_union.origin, Size2D::zero()));
     };
@@ -136,7 +136,7 @@ pub(crate) fn process_box_areas_request(
         .map(|rect| rect.to_untyped());
 
     let Some(transform) =
-        root_transform_for_layout_node(&stacking_context_tree.compositor_info.scroll_tree, node)
+        root_transform_for_layout_node(&stacking_context_tree.paint_info.scroll_tree, node)
     else {
         return box_areas
             .map(|rect| Rect::new(rect.origin, Size2D::zero()))

--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -375,7 +375,7 @@ pub(crate) struct Document {
     /// Whether we're in the process of running animation callbacks.
     ///
     /// Tracking this is not necessary for correctness. Instead, it is an optimization to avoid
-    /// sending needless `ChangeRunningAnimationsState` messages to the compositor.
+    /// sending needless `ChangeRunningAnimationsState` messages to `Paint`.
     running_animation_callbacks: Cell<bool>,
     /// Tracks all outstanding loads related to this document.
     loader: DomRefCell<DocumentLoader>,
@@ -2801,7 +2801,7 @@ impl Document {
         if !image_keys.is_empty() {
             results.insert(ReflowPhasesRun::UpdatedImageData);
             self.waiting_on_canvas_image_updates.set(true);
-            self.window().compositor_api().delay_new_frame_for_canvas(
+            self.window().paint_api().delay_new_frame_for_canvas(
                 self.webview_id(),
                 self.window().pipeline_id(),
                 current_rendering_epoch,
@@ -2811,7 +2811,7 @@ impl Document {
 
         let results = results.union(self.window().reflow(ReflowGoal::UpdateTheRendering));
 
-        self.window().compositor_api().update_epoch(
+        self.window().paint_api().update_epoch(
             self.webview_id(),
             pipeline_id,
             current_rendering_epoch,

--- a/components/script/dom/html/htmlmetaelement.rs
+++ b/components/script/dom/html/htmlmetaelement.rs
@@ -144,7 +144,7 @@ impl HTMLMetaElement {
 
         if let Ok(viewport) = ViewportDescription::from_str(&content.value()) {
             self.owner_window()
-                .compositor_api()
+                .paint_api()
                 .viewport(self.owner_window().webview_id(), viewport);
         }
     }

--- a/components/script/dom/inputevent.rs
+++ b/components/script/dom/inputevent.rs
@@ -120,7 +120,7 @@ impl InputEventMethods<crate::DomTypeHolder> for InputEvent {
 }
 
 /// A [`HitTestResult`] that is the result of doing a hit test based on a less-fine-grained
-/// `CompositorHitTestResult` against our current layout.
+/// `PaintHitTestResult` against our current layout.
 pub(crate) struct HitTestResult {
     pub node: DomRoot<Node>,
     pub cursor: Cursor,

--- a/components/script/image_animation.rs
+++ b/components/script/image_animation.rs
@@ -79,7 +79,7 @@ impl ImageAnimationManager {
             })
             .collect();
         window
-            .compositor_api()
+            .paint_api()
             .update_images(window.webview_id().into(), updates);
 
         self.maybe_schedule_update(window, now);

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -40,7 +40,7 @@ use base::id::{
 };
 use canvas_traits::webgl::WebGLPipeline;
 use chrono::{DateTime, Local};
-use compositing_traits::{CrossProcessCompositorApi, PipelineExitSource};
+use compositing_traits::{CrossProcessPaintApi, PipelineExitSource};
 use constellation_traits::{
     JsEvalResult, LoadData, LoadOrigin, NavigationHistoryBehavior, ScreenshotReadinessResponse,
     ScriptToConstellationChan, ScriptToConstellationMessage, StructuredSerializedData,
@@ -306,9 +306,9 @@ pub struct ScriptThread {
     /// <https://html.spec.whatwg.org/multipage/#custom-element-reactions-stack>
     custom_element_reaction_stack: Rc<CustomElementReactionStack>,
 
-    /// Cross-process access to the compositor's API.
+    /// Cross-process access to `Paint`'s API.
     #[no_trace]
-    compositor_api: CrossProcessCompositorApi,
+    paint_api: CrossProcessPaintApi,
 
     /// Periodically print out on which events script threads spend their processing time.
     profile_script_events: bool,
@@ -963,7 +963,7 @@ impl ScriptThread {
             worklet_thread_pool: Default::default(),
             docs_with_no_blocking_loads: Default::default(),
             custom_element_reaction_stack: Rc::new(CustomElementReactionStack::new()),
-            compositor_api: state.cross_process_compositor_api,
+            paint_api: state.cross_process_paint_api,
             profile_script_events: opts.debug.profile_script_events,
             print_pwm: opts.print_pwm,
             unminify_js: opts.unminify_js,
@@ -1018,15 +1018,15 @@ impl ScriptThread {
         debug!("Stopped script thread.");
     }
 
-    /// Process compositor events as part of a "update the rendering task".
+    /// Process input events as part of a "update the rendering task".
     fn process_pending_input_events(&self, pipeline_id: PipelineId, can_gc: CanGc) {
         let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
-            warn!("Processing pending compositor events for closed pipeline {pipeline_id}.");
+            warn!("Processing pending input events for closed pipeline {pipeline_id}.");
             return;
         };
         // Do not handle events if the BC has been, or is being, discarded
         if document.window().Closed() {
-            warn!("Compositor event sent to a pipeline with a closed window {pipeline_id}.");
+            warn!("Paint event sent to a pipeline with a closed window {pipeline_id}.");
             return;
         }
 
@@ -1122,7 +1122,7 @@ impl ScriptThread {
 
             // TODO(#31581): The steps in the "Revealing the document" section need to be implemented
             // `process_pending_input_events` handles the focusing steps as well as other events
-            // from the compositor.
+            // from `Paint`.
 
             // TODO: Should this be broken and to match the specification more closely? For instance see
             // https://html.spec.whatwg.org/multipage/#flush-autofocus-candidates.
@@ -1205,7 +1205,7 @@ impl ScriptThread {
 
         let should_generate_frame = !painters_generating_frames.is_empty();
         if should_generate_frame {
-            self.compositor_api
+            self.paint_api
                 .generate_frame(painters_generating_frames.into_iter().collect());
         }
 
@@ -2960,7 +2960,7 @@ impl ScriptThread {
             ))
             .ok();
 
-        self.compositor_api
+        self.paint_api
             .pipeline_exited(webview_id, pipeline_id, PipelineExitSource::Script);
 
         debug!("{pipeline_id}: Finished pipeline exit");
@@ -3128,14 +3128,14 @@ impl ScriptThread {
 
         let font_context = Arc::new(FontContext::new(
             self.system_font_service.clone(),
-            self.compositor_api.clone(),
+            self.paint_api.clone(),
             self.resource_threads.clone(),
         ));
 
         let image_cache = self.image_cache_factory.create(
             incomplete.webview_id,
             incomplete.pipeline_id,
-            &self.compositor_api,
+            &self.paint_api,
         );
 
         let layout_config = LayoutConfig {
@@ -3147,7 +3147,7 @@ impl ScriptThread {
             image_cache: image_cache.clone(),
             font_context: font_context.clone(),
             time_profiler_chan: self.senders.time_profiler_sender.clone(),
-            compositor_api: self.compositor_api.clone(),
+            paint_api: self.paint_api.clone(),
             viewport_details: incomplete.viewport_details,
             theme: incomplete.theme,
         };
@@ -3185,7 +3185,7 @@ impl ScriptThread {
             self.webgl_chan.as_ref().map(|chan| chan.channel()),
             #[cfg(feature = "webxr")]
             self.webxr_registry.clone(),
-            self.compositor_api.clone(),
+            self.paint_api.clone(),
             self.unminify_js,
             self.unminify_css,
             self.local_script_source.clone(),
@@ -3400,8 +3400,7 @@ impl ScriptThread {
         }
     }
 
-    /// Queue compositor events for later dispatching as part of a
-    /// `update_the_rendering` task.
+    /// Queue input events for later dispatching as part of a `update_the_rendering` task.
     fn handle_input_event(
         &self,
         webview_id: WebViewId,
@@ -3409,7 +3408,7 @@ impl ScriptThread {
         event: ConstellationInputEvent,
     ) {
         let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
-            warn!("Compositor event sent to closed pipeline {pipeline_id}.");
+            warn!("Paint event sent to closed pipeline {pipeline_id}.");
             let _ = self
                 .senders
                 .pipeline_to_embedder_sender

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -1026,7 +1026,7 @@ impl ScriptThread {
         };
         // Do not handle events if the BC has been, or is being, discarded
         if document.window().Closed() {
-            warn!("Paint event sent to a pipeline with a closed window {pipeline_id}.");
+            warn!("Input event sent to a pipeline with a closed window {pipeline_id}.");
             return;
         }
 
@@ -3408,7 +3408,7 @@ impl ScriptThread {
         event: ConstellationInputEvent,
     ) {
         let Some(document) = self.documents.borrow().find_document(pipeline_id) else {
-            warn!("Paint event sent to closed pipeline {pipeline_id}.");
+            warn!("Input event sent to closed pipeline {pipeline_id}.");
             let _ = self
                 .senders
                 .pipeline_to_embedder_sender

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -508,7 +508,7 @@ impl ServiceWorkerManagerFactory for ServiceWorkerManager {
             receiver,
             swmanager_sender: constellation_sender,
             system_font_service_sender,
-            paint_aip: paint_api,
+            paint_api,
         } = sw_senders;
 
         let from_constellation = receiver.route_preserving_errors();

--- a/components/script/serviceworker_manager.rs
+++ b/components/script/serviceworker_manager.rs
@@ -508,7 +508,7 @@ impl ServiceWorkerManagerFactory for ServiceWorkerManager {
             receiver,
             swmanager_sender: constellation_sender,
             system_font_service_sender,
-            compositor_api,
+            paint_aip: paint_api,
         } = sw_senders;
 
         let from_constellation = receiver.route_preserving_errors();
@@ -519,7 +519,7 @@ impl ServiceWorkerManagerFactory for ServiceWorkerManager {
 
         let font_context = Arc::new(FontContext::new(
             Arc::new(system_font_service_sender.to_proxy()),
-            compositor_api,
+            paint_api,
             resource_threads,
         ));
 

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -17,9 +17,9 @@ use base::id::{PipelineNamespace, PipelineNamespaceId};
 use bluetooth::BluetoothThreadFactory;
 #[cfg(feature = "bluetooth")]
 use bluetooth_traits::BluetoothRequest;
-use compositing::{IOCompositor, InitialCompositorState};
+use compositing::{InitialPaintState, Paint};
 pub use compositing_traits::rendering_context::RenderingContext;
-use compositing_traits::{CompositorMsg, CompositorProxy, CrossProcessCompositorApi};
+use compositing_traits::{CrossProcessPaintApi, PaintMessage, PaintProxy};
 #[cfg(all(
     not(target_os = "windows"),
     not(target_os = "ios"),
@@ -135,7 +135,7 @@ mod media_platform {
 
 struct ServoInner {
     delegate: RefCell<Rc<dyn ServoDelegate>>,
-    compositor: Rc<RefCell<IOCompositor>>,
+    paint: Rc<RefCell<Paint>>,
     constellation_proxy: ConstellationProxy,
     embedder_receiver: Receiver<EmbedderMsg>,
     public_resource_threads: ResourceThreads,
@@ -172,20 +172,20 @@ impl ServoInner {
         }
 
         {
-            let compositor = self.compositor.borrow();
+            let paint = self.paint.borrow();
             let mut messages = Vec::new();
-            while let Ok(message) = compositor.receiver().try_recv() {
+            while let Ok(message) = paint.receiver().try_recv() {
                 match message {
                     Ok(message) => messages.push(message),
                     Err(error) => {
-                        warn!("Router deserialization error: {error}. Ignoring this CompositorMsg.")
+                        warn!("Router deserialization error: {error}. Ignoring this PaintMessage.")
                     },
                 }
             }
-            compositor.handle_messages(messages);
+            paint.handle_messages(messages);
         }
 
-        // Only handle incoming embedder messages if the compositor hasn't already started shutting down.
+        // Only handle incoming embedder messages if `Paint` hasn't already started shutting down.
         while let Ok(message) = self.embedder_receiver.try_recv() {
             self.handle_embedder_message(message);
 
@@ -200,7 +200,7 @@ impl ServoInner {
                 .notify_error(ServoError::LostConnectionWithBackend);
         }
 
-        self.compositor.borrow_mut().perform_updates();
+        self.paint.borrow_mut().perform_updates();
         self.send_new_frame_ready_messages();
         self.handle_delegate_errors();
         self.clean_up_destroyed_webview_handles();
@@ -213,7 +213,7 @@ impl ServoInner {
     }
 
     fn send_new_frame_ready_messages(&self) {
-        let webviews_needing_repaint = self.compositor.borrow().webviews_needing_repaint();
+        let webviews_needing_repaint = self.paint.borrow().webviews_needing_repaint();
 
         for webview in webviews_needing_repaint
             .iter()
@@ -242,7 +242,7 @@ impl ServoInner {
     fn finish_shutting_down(&self) {
         debug!("Servo received message that Constellation shutdown is complete");
         self.shutdown_state.set(ShutdownState::FinishedShuttingDown);
-        self.compositor.borrow_mut().finish_shutting_down();
+        self.paint.borrow_mut().finish_shutting_down();
     }
 
     fn handle_embedder_message(&self, message: EmbedderMsg) {
@@ -364,7 +364,7 @@ impl ServoInner {
                     .finish_evaluation(evaluation_id, result);
             },
             EmbedderMsg::InputEventHandled(webview_id, input_event_id, result) => {
-                self.compositor.borrow_mut().notify_input_event_handled(
+                self.paint.borrow_mut().notify_input_event_handled(
                     webview_id,
                     input_event_id,
                     result,
@@ -682,12 +682,11 @@ impl Servo {
         PipelineNamespace::install(PipelineNamespaceId(0));
 
         // Get both endpoints of a special channel for communication between
-        // the client window and the compositor. This channel is unique because
+        // the client window and `Paint`. This channel is unique because
         // messages to client may need to pump a platform-specific event loop
         // to deliver the message.
         let event_loop_waker = builder.event_loop_waker;
-        let (compositor_proxy, compositor_receiver) =
-            create_compositor_channel(event_loop_waker.clone());
+        let (paint_proxy, paint_receiver) = create_paint_channel(event_loop_waker.clone());
         let (constellation_proxy, embedder_to_constellation_receiver) = ConstellationProxy::new();
         let (embedder_proxy, embedder_receiver) = create_embedder_channel(event_loop_waker.clone());
         let time_profiler_chan = profile_time::Profiler::create(
@@ -718,12 +717,12 @@ impl Servo {
         let mut protocols = ProtocolRegistry::with_internal_protocols();
         protocols.merge(builder.protocol_registry);
 
-        // The compositor coordinates with the client window to create the final
+        // The `Paint` coordinates with the client window to create the final
         // rendered page and display it somewhere.
         let shutdown_state = Rc::new(Cell::new(ShutdownState::NotShuttingDown));
-        let compositor = IOCompositor::new(InitialCompositorState {
-            compositor_proxy: compositor_proxy.clone(),
-            receiver: compositor_receiver,
+        let paint = Paint::new(InitialPaintState {
+            paint_proxy: paint_proxy.clone(),
+            receiver: paint_receiver,
             embedder_to_constellation_sender: constellation_proxy.sender().clone(),
             time_profiler_chan: time_profiler_chan.clone(),
             mem_profiler_chan: mem_profiler_chan.clone(),
@@ -748,10 +747,10 @@ impl Servo {
 
         create_constellation(
             embedder_to_constellation_receiver,
-            &compositor.borrow(),
+            &paint.borrow(),
             opts.config_dir.clone(),
             embedder_proxy,
-            compositor_proxy.clone(),
+            paint_proxy.clone(),
             time_profiler_chan,
             mem_profiler_chan,
             devtools_sender,
@@ -768,7 +767,7 @@ impl Servo {
 
         Servo(Rc::new(ServoInner {
             delegate: RefCell::new(Rc::new(DefaultServoDelegate)),
-            compositor,
+            paint,
             javascript_evaluator: Rc::new(RefCell::new(JavaScriptEvaluator::new(
                 constellation_proxy.clone(),
             ))),
@@ -799,9 +798,9 @@ impl Servo {
 
     /// Spin the Servo event loop, which:
     ///
-    ///   - Performs updates in the compositor, such as queued pinch zoom events
+    ///   - Performs updates in `Paint`, such as queued pinch zoom events
     ///   - Runs delebgate methods on all `WebView`s and `Servo` itself
-    ///   - Maybe update the rendered compositor output, but *without* swapping buffers.
+    ///   - Maybe update the rendered `Paint` output, but *without* swapping buffers.
     pub fn spin_event_loop(&self) {
         self.0.spin_event_loop();
     }
@@ -846,12 +845,12 @@ impl Servo {
         self.0.private_resource_threads.clear_cookies();
     }
 
-    pub(crate) fn compositor<'a>(&'a self) -> Ref<'a, IOCompositor> {
-        self.0.compositor.borrow()
+    pub(crate) fn paint<'a>(&'a self) -> Ref<'a, Paint> {
+        self.0.paint.borrow()
     }
 
-    pub(crate) fn compositor_mut<'a>(&'a self) -> RefMut<'a, IOCompositor> {
-        self.0.compositor.borrow_mut()
+    pub(crate) fn paint_mut<'a>(&'a self) -> RefMut<'a, Paint> {
+        self.0.paint.borrow_mut()
     }
 
     pub(crate) fn webviews_mut<'a>(
@@ -882,14 +881,14 @@ fn create_embedder_channel(
     )
 }
 
-fn create_compositor_channel(
+fn create_paint_channel(
     event_loop_waker: Box<dyn EventLoopWaker>,
-) -> (CompositorProxy, RoutedReceiver<CompositorMsg>) {
+) -> (PaintProxy, RoutedReceiver<PaintMessage>) {
     let (sender, receiver) = unbounded();
     let sender_clone = sender.clone();
     let event_loop_waker_clone = event_loop_waker.clone();
-    // This callback is equivalent to `CompositorProxy::send`
-    let result_callback = move |msg: Result<CompositorMsg, ipc_channel::Error>| {
+    // This callback is equivalent to `PaintProxy::send`
+    let result_callback = move |msg: Result<PaintMessage, ipc_channel::Error>| {
         if let Err(err) = sender_clone.send(msg) {
             warn!("Failed to send response ({:?}).", err);
         }
@@ -898,23 +897,23 @@ fn create_compositor_channel(
 
     let generic_callback =
         GenericCallback::new(result_callback).expect("Failed to create callback");
-    let cross_process_compositor_api = CrossProcessCompositorApi::new(generic_callback);
-    let compositor_proxy = CompositorProxy {
+    let cross_process_paint_api = CrossProcessPaintApi::new(generic_callback);
+    let paint_proxy = PaintProxy {
         sender,
-        cross_process_compositor_api,
+        cross_process_paint_api,
         event_loop_waker,
     };
 
-    (compositor_proxy, receiver)
+    (paint_proxy, receiver)
 }
 
 #[allow(clippy::too_many_arguments)]
 fn create_constellation(
     embedder_to_constellation_receiver: Receiver<EmbedderToConstellationMessage>,
-    compositor: &IOCompositor,
+    paint: &Paint,
     config_dir: Option<PathBuf>,
     embedder_proxy: EmbedderProxy,
-    compositor_proxy: CompositorProxy,
+    paint_proxy: PaintProxy,
     time_profiler_chan: time::ProfilerChan,
     mem_profiler_chan: mem::ProfilerChan,
     devtools_sender: Option<Sender<devtools_traits::DevtoolsControlMsg>>,
@@ -938,14 +937,14 @@ fn create_constellation(
 
     let system_font_service = Arc::new(
         SystemFontService::spawn(
-            compositor_proxy.cross_process_compositor_api.clone(),
+            paint_proxy.cross_process_paint_api.clone(),
             mem_profiler_chan.clone(),
         )
         .to_proxy(),
     );
 
     let initial_state = InitialConstellationState {
-        compositor_proxy,
+        paint_proxy,
         embedder_proxy,
         devtools_sender,
         #[cfg(feature = "bluetooth")]
@@ -958,13 +957,13 @@ fn create_constellation(
         time_profiler_chan,
         mem_profiler_chan,
         #[cfg(feature = "webxr")]
-        webxr_registry: Some(compositor.webxr_main_thread_registry()),
+        webxr_registry: Some(paint.webxr_main_thread_registry()),
         #[cfg(not(feature = "webxr"))]
         webxr_registry: None,
-        webgl_threads: Some(compositor.webgl_threads()),
-        webrender_external_image_id_manager: compositor.webrender_external_image_id_manager(),
+        webgl_threads: Some(paint.webgl_threads()),
+        webrender_external_image_id_manager: paint.webrender_external_image_id_manager(),
         #[cfg(feature = "webgpu")]
-        wgpu_image_map: compositor.webgpu_image_map(),
+        wgpu_image_map: paint.webgpu_image_map(),
         user_content_manager,
         async_runtime,
         privileged_urls,

--- a/components/shared/compositing/display_list.rs
+++ b/components/shared/compositing/display_list.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! Defines data structures which are consumed by the Compositor.
+//! Defines data structures which are consumed by `Paint`.
 
 use std::cell::Cell;
 use std::collections::HashMap;
@@ -419,12 +419,12 @@ impl ScrollTreeNode {
 }
 
 /// A tree of spatial nodes, which mirrors the spatial nodes in the WebRender
-/// display list, except these are used to scrolling in the compositor so that
+/// display list, except these are used to scrolling in `Paint` so that
 /// new offsets can be sent to WebRender.
 #[derive(Debug, Default, Deserialize, MallocSizeOf, Serialize)]
 pub struct ScrollTree {
-    /// A list of compositor-side scroll nodes that describe the tree
-    /// of WebRender spatial nodes, used by the compositor to scroll the
+    /// A list of `Paint`-side scroll nodes that describe the tree
+    /// of WebRender spatial nodes, used by `Paint` to scroll the
     /// contents of the display list.
     pub nodes: Vec<ScrollTreeNode>,
 }
@@ -799,10 +799,10 @@ impl ScrollTree {
     }
 }
 
-/// A data structure which stores compositor-side information about
-/// display lists sent to the compositor.
+/// A data structure which stores `Paint`-side information about
+/// display lists sent to `Paint`.
 #[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
-pub struct CompositorDisplayListInfo {
+pub struct PaintDisplayListInfo {
     /// The WebRender [PipelineId] of this display list.
     pub pipeline_id: PipelineId,
 
@@ -816,7 +816,7 @@ pub struct CompositorDisplayListInfo {
     /// The epoch of the display list.
     pub epoch: Epoch,
 
-    /// A ScrollTree used by the compositor to scroll the contents of the
+    /// A ScrollTree used by `Paint` to scroll the contents of the
     /// display list.
     pub scroll_tree: ScrollTree,
 
@@ -838,8 +838,8 @@ pub struct CompositorDisplayListInfo {
     pub first_reflow: bool,
 }
 
-impl CompositorDisplayListInfo {
-    /// Create a new CompositorDisplayListInfo with the root reference frame
+impl PaintDisplayListInfo {
+    /// Create a new PaintDisplayListInfo with the root reference frame
     /// and scroll frame already added to the scroll tree.
     pub fn new(
         viewport_details: ViewportDetails,
@@ -875,7 +875,7 @@ impl CompositorDisplayListInfo {
             }),
         );
 
-        CompositorDisplayListInfo {
+        PaintDisplayListInfo {
             pipeline_id,
             viewport_details,
             content_size,

--- a/components/shared/compositing/display_list.rs
+++ b/components/shared/compositing/display_list.rs
@@ -419,7 +419,7 @@ impl ScrollTreeNode {
 }
 
 /// A tree of spatial nodes, which mirrors the spatial nodes in the WebRender
-/// display list, except these are used to scrolling in `Paint` so that
+/// display list, except these are used for scrolling in `Paint` so that
 /// new offsets can be sent to WebRender.
 #[derive(Debug, Default, Deserialize, MallocSizeOf, Serialize)]
 pub struct ScrollTree {

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -14,7 +14,7 @@ use base::id::{
     ServiceWorkerRegistrationId, WebViewId,
 };
 use canvas_traits::canvas::{CanvasId, CanvasMsg};
-use compositing_traits::CrossProcessCompositorApi;
+use compositing_traits::CrossProcessPaintApi;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId};
 use embedder_traits::{
@@ -236,8 +236,8 @@ pub struct SWManagerSenders {
     pub swmanager_sender: GenericSender<SWManagerMsg>,
     /// [`ResourceThreads`] for initating fetches or using i/o.
     pub resource_threads: ResourceThreads,
-    /// [`CrossProcessCompositorApi`] for communicating with the compositor.
-    pub compositor_api: CrossProcessCompositorApi,
+    /// [`CrossProcessPaintApi`] for communicating with `Paint`.
+    pub paint_aip: CrossProcessPaintApi,
     /// The [`SystemFontServiceProxy`] used to communicate with the `SystemFontService`.
     pub system_font_service_sender: SystemFontServiceProxySender,
     /// Sender of messages to the manager.

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -237,7 +237,7 @@ pub struct SWManagerSenders {
     /// [`ResourceThreads`] for initating fetches or using i/o.
     pub resource_threads: ResourceThreads,
     /// [`CrossProcessPaintApi`] for communicating with `Paint`.
-    pub paint_aip: CrossProcessPaintApi,
+    pub paint_api: CrossProcessPaintApi,
     /// The [`SystemFontServiceProxy`] used to communicate with the `SystemFontService`.
     pub system_font_service_sender: SystemFontServiceProxySender,
     /// Sender of messages to the manager.

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -19,8 +19,8 @@ use base::cross_process_instant::CrossProcessInstant;
 use base::id::{MessagePortId, PipelineId, ScriptEventLoopId, WebViewId};
 use compositing_traits::largest_contentful_paint_candidate::LargestContentfulPaintType;
 use embedder_traits::{
-    CompositorHitTestResult, EmbedderControlId, EmbedderControlResponse, InputEventAndId,
-    JavaScriptEvaluationId, MediaSessionActionType, Theme, TraversalId, ViewportDetails,
+    EmbedderControlId, EmbedderControlResponse, InputEventAndId, JavaScriptEvaluationId,
+    MediaSessionActionType, PaintHitTestResult, Theme, TraversalId, ViewportDetails,
     WebDriverCommandMsg,
 };
 pub use from_script_message::*;
@@ -79,7 +79,7 @@ pub enum EmbedderToConstellationMessage {
     /// Make none of the webviews focused.
     BlurWebView,
     /// Forward an input event to an appropriate ScriptTask.
-    ForwardInputEvent(WebViewId, InputEventAndId, Option<CompositorHitTestResult>),
+    ForwardInputEvent(WebViewId, InputEventAndId, Option<PaintHitTestResult>),
     /// Request that the given pipeline refresh the cursor by doing a hit test at the most
     /// recently hovered cursor position and resetting the cursor. This happens after a
     /// display list update is rendered.

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -306,7 +306,7 @@ pub struct ViewportDetails {
     pub size: Size2D<f32, CSSPixel>,
 
     /// The scale factor to use to account for HiDPI scaling. This does not take into account
-    /// any page or pinch zoom applied by the compositor to the contents.
+    /// any page or pinch zoom applied by `Paint` to the contents.
     pub hidpi_scale_factor: Scale<f32, CSSPixel, DevicePixel>,
 }
 
@@ -877,9 +877,9 @@ impl UntrustedNodeAddress {
     }
 }
 
-/// The result of a hit test in the compositor.
+/// The result of a hit test in `Paint`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct CompositorHitTestResult {
+pub struct PaintHitTestResult {
     /// The pipeline id of the resulting item.
     pub pipeline_id: PipelineId,
 

--- a/components/shared/layout/lib.rs
+++ b/components/shared/layout/lib.rs
@@ -24,7 +24,7 @@ use base::Epoch;
 use base::generic_channel::GenericSender;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use bitflags::bitflags;
-use compositing_traits::CrossProcessCompositorApi;
+use compositing_traits::CrossProcessPaintApi;
 use embedder_traits::{Cursor, Theme, UntrustedNodeAddress, ViewportDetails};
 use euclid::Point2D;
 use euclid::default::{Point2D as UntypedPoint2D, Rect};
@@ -209,7 +209,7 @@ pub struct LayoutConfig {
     pub image_cache: Arc<dyn ImageCache>,
     pub font_context: Arc<FontContext>,
     pub time_profiler_chan: time::ProfilerChan,
-    pub compositor_api: CrossProcessCompositorApi,
+    pub paint_api: CrossProcessPaintApi,
     pub viewport_details: ViewportDetails,
     pub theme: Theme,
 }
@@ -297,7 +297,7 @@ pub trait Layout {
         painter: Box<dyn Painter>,
     );
 
-    /// Set the scroll states of this layout after a compositor scroll.
+    /// Set the scroll states of this layout after a `Paint` scroll.
     fn set_scroll_offsets_from_renderer(
         &mut self,
         scroll_states: &FxHashMap<ExternalScrollId, LayoutVector2D>,

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use base::id::{PipelineId, WebViewId};
-use compositing_traits::CrossProcessCompositorApi;
+use compositing_traits::CrossProcessPaintApi;
 use log::debug;
 use malloc_size_of::MallocSizeOfOps;
 use malloc_size_of_derive::MallocSizeOf;
@@ -164,7 +164,7 @@ pub trait ImageCacheFactory: Sync + Send {
         &self,
         webview_id: WebViewId,
         pipeline_id: PipelineId,
-        compositor_api: &CrossProcessCompositorApi,
+        paint_api: &CrossProcessPaintApi,
     ) -> Arc<dyn ImageCache>;
 }
 

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -61,7 +61,7 @@ pub enum ProfilerMsg {
 #[repr(u32)]
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum ProfilerCategory {
-    /// The compositor is rasterising or presenting.
+    /// `Paint` is rasterising or presenting.
     ///
     /// Not associated with a specific URL.
     Compositing = 0x00,

--- a/components/shared/profile/time.rs
+++ b/components/shared/profile/time.rs
@@ -64,7 +64,7 @@ pub enum ProfilerCategory {
     /// `Paint` is rasterising or presenting.
     ///
     /// Not associated with a specific URL.
-    Compositing = 0x00,
+    Painting = 0x00,
 
     /// The script thread is doing layout work.
     Layout = 0x10,
@@ -128,7 +128,7 @@ pub enum ProfilerCategory {
 impl ProfilerCategory {
     pub const fn variant_name(&self) -> &'static str {
         match self {
-            ProfilerCategory::Compositing => "Compositing",
+            ProfilerCategory::Painting => "Painting",
             ProfilerCategory::Layout => "Layout",
             ProfilerCategory::ImageSaving => "ImageSaving",
             ProfilerCategory::ScriptSpawnPipeline => "ScriptSpawnPipeline",

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -20,7 +20,7 @@ use base::id::{
 #[cfg(feature = "bluetooth")]
 use bluetooth_traits::BluetoothRequest;
 use canvas_traits::webgl::WebGLPipeline;
-use compositing_traits::CrossProcessCompositorApi;
+use compositing_traits::CrossProcessPaintApi;
 use compositing_traits::largest_contentful_paint_candidate::LargestContentfulPaintType;
 use constellation_traits::{
     KeyboardScroll, LoadData, NavigationHistoryBehavior, ScriptToConstellationSender,
@@ -30,9 +30,9 @@ use crossbeam_channel::RecvTimeoutError;
 use devtools_traits::ScriptToDevtoolsControlMsg;
 use embedder_traits::user_content_manager::UserContentManager;
 use embedder_traits::{
-    CompositorHitTestResult, EmbedderControlId, EmbedderControlResponse, FocusSequenceNumber,
-    InputEventAndId, JavaScriptEvaluationId, MediaSessionActionType, ScriptToEmbedderChan, Theme,
-    ViewportDetails, WebDriverScriptCommand,
+    EmbedderControlId, EmbedderControlResponse, FocusSequenceNumber, InputEventAndId,
+    JavaScriptEvaluationId, MediaSessionActionType, PaintHitTestResult, ScriptToEmbedderChan,
+    Theme, ViewportDetails, WebDriverScriptCommand,
 };
 use euclid::{Scale, Size2D};
 use fonts_traits::SystemFontServiceProxySender;
@@ -142,7 +142,7 @@ pub enum UpdatePipelineIdReason {
     Traversal,
 }
 
-/// Messages sent to the `ScriptThread` event loop from the `Constellation`, `Compositor`, and (for
+/// Messages sent to the `ScriptThread` event loop from the `Constellation`, `Paint`, and (for
 /// now) `Layout`.
 #[derive(Deserialize, IntoStaticStr, Serialize)]
 pub enum ScriptThreadMessage {
@@ -273,7 +273,7 @@ pub enum ScriptThreadMessage {
     /// Notifies script thread that WebGPU server has started
     #[cfg(feature = "webgpu")]
     SetWebGPUPort(IpcReceiver<WebGPUMsg>),
-    /// The compositor scrolled and is updating the scroll states of the nodes in the given
+    /// `Paint` scrolled and is updating the scroll states of the nodes in the given
     /// pipeline via the Constellation.
     SetScrollStates(PipelineId, FxHashMap<ExternalScrollId, LayoutVector2D>),
     /// Evaluate the given JavaScript and return a result via a corresponding message
@@ -317,7 +317,7 @@ pub enum DocumentState {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ConstellationInputEvent {
     /// The hit test result of this input event, if any.
-    pub hit_test_result: Option<CompositorHitTestResult>,
+    pub hit_test_result: Option<PaintHitTestResult>,
     /// The pressed mouse button state of the constellation when this input
     /// event was triggered.
     pub pressed_mouse_buttons: u16,
@@ -368,8 +368,8 @@ pub struct InitialScriptState {
     pub webgl_chan: Option<WebGLPipeline>,
     /// The XR device registry
     pub webxr_registry: Option<webxr_api::Registry>,
-    /// Access to the compositor across a process boundary.
-    pub cross_process_compositor_api: CrossProcessCompositorApi,
+    /// Access to `Paint` across a process boundary.
+    pub cross_process_paint_api: CrossProcessPaintApi,
     /// Application window's GL Context for Media player
     pub player_context: WindowGLContext,
     /// User content manager

--- a/components/webgl/webgl_mode/inprocess.rs
+++ b/components/webgl/webgl_mode/inprocess.rs
@@ -4,7 +4,7 @@
 
 use canvas_traits::webgl::{WebGLContextId, WebGLMsg, WebGLThreads, webgl_channel};
 use compositing_traits::{
-    CrossProcessCompositorApi, PainterSurfmanDetailsMap, WebRenderExternalImageIdManager,
+    CrossProcessPaintApi, PainterSurfmanDetailsMap, WebRenderExternalImageIdManager,
 };
 use log::debug;
 use surfman::Device;
@@ -27,7 +27,7 @@ pub struct WebGLComm {
 impl WebGLComm {
     /// Creates a new `WebGLComm` object.
     pub fn new(
-        compositor_api: CrossProcessCompositorApi,
+        paint_api: CrossProcessPaintApi,
         external_image_id_manager: WebRenderExternalImageIdManager,
         painter_surfman_details_map: PainterSurfmanDetailsMap,
     ) -> WebGLComm {
@@ -43,7 +43,7 @@ impl WebGLComm {
 
         // This implementation creates a single `WebGLThread` for all the pipelines.
         let init = WebGLThreadInit {
-            compositor_api,
+            paint_api,
             external_image_id_manager,
             sender: sender.clone(),
             receiver,

--- a/components/webgpu/lib.rs
+++ b/components/webgpu/lib.rs
@@ -14,14 +14,14 @@ mod wgpu_thread;
 
 use std::borrow::Cow;
 
-use compositing_traits::{CrossProcessCompositorApi, WebRenderExternalImageIdManager};
+use compositing_traits::{CrossProcessPaintApi, WebRenderExternalImageIdManager};
 use ipc_channel::ipc::{self, IpcReceiver};
 use servo_config::pref;
 
 pub mod canvas_context;
 
 pub fn start_webgpu_thread(
-    compositor_api: CrossProcessCompositorApi,
+    paint_api: CrossProcessPaintApi,
     webrender_external_image_id_manager: WebRenderExternalImageIdManager,
     wgpu_image_map: WebGpuExternalImageMap,
 ) -> Option<(WebGPU, IpcReceiver<WebGPUMsg>)> {
@@ -58,7 +58,7 @@ pub fn start_webgpu_thread(
                 receiver,
                 sender_clone,
                 script_sender,
-                compositor_api,
+                paint_api,
                 webrender_external_image_id_manager,
                 wgpu_image_map,
             )

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 
 use base::id::PipelineId;
 use compositing_traits::{
-    CrossProcessCompositorApi, WebRenderExternalImageIdManager, WebRenderImageHandlerType,
+    CrossProcessPaintApi, WebRenderExternalImageIdManager, WebRenderImageHandlerType,
 };
 use ipc_channel::ipc::{IpcReceiver, IpcSender, IpcSharedMemory};
 use log::{info, warn};
@@ -104,7 +104,7 @@ pub(crate) struct WGPU {
     /// because wgpu does not invalidate command encoder object
     /// (this is also reused for invalidation of command buffers)
     error_command_encoders: FxHashMap<id::CommandEncoderId, String>,
-    pub(crate) compositor_api: CrossProcessCompositorApi,
+    pub(crate) paint_api: CrossProcessPaintApi,
     pub(crate) webrender_external_image_id_manager: WebRenderExternalImageIdManager,
     pub(crate) wgpu_image_map: WebGpuExternalImageMap,
     /// Provides access to poller thread
@@ -120,7 +120,7 @@ impl WGPU {
         receiver: IpcReceiver<WebGPURequest>,
         sender: IpcSender<WebGPURequest>,
         script_sender: IpcSender<WebGPUMsg>,
-        compositor_api: CrossProcessCompositorApi,
+        paint_api: CrossProcessPaintApi,
         webrender_external_image_id_manager: WebRenderExternalImageIdManager,
         wgpu_image_map: WebGpuExternalImageMap,
     ) -> Self {
@@ -149,7 +149,7 @@ impl WGPU {
             global,
             devices: Arc::new(Mutex::new(FxHashMap::default())),
             error_command_encoders: FxHashMap::default(),
-            compositor_api,
+            paint_api,
             webrender_external_image_id_manager,
             wgpu_image_map,
             compute_passes: FxHashMap::default(),

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -100,7 +100,7 @@ impl PlatformWindow for Window {
 
         // Because we are managing the rendering surface ourselves, there will be no other
         // notification (such as from the display manager) that it has changed size, so we
-        // must notify the compositor here.
+        // must notify `Paint` here.
         webview.resize(PhysicalSize::new(
             new_size.width as u32,
             new_size.height as u32,
@@ -150,7 +150,7 @@ impl PlatformWindow for Window {
         self.inner_size.set(self.screen_size);
         // Because we are managing the rendering surface ourselves, there will be no other
         // notification (such as from the display manager) that it has changed size, so we
-        // must notify the compositor here.
+        // must notify the `Paint` here.
         webview.resize(PhysicalSize::new(
             self.screen_size.width as u32,
             self.screen_size.height as u32,

--- a/ports/servoshell/egl/android/mod.rs
+++ b/ports/servoshell/egl/android/mod.rs
@@ -123,7 +123,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_init<'local>(
             "script::dom::bindings::error",
             // Show GL errors by default.
             "canvas::webgl_thread",
-            "compositing::compositor",
+            "compositing::paint",
             "constellation::constellation",
         ];
         let mut filter_builder = FilterBuilder::new();
@@ -518,22 +518,19 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_click(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn Java_org_servo_servoview_JNIServo_pauseCompositor(
-    mut env: JNIEnv,
-    _: JClass<'_>,
-) {
-    debug!("pauseCompositor");
-    call(&mut env, |s| s.pause_compositor());
+pub extern "C" fn Java_org_servo_servoview_JNIServo_pausePainting(mut env: JNIEnv, _: JClass<'_>) {
+    debug!("pausePainting");
+    call(&mut env, |s| s.pause_painting());
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn Java_org_servo_servoview_JNIServo_resumeCompositor<'local>(
+pub extern "C" fn Java_org_servo_servoview_JNIServo_resumePainting<'local>(
     mut env: JNIEnv<'local>,
     _: JClass<'local>,
     surface: JObject<'local>,
     coordinates: JObject<'local>,
 ) {
-    debug!("resumeCompositor");
+    debug!("resumePainting");
     let viewport_rect = match jni_coordinate_to_rust_viewport_rect(&mut env, &coordinates) {
         Ok(viewport_rect) => viewport_rect,
         Err(error) => return throw(&mut env, &error),
@@ -541,7 +538,7 @@ pub extern "C" fn Java_org_servo_servoview_JNIServo_resumeCompositor<'local>(
 
     let (_, window_handle) = display_and_window_handle(&mut env, &surface);
     call(&mut env, |app| {
-        app.resume_compositor(window_handle, viewport_rect);
+        app.resume_painting(window_handle, viewport_rect);
     });
 }
 

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -583,14 +583,14 @@ impl App {
         self.spin_event_loop();
     }
 
-    pub fn pause_compositor(&self) {
+    pub fn pause_painting(&self) {
         if let Err(e) = self.platform_window.rendering_context.take_window() {
             warn!("Unbinding native surface from context failed ({:?})", e);
         }
         self.spin_event_loop();
     }
 
-    pub fn resume_compositor(
+    pub fn resume_painting(
         &self,
         window_handle: RawWindowHandle,
         viewport_rect: Rect<i32, DevicePixel>,

--- a/ports/servoshell/egl/ohos/mod.rs
+++ b/ports/servoshell/egl/ohos/mod.rs
@@ -400,12 +400,12 @@ impl ServoAction {
                         .expect("Should always start with at least one WebView");
                     if webview.id() != native_webview_components.id {
                         servo.activate_webview(native_webview_components.id);
-                        servo.pause_compositor();
+                        servo.pause_painting();
                         let (window_handle, viewport_rect) = get_raw_window_handle(
                             native_webview_components.xcomponent.0,
                             native_webview_components.window.0,
                         );
-                        servo.resume_compositor(window_handle, viewport_rect);
+                        servo.resume_painting(window_handle, viewport_rect);
                         let url = webview
                             .url()
                             .map(|u| u.to_string())
@@ -419,12 +419,12 @@ impl ServoAction {
                 }
             },
             NewWebview(xcomponent, window) => {
-                servo.pause_compositor();
+                servo.pause_painting();
                 let webview =
                     servo.create_and_activate_toplevel_webview("about:blank".parse().unwrap());
                 let (window_handle, viewport_rect) = get_raw_window_handle(xcomponent.0, window.0);
 
-                servo.resume_compositor(window_handle, viewport_rect);
+                servo.resume_painting(window_handle, viewport_rect);
                 let id = webview.id();
                 NATIVE_WEBVIEWS
                     .lock()
@@ -700,7 +700,7 @@ static LOGGER: LazyLock<hilog::Logger> = LazyLock::new(|| {
         "script::dom::console",
         // Show GL errors by default.
         "canvas::webgl_thread",
-        "compositing::compositor",
+        "compositing::paint",
         "compositing::touch",
         "constellation::constellation",
         "ohos_ime",

--- a/ports/servoshell/main.rs
+++ b/ports/servoshell/main.rs
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! The `servo` test application.
+//! The `servoshell` test application.
 //!
-//! Creates a `Servo` instance with a simple implementation of
-//! the compositor's `WindowMethods` to create a working web browser.
+//! Creates a `Servo` instance with a example implementation of a working
+//! web browser.
 //!
 //! This browser's implementation of `WindowMethods` is built on top
 //! of [winit], the cross-platform windowing library.

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -309,7 +309,8 @@ impl RunningAppState {
     /// Spins the internal application event loop.
     ///
     /// - Notifies Servo about incoming gamepad events
-    /// - Spin the Servo event loop, which will run the compositor and trigger delegate methods.
+    /// - Spin the Servo event loop, which will update Servo's embedding layer and trigger
+    ///   delegate methods.
     ///
     /// Returns true if the event loop should continue spinning and false if it should exit.
     pub(crate) fn spin_event_loop(self: &Rc<Self>) -> bool {

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -186,7 +186,7 @@ impl ServoShellWindow {
             self.platform_window
                 .update_user_interface_state(state, self);
 
-        // Delegate handlers may have asked us to present or update compositor contents.
+        // Delegate handlers may have asked us to present or update painted WebView contents.
         // Currently, egui-file-dialog dialogs need to be constantly redrawn or animations aren't fluid.
         let needs_repaint = self.needs_repaint.take();
         if updated_user_interface || needs_repaint {


### PR DESCRIPTION
For a long time, the "Compositor" hasn't done any compositing. This is
handled by WebRender. In addition the "Compositor" does many other
tasks. This change renames `IOCompositor` to `Paint`.

`Paint` is Servo's paint subsystem and contains multiple `Painter`s.
This change does not rename the crate; that will be done in a
followup change.

Testing: This just renames types and updates comments, so no new tests are necessary.
