### PR TITLE
script: Use rooted typed arrays in generated code and buffer source APIs

### DIFF
--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -6,7 +6,8 @@ use std::cmp::min;
 
 use dom_struct::dom_struct;
 use js::rust::{CustomAutoRooterGuard, HandleObject};
-use js::typedarray::{Float32, Float32Array};
+use js::typedarray::{Float32, Float32Array, HeapFloat32Array};
+use script_bindings::trace::RootedTraceableBox;
 use servo_media::audio::buffer_source_node::AudioBuffer as ServoMediaAudioBuffer;
 
 use crate::dom::audio::audionode::MAX_CHANNEL_COUNT;
@@ -238,7 +239,12 @@ impl AudioBufferMethods<crate::DomTypeHolder> for AudioBuffer {
     }
 
     /// <https://webaudio.github.io/web-audio-api/#dom-audiobuffer-getchanneldata>
-    fn GetChannelData(&self, cx: JSContext, channel: u32, can_gc: CanGc) -> Fallible<Float32Array> {
+    fn GetChannelData(
+        &self,
+        cx: JSContext,
+        channel: u32,
+        can_gc: CanGc,
+    ) -> Fallible<RootedTraceableBox<HeapFloat32Array>> {
         if channel >= self.number_of_channels {
             return Err(Error::IndexSize(None));
         }

--- a/components/script/dom/compressionstream.rs
+++ b/components/script/dom/compressionstream.rs
@@ -13,7 +13,7 @@ use flate2::write::{DeflateEncoder, GzEncoder, ZlibEncoder};
 use js::jsapi::JSObject;
 use js::jsval::UndefinedValue;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
-use js::typedarray::Uint8Array;
+use js::typedarray::Uint8;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
@@ -239,8 +239,8 @@ pub(crate) fn compress_and_enqueue_a_chunk(
     // Step 5. For each Uint8Array array of arrays, enqueue array in cs’s transform.
     // NOTE: We process the result in a single Uint8Array.
     rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-    let buffer_source: Uint8Array =
-        create_buffer_source(cx, buffer, js_object.handle_mut(), can_gc)
+    let buffer_source =
+        create_buffer_source::<Uint8>(cx, buffer, js_object.handle_mut(), can_gc)
             .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(in(*cx) let mut rval = UndefinedValue());
     buffer_source.safe_to_jsval(cx, rval.handle_mut(), can_gc);
@@ -281,8 +281,8 @@ pub(crate) fn compress_flush_and_enqueue(
     // Step 4. For each Uint8Array array of arrays, enqueue array in cs’s transform.
     // NOTE: We process the result in a single Uint8Array.
     rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-    let buffer_source: Uint8Array =
-        create_buffer_source(cx, buffer, js_object.handle_mut(), can_gc)
+    let buffer_source =
+        create_buffer_source::<Uint8>(cx, buffer, js_object.handle_mut(), can_gc)
             .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(in(*cx) let mut rval = UndefinedValue());
     buffer_source.safe_to_jsval(cx, rval.handle_mut(), can_gc);

--- a/components/script/dom/decompressionstream.rs
+++ b/components/script/dom/decompressionstream.rs
@@ -12,7 +12,7 @@ use flate2::write::{DeflateDecoder, GzDecoder, ZlibDecoder};
 use js::jsapi::JSObject;
 use js::jsval::UndefinedValue;
 use js::rust::{HandleObject as SafeHandleObject, HandleValue as SafeHandleValue};
-use js::typedarray::Uint8Array;
+use js::typedarray::Uint8;
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
@@ -241,7 +241,7 @@ pub(crate) fn decompress_and_enqueue_a_chunk(
     // Step 5. For each Uint8Array array of arrays, enqueue array in ds’s transform.
     // NOTE: We process the result in a single Uint8Array.
     rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-    let array: Uint8Array = create_buffer_source(cx, buffer, js_object.handle_mut(), can_gc)
+    let array = create_buffer_source::<Uint8>(cx, buffer, js_object.handle_mut(), can_gc)
         .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(in(*cx) let mut rval = UndefinedValue());
     array.safe_to_jsval(cx, rval.handle_mut(), can_gc);
@@ -291,7 +291,7 @@ pub(crate) fn decompress_flush_and_enqueue(
         // Step 2.2. For each Uint8Array array of arrays, enqueue array in ds’s transform.
         // NOTE: We process the result in a single Uint8Array.
         rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-        let array: Uint8Array = create_buffer_source(cx, buffer, js_object.handle_mut(), can_gc)
+        let array = create_buffer_source::<Uint8>(cx, buffer, js_object.handle_mut(), can_gc)
             .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
         rooted!(in(*cx) let mut rval = UndefinedValue());
         array.safe_to_jsval(cx, rval.handle_mut(), can_gc);

--- a/components/script/dom/dommatrixreadonly.rs
+++ b/components/script/dom/dommatrixreadonly.rs
@@ -15,8 +15,9 @@ use js::conversions::jsstr_to_string;
 use js::jsapi::JSObject;
 use js::jsval;
 use js::rust::{CustomAutoRooterGuard, HandleObject, ToString};
-use js::typedarray::{Float32Array, Float64Array};
+use js::typedarray::{Float32Array, Float64Array, HeapFloat32Array, HeapFloat64Array};
 use rustc_hash::FxHashMap;
+use script_bindings::trace::RootedTraceableBox;
 use style::parser::ParserContext;
 use url::Url;
 
@@ -812,7 +813,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat32array>
-    fn ToFloat32Array(&self, cx: JSContext, can_gc: CanGc) -> Float32Array {
+    fn ToFloat32Array(&self, cx: JSContext, can_gc: CanGc) -> RootedTraceableBox<HeapFloat32Array> {
         let vec: Vec<f32> = self
             .matrix
             .borrow()
@@ -826,7 +827,7 @@ impl DOMMatrixReadOnlyMethods<crate::DomTypeHolder> for DOMMatrixReadOnly {
     }
 
     /// <https://drafts.fxtf.org/geometry-1/#dom-dommatrixreadonly-tofloat64array>
-    fn ToFloat64Array(&self, cx: JSContext, can_gc: CanGc) -> Float64Array {
+    fn ToFloat64Array(&self, cx: JSContext, can_gc: CanGc) -> RootedTraceableBox<HeapFloat64Array> {
         rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());
         create_buffer_source(
             cx,

--- a/components/script/dom/filereadersync.rs
+++ b/components/script/dom/filereadersync.rs
@@ -7,7 +7,8 @@ use std::ptr;
 use dom_struct::dom_struct;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
-use js::typedarray::{ArrayBuffer, ArrayBufferU8};
+use js::typedarray::{ArrayBufferU8, HeapArrayBuffer};
+use script_bindings::trace::RootedTraceableBox;
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::codegen::Bindings::BlobBinding::BlobMethods;
@@ -103,7 +104,7 @@ impl FileReaderSyncMethods<crate::DomTypeHolder> for FileReaderSync {
         cx: JSContext,
         blob: &Blob,
         can_gc: CanGc,
-    ) -> Fallible<ArrayBuffer> {
+    ) -> Fallible<RootedTraceableBox<HeapArrayBuffer>> {
         // step 1
         let blob_contents = FileReaderSync::get_blob_bytes(blob)?;
 

--- a/components/script/dom/gamepad/gamepad.rs
+++ b/components/script/dom/gamepad/gamepad.rs
@@ -6,7 +6,8 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use embedder_traits::{GamepadSupportedHapticEffects, GamepadUpdateType};
-use js::typedarray::{Float64, Float64Array};
+use js::typedarray::{Float64, HeapFloat64Array};
+use script_bindings::trace::RootedTraceableBox;
 
 use super::gamepadbuttonlist::GamepadButtonList;
 use super::gamepadhapticactuator::GamepadHapticActuator;
@@ -160,7 +161,7 @@ impl GamepadMethods<crate::DomTypeHolder> for Gamepad {
     }
 
     /// <https://w3c.github.io/gamepad/#dom-gamepad-axes>
-    fn Axes(&self, _cx: JSContext) -> Float64Array {
+    fn Axes(&self, _cx: JSContext) -> RootedTraceableBox<HeapFloat64Array> {
         self.axes
             .get_typed_array()
             .expect("Failed to get gamepad axes.")

--- a/components/script/dom/gamepad/gamepadpose.rs
+++ b/components/script/dom/gamepad/gamepadpose.rs
@@ -3,7 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use dom_struct::dom_struct;
-use js::typedarray::{Float32, Float32Array};
+use js::typedarray::{Float32, HeapFloat32Array};
+use script_bindings::trace::RootedTraceableBox;
 
 use crate::dom::bindings::buffer_source::HeapBufferSource;
 use crate::dom::bindings::codegen::Bindings::GamepadPoseBinding::GamepadPoseMethods;
@@ -51,7 +52,7 @@ impl GamepadPose {
 
 impl GamepadPoseMethods<crate::DomTypeHolder> for GamepadPose {
     /// <https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose-position>
-    fn GetPosition(&self, _cx: JSContext) -> Option<Float32Array> {
+    fn GetPosition(&self, _cx: JSContext) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         self.position.typed_array_to_option()
     }
 
@@ -61,17 +62,20 @@ impl GamepadPoseMethods<crate::DomTypeHolder> for GamepadPose {
     }
 
     /// <https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose-linearvelocity>
-    fn GetLinearVelocity(&self, _cx: JSContext) -> Option<Float32Array> {
+    fn GetLinearVelocity(&self, _cx: JSContext) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         self.linear_vel.typed_array_to_option()
     }
 
     /// <https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose-linearacceleration>
-    fn GetLinearAcceleration(&self, _cx: JSContext) -> Option<Float32Array> {
+    fn GetLinearAcceleration(
+        &self,
+        _cx: JSContext,
+    ) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         self.linear_acc.typed_array_to_option()
     }
 
     /// <https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose-orientation>
-    fn GetOrientation(&self, _cx: JSContext) -> Option<Float32Array> {
+    fn GetOrientation(&self, _cx: JSContext) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         self.orientation.typed_array_to_option()
     }
 
@@ -81,12 +85,15 @@ impl GamepadPoseMethods<crate::DomTypeHolder> for GamepadPose {
     }
 
     /// <https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose-angularvelocity>
-    fn GetAngularVelocity(&self, _cx: JSContext) -> Option<Float32Array> {
+    fn GetAngularVelocity(&self, _cx: JSContext) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         self.angular_vel.typed_array_to_option()
     }
 
     /// <https://w3c.github.io/gamepad/extensions.html#dom-gamepadpose-angularacceleration>
-    fn GetAngularAcceleration(&self, _cx: JSContext) -> Option<Float32Array> {
+    fn GetAngularAcceleration(
+        &self,
+        _cx: JSContext,
+    ) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         self.angular_acc.typed_array_to_option()
     }
 }

--- a/components/script/dom/readablestreambyobrequest.rs
+++ b/components/script/dom/readablestreambyobrequest.rs
@@ -5,6 +5,7 @@
 use dom_struct::dom_struct;
 use js::gc::CustomAutoRooterGuard;
 use js::typedarray::{ArrayBufferView, ArrayBufferViewU8};
+use script_bindings::trace::RootedTraceableBox;
 
 use super::bindings::buffer_source::HeapBufferSource;
 use super::bindings::cell::DomRefCell;
@@ -62,7 +63,10 @@ impl ReadableStreamBYOBRequest {
 
 impl ReadableStreamBYOBRequestMethods<crate::DomTypeHolder> for ReadableStreamBYOBRequest {
     /// <https://streams.spec.whatwg.org/#rs-byob-request-view>
-    fn GetView(&self, _cx: SafeJSContext) -> Option<js::typedarray::ArrayBufferView> {
+    fn GetView(
+        &self,
+        _cx: SafeJSContext,
+    ) -> Option<RootedTraceableBox<js::typedarray::HeapArrayBufferView>> {
         // Return this.[[view]].
         self.view.borrow().typed_array_to_option()
     }

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -15,6 +15,7 @@ use js::jsapi::{Heap, JS_NewPlainObject, JSObject};
 use js::jsval::JSVal;
 use js::rust::{CustomAutoRooterGuard, HandleObject, HandleValue, MutableHandleValue};
 use js::typedarray::{self, HeapUint8ClampedArray};
+use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::interfaces::TestBindingHelpers;
 use script_bindings::record::Record;
 use servo_config::prefs;
@@ -25,7 +26,8 @@ use crate::dom::bindings::codegen::Bindings::EventListenerBinding::EventListener
 use crate::dom::bindings::codegen::Bindings::FunctionBinding::Function;
 use crate::dom::bindings::codegen::Bindings::TestBindingBinding::{
     SimpleCallback, TestBindingMethods, TestDictionary, TestDictionaryDefaults,
-    TestDictionaryParent, TestDictionaryWithParent, TestEnum, TestURLLike,
+    TestDictionaryParent, TestDictionaryWithParent, TestDictionaryWithTypedArray, TestEnum,
+    TestURLLike,
 };
 use crate::dom::bindings::codegen::UnionTypes;
 use crate::dom::bindings::codegen::UnionTypes::{
@@ -560,6 +562,12 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
     }
     fn ReceiveNullableSequence(&self) -> Option<Vec<i32>> {
         Some(vec![1])
+    }
+    fn GetDictionaryWithTypedArray(
+        &self,
+        _dictionary: RootedTraceableBox<TestDictionaryWithTypedArray>,
+    ) {
+        self.global().as_window().Gc();
     }
     fn ReceiveTestDictionaryWithSuccessOnKeyword(&self) -> RootedTraceableBox<TestDictionary> {
         RootedTraceableBox::new(TestDictionary {

--- a/components/script/dom/testing/testbinding.rs
+++ b/components/script/dom/testing/testbinding.rs
@@ -14,7 +14,7 @@ use dom_struct::dom_struct;
 use js::jsapi::{Heap, JS_NewPlainObject, JSObject};
 use js::jsval::JSVal;
 use js::rust::{CustomAutoRooterGuard, HandleObject, HandleValue, MutableHandleValue};
-use js::typedarray::{self, Uint8ClampedArray};
+use js::typedarray::{self, HeapUint8ClampedArray};
 use script_bindings::interfaces::TestBindingHelpers;
 use script_bindings::record::Record;
 use servo_config::prefs;
@@ -222,7 +222,7 @@ impl TestBindingMethods<crate::DomTypeHolder> for TestBinding {
         ByteStringOrLong::ByteString(ByteString::new(vec![]))
     }
     fn SetUnion9Attribute(&self, _: ByteStringOrLong) {}
-    fn ArrayAttribute(&self, cx: SafeJSContext) -> Uint8ClampedArray {
+    fn ArrayAttribute(&self, cx: SafeJSContext) -> RootedTraceableBox<HeapUint8ClampedArray> {
         let data: [u8; 16] = [0; 16];
 
         rooted!(in (*cx) let mut array = ptr::null_mut::<JSObject>());

--- a/components/script/dom/textencoder.rs
+++ b/components/script/dom/textencoder.rs
@@ -9,7 +9,8 @@ use js::gc::CustomAutoRooterGuard;
 use js::jsapi::JSObject;
 use js::rust::HandleObject;
 use js::typedarray;
-use js::typedarray::Uint8Array;
+use js::typedarray::HeapUint8Array;
+use script_bindings::trace::RootedTraceableBox;
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
 use crate::dom::bindings::codegen::Bindings::TextEncoderBinding::{
@@ -64,7 +65,12 @@ impl TextEncoderMethods<crate::DomTypeHolder> for TextEncoder {
     }
 
     /// <https://encoding.spec.whatwg.org/#dom-textencoder-encode>
-    fn Encode(&self, cx: JSContext, input: USVString, can_gc: CanGc) -> Uint8Array {
+    fn Encode(
+        &self,
+        cx: JSContext,
+        input: USVString,
+        can_gc: CanGc,
+    ) -> RootedTraceableBox<HeapUint8Array> {
         let encoded = input.0.as_bytes();
 
         rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());

--- a/components/script/dom/textencoderstream.rs
+++ b/components/script/dom/textencoderstream.rs
@@ -17,7 +17,7 @@ use js::rust::{
     HandleObject as SafeHandleObject, HandleValue as SafeHandleValue,
     MutableHandleValue as SafeMutableHandleValue, ToString,
 };
-use js::typedarray::Uint8Array;
+use js::typedarray::Uint8;
 use script_bindings::conversions::SafeToJSValConvertible;
 
 use crate::dom::bindings::buffer_source::create_buffer_source;
@@ -274,7 +274,7 @@ pub(crate) fn encode_and_enqueue_a_chunk(
     // Step 4.2.2.1 Let chunk be the result of creating a Uint8Array object
     //      given output and encoder’s relevant realm.
     rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-    let chunk: Uint8Array = create_buffer_source(cx, output, js_object.handle_mut(), can_gc)
+    let chunk = create_buffer_source::<Uint8>(cx, output, js_object.handle_mut(), can_gc)
         .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
     rooted!(in(*cx) let mut rval = UndefinedValue());
     chunk.safe_to_jsval(cx, rval.handle_mut(), can_gc);
@@ -296,11 +296,13 @@ pub(crate) fn encode_and_flush(
         // Step 1.1 Let chunk be the result of creating a Uint8Array object
         //      given « 0xEF, 0xBF, 0xBD » and encoder’s relevant realm.
         rooted!(in(*cx) let mut js_object = ptr::null_mut::<JSObject>());
-        let chunk: Uint8Array =
-            create_buffer_source(cx, &[0xEF_u8, 0xBF, 0xBD], js_object.handle_mut(), can_gc)
-                .map_err(|_| {
-                    Error::Type("Cannot convert byte sequence to Uint8Array".to_owned())
-                })?;
+        let chunk = create_buffer_source::<Uint8>(
+            cx,
+            &[0xEF_u8, 0xBF, 0xBD],
+            js_object.handle_mut(),
+            can_gc,
+        )
+        .map_err(|_| Error::Type("Cannot convert byte sequence to Uint8Array".to_owned()))?;
         rooted!(in(*cx) let mut rval = UndefinedValue());
         chunk.safe_to_jsval(cx, rval.handle_mut(), can_gc);
         // Step 1.2 Enqueue chunk into encoder’s transform.

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -8,7 +8,8 @@ use std::string::String;
 
 use dom_struct::dom_struct;
 use ipc_channel::ipc::IpcSharedMemory;
-use js::typedarray::ArrayBuffer;
+use js::typedarray::HeapArrayBuffer;
+use script_bindings::trace::RootedTraceableBox;
 use webgpu_traits::{Mapping, WebGPU, WebGPUBuffer, WebGPURequest};
 use wgpu_core::device::HostMap;
 use wgpu_core::resource::BufferAccessError;
@@ -301,7 +302,7 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
         offset: GPUSize64,
         size: Option<GPUSize64>,
         can_gc: CanGc,
-    ) -> Fallible<ArrayBuffer> {
+    ) -> Fallible<RootedTraceableBox<HeapArrayBuffer>> {
         let range_size = if let Some(s) = size {
             s
         } else {

--- a/components/script/dom/webxr/xrray.rs
+++ b/components/script/dom/webxr/xrray.rs
@@ -5,7 +5,8 @@
 use dom_struct::dom_struct;
 use euclid::{Angle, RigidTransform3D, Rotation3D, Vector3D};
 use js::rust::HandleObject;
-use js::typedarray::{Float32, Float32Array};
+use js::typedarray::{Float32, HeapFloat32Array};
+use script_bindings::trace::RootedTraceableBox;
 use webxr_api::{ApiSpace, Ray};
 
 use crate::dom::bindings::buffer_source::HeapBufferSource;
@@ -125,7 +126,7 @@ impl XRRayMethods<crate::DomTypeHolder> for XRRay {
     }
 
     /// <https://immersive-web.github.io/hit-test/#dom-xrray-matrix>
-    fn Matrix(&self, _cx: JSContext, can_gc: CanGc) -> Float32Array {
+    fn Matrix(&self, _cx: JSContext, can_gc: CanGc) -> RootedTraceableBox<HeapFloat32Array> {
         // https://immersive-web.github.io/hit-test/#xrray-obtain-the-matrix
         if !self.matrix.is_initialized() {
             // Step 1

--- a/components/script/dom/webxr/xrrigidtransform.rs
+++ b/components/script/dom/webxr/xrrigidtransform.rs
@@ -5,7 +5,8 @@
 use dom_struct::dom_struct;
 use euclid::{RigidTransform3D, Rotation3D, Vector3D};
 use js::rust::HandleObject;
-use js::typedarray::{Float32, Float32Array};
+use js::typedarray::{Float32, HeapFloat32Array};
+use script_bindings::trace::RootedTraceableBox;
 
 use crate::dom::bindings::buffer_source::HeapBufferSource;
 use crate::dom::bindings::codegen::Bindings::DOMPointBinding::DOMPointInit;
@@ -164,7 +165,7 @@ impl XRRigidTransformMethods<crate::DomTypeHolder> for XRRigidTransform {
         })
     }
     /// <https://immersive-web.github.io/webxr/#dom-xrrigidtransform-matrix>
-    fn Matrix(&self, _cx: JSContext, can_gc: CanGc) -> Float32Array {
+    fn Matrix(&self, _cx: JSContext, can_gc: CanGc) -> RootedTraceableBox<HeapFloat32Array> {
         if !self.matrix.is_initialized() {
             self.matrix
                 .set_data(_cx, &self.transform.to_transform().to_array(), can_gc)

--- a/components/script/dom/webxr/xrsession.rs
+++ b/components/script/dom/webxr/xrsession.rs
@@ -15,9 +15,10 @@ use ipc_channel::ipc::IpcReceiver;
 use ipc_channel::router::ROUTER;
 use js::jsapi::JSObject;
 use js::rust::MutableHandleValue;
-use js::typedarray::Float32Array;
+use js::typedarray::HeapFloat32Array;
 use profile_traits::ipc;
 use rustc_hash::FxBuildHasher;
+use script_bindings::trace::RootedTraceableBox;
 use stylo_atoms::Atom;
 use webxr_api::{
     self, ApiSpace, ContextId as WebXRContextId, Display, EntityTypes, EnvironmentBlendMode,
@@ -1001,7 +1002,11 @@ impl XRSessionMethods<crate::DomTypeHolder> for XRSession {
     }
 
     /// <https://www.w3.org/TR/webxr/#dom-xrsession-supportedframerates>
-    fn GetSupportedFrameRates(&self, cx: JSContext, can_gc: CanGc) -> Option<Float32Array> {
+    fn GetSupportedFrameRates(
+        &self,
+        cx: JSContext,
+        can_gc: CanGc,
+    ) -> Option<RootedTraceableBox<HeapFloat32Array>> {
         let session = self.session.borrow();
         if self.mode == XRSessionMode::Inline || session.supported_frame_rates().is_empty() {
             None

--- a/components/script/dom/webxr/xrview.rs
+++ b/components/script/dom/webxr/xrview.rs
@@ -6,7 +6,8 @@ use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use euclid::RigidTransform3D;
-use js::typedarray::{Float32, Float32Array};
+use js::typedarray::{Float32, HeapFloat32Array};
+use script_bindings::trace::RootedTraceableBox;
 use webxr_api::{ApiSpace, View};
 
 use crate::dom::bindings::buffer_source::HeapBufferSource;
@@ -96,7 +97,11 @@ impl XRViewMethods<crate::DomTypeHolder> for XRView {
     }
 
     /// <https://immersive-web.github.io/webxr/#dom-xrview-projectionmatrix>
-    fn ProjectionMatrix(&self, _cx: JSContext, can_gc: CanGc) -> Float32Array {
+    fn ProjectionMatrix(
+        &self,
+        _cx: JSContext,
+        can_gc: CanGc,
+    ) -> RootedTraceableBox<HeapFloat32Array> {
         if !self.proj.is_initialized() {
             let cx = GlobalScope::get_cx();
             // row_major since euclid uses row vectors

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -25,7 +25,7 @@ use js::jsapi::{Heap, JS_ClearPendingException};
 use js::jsval::{JSVal, NullValue};
 use js::rust::wrappers::JS_ParseJSON;
 use js::rust::{HandleObject, MutableHandleValue};
-use js::typedarray::{ArrayBuffer, ArrayBufferU8};
+use js::typedarray::{ArrayBufferU8, HeapArrayBuffer};
 use net_traits::fetch::headers::extract_mime_type_as_dataurl_mime;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{CredentialsMode, Referrer, RequestBuilder, RequestId, RequestMode};
@@ -35,6 +35,7 @@ use net_traits::{
 };
 use script_bindings::conversions::SafeToJSValConvertible;
 use script_bindings::num::Finite;
+use script_bindings::trace::RootedTraceableBox;
 use script_traits::DocumentActivity;
 use servo_url::ServoUrl;
 use stylo_atoms::Atom;
@@ -1342,7 +1343,11 @@ impl XMLHttpRequest {
     }
 
     /// <https://xhr.spec.whatwg.org/#arraybuffer-response>
-    fn arraybuffer_response(&self, cx: JSContext, can_gc: CanGc) -> Option<ArrayBuffer> {
+    fn arraybuffer_response(
+        &self,
+        cx: JSContext,
+        can_gc: CanGc,
+    ) -> Option<RootedTraceableBox<HeapArrayBuffer>> {
         // Step 5: Set the response object to a new ArrayBuffer with the received bytes
         // For caching purposes, skip this step if the response is already created
         if !self.response_arraybuffer.is_initialized() {

--- a/components/script_bindings/import.rs
+++ b/components/script_bindings/import.rs
@@ -20,12 +20,11 @@ pub(crate) mod base {
     #[allow(unused_imports)]
     pub(crate) use js::realm::{AutoRealm, CurrentRealm};
     pub(crate) use js::rust::wrappers::Call;
-    pub(crate) use js::rust::{
-        CustomTrace, HandleObject, HandleValue, MutableHandleObject, MutableHandleValue,
-    };
+    pub(crate) use js::rust::{HandleObject, HandleValue, MutableHandleObject, MutableHandleValue};
     pub(crate) use js::typedarray;
     pub(crate) use js::typedarray::{
-        ArrayBuffer, ArrayBufferView, Float32Array, Float64Array, Uint8Array, Uint8ClampedArray,
+        HeapArrayBuffer, HeapArrayBufferView, HeapFloat32Array, HeapFloat64Array, HeapUint8Array,
+        HeapUint8ClampedArray,
     };
 
     pub(crate) use crate::callback::{

--- a/components/script_bindings/webidls/TestBinding.webidl
+++ b/components/script_bindings/webidls/TestBinding.webidl
@@ -49,6 +49,10 @@ dictionary TestDictionary {
   callbackWithOnlyOneOptionalArg noCallbackImport2;
 };
 
+dictionary TestDictionaryWithTypedArray {
+  Uint8Array typedArray;
+};
+
 dictionary TestDictionaryParent {
   DOMString parentStringMember;
 };
@@ -594,6 +598,7 @@ interface TestBinding {
   readonly attribute boolean semiExposedBoolFromInterface;
 
   TestDictionaryWithParent getDictionaryWithParent(DOMString parent, DOMString child);
+  undefined getDictionaryWithTypedArray(optional TestDictionaryWithTypedArray dict = {});
 };
 
 [Exposed=(Window)]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -102,6 +102,13 @@
       {}
      ]
     ],
+    "typed-array-crash.html": [
+     "811e41863e3df24b1c8268f4b050530644b24210",
+     [
+      null,
+      {}
+     ]
+    ],
     "window_resizeTo_not_permitted-crash.html": [
      "7b6a67ff81436a91048bdb627f303f7fab2762f7",
      [

--- a/tests/wpt/mozilla/tests/mozilla/typed-array-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/typed-array-crash.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<title>Typed array dictionary member rooting crash</title>
+<script>
+  let buffer = new Uint8Array(10);
+  (new TestBinding()).getDictionaryWithTypedArray({ typedArray: buffer });
+</script>


### PR DESCRIPTION
There are two flavours of the mozjs `TypedArray<T>` wrapper for typed array objects: one stores a `Box<Heap<*mut JSObject>>`, while the other just has a bare `*mut JSObject`. The second one must only be stored inside the `CustomAutoRoot` rooting values, but we were using it in many other places like WebIDL dictionaries without rooting it safely. These changes make our typed array APIs always use `RootedTraceableBox<TypedArray<T>>` with the `Box<Heap<*mut JSObject>>` flavour, which ensures that the JS object stored inside the typed array wrapper is always visible to the SpiderMonkey GC.

Testing: Adds a new test that crashes without these changes.
Fixes: #41206
