### PR TITLE
Add tendril to the list of html5ever-crates to patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,6 +273,7 @@ codegen-units = 1
 # markup5ever = { path = "../html5ever/markup5ever" }
 # web_atoms = { path = "../html5ever/web_atoms" }
 # xml5ever = { path = "../html5ever/xml5ever" }
+# tendril = { path = "../html5ever/tendril" }
 #
 # Or for Stylo:
 #


### PR DESCRIPTION
`tendril` has moved into the html5ever repository, so when we patch html5ever then we need to patch tendril too.