### PR TITLE
servoshell: Use `WheelMode::DeltaPixel` on line-based wheel events converted to pixels

### DIFF
--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -699,7 +699,7 @@ impl PlatformWindow for Window {
                             MouseScrollDelta::LineDelta(delta_x, delta_y) => (
                                 (delta_x * LINE_WIDTH) as f64,
                                 (delta_y * LINE_HEIGHT) as f64,
-                                WheelMode::DeltaLine,
+                                WheelMode::DeltaPixel,
                             ),
                             MouseScrollDelta::PixelDelta(delta) => {
                                 (delta.x, delta.y, WheelMode::DeltaPixel)


### PR DESCRIPTION
servoshell is converting line-based wheel scrolls to pixels, so we need
to send `WheelMode::DeltaPixel` in with the value. This value is
processed directly by script and is the way it interprets the delta.

A better fix here would be to actually process these values fully in
script, but that is aved for a followup.

Testing: This part of servoshell is untested, so it's difficult to add
a test for this.
Fixes: #41164.
