### PR TITLE
mach: Allow updating test result metadata from GitHub Action run

### DIFF
--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -8,7 +8,6 @@
 # except according to those terms.
 
 import argparse
-from argparse import ArgumentParser
 import json
 import logging
 import os
@@ -18,8 +17,9 @@ import shutil
 import subprocess
 import sys
 import textwrap
-from typing import Any, Optional, List
+from argparse import ArgumentParser
 from pathlib import Path
+from typing import Any, List, Optional
 
 import tidy
 import wpt

--- a/python/wpt/update.py
+++ b/python/wpt/update.py
@@ -3,23 +3,24 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 # pylint: disable=missing-docstring
 
-from typing import Any
 import os
-import subprocess
+import re
 import shutil
+import subprocess
 import sys
-
-from wptrunner.update import setup_logging, WPTUpdate  # noqa: F401
-from wptrunner.update.base import exit_unclean  # noqa: F401
-from wptrunner import wptcommandline  # noqa: F401
-
+import tempfile
 from argparse import ArgumentParser
+from typing import Any
 
-from . import WPT_PATH
-from . import manifestupdate
+from wptrunner import wptcommandline  # noqa: F401
+from wptrunner.update import WPTUpdate, setup_logging  # noqa: F401
+from wptrunner.update.base import exit_unclean  # noqa: F401
+
+from . import WPT_PATH, manifestupdate
 
 TEST_ROOT = os.path.join(WPT_PATH, "tests")
 META_ROOTS = [os.path.join(WPT_PATH, "meta"), os.path.join(WPT_PATH, "meta-legacy")]
+GITHUB_ACTION_RUN_URL_REGEX = re.compile(r"github\.com\/(\w+\/\w+)\/actions\/runs\/(\d+)$")
 
 
 def do_sync(**kwargs: str) -> int:
@@ -116,9 +117,61 @@ def update_tests(**kwargs: Any) -> int:
 
 def run_update(**kwargs: Any) -> bool:
     """Run the update process returning True if the process is successful."""
+    run_logs: list[str] = kwargs.get("run_log", "")
+    if any([GITHUB_ACTION_RUN_URL_REGEX.search(run_log) for run_log in run_logs]):
+        return download_run_resultsa_and_then_run_update(kwargs)
+
     logger = setup_logging(kwargs, {"mach": sys.stdout})
     return WPTUpdate(logger, **kwargs).run() != exit_unclean
 
 
-def create_parser(**_kwargs: Any) -> ArgumentParser:
+def download_run_resultsa_and_then_run_update(kwargs: dict[str, Any]) -> bool:
+    """If any of the arguments passed to `./mach update-wpt` are URLs, attempt to
+    interpret them as GitHub Action Run URLs and download any test results, passing
+    the downloaded results as the input to the WPT metadata update."""
+    run_logs: list[str] = kwargs.get("run_log", "")
+    with tempfile.TemporaryDirectory() as directory:
+        downloaded_run_logs = []
+        for run_log in run_logs:
+            match = GITHUB_ACTION_RUN_URL_REGEX.search(run_log)
+            if not match:
+                downloaded_run_logs.append(run_log)
+                continue
+
+            repository = match.group(1)
+            run_id = match.group(2)
+            run_path = os.path.join(directory, run_id)
+            os.makedirs(run_path)
+
+            print(f"Downloading unexpected stable results from run {run_id} of {repository}")
+            if (
+                subprocess.check_call(
+                    [
+                        "gh",
+                        "run",
+                        "download",
+                        run_id,
+                        "-R",
+                        repository,
+                        "--dir",
+                        run_path,
+                        "--pattern",
+                        "*stable-unexpected-results-linux*",
+                    ]
+                )
+                != 0
+            ):
+                print(f"Could not download artifact from run id {run_id}.")
+                print("Is `gh` installed and authenticated?")
+                return False
+            downloaded_run_logs.append(
+                os.path.join(run_path, "stable-unexpected-results-linux", "stable-unexpected-results.log")
+            )
+
+        kwargs["run_log"] = downloaded_run_logs
+        logger = setup_logging(kwargs, {"mach": sys.stdout})
+        return WPTUpdate(logger, **kwargs).run() != exit_unclean
+
+
+def create_parser() -> ArgumentParser:
     return wptcommandline.create_parser_update()


### PR DESCRIPTION
This change allows `./mach update-wpt` to accept a URL to a GitHub
Action run. If a URL is passed, it will attempt to download the stable
unexpected results from the run and update the expected test results.
Note that this currently requires having the `gh` command-line tool
installed and authenticated. Although you can download artifacts without
logging in via the web interface, doing this via the API requires an
access token.

Testing: This change adds a unit test for the regex that matches GitHub Action URLs.
