### PR TITLE
Add `ServoDelegate` and `WebViewDelegate` methods for Console API

### DIFF
--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -568,6 +568,14 @@ impl ServoInner {
                     None => self.delegate.borrow().show_notification(notification),
                 }
             },
+            EmbedderMsg::ShowConsoleApiMessage(webview_id, level, message) => {
+                match webview_id.and_then(|webview_id| self.get_webview_handle(webview_id)) {
+                    Some(webview) => webview
+                        .delegate()
+                        .show_console_message(webview, level, message),
+                    None => self.delegate.borrow().show_console_message(level, message),
+                }
+            },
             EmbedderMsg::ShowEmbedderControl(control_id, position, embedder_control_request) => {
                 if let Some(webview) = self.get_webview_handle(control_id.webview_id) {
                     webview.show_embedder_control(control_id, position, embedder_control_request);

--- a/components/servo/servo_delegate.rs
+++ b/components/servo/servo_delegate.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 use base::generic_channel;
-use embedder_traits::Notification;
+use embedder_traits::{ConsoleLogLevel, Notification};
 
 use crate::webview_delegate::{AllowOrDenyRequest, WebResourceLoad};
 
@@ -38,6 +38,10 @@ pub trait ServoDelegate {
 
     /// Request to display a notification.
     fn show_notification(&self, _notification: Notification) {}
+
+    /// A console message was logged by content not associated with a specific [`WebView`].
+    /// <https://developer.mozilla.org/en-US/docs/Web/API/Console_API>
+    fn show_console_message(&self, _level: ConsoleLogLevel, _message: String) {}
 }
 
 pub(crate) struct DefaultServoDelegate;

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -10,8 +10,8 @@ use base::id::{PipelineId, WebViewId};
 use compositing_traits::rendering_context::RenderingContext;
 use constellation_traits::EmbedderToConstellationMessage;
 use embedder_traits::{
-    AlertResponse, AllowOrDeny, AuthenticationResponse, ConfirmResponse, ContextMenuAction,
-    ContextMenuElementInformation, ContextMenuItem, Cursor, EmbedderControlId,
+    AlertResponse, AllowOrDeny, AuthenticationResponse, ConfirmResponse, ConsoleLogLevel,
+    ContextMenuAction, ContextMenuElementInformation, ContextMenuItem, Cursor, EmbedderControlId,
     EmbedderControlResponse, FilePickerRequest, FilterPattern, GamepadHapticEffectType,
     InputEventId, InputEventResult, InputMethodType, LoadStatus, MediaSessionEvent, Notification,
     PermissionFeature, PromptResponse, RgbColor, ScreenGeometry, SelectElementOptionOrOptgroup,
@@ -963,6 +963,10 @@ pub trait WebViewDelegate {
 
     /// Request to display a notification.
     fn show_notification(&self, _webview: WebView, _notification: Notification) {}
+
+    /// A console message was logged by content in this [`WebView`].
+    /// <https://developer.mozilla.org/en-US/docs/Web/API/Console_API>
+    fn show_console_message(&self, _webview: WebView, _level: ConsoleLogLevel, _message: String) {}
 }
 
 pub(crate) struct DefaultWebViewDelegate;

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -512,6 +512,9 @@ pub enum EmbedderMsg {
     ShutdownComplete,
     /// Request to display a notification.
     ShowNotification(Option<WebViewId>, Notification),
+    /// Let the embedder process a DOM Console API message.
+    /// <https://developer.mozilla.org/en-US/docs/Web/API/Console_API>
+    ShowConsoleApiMessage(Option<WebViewId>, ConsoleLogLevel, String),
     /// Request to display a form control to the embedder.
     ShowEmbedderControl(EmbedderControlId, DeviceIntRect, EmbedderControlRequest),
     /// Request to display a form control to the embedder.

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -1117,6 +1117,11 @@ impl PlatformWindow for Window {
     fn dismiss_embedder_controls_for_webview(&self, webview_id: WebViewId) {
         self.dialogs.borrow_mut().remove(&webview_id);
     }
+
+    fn show_console_message(&self, level: servo::ConsoleLogLevel, message: &str) {
+        println!("{message}");
+        log::log!(level.into(), "{message}");
+    }
 }
 
 fn winit_phase_to_touch_event_type(phase: TouchPhase) -> TouchEventType {

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -171,4 +171,9 @@ impl PlatformWindow for Window {
             self.screen_size.height as u32,
         ));
     }
+
+    fn show_console_message(&self, level: servo::ConsoleLogLevel, message: &str) {
+        println!("{message}");
+        log::log!(level.into(), "{message}");
+    }
 }

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -211,6 +211,10 @@ impl PlatformWindow for EmbeddedPlatformWindow {
     fn notify_crashed(&self, _webview: WebView, reason: String, backtrace: Option<String>) {
         self.host.on_panic(reason, backtrace);
     }
+
+    fn show_console_message(&self, level: servo::ConsoleLogLevel, message: &str) {
+        log::log!(level.into(), "{message}");
+    }
 }
 
 #[derive(Default)]

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -8,10 +8,10 @@ use std::rc::Rc;
 use euclid::Scale;
 use log::warn;
 use servo::{
-    AuthenticationRequest, Cursor, DeviceIndependentIntRect, DeviceIndependentPixel,
-    DeviceIntPoint, DeviceIntSize, DevicePixel, EmbedderControl, EmbedderControlId, GenericSender,
-    InputEventId, InputEventResult, MediaSessionEvent, PermissionRequest, RenderingContext,
-    ScreenGeometry, WebView, WebViewBuilder, WebViewId,
+    AuthenticationRequest, ConsoleLogLevel, Cursor, DeviceIndependentIntRect,
+    DeviceIndependentPixel, DeviceIntPoint, DeviceIntSize, DevicePixel, EmbedderControl,
+    EmbedderControlId, GenericSender, InputEventId, InputEventResult, MediaSessionEvent,
+    PermissionRequest, RenderingContext, ScreenGeometry, WebView, WebViewBuilder, WebViewId,
 };
 use url::Url;
 
@@ -436,4 +436,5 @@ pub(crate) trait PlatformWindow {
 
     fn notify_media_session_event(&self, _: MediaSessionEvent) {}
     fn notify_crashed(&self, _: WebView, _reason: String, _backtrace: Option<String>) {}
+    fn show_console_message(&self, _level: ConsoleLogLevel, _message: &str) {}
 }


### PR DESCRIPTION
Route console messages through the embedding API instead of printing directly, giving embedders control over console output handling.

Testing: Should be covered by exsisting tests
Fixes: #41145
