### PR TITLE
ci: Correctly pass `arm: false` to x86 macOS WPT jobs

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -219,7 +219,7 @@ jobs:
     with:
       profile: ${{ inputs.profile }}
       wpt-args: ${{ inputs.wpt-args }}
-      arm: true
+      arm: false
     secrets: inherit
 
   bencher:


### PR DESCRIPTION
Testing: I did a try run to test this change.
