### PR TITLE
layout: Do not send display lists over a `ipc::bytes_channel()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6560,6 +6560,8 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 2.1.1",
  "serde",
+ "serde_bytes",
+ "servo-tracing",
  "servo_geometry",
  "servo_malloc_size_of",
  "smallvec",
@@ -6567,6 +6569,7 @@ dependencies = [
  "stylo",
  "stylo_traits",
  "surfman",
+ "tracing",
  "webrender_api",
 ]
 

--- a/components/paint/paint.rs
+++ b/components/paint/paint.rs
@@ -437,13 +437,15 @@ impl Paint {
             PaintMessage::SendDisplayList {
                 webview_id,
                 display_list_descriptor,
-                display_list_receiver,
+                display_list_info_receiver,
+                display_list_data_receiver,
             } => {
                 if let Some(mut painter) = self.maybe_painter_mut(webview_id.into()) {
                     painter.handle_new_display_list(
                         webview_id,
                         display_list_descriptor,
-                        display_list_receiver,
+                        display_list_info_receiver,
+                        display_list_data_receiver,
                     );
                 }
             },

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
 use base::generic_channel::GenericSharedMemory;
+use base::generic_channel::GenericReceiver;
 use base::id::{PainterId, PipelineId, WebViewId};
 use constellation_traits::{EmbedderToConstellationMessage, PaintMetricEvent};
 use crossbeam_channel::Sender;
@@ -21,7 +22,7 @@ use embedder_traits::{
 use euclid::{Point2D, Rect, Scale, Size2D};
 use gleam::gl::RENDERER;
 use image::RgbaImage;
-use ipc_channel::ipc::IpcBytesReceiver;
+use ipc_channel::ipc::IpcSharedMemory;
 use log::{debug, error, info, warn};
 use media::WindowGLContext;
 use paint_api::display_list::{PaintDisplayListInfo, ScrollType};
@@ -29,7 +30,7 @@ use paint_api::largest_contentful_paint_candidate::LCPCandidate;
 use paint_api::rendering_context::RenderingContext;
 use paint_api::viewport_description::ViewportDescription;
 use paint_api::{
-    ImageUpdate, PipelineExitSource, SendableFrameTree, SerializableImageData,
+    ImageUpdate, PipelineExitSource, SendableFrameTree, SerializableImageData, DisplayListPayloadSerializeable,
     WebRenderExternalImageHandlers, WebRenderImageHandlerType, WebViewTrait,
 };
 use profile_traits::time::{ProfilerCategory, ProfilerChan};
@@ -917,44 +918,25 @@ impl Painter {
             .display_list_epoch = Some(Epoch(epoch.0));
     }
 
+    #[servo_tracing::instrument(skip_all)]
     pub(crate) fn handle_new_display_list(
         &mut self,
         webview_id: WebViewId,
         display_list_descriptor: BuiltDisplayListDescriptor,
-        display_list_receiver: IpcBytesReceiver,
+        display_list_info_receiver: GenericReceiver<PaintDisplayListInfo>,
+        display_list_data_receiver: GenericReceiver<DisplayListPayloadSerializeable>,
     ) {
-        // This must match the order from the sender, currently in `shared/script/lib.rs`.
-        let display_list_info = match display_list_receiver.recv() {
-            Ok(display_list_info) => display_list_info,
-            Err(error) => {
-                return warn!("Could not receive display list info: {error}");
-            },
+        let Ok(display_list_info) = display_list_info_receiver.recv() else {
+            return log::error!("Could not receive display list info");
         };
-        let display_list_info: PaintDisplayListInfo = match bincode::deserialize(&display_list_info)
-        {
-            Ok(display_list_info) => display_list_info,
-            Err(error) => {
-                return warn!("Could not deserialize display list info: {error}");
-            },
+        let Ok(display_list_data) = display_list_data_receiver.recv() else {
+            return log::error!("Could not receive display list data");
         };
-        let items_data = match display_list_receiver.recv() {
-            Ok(display_list_data) => display_list_data,
-            Err(error) => {
-                return warn!("Could not receive WebRender display list items data: {error}");
-            },
-        };
-        let cache_data = match display_list_receiver.recv() {
-            Ok(display_list_data) => display_list_data,
-            Err(error) => {
-                return warn!("Could not receive WebRender display list cache data: {error}");
-            },
-        };
-        let spatial_tree = match display_list_receiver.recv() {
-            Ok(display_list_data) => display_list_data,
-            Err(error) => {
-                return warn!("Could not receive WebRender display list spatial tree: {error}.");
-            },
-        };
+
+        let items_data = display_list_data.items_data;
+        let cache_data = display_list_data.cache_data;
+        let spatial_tree = display_list_data.spatial_tree;
+
         let built_display_list = BuiltDisplayList::from_data(
             DisplayListPayload {
                 items_data,

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -9,8 +9,7 @@ use std::sync::Arc;
 
 use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
-use base::generic_channel::GenericSharedMemory;
-use base::generic_channel::GenericReceiver;
+use base::generic_channel::{GenericReceiver, GenericSharedMemory};
 use base::id::{PainterId, PipelineId, WebViewId};
 use constellation_traits::{EmbedderToConstellationMessage, PaintMetricEvent};
 use crossbeam_channel::Sender;
@@ -22,7 +21,6 @@ use embedder_traits::{
 use euclid::{Point2D, Rect, Scale, Size2D};
 use gleam::gl::RENDERER;
 use image::RgbaImage;
-use ipc_channel::ipc::IpcSharedMemory;
 use log::{debug, error, info, warn};
 use media::WindowGLContext;
 use paint_api::display_list::{PaintDisplayListInfo, ScrollType};

--- a/components/paint/painter.rs
+++ b/components/paint/painter.rs
@@ -28,8 +28,8 @@ use paint_api::largest_contentful_paint_candidate::LCPCandidate;
 use paint_api::rendering_context::RenderingContext;
 use paint_api::viewport_description::ViewportDescription;
 use paint_api::{
-    ImageUpdate, PipelineExitSource, SendableFrameTree, SerializableImageData, DisplayListPayloadSerializeable,
-    WebRenderExternalImageHandlers, WebRenderImageHandlerType, WebViewTrait,
+    ImageUpdate, PipelineExitSource, SendableFrameTree, SerializableDisplayListPayload,
+    SerializableImageData, WebRenderExternalImageHandlers, WebRenderImageHandlerType, WebViewTrait,
 };
 use profile_traits::time::{ProfilerCategory, ProfilerChan};
 use profile_traits::time_profile;
@@ -922,7 +922,7 @@ impl Painter {
         webview_id: WebViewId,
         display_list_descriptor: BuiltDisplayListDescriptor,
         display_list_info_receiver: GenericReceiver<PaintDisplayListInfo>,
-        display_list_data_receiver: GenericReceiver<DisplayListPayloadSerializeable>,
+        display_list_data_receiver: GenericReceiver<SerializableDisplayListPayload>,
     ) {
         let Ok(display_list_info) = display_list_info_receiver.recv() else {
             return log::error!("Could not receive display list info");

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -45,13 +45,13 @@ refcell_backtrace = ["script/refcell_backtrace"]
 testbinding = ["script/testbinding"]
 tracing = [
     "dep:tracing",
-    "paint/tracing",
+    "compositing/tracing",
+    "compositing_traits/tracing",
     "constellation/tracing",
     "fonts/tracing",
     "layout/tracing",
     "profile_traits/tracing",
     "script/tracing",
-    "compositing_traits/tracing",
 ]
 vello = ["constellation/vello"]
 webgl_backtrace = [

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -51,6 +51,7 @@ tracing = [
     "layout/tracing",
     "profile_traits/tracing",
     "script/tracing",
+    "compositing_traits/tracing",
 ]
 vello = ["constellation/vello"]
 webgl_backtrace = [

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -45,8 +45,7 @@ refcell_backtrace = ["script/refcell_backtrace"]
 testbinding = ["script/testbinding"]
 tracing = [
     "dep:tracing",
-    "compositing/tracing",
-    "compositing_traits/tracing",
+    "paint/tracing",
     "constellation/tracing",
     "fonts/tracing",
     "layout/tracing",

--- a/components/shared/paint/Cargo.toml
+++ b/components/shared/paint/Cargo.toml
@@ -13,6 +13,7 @@ path = "lib.rs"
 
 [features]
 no-wgl = ["surfman/sm-angle-default"]
+tracing = ["dep:tracing"]
 
 [dependencies]
 base = { workspace = true }
@@ -35,10 +36,13 @@ profile_traits = { path = '../profile' }
 raw-window-handle = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
+serde_bytes = { workspace = true }
 servo_geometry = { path = "../../geometry" }
 smallvec = { workspace = true }
 strum = { workspace = true }
+servo-tracing = { workspace = true }
 stylo = { workspace = true }
 stylo_traits = { workspace = true }
 surfman = { workspace = true, features = ["sm-x11"] }
+tracing = { workspace = true, optional = true }
 webrender_api = { workspace = true }

--- a/components/shared/paint/display_list.rs
+++ b/components/shared/paint/display_list.rs
@@ -58,14 +58,14 @@ pub struct AxesScrollSensitivity {
     pub y: ScrollType,
 }
 
-#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub enum SpatialTreeNodeInfo {
     ReferenceFrame(ReferenceFrameNodeInfo),
     Scroll(ScrollableNodeInfo),
     Sticky(StickyNodeInfo),
 }
 
-#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct StickyNodeInfo {
     pub frame_rect: LayoutRect,
     pub margins: SideOffsets2D<Option<f32>, LayoutPixel>,
@@ -163,7 +163,7 @@ impl StickyNodeInfo {
     }
 }
 
-#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct ReferenceFrameNodeInfo {
     pub origin: LayoutPoint,
     /// Origin of this frame relative to the document for bounding box queries.
@@ -175,7 +175,7 @@ pub struct ReferenceFrameNodeInfo {
 
 /// Data stored for nodes in the [ScrollTree] that actually scroll,
 /// as opposed to reference frames and sticky nodes which do not.
-#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct ScrollableNodeInfo {
     /// The external scroll id of this node, used to track
     /// it between successive re-layouts.
@@ -290,7 +290,7 @@ pub struct ScrollTreeNodeTransformationCache {
     cumulative_sticky_offsets: LayoutVector2D,
 }
 
-#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 /// A node in a tree of scroll nodes. This may either be a scrollable
 /// node which responds to scroll events or a non-scrollable one.
 pub struct ScrollTreeNode {
@@ -421,7 +421,7 @@ impl ScrollTreeNode {
 /// A tree of spatial nodes, which mirrors the spatial nodes in the WebRender
 /// display list, except these are used for scrolling in `Paint` so that
 /// new offsets can be sent to WebRender.
-#[derive(Debug, Default, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, Serialize)]
 pub struct ScrollTree {
     /// A list of `Paint`-side scroll nodes that describe the tree
     /// of WebRender spatial nodes, used by `Paint` to scroll the
@@ -815,7 +815,7 @@ impl ScrollTree {
 
 /// A data structure which stores `Paint`-side information about
 /// display lists sent to `Paint`.
-#[derive(Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct PaintDisplayListInfo {
     /// The WebRender [PipelineId] of this display list.
     pub pipeline_id: PipelineId,

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -215,14 +215,13 @@ pub struct CompositionPipeline {
 #[derive(Serialize, Deserialize)]
 pub struct DisplayListForPainter {
     pub display_list_info: PaintDisplayListInfo,
-
     pub display_list_data: DisplayListPayloadSerializeable,
 }
 
 /// A serializable version of `DisplayListPayload`
 #[derive(Serialize, Deserialize)]
 pub struct DisplayListPayloadSerializeable {
-    /// Serde encoded bytes. Mostly DisplayItems, but some mixed in slices.
+    /// Serde encoded bytes. Mostly DisplayItems
     #[serde(with = "serde_bytes")]
     pub items_data: Vec<u8>,
 

--- a/components/shared/paint/lib.rs
+++ b/components/shared/paint/lib.rs
@@ -34,7 +34,6 @@ use bitflags::bitflags;
 use display_list::PaintDisplayListInfo;
 use embedder_traits::ScreenGeometry;
 use euclid::default::Size2D as UntypedSize2D;
-use ipc_channel::ipc::IpcSharedMemory;
 use profile_traits::mem::{OpaqueSender, ReportsChan};
 use serde::{Deserialize, Serialize};
 pub use webrender_api::ExternalImageSource;


### PR DESCRIPTION
This improves the sending (and receiving) of displaylist.
- In the case that we are not in IPC mode, we essentially replace serialization with a clone of 'DisplayListInfo'.
This the desktop total time spend in the receiving the DisplayList by half and increases the sending slightly.
Perfetto shows for sending 51_354_000 vs 71_476_000 and receiving from 440_455_008 vs 194_509_000). All numbers are on desktop machines but mobile phones on different tests are similar big improvements.

- More surprisingly, in the IPC cases. we still get a slight improvement in this case too. We go from the overall handling case from 24_842_000 to 30_989_752 (handle displaylist) but a significant decrease in the send decrease in the sending from 88_199_572 to 23_025_033.
The reason is a bit of a mystery to me.

This also makes the code cleaner as we do not have to implement the GenericByteReceiver channel.

Testing: It essentially just changes types and how they are serialized.
