### PR TITLE
servoshell: Create new WebDriver `WebView`s in new toplevel windows

### DIFF
--- a/components/compositing/painter.rs
+++ b/components/compositing/painter.rs
@@ -29,7 +29,7 @@ use euclid::{Point2D, Rect, Scale, Size2D};
 use gleam::gl::RENDERER;
 use image::RgbaImage;
 use ipc_channel::ipc::{IpcBytesReceiver, IpcSharedMemory};
-use log::{debug, info, warn};
+use log::{debug, error, info, warn};
 use media::WindowGLContext;
 use profile_traits::time::{ProfilerCategory, ProfilerChan};
 use profile_traits::time_profile;
@@ -128,7 +128,7 @@ pub(crate) struct Painter {
 impl Drop for Painter {
     fn drop(&mut self) {
         if let Err(error) = self.rendering_context.make_current() {
-            warn!("Failed to make the rendering context current: {error:?}");
+            error!("Failed to make the rendering context current: {error:?}");
         }
 
         self.webrender_api.stop_render_backend();
@@ -375,8 +375,8 @@ impl Painter {
         let refresh_driver = self.refresh_driver.clone();
         refresh_driver.notify_will_paint(self);
 
-        if let Err(err) = self.rendering_context.make_current() {
-            warn!("Failed to make the rendering context current: {:?}", err);
+        if let Err(error) = self.rendering_context.make_current() {
+            error!("Failed to make the rendering context current: {error:?}");
         }
         self.assert_no_gl_error();
 
@@ -1212,6 +1212,9 @@ impl Painter {
             return;
         }
 
+        if let Err(error) = self.rendering_context.make_current() {
+            error!("Failed to make the rendering context current: {error:?}");
+        }
         self.rendering_context.resize(new_size);
 
         let new_size = Size2D::new(new_size.width as f32, new_size.height as f32);

--- a/components/compositing/screenshot.rs
+++ b/components/compositing/screenshot.rs
@@ -10,6 +10,7 @@ use base::id::{PipelineId, WebViewId};
 use embedder_traits::ScreenshotCaptureError;
 use euclid::{Point2D, Size2D};
 use image::RgbaImage;
+use log::error;
 use rustc_hash::FxHashMap;
 use webrender_api::units::{DeviceIntRect, DeviceRect};
 
@@ -196,6 +197,9 @@ impl ScreenshotTaker {
 
                     DeviceIntRect::from_origin_and_size(Point2D::new(x, y), Size2D::new(w, h))
                 });
+                if let Err(error) = renderer.rendering_context.make_current() {
+                    error!("Failed to make the rendering context current: {error:?}");
+                }
                 let result = renderer
                     .rendering_context
                     .read_to_image(rect)

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -4484,7 +4484,7 @@ where
                 );
             },
             WebDriverCommandMsg::CloseWebView(..) |
-            WebDriverCommandMsg::NewWebView(..) |
+            WebDriverCommandMsg::NewWindow(..) |
             WebDriverCommandMsg::FocusWebView(..) |
             WebDriverCommandMsg::IsWebViewOpen(..) |
             WebDriverCommandMsg::GetWindowRect(..) |

--- a/components/shared/embedder/webdriver.rs
+++ b/components/shared/embedder/webdriver.rs
@@ -79,6 +79,14 @@ pub enum CustomHandlersAutomationMode {
     None,
 }
 
+/// <https://w3c.github.io/webdriver/#new-window>
+#[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize)]
+pub enum NewWindowTypeHint {
+    Auto,
+    Tab,
+    Window,
+}
+
 /// Messages to the constellation originating from the WebDriver server.
 #[derive(Debug)]
 pub enum WebDriverCommandMsg {
@@ -118,7 +126,8 @@ pub enum WebDriverCommandMsg {
     /// Create a new webview that loads about:blank. The embedder will use
     /// the provided channels to return the top level browsing context id
     /// associated with the new webview, and sets a "load status sender" if provided.
-    NewWebView(
+    NewWindow(
+        NewWindowTypeHint,
         GenericOneshotSender<WebViewId>,
         Option<GenericSender<WebDriverLoadStatus>>,
     ),

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -993,8 +993,8 @@ impl PlatformWindow for Window {
             });
     }
 
-    fn focused(&self) -> bool {
-        self.winit_window.has_focus()
+    fn focus(&self) {
+        self.winit_window.focus_window();
     }
 
     fn show_embedder_control(&self, webview_id: WebViewId, embedder_control: EmbedderControl) {

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -160,10 +160,6 @@ impl PlatformWindow for EmbeddedPlatformWindow {
         )
     }
 
-    fn focused(&self) -> bool {
-        true
-    }
-
     fn show_embedder_control(&self, _: WebViewId, embedder_control: EmbedderControl) {
         let control_id = embedder_control.id();
         match embedder_control {
@@ -314,12 +310,20 @@ impl App {
     }
 
     pub(crate) fn active_or_newest_webview(&self) -> Option<WebView> {
-        self.state.any_window().active_or_newest_webview()
+        self.state
+            .windows()
+            .values()
+            .nth(0)
+            .expect("Should always have one open window")
+            .active_or_newest_webview()
     }
 
     pub(crate) fn create_and_activate_toplevel_webview(self: &Rc<Self>, url: Url) -> WebView {
         self.state
-            .any_window()
+            .windows()
+            .values()
+            .nth(0)
+            .expect("Should always have one open window")
             .create_and_activate_toplevel_webview(self.state.clone(), url)
     }
 
@@ -332,7 +336,10 @@ impl App {
     /// everytime wakeup is called or when embedder wants Servo
     /// to act on its pending events.
     pub fn spin_event_loop(&self) {
-        if !self.state.spin_event_loop() {
+        if !self
+            .state
+            .spin_event_loop(None /* create_platform_window */)
+        {
             self.platform_window.host.on_shutdown_complete();
         }
     }


### PR DESCRIPTION
This change makes it is that WebDriver can create whole new windows for
each new `WebView` in servoshell. The motivation for this is:

1. This is how the WebDriver specification is written. The command that
   create a new WebView is actually called "New Window" [^1], so this
   increases compliance with the specification and now we obey the
   type hint sent with that command.
2. This change allows testing multi-window support via the WPT.
3. This will allow adding optimizations (#39923) that are otherwise
   impossible because the WPT expects all open `WebView` to be live and
   visible.

This does not make the change yet for windows opened via `window.open()`
(popups), as that requires #41220 to fix. In order to make this possible
a few changes to the code had to take place:

1. The new `PlatformWindow` creation function has to be passed down to
   the WebDriver handler, which normally doesn't know how to make
   `PlatformWindow`s.
2. This allows moving the UI command code back to the shared part of
   servoshell, meaning that the embedded ports can use it as well
   eventually.
3. Headless windows need a real id to differeniate them now intead of
   just 0.
4. When dropping the headless `PlatformWindow` we need to make it
   current. I'm not sure why surfman doesn't do this, but this is now
   necessary as there are multiple contexts. This is also true when
   resizing the `RenderingContext`.

Finally, errors when making the context current are upgraded to
`error!`s as they typically break the entire execution of the program.

[^1]: https://w3c.github.io/webdriver/#new-window

Testing: This is tested by the entire WPT suite.
