### PR TITLE
script: Implement destroying of documents

### DIFF
--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1281,6 +1281,8 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
                         // https://html.spec.whatwg.org/multipage/#a-browsing-context-is-discarded
                         // which calls into https://html.spec.whatwg.org/multipage/#discard-a-document.
+                        // TODO: This should be removed once step 20 of `document.unload` is correctly
+                        // implemented.
                         window.discard_browsing_context();
 
                         window.send_to_constellation(ScriptToConstellationMessage::DiscardTopLevelBrowsingContext);

--- a/tests/wpt/meta/fetch/fetch-later/send-on-discard/send-multiple-with-activate-after.https.window.js.ini
+++ b/tests/wpt/meta/fetch/fetch-later/send-on-discard/send-multiple-with-activate-after.https.window.js.ini
@@ -1,3 +1,0 @@
-[send-multiple-with-activate-after.https.window.html]
-  [A discarded document sends all its fetchLater requests, no matter how much their activateAfter timeout remain.]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe-initially-empty-is-updated.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-iframe-element/iframe-initially-empty-is-updated.html.ini
@@ -1,2 +1,2 @@
 [iframe-initially-empty-is-updated.html]
-  expected: CRASH
+  expected: TIMEOUT


### PR DESCRIPTION
The specification has a dedicated method for destroying
documents. Parts of that method were scattered around
various parts of Servo machinery.

This patch consolidates these steps and follow the spec.
Additionally, it now correctly unloads iframes when
they are removed from a parent document.

As a result, the fetch-later WPT test now passes, as
it relies on the correct ordering of iframe unloading
to verify the fetch-later requests are sent.

Part of #31973