### PR TITLE
Base: Rename IpcSharedMemory to GenericSharedMemory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,7 +1152,6 @@ dependencies = [
  "euclid",
  "fonts",
  "futures-intrusive",
- "ipc-channel",
  "kurbo 0.12.0",
  "log",
  "net_traits",
@@ -6749,10 +6748,10 @@ dependencies = [
 name = "pixels"
 version = "0.0.1"
 dependencies = [
+ "base",
  "criterion",
  "euclid",
  "image",
- "ipc-channel",
  "log",
  "malloc_size_of_derive",
  "serde",
@@ -10307,7 +10306,6 @@ dependencies = [
  "euclid",
  "glow",
  "half",
- "ipc-channel",
  "itertools 0.14.0",
  "log",
  "parking_lot",

--- a/components/canvas/Cargo.toml
+++ b/components/canvas/Cargo.toml
@@ -27,7 +27,6 @@ cssparser = { workspace = true }
 euclid = { workspace = true }
 fonts = { path = "../fonts" }
 futures-intrusive = { version = "0.5", optional = true }
-ipc-channel = { workspace = true }
 kurbo = { workspace = true }
 log = { workspace = true }
 net_traits = { workspace = true }

--- a/components/canvas/vello_backend.rs
+++ b/components/canvas/vello_backend.rs
@@ -23,7 +23,7 @@ use canvas_traits::canvas::{
 use compositing_traits::SerializableImageData;
 use euclid::default::{Point2D, Rect, Size2D, Transform2D};
 use fonts::FontIdentifier;
-use ipc_channel::ipc::IpcSharedMemory;
+use ipc_channel::ipc::GenericSharedMemory;
 use kurbo::Shape as _;
 use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 use vello::wgpu::{
@@ -589,14 +589,14 @@ impl GenericDrawTarget for VelloDrawTarget {
                 flags: ImageDescriptorFlags::empty(),
             };
             let data = SerializableImageData::Raw(if let Some(data) = data {
-                let mut data = IpcSharedMemory::from_bytes(data);
+                let mut data = GenericSharedMemory::from_bytes(data);
                 #[expect(unsafe_code)]
                 unsafe {
                     pixels::generic_transform_inplace::<1, false, false>(data.deref_mut());
                 };
                 data
             } else {
-                IpcSharedMemory::from_byte(0, size.area() as usize * 4)
+                GenericSharedMemory::from_byte(0, size.area() as usize * 4)
             });
             (image_desc, data)
         })

--- a/components/canvas/vello_backend.rs
+++ b/components/canvas/vello_backend.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::rc::Rc;
 
+use base::generic_channel::GenericSharedMemory;
 use canvas_traits::canvas::{
     CompositionOptions, CompositionOrBlending, CompositionStyle, FillOrStrokeStyle, FillRule,
     LineOptions, Path, ShadowOptions, TextRun,
@@ -23,7 +24,6 @@ use canvas_traits::canvas::{
 use compositing_traits::SerializableImageData;
 use euclid::default::{Point2D, Rect, Size2D, Transform2D};
 use fonts::FontIdentifier;
-use ipc_channel::ipc::GenericSharedMemory;
 use kurbo::Shape as _;
 use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 use vello::wgpu::{

--- a/components/canvas/vello_cpu_backend.rs
+++ b/components/canvas/vello_cpu_backend.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use base::generic_channel::GenericSharedMemory;
 use canvas_traits::canvas::{
     CompositionOptions, CompositionOrBlending, CompositionStyle, FillOrStrokeStyle, FillRule,
     LineOptions, Path, ShadowOptions, TextRun,
@@ -13,7 +14,6 @@ use canvas_traits::canvas::{
 use compositing_traits::SerializableImageData;
 use euclid::default::{Point2D, Rect, Size2D, Transform2D};
 use fonts::FontIdentifier;
-use ipc_channel::ipc::IpcSharedMemory;
 use kurbo::Shape;
 use pixels::{Snapshot, SnapshotAlphaMode, SnapshotPixelFormat};
 use vello_cpu::{kurbo, peniko};
@@ -464,7 +464,7 @@ impl GenericDrawTarget for VelloCPUDrawTarget {
             offset: 0,
             flags: ImageDescriptorFlags::empty(),
         };
-        let data = SerializableImageData::Raw(IpcSharedMemory::from_bytes(self.pixmap()));
+        let data = SerializableImageData::Raw(GenericSharedMemory::from_bytes(self.pixmap()));
         (image_desc, data)
     }
 

--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use base::Epoch;
 use base::cross_process_instant::CrossProcessInstant;
+use base::generic_channel::GenericSharedMemory;
 use base::id::{PainterId, PipelineId, WebViewId};
 use compositing_traits::display_list::{PaintDisplayListInfo, ScrollType};
 use compositing_traits::largest_contentful_paint_candidate::LCPCandidate;
@@ -28,7 +29,7 @@ use embedder_traits::{
 use euclid::{Point2D, Rect, Scale, Size2D};
 use gleam::gl::RENDERER;
 use image::RgbaImage;
-use ipc_channel::ipc::{IpcBytesReceiver, IpcSharedMemory};
+use ipc_channel::ipc::IpcBytesReceiver;
 use log::{debug, error, info, warn};
 use media::WindowGLContext;
 use profile_traits::time::{ProfilerCategory, ProfilerChan};
@@ -1069,7 +1070,12 @@ impl Painter {
             .add_delay(pipeline_id, canvas_epoch, image_keys);
     }
 
-    pub(crate) fn add_font(&mut self, font_key: FontKey, data: Arc<IpcSharedMemory>, index: u32) {
+    pub(crate) fn add_font(
+        &mut self,
+        font_key: FontKey,
+        data: Arc<GenericSharedMemory>,
+        index: u32,
+    ) {
         let mut transaction = Transaction::new();
         transaction.add_raw_font(font_key, (**data).into(), index);
         self.send_transaction(transaction);

--- a/components/net/http_loader.rs
+++ b/components/net/http_loader.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use async_recursion::async_recursion;
 use base::cross_process_instant::CrossProcessInstant;
 use base::generic_channel;
+use base::generic_channel::GenericSharedMemory;
 use base::id::{BrowsingContextId, HistoryStateId, PipelineId};
 use crossbeam_channel::Sender;
 use devtools_traits::{
@@ -38,7 +39,7 @@ use hyper::body::{Bytes, Frame};
 use hyper::ext::ReasonPhrase;
 use hyper::header::{HeaderName, TRANSFER_ENCODING};
 use hyper_serde::Serde;
-use ipc_channel::ipc::{self, IpcSender, IpcSharedMemory};
+use ipc_channel::ipc::{self, IpcSender};
 use ipc_channel::router::ROUTER;
 use log::{debug, error, info, log_enabled, warn};
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
@@ -631,7 +632,7 @@ fn auth_from_cache(
 /// used to fill the body with bytes coming-in over IPC.
 enum BodyChunk {
     /// A chunk of bytes.
-    Chunk(IpcSharedMemory),
+    Chunk(GenericSharedMemory),
     /// Body is done.
     Done,
 }
@@ -658,7 +659,7 @@ enum BodySink {
 }
 
 impl BodySink {
-    fn transmit_bytes(&self, bytes: IpcSharedMemory) {
+    fn transmit_bytes(&self, bytes: GenericSharedMemory) {
         match self {
             BodySink::Chunked(sender) => {
                 let sender = sender.clone();

--- a/components/pixels/Cargo.toml
+++ b/components/pixels/Cargo.toml
@@ -12,9 +12,9 @@ name = "pixels"
 path = "lib.rs"
 
 [dependencies]
+base = { workspace = true }
 euclid = { workspace = true }
 image = { workspace = true }
-ipc-channel = { workspace = true }
 log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }

--- a/components/pixels/lib.rs
+++ b/components/pixels/lib.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{cmp, fmt, vec};
 
+use base::generic_channel::GenericSharedMemory;
 use euclid::default::{Point2D, Rect, Size2D};
 use image::codecs::{bmp, gif, ico, jpeg, png, webp};
 use image::error::ImageFormatHint;
@@ -19,7 +20,6 @@ use image::{
     AnimationDecoder, DynamicImage, ImageBuffer, ImageDecoder, ImageError, ImageFormat,
     ImageResult, Limits, Rgba,
 };
-use ipc_channel::ipc::IpcSharedMemory;
 use log::debug;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
@@ -289,7 +289,7 @@ pub struct SharedRasterImage {
     pub id: Option<ImageKey>,
     pub cors_status: CorsStatus,
     #[conditional_malloc_size_of]
-    pub bytes: Arc<IpcSharedMemory>,
+    pub bytes: Arc<GenericSharedMemory>,
     pub frames: Vec<ImageFrame>,
     /// Whether or not all of the frames of this image are opaque.
     pub is_opaque: bool,
@@ -400,7 +400,7 @@ impl RasterImage {
     pub fn webrender_image_descriptor_and_data_for_frame(
         &self,
         frame_index: usize,
-    ) -> (ImageDescriptor, IpcSharedMemory) {
+    ) -> (ImageDescriptor, GenericSharedMemory) {
         let frame = self
             .frames
             .get(frame_index)
@@ -432,7 +432,7 @@ impl RasterImage {
             offset: frame.byte_range.start as i32,
             flags,
         };
-        (descriptor, IpcSharedMemory::from_bytes(&data))
+        (descriptor, GenericSharedMemory::from_bytes(&data))
     }
 
     pub fn to_shared(&self) -> Arc<SharedRasterImage> {
@@ -441,7 +441,7 @@ impl RasterImage {
             format: self.format,
             id: self.id,
             cors_status: self.cors_status,
-            bytes: Arc::new(IpcSharedMemory::from_bytes(&self.bytes)),
+            bytes: Arc::new(GenericSharedMemory::from_bytes(&self.bytes)),
             frames: self.frames.clone(),
             is_opaque: self.is_opaque,
         })

--- a/components/script/body.rs
+++ b/components/script/body.rs
@@ -5,9 +5,10 @@
 use std::rc::Rc;
 use std::{ptr, slice, str};
 
+use base::generic_channel::GenericSharedMemory;
 use constellation_traits::BlobImpl;
 use encoding_rs::{Encoding, UTF_8};
-use ipc_channel::ipc::{self, IpcReceiver, IpcSender, IpcSharedMemory};
+use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
 use js::jsapi::{Heap, JS_ClearPendingException, JSObject, Value as JSValue};
 use js::jsval::{JSVal, UndefinedValue};
@@ -73,7 +74,7 @@ struct TransmitBodyConnectHandler {
     task_source: SendableTaskSource,
     bytes_sender: Option<IpcSender<BodyChunkResponse>>,
     control_sender: IpcSender<BodyChunkRequest>,
-    in_memory: Option<IpcSharedMemory>,
+    in_memory: Option<GenericSharedMemory>,
     in_memory_done: bool,
     source: BodySource,
 }
@@ -83,7 +84,7 @@ impl TransmitBodyConnectHandler {
         stream: Trusted<ReadableStream>,
         task_source: SendableTaskSource,
         control_sender: IpcSender<BodyChunkRequest>,
-        in_memory: Option<IpcSharedMemory>,
+        in_memory: Option<GenericSharedMemory>,
         source: BodySource,
     ) -> TransmitBodyConnectHandler {
         TransmitBodyConnectHandler {
@@ -315,7 +316,7 @@ impl Callback for TransmitBodyPromiseHandler {
         // TODO: queue a fetch task on request to process request body for request.
         let _ = self
             .bytes_sender
-            .send(BodyChunkResponse::Chunk(IpcSharedMemory::from_bytes(
+            .send(BodyChunkResponse::Chunk(GenericSharedMemory::from_bytes(
                 &chunk,
             )));
     }

--- a/components/script/dom/canvas/imagedata.rs
+++ b/components/script/dom/canvas/imagedata.rs
@@ -5,11 +5,11 @@
 use std::borrow::Cow;
 use std::vec::Vec;
 
+use base::generic_channel::GenericSharedMemory;
 use base::id::{ImageDataId, ImageDataIndex};
 use constellation_traits::SerializableImageData;
 use dom_struct::dom_struct;
 use euclid::default::{Rect, Size2D};
-use ipc_channel::ipc::IpcSharedMemory;
 use js::gc::CustomAutoRooterGuard;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
@@ -205,9 +205,9 @@ impl ImageData {
     }
 
     #[expect(unsafe_code)]
-    pub(crate) fn to_shared_memory(&self) -> IpcSharedMemory {
+    pub(crate) fn to_shared_memory(&self) -> GenericSharedMemory {
         // This is safe because we copy the slice content
-        IpcSharedMemory::from_bytes(unsafe { self.as_slice() })
+        GenericSharedMemory::from_bytes(unsafe { self.as_slice() })
     }
 
     #[expect(unsafe_code)]

--- a/components/script/dom/html/htmllinkelement.rs
+++ b/components/script/dom/html/htmllinkelement.rs
@@ -6,9 +6,9 @@ use std::borrow::{Borrow, ToOwned};
 use std::cell::Cell;
 use std::default::Default;
 
+use base::generic_channel::GenericSharedMemory;
 use dom_struct::dom_struct;
 use html5ever::{LocalName, Prefix, local_name, ns};
-use ipc_channel::ipc::IpcSharedMemory;
 use js::rust::HandleObject;
 use net_traits::image_cache::{
     Image, ImageCache, ImageCacheResponseCallback, ImageCacheResult, ImageLoadListener,
@@ -739,7 +739,7 @@ impl HTMLLinkElement {
             let embedder_image = embedder_traits::Image::new(
                 frame.width,
                 frame.height,
-                std::sync::Arc::new(IpcSharedMemory::from_bytes(&raster_image.bytes)),
+                std::sync::Arc::new(GenericSharedMemory::from_bytes(&raster_image.bytes)),
                 raster_image.frames[0].byte_range.clone(),
                 format,
             );

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 use std::{f64, mem};
 
+use base::generic_channel::GenericSharedMemory;
 use base::id::WebViewId;
 use compositing_traits::{CrossProcessPaintApi, ImageUpdate, SerializableImageData};
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
@@ -19,7 +20,7 @@ use headers::{ContentLength, ContentRange, HeaderMapExt};
 use html5ever::{LocalName, Prefix, QualName, local_name, ns};
 use http::StatusCode;
 use http::header::{self, HeaderMap, HeaderValue};
-use ipc_channel::ipc::{self, IpcSharedMemory};
+use ipc_channel::ipc::{self};
 use ipc_channel::router::ROUTER;
 use js::jsapi::JSAutoRealm;
 use layout_api::MediaFrame;
@@ -345,7 +346,9 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                     updates.push(ImageUpdate::UpdateImage(
                         current_frame.image_key,
                         descriptor,
-                        SerializableImageData::Raw(IpcSharedMemory::from_bytes(&frame.get_data())),
+                        SerializableImageData::Raw(GenericSharedMemory::from_bytes(
+                            &frame.get_data(),
+                        )),
                         None,
                     ));
                 }
@@ -386,7 +389,7 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                         normalized_uvs: false,
                     })
                 } else {
-                    SerializableImageData::Raw(IpcSharedMemory::from_bytes(&frame.get_data()))
+                    SerializableImageData::Raw(GenericSharedMemory::from_bytes(&frame.get_data()))
                 };
 
                 self.current_frame_holder
@@ -421,7 +424,7 @@ impl VideoFrameRenderer for MediaFrameRenderer {
                         normalized_uvs: false,
                     })
                 } else {
-                    SerializableImageData::Raw(IpcSharedMemory::from_bytes(&frame.get_data()))
+                    SerializableImageData::Raw(GenericSharedMemory::from_bytes(&frame.get_data()))
                 };
 
                 self.current_frame_holder = Some(FrameHolder::new(frame));

--- a/components/script/dom/readablestream.rs
+++ b/components/script/dom/readablestream.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 use base::id::{MessagePortId, MessagePortIndex};
 use constellation_traits::MessagePortImpl;
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSharedMemory;
+use base::generic_channel::GenericSharedMemory;
 use js::jsapi::{Heap, JSObject};
 use js::jsval::{JSVal, ObjectValue, UndefinedValue};
 use js::rust::{
@@ -1272,14 +1272,14 @@ impl ReadableStream {
 
     /// Return bytes for synchronous use, if the stream has all data in memory.
     /// Useful for native source integration only.
-    pub(crate) fn get_in_memory_bytes(&self) -> Option<IpcSharedMemory> {
+    pub(crate) fn get_in_memory_bytes(&self) -> Option<GenericSharedMemory> {
         match self.controller.borrow().as_ref() {
             Some(ControllerType::Default(controller)) => controller
                 .get()
                 .expect("Stream should have controller.")
                 .get_in_memory_bytes()
                 .as_deref()
-                .map(IpcSharedMemory::from_bytes),
+                .map(GenericSharedMemory::from_bytes),
             _ => {
                 unreachable!("Getting in-memory bytes for a stream with a non-default controller")
             },

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -6,8 +6,8 @@ use std::ops::Range;
 use std::rc::Rc;
 use std::string::String;
 
+use base::generic_channel::GenericSharedMemory;
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSharedMemory;
 use js::typedarray::HeapArrayBuffer;
 use script_bindings::trace::RootedTraceableBox;
 use webgpu_traits::{Mapping, WebGPU, WebGPUBuffer, WebGPURequest};
@@ -34,7 +34,7 @@ use crate::script_runtime::{CanGc, JSContext};
 
 #[derive(JSTraceable, MallocSizeOf)]
 pub(crate) struct ActiveBufferMapping {
-    // TODO(sagudev): Use IpcSharedMemory when https://github.com/servo/ipc-channel/pull/356 lands
+    // TODO(sagudev): Use GenericSharedMemory when https://github.com/servo/ipc-channel/pull/356 lands
     /// <https://gpuweb.github.io/gpuweb/#active-buffer-mapping-data>
     /// <https://gpuweb.github.io/gpuweb/#active-buffer-mapping-views>
     pub(crate) data: DataBlock,
@@ -211,7 +211,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             buffer_id: self.id().0,
             mapping: if mapping.mode >= GPUMapModeConstants::WRITE {
                 Some(Mapping {
-                    data: IpcSharedMemory::from_bytes(mapping.data.data()),
+                    data: GenericSharedMemory::from_bytes(mapping.data.data()),
                     range: mapping.range.clone(),
                     mode: HostMap::Write,
                 })

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -4,8 +4,8 @@
 
 use std::rc::Rc;
 
+use base::generic_channel::GenericSharedMemory;
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSharedMemory;
 use webgpu_traits::{WebGPU, WebGPUQueue, WebGPURequest};
 
 use crate::conversions::{Convert, TryConvert};
@@ -135,7 +135,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
         }
 
         // Step 5&6
-        let contents = IpcSharedMemory::from_bytes(
+        let contents = GenericSharedMemory::from_bytes(
             &data[(data_offset as usize) * sizeof_element..
                 ((data_offset + content_size) as usize) * sizeof_element],
         );
@@ -174,7 +174,7 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
         let texture_cv = destination.try_convert()?;
         let texture_layout = data_layout.convert();
         let write_size = (&size).try_convert()?;
-        let final_data = IpcSharedMemory::from_bytes(&bytes);
+        let final_data = GenericSharedMemory::from_bytes(&bytes);
 
         if let Err(e) = self.channel.0.send(WebGPURequest::WriteTexture {
             device_id: self.device.borrow().as_ref().unwrap().id().0,

--- a/components/shared/base/generic_channel.rs
+++ b/components/shared/base/generic_channel.rs
@@ -18,6 +18,9 @@ use servo_config::opts;
 mod callback;
 pub use callback::GenericCallback;
 mod oneshot;
+/// We want to discourage anybody from using the ipc_channel crate in servo and use 'GenericChannels' instead.
+/// 'GenericSharedMemory' is, however, still useful so we reexport it under a different name for future optimization.
+pub use ipc_channel::ipc::IpcSharedMemory as GenericSharedMemory;
 pub use oneshot::{GenericOneshotReceiver, GenericOneshotSender, oneshot};
 
 /// Abstraction of the ability to send a particular type of message cross-process.

--- a/components/shared/canvas/webgl.rs
+++ b/components/shared/canvas/webgl.rs
@@ -12,6 +12,7 @@ use base::Epoch;
 pub use base::generic_channel::GenericReceiver as WebGLReceiver;
 /// Sender type used in WebGLCommands.
 pub use base::generic_channel::GenericSender as WebGLSender;
+use base::generic_channel::GenericSharedMemory;
 /// Result type for send()/recv() calls in in WebGLCommands.
 pub use base::generic_channel::SendResult as WebGLSendResult;
 use base::id::PainterId;
@@ -20,7 +21,7 @@ use glow::{
     self as gl, NativeBuffer, NativeFence, NativeFramebuffer, NativeProgram, NativeQuery,
     NativeRenderbuffer, NativeSampler, NativeShader, NativeTexture, NativeVertexArray,
 };
-use ipc_channel::ipc::{IpcBytesReceiver, IpcBytesSender, IpcSender, IpcSharedMemory};
+use ipc_channel::ipc::{IpcBytesReceiver, IpcBytesSender, IpcSender};
 use malloc_size_of_derive::MallocSizeOf;
 use pixels::{PixelFormat, SnapshotAlphaMode};
 use serde::{Deserialize, Serialize};
@@ -323,7 +324,7 @@ pub enum WebGLCommand {
         Rect<u32>,
         u32,
         u32,
-        IpcSender<(IpcSharedMemory, SnapshotAlphaMode)>,
+        IpcSender<(GenericSharedMemory, SnapshotAlphaMode)>,
     ),
     ReadPixelsPP(Rect<i32>, u32, u32, usize),
     SampleCoverage(f32, bool),
@@ -399,7 +400,7 @@ pub enum WebGLCommand {
         alpha_treatment: Option<AlphaTreatment>,
         y_axis_treatment: YAxisTreatment,
         pixel_format: Option<PixelFormat>,
-        data: TruncatedDebug<IpcSharedMemory>,
+        data: TruncatedDebug<GenericSharedMemory>,
     },
     TexImage2D {
         target: u32,
@@ -414,7 +415,7 @@ pub enum WebGLCommand {
         alpha_treatment: Option<AlphaTreatment>,
         y_axis_treatment: YAxisTreatment,
         pixel_format: Option<PixelFormat>,
-        data: TruncatedDebug<IpcSharedMemory>,
+        data: TruncatedDebug<GenericSharedMemory>,
     },
     TexImage2DPBO {
         target: u32,
@@ -440,14 +441,14 @@ pub enum WebGLCommand {
         alpha_treatment: Option<AlphaTreatment>,
         y_axis_treatment: YAxisTreatment,
         pixel_format: Option<PixelFormat>,
-        data: TruncatedDebug<IpcSharedMemory>,
+        data: TruncatedDebug<GenericSharedMemory>,
     },
     CompressedTexImage2D {
         target: u32,
         level: u32,
         internal_format: u32,
         size: Size2D<u32>,
-        data: TruncatedDebug<IpcSharedMemory>,
+        data: TruncatedDebug<GenericSharedMemory>,
     },
     CompressedTexSubImage2D {
         target: u32,
@@ -456,7 +457,7 @@ pub enum WebGLCommand {
         yoffset: i32,
         size: Size2D<u32>,
         format: u32,
-        data: TruncatedDebug<IpcSharedMemory>,
+        data: TruncatedDebug<GenericSharedMemory>,
     },
     DrawingBufferWidth(WebGLSender<i32>),
     DrawingBufferHeight(WebGLSender<i32>),

--- a/components/shared/compositing/lib.rs
+++ b/components/shared/compositing/lib.rs
@@ -27,12 +27,12 @@ pub mod viewport_description;
 
 use std::sync::{Arc, Mutex};
 
-use base::generic_channel::{self, GenericCallback, GenericSender};
+use base::generic_channel::{self, GenericCallback, GenericSender, GenericSharedMemory};
 use bitflags::bitflags;
 use display_list::PaintDisplayListInfo;
 use embedder_traits::ScreenGeometry;
 use euclid::default::Size2D as UntypedSize2D;
-use ipc_channel::ipc::{self, IpcSharedMemory};
+use ipc_channel::ipc::{self};
 use profile_traits::mem::{OpaqueSender, ReportsChan};
 use serde::{Deserialize, Serialize};
 pub use webrender_api::ExternalImageSource;
@@ -158,7 +158,7 @@ pub enum PaintMessage {
         PainterId,
     ),
     /// Add a font with the given data and font key.
-    AddFont(PainterId, FontKey, Arc<IpcSharedMemory>, u32),
+    AddFont(PainterId, FontKey, Arc<GenericSharedMemory>, u32),
     /// Add a system font with the given font key and handle.
     AddSystemFont(PainterId, FontKey, NativeFontHandle),
     /// Add an instance of a font with the given instance key.
@@ -458,7 +458,7 @@ impl CrossProcessPaintApi {
         ));
     }
 
-    pub fn add_font(&self, font_key: FontKey, data: Arc<IpcSharedMemory>, index: u32) {
+    pub fn add_font(&self, font_key: FontKey, data: Arc<GenericSharedMemory>, index: u32) {
         let _ = self.0.send(PaintMessage::AddFont(
             font_key.into(),
             font_key,
@@ -735,7 +735,7 @@ impl Debug for ImageUpdate {
 pub enum SerializableImageData {
     /// A simple series of bytes, provided by the embedding and owned by WebRender.
     /// The format is stored out-of-band, currently in ImageDescriptor.
-    Raw(IpcSharedMemory),
+    Raw(GenericSharedMemory),
     /// An image owned by the embedding, and referenced by WebRender. This may
     /// take the form of a texture or a heap-allocated buffer.
     External(ExternalImageData),

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -22,12 +22,12 @@ use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use base::generic_channel::{GenericCallback, GenericSender, SendResult};
+use base::generic_channel::{GenericCallback, GenericSender, GenericSharedMemory, SendResult};
 use base::id::{PipelineId, WebViewId};
 use crossbeam_channel::Sender;
 use euclid::{Box2D, Point2D, Scale, Size2D, Vector2D};
 use http::{HeaderMap, Method, StatusCode};
-use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
+use ipc_channel::ipc::IpcSender;
 use log::warn;
 use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
@@ -358,7 +358,7 @@ pub struct Image {
     pub height: u32,
     pub format: PixelFormat,
     /// A shared memory block containing the data of one or more image frames.
-    data: Arc<IpcSharedMemory>,
+    data: Arc<GenericSharedMemory>,
     range: Range<usize>,
 }
 
@@ -366,7 +366,7 @@ impl Image {
     pub fn new(
         width: u32,
         height: u32,
-        data: Arc<IpcSharedMemory>,
+        data: Arc<GenericSharedMemory>,
         range: Range<usize>,
         format: PixelFormat,
     ) -> Self {

--- a/components/shared/fonts/lib.rs
+++ b/components/shared/fonts/lib.rs
@@ -11,10 +11,10 @@ mod system_font_service_proxy;
 
 use std::sync::Arc;
 
+use base::generic_channel::GenericSharedMemory;
 pub use font_descriptor::*;
 pub use font_identifier::*;
 pub use font_template::*;
-use ipc_channel::ipc::IpcSharedMemory;
 use malloc_size_of_derive::MallocSizeOf;
 use range::{RangeIndex, int_range_index};
 use serde::{Deserialize, Serialize};
@@ -30,17 +30,17 @@ int_range_index! {
 pub type StylesheetWebFontLoadFinishedCallback = Arc<dyn Fn(bool) + Send + Sync + 'static>;
 
 /// A data structure to store data for fonts. Data is stored internally in an
-/// [`IpcSharedMemory`] handle, so that it can be sent without serialization
+/// [`GenericSharedMemory`] handle, so that it can be sent without serialization
 /// across IPC channels.
 #[derive(Clone, Deserialize, MallocSizeOf, Serialize)]
-pub struct FontData(#[conditional_malloc_size_of] pub(crate) Arc<IpcSharedMemory>);
+pub struct FontData(#[conditional_malloc_size_of] pub(crate) Arc<GenericSharedMemory>);
 
 impl FontData {
     pub fn from_bytes(bytes: &[u8]) -> Self {
-        Self(Arc::new(IpcSharedMemory::from_bytes(bytes)))
+        Self(Arc::new(GenericSharedMemory::from_bytes(bytes)))
     }
 
-    pub fn as_ipc_shared_memory(&self) -> Arc<IpcSharedMemory> {
+    pub fn as_ipc_shared_memory(&self) -> Arc<GenericSharedMemory> {
         self.0.clone()
     }
 }

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -4,12 +4,13 @@
 
 use std::sync::Arc;
 
+use base::generic_channel::GenericSharedMemory;
 use base::id::{PipelineId, WebViewId};
 use content_security_policy::{self as csp};
 use http::header::{AUTHORIZATION, HeaderName};
 use http::{HeaderMap, Method};
 use indexmap::IndexMap;
-use ipc_channel::ipc::{self, IpcReceiver, IpcSender, IpcSharedMemory};
+use ipc_channel::ipc::{self, IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
 use malloc_size_of_derive::MallocSizeOf;
 use mime::Mime;
@@ -316,7 +317,7 @@ pub enum BodySource {
 #[derive(Debug, Deserialize, Serialize)]
 pub enum BodyChunkResponse {
     /// A chunk of bytes.
-    Chunk(IpcSharedMemory),
+    Chunk(GenericSharedMemory),
     /// The body is done.
     Done,
     /// There was an error streaming the body,
@@ -1147,7 +1148,7 @@ pub fn convert_header_names_to_sorted_lowercase_set(
 }
 
 pub fn create_request_body_with_content(content: &str) -> RequestBody {
-    let content_bytes = IpcSharedMemory::from_bytes(content.as_bytes());
+    let content_bytes = GenericSharedMemory::from_bytes(content.as_bytes());
     let content_len = content_bytes.len();
 
     let (chunk_request_sender, chunk_request_receiver) = ipc::channel().unwrap();

--- a/components/shared/webgpu/lib.rs
+++ b/components/shared/webgpu/lib.rs
@@ -9,7 +9,8 @@ pub mod render_commands;
 
 use std::ops::Range;
 
-use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
+use base::generic_channel::GenericSharedMemory;
+use ipc_channel::ipc::IpcSender;
 use serde::{Deserialize, Serialize};
 use webrender_api::euclid::default::Size2D;
 use webrender_api::{ImageDescriptor, ImageDescriptorFlags, ImageFormat};
@@ -150,7 +151,7 @@ pub struct Pipeline<T: std::fmt::Debug + Serialize> {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Mapping {
-    pub data: IpcSharedMemory,
+    pub data: GenericSharedMemory,
     pub mode: HostMap,
     pub range: Range<u64>,
 }

--- a/components/shared/webgpu/messages/recv.rs
+++ b/components/shared/webgpu/messages/recv.rs
@@ -7,8 +7,9 @@
 
 use arrayvec::ArrayVec;
 use base::Epoch;
+use base::generic_channel::GenericSharedMemory;
 use base::id::PipelineId;
-use ipc_channel::ipc::{IpcSender, IpcSharedMemory};
+use ipc_channel::ipc::IpcSender;
 use pixels::SharedSnapshot;
 use serde::{Deserialize, Serialize};
 use webrender_api::ImageKey;
@@ -308,7 +309,7 @@ pub enum WebGPURequest {
         queue_id: QueueId,
         buffer_id: BufferId,
         buffer_offset: u64,
-        data: IpcSharedMemory,
+        data: GenericSharedMemory,
     },
     WriteTexture {
         device_id: DeviceId,
@@ -316,7 +317,7 @@ pub enum WebGPURequest {
         texture_cv: TexelCopyTextureInfo,
         data_layout: TexelCopyBufferLayout,
         size: Extent3d,
-        data: IpcSharedMemory,
+        data: GenericSharedMemory,
     },
     QueueOnSubmittedWorkDone {
         sender: IpcSender<()>,

--- a/components/webgl/Cargo.toml
+++ b/components/webgl/Cargo.toml
@@ -25,7 +25,6 @@ crossbeam-channel = { workspace = true }
 euclid = { workspace = true }
 glow = { workspace = true }
 half = "2"
-ipc-channel = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 parking_lot = { workspace = true }

--- a/components/webgl/webgl_thread.rs
+++ b/components/webgl/webgl_thread.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::{slice, thread};
 
 use base::Epoch;
-use base::generic_channel::RoutedReceiver;
+use base::generic_channel::{GenericSharedMemory, RoutedReceiver};
 use base::id::PainterId;
 use bitflags::bitflags;
 use byteorder::{ByteOrder, NativeEndian, WriteBytesExt};
@@ -38,7 +38,6 @@ use glow::{
     bytes_per_type, components_per_format,
 };
 use half::f16;
-use ipc_channel::ipc::IpcSharedMemory;
 use itertools::Itertools;
 use log::{debug, error, trace, warn};
 use parking_lot::RwLock;
@@ -1259,7 +1258,7 @@ impl WebGLImpl {
                     (false, _) => SnapshotAlphaMode::Opaque,
                 };
                 sender
-                    .send((IpcSharedMemory::from_bytes(&pixels), alpha_mode))
+                    .send((GenericSharedMemory::from_bytes(&pixels), alpha_mode))
                     .unwrap();
             },
             WebGLCommand::ReadPixelsPP(rect, format, pixel_type, offset) => unsafe {

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -8,11 +8,12 @@ use std::borrow::Cow;
 use std::slice;
 use std::sync::{Arc, Mutex};
 
+use base::generic_channel::GenericSharedMemory;
 use base::id::PipelineId;
 use compositing_traits::{
     CrossProcessPaintApi, WebRenderExternalImageIdManager, WebRenderImageHandlerType,
 };
-use ipc_channel::ipc::{IpcReceiver, IpcSender, IpcSharedMemory};
+use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use log::{info, warn};
 use rustc_hash::FxHashMap;
 use servo_config::pref;
@@ -192,7 +193,7 @@ impl WGPU {
                                 };
 
                                 Ok(Mapping {
-                                    data: IpcSharedMemory::from_bytes(data),
+                                    data: GenericSharedMemory::from_bytes(data),
                                     range: offset..offset + range_size,
                                     mode: host_map,
                                 })


### PR DESCRIPTION
In the future, servo components should depend on the generic channels in base instead of IpcChannels to correctly optimize for multiprocess vs non-multiprocess mode.
This reexports IpcSharedMemory as GenericSharedMemory in GenericChannel and changes all dependencies on it.

Currently this is only a type/name change and does not change functionality. But in the future we would want want to use non-ipc things for the data.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: This changes types and does not need testing.
