### PR TITLE
net: Track fontdb allocations from SVG images by about:memory

### DIFF
--- a/components/layout/layout_impl.rs
+++ b/components/layout/layout_impl.rs
@@ -553,7 +553,7 @@ impl Layout for LayoutThread {
             size: self.stacking_context_tree.size_of(ops),
         });
 
-        reports.push(self.image_cache.memory_report(formatted_url, ops));
+        reports.extend(self.image_cache.memory_reports(formatted_url, ops));
     }
 
     fn set_quirks_mode(&mut self, quirks_mode: QuirksMode) {

--- a/components/malloc_size_of/lib.rs
+++ b/components/malloc_size_of/lib.rs
@@ -53,6 +53,7 @@ use std::ops::Range;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use resvg::usvg::fontdb::Source;
 use style::properties::ComputedValues;
 use style::values::generics::length::GenericLengthPercentageOrAuto;
 pub use stylo_malloc_size_of::MallocSizeOfOps;
@@ -865,6 +866,11 @@ malloc_size_of_is_0!(http::StatusCode);
 malloc_size_of_is_0!(keyboard_types::Modifiers);
 malloc_size_of_is_0!(mime::Mime);
 malloc_size_of_is_0!(resvg::usvg::Tree);
+malloc_size_of_is_0!(resvg::usvg::fontdb::ID);
+malloc_size_of_is_0!(resvg::usvg::fontdb::Style);
+malloc_size_of_is_0!(resvg::usvg::fontdb::Weight);
+malloc_size_of_is_0!(resvg::usvg::fontdb::Stretch);
+malloc_size_of_is_0!(resvg::usvg::fontdb::Language);
 malloc_size_of_is_0!(std::num::NonZeroU16);
 malloc_size_of_is_0!(std::num::NonZeroU64);
 malloc_size_of_is_0!(std::num::NonZeroUsize);
@@ -1018,5 +1024,33 @@ where
 {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         <GenericLengthPercentageOrAuto<T> as stylo_malloc_size_of::MallocSizeOf>::size_of(self, ops)
+    }
+}
+
+impl MallocSizeOf for resvg::usvg::fontdb::Source {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        match self {
+            Source::Binary(_) => 0,
+            Source::File(path) => path.size_of(ops),
+            Source::SharedFile(path, _) => path.size_of(ops),
+        }
+    }
+}
+
+impl MallocSizeOf for resvg::usvg::fontdb::FaceInfo {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        self.id.size_of(ops) +
+            self.source.size_of(ops) +
+            self.families.size_of(ops) +
+            self.post_script_name.size_of(ops) +
+            self.style.size_of(ops) +
+            self.weight.size_of(ops) +
+            self.stretch.size_of(ops)
+    }
+}
+
+impl MallocSizeOf for resvg::usvg::fontdb::Database {
+    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
+        self.faces().map(|face| face.size_of(ops)).sum()
     }
 }

--- a/components/shared/net/image_cache.rs
+++ b/components/shared/net/image_cache.rs
@@ -171,7 +171,7 @@ pub trait ImageCacheFactory: Sync + Send {
 /// An [`ImageCache`] manages fetching and decoding images for a single `Pipeline` for its
 /// `Document` and all of its associated `Worker`s.
 pub trait ImageCache: Sync + Send {
-    fn memory_report(&self, prefix: &str, ops: &mut MallocSizeOfOps) -> Report;
+    fn memory_reports(&self, prefix: &str, ops: &mut MallocSizeOfOps) -> Vec<Report>;
 
     /// Get an [`ImageKey`] to be used for external WebRender image management for
     /// things like canvas rendering. Returns `None` when an [`ImageKey`] cannot


### PR DESCRIPTION
- make `ImageCache::memory_report` return `Vec<Report>` and rename `memory_report` to `memory_reports`
- update `ImageCacheImpl::memory_report` to return a new Report for the fontdb member
- add an implementation of `MallocSizeOf` for `fontdb::FaceInfo` which sums the result of calling malloc_size_of on each of the string/vector members
- add an implementation of `MallocSizeOf` for `fontdb::Database` which sums the result of malloc_size_of on each of the faces

Testing: `./mach check` `./mach clippy`
`grep fontdb::Database::load_fonts_from_file untracked | wc -l` results: 2390 -> 545
- before:
<img width="1536" height="108" alt="截图 2025-12-14 13-53-32" src="https://github.com/user-attachments/assets/422ce9d4-e962-45af-a072-7d1c0c9e80aa" />

- now:
<img width="1536" height="108" alt="截图 2025-12-14 13-58-26" src="https://github.com/user-attachments/assets/363f933d-8ab0-4354-b8ae-89f6de46ca7b" />

Fixes: #38730 
