### PR TITLE
CI: Use requested profile for Benchmark + Do not build/upload duplicate Linux artifact 

### DIFF
--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Dromaeo
         if: ${{ inputs.dromaeo == true }}
         run: |
-            ./mach test-dromaeo -r dom --bmf-output dromaeo.json
+            ./mach test-dromaeo --bin ${{ inputs.binary-path }} dom --bmf-output dromaeo.json
             echo "SERVO_DROMAEO_RESULT=dromaeo.json" >> "$GITHUB_ENV"
       # set options
       - name: Set bencher opts for PRs (label try run)

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -80,8 +80,8 @@ jobs:
       - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
       - uses: actions/download-artifact@v4
         with:
-          name: linux-${{ inputs.profile }}
-          path: linux-${{ inputs.profile }}
+          name: ${{ inputs.profile }}-binary-${{ inputs.target }}
+          path: ${{ inputs.profile }}-binary-${{ inputs.target }}
       # Linux and macOS uploads compressed binary, need to extract first
       - name: unPackage binary (tar)
         if: ${{ inputs.compressed-file-path != '' && contains(inputs.compressed-file-path, '.tar.gz') }}

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Speedometer
         if: ${{ inputs.speedometer == true }}
         run: |
-            ./mach test-speedometer -r --bmf-output speedometer.json
+            ./mach test-speedometer --bin ${{ inputs.binary-path }} --bmf-output speedometer.json
             echo "SERVO_SPEEDOMETER_RESULT=speedometer.json" >> "$GITHUB_ENV"
       - name: Dromaeo
         if: ${{ inputs.dromaeo == true }}

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -122,12 +122,12 @@ jobs:
       - name: Speedometer
         if: ${{ inputs.speedometer == true }}
         run: |
-            ./mach test-speedometer --bin ${{ inputs.binary-path }} --bmf-output speedometer.json
+            ./mach test-speedometer --bin ${{ inputs.binary-path }} --profile ${{ inputs.profile }} --bmf-output speedometer.json
             echo "SERVO_SPEEDOMETER_RESULT=speedometer.json" >> "$GITHUB_ENV"
       - name: Dromaeo
         if: ${{ inputs.dromaeo == true }}
         run: |
-            ./mach test-dromaeo --bin ${{ inputs.binary-path }} dom --bmf-output dromaeo.json
+            ./mach test-dromaeo --bin ${{ inputs.binary-path }} --profile ${{ inputs.profile }} dom --bmf-output dromaeo.json
             echo "SERVO_DROMAEO_RESULT=dromaeo.json" >> "$GITHUB_ENV"
       # set options
       - name: Set bencher opts for PRs (label try run)

--- a/.github/workflows/bencher.yml
+++ b/.github/workflows/bencher.yml
@@ -80,8 +80,8 @@ jobs:
       - uses: servo/ci-runners/actions/checkout@44317e3cd86c5ff2ef0b08878b90da246bc237da
       - uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.profile }}-binary-${{ inputs.target }}
-          path: ${{ inputs.profile }}-binary-${{ inputs.target }}
+          name: linux-${{ inputs.profile }}
+          path: linux-${{ inputs.profile }}
       # Linux and macOS uploads compressed binary, need to extract first
       - name: unPackage binary (tar)
         if: ${{ inputs.compressed-file-path != '' && contains(inputs.compressed-file-path, '.tar.gz') }}

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: number
       binary-path:
-        required: false
+        required: true
         default: ""
         type: string
 

--- a/.github/workflows/linux-wpt.yml
+++ b/.github/workflows/linux-wpt.yml
@@ -17,6 +17,10 @@ on:
         default: 20
         required: false
         type: number
+      binary-path:
+        required: false
+        default: ""
+        type: string
 
 env:
   RUST_BACKTRACE: 1
@@ -61,7 +65,7 @@ jobs:
           name: ${{ inputs.profile }}-binary-linux
           path: ${{ inputs.profile }}-binary-linux
       - name: unPackage binary
-        run: tar -xzf ${{ inputs.profile }}-binary-linux/target.tar.gz
+        run: tar -xzf ${{ inputs.profile }}-binary-linux/servo-tech-demo.tar.gz
       - name: Setup Python
         uses: ./.github/actions/setup-python
       - name: Change Mirror Priorities
@@ -80,6 +84,7 @@ jobs:
           mkdir -p wpt-filtered-logs/linux
           mkdir -p wpt-full-logs/linux
           ./mach test-wpt \
+            --bin ${{ inputs.binary-path }} \
             $WPT_ALWAYS_SUCCEED_ARG \
             --profile ${{ inputs.profile }} --processes $(nproc) --timeout-multiplier 2 \
             --total-chunks ${{ inputs.number-of-wpt-chunks }} --this-chunk ${{ matrix.chunk_id }} \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -241,7 +241,7 @@ jobs:
     with:
       target: 'linux'
       profile: ${{ inputs.profile }}
-      compressed-file-path: $linux-{{ inputs.profile }}/servo-tech-demo.tar.gz
+      compressed-file-path: linux-{{ inputs.profile }}/servo-tech-demo.tar.gz
       binary-path: servo/servo
       file-size: true
       # We only evaluate speedometer and dromaeo score in release

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Upload artifact for mach package
         uses: actions/upload-artifact@v4
         with:
-          name: linux-${{ inputs.profile }}
+          name: ${{ inputs.profile }}-binary-linux
           path: target/${{ inputs.profile }}/servo-tech-demo.tar.gz
       - name: Upload nightly
         if: ${{ inputs.upload }}
@@ -241,7 +241,7 @@ jobs:
     with:
       target: 'linux'
       profile: ${{ inputs.profile }}
-      compressed-file-path: linux-${{ inputs.profile }}/servo-tech-demo.tar.gz
+      compressed-file-path: ${{ inputs.profile }}-binary-linux/servo-tech-demo.tar.gz
       binary-path: servo/servo
       file-size: true
       # We only evaluate speedometer and dromaeo score in release

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -221,13 +221,6 @@ jobs:
           S3_UPLOAD_CREDENTIALS: ${{ secrets.S3_UPLOAD_CREDENTIALS }}
           NIGHTLY_REPO_TOKEN: ${{ secrets.NIGHTLY_REPO_TOKEN }}
           NIGHTLY_REPO: ${{ github.repository_owner }}/servo-nightly-builds
-      - name: Build package for target
-        run: tar -czf target.tar.gz target/${{ inputs.profile }}/servo resources
-      - name: Upload artifact for target
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ inputs.profile }}-binary-linux
-          path: target.tar.gz
 
   wpt-2020:
     if: ${{ inputs.wpt }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -241,7 +241,7 @@ jobs:
     with:
       target: 'linux'
       profile: ${{ inputs.profile }}
-      compressed-file-path: linux-{{ inputs.profile }}/servo-tech-demo.tar.gz
+      compressed-file-path: linux-${{ inputs.profile }}/servo-tech-demo.tar.gz
       binary-path: servo/servo
       file-size: true
       # We only evaluate speedometer and dromaeo score in release

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -232,6 +232,7 @@ jobs:
       profile: ${{ inputs.profile }}
       wpt-sync-from-upstream: ${{ inputs.wpt-sync-from-upstream }}
       number-of-wpt-chunks: ${{ inputs. number-of-wpt-chunks }}
+      binary-path: servo/servo
     secrets: inherit
 
   bencher:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -241,8 +241,8 @@ jobs:
     with:
       target: 'linux'
       profile: ${{ inputs.profile }}
-      compressed-file-path: ${{ inputs.profile }}-binary-linux/target.tar.gz
-      binary-path: target/${{ inputs.profile }}/servo
+      compressed-file-path: $linux-{{ inputs.profile }}/servo-tech-demo.tar.gz
+      binary-path: servo/servo
       file-size: true
       # We only evaluate speedometer and dromaeo score in release
       speedometer: ${{ inputs.profile == 'release' }}


### PR DESCRIPTION
There are two duplicate artifacts for Linux:
1. release-binary-linux
2. linux-release 

When I unzip them, they have exactly same size and number of files, with slightly different folder structure. 

This PR only keeps `linux-release` from `./mach package` to save some workload/space for the runner. We rename it to `release-binary-linux` to be consistent with other OS artifacts.

Also fixed a bug where we always used release build for benchmark instead of requested profile:
For `test-speedometer` and `test-dromaeo`, instead of passing hard-coded profile `-r`, we use `--bin ${{ inputs.binary-path }} --profile ${{ inputs.profile }}` instead. Both `--bin` and `--profile` are necessary, as the binary path assumed by the profile is not always correct.

Testing: Try run:
Full:
https://github.com/servo/servo/actions/runs/20330441348

macOS ARM (as it is not included in full profile nowadays):
https://github.com/servo/servo/actions/runs/20331385391

x86_64:
https://github.com/servo/servo/actions/runs/20332775039

Bencher:
https://github.com/servo/servo/actions/runs/20359208540