### PR TITLE
script: Add unsafe block in set_gc_zeal_options.

### DIFF
--- a/components/script/script_runtime.rs
+++ b/components/script/script_runtime.rs
@@ -1141,7 +1141,9 @@ unsafe fn set_gc_zeal_options(cx: *mut RawJSContext) {
         // https://searchfox.org/mozilla-esr128/source/js/public/GCAPI.h#1392
         _ => 5000,
     };
-    SetGCZeal(cx, level, frequency);
+    unsafe {
+        SetGCZeal(cx, level, frequency);
+    }
 }
 
 #[expect(unsafe_code)]


### PR DESCRIPTION
Fixes the following warning:
```
warning[E0133]: call to unsafe function `js::jsapi::SetGCZeal` is unsafe and requires unsafe block
    --> components/script/script_runtime.rs:1144:5
     |
1144 |     SetGCZeal(cx, level, frequency);
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
     |
     = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
     = note: consult the function's documentation for information on how to avoid undefined behavior
note: an unsafe function restricts its caller, but its body is safe by default
    --> components/script/script_runtime.rs:1132:1
     |
1132 | unsafe fn set_gc_zeal_options(cx: *mut RawJSContext) {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     = note: `#[warn(unsafe_op_in_unsafe_fn)]` (part of `#[warn(rust_2024_compatibility)]`) on by default
```

Testing: Build-time only.