### PR TITLE
constellation: Remove unused `ClearCache` message

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1394,10 +1394,6 @@ where
                     },
                 }
             },
-            EmbedderToConstellationMessage::ClearCache => {
-                self.public_resource_threads.clear_cache();
-                self.private_resource_threads.clear_cache();
-            },
             // Load a new page from a typed url
             // If there is already a pending page (self.pending_changes), it will not be overridden;
             // However, if the id is not encompassed by another change, it will be.

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -52,7 +52,6 @@ mod from_embedder {
                 Self::Exit => target!("Exit"),
                 Self::AllowNavigationResponse(..) => target!("AllowNavigationResponse"),
                 Self::LoadUrl(..) => target!("LoadUrl"),
-                Self::ClearCache => target!("ClearCache"),
                 Self::TraverseHistory(..) => target!("TraverseHistory"),
                 Self::ChangeViewportDetails(..) => target!("ChangeViewportDetails"),
                 Self::ThemeChange(..) => target!("ThemeChange"),

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -46,8 +46,6 @@ pub enum EmbedderToConstellationMessage {
     AllowNavigationResponse(PipelineId, bool),
     /// Request to load a page.
     LoadUrl(WebViewId, ServoUrl),
-    /// Clear the network cache.
-    ClearCache,
     /// Request to traverse the joint session history of the provided browsing context.
     TraverseHistory(WebViewId, TraversalDirection, TraversalId),
     /// Inform the Constellation that a `WebView`'s [`ViewportDetails`] have changed.


### PR DESCRIPTION
This PR removes the unused `EmbedderToConstellationMessage::ClearCache`
variant.
    
Clearing the network cache is now expected to be handled through
upcoming `SiteDataManager`, with direct communication to the resource threads,
rather than via the constellation.

Testing: Unit tests continue to pass
