### PR TITLE
libservo: Allow responding to auxiliary `WebView` open requests asynchronously

### DIFF
--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -65,8 +65,9 @@ pub use crate::servo_delegate::{ServoDelegate, ServoError};
 pub use crate::webview::{WebView, WebViewBuilder};
 pub use crate::webview_delegate::{
     AlertDialog, AllowOrDenyRequest, AuthenticationRequest, ColorPicker, ConfirmDialog,
-    ContextMenu, EmbedderControl, FilePicker, InputMethodControl, NavigationRequest,
-    PermissionRequest, PromptDialog, SelectElement, SimpleDialog, WebResourceLoad, WebViewDelegate,
+    ContextMenu, CreateNewWebViewRequest, EmbedderControl, FilePicker, InputMethodControl,
+    NavigationRequest, PermissionRequest, PromptDialog, SelectElement, SimpleDialog,
+    WebResourceLoad, WebViewDelegate,
 };
 
 // Since WebXR is guarded by conditional compilation it is exported via submodule.

--- a/components/servo/responders.rs
+++ b/components/servo/responders.rs
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base::generic_channel;
+use base::generic_channel::{GenericSender, SendError, SendResult};
 use crossbeam_channel::{Receiver, Sender, TryRecvError, unbounded};
 use log::warn;
+use serde::Serialize;
 
 use crate::ServoError;
 
@@ -16,7 +17,7 @@ pub(crate) struct ServoErrorSender {
 }
 
 impl ServoErrorSender {
-    pub(crate) fn raise_response_send_error(&self, error: generic_channel::SendError) {
+    pub(crate) fn raise_response_send_error(&self, error: SendError) {
         if let Err(error) = self.sender.send(ServoError::ResponseFailedToSend(error)) {
             warn!("Failed to send Servo error: {error:?}");
         }
@@ -52,6 +53,48 @@ impl ServoErrorChannel {
                 debug_assert_eq!(error, TryRecvError::Empty);
                 None
             },
+        }
+    }
+}
+
+/// Sends a response over an IPC channel, or a default response on [`Drop`] if no response was sent.
+pub(crate) struct IpcResponder<T: Serialize> {
+    response_sender: GenericSender<T>,
+    response_sent: bool,
+    /// Always present, except when taken by [`Drop`].
+    default_response: Option<T>,
+}
+
+impl<T: Serialize> IpcResponder<T> {
+    pub(crate) fn new(response_sender: GenericSender<T>, default_response: T) -> Self {
+        Self {
+            response_sender,
+            response_sent: false,
+            default_response: Some(default_response),
+        }
+    }
+
+    pub(crate) fn send(&mut self, response: T) -> SendResult {
+        let result = self.response_sender.send(response);
+        self.response_sent = true;
+        result
+    }
+
+    pub(crate) fn into_inner(self) -> GenericSender<T> {
+        self.response_sender.clone()
+    }
+}
+
+impl<T: Serialize> Drop for IpcResponder<T> {
+    fn drop(&mut self) {
+        if !self.response_sent {
+            let response = self
+                .default_response
+                .take()
+                .expect("Guaranteed by inherent impl");
+            // Don’t notify embedder about send errors for the default response,
+            // since they didn’t send anything and probably don’t care.
+            let _ = self.response_sender.send(response);
         }
     }
 }

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -321,11 +321,7 @@ impl ServoInner {
             },
             EmbedderMsg::AllowOpeningWebView(webview_id, response_sender) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
-                    let webview_id_and_viewport_details = webview
-                        .delegate()
-                        .request_open_auxiliary_webview(webview)
-                        .map(|webview| (webview.id(), webview.viewport_details()));
-                    let _ = response_sender.send(webview_id_and_viewport_details);
+                    webview.request_create_new(response_sender);
                 }
             },
             EmbedderMsg::WebViewClosed(webview_id) => {


### PR DESCRIPTION
This change renames the `WebView::request_open_auxiliary_webview` to
`WebView::request_create_new` and allows responding to it
asynchronously. A new `CreateNewWebViewRequest` is exposed that keeps
the response sender alive as long as it is not dropped. If dropped
without a response, the original request is denied with `None`.

This also makes the API a bit harder to misuse, because the public
`WebViewBuilder::new_auxiliary` factory is no longer exposed, in favor
of `CreateNewWebViewRequest::builder`. This makes it impossible to
create an auxiliary `WebView` without a corresponding request. This
still isn't the idea API, which would be to make creating an auxiliary
`WebView` and normal `WebView` exactly the same, but it's an
improvement.

This will allow opening auxiliary `WebView`s in new toplevel platform
windows in servoshell. That will be handled in a followup. In addition,
the `CreateNewWebViewRequest` can eventually hold the arguments passed
to `window.open`.

Testing: Corresponding changes are made in servoshell, which means that
this is tested by the WPT calling `window.open`.
Fixes: #41220.
