### PR TITLE
Fix all Android build warnings and make the CA verifier preference more flexible

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -250,8 +250,10 @@ pub struct Preferences {
     pub network_http_proxy_uri: String,
     pub network_local_directory_listing_enabled: bool,
     pub network_mime_sniff: bool,
-    /// Use the webpki roots if no root store path is given.
-    pub network_webpki_roots: bool,
+    /// Force the use of `rust-webpki` verification for CA roots. If this is false (the
+    /// default), then `rustls-platform-verifier` will be used, except on Android where
+    /// `rust-webpki` is always used.
+    pub network_use_webpki_roots: bool,
     pub session_history_max_length: i64,
     /// The background color of shell's viewport. This will be used by OpenGL's `glClearColor`.
     pub shell_background_color_rgba: [f64; 4],
@@ -436,7 +438,7 @@ impl Preferences {
             network_http_proxy_uri: String::new(),
             network_local_directory_listing_enabled: true,
             network_mime_sniff: false,
-            network_webpki_roots: false,
+            network_use_webpki_roots: false,
             session_history_max_length: 20,
             shell_background_color_rgba: [1.0, 1.0, 1.0, 1.0],
             threadpools_async_runtime_workers_max: 6,

--- a/components/fonts/lib.rs
+++ b/components/fonts/lib.rs
@@ -45,7 +45,7 @@ pub(crate) enum EmojiPresentationPreference {
 pub struct FallbackFontSelectionOptions {
     pub(crate) character: char,
     pub(crate) presentation_preference: EmojiPresentationPreference,
-    #[cfg_attr(target_os = "windows", allow(dead_code))]
+    #[cfg_attr(any(target_os = "android", target_os = "windows"), allow(dead_code))]
     pub(crate) lang: Option<String>,
 }
 

--- a/components/net/connector.rs
+++ b/components/net/connector.rs
@@ -24,9 +24,10 @@ use log::warn;
 use parking_lot::Mutex;
 use rustls::client::danger::ServerCertVerifier;
 use rustls::client::{ClientConnection, EchStatus};
-use rustls::crypto::aws_lc_rs;
+use rustls::crypto::{CryptoProvider, aws_lc_rs};
 use rustls::{ClientConfig, ProtocolVersion};
 use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
+use servo_config::pref;
 use tokio::net::TcpStream;
 use tower::Service;
 
@@ -361,11 +362,10 @@ impl CertificateErrorOverrideManager {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum CACertificates<'de> {
-    #[cfg(not(target_os = "android"))]
-    PlatformVerifier,
-    WebPKI,
+    #[default]
+    Default,
     Override(Vec<CertificateDer<'de>>),
 }
 
@@ -416,49 +416,56 @@ impl CertificateVerificationOverrideVerifier {
         ignore_certificate_errors: bool,
         override_manager: CertificateErrorOverrideManager,
     ) -> Self {
-        let crypto_provider = rustls::crypto::CryptoProvider::get_default()
-            .unwrap_or(&Arc::new(aws_lc_rs::default_provider()))
-            .clone();
-        let main_verifier = match ca_certficates {
-            #[cfg(not(target_os = "android"))]
-            CACertificates::PlatformVerifier => Arc::new(
-                rustls_platform_verifier::Verifier::new(crypto_provider)
-                    .expect("Could not initialize platform certificate verifier."),
-            ),
-            CACertificates::WebPKI => {
-                let root_store = Arc::new(rustls::RootCertStore::from_iter(
-                    webpki_roots::TLS_SERVER_ROOTS.iter().cloned(),
-                ));
+        // From <https://github.com/rustls/rustls-platform-verifier/blob/main/README.md>:
+        // > Some manual setup is required, outside of cargo, to use this crate on
+        // > Android. In order to use Android's certificate verifier, the crate needs to
+        // > call into the JVM. A small Kotlin component must be included in your app's
+        // > build to support rustls-platform-verifier.
+        //
+        // Since we cannot count on embedders to do this setup, just stick with webpki roots
+        // on Android.
+        let use_platform_verifier =
+            !cfg!(target_os = "android") || !pref!(network_use_webpki_roots);
 
-                rustls::client::WebPkiServerVerifier::builder(root_store)
-                    .build()
-                    .expect("Could not initialize platform certificate verifier.")
-                    as Arc<dyn ServerCertVerifier>
-            },
-            #[cfg(not(target_os = "android"))]
-            CACertificates::Override(root_cert_store) => Arc::new(
-                rustls_platform_verifier::Verifier::new_with_extra_roots(
-                    root_cert_store,
-                    crypto_provider,
-                )
-                .expect("Could not build platform verifier with additional certs."),
-            ),
-            #[cfg(target_os = "android")]
-            CACertificates::Override(root_cert_store) => {
-                // Android does not support rustls_platform_verifier::Verifier::new_with_extra_roots.
-                let mut main_store = rustls::RootCertStore::from_iter(
-                    webpki_roots::TLS_SERVER_ROOTS.iter().cloned(),
-                );
-                for i in root_cert_store {
-                    if main_store.add(i).is_err() {
-                        log::error!("Could not add an override certificate.");
+        let main_verifier = if use_platform_verifier {
+            let crypto_provider = CryptoProvider::get_default()
+                .unwrap_or(&Arc::new(aws_lc_rs::default_provider()))
+                .clone();
+            let verifier = match ca_certficates {
+                CACertificates::Default => rustls_platform_verifier::Verifier::new(crypto_provider),
+                // Android doesn't support `Verifier::new_with_extra_roots`, but currently Android
+                // never uses the platform verifier at all.
+                #[cfg(target_os = "android")]
+                CACertificates::Override(..) => {
+                    rustls_platform_verifier::Verifier::new(crypto_provider)
+                },
+                #[cfg(not(target_os = "android"))]
+                CACertificates::Override(certificates) => {
+                    rustls_platform_verifier::Verifier::new_with_extra_roots(
+                        certificates,
+                        crypto_provider,
+                    )
+                },
+            }
+            .expect("Could not initialize platform certificate verifier");
+            Arc::new(verifier) as Arc<dyn ServerCertVerifier>
+        } else {
+            let mut root_store =
+                rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            match ca_certficates {
+                CACertificates::Default => {},
+                CACertificates::Override(certificates) => {
+                    for certificate in certificates {
+                        if root_store.add(certificate).is_err() {
+                            log::error!("Could not add an override certificate.");
+                        }
                     }
-                }
-                rustls::client::WebPkiServerVerifier::builder(main_store.into())
-                    .build()
-                    .expect("Could not initialize platform certificate verifier.")
-                    as Arc<dyn ServerCertVerifier>
-            },
+                },
+            }
+            rustls::client::WebPkiServerVerifier::builder(root_store.into())
+                .build()
+                .expect("Could not initialize platform certificate verifier.")
+                as Arc<dyn ServerCertVerifier>
         };
 
         Self {

--- a/components/net/tests/fetch.rs
+++ b/components/net/tests/fetch.rs
@@ -768,7 +768,7 @@ fn test_fetch_with_hsts() {
         ))),
         protocols: Arc::new(ProtocolRegistry::default()),
         websocket_chan: None,
-        ca_certificates: CACertificates::PlatformVerifier,
+        ca_certificates: CACertificates::Default,
         ignore_certificate_errors: false,
     };
 
@@ -832,7 +832,7 @@ fn test_load_adds_host_to_hsts_list_when_url_is_https() {
         ))),
         protocols: Arc::new(ProtocolRegistry::default()),
         websocket_chan: None,
-        ca_certificates: CACertificates::PlatformVerifier,
+        ca_certificates: CACertificates::Default,
         ignore_certificate_errors: false,
     };
 
@@ -901,7 +901,7 @@ fn test_fetch_self_signed() {
         ))),
         protocols: Arc::new(ProtocolRegistry::default()),
         websocket_chan: None,
-        ca_certificates: CACertificates::PlatformVerifier,
+        ca_certificates: CACertificates::Default,
         ignore_certificate_errors: false,
     };
 
@@ -1552,7 +1552,7 @@ fn test_fetch_request_intercepted() {
         ))),
         protocols: Arc::new(ProtocolRegistry::default()),
         websocket_chan: None,
-        ca_certificates: CACertificates::PlatformVerifier,
+        ca_certificates: CACertificates::Default,
         ignore_certificate_errors: false,
     };
 

--- a/components/net/tests/main.rs
+++ b/components/net/tests/main.rs
@@ -107,7 +107,7 @@ fn create_http_state(fc: Option<EmbedderProxy>) -> HttpState {
         http_cache: RwLock::new(net::http_cache::HttpCache::default()),
         http_cache_state: Mutex::new(HashMap::new()),
         client: create_http_client(create_tls_config(
-            net::connector::CACertificates::PlatformVerifier,
+            net::connector::CACertificates::Default,
             false, /* ignore_certificate_errors */
             override_manager.clone(),
         )),
@@ -139,7 +139,7 @@ fn new_fetch_context(
         ))),
         protocols: Arc::new(ProtocolRegistry::with_internal_protocols()),
         websocket_chan: None,
-        ca_certificates: CACertificates::PlatformVerifier,
+        ca_certificates: CACertificates::Default,
         ignore_certificate_errors: false,
     }
 }

--- a/components/net/tests/resource_thread.rs
+++ b/components/net/tests/resource_thread.rs
@@ -30,7 +30,7 @@ fn test_exit() {
         MemProfilerChan(mtx),
         create_embedder_proxy(),
         None,
-        CACertificates::PlatformVerifier,
+        CACertificates::Default,
         false, /* ignore_certificate_errors */
         std::sync::Arc::new(ProtocolRegistry::default()),
     );

--- a/components/script/dom/console.rs
+++ b/components/script/dom/console.rs
@@ -350,20 +350,21 @@ fn stringify_handle_values(messages: &[HandleValue]) -> DOMString {
     ))
 }
 
+#[cfg(not(any(target_os = "android", target_env = "ohos")))]
+fn console_message_to_stdout(global: &GlobalScope, message: &DOMString) {
+    let prefix = global.current_group_label().unwrap_or_default();
+    let formatted_message = format!("{}{}", prefix, message);
+    with_stderr_lock(move || {
+        println!("{}", formatted_message);
+    });
+}
+
 /// On OHOS/ Android, stdout and stderr will be redirected to go
 /// to the logger. As `Console::method` and `Console::send_string_message`
 /// already forwards all messages to the logger with appropriate level
 /// this does not need to do anything for these targets.
-fn console_message_to_stdout(global: &GlobalScope, message: &DOMString) {
-    #[cfg(not(any(target_os = "android", target_env = "ohos")))]
-    {
-        let prefix = global.current_group_label().unwrap_or_default();
-        let formatted_message = format!("{}{}", prefix, message);
-        with_stderr_lock(move || {
-            println!("{}", formatted_message);
-        });
-    }
-}
+#[cfg(any(target_os = "android", target_env = "ohos"))]
+fn console_message_to_stdout(_: &GlobalScope, _: &DOMString) {}
 
 #[derive(Debug, Eq, PartialEq)]
 enum IncludeStackTrace {


### PR DESCRIPTION
This change fixes a variety of build warnings on Android. In a related
change, the CA verifier preference allows using a list of certificate
overrides and the `rust-webpki` verifier regardless of platform. Whether
to use a list of certificate overrides and whether to use the platform
verifier are orthagonal, so this change unlinks those two and in the process
fixes a build warning on Android.

Testing: This preference is untested (and quite hard to test honestly), so this change
does not have tests. There should be no behavior change unless using a combination
of forcing the webpki verifier and providing a list of CA overrides.
