### PR TITLE
devtools: Handle unsupported messages related to devtools settings.

### DIFF
--- a/components/devtools/actors/watcher/network_parent.rs
+++ b/components/devtools/actors/watcher/network_parent.rs
@@ -33,6 +33,10 @@ impl Actor for NetworkParentActor {
                 let msg = EmptyReplyMsg { from: self.name() };
                 request.reply_final(&msg)?
             },
+            "setPersist" => {
+                let msg = EmptyReplyMsg { from: self.name() };
+                request.reply_final(&msg)?
+            },
             _ => return Err(ActorError::UnrecognizedPacketType),
         };
         Ok(())

--- a/components/devtools/actors/watcher/target_configuration.rs
+++ b/components/devtools/actors/watcher/target_configuration.rs
@@ -37,6 +37,13 @@ pub struct TargetConfigurationActor {
     supported_options: HashMap<&'static str, bool>,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JavascriptEnabledReply {
+    from: String,
+    javascript_enabled: bool,
+}
+
 impl Actor for TargetConfigurationActor {
     fn name(&self) -> String {
         self.name.clone()
@@ -80,6 +87,13 @@ impl Actor for TargetConfigurationActor {
                     }
                 }
                 let msg = EmptyReplyMsg { from: self.name() };
+                request.reply_final(&msg)?
+            },
+            "isJavascriptEnabled" => {
+                let msg = JavascriptEnabledReply {
+                    from: self.name(),
+                    javascript_enabled: true,
+                };
                 request.reply_final(&msg)?
             },
             _ => return Err(ActorError::UnrecognizedPacketType),


### PR DESCRIPTION
These commits allow the frontend to open the devtools settings panel successfully and allow the network monitor to function when the "Persist Logs" frontend option is enabled.

Testing: Manually tested. No harness for automated tests for the network monitor exist yet.
Fixes: #41196
