### PR TITLE
script_bindings: Correct binding type for Uint8Array in dictionary

### DIFF
--- a/components/script_bindings/codegen/codegen.py
+++ b/components/script_bindings/codegen/codegen.py
@@ -1014,8 +1014,9 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
         typeName = type.unroll().name  # unroll because it may be nullable
 
         is_union_member = (isMember == "Union")
+        is_dictionary_member = (isMember == "Dictionary")
 
-        if is_union_member:
+        if is_union_member or is_dictionary_member:
             typeName = f"Heap{typeName}"
             map_call = ".map(RootedTraceableBox::new)"
         else:
@@ -1035,7 +1036,7 @@ def getJSToNativeConversionInfo(type: IDLType, descriptorProvider: DescriptorPro
         )
 
         declType = CGGeneric(f"typedarray::{typeName}")
-        if is_union_member:
+        if is_union_member or is_dictionary_member:
             declType = CGWrapper(declType, pre="RootedTraceableBox<", post=">")
 
         if type.nullable():

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -20,9 +20,7 @@ pub(crate) mod base {
     #[allow(unused_imports)]
     pub(crate) use js::realm::{AutoRealm, CurrentRealm};
     pub(crate) use js::rust::wrappers::Call;
-    pub(crate) use js::rust::{
-        CustomTrace, HandleObject, HandleValue, MutableHandleObject, MutableHandleValue,
-    };
+    pub(crate) use js::rust::{HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
     pub(crate) use js::typedarray;
     pub(crate) use js::typedarray::{
         ArrayBuffer, ArrayBufferView, Float32Array, Float64Array, Uint8Array, Uint8ClampedArray,


### PR DESCRIPTION
We currently trace `Uint8Array` in WebIDL dictionary with `typedarray::Uint8Array`. We should use `typedarray::HeapUint8Array` instead.

The patch also applies to other typed array.

Testing: Existing tests suffice.
Fixes: #41206