### PR TITLE
libservo: Add callback to `SiteDataManager::clear_cache`

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -523,8 +523,9 @@ impl ResourceChannelManager {
                     history_states.remove(&history_state);
                 }
             },
-            CoreResourceMsg::ClearCache => {
+            CoreResourceMsg::ClearCache(callback) => {
                 http_state.http_cache.write().clear();
+                let _ = callback.send(());
             },
             CoreResourceMsg::ToFileManager(msg) => self.resource_manager.filemanager.handle(msg),
             CoreResourceMsg::Exit(sender) => {

--- a/components/servo/Cargo.toml
+++ b/components/servo/Cargo.toml
@@ -161,5 +161,8 @@ name = "webview"
 name = "servo"
 
 [[test]]
+name = "site_data"
+
+[[test]]
 name = "multiprocess"
 harness = false

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -19,6 +19,7 @@ mod proxies;
 mod responders;
 mod servo;
 mod servo_delegate;
+mod site_data;
 mod webview;
 mod webview_delegate;
 

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -626,6 +626,9 @@ impl ServoInner {
                     warn!("Failed to respond to GetScreenMetrics: {error}");
                 }
             },
+            EmbedderMsg::RunSiteDataManagerCallback(id) => {
+                self.site_data_manager.borrow_mut().run_callback(id);
+            },
         }
     }
 }
@@ -751,7 +754,7 @@ impl Servo {
             embedder_to_constellation_receiver,
             &paint.borrow(),
             opts.config_dir.clone(),
-            embedder_proxy,
+            embedder_proxy.clone(),
             paint_proxy.clone(),
             time_profiler_chan,
             mem_profiler_chan,
@@ -775,6 +778,7 @@ impl Servo {
                 private_resource_threads.clone(),
             ))),
             site_data_manager: Rc::new(RefCell::new(SiteDataManager::new(
+                embedder_proxy,
                 public_resource_threads,
                 private_resource_threads,
             ))),
@@ -854,6 +858,10 @@ impl Servo {
 
     pub fn site_data_manager<'a>(&'a self) -> Ref<'a, SiteDataManager> {
         self.0.site_data_manager.borrow()
+    }
+
+    pub fn site_data_manager_mut<'a>(&'a self) -> RefMut<'a, SiteDataManager> {
+        self.0.site_data_manager.borrow_mut()
     }
 
     pub(crate) fn paint<'a>(&'a self) -> Ref<'a, Paint> {

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -80,6 +80,7 @@ use crate::javascript_evaluator::JavaScriptEvaluator;
 use crate::proxies::ConstellationProxy;
 use crate::responders::ServoErrorChannel;
 use crate::servo_delegate::{DefaultServoDelegate, ServoDelegate, ServoError};
+use crate::site_data::SiteDataManager;
 use crate::webview::{MINIMUM_WEBVIEW_SIZE, WebView, WebViewInner};
 use crate::webview_delegate::{
     AllowOrDenyRequest, AuthenticationRequest, EmbedderControl, FilePicker, NavigationRequest,
@@ -140,6 +141,7 @@ struct ServoInner {
     constellation_proxy: ConstellationProxy,
     embedder_receiver: Receiver<EmbedderMsg>,
     cookie_manager: Rc<RefCell<CookieManager>>,
+    site_data_manager: Rc<RefCell<SiteDataManager>>,
     /// A struct that tracks ongoing JavaScript evaluations and is responsible for
     /// calling the callback when the evaluation is complete.
     javascript_evaluator: Rc<RefCell<JavaScriptEvaluator>>,
@@ -769,6 +771,10 @@ impl Servo {
             delegate: RefCell::new(Rc::new(DefaultServoDelegate)),
             paint,
             cookie_manager: Rc::new(RefCell::new(CookieManager::new(
+                public_resource_threads.clone(),
+                private_resource_threads.clone(),
+            ))),
+            site_data_manager: Rc::new(RefCell::new(SiteDataManager::new(
                 public_resource_threads,
                 private_resource_threads,
             ))),
@@ -844,6 +850,10 @@ impl Servo {
 
     pub fn cookie_manager<'a>(&'a self) -> Ref<'a, CookieManager> {
         self.0.cookie_manager.borrow()
+    }
+
+    pub fn site_data_manager<'a>(&'a self) -> Ref<'a, SiteDataManager> {
+        self.0.site_data_manager.borrow()
     }
 
     pub(crate) fn paint<'a>(&'a self) -> Ref<'a, Paint> {

--- a/components/servo/site_data.rs
+++ b/components/servo/site_data.rs
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use net_traits::ResourceThreads;
+
+pub struct SiteDataManager {
+    public_resource_threads: ResourceThreads,
+    private_resource_threads: ResourceThreads,
+}
+
+impl SiteDataManager {
+    pub(crate) fn new(
+        public_resource_threads: ResourceThreads,
+        private_resource_threads: ResourceThreads,
+    ) -> Self {
+        Self {
+            public_resource_threads,
+            private_resource_threads,
+        }
+    }
+
+    // TODO: This currently does not wait for cache clearing to complete.
+    pub fn clear_cache(&self) {
+        self.public_resource_threads.clear_cache();
+        self.private_resource_threads.clear_cache();
+    }
+}

--- a/components/servo/site_data.rs
+++ b/components/servo/site_data.rs
@@ -2,27 +2,137 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use base::generic_channel::GenericCallback;
+use embedder_traits::{EmbedderMsg, EmbedderProxy};
 use net_traits::ResourceThreads;
+use rustc_hash::FxHashMap;
+
+struct Callback {
+    callback: Box<dyn FnOnce()>,
+}
+
+pub(crate) struct CallbackProxy {
+    embedder_proxy: EmbedderProxy,
+    id: usize,
+}
+
+impl CallbackProxy {
+    pub fn new(embedder_proxy: EmbedderProxy, id: usize) -> Self {
+        Self { embedder_proxy, id }
+    }
+
+    pub fn send(&self) {
+        self.embedder_proxy
+            .send(EmbedderMsg::RunSiteDataManagerCallback(self.id));
+    }
+}
+
+struct AllCompleted {
+    count: usize,
+    callback: Option<Box<dyn FnOnce()>>,
+}
+
+impl AllCompleted {
+    fn new(count: usize, callback: Box<dyn FnOnce()>) -> Self {
+        Self {
+            count,
+            callback: Some(callback),
+        }
+    }
+
+    fn complete(&mut self) {
+        self.count -= 1;
+        if self.count == 0 {
+            if let Some(cb) = self.callback.take() {
+                cb();
+            }
+        }
+    }
+}
 
 pub struct SiteDataManager {
+    embedder_proxy: EmbedderProxy,
     public_resource_threads: ResourceThreads,
     private_resource_threads: ResourceThreads,
+    callbacks: FxHashMap<usize, Callback>,
+    next_id: usize,
 }
 
 impl SiteDataManager {
     pub(crate) fn new(
+        embedder_proxy: EmbedderProxy,
         public_resource_threads: ResourceThreads,
         private_resource_threads: ResourceThreads,
     ) -> Self {
         Self {
+            embedder_proxy,
             public_resource_threads,
             private_resource_threads,
+            callbacks: Default::default(),
+            next_id: 1,
         }
     }
 
-    // TODO: This currently does not wait for cache clearing to complete.
-    pub fn clear_cache(&self) {
-        self.public_resource_threads.clear_cache();
-        self.private_resource_threads.clear_cache();
+    pub fn clear_cache(&mut self, callback: Box<dyn FnOnce()>) {
+        let mut proxies = self.create_joined_callback_proxies(2, callback);
+
+        let public_done = proxies.pop().unwrap();
+        let private_done = proxies.pop().unwrap();
+
+        self.public_resource_threads.clear_cache(
+            GenericCallback::new(move |_msg| {
+                public_done.send();
+            })
+            .unwrap(),
+        );
+
+        self.private_resource_threads.clear_cache(
+            GenericCallback::new(move |_msg| {
+                private_done.send();
+            })
+            .unwrap(),
+        );
+    }
+
+    pub(crate) fn create_callback_proxy(&mut self, callback: Box<dyn FnOnce()>) -> CallbackProxy {
+        let id = self.next_id;
+        self.next_id = id + 1;
+
+        self.callbacks.insert(id, Callback { callback });
+
+        CallbackProxy::new(self.embedder_proxy.clone(), id)
+    }
+
+    pub(crate) fn create_joined_callback_proxies(
+        &mut self,
+        count: usize,
+        final_callback: Box<dyn FnOnce()>,
+    ) -> Vec<CallbackProxy> {
+        assert!(count > 0);
+
+        let join = Rc::new(RefCell::new(AllCompleted::new(count, final_callback)));
+
+        let mut proxies = Vec::with_capacity(count);
+
+        for _ in 0..count {
+            let join = Rc::clone(&join);
+            let proxy = self.create_callback_proxy(Box::new(move || {
+                join.borrow_mut().complete();
+            }));
+            proxies.push(proxy);
+        }
+
+        proxies
+    }
+
+    pub(crate) fn run_callback(&mut self, id: usize) {
+        (self
+            .callbacks
+            .remove(&id)
+            .expect("Received request to run unknown callback.")
+            .callback)();
     }
 }

--- a/components/servo/tests/site_data.rs
+++ b/components/servo/tests/site_data.rs
@@ -4,6 +4,7 @@
 
 mod common;
 
+use std::cell::Cell;
 use std::rc::Rc;
 
 use http_body_util::combinators::BoxBody;
@@ -38,7 +39,17 @@ fn test_clear_cache() {
 
     let _ = server.close();
 
-    servo_test.servo().site_data_manager().clear_cache();
+    let cleared = Rc::new(Cell::new(false));
+
+    let cleared_clone = cleared.clone();
+    servo_test
+        .servo()
+        .site_data_manager_mut()
+        .clear_cache(Box::new(move || {
+            cleared_clone.set(true);
+        }));
+
+    servo_test.spin(move || !cleared.get());
 
     // TODO: Check that the cache was actually cleared once there's a way to
     //       check it.

--- a/components/servo/tests/site_data.rs
+++ b/components/servo/tests/site_data.rs
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+mod common;
+
+use std::rc::Rc;
+
+use http_body_util::combinators::BoxBody;
+use hyper::body::{Bytes, Incoming};
+use hyper::{Request as HyperRequest, Response as HyperResponse};
+use net::test_util::{make_body, make_server};
+use servo::WebViewBuilder;
+
+use crate::common::{ServoTest, WebViewDelegateImpl};
+
+#[test]
+fn test_clear_cache() {
+    let servo_test = ServoTest::new();
+
+    static MESSAGE: &'static [u8] = b"<!DOCTYPE html>\nHello";
+
+    let handler =
+        move |_: HyperRequest<Incoming>,
+              response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+            *response.body_mut() = make_body(MESSAGE.to_vec());
+        };
+    let (server, url) = make_server(handler);
+
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+
+    let _webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .url(url.into_url())
+        .build();
+
+    servo_test.spin(move || !delegate.url_changed.get());
+
+    let _ = server.close();
+
+    servo_test.servo().site_data_manager().clear_cache();
+
+    // TODO: Check that the cache was actually cleared once there's a way to
+    //       check it.
+}

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -500,6 +500,7 @@ pub enum EmbedderMsg {
     /// Inform the embedding layer that a particular `InputEvent` was handled by Servo
     /// and the embedder can continue processing it, if necessary.
     InputEventHandled(WebViewId, InputEventId, InputEventResult),
+    RunSiteDataManagerCallback(usize),
 }
 
 impl Debug for EmbedderMsg {

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -9,6 +9,7 @@ use std::sync::{LazyLock, OnceLock};
 use std::thread::{self, JoinHandle};
 
 use base::cross_process_instant::CrossProcessInstant;
+use base::generic_channel::GenericCallback;
 use base::id::{CookieStoreId, HistoryStateId};
 use base::{IpcSend, IpcSendResult};
 use content_security_policy::{self as csp};
@@ -503,8 +504,8 @@ impl ResourceThreads {
         ResourceThreads { core_thread }
     }
 
-    pub fn clear_cache(&self) {
-        let _ = self.core_thread.send(CoreResourceMsg::ClearCache);
+    pub fn clear_cache(&self, callback: GenericCallback<()>) {
+        let _ = self.core_thread.send(CoreResourceMsg::ClearCache(callback));
     }
 
     pub fn clear_cookies(&self) {
@@ -607,7 +608,7 @@ pub enum CoreResourceMsg {
     /// Removes history states for the given ids
     RemoveHistoryStates(Vec<HistoryStateId>),
     /// Clear the network cache.
-    ClearCache,
+    ClearCache(GenericCallback<()>),
     /// Send the service worker network mediator for an origin to CoreResourceThread
     NetworkMediator(IpcSender<CustomResponseMediator>, ImmutableOrigin),
     /// Message forwarded to file manager's handler


### PR DESCRIPTION
This PR makes `SiteDataManager::clear_cache` accept a callback that fires
once all underlying cache clearing operations have finished.

`ResourceThreads::clear_cache` is extended to take a `GenericCallback` (so it
is not limited to embedding-only use). On the embedder side, `SiteDataManager`
introduces new callback infrastructure that allows multiple async operations
(e.g. public and private resource threads) to share a single final completion
callback.

This callback infrastructure may be moved to `Servo`/`ServoInner` later so it
can also be reused by `CookieManager`.

Testing: The existing integration test is updated to wait for the completion
callback.

Depends on #41255