### PR TITLE
layout: Do not set `cursor: text` on `<input type=color>`

### DIFF
--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -150,7 +150,7 @@ canvas, embed, iframe, img, video {
   overflow-clip-margin: 0 !important;
 }
 
-input:not([type=radio i]):not([type=checkbox i]):not([type=reset i]):not([type=button i]):not([type=submit i]) {
+input:not([type=radio i]):not([type=checkbox i]):not([type=reset i]):not([type=button i]):not([type=submit i]):not([type=color i]) {
   cursor: text;
   overflow: hidden !important;
   white-space: pre;

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -150,7 +150,7 @@ canvas, embed, iframe, img, video {
   overflow-clip-margin: 0 !important;
 }
 
-input:not([type=radio i]):not([type=checkbox i]):not([type=reset i]):not([type=button i]):not([type=submit i]):not([type=color i]) {
+input:not([type=radio i], [type=checkbox i], [type=reset i], [type=button i], [type=submit i], [type=color i]) {
   cursor: text;
   overflow: hidden !important;
   white-space: pre;

--- a/components/layout/stylesheets/servo.css
+++ b/components/layout/stylesheets/servo.css
@@ -150,13 +150,13 @@ canvas, embed, iframe, img, video {
   overflow-clip-margin: 0 !important;
 }
 
-input:not([type=radio i], [type=checkbox i], [type=reset i], [type=button i], [type=submit i], [type=color i]) {
+input:not([type=radio i], [type=checkbox i], [type=reset i], [type=button i], [type=submit i]) {
   cursor: text;
   overflow: hidden !important;
   white-space: pre;
 }
 
-input:is([type=submit i], [type=reset i], [type=button i], [type=checkbox i], [type=radio i]) {
+input:is([type=submit i], [type=reset i], [type=button i], [type=checkbox i], [type=radio i], [type=color i]) {
   cursor: default;
 }
 

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -316,7 +316,7 @@ fn test_cursor_unchanged_input_color() {
         .delegate(delegate.clone())
         .url(
             Url::parse(
-                "data:text/html,<!DOCTYPE html><body><input type=\"color\"></body>",
+                "data:text/html,<!DOCTYPE html><body><input type=\"color\"><p>Test text for Cursor change</p></body>",
             )
             .unwrap(),
         )
@@ -325,7 +325,16 @@ fn test_cursor_unchanged_input_color() {
     show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
 
     webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(
-        DevicePoint::new(10., 10.).into(),
+        DevicePoint::new(20., 65.).into(),
+    )));
+
+    let captured_delegate = delegate.clone();
+    servo_test.spin(move || !captured_delegate.cursor_changed.get());
+    assert_eq!(webview.cursor(), Cursor::Text);
+
+    delegate.reset();
+    webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(
+        DevicePoint::new(20., 25.).into(),
     )));
 
     let captured_delegate = delegate.clone();

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -307,6 +307,32 @@ fn test_cursor_change() {
     assert_eq!(webview.cursor(), Cursor::Default);
 }
 
+// A test to ensure that the cursor doesn't change when hovering over a input with type color
+#[test]
+fn test_cursor_unchanged_input_color() {
+    let servo_test = ServoTest::new();
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(
+            Url::parse(
+                "data:text/html,<!DOCTYPE html><body><input type=\"color\"></body>",
+            )
+            .unwrap(),
+        )
+        .build();
+
+    show_webview_and_wait_for_rendering_to_be_ready(&servo_test, &webview, &delegate);
+
+    webview.notify_input_event(InputEvent::MouseMove(MouseMoveEvent::new(
+        DevicePoint::new(10., 10.).into(),
+    )));
+
+    let captured_delegate = delegate.clone();
+    servo_test.spin(move || !captured_delegate.cursor_changed.get());
+    assert_eq!(webview.cursor(), Cursor::Default);
+}
+
 /// A test that ensure that negative resize requests do not get passed to the embedder.
 #[test]
 fn test_negative_resize_to_request() {

--- a/tests/wpt/tests/css/css-ui/cursor-input-001-manual.html
+++ b/tests/wpt/tests/css/css-ui/cursor-input-001-manual.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>CSS Basic User Interface Test: cursor on a color picker</title>
+<link rel="author" title="Daniel Obieglo" href="mailto:d.obieglo@gmail.com">
+<link rel="help" href="http://www.w3.org/TR/css3-ui/#cursor">
+<meta name="flags" content="interact">
+<meta charset="UTF-8">
+<meta name="assert" content="The cursor should not change on a hover over a input color type">
+<body>
+  <p>The test passes if, when moved over the color picker, the cursor stays unchanged as pointer.</p>
+  <input type="color">
+</body>


### PR DESCRIPTION
type=color was just missing in the `servo.css`. Since i am new to the project it would be awesome to get more infos about the testing. Its a bit overwhelming with all the directories so i am not sure if the test is okay like this or even in the right place.

Fixes: #41101
