### PR TITLE
Fix RefCell double-borrow in Window::remove_reporting_observer

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -566,12 +566,13 @@ impl Window {
     }
 
     pub(crate) fn remove_reporting_observer(&self, reporting_observer: &ReportingObserver) {
-        if let Some(index) = self
-            .reporting_observer_list
-            .borrow()
-            .iter()
-            .position(|observer| &**observer == reporting_observer)
-        {
+        let index = {
+            let list = self.reporting_observer_list.borrow();
+            list.iter()
+                .position(|observer| &**observer == reporting_observer)
+        };
+
+        if let Some(index) = index {
             self.reporting_observer_list.borrow_mut().remove(index);
         }
     }

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -88,6 +88,13 @@
       {}
      ]
     ],
+    "reporting-observer-disconnect-no-crash.html": [
+     "02fa141ce4e15db1e4442e81df7bb52244843b75",
+     [
+      null,
+      {}
+     ]
+    ],
     "slice-blob-twice-crash.html": [
      "94227dcc74d80dae19b39df025708ffc24ee78c5",
      [

--- a/tests/wpt/mozilla/tests/mozilla/reporting-observer-disconnect-no-crash.html
+++ b/tests/wpt/mozilla/tests/mozilla/reporting-observer-disconnect-no-crash.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>ReportingObserver disconnect should not crash</title>
+
+<script>
+    const ro = new ReportingObserver(() => { }, { types: ["deprecation"], buffered: true });
+    ro.observe();
+    ro.disconnect();
+</script>


### PR DESCRIPTION
lot of RefCell already borrowed crashes are because of code like this:
```
if let Some(index) = self
    .array
    .borrow()
    .iter()
    .position(|p| &**p == r_p)
{
    self.array.borrow_mut().remove(index);
}
```
this will always panic whenever the position() finds an index, because the immutable borrow from borrow() is still alive when we call borrow_mut().

Fix by ensuring the borrow is dropped before taking a mutable borrow (by computing the index in a separate scope / temporary), then remove safely.



Testing: added crash test.
Fixes: #41260
