### PR TITLE
compositing: Have `preventDefault` prevent the scroll behavior of wheel events

### DIFF
--- a/components/compositing/webview_renderer.rs
+++ b/components/compositing/webview_renderer.rs
@@ -92,6 +92,10 @@ pub(crate) struct WebViewRenderer {
     pub pipelines: FxHashMap<PipelineId, PipelineDetails>,
     /// Pending scroll/zoom events.
     pending_scroll_zoom_events: Vec<ScrollZoomEvent>,
+    /// A map of pending wheel events. These are events that have been sent to script,
+    /// but are waiting for processing. When they are handled by script, they may trigger
+    /// scroll events depending on whether `preventDefault()` was called on the event.
+    pending_wheel_events: FxHashMap<InputEventId, WheelEvent>,
     /// Touch input state machine
     touch_handler: TouchHandler,
     /// "Desktop-style" zoom that resizes the viewport to fit the window.
@@ -142,6 +146,7 @@ impl WebViewRenderer {
             pipelines: Default::default(),
             touch_handler: TouchHandler::new(webview_id),
             pending_scroll_zoom_events: Default::default(),
+            pending_wheel_events: Default::default(),
             page_zoom: DEFAULT_PAGE_ZOOM,
             pinch_zoom: PinchZoom::new(rect),
             hidpi_scale_factor: Scale::new(hidpi_scale_factor.0),
@@ -383,25 +388,11 @@ impl WebViewRenderer {
         }
 
         if let InputEvent::Wheel(wheel_event) = event_and_id.event {
-            self.on_wheel_event(render_api, wheel_event, event_and_id);
-            return;
+            self.pending_wheel_events
+                .insert(event_and_id.id, wheel_event);
         }
 
         self.dispatch_input_event_with_hit_testing(render_api, event_and_id);
-    }
-
-    fn on_wheel_event(
-        &mut self,
-        render_api: &RenderApi,
-        wheel_event: WheelEvent,
-        event_and_id: InputEventAndId,
-    ) {
-        self.dispatch_input_event_with_hit_testing(render_api, event_and_id);
-
-        // A scroll delta for a wheel event is the inverse of the wheel delta.
-        let scroll_delta =
-            DeviceVector2D::new(-wheel_event.delta.x as f32, -wheel_event.delta.y as f32);
-        self.notify_scroll_event(Scroll::Delta(scroll_delta.into()), wheel_event.point);
     }
 
     fn send_touch_event(
@@ -1060,6 +1051,15 @@ impl WebViewRenderer {
                     self.refresh_driver.clone(),
                     repaint_reason,
                 );
+        }
+
+        if let Some(wheel_event) = self.pending_wheel_events.remove(&id) {
+            if !result.contains(InputEventResult::DefaultPrevented) {
+                // A scroll delta for a wheel event is the inverse of the wheel delta.
+                let scroll_delta =
+                    DeviceVector2D::new(-wheel_event.delta.x as f32, -wheel_event.delta.y as f32);
+                self.notify_scroll_event(Scroll::Delta(scroll_delta.into()), wheel_event.point);
+            }
         }
     }
 }

--- a/tests/wpt/tests/dom/events/scrolling/wheel-event-no-scroll-after-prevent-default.html
+++ b/tests/wpt/tests/dom/events/scrolling/wheel-event-no-scroll-after-prevent-default.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+
+<head>
+<meta charset="utf-8">
+<title>Ensure that the calling `preventDefault` on a wheel event prevents a scroll from happening</title>
+<link rel="author" title="Martin Robinson" href="mailto:mrobinson@igalia.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</head>
+
+<body>
+    <div id="scroller" style="width: 100px; height: 100px; overflow: scroll; position: relative;">
+        <div style="position: absolute; width: 100px; height: 500px; background: red;"></div>
+        <div style="position: absolute; width: 100px; height: 100px; background: green;"></div>
+    </div>
+
+    <script>
+        function waitForFrame() {
+          return new Promise(resolve => {
+            window.requestAnimationFrame(resolve);
+          });
+        }
+
+        function runTest() {
+            promise_test(async(t) => {
+                let wheelEventFired = false;
+                let scrollEventFired = false;
+                scroller.addEventListener("wheel", (event) => {
+                    wheelEventFired = true;
+                    event.preventDefault()
+                });
+                scroller.addEventListener("scroll", (event) => {
+                    scrollEventFired = true;
+                    event.preventDefault()
+                });
+
+                await new test_driver.Actions()
+                  .addWheel("wheel1")
+                  .scroll(50, 50, 0, 30, {origin: "viewport"})
+                  .pause(1)
+                  .scroll(50, 50, 0, 30, {origin: "viewport"})
+                  .pause(1)
+                  .scroll(50, 50, 0, 30, {origin: "viewport"})
+                  .send();
+
+                await waitForFrame();
+                await waitForFrame();
+                await waitForFrame();
+                await waitForFrame();
+
+                assert_true(wheelEventFired);
+                assert_false(scrollEventFired);
+            }, "When `preventDefault` is called on a WheelEvent, scrolling should be prevented.");
+        }
+        window.onload = runTest;
+    </script>
+</body>
+


### PR DESCRIPTION
This change makes it so that when `preventDefault` is called on a wheel
event, the scroll is prevented. The downside here is that there is more
latency on wheel based scroll events. This can be mitigated in the
future by moving the scroll initiation to script. That's left for a
followup though.

Testing: `/dom/events/scrolling/wheel-event-no-scroll-after-prevent-default.html` is added to test this.
Fixes: #41154.
