### PR TITLE
net: Align `ResourceThreads::clear_cache` with `clear_cookies`

### DIFF
--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -521,8 +521,11 @@ impl ResourceChannelManager {
                     history_states.remove(&history_state);
                 }
             },
-            CoreResourceMsg::ClearCache => {
+            CoreResourceMsg::ClearCache(sender) => {
                 http_state.http_cache.clear();
+                if let Some(sender) = sender {
+                    let _ = sender.send(());
+                }
             },
             CoreResourceMsg::ToFileManager(msg) => self.resource_manager.filemanager.handle(msg),
             CoreResourceMsg::Exit(sender) => {

--- a/components/servo/site_data_manager.rs
+++ b/components/servo/site_data_manager.rs
@@ -25,7 +25,6 @@ impl SiteDataManager {
         self.private_resource_threads.clear_cookies();
     }
 
-    // TODO: This currently does not wait for cache clearing to complete.
     pub fn clear_cache(&self) {
         self.public_resource_threads.clear_cache();
         self.private_resource_threads.clear_cache();


### PR DESCRIPTION
This PR aligns `ResourceThreads::clear_cache` with the existing
`clear_cookies` function by waiting for a response synchronously.

Testing: Unit tests continue to pass.
