### PR TITLE
indexeddb: implement databases concept(detete and `databases` method)

### DIFF
--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -40,6 +40,8 @@ pub struct IDBFactory {
     /// The connections pending #open-a-database-connection.
     connections_pending_open: DomRefCell<HashMapTracedValues<DBName, Dom<IDBDatabase>>>,
 
+    /// Keeping track of pending promises resolving to database info.
+    /// Only necessary because of #41356
     #[ignore_malloc_size_of = "rc"]
     pending_db_info_promises: DomRefCell<VecDeque<Rc<Promise>>>,
 }

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -1,12 +1,16 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use std::rc::Rc;
+
 use dom_struct::dom_struct;
 use js::rust::HandleValue;
 use servo_url::origin::ImmutableOrigin;
 
 use crate::dom::bindings::cell::DomRefCell;
-use crate::dom::bindings::codegen::Bindings::IDBFactoryBinding::IDBFactoryMethods;
+use crate::dom::bindings::codegen::Bindings::IDBFactoryBinding::{
+    IDBDatabaseInfo, IDBFactoryMethods,
+};
 use crate::dom::bindings::error::{Error, Fallible};
 use crate::dom::bindings::import::base::SafeJSContext;
 use crate::dom::bindings::reflector::{DomGlobal, Reflector, reflect_dom_object};
@@ -16,6 +20,7 @@ use crate::dom::bindings::trace::HashMapTracedValues;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::indexeddb::idbdatabase::IDBDatabase;
 use crate::dom::indexeddb::idbopendbrequest::IDBOpenDBRequest;
+use crate::dom::promise::Promise;
 use crate::indexeddb::convert_value_to_key;
 use crate::script_runtime::CanGc;
 
@@ -90,15 +95,19 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         Ok(request)
     }
 
-    /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbfactory-deletedatabase>
+    /// <https://www.w3.org/TR/IndexedDB/#dom-idbfactory-deletedatabase>
     fn DeleteDatabase(&self, name: DOMString) -> Fallible<DomRoot<IDBOpenDBRequest>> {
-        // Step 1: Let origin be the origin of the global scope used to
-        // access this IDBFactory.
+        // Step 1: Let environment be this’s relevant settings object.
         let global = self.global();
+
+        // Step 2: Let storageKey be the result of running obtain a storage key given environment.
+        // If failure is returned, then throw a "SecurityError" DOMException and abort these steps.
+        // TODO: use a storage key.
         let origin = global.origin();
 
-        // Step 2: if origin is an opaque origin,
+        // Legacy step 2: if origin is an opaque origin,
         // throw a "SecurityError" DOMException and abort these steps.
+        // TODO: remove when a storage key is used.
         if let ImmutableOrigin::Opaque(_) = origin.immutable() {
             return Err(Error::Security(None));
         }
@@ -115,10 +124,10 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         Ok(request)
     }
 
-    // // https://www.w3.org/TR/IndexedDB-2/#dom-idbfactory-databases
-    // fn Databases(&self) -> Rc<Promise> {
-    //     unimplemented!();
-    // }
+    /// https://www.w3.org/TR/IndexedDB/#dom-idbfactory-databases
+    fn Databases(&self) -> Rc<Promise> {
+        unimplemented!();
+    }
 
     /// <https://www.w3.org/TR/IndexedDB-2/#dom-idbfactory-cmp>
     fn Cmp(&self, cx: SafeJSContext, first: HandleValue, second: HandleValue) -> Fallible<i16> {

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -184,16 +184,16 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
                 let can_gc = CanGc::note();
                 let factory = trusted_clone.root();
                 match result {
-                Err(_) => factory.reject_pending_db_info_promise(can_gc),
-                Ok(info_list) => {
-                    let info_list: Vec<IDBDatabaseInfo> = info_list
-                        .into_iter()
-                        .map(|info| IDBDatabaseInfo {
-                            name: Some(DOMString::from(info.name)),
-                            version: Some(info.version),
+                    Err(_) => factory.reject_pending_db_info_promise(can_gc),
+                    Ok(info_list) => {
+                        let info_list: Vec<IDBDatabaseInfo> = info_list
+                            .into_iter()
+                            .map(|info| IDBDatabaseInfo {
+                                name: Some(DOMString::from(info.name)),
+                                version: Some(info.version),
                         })
                         .collect();
-                    factory.resolve_pending_db_info_promise(info_list, can_gc);
+                         factory.resolve_pending_db_info_promise(info_list, can_gc);
                 },
             }
             }));

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -163,7 +163,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
         Ok(request)
     }
 
-    /// https://www.w3.org/TR/IndexedDB/#dom-idbfactory-databases
+    /// <https://www.w3.org/TR/IndexedDB/#dom-idbfactory-databases>
     fn Databases(&self, can_gc: CanGc) -> Rc<Promise> {
         // Step 1: Let environment be this’s relevant settings object
         let global = self.global();

--- a/components/script/dom/indexeddb/idbfactory.rs
+++ b/components/script/dom/indexeddb/idbfactory.rs
@@ -9,7 +9,7 @@ use js::jsval::UndefinedValue;
 use js::rust::HandleValue;
 use profile_traits::generic_callback::GenericCallback;
 use servo_url::origin::ImmutableOrigin;
-use storage_traits::indexeddb::{BackendResult, DataBaseInfo, IndexedDBThreadMsg, SyncOperation};
+use storage_traits::indexeddb::{BackendResult, DatabaseInfo, IndexedDBThreadMsg, SyncOperation};
 
 use crate::dom::bindings::cell::DomRefCell;
 use crate::dom::bindings::codegen::Bindings::IDBFactoryBinding::{
@@ -156,7 +156,7 @@ impl IDBFactoryMethods<crate::DomTypeHolder> for IDBFactory {
             .database_access_task_source()
             .to_sendable();
         let callback = GenericCallback::new(global.time_profiler_chan().clone(), move |message| {
-            let result: BackendResult<Vec<DataBaseInfo>> = message.unwrap();
+            let result: BackendResult<Vec<DatabaseInfo>> = message.unwrap();
             let Some(trusted_promise) = trusted_promise.take() else {
                 return error!("Callback for `DataBases` called twice.");
             };

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -121,7 +121,7 @@ impl OpenRequestListener {
     }
 
     /// The contionuation of the parallel steps of
-    /// https://www.w3.org/TR/IndexedDB/#dom-idbfactory-deletedatabase
+    /// <https://www.w3.org/TR/IndexedDB/#dom-idbfactory-deletedatabase>
     fn handle_delete_db(&self, result: BackendResult<u64>, can_gc: CanGc) {
         // Step 4.1: Let result be the result of deleting a database, with storageKey, name, and request.
         // Note: done with the `result` argument.

--- a/components/script/dom/indexeddb/idbopendbrequest.rs
+++ b/components/script/dom/indexeddb/idbopendbrequest.rs
@@ -28,7 +28,7 @@ use crate::dom::indexeddb::idbfactory::DBName;
 use crate::dom::indexeddb::idbrequest::IDBRequest;
 use crate::dom::indexeddb::idbtransaction::IDBTransaction;
 use crate::dom::indexeddb::idbversionchangeevent::IDBVersionChangeEvent;
-use crate::dom::map_backend_error_to_dom_error;
+use crate::indexeddb::map_backend_error_to_dom_error;
 use crate::realms::enter_realm;
 use crate::script_runtime::CanGc;
 

--- a/components/script/dom/indexeddb/mod.rs
+++ b/components/script/dom/indexeddb/mod.rs
@@ -17,16 +17,3 @@ pub(crate) mod idbopendbrequest;
 pub(crate) mod idbrequest;
 pub(crate) mod idbtransaction;
 pub(crate) mod idbversionchangeevent;
-
-pub(crate) fn map_backend_error_to_dom_error(error: BackendError) -> Error {
-    match error {
-        BackendError::QuotaExceeded => Error::QuotaExceeded {
-            quota: None,
-            requested: None,
-        },
-        BackendError::DbErr(details) => {
-            Error::Operation(Some(format!("IndexedDB open failed: {details}")))
-        },
-        other => Error::Operation(Some(format!("IndexedDB open failed: {other:?}"))),
-    }
-}

--- a/components/script/dom/indexeddb/mod.rs
+++ b/components/script/dom/indexeddb/mod.rs
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use storage_traits::indexeddb::BackendError;
-
-use crate::dom::bindings::error::Error;
-
 pub(crate) mod idbcursor;
 pub(crate) mod idbcursorwithvalue;
 pub(crate) mod idbdatabase;

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -545,6 +545,10 @@ DOMInterfaces = {
     'canGc': ['Key', 'PrimaryKey']
 },
 
+'IDBFactory': {
+    'canGc': ["Databases"]
+},
+
 'IDBKeyRange': {
     'canGc': ['Lower', 'Upper']
 },

--- a/components/script_bindings/webidls/IDBFactory.webidl
+++ b/components/script_bindings/webidls/IDBFactory.webidl
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 /*
  * The origin of this IDL file is
- * https://w3c.github.io/IndexedDB/#idbfactory
+ * https://www.w3.org/TR/IndexedDB/#idbfactory
  *
  */
 
@@ -19,7 +19,7 @@ interface IDBFactory {
                                     optional [EnforceRange] unsigned long long version);
   [NewObject, Throws] IDBOpenDBRequest deleteDatabase(DOMString name);
 
-  // Promise<sequence<IDBDatabaseInfo>> databases();
+  Promise<sequence<IDBDatabaseInfo>> databases();
 
   [Throws] short cmp(any first, any second);
 };

--- a/components/shared/storage/indexeddb.rs
+++ b/components/shared/storage/indexeddb.rs
@@ -432,7 +432,7 @@ pub enum SyncOperation {
 
     /// Deletes the database
     DeleteDatabase(
-        GenericCallback<BackendResult<()>>,
+        GenericCallback<BackendResult<u64>>,
         ImmutableOrigin,
         String, // Database
     ),

--- a/components/shared/storage/indexeddb.rs
+++ b/components/shared/storage/indexeddb.rs
@@ -346,7 +346,18 @@ pub enum OpenDatabaseResult {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct DataBaseInfo {
+    pub name: String,
+    pub version: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub enum SyncOperation {
+    /// Gets existing databases.
+    GetDatabases(
+        GenericCallback<BackendResult<Vec<DataBaseInfo>>>,
+        ImmutableOrigin,
+    ),
     /// Upgrades the version of the database
     UpgradeVersion(
         /// Sender to send new version as the result of the operation

--- a/components/shared/storage/indexeddb.rs
+++ b/components/shared/storage/indexeddb.rs
@@ -346,7 +346,7 @@ pub enum OpenDatabaseResult {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct DataBaseInfo {
+pub struct DatabaseInfo {
     pub name: String,
     pub version: u64,
 }
@@ -355,7 +355,7 @@ pub struct DataBaseInfo {
 pub enum SyncOperation {
     /// Gets existing databases.
     GetDatabases(
-        GenericCallback<BackendResult<Vec<DataBaseInfo>>>,
+        GenericCallback<BackendResult<Vec<DatabaseInfo>>>,
         ImmutableOrigin,
     ),
     /// Upgrades the version of the database

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -548,7 +548,7 @@ impl IndexedDBManager {
             // TODO: implement connections.
 
             // Step 10: Let version be db’s version.
-            let version = db.version()?;
+            let version = db.version().map_err(backend_error_from_sqlite_error)?;
 
             // Step 11: Delete db.
             // If this fails for any reason,

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -53,6 +53,8 @@ impl IndexedDBThreadFactory for GenericSender<IndexedDBThreadMsg> {
     }
 }
 
+/// A key used to track databases.
+/// TODO: use a storage key.
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub struct IndexedDBDescription {
     pub origin: ImmutableOrigin,
@@ -176,13 +178,11 @@ impl<E: KvsEngine> IndexedDBEnvironment<E> {
         result.map_err(|err| format!("{err:?}"))
     }
 
-    fn delete_database(self, sender: GenericCallback<BackendResult<()>>) {
+    fn delete_database(self) -> BackendResult<()> {
         let result = self.engine.delete_database();
-        let _ = sender.send(
-            result
-                .map_err(|err| format!("{err:?}"))
-                .map_err(BackendError::from),
-        );
+        result
+            .map_err(|err| format!("{err:?}"))
+            .map_err(BackendError::from)
     }
 
     fn version(&self) -> Result<u64, E::Error> {
@@ -527,11 +527,48 @@ impl IndexedDBManager {
         };
     }
 
+    /// <https://www.w3.org/TR/IndexedDB/#delete-a-database>
+    fn delete_database(&mut self, idb_description: IndexedDBDescription) -> BackendResult<u64> {
+        // Step 1: Let queue be the connection queue for storageKey and name.
+        // Step 2: Add request to queue.
+        // Step 3: Wait until all previous requests in queue have been processed.
+        // TODO: implement connection queue.
+
+        // Step4: Let db be the database named name in storageKey, if one exists. Otherwise, return 0 (zero).
+        let version = if let Some(db) = self.databases.remove(&idb_description) {
+            // Step 5: Let openConnections be the set of all connections associated with db.
+            // Step6: For each entry of openConnections that does not have its close pending flag set to true,
+            // queue a database task to fire a version change event named versionchange
+            // at entry with db’s version and null.
+            // Step 7: Wait for all of the events to be fired.
+            // Step 8: If any of the connections in openConnections are still not closed,
+            // queue a database task to fire a version change event
+            // named blocked at request with db’s version and null.
+            // Step 9: Wait until all connections in openConnections are closed.
+            // TODO: implement connections.
+
+            // Step 10: Let version be db’s version.
+            let version = db.version()?;
+
+            // Step 11: Delete db.
+            // If this fails for any reason,
+            // return an appropriate error (e.g. a QuotaExceededError, or an "UnknownError" DOMException).
+            db.delete_database()?;
+            version
+        } else {
+            0
+        };
+
+        // step 12: Return version.
+        BackendResult::Ok(version)
+    }
+
     fn handle_sync_operation(&mut self, operation: SyncOperation) {
         match operation {
             SyncOperation::CloseDatabase(sender, origin, db_name) => {
                 // TODO: Wait for all transactions created using connection to complete.
                 // Note: current behavior is as if the `forced` flag is always set.
+                // TODO: do not delete the database, only the connection.
                 let idb_description = IndexedDBDescription {
                     origin,
                     name: db_name,
@@ -545,17 +582,16 @@ impl IndexedDBManager {
                 self.open_database(sender, origin, db_name, version);
             },
             SyncOperation::DeleteDatabase(callback, origin, db_name) => {
-                // https://w3c.github.io/IndexedDB/#delete-a-database
-                // Step 4. Let db be the database named name in storageKey,
-                // if one exists. Otherwise, return 0 (zero).
                 let idb_description = IndexedDBDescription {
                     origin,
                     name: db_name,
                 };
-                if let Some(db) = self.databases.remove(&idb_description) {
-                    db.delete_database(callback);
-                } else {
-                    let _ = callback.send(Ok(()));
+                // https://www.w3.org/TR/IndexedDB/#dom-idbfactory-deletedatabase
+                // Step 4.1: Let result be the result of deleting a database,
+                // with storageKey, name, and request.
+                let result = self.delete_database(idb_description);
+                if callback.send(result).is_err() {
+                    error!("Failed to send delete database result to script");
                 }
             },
             SyncOperation::HasKeyGenerator(sender, origin, db_name, store_name) => {

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -565,6 +565,7 @@ impl IndexedDBManager {
 
     fn handle_sync_operation(&mut self, operation: SyncOperation) {
         match operation {
+            SyncOperation::GetDatabases(sender, origin) => {},
             SyncOperation::CloseDatabase(sender, origin, db_name) => {
                 // TODO: Wait for all transactions created using connection to complete.
                 // Note: current behavior is as if the `forced` flag is always set.

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -20,7 +20,7 @@ use rustc_hash::FxHashMap;
 use servo_config::pref;
 use servo_url::origin::ImmutableOrigin;
 use storage_traits::indexeddb::{
-    AsyncOperation, BackendError, BackendResult, CreateObjectResult, DataBaseInfo, DbResult,
+    AsyncOperation, BackendError, BackendResult, CreateObjectResult, DatabaseInfo, DbResult,
     IndexedDBThreadMsg, IndexedDBTxnMode, KeyPath, OpenDatabaseResult, SyncOperation,
 };
 use uuid::Uuid;
@@ -576,7 +576,7 @@ impl IndexedDBManager {
                 // For now using `self.databases`, which track connections.
 
                 // Step 4.2: Let result be a new list.
-                let info_list: Vec<DataBaseInfo> = self
+                let info_list: Vec<DatabaseInfo> = self
                     .databases
                     .iter()
                     .filter_map(|(description, info)| {
@@ -591,7 +591,7 @@ impl IndexedDBManager {
                                 // Step 4.3.7: Set info’s version dictionary member to db’s version.
                                 // Step 4.3.8: Append info to result.
                                 if description.origin == origin {
-                                    Some(DataBaseInfo {
+                                    Some(DatabaseInfo {
                                         name: description.name.clone(),
                                         version,
                                     })

--- a/components/storage/indexeddb/mod.rs
+++ b/components/storage/indexeddb/mod.rs
@@ -593,7 +593,7 @@ impl IndexedDBManager {
                                 if description.origin == origin {
                                     Some(DataBaseInfo {
                                         name: description.name.clone(),
-                                        version: version,
+                                        version,
                                     })
                                 } else {
                                     None

--- a/tests/wpt/meta/IndexedDB/get-databases.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/get-databases.any.js.ini
@@ -1,14 +1,5 @@
 [get-databases.any.worker.html]
-  [Ensure that databases() returns a promise.]
-    expected: FAIL
-
-  [Enumerate one database.]
-    expected: FAIL
-
   [Enumerate multiple databases.]
-    expected: FAIL
-
-  [Make sure an empty list is returned for the case of no databases.]
     expected: FAIL
 
   [Ensure that databases() doesn't pick up changes that haven't commited.]
@@ -16,16 +7,7 @@
 
 
 [get-databases.any.html]
-  [Ensure that databases() returns a promise.]
-    expected: FAIL
-
-  [Enumerate one database.]
-    expected: FAIL
-
   [Enumerate multiple databases.]
-    expected: FAIL
-
-  [Make sure an empty list is returned for the case of no databases.]
     expected: FAIL
 
   [Ensure that databases() doesn't pick up changes that haven't commited.]

--- a/tests/wpt/meta/IndexedDB/idbfactory-databases-opaque-origin.html.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory-databases-opaque-origin.html.ini
@@ -1,7 +1,4 @@
 [idbfactory-databases-opaque-origin.html]
-  [IDBFactory.databases() in non-sandboxed iframe should not reject]
-    expected: FAIL
-
   [IDBFactory.databases() in sandboxed iframe should reject]
     expected: FAIL
 

--- a/tests/wpt/meta/IndexedDB/idbfactory-origin-isolation.html.ini
+++ b/tests/wpt/meta/IndexedDB/idbfactory-origin-isolation.html.ini
@@ -1,3 +1,0 @@
-[idbfactory-origin-isolation.html]
-  [Test to make sure that origins have separate locking schemes]
-    expected: FAIL

--- a/tests/wpt/meta/IndexedDB/idbversionchangeevent.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idbversionchangeevent.any.js.ini
@@ -1,15 +1,5 @@
-[idbversionchangeevent.any.html]
-  [IDBVersionChangeEvent fired in upgradeneeded, versionchange and deleteDatabase]
-    expected: FAIL
-
-
 [idbversionchangeevent.any.serviceworker.html]
   expected: ERROR
-
-[idbversionchangeevent.any.worker.html]
-  [IDBVersionChangeEvent fired in upgradeneeded, versionchange and deleteDatabase]
-    expected: FAIL
-
 
 [idbversionchangeevent.any.sharedworker.html]
   expected: ERROR

--- a/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
+++ b/tests/wpt/meta/IndexedDB/idlharness.any.js.ini
@@ -2,9 +2,6 @@
   expected: ERROR
 
 [idlharness.any.html]
-  [IDBFactory interface: operation databases()]
-    expected: FAIL
-
   [IDBObjectStore interface: operation index(DOMString)]
     expected: FAIL
 
@@ -57,9 +54,6 @@
     expected: FAIL
 
   [IDBTransaction interface: attribute durability]
-    expected: FAIL
-
-  [IDBFactory interface: [object IDBFactory\] must inherit property "databases()" with the proper type]
     expected: FAIL
 
   [IDBObjectStore interface: operation getAllRecords(optional IDBGetAllOptions)]
@@ -100,8 +94,6 @@
   expected: ERROR
 
 [idlharness.any.worker.html]
-  [IDBFactory interface: operation databases()]
-    expected: FAIL
 
   [IDBObjectStore interface: operation index(DOMString)]
     expected: FAIL
@@ -155,9 +147,6 @@
     expected: FAIL
 
   [IDBTransaction interface: attribute durability]
-    expected: FAIL
-
-  [IDBFactory interface: [object IDBFactory\] must inherit property "databases()" with the proper type]
     expected: FAIL
 
   [IDBObjectStore interface: operation getAllRecords(optional IDBGetAllOptions)]


### PR DESCRIPTION
Moves the concept of databases closer to the 3.0 spec, by implementing the delete functionality, and the method returning current databases to script. 

Testing: WPT tests with new passes
Fixes: The "Implement databases deletion and `databases`" item of https://github.com/servo/servo/issues/40983
