### PR TITLE
script: Replace `borrow_mut()` with `borrow()` in `AudioBuffer::restore_js_channel_data`

### DIFF
--- a/components/script/dom/audio/audiobuffer.rs
+++ b/components/script/dom/audio/audiobuffer.rs
@@ -134,7 +134,7 @@ impl AudioBuffer {
 
     fn restore_js_channel_data(&self, cx: JSContext, can_gc: CanGc) -> bool {
         let _ac = enter_realm(self);
-        for (i, channel) in self.js_channels.borrow_mut().iter().enumerate() {
+        for (i, channel) in self.js_channels.borrow().iter().enumerate() {
             if channel.is_initialized() {
                 // Already have data in JS array.
                 continue;


### PR DESCRIPTION
Avoid borrow hazard in `AudioBuffer::restore_js_channel_data`

Testing: `./mach check` and `./mach test-wpt tests/wpt/tests/webaudio/the-audio-api/the-analysernode-interface/test-analyser-output.html --pref js_mem_gc_zeal_level=2 --pref js_mem_gc_zeal_frequency=1 --timeout-multiplier=5 --product=servo`
<img width="2661" height="1385" alt="截图 2025-12-14 11-32-13" src="https://github.com/user-attachments/assets/830ec4a7-17b8-4931-951f-1eb60d373d82" />
now it won't crash
Fixes: #41248 
