### PR TITLE
storage: Add initial `StorageKeyConnection` infrastructure for client storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8704,6 +8704,7 @@ name = "storage_traits"
 version = "0.0.1"
 dependencies = [
  "base",
+ "log",
  "malloc_size_of_derive",
  "profile_traits",
  "serde",

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -104,6 +104,7 @@ pub struct Preferences {
     /// - vello
     /// - vello_cpu
     pub dom_canvas_backend: String,
+    pub dom_client_storage_testing_enabled: bool,
     pub dom_clipboardevent_enabled: bool,
     pub dom_command_invokers_enabled: bool,
     pub dom_composition_event_enabled: bool,
@@ -299,6 +300,7 @@ impl Preferences {
             dom_canvas_capture_enabled: false,
             dom_canvas_text_enabled: true,
             dom_canvas_backend: String::new(),
+            dom_client_storage_testing_enabled: false,
             dom_clipboardevent_enabled: true,
             dom_command_invokers_enabled: false,
             dom_composition_event_enabled: false,

--- a/components/script/client_storage.rs
+++ b/components/script/client_storage.rs
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use base::generic_channel::GenericSender;
+use base::id::StorageKeyConnectionId;
+use storage_traits::client_storage::{ClientStorageProxy, StorageKeyConnectionBackendMessage};
+
+pub struct StorageKeyConnection {
+    proxy: ClientStorageProxy,
+    connection_id: StorageKeyConnectionId,
+}
+
+impl StorageKeyConnection {
+    pub fn new(proxy: ClientStorageProxy) -> StorageKeyConnection {
+        let connection_id = StorageKeyConnectionId::new();
+
+        proxy.send_new_storage_key_connection(connection_id);
+
+        StorageKeyConnection {
+            proxy,
+            connection_id,
+        }
+    }
+
+    pub fn send_test(&self, sender: GenericSender<i32>) {
+        self.proxy.send_storage_key_connection_backend_message(
+            self.connection_id,
+            StorageKeyConnectionBackendMessage::Test(sender),
+        );
+    }
+}

--- a/components/script/client_storage.rs
+++ b/components/script/client_storage.rs
@@ -4,22 +4,25 @@
 
 use base::generic_channel::GenericSender;
 use base::id::StorageKeyConnectionId;
+use servo_url::origin::ImmutableOrigin;
 use storage_traits::client_storage::{ClientStorageProxy, StorageKeyConnectionBackendMessage};
 
 pub struct StorageKeyConnection {
     proxy: ClientStorageProxy,
     connection_id: StorageKeyConnectionId,
+    _origin: ImmutableOrigin,
 }
 
 impl StorageKeyConnection {
-    pub fn new(proxy: ClientStorageProxy) -> StorageKeyConnection {
+    pub fn new(proxy: ClientStorageProxy, origin: ImmutableOrigin) -> StorageKeyConnection {
         let connection_id = StorageKeyConnectionId::new();
 
-        proxy.send_new_storage_key_connection(connection_id);
+        proxy.send_new_storage_key_connection(connection_id, origin.clone());
 
         StorageKeyConnection {
             proxy,
             connection_id,
+            _origin: origin,
         }
     }
 

--- a/components/script/client_storage.rs
+++ b/components/script/client_storage.rs
@@ -4,6 +4,7 @@
 
 use base::generic_channel::GenericSender;
 use base::id::StorageKeyConnectionId;
+use log::debug;
 use servo_url::origin::ImmutableOrigin;
 use storage_traits::client_storage::{ClientStorageProxy, StorageKeyConnectionBackendMessage};
 
@@ -31,5 +32,14 @@ impl StorageKeyConnection {
             self.connection_id,
             StorageKeyConnectionBackendMessage::Test(sender),
         );
+    }
+}
+
+impl Drop for StorageKeyConnection {
+    fn drop(&mut self) {
+        debug!("Dropping script::StorageKeyConnection");
+
+        self.proxy
+            .send_remove_storage_key_connection(self.connection_id);
     }
 }

--- a/components/script/dom/clientstoragetest.rs
+++ b/components/script/dom/clientstoragetest.rs
@@ -70,3 +70,9 @@ impl ClientStorageTestMethods<crate::DomTypeHolder> for ClientStorageTest {
         receiver.recv().unwrap()
     }
 }
+
+impl Drop for ClientStorageTest {
+    fn drop(&mut self) {
+        debug!("Dropping script::ClientStorageTest");
+    }
+}

--- a/components/script/dom/clientstoragetest.rs
+++ b/components/script/dom/clientstoragetest.rs
@@ -42,7 +42,9 @@ impl ClientStorageTest {
 
         let proxy = ClientStorageProxy::new(thread);
 
-        let connection = StorageKeyConnection::new(proxy);
+        let origin = global.origin().immutable().clone();
+
+        let connection = StorageKeyConnection::new(proxy, origin);
 
         reflect_dom_object_with_proto(
             Box::new(ClientStorageTest::new_inherited(connection)),

--- a/components/script/dom/clientstoragetest.rs
+++ b/components/script/dom/clientstoragetest.rs
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// check-tidy: no specs after this line
+
+use dom_struct::dom_struct;
+use js::rust::HandleObject;
+
+use crate::dom::bindings::codegen::Bindings::ClientStorageTestBinding::ClientStorageTestMethods;
+use crate::dom::bindings::reflector::{Reflector, reflect_dom_object_with_proto};
+use crate::dom::bindings::root::DomRoot;
+use crate::dom::globalscope::GlobalScope;
+use crate::script_runtime::CanGc;
+
+#[dom_struct]
+pub(crate) struct ClientStorageTest {
+    reflector: Reflector,
+}
+
+impl ClientStorageTest {
+    fn new_inherited() -> ClientStorageTest {
+        ClientStorageTest {
+            reflector: Reflector::new(),
+        }
+    }
+
+    fn new(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<ClientStorageTest> {
+        reflect_dom_object_with_proto(
+            Box::new(ClientStorageTest::new_inherited()),
+            global,
+            proto,
+            can_gc,
+        )
+    }
+}
+
+impl ClientStorageTestMethods<crate::DomTypeHolder> for ClientStorageTest {
+    fn Constructor(
+        global: &GlobalScope,
+        proto: Option<HandleObject>,
+        can_gc: CanGc,
+    ) -> DomRoot<ClientStorageTest> {
+        ClientStorageTest::new(global, proto, can_gc)
+    }
+
+    fn Test(&self) -> i32 {
+        42
+    }
+}

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -236,6 +236,7 @@ pub(crate) mod byteteeunderlyingsource;
 pub(crate) mod cdatasection;
 pub(crate) mod characterdata;
 pub(crate) mod client;
+pub(crate) mod clientstoragetest;
 pub(crate) mod clipboard;
 pub(crate) mod clipboardevent;
 pub(crate) mod clipboarditem;

--- a/components/script/lib.rs
+++ b/components/script/lib.rs
@@ -26,6 +26,7 @@ mod script_window_proxies;
 #[macro_use]
 mod task;
 mod body;
+pub(crate) mod client_storage;
 pub(crate) mod clipboard_provider;
 pub(crate) mod conversions;
 mod devtools;

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -94,6 +94,10 @@ DOMInterfaces = {
     'canGc': ['Before', 'After', 'Remove', 'ReplaceWith']
 },
 
+'ClientStorageTest': {
+    'allowDropImpl': True,
+},
+
 'Clipboard': {
     'canGc': ['ReadText', 'WriteText']
 },

--- a/components/script_bindings/webidls/ClientStorageTest.webidl
+++ b/components/script_bindings/webidls/ClientStorageTest.webidl
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This interface is entirely internal to Servo, and should not be accessible to
+// web pages.
+
+[Exposed=(Window, Worker), Pref="dom_client_storage_testing_enabled"]
+interface ClientStorageTest {
+   constructor();
+
+   long test();
+};

--- a/components/shared/base/id.rs
+++ b/components/shared/base/id.rs
@@ -405,6 +405,8 @@ namespace_id! {CookieStoreId, CookieStoreIndex, "CookieStore"}
 
 namespace_id! {ImageDataId, ImageDataIndex, "ImageData"}
 
+namespace_id! {StorageKeyConnectionId, StorageKeyConnectionIndex, "StorageKeyConnection"}
+
 // We provide ids just for unit testing.
 pub const TEST_NAMESPACE: PipelineNamespaceId = PipelineNamespaceId(1234);
 pub const TEST_PIPELINE_INDEX: Index<PipelineIndex> =

--- a/components/shared/storage/Cargo.toml
+++ b/components/shared/storage/Cargo.toml
@@ -13,6 +13,7 @@ path = "lib.rs"
 
 [dependencies]
 base = { workspace = true }
+log = { workspace = true }
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = { workspace = true }
 profile_traits = { path = "../profile" }

--- a/components/shared/storage/client_storage.rs
+++ b/components/shared/storage/client_storage.rs
@@ -2,11 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base::generic_channel::GenericSender;
+use base::generic_channel::{self, GenericSender};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum ClientStorageThreadMessage {
     /// Send a reply when done cleaning up thread resources and then shut it down
     Exit(GenericSender<()>),
+}
+
+pub struct ClientStorageProxy {
+    generic_sender: GenericSender<ClientStorageThreadMessage>,
+}
+
+impl ClientStorageProxy {
+    pub fn new(generic_sender: GenericSender<ClientStorageThreadMessage>) -> ClientStorageProxy {
+        ClientStorageProxy { generic_sender }
+    }
+
+    pub fn send_exit(&self) {
+        let (sender, receiver) = generic_channel::channel().unwrap();
+        self.generic_sender
+            .send(ClientStorageThreadMessage::Exit(sender))
+            .unwrap();
+        receiver.recv().unwrap()
+    }
 }

--- a/components/shared/storage/client_storage.rs
+++ b/components/shared/storage/client_storage.rs
@@ -5,11 +5,13 @@
 use base::generic_channel::{self, GenericSender};
 use base::id::StorageKeyConnectionId;
 use serde::{Deserialize, Serialize};
+use servo_url::origin::ImmutableOrigin;
 
 #[derive(Deserialize, Serialize)]
 pub enum ClientStorageThreadMessage {
     NewStorageKeyConnection {
         connection_id: StorageKeyConnectionId,
+        origin: ImmutableOrigin,
     },
 
     StorageKeyConnectionBackendMessage {
@@ -30,9 +32,16 @@ impl ClientStorageProxy {
         ClientStorageProxy { generic_sender }
     }
 
-    pub fn send_new_storage_key_connection(&self, connection_id: StorageKeyConnectionId) {
+    pub fn send_new_storage_key_connection(
+        &self,
+        connection_id: StorageKeyConnectionId,
+        origin: ImmutableOrigin,
+    ) {
         self.generic_sender
-            .send(ClientStorageThreadMessage::NewStorageKeyConnection { connection_id })
+            .send(ClientStorageThreadMessage::NewStorageKeyConnection {
+                connection_id,
+                origin,
+            })
             .unwrap();
     }
 

--- a/components/shared/storage/client_storage.rs
+++ b/components/shared/storage/client_storage.rs
@@ -3,10 +3,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use base::generic_channel::{self, GenericSender};
+use base::id::StorageKeyConnectionId;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub enum ClientStorageThreadMessage {
+    NewStorageKeyConnection {
+        connection_id: StorageKeyConnectionId,
+    },
+
+    StorageKeyConnectionBackendMessage {
+        connection_id: StorageKeyConnectionId,
+        message: StorageKeyConnectionBackendMessage,
+    },
+
     /// Send a reply when done cleaning up thread resources and then shut it down
     Exit(GenericSender<()>),
 }
@@ -20,6 +30,27 @@ impl ClientStorageProxy {
         ClientStorageProxy { generic_sender }
     }
 
+    pub fn send_new_storage_key_connection(&self, connection_id: StorageKeyConnectionId) {
+        self.generic_sender
+            .send(ClientStorageThreadMessage::NewStorageKeyConnection { connection_id })
+            .unwrap();
+    }
+
+    pub fn send_storage_key_connection_backend_message(
+        &self,
+        connection_id: StorageKeyConnectionId,
+        message: StorageKeyConnectionBackendMessage,
+    ) {
+        self.generic_sender
+            .send(
+                ClientStorageThreadMessage::StorageKeyConnectionBackendMessage {
+                    connection_id,
+                    message,
+                },
+            )
+            .unwrap();
+    }
+
     pub fn send_exit(&self) {
         let (sender, receiver) = generic_channel::channel().unwrap();
         self.generic_sender
@@ -27,4 +58,11 @@ impl ClientStorageProxy {
             .unwrap();
         receiver.recv().unwrap()
     }
+}
+
+// Messages towards the backend.
+
+#[derive(Deserialize, Serialize)]
+pub enum StorageKeyConnectionBackendMessage {
+    Test(GenericSender<i32>),
 }

--- a/components/storage/client_storage.rs
+++ b/components/storage/client_storage.rs
@@ -11,6 +11,7 @@ use base::generic_channel::{
 };
 use base::id::StorageKeyConnectionId;
 use log::{debug, warn};
+use servo_url::origin::ImmutableOrigin;
 use storage_traits::client_storage::{
     ClientStorageThreadMessage, StorageKeyConnectionBackendMessage,
 };
@@ -87,8 +88,11 @@ impl ClientStorageThread {
 
     fn handle_message(&mut self, message: ClientStorageThreadMessage) {
         match message {
-            ClientStorageThreadMessage::NewStorageKeyConnection { connection_id } => {
-                self.handle_new_storage_key_connection(connection_id);
+            ClientStorageThreadMessage::NewStorageKeyConnection {
+                connection_id,
+                origin,
+            } => {
+                self.handle_new_storage_key_connection(connection_id, origin);
             },
             ClientStorageThreadMessage::StorageKeyConnectionBackendMessage {
                 connection_id,
@@ -103,8 +107,12 @@ impl ClientStorageThread {
         }
     }
 
-    fn handle_new_storage_key_connection(&mut self, connection_id: StorageKeyConnectionId) {
-        let connection = StorageKeyConnection::new(connection_id);
+    fn handle_new_storage_key_connection(
+        &mut self,
+        connection_id: StorageKeyConnectionId,
+        origin: ImmutableOrigin,
+    ) {
+        let connection = StorageKeyConnection::new(connection_id, origin);
 
         self.storage_key_connections
             .insert(connection_id, connection);
@@ -127,12 +135,14 @@ impl ClientStorageThread {
 
 pub struct StorageKeyConnection {
     _connection_id: StorageKeyConnectionId,
+    _origin: ImmutableOrigin,
 }
 
 impl StorageKeyConnection {
-    pub fn new(connection_id: StorageKeyConnectionId) -> Self {
+    pub fn new(connection_id: StorageKeyConnectionId, origin: ImmutableOrigin) -> Self {
         StorageKeyConnection {
             _connection_id: connection_id,
+            _origin: origin,
         }
     }
 

--- a/components/storage/client_storage.rs
+++ b/components/storage/client_storage.rs
@@ -100,6 +100,9 @@ impl ClientStorageThread {
             } => {
                 self.handle_storage_key_connection_backend_message(connection_id, message);
             },
+            ClientStorageThreadMessage::RemoveStorageKeyConnection { connection_id } => {
+                self.handle_remove_storage_key_connection(connection_id);
+            },
             ClientStorageThreadMessage::Exit(sender) => {
                 self.handle_exit();
                 let _ = sender.send(());
@@ -128,8 +131,18 @@ impl ClientStorageThread {
         connection.handle_message(message);
     }
 
+    fn handle_remove_storage_key_connection(&mut self, connection_id: StorageKeyConnectionId) {
+        self.storage_key_connections.remove(&connection_id);
+    }
+
     fn handle_exit(&mut self) {
         self.exiting = true;
+    }
+}
+
+impl Drop for ClientStorageThread {
+    fn drop(&mut self) {
+        debug!("Dropping storage::ClientStorageThread");
     }
 }
 
@@ -157,5 +170,11 @@ impl StorageKeyConnection {
     fn handle_test(&self, sender: GenericSender<i32>) {
         debug!("Handlig Test");
         let _ = sender.send(42);
+    }
+}
+
+impl Drop for StorageKeyConnection {
+    fn drop(&mut self) {
+        debug!("Dropping storage::StorageKeyConnection");
     }
 }

--- a/components/storage/tests/client_storage.rs
+++ b/components/storage/tests/client_storage.rs
@@ -2,19 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use base::generic_channel::{self, GenericSender};
+use base::generic_channel::GenericSender;
 use storage::ClientStorageThreadFactory;
-use storage_traits::client_storage::ClientStorageThreadMessage;
+use storage_traits::client_storage::{ClientStorageProxy, ClientStorageThreadMessage};
 
 #[test]
 fn test_exit() {
     let thread: GenericSender<ClientStorageThreadMessage> = ClientStorageThreadFactory::new(None);
 
-    let (sender, receiver) = generic_channel::channel().unwrap();
-    thread
-        .send(ClientStorageThreadMessage::Exit(sender))
-        .unwrap();
-    receiver.recv().unwrap();
+    let proxy = ClientStorageProxy::new(thread);
+
+    proxy.send_exit();
 
     // Workaround for https://github.com/servo/servo/issues/32912
     #[cfg(windows)]

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -13136,6 +13136,17 @@
       {}
      ]
     ],
+    "client_storage.any.js": [
+     "90d76d522d3e1205c10bc56dac3ca1dc8658d263",
+     [
+      "mozilla/client_storage.any.html",
+      {}
+     ],
+     [
+      "mozilla/client_storage.any.worker.html",
+      {}
+     ]
+    ],
     "codegen_unions.html": [
      "1fff0e01c89cfa3bff91a6f19c00171bbb55b692",
      [

--- a/tests/wpt/mozilla/meta/mozilla/client_storage.any.js.ini
+++ b/tests/wpt/mozilla/meta/mozilla/client_storage.any.js.ini
@@ -1,0 +1,7 @@
+[client_storage.any.html]
+  type: testharness
+  prefs: [dom_client_storage_testing_enabled:true]
+
+[client_storage.any.worker.html]
+  type: testharness
+  prefs: [dom_client_storage_testing_enabled:true]

--- a/tests/wpt/mozilla/tests/mozilla/client_storage.any.js
+++ b/tests/wpt/mozilla/tests/mozilla/client_storage.any.js
@@ -1,0 +1,6 @@
+test(function() {
+  let clientStorageTest = new ClientStorageTest();
+
+  let result = clientStorageTest.test();
+  assert_equals(result, 42);
+});


### PR DESCRIPTION
This PR introduces initial `StorageKeyConnection` infrastructure for the new
client storage module and `ClientStorageThread`, establishing a communication
foundation for storage APIs partitioned by storage keys.

The new connection abstraction allows storage operations to be routed and
associated with a specific storage key without sending the full storage key
with every message. Connections are currently scoped by origin using
`ImmutableOrigin`, which is intended to be replaced by a dedicated
`StorageKey` type in the future.

In the future, `StorageKeyConnection` may also be used to improve security by
validating access to storage keys (for example by consulting constellation).

Testing: A new WPT test is added.
