### PR TITLE
layout: Treat `<audio>` as replaced and do not display when there is no `controls` attribute

### DIFF
--- a/components/layout/stylesheets/user-agent.css
+++ b/components/layout/stylesheets/user-agent.css
@@ -394,6 +394,10 @@ iframe:not([seamless]) { border: 2px inset; }
 iframe[seamless] { display: block; }
 video { object-fit: contain; }
 
+audio:not([controls]) {
+  display: none !important;
+}
+
 
 textarea { white-space: pre-wrap; }
 

--- a/tests/wpt/meta/html/dom/elements/the-innertext-and-outertext-properties/getter.html.ini
+++ b/tests/wpt/meta/html/dom/elements/the-innertext-and-outertext-properties/getter.html.ini
@@ -46,3 +46,6 @@
 
   [undefined ("<select><option>one</option><div><optgroup label=optgroup><div><option><span>two")]
     expected: FAIL
+
+  [<audio> contents ignored ("<audio style='display:block'>abc")]
+    expected: FAIL

--- a/tests/wpt/meta/html/rendering/replaced-elements/embedded-content-rendering-rules/audio-without-controls.html.ini
+++ b/tests/wpt/meta/html/rendering/replaced-elements/embedded-content-rendering-rules/audio-without-controls.html.ini
@@ -1,2 +1,0 @@
-[audio-without-controls.html]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-audio-element/audio_001.htm.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-audio-element/audio_001.htm.ini
@@ -1,2 +1,0 @@
-[audio_001.htm]
-  expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-audio-element/audio_002.htm.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-audio-element/audio_002.htm.ini
@@ -1,2 +1,0 @@
-[audio_002.htm]
-  expected: FAIL

--- a/tests/wpt/tests/html/semantics/embedded-content/the-audio-element/audio-with-replaced-after-pseudo-crash.html
+++ b/tests/wpt/tests/html/semantics/embedded-content/the-audio-element/audio-with-replaced-after-pseudo-crash.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html class="test-wait">
+<meta charset="utf-8">
+<title>HTML5 Media Elements: An 'audio' element with a replaced ::after shouldn't crash</title>
+<link rel="author" title="Oriol Brufau" href="obrufau@igalia.com">
+<link rel="help" href="https://github.com/servo/servo/issues/41183">
+
+<style>
+audio::after {
+  content: url("/css/support/60x60-red.png");
+}
+</style>
+<audio controls></audio>
+<script src="/common/media.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<script>
+(async function() {
+  const audio = document.querySelector("audio");
+  audio.src = getAudioURI("/media/sound_5");
+  for (let i = 0; i < 100; ++i) {
+    await waitForAtLeastOneFrame();
+    await audio.play();
+    document.body.style.color = "cyan";
+    await waitForAtLeastOneFrame();
+    audio.pause();
+    await waitForAtLeastOneFrame();
+    document.body.style.color = "magenta";
+  }
+  document.documentElement.removeAttribute("class");
+})();
+</script>
+</html>


### PR DESCRIPTION
Add an important UA style to ensure that `<audio>` isn't displayed at all when it doesn't have the `controls` attribute. This matches Gecko, Blink and WebKit.

When it does have the attribute, then treat it as replaced. For example, this means that it won't stretch by default if it's block-level, that it will be atomic if inline-level, and that it won't generate boxes for its children (including `::before` and `::after`).

Previously we were generating `::before` and `::after`, but there was a bug: if they had some replaced content, the controls of the `<audio>` would be duplicated, and also appear on the pseudo-element. Then, since the various boxes for the controls would be backed by the same elements, Servo could panic because of a double borrow. This is now avoided.

Testing: Some WPT are now passing, also adding a new crashtest. There is one failure about `innerText`, but the test is probably wrong, now we match other browsers.
Fixes: #40693
Fixes: #41183
