### PR TITLE
Fix hashchange only queue when fragment actually changes

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2999,7 +2999,7 @@ impl Window {
                 let old_url = doc.url().into_string();
                 let new_url = load_data.url.clone().into_string();
 
-                // https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-document-for-history-step-application
+                // https://html.spec.whatwg.org/multipage/#update-document-for-history-step-application
                 // Step 6.4.5: If oldURL's fragment is not equal to entry's URL's fragment, then queue a global task on the
                 // DOM manipulation task source given document's relevant global object to fire an event named hashchange at
                 // document's relevant global object, using HashChangeEvent, with the oldURL attribute initialized to the
@@ -3010,8 +3010,6 @@ impl Window {
                 if old_fragment != new_fragment {
                     let webdriver_sender_for_task = webdriver_sender.clone();
                     let task = task!(hashchange_event: move || {
-                        println!("hashchange task: firing hashchange old_url={} new_url={}", old_url, new_url);
-
                         let this = this.root();
                         let event = HashChangeEvent::new(
                             &this,
@@ -3032,10 +3030,8 @@ impl Window {
                         .task_manager()
                         .dom_manipulation_task_source()
                         .queue(task);
-                } else {
-                    if let Some(sender) = webdriver_sender {
-                        let _ = sender.send(WebDriverLoadStatus::NavigationStop);
-                    }
+                } else if let Some(sender) = webdriver_sender {
+                    let _ = sender.send(WebDriverLoadStatus::NavigationStop);
                 }
                 doc.set_url(load_data.url.clone());
                 return;

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -2998,25 +2998,45 @@ impl Window {
                 let this = Trusted::new(self);
                 let old_url = doc.url().into_string();
                 let new_url = load_data.url.clone().into_string();
-                let task = task!(hashchange_event: move || {
-                    let this = this.root();
-                    let event = HashChangeEvent::new(
-                        &this,
-                        atom!("hashchange"),
-                        false,
-                        false,
-                        old_url,
-                        new_url,
-                        CanGc::note());
-                    event.upcast::<Event>().fire(this.upcast::<EventTarget>(), CanGc::note());
+
+                // https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-document-for-history-step-application
+                // Step 6.4.5: If oldURL's fragment is not equal to entry's URL's fragment, then queue a global task on the
+                // DOM manipulation task source given document's relevant global object to fire an event named hashchange at
+                // document's relevant global object, using HashChangeEvent, with the oldURL attribute initialized to the
+                // serialization of oldURL and the newURL attribute initialized to the serialization of entry's URL.
+                let old_fragment = doc.url().fragment().map(ToOwned::to_owned);
+                let new_fragment = load_data.url.fragment().map(ToOwned::to_owned);
+
+                if old_fragment != new_fragment {
+                    let webdriver_sender_for_task = webdriver_sender.clone();
+                    let task = task!(hashchange_event: move || {
+                        println!("hashchange task: firing hashchange old_url={} new_url={}", old_url, new_url);
+
+                        let this = this.root();
+                        let event = HashChangeEvent::new(
+                            &this,
+                            atom!("hashchange"),
+                            false,
+                            false,
+                            old_url,
+                            new_url,
+                            CanGc::note(),
+                        );
+                        event.upcast::<Event>().fire(this.upcast::<EventTarget>(), CanGc::note());
+                        if let Some(sender) = webdriver_sender_for_task {
+                            let _ = sender.send(WebDriverLoadStatus::NavigationStop);
+                        }
+                    });
+
+                    self.as_global_scope()
+                        .task_manager()
+                        .dom_manipulation_task_source()
+                        .queue(task);
+                } else {
                     if let Some(sender) = webdriver_sender {
                         let _ = sender.send(WebDriverLoadStatus::NavigationStop);
                     }
-                });
-                self.as_global_scope()
-                    .task_manager()
-                    .dom_manipulation_task_source()
-                    .queue(task);
+                }
                 doc.set_url(load_data.url.clone());
                 return;
             }

--- a/tests/wpt/tests/html/browsers/browsing-the-web/history-traversal/hashchange-same-fragment-does-not-fire.html
+++ b/tests/wpt/tests/html/browsers/browsing-the-web/history-traversal/hashchange-same-fragment-does-not-fire.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>hashchange is not fired when setting the same fragment</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<script>
+promise_test(async t => {
+  t.add_cleanup(() => history.replaceState(null, "", location.pathname + location.search));
+
+  const first = new Promise(resolve => addEventListener("hashchange", resolve, { once: true }));
+  location.hash = "#foo";
+  await first;
+
+  const secondHashchange = new Promise(resolve => {
+    addEventListener("hashchange", () => resolve("fired"), { once: true });
+  });
+  const timeout = new Promise(resolve => t.step_timeout(() => resolve("timeout"), 100));
+
+  location.hash = "#foo";
+
+  const result = await Promise.race([secondHashchange, timeout]);
+  assert_equals(result, "timeout", "hashchange must not fire when fragment does not change");
+}, "Setting the same location.hash twice must not fire hashchange the second time");
+</script>


### PR DESCRIPTION
Fix hashchange only queue when fragment actually changes

Testing: tested it manually for now. 
Fixes: #41304
