### PR TITLE
deps: Lock bincode in the Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,12 @@ backtrace = "0.3"
 base = { path = "components/shared/base" }
 base64 = "0.22.1"
 base64ct = { version = "1.8", features = ["alloc"] }
-bincode = "1"
+# bincode 1.3.3 is the last known good version of bincode 1.
+# The crate was declared finished and won't receive further updates by the author.
+# Since the git history was rewritten by the author, any bump of this crate should
+# be reviewed carefully by doing a manual diff based on the crates.io version,
+# before doing **any** bump to this dependency to rule out a supply chain attack.
+bincode = "=1.3.3"
 bitflags = "2.10"
 bluetooth_traits = { path = "components/shared/bluetooth" }
 brotli = "8.0.2"


### PR DESCRIPTION
To reduce our risk of future supply chain attacks, pin bincode 1.3.3 in our Cargo.toml.
Author actions like rewriting git history and nuking the original repository make validating updates more difficult.
Since the author has announced, the development is stopped, the most reasonable thing to do is pin our version the Cargo.toml. In the unlikely case of an update, it should require a review based on a diff of the crates.io releases.

Testing: no functional changes, not required

