### PR TITLE
config: Set the default value of the `network_http_proxy_uri` setting via the `http_proxy` variable

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -458,6 +458,9 @@ impl Default for Preferences {
     fn default() -> Self {
         let mut preferences = Self::const_default();
         preferences.user_agent = UserAgentPlatform::default().to_user_agent_string();
+        if let Ok(proxy_uri) = std::env::var("http_proxy") {
+            preferences.network_http_proxy_uri = proxy_uri;
+        }
         preferences
     }
 }

--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -19,7 +19,7 @@ pub fn main() {
     panic::set_hook(Box::new(panic_hook::panic_hook));
 
     let args = env::args().collect();
-    let (opts, mut preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
+    let (opts, preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
         ArgumentParsingResult::ContentProcess(token) => return servo::run_content_process(token),
         ArgumentParsingResult::ChromeProcess(opts, preferences, servoshell_preferences) => {
             (opts, preferences, servoshell_preferences)
@@ -33,10 +33,6 @@ pub fn main() {
     };
 
     crate::init_tracing(servoshell_preferences.tracing_filter.as_deref());
-
-    if let Ok(proxy_uri) = env::var("http_proxy") {
-        preferences.network_http_proxy_uri = proxy_uri;
-    }
 
     let clean_shutdown = servoshell_preferences.clean_shutdown;
     let event_loop = match servoshell_preferences.headless {

--- a/ports/servoshell/desktop/cli.rs
+++ b/ports/servoshell/desktop/cli.rs
@@ -19,7 +19,7 @@ pub fn main() {
     panic::set_hook(Box::new(panic_hook::panic_hook));
 
     let args = env::args().collect();
-    let (opts, preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
+    let (opts, mut preferences, servoshell_preferences) = match parse_command_line_arguments(args) {
         ArgumentParsingResult::ContentProcess(token) => return servo::run_content_process(token),
         ArgumentParsingResult::ChromeProcess(opts, preferences, servoshell_preferences) => {
             (opts, preferences, servoshell_preferences)
@@ -33,6 +33,10 @@ pub fn main() {
     };
 
     crate::init_tracing(servoshell_preferences.tracing_filter.as_deref());
+
+    if let Ok(proxy_uri) = env::var("http_proxy") {
+        preferences.network_http_proxy_uri = proxy_uri;
+    }
 
     let clean_shutdown = servoshell_preferences.clean_shutdown;
     let event_loop = match servoshell_preferences.headless {


### PR DESCRIPTION
This parses the env variable "http_proxy" for servoshell and sets the network_http_proxy_uri if it exists to the same value.

Testing: Tested that it correctly picks it up.
