### PR TITLE
script: Mark fetch-later requests as keep-alive

### DIFF
--- a/components/script/document_loader.rs
+++ b/components/script/document_loader.rs
@@ -158,6 +158,7 @@ impl DocumentLoader {
     ) {
         self.cancellers.push(FetchCanceller::new(
             request.id,
+            request.keep_alive,
             self.resource_threads.core_thread.clone(),
         ));
         fetch_async(&self.resource_threads.core_thread, request, None, callback);

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -600,6 +600,7 @@ impl EventSourceMethods<crate::DomTypeHolder> for EventSource {
 
         event_source.droppable.set_canceller(FetchCanceller::new(
             request.id,
+            request.keep_alive,
             global.core_resource_thread(),
         ));
 

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -1446,6 +1446,7 @@ impl HTMLMediaElement {
 
         *current_fetch_context = Some(HTMLMediaElementFetchContext::new(
             request.id,
+            request.keep_alive,
             global.core_resource_thread(),
         ));
         let listener =
@@ -3618,6 +3619,7 @@ pub(crate) struct HTMLMediaElementFetchContext {
 impl HTMLMediaElementFetchContext {
     fn new(
         request_id: RequestId,
+        keep_alive: bool,
         core_resource_thread: CoreResourceThread,
     ) -> HTMLMediaElementFetchContext {
         HTMLMediaElementFetchContext {
@@ -3626,7 +3628,11 @@ impl HTMLMediaElementFetchContext {
             is_seekable: false,
             origin_clean: true,
             data_source: RefCell::new(BufferedDataSource::new()),
-            fetch_canceller: FetchCanceller::new(request_id, core_resource_thread.clone()),
+            fetch_canceller: FetchCanceller::new(
+                request_id,
+                keep_alive,
+                core_resource_thread.clone(),
+            ),
         }
     }
 

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -258,6 +258,7 @@ impl HTMLVideoElement {
             poster_url,
             id,
             request.id,
+            request.keep_alive,
             self.global().core_resource_thread(),
         );
         self.owner_document().fetch_background(request, context);
@@ -491,6 +492,7 @@ impl PosterFrameFetchContext {
         url: ServoUrl,
         id: PendingImageId,
         request_id: RequestId,
+        keep_alive: bool,
         core_resource_thread: CoreResourceThread,
     ) -> PosterFrameFetchContext {
         let window = elem.owner_window();
@@ -500,7 +502,7 @@ impl PosterFrameFetchContext {
             id,
             cancelled: false,
             url,
-            fetch_canceller: FetchCanceller::new(request_id, core_resource_thread),
+            fetch_canceller: FetchCanceller::new(request_id, keep_alive, core_resource_thread),
         }
     }
 }

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -683,6 +683,11 @@ impl RequestMethods<crate::DomTypeHolder> for Request {
         DOMString::from_string(r.integrity_metadata.clone())
     }
 
+    /// <https://fetch.spec.whatwg.org/#dom-request-keepalive>
+    fn Keepalive(&self) -> bool {
+        self.request.borrow().keep_alive
+    }
+
     /// <https://fetch.spec.whatwg.org/#dom-body-body>
     fn GetBody(&self) -> Option<DomRoot<ReadableStream>> {
         self.body()

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1594,8 +1594,11 @@ impl XMLHttpRequest {
             )
         };
 
-        *self.canceller.borrow_mut() =
-            FetchCanceller::new(request_builder.id, global.core_resource_thread());
+        *self.canceller.borrow_mut() = FetchCanceller::new(
+            request_builder.id,
+            request_builder.keep_alive,
+            global.core_resource_thread(),
+        );
 
         global.fetch(request_builder, context, task_source);
 

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3510,6 +3510,7 @@ impl ScriptThread {
         let request_builder = incomplete.request_builder();
         incomplete.canceller = FetchCanceller::new(
             request_builder.id,
+            request_builder.keep_alive,
             self.resource_threads.core_thread.clone(),
         );
         NavigationListener::new(request_builder, self.senders.self_sender.clone())
@@ -3646,6 +3647,7 @@ impl ScriptThread {
 
         incomplete_load.canceller = FetchCanceller::new(
             request_builder.id,
+            request_builder.keep_alive,
             self.resource_threads.core_thread.clone(),
         );
         NavigationListener::new(request_builder, self.senders.self_sender.clone())

--- a/components/script_bindings/webidls/Request.webidl
+++ b/components/script_bindings/webidls/Request.webidl
@@ -22,7 +22,7 @@ interface Request {
   readonly attribute RequestCache cache;
   readonly attribute RequestRedirect redirect;
   readonly attribute DOMString integrity;
-  // readonly attribute boolean keepalive;
+  readonly attribute boolean keepalive;
   // readonly attribute boolean isReloadNavigation;
   // readonly attribute boolean isHistoryNavigation;
   readonly attribute AbortSignal signal;

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -442,6 +442,9 @@ pub struct RequestBuilder {
     /// <https://fetch.spec.whatwg.org/#use-cors-preflight-flag>
     pub use_cors_preflight: bool,
 
+    /// <https://fetch.spec.whatwg.org/#request-keepalive-flag>
+    pub keep_alive: bool,
+
     /// <https://fetch.spec.whatwg.org/#concept-request-credentials-mode>
     pub credentials_mode: CredentialsMode,
     pub use_url_credentials: bool,
@@ -500,6 +503,7 @@ impl RequestBuilder {
             mode: RequestMode::NoCors,
             cache_mode: CacheMode::Default,
             use_cors_preflight: false,
+            keep_alive: false,
             credentials_mode: CredentialsMode::CredentialsSameOrigin,
             use_url_credentials: false,
             origin: Origin::Client,
@@ -572,6 +576,12 @@ impl RequestBuilder {
     /// <https://fetch.spec.whatwg.org/#use-cors-preflight-flag>
     pub fn use_cors_preflight(mut self, use_cors_preflight: bool) -> RequestBuilder {
         self.use_cors_preflight = use_cors_preflight;
+        self
+    }
+
+    /// <https://fetch.spec.whatwg.org/#request-keepalive-flag>
+    pub fn keep_alive(mut self, keep_alive: bool) -> RequestBuilder {
+        self.keep_alive = keep_alive;
         self
     }
 
@@ -705,6 +715,7 @@ impl RequestBuilder {
         request.synchronous = self.synchronous;
         request.mode = self.mode;
         request.use_cors_preflight = self.use_cors_preflight;
+        request.keep_alive = self.keep_alive;
         request.credentials_mode = self.credentials_mode;
         request.use_url_credentials = self.use_url_credentials;
         request.cache_mode = self.cache_mode;

--- a/tests/wpt/meta/fetch/api/idlharness.https.any.js.ini
+++ b/tests/wpt/meta/fetch/api/idlharness.https.any.js.ini
@@ -1,7 +1,4 @@
 [idlharness.https.any.html]
-  [Request interface: attribute keepalive]
-    expected: FAIL
-
   [Request interface: attribute isReloadNavigation]
     expected: FAIL
 
@@ -9,9 +6,6 @@
     expected: FAIL
 
   [Request interface: attribute duplex]
-    expected: FAIL
-
-  [Request interface: new Request('about:blank') must inherit property "keepalive" with the proper type]
     expected: FAIL
 
   [Request interface: new Request('about:blank') must inherit property "isReloadNavigation" with the proper type]
@@ -28,9 +22,6 @@
   expected: ERROR
 
 [idlharness.https.any.worker.html]
-  [Request interface: attribute keepalive]
-    expected: FAIL
-
   [Request interface: attribute isReloadNavigation]
     expected: FAIL
 
@@ -38,9 +29,6 @@
     expected: FAIL
 
   [Request interface: attribute duplex]
-    expected: FAIL
-
-  [Request interface: new Request('about:blank') must inherit property "keepalive" with the proper type]
     expected: FAIL
 
   [Request interface: new Request('about:blank') must inherit property "isReloadNavigation" with the proper type]


### PR DESCRIPTION
This implements the required plumbing for the keep-alive flag on requests. The flag already exists on the request object, but now also exists on the builder itself.

The flag is then passed into a canceller. While we could make canceller optional, in many cases it isn't and would require a whole lot more changes. To follow the spec more closely, opted to put the keep_alive flag on the canceller as well.

Note that this doesn't pass any extra fetch-later tests since we are not correctly unloading iframe documents. That will be fixed in a follow-up PR.

Part of #41230