### PR TITLE
script: retarget dblclick from input UA shadow DOM to host

### DIFF
--- a/components/script/dom/document_event_handler.rs
+++ b/components/script/dom/document_event_handler.rs
@@ -684,6 +684,9 @@ impl DocumentEventHandler {
         // > The click event type MUST be dispatched on the topmost event target indicated by the
         // > pointer, when the user presses down and releases the primary pointer button.
 
+        // For nodes inside a text input UA shadow DOM, dispatch dblclick at the shadow host.
+        let delegated = element.find_focusable_shadow_host_if_necessary();
+        let element = delegated.as_deref().unwrap_or(element);
         self.most_recently_clicked_element.set(Some(element));
 
         element.set_click_in_progress(true);

--- a/tests/wpt/tests/uievents/click/dblclick_event_on_text_control_inputs.html
+++ b/tests/wpt/tests/uievents/click/dblclick_event_on_text_control_inputs.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>dblclick event on a text input</title>
-    <link rel="help" href="https://www.w3.org/TR/uievents/#event-type-dblclick">
+    <link rel="author" href="haddadi.taym@gmail.com>">
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/resources/testdriver.js"></script>

--- a/tests/wpt/tests/uievents/click/dblclick_event_on_text_control_inputs.html
+++ b/tests/wpt/tests/uievents/click/dblclick_event_on_text_control_inputs.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>dblclick event on a text input</title>
+    <link rel="help" href="https://www.w3.org/TR/uievents/#event-type-dblclick">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/resources/testdriver.js"></script>
+    <script src="/resources/testdriver-actions.js"></script>
+    <script src="/resources/testdriver-vendor.js"></script>
+    <style>
+      #target {
+        width: 200px;
+        height: 32px;
+        font-size: 16px;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Double click on the input with the left mouse button.</p>
+    <input id="target" type="text" value="abc">
+    <script>
+      promise_test(async (t) => {
+        const target = document.getElementById("target");
+        const event_watcher = new EventWatcher(t, target, ["click", "dblclick"]);
+
+        const actions_promise = new test_driver.Actions()
+          .pointerMove(5, 5, { origin: target })
+          .pointerDown()
+          .pointerUp()
+          .pointerDown()
+          .pointerUp()
+          .send();
+
+        t.add_cleanup(() => actions_promise);
+
+        const event = await event_watcher.wait_for(["click", "click", "dblclick"]);
+        assert_equals(event.type, "dblclick");
+        assert_equals(event.target, target);
+        assert_equals(event.detail, 2);
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION

dblclick on text inputs was being dispatched to an internal element used for the input, not to the <input> itself. As a result, page scripts listening for dblclick on the input never received the event.

Testing: tested manually.
Fixes: #41303
