### PR TITLE
CI: Make ohos scenario tests adapatable to screen dimension changes

### DIFF
--- a/etc/ci/scenario/common_function_for_mossel.py
+++ b/etc/ci/scenario/common_function_for_mossel.py
@@ -32,3 +32,14 @@ def close_popup(driver: webdriver.Remote):
         print("Closed the popup")
     except NoSuchElementException:
         print(f"Failed to find pop_up element with selector `{popup_css_selector}`. Skip it.")
+
+
+def click_category(driver: webdriver.Remote):
+    print("Clicking 'Categories' element.")
+    category_css_selector = "div.uni-tabbar__item:nth-child(3)"
+    try:
+        category_element = driver.find_element(By.CSS_SELECTOR, category_css_selector)
+    except NoSuchElementException:
+        raise NoSuchElementException("Category element not found. Test failed.")
+
+    category_element.click()

--- a/etc/ci/scenario/servo_test_redirection.py
+++ b/etc/ci/scenario/servo_test_redirection.py
@@ -10,7 +10,6 @@
 # except according to those terms.
 
 import time
-import subprocess
 
 from selenium.common import NoSuchElementException
 
@@ -20,15 +19,17 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    IMPLICIT_WAIT_TIME = 30
+    IMPLICIT_WAIT_TIME_FOR_POPUP = 15
     PAGE_URL = "https://m.huaweimossel.com"
+    # Based on experience, it could take up to 40 seconds to load the page after click.
+    IMPLICIT_WAIT_TIME_AFTER_REDIRECTION = 60
     driver = common_function_for_servo_test.create_driver()
     driver.get(PAGE_URL)
 
     print("Page loaded.")
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
-    driver.implicitly_wait(IMPLICIT_WAIT_TIME)
+    driver.implicitly_wait(IMPLICIT_WAIT_TIME_FOR_POPUP)
 
     # Step 2. Click to close the pop-up
     common_function_for_mossel.close_popup(driver)
@@ -36,13 +37,9 @@ def operator():
     time.sleep(2)
 
     # Step 3. Click to page: Categories
-    print("Clicking 'Categories' element.")
-    # TODO: Replace with Element click to be robust against screen size changes.
-    cmd = ["hdc", "shell", "uinput -T -c 380 2556"]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    common_function_for_mossel.click_category(driver)
 
     # Step 4. Find components
-    print("Finding components ...")
     target_css_selector = (
         "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
         "> uni-view.sort-main.m-flex.m-bgWhite > uni-scroll-view > div > div > div "
@@ -50,6 +47,8 @@ def operator():
     )
 
     try:
+        print("Finding components ...")
+        driver.implicitly_wait(IMPLICIT_WAIT_TIME_AFTER_REDIRECTION)
         driver.find_element(By.CSS_SELECTOR, target_css_selector)
     except NoSuchElementException:
         raise NoSuchElementException("Components not found. Test failed.")

--- a/etc/ci/scenario/servo_test_slide.py
+++ b/etc/ci/scenario/servo_test_slide.py
@@ -21,27 +21,25 @@ from selenium.webdriver.common.by import By
 
 
 def operator():
-    IMPLICIT_WAIT_TIME = 30
+    IMPLICIT_WAIT_TIME_FOR_POPUP = 15
     PAGE_URL = "https://m.huaweimossel.com"
+    # Based on experience, it could take up to seconds to load the page after click.
+    IMPLICIT_WAIT_TIME_AFTER_REDIRECTION = 60
     driver = common_function_for_servo_test.create_driver()
     driver.get(PAGE_URL)
 
     print("Page loaded.")
     # This is used to wait for element retrieval if not found
     # and certain element click, element send key exceptions.
-    driver.implicitly_wait(IMPLICIT_WAIT_TIME)
+    driver.implicitly_wait(IMPLICIT_WAIT_TIME_FOR_POPUP)
 
     # Step 2. Click to close the pop-up
     common_function_for_mossel.close_popup(driver)
 
     # Step 3. Click to page: Categories
-    print("Clicking 'Categories' element.")
-    # TODO: Replace with Element click to be robust against screen size changes.
-    cmd = ["hdc", "shell", "uinput -T -c 380 2556"]
-    subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    common_function_for_mossel.click_category(driver)
 
     # Step 4. Find components which indicates the page has loaded, before sliding.
-    print("Finding components ...")
     target_css_selector = (
         "#app > uni-app > uni-page > uni-page-wrapper > uni-page-body > uni-view "
         "> uni-view.sort-main.m-flex.m-bgWhite > uni-scroll-view > div > div > div "
@@ -49,6 +47,8 @@ def operator():
     )
 
     try:
+        print("Finding components ...")
+        driver.implicitly_wait(IMPLICIT_WAIT_TIME_AFTER_REDIRECTION)
         driver.find_element(By.CSS_SELECTOR, target_css_selector)
     except NoSuchElementException:
         raise NoSuchElementException("Components not found. Test failed.")


### PR DESCRIPTION
We have seen consecutive ✅ for commits since #41276. This further improves tests stability:
1. No need to wait for pop up that long, as we only start to search for it after page is loaded. JS is efficient here.
2. Click another tab based on webdriver instead of hard-coded coordinates.
3. Give longer implicit time after redirection. For whatever reason, `document.readyState` is a big liar so that approach has never been adopted. We fall back to longer implicit wait time now.

Testing: https://github.com/servo/servo/actions/runs/20264413218
