### PR TITLE
layout: Fix caret never rendering following a newline

### DIFF
--- a/components/layout/flow/inline/mod.rs
+++ b/components/layout/flow/inline/mod.rs
@@ -1421,12 +1421,7 @@ impl InlineFormattingContextLayout<'_> {
             let intersection = selection.intersect(&range);
             if intersection.is_empty() {
                 let insertion_point_index = selection.begin();
-                // We only allow the caret to be shown in the start of the fragment if it is the first fragment.
-                // Otherwise this will cause duplicate caret, especially apparent when encountered line break.
-                if insertion_point_index >= range.begin() &&
-                    insertion_point_index <= range.end() &&
-                    (range.begin() != insertion_point_index || range.begin().0 == 0)
-                {
+                if range.contains_inclusive(insertion_point_index) {
                     Some(Range::new(
                         insertion_point_index - range.begin(),
                         ByteIndex(0),

--- a/components/range/lib.rs
+++ b/components/range/lib.rs
@@ -261,7 +261,7 @@ impl<I: RangeIndex> Range<I> {
         self.begin + self.length
     }
 
-    /// `true` if the index is between the beginning and the end of the range.
+    /// `true` if the index is between the beginning and the end (exclusive) of the range.
     ///
     /// ~~~ignore
     ///        false        true      false
@@ -271,6 +271,18 @@ impl<I: RangeIndex> Range<I> {
     #[inline]
     pub fn contains(&self, i: I) -> bool {
         i >= self.begin() && i < self.end()
+    }
+
+    /// `true` if the index is between the beginning and the end (inclusive) of the range.
+    ///
+    /// ~~~ignore
+    ///        false        true      false
+    ///          |           |          |
+    /// <- o - - + - - +=====+======+ - + - ->
+    /// ~~~
+    #[inline]
+    pub fn contains_inclusive(&self, i: I) -> bool {
+        i >= self.begin() && i <= self.end()
     }
 
     /// `true` if the offset from the beginning to the end of the range is zero.

--- a/tests/wpt/mozilla/meta/MANIFEST.json
+++ b/tests/wpt/mozilla/meta/MANIFEST.json
@@ -239,6 +239,19 @@
       ],
       {}
      ]
+    ],
+    "textarea-caret-following-linebreak.html": [
+     "55bc06e372e9ce8ad4d62d368a644c1f1cd3ffd9",
+     [
+      null,
+      [
+       [
+        "/_mozilla/appearance/textarea-caret-following-linebreak-ref.html",
+        "=="
+       ]
+      ],
+      {}
+     ]
     ]
    },
    "css": {
@@ -8237,7 +8250,11 @@
       "2aa42d2fc6877665357bc2f46a5fbb309230b507",
       []
      ]
-    }
+    },
+    "textarea-caret-following-linebreak-ref.html": [
+     "f424853f243ff0fe4c43506db800b51afc294113",
+     []
+    ]
    },
    "bluetooth": {
     "bluetooth-helpers.js": [

--- a/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-ref.html
+++ b/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+    textarea {
+        caret-animation: manual;
+    }
+    </style>
+</head>
+<body>
+    <textarea cols=50 rows="5">&#13;&ZeroWidthSpace;&lt;--caret should render here</textarea>
+    <script>
+        const textarea = document.getElementsByTagName('textarea')[0];
+        textarea.setSelectionRange(2, 2);
+        textarea.focus();
+    </script>
+</body>

--- a/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak.html
+++ b/tests/wpt/mozilla/tests/appearance/textarea-caret-following-linebreak.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="match" href="textarea-caret-following-linebreak-ref.html">
+    <style>
+    textarea {
+        caret-animation: manual;
+    }
+    </style>
+</head>
+<body>
+    <textarea cols=50 rows="5">&#13;&lt;--caret should render here</textarea>
+    <script>
+        const textarea = document.getElementsByTagName('textarea')[0];
+        textarea.setSelectionRange(1, 1);
+        textarea.focus();
+    </script>
+</body>


### PR DESCRIPTION
Fixes caret rendering when the caret is placed a the start of a line

```
Hello,

{here}World!
```

Also adds a utility function to the `range` crate.

Note that the rendering of the caret on many non-empty lines is still broken due to the presence of several other bugs

Testing: I ran unit tests. Add a new reftest
Fixes: Part of #40839