### PR TITLE
Don't persist session storage changes

### DIFF
--- a/components/shared/storage/webstorage_thread.rs
+++ b/components/shared/storage/webstorage_thread.rs
@@ -9,7 +9,7 @@ use profile_traits::mem::ReportsChan;
 use serde::{Deserialize, Serialize};
 use servo_url::ServoUrl;
 
-#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, MallocSizeOf, Serialize)]
 pub enum WebStorageType {
     Session,
     Local,

--- a/components/storage/tests/webstorage.rs
+++ b/components/storage/tests/webstorage.rs
@@ -403,7 +403,7 @@ fn clear_data_for_sites_local_in_memory() {
 #[test]
 fn no_storage_type_conflict() {
     // Ensures that editing session storage does not affect local storage and vice versa.
-    let (_tmp_dir, threads) = init();
+    let (tmp_dir, threads) = init();
     let url = ServoUrl::parse("https://example.com").unwrap();
     // Set local storage item.
     let (sender, receiver) = base_channel::channel().unwrap();
@@ -431,6 +431,9 @@ fn no_storage_type_conflict() {
         ))
         .unwrap();
     let _ = receiver.recv().unwrap();
+    // Shutdown threads to ensure data is cleared from session storage and local storage is loaded from disk
+    shutdown(&threads);
+    let threads = init_with(&tmp_dir);
     // Get local storage item.
     let (sender, receiver) = base_channel::channel().unwrap();
     threads
@@ -443,6 +446,8 @@ fn no_storage_type_conflict() {
         ))
         .unwrap();
     assert_eq!(receiver.recv().unwrap(), Some("local_value".into()));
+    shutdown(&threads);
+    let threads = init_with(&tmp_dir);
     // Get session storage item.
     let (sender, receiver) = base_channel::channel().unwrap();
     threads
@@ -454,5 +459,5 @@ fn no_storage_type_conflict() {
             "key".into(),
         ))
         .unwrap();
-    assert_eq!(receiver.recv().unwrap(), Some("session_value".into()));
+    assert_eq!(receiver.recv().unwrap(), None);
 }

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -523,10 +523,10 @@ impl WebStorageManager {
                             Ok((true, Some(old)))
                         }
                     });
-            // XXX Should this be scoped to localStorage only?
-            // Tracked in issue #41324.
-            let env = self.get_environment_mut(&url.origin());
-            env.set(&name, &value);
+            if storage_type == StorageType::Local {
+                let env = self.get_environment_mut(&url.origin());
+                env.set(&name, &value);
+            }
             result
         };
         sender.send(message).unwrap();
@@ -558,8 +558,10 @@ impl WebStorageManager {
         let data = self.select_data_mut(storage_type, webview_id, url.origin());
         let old_value = data.and_then(|entry| entry.remove(&name));
         sender.send(old_value).unwrap();
-        let env = self.get_environment_mut(&url.origin());
-        env.delete(&name);
+        if storage_type == StorageType::Local {
+            let env = self.get_environment_mut(&url.origin());
+            env.delete(&name);
+        }
     }
 
     fn clear(
@@ -580,8 +582,10 @@ impl WebStorageManager {
                 }
             }))
             .unwrap();
-        let env = self.get_environment_mut(&url.origin());
-        env.clear();
+        if storage_type == StorageType::Local {
+            let env = self.get_environment_mut(&url.origin());
+            env.clear();
+        }
     }
 
     fn clone(&mut self, src_webview_id: WebViewId, dest_webview_id: WebViewId) {

--- a/components/storage/webstorage/mod.rs
+++ b/components/storage/webstorage/mod.rs
@@ -523,7 +523,7 @@ impl WebStorageManager {
                             Ok((true, Some(old)))
                         }
                     });
-            if storage_type == StorageType::Local {
+            if storage_type == WebStorageType::Local {
                 let env = self.get_environment_mut(&url.origin());
                 env.set(&name, &value);
             }
@@ -558,7 +558,7 @@ impl WebStorageManager {
         let data = self.select_data_mut(storage_type, webview_id, url.origin());
         let old_value = data.and_then(|entry| entry.remove(&name));
         sender.send(old_value).unwrap();
-        if storage_type == StorageType::Local {
+        if storage_type == WebStorageType::Local {
             let env = self.get_environment_mut(&url.origin());
             env.delete(&name);
         }
@@ -582,7 +582,7 @@ impl WebStorageManager {
                 }
             }))
             .unwrap();
-        if storage_type == StorageType::Local {
+        if storage_type == WebStorageType::Local {
             let env = self.get_environment_mut(&url.origin());
             env.clear();
         }


### PR DESCRIPTION
Bug that would result in local storage changes being overwritten by session storage ones.

Testing: Added a unit test
Fixes: #41324