### PR TITLE
script: Implement storing deferred fetches

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -13,7 +13,7 @@ use servo_url::ServoUrl;
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::root::Dom;
 use crate::dom::document::Document;
-use crate::fetch::FetchCanceller;
+use crate::fetch::{FetchCanceller, QueuedDeferredFetchRecord};
 use crate::script_runtime::CanGc;
 
 #[derive(Clone, Debug, JSTraceable, MallocSizeOf, PartialEq)]
@@ -81,6 +81,10 @@ pub(crate) struct DocumentLoader {
     blocking_loads: Vec<LoadType>,
     events_inhibited: bool,
     cancellers: Vec<FetchCanceller>,
+    /// <https://fetch.spec.whatwg.org/#fetch-group-deferred-fetch-records>
+    #[no_trace]
+    #[conditional_malloc_size_of]
+    deferred_fetches: Vec<QueuedDeferredFetchRecord>,
 }
 
 impl DocumentLoader {
@@ -100,13 +104,24 @@ impl DocumentLoader {
             blocking_loads: initial_loads,
             events_inhibited: false,
             cancellers: Vec::new(),
+            deferred_fetches: Vec::new(),
         }
     }
 
+    /// <https://fetch.spec.whatwg.org/#concept-fetch-group-terminate>
     pub(crate) fn cancel_all_loads(&mut self) -> bool {
+        // Step 1. For each fetch record record of fetchGroup’s fetch records,
+        // if record’s controller is non-null and record’s request’s done flag
+        // is unset and keepalive is false, terminate record’s controller.
+        //
+        // Implemented in [`FetchCanceller::cancel`] which runs when these cancellers are dropped.
         let canceled_any = !self.cancellers.is_empty();
-        // Associated fetches will be canceled when dropping the canceller.
         self.cancellers.clear();
+        // Step 2. Process deferred fetches for fetchGroup.
+        for deferred_fetch in self.deferred_fetches.drain(..) {
+            deferred_fetch.lock().unwrap().process();
+        }
+
         canceled_any
     }
 
@@ -118,6 +133,10 @@ impl DocumentLoader {
             self.blocking_loads.len()
         );
         self.blocking_loads.push(load);
+    }
+
+    pub(crate) fn append_deferred_fetch(&mut self, deferred_fetch: QueuedDeferredFetchRecord) {
+        self.deferred_fetches.push(deferred_fetch);
     }
 
     /// Initiate a new fetch given a response callback.

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -142,6 +142,7 @@ use crate::dom::window::Window;
 use crate::dom::workerglobalscope::WorkerGlobalScope;
 use crate::dom::workletglobalscope::WorkletGlobalScope;
 use crate::dom::writablestream::CrossRealmTransformWritable;
+use crate::fetch::QueuedDeferredFetchRecord;
 use crate::messaging::{CommonScriptMsg, ScriptEventLoopReceiver, ScriptEventLoopSender};
 use crate::microtask::Microtask;
 use crate::network_listener::{FetchResponseListener, NetworkListener};
@@ -3453,6 +3454,13 @@ impl GlobalScope {
             return worker.buffered_reports();
         }
         unreachable!();
+    }
+
+    pub(crate) fn append_deferred_fetch(&self, deferred_fetch: QueuedDeferredFetchRecord) {
+        if let Some(window) = self.downcast::<Window>() {
+            return window.Document().append_deferred_fetch(deferred_fetch);
+        }
+        unreachable!("Deferred fetches (e.g. `fetchLater`) are only available on window");
     }
 
     pub(crate) fn import_map(&self) -> Ref<'_, ImportMap> {

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -703,7 +703,12 @@ impl FetchThread {
 
                     core_resource_thread.send(message).unwrap();
 
-                    self.active_fetches.insert(request_builder_id, callback);
+                    let preexisting_fetch =
+                        self.active_fetches.insert(request_builder_id, callback);
+                    // When we terminate a fetch group, all deferred fetches are processed.
+                    // In case we were already processing a deferred fetch, we should not
+                    // process the second call. This should be handled by [`DeferredFetchRecord::process`]
+                    assert!(preexisting_fetch.is_none());
                 },
                 ToFetchThreadMessage::FetchResponse(fetch_response_msg) => {
                     let request_id = fetch_response_msg.request_id();


### PR DESCRIPTION
This is the first part of preparation for implementing the keepalive flag for requests. It requires implementation of the concept of a task group, which we already sort of have with `DocumentLoader`. Therefore, we currently already cancel any loads, which should be updated to ignored kept-alive requests.

However, termination also requires storing of deferred fetches, which are also kept-alive. Therefore, to distinguish the two, we need to store them separately as stated with the TODO.

In a follow-up, we can then skip canceling keep-alive requests for both `navigator.sendBeacon` (which aren't deferred) and `fetchLater` (which are deferred).

Part of #41230