### PR TITLE
Net: Replace fetch thread with tokio based solution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5734,6 +5734,7 @@ dependencies = [
  "servo_arc",
  "servo_malloc_size_of",
  "servo_url",
+ "tokio",
  "tower",
  "url",
  "uuid",

--- a/components/fonts/font_context.rs
+++ b/components/fonts/font_context.rs
@@ -920,7 +920,7 @@ impl RemoteWebFontDownloader {
         };
 
         fetch_async(
-            &core_resource_thread_clone,
+            core_resource_thread_clone.clone(),
             request,
             None,
             Box::new(move |response_message| {

--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -141,7 +141,12 @@ impl DocumentLoader {
             request.id,
             self.resource_threads.core_thread.clone(),
         ));
-        fetch_async(&self.resource_threads.core_thread, request, None, callback);
+        fetch_async(
+            self.resource_threads.core_thread.clone(),
+            request,
+            None,
+            callback,
+        );
     }
 
     /// Mark an in-progress network request complete.

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -3331,7 +3331,7 @@ impl GlobalScope {
         network_listener: NetworkListener<Listener>,
     ) {
         fetch_async(
-            &self.core_resource_thread(),
+            self.core_resource_thread(),
             request_builder,
             None,
             network_listener.into_callback(),

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -92,7 +92,7 @@ impl FetchCanceller {
             if let Some(ref core_resource_thread) = self.core_resource_thread {
                 // No error handling here. Cancellation is a courtesy call,
                 // we don't actually care if the other side heard.
-                cancel_async_fetch(vec![request_id], core_resource_thread);
+                cancel_async_fetch(vec![request_id], core_resource_thread.clone());
             }
         }
     }

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -55,7 +55,7 @@ impl NavigationListener {
 
     pub fn initiate_fetch(
         self,
-        core_resource_thread: &CoreResourceThread,
+        core_resource_thread: CoreResourceThread,
         response_init: Option<ResponseInit>,
     ) {
         fetch_async(

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3513,7 +3513,7 @@ impl ScriptThread {
             self.resource_threads.core_thread.clone(),
         );
         NavigationListener::new(request_builder, self.senders.self_sender.clone())
-            .initiate_fetch(&self.resource_threads.core_thread, None);
+            .initiate_fetch(self.resource_threads.core_thread.clone(), None);
         self.incomplete_loads.borrow_mut().push(incomplete);
     }
 
@@ -3649,7 +3649,7 @@ impl ScriptThread {
             self.resource_threads.core_thread.clone(),
         );
         NavigationListener::new(request_builder, self.senders.self_sender.clone())
-            .initiate_fetch(&self.resource_threads.core_thread, response_init);
+            .initiate_fetch(self.resource_threads.core_thread.clone(), response_init);
     }
 
     /// Synchronously fetch `about:blank`. Stores the `InProgressLoad`

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -57,7 +57,7 @@ use media::{GlApi, NativeDisplay, WindowGLContext};
 use net::image_cache::ImageCacheFactoryImpl;
 use net::protocols::ProtocolRegistry;
 use net::resource_thread::new_resource_threads;
-use net_traits::{ResourceThreads, exit_fetch_thread, start_fetch_thread};
+use net_traits::{ResourceThreads, start_fetch_thread};
 use profile::{mem as profile_mem, system_reporter, time as profile_time};
 use profile_traits::mem::{MemoryReportResult, ProfilerMsg, Reporter};
 use profile_traits::{mem, time};
@@ -1044,7 +1044,7 @@ pub fn run_content_process(token: String) {
             media_platform::init();
 
             // Start the fetch thread for this content process.
-            let fetch_thread_join_handle = start_fetch_thread();
+            let _fetch_thread_guard = start_fetch_thread();
 
             set_logger(
                 new_event_loop_info
@@ -1080,12 +1080,6 @@ pub fn run_content_process(token: String) {
                 .expect("Failed to join on the BHM background thread.");
 
             StyleThreadPool::shutdown();
-
-            // Shut down the fetch thread started above.
-            exit_fetch_thread();
-            fetch_thread_join_handle
-                .join()
-                .expect("Failed to join on the fetch thread in the constellation");
         },
         UnprivilegedContent::ServiceWorker(content) => {
             content.start::<ServiceWorkerManager>();

--- a/components/shared/net/Cargo.toml
+++ b/components/shared/net/Cargo.toml
@@ -43,6 +43,7 @@ serde = { workspace = true }
 servo_arc = { workspace = true }
 servo_url = { path = "../../url" }
 tower = { workspace = true }
+tokio = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 webrender_api = { workspace = true }


### PR DESCRIPTION
Currently we have the FetchThread (which should be named FetchCoordinationThread or FetchCallbackThread) which does mostly coordinates
fetches and fetch callbacks. Using a whole thread for this when we already have a tokio runtime seems excessive. Especially because the main fetch logic is tokio based. Additionally, this does not seem to have any security implications.

This PR replaces this with a tokio based aproach with the cost of a couple more clones of an IpcSender.

WARNING: Currently this does not work as we do not start the tokio runtime early enough but that should be easy to ffix.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: *Describe how this pull request is tested or why it doesn't require tests*
Fixes: *Link to an issue this pull requests fixes or remove this line if there is no issue*
