### PR TITLE
Move `devtools_traits::LogLevel` to `embedder_traits`

### DIFF
--- a/components/devtools/lib.rs
+++ b/components/devtools/lib.rs
@@ -22,9 +22,9 @@ use base::generic_channel::{self, GenericSender};
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use devtools_traits::{
-    ChromeToDevtoolsControlMsg, ConsoleMessage, ConsoleMessageBuilder, DevtoolScriptControlMsg,
-    DevtoolsControlMsg, DevtoolsPageInfo, LogLevel, NavigationState, NetworkEvent, PageError,
-    ScriptToDevtoolsControlMsg, SourceInfo, WorkerId,
+    ChromeToDevtoolsControlMsg, ConsoleLogLevel, ConsoleMessage, ConsoleMessageBuilder,
+    DevtoolScriptControlMsg, DevtoolsControlMsg, DevtoolsPageInfo, NavigationState, NetworkEvent,
+    PageError, ScriptToDevtoolsControlMsg, SourceInfo, WorkerId,
 };
 use embedder_traits::{AllowOrDeny, EmbedderMsg, EmbedderProxy};
 use log::{trace, warn};
@@ -259,7 +259,7 @@ impl DevtoolsInstance {
                     css_error,
                 )) => {
                     let mut console_message = ConsoleMessageBuilder::new(
-                        LogLevel::Warn,
+                        ConsoleLogLevel::Warn,
                         css_error.filename,
                         css_error.line,
                         css_error.column,

--- a/components/shared/devtools/lib.rs
+++ b/components/shared/devtools/lib.rs
@@ -21,6 +21,7 @@ use base::cross_process_instant::CrossProcessInstant;
 use base::generic_channel::GenericSender;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use bitflags::bitflags;
+pub use embedder_traits::ConsoleLogLevel;
 use embedder_traits::Theme;
 use http::{HeaderMap, Method};
 use malloc_size_of_derive::MallocSizeOf;
@@ -321,37 +322,11 @@ pub struct RuleModification {
     pub priority: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum LogLevel {
-    Log,
-    Debug,
-    Info,
-    Warn,
-    Error,
-    Clear,
-    Trace,
-}
-
-impl From<LogLevel> for log::Level {
-    fn from(value: LogLevel) -> Self {
-        match value {
-            LogLevel::Log => log::Level::Info,
-            LogLevel::Clear => log::Level::Info,
-
-            LogLevel::Debug => log::Level::Debug,
-            LogLevel::Info => log::Level::Info,
-            LogLevel::Warn => log::Level::Warn,
-            LogLevel::Error => log::Level::Error,
-            LogLevel::Trace => log::Level::Trace,
-        }
-    }
-}
-
 /// A console message as it is sent from script to the constellation
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConsoleMessage {
-    pub log_level: LogLevel,
+    pub log_level: ConsoleLogLevel,
     pub filename: String,
     pub line_number: usize,
     pub column_number: usize,
@@ -423,13 +398,13 @@ pub struct ConsoleLog {
 impl From<ConsoleMessage> for ConsoleLog {
     fn from(value: ConsoleMessage) -> Self {
         let level = match value.log_level {
-            LogLevel::Debug => "debug",
-            LogLevel::Info => "info",
-            LogLevel::Warn => "warn",
-            LogLevel::Error => "error",
-            LogLevel::Clear => "clear",
-            LogLevel::Trace => "trace",
-            LogLevel::Log => "log",
+            ConsoleLogLevel::Debug => "debug",
+            ConsoleLogLevel::Info => "info",
+            ConsoleLogLevel::Warn => "warn",
+            ConsoleLogLevel::Error => "error",
+            ConsoleLogLevel::Clear => "clear",
+            ConsoleLogLevel::Trace => "trace",
+            ConsoleLogLevel::Log => "log",
         }
         .to_owned();
 
@@ -577,7 +552,7 @@ impl From<String> for ConsoleMessageArgument {
 }
 
 pub struct ConsoleMessageBuilder {
-    level: LogLevel,
+    level: ConsoleLogLevel,
     filename: String,
     line_number: u32,
     column_number: u32,
@@ -586,7 +561,12 @@ pub struct ConsoleMessageBuilder {
 }
 
 impl ConsoleMessageBuilder {
-    pub fn new(level: LogLevel, filename: String, line_number: u32, column_number: u32) -> Self {
+    pub fn new(
+        level: ConsoleLogLevel,
+        filename: String,
+        line_number: u32,
+        column_number: u32,
+    ) -> Self {
         Self {
             level,
             filename,

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -385,6 +385,31 @@ impl Image {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ConsoleLogLevel {
+    Log,
+    Debug,
+    Info,
+    Warn,
+    Error,
+    Clear,
+    Trace,
+}
+
+impl From<ConsoleLogLevel> for log::Level {
+    fn from(value: ConsoleLogLevel) -> Self {
+        match value {
+            ConsoleLogLevel::Log => log::Level::Info,
+            ConsoleLogLevel::Clear => log::Level::Info,
+            ConsoleLogLevel::Debug => log::Level::Debug,
+            ConsoleLogLevel::Info => log::Level::Info,
+            ConsoleLogLevel::Warn => log::Level::Warn,
+            ConsoleLogLevel::Error => log::Level::Error,
+            ConsoleLogLevel::Trace => log::Level::Trace,
+        }
+    }
+}
+
 /// Messages towards the embedder.
 #[derive(Deserialize, IntoStaticStr, Serialize)]
 pub enum EmbedderMsg {


### PR DESCRIPTION
This PR moves devtools_traits::LogLevel to embedder_traits in preparation of upcoming work on creating a ServoDelegate and WebViewDelegate method for Console API output. Also see https://github.com/servo/servo/issues/41145

Testing: only moves code, no functional change
Fixes: part of https://github.com/servo/servo/issues/41145
