### PR TITLE
ohos: Warn on common commandline argument mistakes

### DIFF
--- a/support/openharmony/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/support/openharmony/entry/src/main/ets/entryability/EntryAbility.ets
@@ -32,6 +32,11 @@ export default class EntryAbility extends UIAbility {
             if (value) {
                 params.push(value)
             }
+        } else if (key.startsWith("tracing") || key.startsWith("devtools") || key.startsWith("force_ipc") || key.startsWith("multiprocess") || key.startsWith("webdriver")) {
+          hilog.error(0xE0C3, "Servo EntryAbility", "-------------------------------------------------------------------------------------------------");
+          hilog.error(0xE0C3, "Servo EntryAbility", "\n\nYou probably meant to add -- infront of your argument, i.e., --psn=--tracing vs --psn=tracing");
+          hilog.error(0xE0C3, "Servo EntryAbility", "-------------------------------------------------------------------------------------------------");
+          return;
         }
       })
     }

--- a/support/openharmony/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/support/openharmony/entry/src/main/ets/entryability/EntryAbility.ets
@@ -4,6 +4,8 @@ import UIAbility from '@ohos.app.ability.UIAbility';
 import Want from '@ohos.app.ability.Want';
 import window from '@ohos.window';
 
+const WRONG_COMMAND_ARRAY = ["tracing", "devtools", "force_ipc", "multiprocess", "webdriver"];
+
 export default class EntryAbility extends UIAbility {
   init_params: LocalStorage = new LocalStorage();
   onCreate(want: Want, launchParam: AbilityConstant.LaunchParam) {
@@ -32,7 +34,7 @@ export default class EntryAbility extends UIAbility {
             if (value) {
                 params.push(value)
             }
-        } else if (["tracing", "devtools", "force_ipc", "multiprocess", "webdriver"].some(value => key.startsWith(value))) {
+        } else if (WRONG_COMMAND_ARRAY.some(value => key.startsWith(value))) {
           hilog.error(0xE0C3, "Servo EntryAbility", "-------------------------------------------------------------------------------------------------");
           hilog.error(0xE0C3, "Servo EntryAbility", "\n\nYou probably meant to add -- infront of your argument, i.e., --psn=--tracing vs --psn=tracing");
           hilog.error(0xE0C3, "Servo EntryAbility", "-------------------------------------------------------------------------------------------------");

--- a/support/openharmony/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/support/openharmony/entry/src/main/ets/entryability/EntryAbility.ets
@@ -36,7 +36,7 @@ export default class EntryAbility extends UIAbility {
             }
         } else if (WRONG_COMMAND_ARRAY.some(value => key.startsWith(value))) {
           hilog.error(0xE0C3, "Servo EntryAbility", "-------------------------------------------------------------------------------------------------");
-          hilog.error(0xE0C3, "Servo EntryAbility", "\n\nYou probably meant to add -- infront of your argument, i.e., --psn=--tracing vs --psn=tracing");
+          hilog.error(0xE0C3, "Servo EntryAbility", "\n\nYou probably meant to add -- infront of your argument, i.e., --psn=--tracing vs --psn=tracing. You used " + entry);
           hilog.error(0xE0C3, "Servo EntryAbility", "-------------------------------------------------------------------------------------------------");
           return;
         }

--- a/support/openharmony/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/support/openharmony/entry/src/main/ets/entryability/EntryAbility.ets
@@ -32,7 +32,7 @@ export default class EntryAbility extends UIAbility {
             if (value) {
                 params.push(value)
             }
-        } else if (key.startsWith("tracing") || key.startsWith("devtools") || key.startsWith("force_ipc") || key.startsWith("multiprocess") || key.startsWith("webdriver")) {
+        } else if (["tracing", "devtools", "force_ipc", "multiprocess", "webdriver"].some(value => key.startsWith(value))) {
           hilog.error(0xE0C3, "Servo EntryAbility", "-------------------------------------------------------------------------------------------------");
           hilog.error(0xE0C3, "Servo EntryAbility", "\n\nYou probably meant to add -- infront of your argument, i.e., --psn=--tracing vs --psn=tracing");
           hilog.error(0xE0C3, "Servo EntryAbility", "-------------------------------------------------------------------------------------------------");


### PR DESCRIPTION
Currently, commandline arguments need to be used like this: '--psn=--tracing_filter' which people can easily forget and use '--psn=tracing_filter'.
This happened to multiple people and leads to weird issues, since the argument is silently dropped.
Because OHOS appends a lot of other arguments and we don't have a good way to filter out the OS provided arguments, we now print a big error message that hopefully should be noticed by the user for a couple of commonly used arguments.

Testing: Tested on device with and without the correct way to invoke arguments.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
