### PR TITLE
net: Make parsing of Access-Control-Allow-Origin header less strict

### DIFF
--- a/tests/wpt/meta/cors/origin.htm.ini
+++ b/tests/wpt/meta/cors/origin.htm.ini
@@ -1,9 +1,0 @@
-[origin.htm]
-  [Disallow origin: http://web-platform.test:8000/]
-    expected: FAIL
-
-  [Disallow origin: http://web-platform.test:8000#]
-    expected: FAIL
-
-  [Disallow origin: HTTP://web-platform.test:8000]
-    expected: FAIL

--- a/tests/wpt/meta/cors/remote-origin.htm.ini
+++ b/tests/wpt/meta/cors/remote-origin.htm.ini
@@ -1,9 +1,0 @@
-[remote-origin.htm]
-  [Disallow origin: http://www1.web-platform.test:8000/]
-    expected: FAIL
-
-  [Disallow origin: http://www1.web-platform.test:8000#]
-    expected: FAIL
-
-  [Disallow origin: HTTP://www1.web-platform.test:8000]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-disabled-by-feature-policy.https.sub.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/autoplay-disabled-by-feature-policy.https.sub.html.ini
@@ -1,7 +1,7 @@
 [autoplay-disabled-by-feature-policy.https.sub.html]
   expected: TIMEOUT
   [Feature-Policy header: autoplay "none" disallows same-origin iframes.]
-    expected: TIMEOUT
+    expected: FAIL
 
   [Feature-Policy header: autoplay "none" disallows cross-origin iframes.]
     expected: FAIL


### PR DESCRIPTION
The typed header parsing is too strict. It parses the value as an origin, which is too strict. Instead, the spec expects a literal string comparison, regardless if the value reflects a valid origin or not.

Initially I thought this was a spec issue (https://github.com/whatwg/fetch/issues/1895), but alas it wasn't.
Testing: This allows multiple WPT tests to pass.