### PR TITLE
CI: Fix ohos speedometer failing

### DIFF
--- a/etc/ci/scenario/servo_speedometer.py
+++ b/etc/ci/scenario/servo_speedometer.py
@@ -71,7 +71,7 @@ def run():
             "-b",
             "org.servo.servo",
             "-U",
-            "https://servospeedometer.netlify.app",
+            "about:blank",
             "--psn",
             "--webdriver",
         ],
@@ -80,15 +80,16 @@ def run():
         timeout=1,
     )
 
-    time.sleep(5)
+    time.sleep(1)
 
     common_function_for_servo_test.setup_hdc_forward()
     with HarmonyDevicePerfMode():
         driver = common_function_for_servo_test.create_driver()
         if driver is not None:
             try:
+                driver.get("https://servospeedometer.netlify.app")
+                driver.implicitly_wait(10)
                 start_button = driver.find_element(By.CLASS_NAME, "start-tests-button")
-                time.sleep(10)
                 print("Clicking start button")
                 start_button.click()
                 print("Waiting for speedometer run to finish")


### PR DESCRIPTION
Speedometer is failing on main after recent changes. The symptom is that when creating the webdriver (in python on the host) servo switches to `about:blank`. This is not expected by the script and hence we fail to find the start button, since the expected page is the speedometer page.
The quick fix is just navigating to the page after creating the driver, but we also take this opportunity to slightly refactor this script and use the common method for running tests, which allows removing some code.

Testing: Tested locally and via [mach try](https://github.com/servo/servo/actions/runs/20303863788)
Fixes: #41348
