### PR TITLE
net: check actual response body length from http cached response

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -483,6 +483,10 @@ fn handle_range_request(
                             _ => continue,
                         };
                         if let Some(bytes) = requested {
+                            if bytes.len() as u64 + beginning < total {
+                                // Requested range goes beyond the available range.
+                                continue;
+                            }
                             let new_resource =
                                 create_resource_with_bytes_from_resource(bytes, partial_resource);
                             let cached_response =

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -483,7 +483,7 @@ fn handle_range_request(
                             _ => continue,
                         };
                         if let Some(bytes) = requested {
-                            if bytes.len() as u64 + beginning < total-1 {
+                            if bytes.len() as u64 + beginning < total - 1 {
                                 // Requested range goes beyond the available range.
                                 continue;
                             }

--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -483,7 +483,7 @@ fn handle_range_request(
                             _ => continue,
                         };
                         if let Some(bytes) = requested {
-                            if bytes.len() as u64 + beginning < total {
+                            if bytes.len() as u64 + beginning < total-1 {
                                 // Requested range goes beyond the available range.
                                 continue;
                             }

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use base::id::TEST_PIPELINE_ID;
-use http::StatusCode;
-use http::header::{EXPIRES, HeaderValue};
+use http::{HeaderMap, StatusCode};
+use http::header::{CONTENT_LENGTH, CONTENT_RANGE, EXPIRES, HeaderValue, RANGE};
 use net::http_cache::HttpCache;
 use net_traits::request::{Referrer, RequestBuilder};
 use net_traits::response::{Response, ResponseBody};
@@ -47,4 +47,39 @@ fn test_refreshing_resource_sets_done_chan_the_appropriate_value() {
             ResponseBody::Empty | ResponseBody::Done(_) => assert!(done_chan.is_none()),
         }
     })
+}
+
+#[test]
+fn test_skip_incomplete_cache_for_range_request_with_no_end_bound() {
+    let actual_body_len = 10;
+    let incomplete_response_body = &[1,2,3,4,5];
+    let url = ServoUrl::parse("https://servo.org").unwrap();
+
+    let mut cache = HttpCache::default();
+    let mut headers = HeaderMap::new();
+    
+    headers.insert(RANGE, HeaderValue::from_str(&format!("bytes={}-", 0)).unwrap());
+    let request = RequestBuilder::new(None, url.clone(), Referrer::NoReferrer)
+    .pipeline_id(Some(TEST_PIPELINE_ID))
+    .origin(url.origin())
+    .headers(headers)
+    .build();
+    
+    // Store incomplete response to http_cache
+    let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
+    let mut initial_incomplete_response = Response::new(url.clone(), timing);
+    *initial_incomplete_response.body.lock() = ResponseBody::Done(incomplete_response_body.to_vec());
+    initial_incomplete_response.headers.insert(
+        CONTENT_RANGE, HeaderValue::from_str(&format!("bytes 0-{}/{}",actual_body_len-1, actual_body_len)).unwrap());
+    initial_incomplete_response.headers.insert(
+        CONTENT_LENGTH, HeaderValue::from_str(&format!("{}",actual_body_len)).unwrap()
+    );
+    initial_incomplete_response.headers.insert(EXPIRES, HeaderValue::from_str("0").unwrap());
+    initial_incomplete_response.status = StatusCode::PARTIAL_CONTENT.into();
+    cache.store(&request, &initial_incomplete_response);
+
+    // Try to construct response from http_cache
+    let mut done_chan = None;
+    let consecutive_response = cache.construct_response(&request, &mut done_chan);
+    assert!(consecutive_response.is_none(), "Should not construct response from incomplete response!");
 }

--- a/components/net/tests/http_cache.rs
+++ b/components/net/tests/http_cache.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use base::id::TEST_PIPELINE_ID;
-use http::{HeaderMap, StatusCode};
 use http::header::{CONTENT_LENGTH, CONTENT_RANGE, EXPIRES, HeaderValue, RANGE};
+use http::{HeaderMap, StatusCode};
 use net::http_cache::HttpCache;
 use net_traits::request::{Referrer, RequestBuilder};
 use net_traits::response::{Response, ResponseBody};
@@ -52,34 +52,51 @@ fn test_refreshing_resource_sets_done_chan_the_appropriate_value() {
 #[test]
 fn test_skip_incomplete_cache_for_range_request_with_no_end_bound() {
     let actual_body_len = 10;
-    let incomplete_response_body = &[1,2,3,4,5];
+    let incomplete_response_body = &[1, 2, 3, 4, 5];
     let url = ServoUrl::parse("https://servo.org").unwrap();
 
     let mut cache = HttpCache::default();
     let mut headers = HeaderMap::new();
-    
-    headers.insert(RANGE, HeaderValue::from_str(&format!("bytes={}-", 0)).unwrap());
+
+    headers.insert(
+        RANGE,
+        HeaderValue::from_str(&format!("bytes={}-", 0)).unwrap(),
+    );
     let request = RequestBuilder::new(None, url.clone(), Referrer::NoReferrer)
-    .pipeline_id(Some(TEST_PIPELINE_ID))
-    .origin(url.origin())
-    .headers(headers)
-    .build();
-    
+        .pipeline_id(Some(TEST_PIPELINE_ID))
+        .origin(url.origin())
+        .headers(headers)
+        .build();
+
     // Store incomplete response to http_cache
     let timing = ResourceFetchTiming::new(ResourceTimingType::Navigation);
     let mut initial_incomplete_response = Response::new(url.clone(), timing);
-    *initial_incomplete_response.body.lock() = ResponseBody::Done(incomplete_response_body.to_vec());
+    *initial_incomplete_response.body.lock() =
+        ResponseBody::Done(incomplete_response_body.to_vec());
     initial_incomplete_response.headers.insert(
-        CONTENT_RANGE, HeaderValue::from_str(&format!("bytes 0-{}/{}",actual_body_len-1, actual_body_len)).unwrap());
-    initial_incomplete_response.headers.insert(
-        CONTENT_LENGTH, HeaderValue::from_str(&format!("{}",actual_body_len)).unwrap()
+        CONTENT_RANGE,
+        HeaderValue::from_str(&format!(
+            "bytes 0-{}/{}",
+            actual_body_len - 1,
+            actual_body_len
+        ))
+        .unwrap(),
     );
-    initial_incomplete_response.headers.insert(EXPIRES, HeaderValue::from_str("0").unwrap());
+    initial_incomplete_response.headers.insert(
+        CONTENT_LENGTH,
+        HeaderValue::from_str(&format!("{}", actual_body_len)).unwrap(),
+    );
+    initial_incomplete_response
+        .headers
+        .insert(EXPIRES, HeaderValue::from_str("0").unwrap());
     initial_incomplete_response.status = StatusCode::PARTIAL_CONTENT.into();
     cache.store(&request, &initial_incomplete_response);
 
     // Try to construct response from http_cache
     let mut done_chan = None;
     let consecutive_response = cache.construct_response(&request, &mut done_chan);
-    assert!(consecutive_response.is_none(), "Should not construct response from incomplete response!");
+    assert!(
+        consecutive_response.is_none(),
+        "Should not construct response from incomplete response!"
+    );
 }


### PR DESCRIPTION
When constructing response for partial content request from previously cached response with `Content-Range` Header (a.k.a Partial Response), add a check whether the body length of this response match what it claims in its `Content-Range` Header. Do not construct resposne from this cached response if the two does not match.

Testing: http_cache unittest and does not affect any existing WPT test result.
Fixes: https://github.com/servo/servo/issues/41174
