### PR TITLE
storage: Add support for listing WebStorage origins

### DIFF
--- a/components/shared/storage/webstorage_thread.rs
+++ b/components/shared/storage/webstorage_thread.rs
@@ -15,6 +15,17 @@ pub enum StorageType {
     Local,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OriginDescriptor {
+    pub name: String,
+}
+
+impl OriginDescriptor {
+    pub fn new(name: String) -> Self {
+        OriginDescriptor { name }
+    }
+}
+
 /// Request operations on the storage data associated with a particular url
 #[derive(Debug, Deserialize, Serialize)]
 pub enum WebStorageThreadMsg {
@@ -71,6 +82,9 @@ pub enum WebStorageThreadMsg {
         src: WebViewId,
         dest: WebViewId,
     },
+
+    /// gets the list of origin descriptors for given storage type
+    GetOriginDescriptors(GenericSender<Vec<OriginDescriptor>>, StorageType),
 
     /// send a reply when done cleaning up thread resources and then shut it down
     Exit(GenericSender<()>),

--- a/components/shared/storage/webstorage_thread.rs
+++ b/components/shared/storage/webstorage_thread.rs
@@ -84,7 +84,7 @@ pub enum WebStorageThreadMsg {
     },
 
     /// gets the list of origin descriptors for given storage type
-    GetOriginDescriptors(GenericSender<Vec<OriginDescriptor>>, StorageType),
+    OriginDescriptors(GenericSender<Vec<OriginDescriptor>>, StorageType),
 
     /// send a reply when done cleaning up thread resources and then shut it down
     Exit(GenericSender<()>),

--- a/components/storage/tests/webstorage.rs
+++ b/components/storage/tests/webstorage.rs
@@ -19,6 +19,13 @@ fn init() -> (TempDir, StorageThreads) {
     (dir, threads.0)
 }
 
+fn init_with(dir: &tempfile::TempDir) -> StorageThreads {
+    let config_dir = dir.path().to_path_buf();
+    let mem_profiler_chan = profile_mem::Profiler::create();
+    let threads = storage::new_storage_threads(mem_profiler_chan, Some(config_dir));
+    threads.0
+}
+
 /// Gracefully shut down the webstorage thread to avoid dangling threads in tests.
 fn shutdown(threads: &StorageThreads) {
     let (sender, receiver) = base_channel::channel().unwrap();
@@ -199,6 +206,71 @@ fn remove_item_and_clear() {
         ))
         .unwrap();
     assert_eq!(receiver.recv().unwrap(), 0);
+
+    shutdown(&threads);
+}
+
+#[test]
+fn get_origin_descriptors() {
+    let url = ServoUrl::parse("https://example.com").unwrap();
+
+    // (storage_type, survives_restart)
+    let cases = [(StorageType::Session, false), (StorageType::Local, true)];
+
+    let (tmp_dir, threads) = init();
+
+    for (storage_type, _) in cases {
+        // Set a value.
+        let (sender, receiver) = base_channel::channel().unwrap();
+        threads
+            .send(WebStorageThreadMsg::SetItem(
+                sender,
+                storage_type,
+                TEST_WEBVIEW_ID,
+                url.clone(),
+                "foo".into(),
+                "bar".into(),
+            ))
+            .unwrap();
+        assert_eq!(receiver.recv().unwrap(), Ok((true, None)));
+
+        // Get origin descriptors.
+        let (sender, receiver) = base_channel::channel().unwrap();
+        threads
+            .send(WebStorageThreadMsg::GetOriginDescriptors(
+                sender,
+                storage_type,
+            ))
+            .unwrap();
+
+        let descriptors = receiver.recv().unwrap();
+        assert_eq!(descriptors.len(), 1);
+        assert_eq!(descriptors[0].name, "https://example.com");
+    }
+
+    // Restart storage threads.
+    shutdown(&threads);
+    let threads = init_with(&tmp_dir);
+
+    for (storage_type, survives_restart) in cases {
+        // Get origin descriptors.
+        let (sender, receiver) = base_channel::channel().unwrap();
+        threads
+            .send(WebStorageThreadMsg::GetOriginDescriptors(
+                sender,
+                storage_type,
+            ))
+            .unwrap();
+
+        let descriptors = receiver.recv().unwrap();
+
+        if survives_restart {
+            assert_eq!(descriptors.len(), 1);
+            assert_eq!(descriptors[0].name, "https://example.com");
+        } else {
+            assert!(descriptors.is_empty());
+        }
+    }
 
     shutdown(&threads);
 }

--- a/components/storage/tests/webstorage.rs
+++ b/components/storage/tests/webstorage.rs
@@ -211,7 +211,7 @@ fn remove_item_and_clear() {
 }
 
 #[test]
-fn get_origin_descriptors() {
+fn origin_descriptors() {
     let url = ServoUrl::parse("https://example.com").unwrap();
 
     // (storage_type, survives_restart)
@@ -237,10 +237,7 @@ fn get_origin_descriptors() {
         // Get origin descriptors.
         let (sender, receiver) = base_channel::channel().unwrap();
         threads
-            .send(WebStorageThreadMsg::GetOriginDescriptors(
-                sender,
-                storage_type,
-            ))
+            .send(WebStorageThreadMsg::OriginDescriptors(sender, storage_type))
             .unwrap();
 
         let descriptors = receiver.recv().unwrap();
@@ -256,10 +253,7 @@ fn get_origin_descriptors() {
         // Get origin descriptors.
         let (sender, receiver) = base_channel::channel().unwrap();
         threads
-            .send(WebStorageThreadMsg::GetOriginDescriptors(
-                sender,
-                storage_type,
-            ))
+            .send(WebStorageThreadMsg::OriginDescriptors(sender, storage_type))
             .unwrap();
 
         let descriptors = receiver.recv().unwrap();


### PR DESCRIPTION
This PR adds support for listing origins that have associated WebStorage
data.

Both localStorage and sessionStorage are supported. For sessionStorage,
origins are reported if data exists in any browsing context, while only
localStorage origins persist across restarts.

The implementation introduces an internal origin descriptor abstraction
to support future extensions, such as reporting perorigin usage.

This functionality is primarily intended to be used by `SiteDataManager`.

Testing: Added a unit test covering origin listing before and after restart.
