### PR TITLE
script: Update spec text of WebCrypto API

### DIFF
--- a/components/script/dom/subtlecrypto/argon2_operation.rs
+++ b/components/script/dom/subtlecrypto/argon2_operation.rs
@@ -164,24 +164,23 @@ pub(crate) fn import_key(
 
     // Step 5. Let key be a new CryptoKey representing keyData.
     // Step 6. Set the [[type]] internal slot of key to "secret".
-    // Step 7. Set the [[extractable]] internal slot of key to false.
-    // Step 8. Let algorithm be a new KeyAlgorithm object.
-    // Step 9. Set the name attribute of algorithm to the name member of normalizedAlgorithm.
-    // Step 10. Set the [[algorithm]] internal slot of key to algorithm.
+    // Step 7. Let algorithm be a new KeyAlgorithm object.
+    // Step 8. Set the name attribute of algorithm to the name member of normalizedAlgorithm.
+    // Step 9. Set the [[algorithm]] internal slot of key to algorithm.
     let algorithm = SubtleKeyAlgorithm {
         name: normalized_algorithm.name.clone(),
     };
     let key = CryptoKey::new(
         global,
         KeyType::Secret,
-        false,
+        extractable,
         KeyAlgorithmAndDerivatives::KeyAlgorithm(algorithm),
         usages,
         Handle::Argon2Password(key_data.to_vec()),
         can_gc,
     );
 
-    // Step 11. Return key.
+    // Step 10. Return key.
     Ok(key)
 }
 

--- a/components/script/dom/subtlecrypto/chacha20_poly1305_operation.rs
+++ b/components/script/dom/subtlecrypto/chacha20_poly1305_operation.rs
@@ -174,11 +174,12 @@ pub(crate) fn generate_key(
     let generated_key = ChaCha20Poly1305::generate_key(&mut OsRng);
 
     // Step 4. Let key be a new CryptoKey object representing the generated key.
-    // Step 5. Let algorithm be a new KeyAlgorithm.
-    // Step 6. Set the name attribute of algorithm to "ChaCha20-Poly1305".
-    // Step 7. Set the [[algorithm]] internal slot of key to algorithm.
-    // Step 8. Set the [[extractable]] internal slot of key to be extractable.
-    // Step 9. Set the [[usages]] internal slot of key to be usages.
+    // Step 5. Set the [[type]] internal slot of key to "secret".
+    // Step 6. Let algorithm be a new KeyAlgorithm.
+    // Step 7. Set the name attribute of algorithm to "ChaCha20-Poly1305".
+    // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
+    // Step 9. Set the [[extractable]] internal slot of key to be extractable.
+    // Step 10. Set the [[usages]] internal slot of key to be usages.
     let algorithm = SubtleKeyAlgorithm {
         name: ALG_CHACHA20_POLY1305.to_string(),
     };
@@ -192,7 +193,7 @@ pub(crate) fn generate_key(
         can_gc,
     );
 
-    // Step 10. Return key.
+    // Step 11. Return key.
     Ok(key)
 }
 
@@ -310,9 +311,10 @@ pub(crate) fn import_key(
     }
 
     // Step 4. Let key be a new CryptoKey object representing a key with value data.
-    // Step 5. Let algorithm be a new KeyAlgorithm.
-    // Step 6. Set the name attribute of algorithm to "ChaCha20-Poly1305".
-    // Step 7. Set the [[algorithm]] internal slot of key to algorithm.
+    // Step 5. Set the [[type]] internal slot of key to "secret".
+    // Step 6. Let algorithm be a new KeyAlgorithm.
+    // Step 7. Set the name attribute of algorithm to "ChaCha20-Poly1305".
+    // Step 8. Set the [[algorithm]] internal slot of key to algorithm.
     let handle = Handle::ChaCha20Poly1305Key(Key::from_exact_iter(data).ok_or(Error::Data(
         Some("ChaCha20-Poly1305 fails to create key from data".to_string()),
     ))?);
@@ -329,7 +331,7 @@ pub(crate) fn import_key(
         can_gc,
     );
 
-    // Step 8. Return key.
+    // Step 9. Return key.
     Ok(key)
 }
 
@@ -381,9 +383,7 @@ pub(crate) fn export_key(format: KeyFormat, key: &CryptoKey) -> Result<ExportedK
                 ..Default::default()
             };
 
-            // Step 2.7. Let result be the result of converting jwk to an ECMAScript Object, as
-            // defined by [WebIDL].
-            // NOTE: We convert it to JSObject in SubtleCrypto::ExportKey.
+            // Step 2.7. Let result be jwk.
             ExportedKey::Jwk(Box::new(jwk))
         },
         // Otherwise:


### PR DESCRIPTION
Update a few spec texts of WebCrypto API with respect to recent changes in the [Web Cryptography](https://w3c.github.io/webcrypto/) and [Modern Algorithms in WICG](https://wicg.github.io/webcrypto-modern-algos/) that refines some expressions. No behavioral changes.

Commits of the changes in the specifications:
- https://github.com/w3c/webcrypto/commit/0213b32f7e7aca5f1a575fbcd41ed1329611e867
- https://github.com/WICG/webcrypto-modern-algos/commit/3b9d192f529c8b8dbbff077c210b9d414784637b
- https://github.com/WICG/webcrypto-modern-algos/commit/0d5f58606c1d84906eb2c37ee9dd91d43f03d03d

Testing: No behavioral changes. Existing tests suffice.