### PR TITLE
libservo: Introduce `CookieManager` for embedders

### DIFF
--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -152,6 +152,9 @@ tracing = { workspace = true }
 winit = { workspace = true }
 
 [[test]]
+name = "cookies"
+
+[[test]]
 name = "webview"
 
 [[test]]

--- a/components/servo/cookies.rs
+++ b/components/servo/cookies.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use net_traits::ResourceThreads;
+
+pub struct CookieManager {
+    public_resource_threads: ResourceThreads,
+    private_resource_threads: ResourceThreads,
+}
+
+// TODO: Eventually rename to `NetworkManager` that could also cover protocol
+// handlers and related networking functionality.
+impl CookieManager {
+    pub(crate) fn new(
+        public_resource_threads: ResourceThreads,
+        private_resource_threads: ResourceThreads,
+    ) -> Self {
+        Self {
+            public_resource_threads,
+            private_resource_threads,
+        }
+    }
+
+    pub fn clear_cookies(&self) {
+        self.public_resource_threads.clear_cookies();
+        self.private_resource_threads.clear_cookies();
+    }
+}

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -13,6 +13,7 @@
 //! `ScriptThread` and the `LayoutThread`, as well maintains the navigation context.
 
 mod clipboard_delegate;
+mod cookies;
 mod javascript_evaluator;
 mod proxies;
 mod responders;

--- a/components/servo/tests/cookies.rs
+++ b/components/servo/tests/cookies.rs
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+mod common;
+
+use std::rc::Rc;
+
+use http_body_util::combinators::BoxBody;
+use hyper::body::{Bytes, Incoming};
+use hyper::{Request as HyperRequest, Response as HyperResponse};
+use net::test_util::{make_body, make_server};
+use servo::{JSValue, WebViewBuilder};
+
+use crate::common::{ServoTest, WebViewDelegateImpl, evaluate_javascript};
+
+#[test]
+fn test_clear_cookies() {
+    let servo_test = ServoTest::new();
+
+    static MESSAGE: &'static [u8] = b"<!DOCTYPE html>\nHello";
+
+    let handler =
+        move |_: HyperRequest<Incoming>,
+              response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+            *response.body_mut() = make_body(MESSAGE.to_vec());
+        };
+    let (server, url) = make_server(handler);
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(url.into_url())
+        .build();
+
+    servo_test.spin(move || !delegate.url_changed.get());
+
+    let _ = server.close();
+
+    let result = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "document.cookie = 'foo1=bar1';\
+         document.cookie = 'foo2=bar2';\
+         document.cookie = 'foo3=bar3';\
+         document.cookie;",
+    );
+    assert_eq!(
+        result,
+        Ok(JSValue::String("foo1=bar1; foo2=bar2; foo3=bar3".into()))
+    );
+
+    servo_test.servo().cookie_manager().clear_cookies();
+
+    let result = evaluate_javascript(&servo_test, webview.clone(), "document.cookie");
+    assert_eq!(result, Ok(JSValue::String("".into())));
+}

--- a/ports/servoshell/webdriver.rs
+++ b/ports/servoshell/webdriver.rs
@@ -135,7 +135,7 @@ impl RunningAppState {
         while let Ok(msg) = webdriver_receiver.try_recv() {
             match msg {
                 WebDriverCommandMsg::ResetAllCookies(sender) => {
-                    self.servo().clear_cookies();
+                    self.servo().cookie_manager().clear_cookies();
                     let _ = sender.send(());
                 },
                 WebDriverCommandMsg::Shutdown => {


### PR DESCRIPTION
This PR introduces an initial CookieManager abstraction intended primarily
for embedders to inspect and manage cookies.

At this stage, only clearing all cookies is supported. Additional
functionality will be added in follow-up PRs

Testing: Added a new integration test.
