### PR TITLE
libservo: Let `UserContentManager` be per WebView and add basic support for mutations.

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -122,7 +122,7 @@ use constellation_traits::{
     LoadData, LogEntry, MessagePortMsg, NavigationHistoryBehavior, PaintMetricEvent,
     PortMessageTask, PortTransferInfo, SWManagerMsg, SWManagerSenders, ScreenshotReadinessResponse,
     ScriptToConstellationMessage, ServiceWorkerManagerFactory, ServiceWorkerMsg,
-    StructuredSerializedData, TraversalDirection, WindowSizeType,
+    StructuredSerializedData, TraversalDirection, UserContentManagerAction, WindowSizeType,
 };
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use crossbeam_channel::{Receiver, Select, Sender, unbounded};
@@ -131,12 +131,12 @@ use devtools_traits::{
     ScriptToDevtoolsControlMsg,
 };
 use embedder_traits::resources::{self, Resource};
-use embedder_traits::user_content_manager::UserContentManager;
+use embedder_traits::user_contents::{UserContentManagerId, UserContents};
 use embedder_traits::{
     AnimationState, EmbedderControlId, EmbedderControlResponse, EmbedderMsg, EmbedderProxy,
     FocusSequenceNumber, InputEvent, InputEventAndId, JSValue, JavaScriptEvaluationError,
     JavaScriptEvaluationId, KeyboardEvent, MediaSessionActionType, MediaSessionEvent,
-    MediaSessionPlaybackState, MouseButton, MouseButtonAction, MouseButtonEvent,
+    MediaSessionPlaybackState, MouseButton, MouseButtonAction, MouseButtonEvent, NewWebViewDetails,
     PaintHitTestResult, Theme, ViewportDetails, WebDriverCommandMsg, WebDriverLoadStatus,
     WebDriverScriptCommand,
 };
@@ -479,9 +479,6 @@ pub struct Constellation<STF, SWF> {
     /// on an as-needed basis, rather than retrieving it every time.
     pub(crate) broken_image_icon_data: Vec<u8>,
 
-    /// User content manager
-    pub(crate) user_content_manager: UserContentManager,
-
     /// The process manager.
     pub(crate) process_manager: ProcessManager,
 
@@ -508,6 +505,12 @@ pub struct Constellation<STF, SWF> {
     /// ready to take place, at which point the Constellation informs the renderer that it
     /// can start the process of taking the screenshot.
     screenshot_readiness_requests: Vec<ScreenshotReadinessRequest>,
+
+    /// A map from `UserContentManagerId` to the `UserContents` for that manager.
+    /// Multiple `WebView`s can share the same `UserContentManager` and any mutations
+    /// to the `UserContents` need to be forwared to all the `ScriptThread`s that host
+    /// the relevant `WebView`.
+    user_contents_for_manager_id: HashMap<UserContentManagerId, UserContents>,
 }
 
 /// State needed to construct a constellation.
@@ -557,9 +560,6 @@ pub struct InitialConstellationState {
 
     #[cfg(feature = "webgpu")]
     pub wgpu_image_map: WebGpuExternalImageMap,
-
-    /// User content manager
-    pub user_content_manager: UserContentManager,
 
     /// A list of URLs that can access privileged internal APIs.
     pub privileged_urls: Vec<ServoUrl>,
@@ -736,7 +736,6 @@ where
                     hard_fail,
                     active_media_session: None,
                     broken_image_icon_data: broken_image_icon_data.clone(),
-                    user_content_manager: state.user_content_manager,
                     process_manager: ProcessManager::new(state.mem_profiler_chan),
                     async_runtime: state.async_runtime,
                     event_loop_join_handles: Default::default(),
@@ -746,6 +745,7 @@ where
                     )),
                     pending_viewport_changes: Default::default(),
                     screenshot_readiness_requests: Vec::new(),
+                    user_contents_for_manager_id: Default::default(),
                 };
 
                 constellation.run();
@@ -1008,6 +1008,22 @@ where
         }
 
         let event_loop = EventLoop::spawn(self, is_private)?;
+        let user_contents = self
+            .webviews
+            .get(&webview_id)
+            .and_then(|webview| webview.user_content_manager_id)
+            .and_then(|user_content_manager_id| {
+                self.user_contents_for_manager_id
+                    .get(&user_content_manager_id)
+            })
+            .cloned();
+        if let Some(user_contents) = user_contents {
+            let _ = event_loop.send(ScriptThreadMessage::SetUserContents(
+                user_contents,
+                vec![webview_id],
+            ));
+        }
+
         if let Some(registered_domain_name) = registered_domain_name {
             self.set_event_loop(&event_loop, registered_domain_name, webview_id, opener);
         }
@@ -1417,8 +1433,8 @@ where
             },
             // Create a new top level browsing context. Will use response_chan to return
             // the browsing context id.
-            EmbedderToConstellationMessage::NewWebView(url, webview_id, viewport_details) => {
-                self.handle_new_top_level_browsing_context(url, webview_id, viewport_details);
+            EmbedderToConstellationMessage::NewWebView(url, new_webview_details) => {
+                self.handle_new_top_level_browsing_context(url, new_webview_details);
             },
             // Close a top level browsing context.
             EmbedderToConstellationMessage::CloseWebView(webview_id) => {
@@ -1555,6 +1571,54 @@ where
             },
             EmbedderToConstellationMessage::EmbedderControlResponse(id, response) => {
                 self.handle_embedder_control_response(id, response);
+            },
+            EmbedderToConstellationMessage::UserContentManagerAction(
+                user_content_manager_id,
+                action,
+            ) => {
+                self.handle_user_content_manager_action(user_content_manager_id, action);
+            },
+        }
+    }
+
+    fn handle_user_content_manager_action(
+        &mut self,
+        user_content_manager_id: UserContentManagerId,
+        action: UserContentManagerAction,
+    ) {
+        match action {
+            UserContentManagerAction::AddUserScript(user_script) => {
+                let user_contents = self
+                    .user_contents_for_manager_id
+                    .entry(user_content_manager_id)
+                    .or_default();
+
+                user_contents.scripts.push(user_script);
+
+                let mut event_loop_to_webview_ids_map =
+                    HashMap::<Rc<EventLoop>, HashSet<WebViewId>>::new();
+                for pipeline in self.pipelines.values() {
+                    let webview = self.webviews.get(&pipeline.webview_id);
+                    if webview.is_some_and(|webview| {
+                        webview.user_content_manager_id == Some(user_content_manager_id)
+                    }) {
+                        event_loop_to_webview_ids_map
+                            .entry(pipeline.event_loop.clone())
+                            .or_default()
+                            .insert(pipeline.webview_id);
+                    }
+                }
+
+                for (event_loop, webview_ids) in event_loop_to_webview_ids_map {
+                    let _ = event_loop.send(ScriptThreadMessage::SetUserContents(
+                        user_contents.clone(),
+                        webview_ids.into_iter().collect(),
+                    ));
+                }
+            },
+            UserContentManagerAction::DestroyUserContentManager => {
+                self.user_contents_for_manager_id
+                    .remove(&user_content_manager_id);
             },
         }
     }
@@ -3005,8 +3069,11 @@ where
     fn handle_new_top_level_browsing_context(
         &mut self,
         url: ServoUrl,
-        webview_id: WebViewId,
-        viewport_details: ViewportDetails,
+        NewWebViewDetails {
+            webview_id,
+            viewport_details,
+            user_content_manager_id,
+        }: NewWebViewDetails,
     ) {
         let pipeline_id = PipelineId::new();
         let browsing_context_id = BrowsingContextId::from(webview_id);
@@ -3018,7 +3085,7 @@ where
         // its focused browsing context to be itself.
         self.webviews.insert(
             webview_id,
-            ConstellationWebView::new(webview_id, browsing_context_id),
+            ConstellationWebView::new(webview_id, browsing_context_id, user_content_manager_id),
         );
 
         // https://html.spec.whatwg.org/multipage/#creating-a-new-browsing-context-group
@@ -3351,8 +3418,12 @@ where
             opener_webview_id,
             webview_id_sender,
         ));
-        let (new_webview_id, viewport_details) = match webview_id_receiver.recv() {
-            Ok(Some((webview_id, viewport_details))) => (webview_id, viewport_details),
+        let NewWebViewDetails {
+            webview_id: new_webview_id,
+            viewport_details,
+            user_content_manager_id,
+        } = match webview_id_receiver.recv() {
+            Ok(Some(new_webview_details)) => new_webview_details,
             Ok(None) | Err(_) => {
                 let _ = response_sender.send(None);
                 return;
@@ -3400,7 +3471,11 @@ where
         self.pipelines.insert(new_pipeline_id, pipeline);
         self.webviews.insert(
             new_webview_id,
-            ConstellationWebView::new(new_webview_id, new_browsing_context_id),
+            ConstellationWebView::new(
+                new_webview_id,
+                new_browsing_context_id,
+                user_content_manager_id,
+            ),
         );
 
         // https://html.spec.whatwg.org/multipage/#bcg-append

--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -510,7 +510,7 @@ pub struct Constellation<STF, SWF> {
     /// Multiple `WebView`s can share the same `UserContentManager` and any mutations
     /// to the `UserContents` need to be forwared to all the `ScriptThread`s that host
     /// the relevant `WebView`.
-    pub(crate) user_contents_for_manager_id: HashMap<UserContentManagerId, UserContents>,
+    pub(crate) user_contents_for_manager_id: FxHashMap<UserContentManagerId, UserContents>,
 }
 
 /// State needed to construct a constellation.

--- a/components/constellation/constellation_webview.rs
+++ b/components/constellation/constellation_webview.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
+use embedder_traits::user_contents::UserContentManagerId;
 use embedder_traits::{InputEvent, MouseLeftViewportEvent, Theme};
 use euclid::Point2D;
 use log::warn;
@@ -36,6 +37,11 @@ pub(crate) struct ConstellationWebView {
     /// The joint session history for this webview.
     pub session_history: JointSessionHistory,
 
+    /// The [`UserContentManagerId`] for all pipelines in this `WebView`. This is `Some`
+    /// if the embedder has set a `UserContentManager` using the WebViewBuilder API and
+    /// it is `None` otherwise.
+    pub user_content_manager_id: Option<UserContentManagerId>,
+
     /// The [`Theme`] that this [`ConstellationWebView`] uses. This is communicated to all
     /// `ScriptThread`s so that they know how to render the contents of a particular `WebView.
     theme: Theme,
@@ -45,9 +51,11 @@ impl ConstellationWebView {
     pub(crate) fn new(
         webview_id: WebViewId,
         focused_browsing_context_id: BrowsingContextId,
+        user_content_manager_id: Option<UserContentManagerId>,
     ) -> Self {
         Self {
             webview_id,
+            user_content_manager_id,
             focused_browsing_context_id,
             hovered_browsing_context_id: None,
             last_mouse_move_point: Default::default(),

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -112,6 +112,7 @@ impl EventLoop {
             webxr_registry: constellation.webxr_registry.clone(),
             player_context: WindowGLContext::get(),
             privileged_urls: constellation.privileged_urls.clone(),
+            user_contents_for_manager_id: constellation.user_contents_for_manager_id.clone(),
         };
 
         let event_loop = if opts::get().multiprocess {

--- a/components/constellation/event_loop.rs
+++ b/components/constellation/event_loop.rs
@@ -111,7 +111,6 @@ impl EventLoop {
                 .map(|threads| threads.pipeline()),
             webxr_registry: constellation.webxr_registry.clone(),
             player_context: WindowGLContext::get(),
-            user_content_manager: constellation.user_content_manager.clone(),
             privileged_urls: constellation.privileged_urls.clone(),
         };
 

--- a/components/constellation/tracing.rs
+++ b/components/constellation/tracing.rs
@@ -81,6 +81,7 @@ mod from_embedder {
                 },
                 Self::RequestScreenshotReadiness(..) => target!("RequestScreenshotReadiness"),
                 Self::EmbedderControlResponse(..) => target!("EmbedderControlResponse"),
+                Self::UserContentManagerAction(..) => target!("UserContentManagerAction"),
             }
         }
     }

--- a/components/script/dom/html/htmliframeelement.rs
+++ b/components/script/dom/html/htmliframeelement.rs
@@ -224,6 +224,7 @@ impl HTMLIFrameElement {
                     opener: None,
                     load_data,
                     viewport_details,
+                    user_content_manager_id: None,
                     theme: window.theme(),
                 };
 

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -346,6 +346,7 @@ impl WindowProxy {
             opener: Some(self.browsing_context_id),
             load_data,
             viewport_details: window.viewport_details(),
+            user_content_manager_id: response.user_content_manager_id,
             // Use the current `WebView`'s theme initially, but the embedder may
             // change this later.
             theme: window.theme(),

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -103,6 +103,7 @@ impl MixedMessage {
                 ScriptThreadMessage::RequestScreenshotReadiness(_, id) => Some(*id),
                 ScriptThreadMessage::EmbedderControlResponse(id, _) => Some(id.pipeline_id),
                 ScriptThreadMessage::SetUserContents(..) => None,
+                ScriptThreadMessage::DestroyUserContentManager(..) => None,
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/messaging.rs
+++ b/components/script/messaging.rs
@@ -102,6 +102,7 @@ impl MixedMessage {
                 ScriptThreadMessage::ForwardKeyboardScroll(id, _) => Some(*id),
                 ScriptThreadMessage::RequestScreenshotReadiness(_, id) => Some(*id),
                 ScriptThreadMessage::EmbedderControlResponse(id, _) => Some(id.pipeline_id),
+                ScriptThreadMessage::SetUserContents(..) => None,
             },
             MixedMessage::FromScript(inner_msg) => match inner_msg {
                 MainThreadScriptMsg::Common(CommonScriptMsg::Task(_, _, pipeline_id, _)) => {

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -12,6 +12,7 @@ use base::cross_process_instant::CrossProcessInstant;
 use base::id::{BrowsingContextId, PipelineId, WebViewId};
 use constellation_traits::LoadData;
 use crossbeam_channel::Sender;
+use embedder_traits::user_contents::UserContentManagerId;
 use embedder_traits::{Theme, ViewportDetails};
 use http::header;
 use net_traits::request::{
@@ -159,6 +160,9 @@ pub(crate) struct InProgressLoad {
     /// this load.
     #[no_trace]
     pub(crate) url_list: Vec<ServoUrl>,
+    #[no_trace]
+    /// The [`UserContentManagerId`] associated with this load's `WebView`.
+    pub(crate) user_content_manager_id: Option<UserContentManagerId>,
     /// The [`Theme`] to use for this page, once it loads.
     #[no_trace]
     pub(crate) theme: Theme,
@@ -182,6 +186,7 @@ impl InProgressLoad {
             canceller: Default::default(),
             load_data: new_pipeline_info.load_data,
             url_list: vec![url],
+            user_content_manager_id: new_pipeline_info.user_content_manager_id,
             theme: new_pipeline_info.theme,
         }
     }

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -941,12 +941,12 @@ impl ScriptThread {
 
         debugger_global.execute(CanGc::note());
 
-        let mut user_contents_for_manager_id = FxHashMap::default();
-        for (user_content_manager_id, user_contents) in
-            state.user_contents_for_manager_id.into_iter()
-        {
-            user_contents_for_manager_id.insert(user_content_manager_id, Rc::new(user_contents));
-        }
+        let user_contents_for_manager_id =
+            FxHashMap::from_iter(state.user_contents_for_manager_id.into_iter().map(
+                |(user_content_manager_id, user_contents)| {
+                    (user_content_manager_id, Rc::new(user_contents))
+                },
+            ));
 
         ScriptThread {
             documents: DomRefCell::new(DocumentCollection::default()),

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -20,6 +20,7 @@ mod responders;
 mod servo;
 mod servo_delegate;
 mod site_data_manager;
+mod user_content_manager;
 mod webview;
 mod webview_delegate;
 
@@ -31,7 +32,7 @@ pub use compositing::WebRenderDebugOption;
 pub use compositing_traits::rendering_context::{
     OffscreenRenderingContext, RenderingContext, SoftwareRenderingContext, WindowRenderingContext,
 };
-pub use embedder_traits::user_content_manager::{UserContentManager, UserScript};
+pub use embedder_traits::user_contents::UserScript;
 pub use embedder_traits::*;
 pub use image::RgbaImage;
 pub use ipc_channel::ipc::IpcSender;
@@ -63,6 +64,7 @@ pub use webrender_api::units::{
 pub use crate::servo::{Servo, ServoBuilder, run_content_process};
 pub use crate::servo_delegate::{ServoDelegate, ServoError};
 pub use crate::site_data_manager::{SiteData, SiteDataManager, StorageType};
+pub use crate::user_content_manager::UserContentManager;
 pub use crate::webview::{WebView, WebViewBuilder};
 pub use crate::webview_delegate::{
     AlertDialog, AllowOrDenyRequest, AuthenticationRequest, ColorPicker, ConfirmDialog,
@@ -71,7 +73,6 @@ pub use crate::webview_delegate::{
     WebResourceLoad, WebViewDelegate,
 };
 
-// Since WebXR is guarded by conditional compilation it is exported via submodule.
 #[cfg(feature = "webxr")]
 pub mod webxr {
     #[cfg(not(any(target_os = "android", target_env = "ohos")))]

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -34,7 +34,6 @@ use constellation::{
 };
 use constellation_traits::{EmbedderToConstellationMessage, ScriptToConstellationSender};
 use crossbeam_channel::{Receiver, Sender, unbounded};
-use embedder_traits::user_content_manager::UserContentManager;
 pub use embedder_traits::*;
 use env_logger::Builder as EnvLoggerBuilder;
 use fonts::SystemFontService;
@@ -764,7 +763,6 @@ impl Servo {
             mem_profiler_chan,
             devtools_sender,
             protocols,
-            builder.user_content_manager,
             public_resource_threads.clone(),
             private_resource_threads.clone(),
             async_runtime,
@@ -939,7 +937,6 @@ fn create_constellation(
     mem_profiler_chan: mem::ProfilerChan,
     devtools_sender: Option<Sender<devtools_traits::DevtoolsControlMsg>>,
     protocols: Arc<ProtocolRegistry>,
-    user_content_manager: UserContentManager,
     public_resource_threads: ResourceThreads,
     private_resource_threads: ResourceThreads,
     async_runtime: Box<dyn net_traits::AsyncRuntime>,
@@ -984,7 +981,6 @@ fn create_constellation(
         webrender_external_image_id_manager: paint.webrender_external_image_id_manager(),
         #[cfg(feature = "webgpu")]
         wgpu_image_map: paint.webgpu_image_map(),
-        user_content_manager,
         async_runtime,
         privileged_urls,
     };
@@ -1155,7 +1151,6 @@ pub struct ServoBuilder {
     opts: Option<Box<Opts>>,
     preferences: Option<Box<Preferences>>,
     event_loop_waker: Box<dyn EventLoopWaker>,
-    user_content_manager: UserContentManager,
     protocol_registry: ProtocolRegistry,
     #[cfg(feature = "webxr")]
     webxr_registry: Box<dyn webxr::WebXrRegistry>,
@@ -1167,7 +1162,6 @@ impl Default for ServoBuilder {
             opts: Default::default(),
             preferences: Default::default(),
             event_loop_waker: Box::new(DefaultEventLoopWaker),
-            user_content_manager: Default::default(),
             protocol_registry: Default::default(),
             #[cfg(feature = "webxr")]
             webxr_registry: Box::new(DefaultWebXrRegistry),
@@ -1192,11 +1186,6 @@ impl ServoBuilder {
 
     pub fn event_loop_waker(mut self, event_loop_waker: Box<dyn EventLoopWaker>) -> Self {
         self.event_loop_waker = event_loop_waker;
-        self
-    }
-
-    pub fn user_content_manager(mut self, user_content_manager: UserContentManager) -> Self {
-        self.user_content_manager = user_content_manager;
         self
     }
 

--- a/components/servo/tests/webview.rs
+++ b/components/servo/tests/webview.rs
@@ -19,8 +19,8 @@ use servo::{
     ContextMenuAction, ContextMenuElementInformation, ContextMenuElementInformationFlags,
     ContextMenuItem, CreateNewWebViewRequest, Cursor, EmbedderControl, InputEvent, InputMethodType,
     JSValue, JavaScriptEvaluationError, LoadStatus, MouseButton, MouseButtonAction,
-    MouseButtonEvent, MouseLeftViewportEvent, MouseMoveEvent, RenderingContext, SimpleDialog,
-    Theme, WebView, WebViewBuilder, WebViewDelegate,
+    MouseButtonEvent, MouseLeftViewportEvent, MouseMoveEvent, RenderingContext, Servo,
+    SimpleDialog, Theme, UserContentManager, WebView, WebViewBuilder, WebViewDelegate,
 };
 use servo_config::prefs::Preferences;
 use servo_url::ServoUrl;
@@ -925,4 +925,173 @@ fn test_can_go_forward_and_can_go_back() {
 
     assert!(webview.can_go_forward());
     assert!(!webview.can_go_back());
+}
+
+#[test]
+fn test_user_content_manager_empty() {
+    let servo_test = ServoTest::new();
+    let user_content_manager = UserContentManager::new(servo_test.servo());
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .user_content_manager(Rc::new(user_content_manager))
+        .url(Url::parse("data:text/html,Hello World").unwrap())
+        .build();
+
+    let load_webview = webview.clone();
+    let _ = servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+    let result = evaluate_javascript(&servo_test, webview.clone(), "window.fromUserContentScript");
+    assert_eq!(result, Ok(JSValue::Undefined));
+}
+
+#[test]
+fn test_user_content_manager() {
+    let servo_test = ServoTest::new();
+
+    // Use a http server instead of a data url to allow the `webview.reload()` call below to reuse
+    // the exisitng script thread. This is necessary to test that mutations on a `UserContentManager`
+    // take effect on script threads created before the mutation.
+    let (_, url) = make_server(move |_, response| {
+        *response.body_mut() = make_body(b"<!DOCTYPE html>\nHello".to_vec());
+    });
+
+    let user_content_manager = Rc::new(UserContentManager::new(servo_test.servo()));
+    user_content_manager.add_script("window.fromUserContentScript = 42;".into());
+
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .user_content_manager(user_content_manager.clone())
+        .url(url.into_url())
+        .build();
+
+    let load_webview = webview.clone();
+    let _ = servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+    let result = evaluate_javascript(&servo_test, webview.clone(), "window.fromUserContentScript");
+    assert_eq!(result, Ok(JSValue::Number(42.0)));
+
+    // Add a second user script to the `UserContentManager`.
+    user_content_manager.add_script("window.fromSecondUserContentScript = 32;".into());
+
+    // The second user script must immediately take effect in any new WebViews.
+    let new_webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .user_content_manager(user_content_manager)
+        .url(Url::parse("data:text/html,<!DOCTYPE html>").unwrap())
+        .build();
+    let load_webview = new_webview.clone();
+    let _ = servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+    let result = evaluate_javascript(
+        &servo_test,
+        new_webview,
+        "window.fromSecondUserContentScript",
+    );
+    assert_eq!(result, Ok(JSValue::Number(32.0)));
+
+    // The existing page in the first webview must not be affected since we haven't reloaded yet.
+    let result = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "window.fromSecondUserContentScript",
+    );
+    assert_eq!(result, Ok(JSValue::Undefined));
+
+    // Now trigger a reload and ensure the second user script has effect on the page.
+    webview.reload();
+
+    let load_webview = webview.clone();
+    let _ = servo_test.spin(move || load_webview.load_status() != LoadStatus::Complete);
+    let result = evaluate_javascript(&servo_test, webview, "window.fromSecondUserContentScript");
+
+    assert_eq!(result, Ok(JSValue::Number(32.0)));
+}
+
+#[test]
+fn test_user_content_manager_for_auxiliary_webviews() {
+    let servo_test = ServoTest::new();
+    struct WebViewAuxiliaryTestDelegate {
+        servo: Servo,
+        rendering_context: Rc<dyn RenderingContext>,
+        auxiliary_webview: RefCell<Option<WebView>>,
+    };
+
+    impl WebViewDelegate for WebViewAuxiliaryTestDelegate {
+        fn request_create_new(&self, _parent_webview: WebView, request: CreateNewWebViewRequest) {
+            let user_content_manager_for_auxiliary_webview = UserContentManager::new(&self.servo);
+            // Add a different user script to the `UserContentManager` of auxiliary webview.
+            user_content_manager_for_auxiliary_webview
+                .add_script("window.fromAuxiliaryUserContentScript = 32;".into());
+            let auxiliary_webview = request
+                .builder(self.rendering_context.clone())
+                .user_content_manager(Rc::new(user_content_manager_for_auxiliary_webview))
+                .build();
+            self.auxiliary_webview
+                .borrow_mut()
+                .replace(auxiliary_webview.clone());
+        }
+    }
+
+    let delegate = Rc::new(WebViewAuxiliaryTestDelegate {
+        servo: servo_test.servo.clone(),
+        rendering_context: servo_test.rendering_context.clone(),
+        auxiliary_webview: RefCell::new(None),
+    });
+
+    let user_content_manager = UserContentManager::new(servo_test.servo());
+    user_content_manager.add_script("window.fromUserContentScript = 42;".into());
+
+    let webview = WebViewBuilder::new(servo_test.servo(), servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .user_content_manager(Rc::new(user_content_manager))
+        .url(
+            Url::parse(
+                "data:text/html,<!DOCTYPE html>\
+                <script>\
+                    onload = () => window.open('data:text/html,<title>Auxiliary WebView</title>')\
+                </script>",
+            )
+            .unwrap(),
+        )
+        .build();
+
+    let load_webview = webview.clone();
+    let delegate_clone = delegate.clone();
+    let _ = servo_test.spin(move || {
+        load_webview.load_status() != LoadStatus::Complete ||
+            delegate_clone
+                .auxiliary_webview
+                .borrow()
+                .as_ref()
+                .is_none_or(|auxiliary_webview| {
+                    auxiliary_webview.page_title() != Some("Auxiliary WebView".into())
+                })
+    });
+
+    let result = evaluate_javascript(
+        &servo_test,
+        webview.clone(),
+        "[ window.fromUserContentScript, window.fromAuxiliaryUserContentScript ]",
+    );
+    assert_eq!(
+        result,
+        Ok(JSValue::Array(vec![
+            JSValue::Number(42.0),
+            JSValue::Undefined
+        ]))
+    );
+
+    let auxiliary_webview = delegate
+        .auxiliary_webview
+        .borrow_mut()
+        .take()
+        .expect("Gauranteed by spin");
+
+    let result = evaluate_javascript(
+        &servo_test,
+        auxiliary_webview.clone(),
+        "[ window.fromUserContentScript, window.fromAuxiliaryUserContentScript ]",
+    );
+
+    assert_eq!(
+        result,
+        Ok(JSValue::Array(vec![
+            JSValue::Undefined,
+            JSValue::Number(32.0),
+        ]))
+    );
 }

--- a/components/servo/user_content_manager.rs
+++ b/components/servo/user_content_manager.rs
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use constellation_traits::{EmbedderToConstellationMessage, UserContentManagerAction};
+use embedder_traits::user_contents::{UserContentManagerId, UserScript};
+
+use crate::Servo;
+
+/// The [`UserContentManager`] allows embedders to inject content (scripts, styles) during
+/// into the pages loaded within the `WebView`. The same `UserContentManager` can be
+/// shared among multiple `WebView`s. Any updates to the `UserContentManager` will
+/// take effect only after the page is reloaded.
+#[derive(Clone)]
+pub struct UserContentManager {
+    pub(crate) id: UserContentManagerId,
+    pub(crate) servo: Servo,
+}
+
+impl UserContentManager {
+    pub fn new(servo: &Servo) -> Self {
+        Self {
+            id: UserContentManagerId::next(),
+            servo: servo.clone(),
+        }
+    }
+
+    pub(crate) fn id(&self) -> UserContentManagerId {
+        self.id
+    }
+
+    pub fn add_script(&self, user_script: UserScript) {
+        self.servo.constellation_proxy().send(
+            EmbedderToConstellationMessage::UserContentManagerAction(
+                self.id,
+                UserContentManagerAction::AddUserScript(user_script),
+            ),
+        );
+    }
+}
+
+impl Drop for UserContentManager {
+    fn drop(&mut self) {
+        self.servo.constellation_proxy().send(
+            EmbedderToConstellationMessage::UserContentManagerAction(
+                self.id,
+                UserContentManagerAction::DestroyUserContentManager,
+            ),
+        );
+    }
+}

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use base::generic_channel::GenericSender;
-use base::id::{PipelineId, WebViewId};
+use base::id::PipelineId;
 use compositing_traits::rendering_context::RenderingContext;
 use constellation_traits::EmbedderToConstellationMessage;
 #[cfg(feature = "gamepad")]
@@ -15,9 +15,10 @@ use embedder_traits::{
     AlertResponse, AllowOrDeny, AuthenticationResponse, ConfirmResponse, ConsoleLogLevel,
     ContextMenuAction, ContextMenuElementInformation, ContextMenuItem, Cursor, EmbedderControlId,
     EmbedderControlResponse, FilePickerRequest, FilterPattern, InputEventId, InputEventResult,
-    InputMethodType, LoadStatus, MediaSessionEvent, Notification, PermissionFeature,
-    PromptResponse, RgbColor, ScreenGeometry, SelectElementOptionOrOptgroup, SimpleDialogRequest,
-    TraversalId, ViewportDetails, WebResourceRequest, WebResourceResponse, WebResourceResponseMsg,
+    InputMethodType, LoadStatus, MediaSessionEvent, NewWebViewDetails, Notification,
+    PermissionFeature, PromptResponse, RgbColor, ScreenGeometry, SelectElementOptionOrOptgroup,
+    SimpleDialogRequest, TraversalId, WebResourceRequest, WebResourceResponse,
+    WebResourceResponseMsg,
 };
 use ipc_channel::ipc::IpcSender;
 use url::Url;
@@ -791,7 +792,7 @@ impl PromptDialog {
 
 pub struct CreateNewWebViewRequest {
     pub(crate) servo: Servo,
-    pub(crate) responder: IpcResponder<Option<(WebViewId, ViewportDetails)>>,
+    pub(crate) responder: IpcResponder<Option<NewWebViewDetails>>,
 }
 
 impl CreateNewWebViewRequest {

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -17,6 +17,7 @@ use canvas_traits::canvas::{CanvasId, CanvasMsg};
 use compositing_traits::CrossProcessPaintApi;
 use content_security_policy::sandboxing_directive::SandboxingFlagSet;
 use devtools_traits::{DevtoolScriptControlMsg, ScriptToDevtoolsControlMsg, WorkerId};
+use embedder_traits::user_contents::UserContentManagerId;
 use embedder_traits::{
     AnimationState, FocusSequenceNumber, JSValue, JavaScriptEvaluationError,
     JavaScriptEvaluationId, MediaSessionEvent, ScriptToEmbedderChan, Theme, ViewportDetails,
@@ -412,6 +413,8 @@ pub struct AuxiliaryWebViewCreationResponse {
     pub new_webview_id: WebViewId,
     /// The new pipeline ID.
     pub new_pipeline_id: PipelineId,
+    /// The [`UserContentManagerId`] for this new auxiliary browsing context.
+    pub user_content_manager_id: Option<UserContentManagerId>,
 }
 
 /// Specifies the information required to load an iframe.

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -18,10 +18,11 @@ use std::time::Duration;
 use base::cross_process_instant::CrossProcessInstant;
 use base::id::{MessagePortId, PipelineId, ScriptEventLoopId, WebViewId};
 use compositing_traits::largest_contentful_paint_candidate::LargestContentfulPaintType;
+use embedder_traits::user_contents::{UserContentManagerId, UserScript};
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, InputEventAndId, JavaScriptEvaluationId,
-    MediaSessionActionType, PaintHitTestResult, Theme, TraversalId, ViewportDetails,
-    WebDriverCommandMsg,
+    MediaSessionActionType, NewWebViewDetails, PaintHitTestResult, Theme, TraversalId,
+    ViewportDetails, WebDriverCommandMsg,
 };
 pub use from_script_message::*;
 use ipc_channel::ipc::IpcSender;
@@ -66,7 +67,7 @@ pub enum EmbedderToConstellationMessage {
     /// A log entry, with the top-level browsing context id and thread name
     LogEntry(Option<ScriptEventLoopId>, Option<String>, LogEntry),
     /// Create a new top level browsing context.
-    NewWebView(ServoUrl, WebViewId, ViewportDetails),
+    NewWebView(ServoUrl, NewWebViewDetails),
     /// Close a top level browsing context.
     CloseWebView(WebViewId),
     /// Panic a top level browsing context.
@@ -109,6 +110,13 @@ pub enum EmbedderToConstellationMessage {
     RequestScreenshotReadiness(WebViewId),
     /// A response to a request to show an embedder user interface control.
     EmbedderControlResponse(EmbedderControlId, EmbedderControlResponse),
+    /// An action to perform on the given `UserContentManagerId`.
+    UserContentManagerAction(UserContentManagerId, UserContentManagerAction),
+}
+
+pub enum UserContentManagerAction {
+    AddUserScript(UserScript),
+    DestroyUserContentManager,
 }
 
 /// A description of a paint metric that is sent from the Servo renderer to the

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -11,7 +11,7 @@
 pub mod embedder_controls;
 pub mod input_events;
 pub mod resources;
-pub mod user_content_manager;
+pub mod user_contents;
 pub mod webdriver;
 
 use std::collections::HashMap;
@@ -48,6 +48,7 @@ use webrender_api::units::{
 
 pub use crate::embedder_controls::*;
 pub use crate::input_events::*;
+use crate::user_contents::UserContentManagerId;
 pub use crate::webdriver::*;
 
 /// A point in a `WebView`, either expressed in device pixels or page pixels.
@@ -441,10 +442,7 @@ pub enum EmbedderMsg {
         GenericSender<AllowOrDeny>,
     ),
     /// Whether or not to allow script to open a new tab/browser
-    AllowOpeningWebView(
-        WebViewId,
-        GenericSender<Option<(WebViewId, ViewportDetails)>>,
-    ),
+    AllowOpeningWebView(WebViewId, GenericSender<Option<NewWebViewDetails>>),
     /// A webview was destroyed.
     WebViewClosed(WebViewId),
     /// A webview potentially gained focus for keyboard events.
@@ -1122,4 +1120,13 @@ impl ScriptToEmbedderChan {
     pub fn send(&self, msg: EmbedderMsg) -> SendResult {
         self.0.send(msg)
     }
+}
+
+/// Used for communicating the details of a new `WebView` created by the embedder
+/// back to the constellation.
+#[derive(Deserialize, Serialize)]
+pub struct NewWebViewDetails {
+    pub webview_id: WebViewId,
+    pub viewport_details: ViewportDetails,
+    pub user_content_manager_id: Option<UserContentManagerId>,
 }

--- a/components/shared/embedder/user_contents.rs
+++ b/components/shared/embedder/user_contents.rs
@@ -3,27 +3,31 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use malloc_size_of::MallocSizeOfOps;
 use malloc_size_of_derive::MallocSizeOf;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, Serialize)]
-pub struct UserContentManager {
-    user_scripts: Vec<UserScript>,
+static USER_CONTENT_MANAGER_ID: AtomicU32 = AtomicU32::new(1);
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct UserContentManagerId(u32);
+
+impl UserContentManagerId {
+    pub fn next() -> Self {
+        Self(USER_CONTENT_MANAGER_ID.fetch_add(1, Ordering::Relaxed))
+    }
 }
 
-impl UserContentManager {
+#[derive(Clone, Debug, Default, Deserialize, MallocSizeOf, Serialize)]
+pub struct UserContents {
+    pub scripts: Vec<UserScript>,
+}
+
+impl UserContents {
     pub fn new() -> Self {
-        UserContentManager::default()
-    }
-
-    pub fn add_script(&mut self, script: impl Into<UserScript>) {
-        self.user_scripts.push(script.into());
-    }
-
-    pub fn scripts(&self) -> &[UserScript] {
-        &self.user_scripts
+        UserContents::default()
     }
 }
 

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -9,7 +9,6 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 
-use std::collections::HashMap;
 use std::fmt;
 
 use base::cross_process_instant::CrossProcessInstant;
@@ -386,7 +385,7 @@ pub struct InitialScriptState {
     /// A list of URLs that can access privileged internal APIs.
     pub privileged_urls: Vec<ServoUrl>,
     /// A copy of constellation's `UserContentManagerId` to `UserContents` map.
-    pub user_contents_for_manager_id: HashMap<UserContentManagerId, UserContents>,
+    pub user_contents_for_manager_id: FxHashMap<UserContentManagerId, UserContents>,
 }
 
 /// Errors from executing a paint worklet

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -28,7 +28,7 @@ use constellation_traits::{
 };
 use crossbeam_channel::RecvTimeoutError;
 use devtools_traits::ScriptToDevtoolsControlMsg;
-use embedder_traits::user_content_manager::UserContentManager;
+use embedder_traits::user_contents::UserContents;
 use embedder_traits::{
     EmbedderControlId, EmbedderControlResponse, FocusSequenceNumber, InputEventAndId,
     JavaScriptEvaluationId, MediaSessionActionType, PaintHitTestResult, ScriptToEmbedderChan,
@@ -295,6 +295,10 @@ pub enum ScriptThreadMessage {
     RequestScreenshotReadiness(WebViewId, PipelineId),
     /// A response to a request to show an embedder user interface control.
     EmbedderControlResponse(EmbedderControlId, EmbedderControlResponse),
+    /// Set the `UserContents` for the given `WebView`s. A `ScriptThread` can host many
+    /// `WebView`s which all share the same `UserContents`. Only documents loaded after
+    /// the processing of this message will observe the new `UserContents`.
+    SetUserContents(UserContents, Vec<WebViewId>),
 }
 
 impl fmt::Debug for ScriptThreadMessage {
@@ -372,8 +376,6 @@ pub struct InitialScriptState {
     pub cross_process_paint_api: CrossProcessPaintApi,
     /// Application window's GL Context for Media player
     pub player_context: WindowGLContext,
-    /// User content manager
-    pub user_content_manager: UserContentManager,
     /// A list of URLs that can access privileged internal APIs.
     pub privileged_urls: Vec<ServoUrl>,
 }

--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -78,13 +78,6 @@ impl App {
 
     /// Initialize Application once event loop start running.
     pub fn init(&mut self, active_event_loop: Option<&ActiveEventLoop>) {
-        let mut user_content_manager = UserContentManager::new();
-        for script in load_userscripts(self.servoshell_preferences.userscripts_directory.as_deref())
-            .expect("Loading userscripts failed")
-        {
-            user_content_manager.add_script(script);
-        }
-
         let mut protocol_registry = ProtocolRegistry::default();
         let _ = protocol_registry.register(
             "urlinfo",
@@ -100,7 +93,6 @@ impl App {
         let servo_builder = ServoBuilder::default()
             .opts(self.opts.clone())
             .preferences(self.preferences.clone())
-            .user_content_manager(user_content_manager)
             .protocol_registry(protocol_registry)
             .event_loop_waker(self.waker.clone());
 
@@ -118,10 +110,18 @@ impl App {
         let servo = servo_builder.build();
         servo.setup_logging();
 
+        let user_content_manager = Rc::new(UserContentManager::new(&servo));
+        for script in load_userscripts(self.servoshell_preferences.userscripts_directory.as_deref())
+            .expect("Loading userscripts failed")
+        {
+            user_content_manager.add_script(script);
+        }
+
         let running_state = Rc::new(RunningAppState::new(
             servo,
             self.servoshell_preferences.clone(),
             self.waker.clone(),
+            user_content_manager,
         ));
         running_state.open_window(platform_window, self.initial_url.as_url().clone());
 

--- a/ports/servoshell/egl/app.rs
+++ b/ports/servoshell/egl/app.rs
@@ -15,7 +15,8 @@ use servo::{
     KeyboardEvent, LoadStatus, MediaSessionActionType, MediaSessionEvent, MouseButton,
     MouseButtonAction, MouseButtonEvent, MouseMoveEvent, Opts, Preferences, RefreshDriver,
     RenderingContext, ScreenGeometry, Scroll, Servo, ServoBuilder, SimpleDialog, TouchEvent,
-    TouchEventType, TouchId, WebView, WebViewId, WindowRenderingContext, convert_rect_to_css_pixel,
+    TouchEventType, TouchId, UserContentManager, WebView, WebViewId, WindowRenderingContext,
+    convert_rect_to_css_pixel,
 };
 use url::Url;
 
@@ -278,10 +279,12 @@ impl App {
             .or_else(|| Url::parse("about:blank").ok())
             .expect("Failed to parse initial URL");
 
+        let user_content_manager = Rc::new(UserContentManager::new(&servo));
         let state = Rc::new(RunningAppState::new(
             servo,
             init.servoshell_preferences,
             init.event_loop_waker,
+            user_content_manager,
         ));
 
         let platform_window = Rc::new(EmbeddedPlatformWindow {

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -20,8 +20,9 @@ use servo::{
     DeviceIntPoint, DeviceIntSize, EmbedderControl, EmbedderControlId, EventLoopWaker,
     GenericSender, InputEvent, InputEventId, InputEventResult, IpcSender, JSValue, LoadStatus,
     MediaSessionEvent, PermissionRequest, PrefValue, ScreenshotCaptureError, Servo, ServoDelegate,
-    ServoError, TraversalId, WebDriverCommandMsg, WebDriverJSResult, WebDriverLoadStatus,
-    WebDriverScriptCommand, WebDriverSenders, WebView, WebViewDelegate, WebViewId, pref,
+    ServoError, TraversalId, UserContentManager, WebDriverCommandMsg, WebDriverJSResult,
+    WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView, WebViewDelegate,
+    WebViewId, pref,
 };
 use url::Url;
 
@@ -178,6 +179,9 @@ pub(crate) struct RunningAppState {
     /// for the `exit_after_stable_image` option.
     pub(crate) achieved_stable_image: Rc<Cell<bool>>,
 
+    /// The [`UserContentManager`] for all `WebView`s created.
+    pub(crate) user_content_manager: Rc<UserContentManager>,
+
     /// Whether or not program exit has been triggered. This means that all windows
     /// will be destroyed and shutdown will start at the end of the current event loop.
     exit_scheduled: Cell<bool>,
@@ -200,6 +204,7 @@ impl RunningAppState {
         servo: Servo,
         servoshell_preferences: ServoShellPreferences,
         event_loop_waker: Box<dyn EventLoopWaker>,
+        user_content_manager: Rc<UserContentManager>,
     ) -> Self {
         servo.set_delegate(Rc::new(ServoShellServoDelegate));
 
@@ -232,6 +237,7 @@ impl RunningAppState {
             servo,
             achieved_stable_image: Default::default(),
             exit_scheduled: Default::default(),
+            user_content_manager,
             experimental_preferences_enabled,
         }
     }

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -88,6 +88,7 @@ impl ServoShellWindow {
         let webview = WebViewBuilder::new(state.servo(), self.platform_window.rendering_context())
             .url(url)
             .hidpi_scale_factor(self.platform_window.hidpi_scale_factor())
+            .user_content_manager(state.user_content_manager.clone())
             .delegate(state.clone())
             .build();
 


### PR DESCRIPTION
This change moves the `UserContentManager` abstraction from the `ServoBuilder` to `WebViewBuilder` so that embedders can inject content for each `WebView` independently. It also adds basic support for runtime mutations to the `UserContentManager` API. Only adding new scripts is currently supported, but future changes will add support for both other mutations such as removal of scripts and addition & removal of stylesheets. Future changes could also optimize the way mutations are propagated to `ScriptThread`s by sending just the "delta" rather than the whole `UserContents` structure for each mutation.

The `UserContentManager` now becomes just a convenient handle for the embedders to invoke the mutation API while the actual management of the manager's content is handled by the Constellation. The mutations are relayed to the constellation via messages. The change also separates the serialized version containg the user contents into a new `UserContent` structure so that the API cannot be misused.

Testing: New unit tests have been added for the different scenarios involving UserContentManager.
