### PR TITLE
CI: Make OHOS scenario tests always succeed

### DIFF
--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -17,6 +17,7 @@ from selenium import webdriver
 # Click to close the pop-up
 # Note that the pop-up may not exist, either because we did this in the past
 # which sets localstorage, or the website does not have seasonal promotions/recommendations.
+# ASSUMPTION: driver is already created, and implicit wait is set properly.
 def close_popup(driver: webdriver.Remote):
     popup_css_selector = (
         "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "

--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -1,3 +1,14 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 The Servo Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
 from selenium.common import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium import webdriver
@@ -18,5 +29,5 @@ def close_popup(driver: webdriver.Remote):
         birthday_element = driver.find_element(By.CSS_SELECTOR, popup_css_selector)
         birthday_element.click()
         print("Closed the popup")
-    except NoSuchElementException as e:
+    except NoSuchElementException:
         print(f"Failed to find pop_up element with selector `{popup_css_selector}`. Skip it.")

--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -1,0 +1,22 @@
+from selenium.common import NoSuchElementException
+from selenium.webdriver.common.by import By
+from selenium import webdriver
+
+
+# Click to close the pop-up
+# Note that the pop-up may not exist, either because we did this in the past
+# which sets localstorage, or the website does not have seasonal promotions/recommendations.
+def close_popup(driver: webdriver.Remote):
+    popup_css_selector = (
+        "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
+        "> uni-view:nth-child(5) "
+        "> uni-view.m-popup.m-popup_transition.m-mask_show.m-mask_fade.m-popup_push.m-fixed_mid "
+        "> uni-view > uni-view > uni-button:nth-child(1)"
+    )
+    print("Waiting for popup to appear ...")
+    try:
+        birthday_element = driver.find_element(By.CSS_SELECTOR, popup_css_selector)
+        birthday_element.click()
+        print("Closed the popup")
+    except NoSuchElementException as e:
+        print(f"Failed to find pop_up element with selector `{popup_css_selector}`. Skip it.")

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -26,6 +26,7 @@ from selenium.webdriver.remote.webelement import WebElement
 
 WEBDRIVER_PORT = 7000
 SERVO_URL = f"http://127.0.0.1:{WEBDRIVER_PORT}"
+ABOUT_BLANK = "about:blank"
 
 
 def calculate_frame_rate():
@@ -197,13 +198,15 @@ def element_screenshot(element: WebElement, filename: str):
         print(f"Element Screenshot failed with error: {e}")
 
 
-def run_test(test_fn, test_name: str, initial_url: str):
+# We always load "about:blank" first, and then use
+# WebDriver to load target url so that it is blocked until fully loaded.
+def run_test(test_fn, test_name: str):
     try:
         print("Stopping potential old servo instance ...")
         stop_servo()
         hdc = HarmonyDeviceConnector()
-        print(f"Starting new servo instance, loading {initial_url} ...")
-        hdc.cmd(f"aa start -a EntryAbility -b org.servo.servo -U {initial_url} --psn --webdriver", timeout=10)
+        print(f"Starting new servo instance...")
+        hdc.cmd(f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn --webdriver", timeout=10)
         setup_hdc_forward()
     except Exception as e:
         print(f"Scenario test setup failed with error: {e} (exception: {type(e)})")
@@ -217,5 +220,5 @@ def run_test(test_fn, test_name: str, initial_url: str):
         hdc.screenshot(f"servo_scenario_{test_name}_error.jpg")
         stop_servo()
         sys.exit(1)
-
+    print("\033[32mTest Succeeded.\033[0m")
     stop_servo()

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -205,7 +205,7 @@ def run_test(test_fn, test_name: str):
         print("Stopping potential old servo instance ...")
         stop_servo()
         hdc = HarmonyDeviceConnector()
-        print(f"Starting new servo instance...")
+        print("Starting new servo instance...")
         hdc.cmd(f"aa start -a EntryAbility -b org.servo.servo -U {ABOUT_BLANK} --psn --webdriver", timeout=10)
         setup_hdc_forward()
     except Exception as e:

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -23,6 +23,7 @@ from selenium.webdriver.common.options import ArgOptions
 from urllib3.exceptions import ProtocolError
 from PIL import Image
 from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.support.wait import WebDriverWait
 
 WEBDRIVER_PORT = 7000
 SERVO_URL = f"http://127.0.0.1:{WEBDRIVER_PORT}"
@@ -196,6 +197,12 @@ def element_screenshot(element: WebElement, filename: str):
         region.save(save_path)
     except Exception as e:
         print(f"Element Screenshot failed with error: {e}")
+
+
+def wait_for_page_load(driver: webdriver.Remote, timeout: float = 60):
+    WebDriverWait(driver, timeout).until(
+        lambda driver: driver.execute_script("return document.readyState") == "complete"
+    )
 
 
 # We always load "about:blank" first, and then use

--- a/etc/ci/scenario/common_function_for_servo_test.py
+++ b/etc/ci/scenario/common_function_for_servo_test.py
@@ -23,7 +23,6 @@ from selenium.webdriver.common.options import ArgOptions
 from urllib3.exceptions import ProtocolError
 from PIL import Image
 from selenium.webdriver.remote.webelement import WebElement
-from selenium.webdriver.support.wait import WebDriverWait
 
 WEBDRIVER_PORT = 7000
 SERVO_URL = f"http://127.0.0.1:{WEBDRIVER_PORT}"
@@ -197,12 +196,6 @@ def element_screenshot(element: WebElement, filename: str):
         region.save(save_path)
     except Exception as e:
         print(f"Element Screenshot failed with error: {e}")
-
-
-def wait_for_page_load(driver: webdriver.Remote, timeout: float = 60):
-    WebDriverWait(driver, timeout).until(
-        lambda driver: driver.execute_script("return document.readyState") == "complete"
-    )
 
 
 # We always load "about:blank" first, and then use

--- a/etc/ci/scenario/servo_test_open_page_base.py
+++ b/etc/ci/scenario/servo_test_open_page_base.py
@@ -9,8 +9,6 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-import time
-import subprocess
 
 from selenium.common import NoSuchElementException
 

--- a/etc/ci/scenario/servo_test_open_page_base.py
+++ b/etc/ci/scenario/servo_test_open_page_base.py
@@ -10,42 +10,41 @@
 # except according to those terms.
 
 import time
+import subprocess
 
-from selenium.common import NoSuchWindowException, NoSuchElementException
-from selenium.webdriver.support import expected_conditions
-from selenium.webdriver.support.wait import WebDriverWait
+from selenium.common import NoSuchElementException
 
 import common_function_for_servo_test
+import common_function_for_mossel
 from selenium.webdriver.common.by import By
 
 
 def operator():
+    WEBDRIVER_WAIT_TIME = 10
+    PAGE_URL = "https://m.huaweimossel.com"
     driver = common_function_for_servo_test.create_driver()
+    driver.get(PAGE_URL)
 
-    popup_css_selector = (
-        "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
-        "> uni-view:nth-child(5) "
-        "> uni-view.m-popup.m-popup_transition.m-mask_show.m-mask_fade.m-popup_push.m-fixed_mid "
-        "> uni-view > uni-view > uni-button:nth-child(1)"
-    )
-    print("Waiting for popup to appear ...")
-    WebDriverWait(driver, 20, ignored_exceptions=[NoSuchWindowException, NoSuchElementException]).until(
-        expected_conditions.presence_of_element_located((By.CSS_SELECTOR, popup_css_selector))
-    )
-    time.sleep(1)
+    print("Page loaded.")
+    # This is used to wait for element retrieval if not found
+    # and certain element click, element send key exceptions.
+    driver.implicitly_wait(WEBDRIVER_WAIT_TIME)
 
     # Step 2. Click to close the pop-up
-    birthday_ = driver.find_element(By.CSS_SELECTOR, popup_css_selector)
-    birthday_.click()
-    print("Closed the popup")
+    # Note that the pop-up may not exist, either because we did this in the past
+    # which sets localstorage, or the website does not have seasonal promotions/recommendations.
+    common_function_for_mossel.close_popup(driver)
 
-    print("finding components ...")
-    goal_css_selector = "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view > uni-view.idx-swiper.m-bgWhite.m-main > uni-scroll-view:nth-child(1) > div > div > div > uni-view:nth-child(3)"
-    WebDriverWait(driver, 20, ignored_exceptions=[NoSuchWindowException, NoSuchElementException]).until(
-        expected_conditions.presence_of_element_located((By.CSS_SELECTOR, goal_css_selector))
-    )
-    print("find components successful!")
+    print("Finding components ...")
+    target_css_selector = "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view > uni-view.idx-swiper.m-bgWhite.m-main > uni-scroll-view:nth-child(1) > div > div > div > uni-view:nth-child(3)"
+
+    try:
+        driver.find_element(By.CSS_SELECTOR, target_css_selector)
+    except NoSuchElementException:
+        raise NoSuchElementException("Components not found. Test failed.")
+
+    print("Find components successful!")
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "open_mossel", "https://m.huaweimossel.com")
+    common_function_for_servo_test.run_test(operator, "open_mossel")

--- a/etc/ci/scenario/servo_test_open_page_base.py
+++ b/etc/ci/scenario/servo_test_open_page_base.py
@@ -18,7 +18,7 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    WEBDRIVER_WAIT_TIME = 10
+    IMPLICIT_WAIT_TIME = 10
     PAGE_URL = "https://m.huaweimossel.com"
     driver = common_function_for_servo_test.create_driver()
     driver.get(PAGE_URL)
@@ -26,7 +26,7 @@ def operator():
     print("Page loaded.")
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
-    driver.implicitly_wait(WEBDRIVER_WAIT_TIME)
+    driver.implicitly_wait(IMPLICIT_WAIT_TIME)
 
     # Step 2. Click to close the pop-up
     common_function_for_mossel.close_popup(driver)

--- a/etc/ci/scenario/servo_test_open_page_base.py
+++ b/etc/ci/scenario/servo_test_open_page_base.py
@@ -29,8 +29,6 @@ def operator():
     driver.implicitly_wait(WEBDRIVER_WAIT_TIME)
 
     # Step 2. Click to close the pop-up
-    # Note that the pop-up may not exist, either because we did this in the past
-    # which sets localstorage, or the website does not have seasonal promotions/recommendations.
     common_function_for_mossel.close_popup(driver)
 
     print("Finding components ...")

--- a/etc/ci/scenario/servo_test_open_page_servo.py
+++ b/etc/ci/scenario/servo_test_open_page_servo.py
@@ -16,7 +16,7 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    WEBDRIVER_WAIT_TIME = 10
+    IMPLICIT_WAIT_TIME = 10
     PAGE_URL = "https://servo.org"
     driver = common_function_for_servo_test.create_driver()
     driver.get(PAGE_URL)
@@ -24,7 +24,7 @@ def operator():
     print("Page loaded.")
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
-    driver.implicitly_wait(WEBDRIVER_WAIT_TIME)
+    driver.implicitly_wait(IMPLICIT_WAIT_TIME)
 
     print("Finding components ...")
     goal_css_selector1 = "#homeHero > div.hero-body > div.container > div > a:nth-child(1)"

--- a/etc/ci/scenario/servo_test_open_page_servo.py
+++ b/etc/ci/scenario/servo_test_open_page_servo.py
@@ -9,28 +9,36 @@
 # option. This file may not be copied, modified, or distributed
 # except according to those terms.
 
-from selenium.common import NoSuchWindowException, NoSuchElementException
-from selenium.webdriver.support import expected_conditions
-from selenium.webdriver.support.wait import WebDriverWait
+from selenium.common import NoSuchElementException
 
 import common_function_for_servo_test
 from selenium.webdriver.common.by import By
 
 
 def operator():
+    WEBDRIVER_WAIT_TIME = 10
+    PAGE_URL = "https://servo.org"
     driver = common_function_for_servo_test.create_driver()
+    driver.get(PAGE_URL)
 
-    print("finding components ...")
+    print("Page loaded.")
+    # This is used to wait for element retrieval if not found
+    # and certain element click, element send key exceptions.
+    driver.implicitly_wait(WEBDRIVER_WAIT_TIME)
+
+    print("Finding components ...")
     goal_css_selector1 = "#homeHero > div.hero-body > div.container > div > a:nth-child(1)"
-    WebDriverWait(driver, 20, ignored_exceptions=[NoSuchWindowException, NoSuchElementException]).until(
-        expected_conditions.presence_of_element_located((By.CSS_SELECTOR, goal_css_selector1))
-    )
-    goal_css_selector1 = "#homeHero > div.hero-body > div.container > h1"
-    WebDriverWait(driver, 20, ignored_exceptions=[NoSuchWindowException, NoSuchElementException]).until(
-        expected_conditions.presence_of_element_located((By.CSS_SELECTOR, goal_css_selector1))
-    )
-    print("find components successful!")
+
+    goal_css_selector2 = "#homeHero > div.hero-body > div.container > h1"
+
+    try:
+        driver.find_element(By.CSS_SELECTOR, goal_css_selector1)
+        driver.find_element(By.CSS_SELECTOR, goal_css_selector2)
+    except NoSuchElementException:
+        raise NoSuchElementException("Components not found. Test failed.")
+
+    print("Find components successful!")
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "open_servo_org", "https://servo.org")
+    common_function_for_servo_test.run_test(operator, "open_servo_org")

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -17,10 +17,12 @@ from selenium.common import NoSuchElementException
 import common_function_for_servo_test
 import common_function_for_mossel
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
 
 
 def operator():
-    WEBDRIVER_WAIT_TIME = 10
+    IMPLICIT_WAIT_TIME = 10
+    WEBDRIVER_WAIT_TIME = 60
     PAGE_URL = "https://m.huaweimossel.com"
     driver = common_function_for_servo_test.create_driver()
     driver.get(PAGE_URL)
@@ -28,7 +30,7 @@ def operator():
     print("Page loaded.")
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
-    driver.implicitly_wait(WEBDRIVER_WAIT_TIME)
+    driver.implicitly_wait(IMPLICIT_WAIT_TIME)
 
     # Step 2. Click to close the pop-up
     common_function_for_mossel.close_popup(driver)
@@ -36,10 +38,14 @@ def operator():
     time.sleep(2)
 
     # Step 3. Click to page: Categories
-    print("Clicking 'Categories' element")
+    print("Clicking 'Categories' element.")
+    # TODO: Replace with Element click to be robust against screen size changes.
     cmd = ["hdc", "shell", "uinput -T -c 380 2556"]
     subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    time.sleep(8)
+    # Wait for the page to load, up to WEBDRIVER_WAIT_TIME seconds.
+    WebDriverWait(driver, WEBDRIVER_WAIT_TIME).until(
+        lambda driver: driver.execute_script("return document.readyState") == "complete"
+    )
 
     # Step 4. Find components
     print("Finding components ...")

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -31,8 +31,6 @@ def operator():
     driver.implicitly_wait(WEBDRIVER_WAIT_TIME)
 
     # Step 2. Click to close the pop-up
-    # Note that the pop-up may not exist, either because we did this in the past
-    # which sets localstorage, or the website does not have seasonal promotions/recommendations.
     common_function_for_mossel.close_popup(driver)
 
     time.sleep(2)

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -20,8 +20,7 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    IMPLICIT_WAIT_TIME = 10
-    WEBDRIVER_WAIT_TIME = 60
+    IMPLICIT_WAIT_TIME = 30
     PAGE_URL = "https://m.huaweimossel.com"
     driver = common_function_for_servo_test.create_driver()
     driver.get(PAGE_URL)
@@ -41,8 +40,6 @@ def operator():
     # TODO: Replace with Element click to be robust against screen size changes.
     cmd = ["hdc", "shell", "uinput -T -c 380 2556"]
     subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    # Wait for the page to load, up to WEBDRIVER_WAIT_TIME seconds.
-    common_function_for_servo_test.wait_for_page_load(driver, WEBDRIVER_WAIT_TIME)
 
     # Step 4. Find components
     print("Finding components ...")

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -12,51 +12,52 @@
 import time
 import subprocess
 
-from selenium.common import NoSuchWindowException, NoSuchElementException
-from selenium.webdriver.support import expected_conditions
-from selenium.webdriver.support.wait import WebDriverWait
+from selenium.common import NoSuchElementException
 
 import common_function_for_servo_test
+import common_function_for_mossel
 from selenium.webdriver.common.by import By
 
 
 def operator():
+    WEBDRIVER_WAIT_TIME = 10
+    PAGE_URL = "https://m.huaweimossel.com"
     driver = common_function_for_servo_test.create_driver()
+    driver.get(PAGE_URL)
+
+    print("Page loaded.")
+    # This is used to wait for element retrieval if not found
+    # and certain element click, element send key exceptions.
+    driver.implicitly_wait(WEBDRIVER_WAIT_TIME)
 
     # Step 2. Click to close the pop-up
-    popup_css_selector = (
-        "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
-        "> uni-view:nth-child(5) "
-        "> uni-view.m-popup.m-popup_transition.m-mask_show.m-mask_fade.m-popup_push.m-fixed_mid "
-        "> uni-view > uni-view > uni-button:nth-child(1)"
-    )
-    print("Waiting for popup to appear ...")
-    WebDriverWait(driver, 20, ignored_exceptions=[NoSuchWindowException, NoSuchElementException]).until(
-        expected_conditions.presence_of_element_located((By.CSS_SELECTOR, popup_css_selector))
-    )
-    time.sleep(1)
+    # Note that the pop-up may not exist, either because we did this in the past
+    # which sets localstorage, or the website does not have seasonal promotions/recommendations.
+    common_function_for_mossel.close_popup(driver)
 
-    birthday_ = driver.find_element(By.CSS_SELECTOR, popup_css_selector)
-    birthday_.click()
-    print("Closed the popup")
+    time.sleep(2)
 
     # Step 3. Click to page: Categories
     print("Clicking 'Categories' element")
     cmd = ["hdc", "shell", "uinput -T -c 380 2556"]
     subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    time.sleep(2)
+    time.sleep(8)
 
+    # Step 4. Find components
     print("Finding components ...")
-    goal_css_selector = (
+    target_css_selector = (
         "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
         "> uni-view.sort-main.m-flex.m-bgWhite > uni-scroll-view > div > div > div "
         "> uni-view.item.active"
     )
-    WebDriverWait(driver, 20, ignored_exceptions=[NoSuchWindowException, NoSuchElementException]).until(
-        expected_conditions.presence_of_element_located((By.CSS_SELECTOR, goal_css_selector))
-    )
+
+    try:
+        driver.find_element(By.CSS_SELECTOR, target_css_selector)
+    except NoSuchElementException:
+        raise NoSuchElementException("Components not found. Test failed.")
+
     print("Find components successful!")
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "mossel_redirection", "https://m.huaweimossel.com")
+    common_function_for_servo_test.run_test(operator, "mossel_redirection")

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -17,7 +17,6 @@ from selenium.common import NoSuchElementException
 import common_function_for_servo_test
 import common_function_for_mossel
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.wait import WebDriverWait
 
 
 def operator():
@@ -43,9 +42,7 @@ def operator():
     cmd = ["hdc", "shell", "uinput -T -c 380 2556"]
     subprocess.run(cmd, capture_output=True, text=True, timeout=10)
     # Wait for the page to load, up to WEBDRIVER_WAIT_TIME seconds.
-    WebDriverWait(driver, WEBDRIVER_WAIT_TIME).until(
-        lambda driver: driver.execute_script("return document.readyState") == "complete"
-    )
+    common_function_for_servo_test.wait_for_page_load(driver, WEBDRIVER_WAIT_TIME)
 
     # Step 4. Find components
     print("Finding components ...")

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -12,44 +12,39 @@
 import time
 import subprocess
 
-from selenium.common import NoSuchWindowException, NoSuchElementException
-from selenium.webdriver.support import expected_conditions
-from selenium.webdriver.support.wait import WebDriverWait
+from selenium.common import NoSuchElementException
+
 import common_function_for_servo_test
+import common_function_for_mossel
 from selenium.webdriver.common.by import By
 
 
 def operator():
-    # Step 1.Connect to Webdriver
-    print("Connecting to Webdriver server...")
+    WEBDRIVER_WAIT_TIME = 10
+    PAGE_URL = "https://m.huaweimossel.com"
     driver = common_function_for_servo_test.create_driver()
+    driver.get(PAGE_URL)
+
+    print("Page loaded.")
+    # This is used to wait for element retrieval if not found
+    # and certain element click, element send key exceptions.
+    driver.implicitly_wait(WEBDRIVER_WAIT_TIME)
 
     # Step 2. Click to close the pop-up
-    popup_css_selector = (
-        "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
-        "> uni-view:nth-child(5) "
-        "> uni-view.m-popup.m-popup_transition.m-mask_show.m-mask_fade.m-popup_push.m-fixed_mid "
-        "> uni-view > uni-view > uni-button:nth-child(1)"
-    )
-    print("Waiting for popup to appear ...")
-    WebDriverWait(driver, 20, ignored_exceptions=[NoSuchWindowException, NoSuchElementException]).until(
-        expected_conditions.presence_of_element_located((By.CSS_SELECTOR, popup_css_selector))
-    )
-    time.sleep(1)
-
-    birthday_ = driver.find_element(By.CSS_SELECTOR, popup_css_selector)
-    birthday_.click()
-    print("Closed the popup")
+    # Note that the pop-up may not exist, either because we did this in the past
+    # which sets localstorage, or the website does not have seasonal promotions/recommendations.
+    common_function_for_mossel.close_popup(driver)
 
     # Step 3. Click to page: Categories
     print("Clicking 'Categories' element.")
     cmd = ["hdc", "shell", "uinput -T -c 380 2556"]
     subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    time.sleep(2)
+    time.sleep(8)
 
-    # Step 4. Check sliding effect
+    # Step 4. Check if slide actually happened.
     print("Screenshot before swiping.")
     before = driver.get_screenshot_as_base64()
+    time.sleep(1)
 
     print("swiping...")
     cmd = ["hdc", "shell", "uinput -T -m 770 2000 770 930"]
@@ -64,4 +59,4 @@ def operator():
 
 
 if __name__ == "__main__":
-    common_function_for_servo_test.run_test(operator, "mossel_slide", "https://m.huaweimossel.com")
+    common_function_for_servo_test.run_test(operator, "mossel_slide")

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -16,10 +16,12 @@ import subprocess
 import common_function_for_servo_test
 import common_function_for_mossel
 
+from selenium.common import NoSuchElementException
+from selenium.webdriver.common.by import By
+
 
 def operator():
-    IMPLICIT_WAIT_TIME = 10
-    WEBDRIVER_WAIT_TIME = 60
+    IMPLICIT_WAIT_TIME = 30
     PAGE_URL = "https://m.huaweimossel.com"
     driver = common_function_for_servo_test.create_driver()
     driver.get(PAGE_URL)
@@ -38,9 +40,21 @@ def operator():
     cmd = ["hdc", "shell", "uinput -T -c 380 2556"]
     subprocess.run(cmd, capture_output=True, text=True, timeout=10)
 
-    common_function_for_servo_test.wait_for_page_load(driver, WEBDRIVER_WAIT_TIME)
+    # Step 4. Find components which indicates the page has loaded, before sliding.
+    print("Finding components ...")
+    target_css_selector = (
+        "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
+        "> uni-view.sort-main.m-flex.m-bgWhite > uni-scroll-view > div > div > div "
+        "> uni-view.item.active"
+    )
 
-    # Step 4. Check if slide actually happened.
+    try:
+        driver.find_element(By.CSS_SELECTOR, target_css_selector)
+    except NoSuchElementException:
+        raise NoSuchElementException("Components not found. Test failed.")
+
+    print("Find components successful! Ready to swipe.")
+    # Step 4. Slide and check if it actually happened.
     print("Screenshot before swiping.")
     before = driver.get_screenshot_as_base64()
     time.sleep(1)

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -29,8 +29,6 @@ def operator():
     driver.implicitly_wait(WEBDRIVER_WAIT_TIME)
 
     # Step 2. Click to close the pop-up
-    # Note that the pop-up may not exist, either because we did this in the past
-    # which sets localstorage, or the website does not have seasonal promotions/recommendations.
     common_function_for_mossel.close_popup(driver)
 
     # Step 3. Click to page: Categories

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -16,8 +16,6 @@ import subprocess
 import common_function_for_servo_test
 import common_function_for_mossel
 
-from selenium.webdriver.support.wait import WebDriverWait
-
 
 def operator():
     IMPLICIT_WAIT_TIME = 10
@@ -40,10 +38,7 @@ def operator():
     cmd = ["hdc", "shell", "uinput -T -c 380 2556"]
     subprocess.run(cmd, capture_output=True, text=True, timeout=10)
 
-    # Wait for the page to load, up to WEBDRIVER_WAIT_TIME seconds.
-    WebDriverWait(driver, WEBDRIVER_WAIT_TIME).until(
-        lambda driver: driver.execute_script("return document.readyState") == "complete"
-    )
+    common_function_for_servo_test.wait_for_page_load(driver, WEBDRIVER_WAIT_TIME)
 
     # Step 4. Check if slide actually happened.
     print("Screenshot before swiping.")

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -16,9 +16,12 @@ import subprocess
 import common_function_for_servo_test
 import common_function_for_mossel
 
+from selenium.webdriver.support.wait import WebDriverWait
+
 
 def operator():
-    WEBDRIVER_WAIT_TIME = 10
+    IMPLICIT_WAIT_TIME = 10
+    WEBDRIVER_WAIT_TIME = 60
     PAGE_URL = "https://m.huaweimossel.com"
     driver = common_function_for_servo_test.create_driver()
     driver.get(PAGE_URL)
@@ -26,16 +29,21 @@ def operator():
     print("Page loaded.")
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
-    driver.implicitly_wait(WEBDRIVER_WAIT_TIME)
+    driver.implicitly_wait(IMPLICIT_WAIT_TIME)
 
     # Step 2. Click to close the pop-up
     common_function_for_mossel.close_popup(driver)
 
     # Step 3. Click to page: Categories
     print("Clicking 'Categories' element.")
+    # TODO: Replace with Element click to be robust against screen size changes.
     cmd = ["hdc", "shell", "uinput -T -c 380 2556"]
     subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-    time.sleep(8)
+
+    # Wait for the page to load, up to WEBDRIVER_WAIT_TIME seconds.
+    WebDriverWait(driver, WEBDRIVER_WAIT_TIME).until(
+        lambda driver: driver.execute_script("return document.readyState") == "complete"
+    )
 
     # Step 4. Check if slide actually happened.
     print("Screenshot before swiping.")

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -12,11 +12,9 @@
 import time
 import subprocess
 
-from selenium.common import NoSuchElementException
 
 import common_function_for_servo_test
 import common_function_for_mossel
-from selenium.webdriver.common.by import By
 
 
 def operator():


### PR DESCRIPTION
1. Extract a lot of common stuff.
2. Improve stability: use WebDriver implicit wait + get url which would block execution until page is loaded. We no longer need to worry about `NoSuchWindow` exception thanks to it.
3. Add detailed doc.

This should make scenario test CI pass with 100% chance with current Mossel page, and when the page restore the pop-up promotion.

Testing: 
https://github.com/servo/servo/actions/runs/20232398375
https://github.com/servo/servo/actions/runs/20227960294
https://github.com/servo/servo/actions/runs/20227602672/job/58063012835
https://github.com/servo/servo/actions/runs/20226998697/job/58061366591
https://github.com/servo/servo/actions/runs/20227006271/job/58061785843

Last two fail because I forgot to update test for servo.org. But Mossel is always passing.

Fixes:  #41270 