### PR TITLE
script: Add stub `VisualViewport` Interface

### DIFF
--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -171,7 +171,8 @@ pub struct Preferences {
     pub dom_worklet_blockingsleep: bool,
     pub dom_worklet_testing_enabled: bool,
     pub dom_worklet_timeout_ms: i64,
-    /// feature: VisualViewport | #41341 | Web/API/VisualViewport
+    /// <https://drafts.csswg.org/cssom-view/#the-visualviewport-interface>
+    // feature: VisualViewport | #41341 | Web/API/VisualViewport
     pub dom_visual_viewport_enabled: bool,
     /// True to compile all WebRender shaders when Servo initializes. This is mostly
     /// useful when modifying the shaders, to ensure they all compile after each change is

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -171,7 +171,7 @@ pub struct Preferences {
     pub dom_worklet_blockingsleep: bool,
     pub dom_worklet_testing_enabled: bool,
     pub dom_worklet_timeout_ms: i64,
-    /// <https://drafts.csswg.org/cssom-view/#visualViewport>
+    /// feature: VisualViewport | #41341 | Web/API/VisualViewport
     pub dom_visual_viewport_enabled: bool,
     /// True to compile all WebRender shaders when Servo initializes. This is mostly
     /// useful when modifying the shaders, to ensure they all compile after each change is

--- a/components/config/prefs.rs
+++ b/components/config/prefs.rs
@@ -171,6 +171,8 @@ pub struct Preferences {
     pub dom_worklet_blockingsleep: bool,
     pub dom_worklet_testing_enabled: bool,
     pub dom_worklet_timeout_ms: i64,
+    /// <https://drafts.csswg.org/cssom-view/#visualViewport>
+    pub dom_visual_viewport_enabled: bool,
     /// True to compile all WebRender shaders when Servo initializes. This is mostly
     /// useful when modifying the shaders, to ensure they all compile after each change is
     /// made.
@@ -363,6 +365,7 @@ impl Preferences {
             dom_worklet_enabled: false,
             dom_worklet_testing_enabled: false,
             dom_worklet_timeout_ms: 10,
+            dom_visual_viewport_enabled: false,
             fonts_default: String::new(),
             fonts_default_monospace_size: 13,
             fonts_default_size: 16,

--- a/components/script/dom/mod.rs
+++ b/components/script/dom/mod.rs
@@ -443,6 +443,7 @@ pub(crate) mod videotrack;
 pub(crate) mod videotracklist;
 pub(crate) mod virtualmethods;
 pub(crate) mod visibilitystateentry;
+pub(crate) mod visualviewport;
 pub(crate) mod vttcue;
 pub(crate) mod vttregion;
 pub(crate) mod webgl;

--- a/components/script/dom/visualviewport.rs
+++ b/components/script/dom/visualviewport.rs
@@ -1,10 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use std::cell::Cell;
 
 use dom_struct::dom_struct;
 use euclid::Rect;
 use script_bindings::codegen::GenericBindings::VisualViewportBinding::VisualViewportMethods;
 use script_bindings::num::Finite;
-use script_bindings::root::DomRoot;
+use script_bindings::root::{Dom, DomRoot};
 use script_bindings::script_runtime::CanGc;
 use style_traits::CSSPixel;
 
@@ -17,46 +21,24 @@ use crate::dom::window::Window;
 pub(crate) struct VisualViewport {
     eventtarget: EventTarget,
 
-    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsetleft>
-    offset_left: Cell<f64>,
+    /// The associated [`Window`] for this visual viewport.
+    window: Dom<Window>,
 
-    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsettop>
-    offset_top: Cell<f64>,
+    /// The rectangle bound of the visual viewport, relative to the layout viewport.
+    #[no_trace]
+    viewport_rect: Cell<Rect<f32, CSSPixel>>,
 
-    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-pageleft>
-    page_left: Cell<f64>,
-
-    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-pagetop>
-    page_top: Cell<f64>,
-
-    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-width>
-    width: Cell<f64>,
-
-    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-height>
-    height: Cell<f64>,
-
-    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-scale>
-    scale: Cell<f64>,
+    /// The scale factor of visual viewport, which is also commonly known as pinch-zoom.
+    /// <https://drafts.csswg.org/cssom-view/#scale-factor>
+    scale: Cell<f32>,
 }
 
 impl VisualViewport {
-    fn new_inherited(
-        offset_left: f64,
-        offset_top: f64,
-        page_left: f64,
-        page_top: f64,
-        width: f64,
-        height: f64,
-        scale: f64,
-    ) -> Self {
+    fn new_inherited(window: &Window, viewport_rect: Rect<f32, CSSPixel>, scale: f32) -> Self {
         Self {
             eventtarget: EventTarget::new_inherited(),
-            offset_left: Cell::new(offset_left),
-            offset_top: Cell::new(offset_top),
-            page_left: Cell::new(page_left),
-            page_top: Cell::new(page_top),
-            width: Cell::new(width),
-            height: Cell::new(height),
+            window: Dom::from_ref(window),
+            viewport_rect: Cell::new(viewport_rect),
             scale: Cell::new(scale),
         }
     }
@@ -68,54 +50,103 @@ impl VisualViewport {
         viewport_rect: Rect<f32, CSSPixel>,
         can_gc: CanGc,
     ) -> DomRoot<Self> {
-        let new_visual_viewport = Self::new_inherited(
-            0.,
-            0.,
-            viewport_rect.min_x() as f64,
-            viewport_rect.min_y() as f64,
-            viewport_rect.width() as f64,
-            viewport_rect.height() as f64,
-            1.,
-        );
-
-        reflect_dom_object(Box::new(new_visual_viewport), window, can_gc)
+        reflect_dom_object(
+            Box::new(Self::new_inherited(window, viewport_rect, 1.)),
+            window,
+            can_gc,
+        )
     }
 }
 
 impl VisualViewportMethods<crate::DomTypeHolder> for VisualViewport {
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsetleft>
     fn OffsetLeft(&self) -> Finite<f64> {
-        Finite::wrap(self.offset_left.get())
+        // > 1. If the visual viewport’s associated document is not fully active, return 0.
+        if !self.window.has_fully_active_document() {
+            return Finite::wrap(0.);
+        }
+
+        // > 2. Otherwise, return the offset of the left edge of the visual viewport from the left edge of the
+        // >    layout viewport.
+        Finite::wrap(self.viewport_rect.get().min_x() as f64)
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsettop>
     fn OffsetTop(&self) -> Finite<f64> {
-        Finite::wrap(self.offset_top.get())
+        // > 1. If the visual viewport’s associated document is not fully active, return 0.
+        if !self.window.has_fully_active_document() {
+            return Finite::wrap(0.);
+        }
+
+        // > 2. Otherwise, return the offset of the top edge of the visual viewport from the top edge of the
+        // >    layout viewport.
+        Finite::wrap(self.viewport_rect.get().min_y() as f64)
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-pageleft>
     fn PageLeft(&self) -> Finite<f64> {
-        Finite::wrap(self.page_left.get())
+        // > 1. If the visual viewport’s associated document is not fully active, return 0.
+        if !self.window.has_fully_active_document() {
+            return Finite::wrap(0.);
+        }
+
+        // > 2. Otherwise, return the offset of the left edge of the visual viewport from the left edge of the
+        // >    initial containing block of the layout viewport’s document.
+        let page_left = self.viewport_rect.get().min_x() + self.window.scroll_offset().x;
+        Finite::wrap(page_left as f64)
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-pagetop>
     fn PageTop(&self) -> Finite<f64> {
-        Finite::wrap(self.page_top.get())
+        // > 1. If the visual viewport’s associated document is not fully active, return 0.
+        if !self.window.has_fully_active_document() {
+            return Finite::wrap(0.);
+        }
+
+        // > 2. Otherwise, return the offset of the top edge of the visual viewport from the top edge of the
+        // >    initial containing block of the layout viewport’s document.
+        let page_top = self.viewport_rect.get().min_y() + self.window.scroll_offset().y;
+        Finite::wrap(page_top as f64)
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-width>
     fn Width(&self) -> Finite<f64> {
-        Finite::wrap(self.width.get())
+        // > 1. If the visual viewport’s associated document is not fully active, return 0.
+        if !self.window.has_fully_active_document() {
+            return Finite::wrap(0.);
+        }
+
+        // > 2. Otherwise, return the width of the visual viewport excluding the width of any rendered vertical
+        // >    classic scrollbar that is fixed to the visual viewport.
+        // TODO(#41341): when classic scrollbar is implemented, exclude it's size from visual viewport width.
+        Finite::wrap(self.viewport_rect.get().width() as f64)
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-height>
     fn Height(&self) -> Finite<f64> {
-        Finite::wrap(self.height.get())
+        // > 1. If the visual viewport’s associated document is not fully active, return 0.
+        if !self.window.has_fully_active_document() {
+            return Finite::wrap(0.);
+        }
+
+        // > 2. Otherwise, return the height of the visual viewport excluding the height of any rendered horizontal
+        // >    classic scrollbar that is fixed to the visual viewport.
+        // TODO(#41341): when classic scrollbar is implemented, exclude it's size from visual viewport height.
+        Finite::wrap(self.viewport_rect.get().height() as f64)
     }
 
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-scale>
     fn Scale(&self) -> Finite<f64> {
-        Finite::wrap(self.scale.get())
+        // > 1. If the visual viewport’s associated document is not fully active, return 0.
+        if !self.window.has_fully_active_document() {
+            return Finite::wrap(0.);
+        }
+
+        // > 2. If there is no output device, return 1 and abort these steps.
+        // TODO(#41341): check for output device.
+
+        // > 3. Otherwise, return the visual viewport’s scale factor.
+        Finite::wrap(self.scale.get() as f64)
     }
 
     // <https://drafts.csswg.org/cssom-view/#dom-visualviewport-onresize>

--- a/components/script/dom/visualviewport.rs
+++ b/components/script/dom/visualviewport.rs
@@ -7,6 +7,7 @@ use std::cell::Cell;
 use dom_struct::dom_struct;
 use euclid::{Rect, Scale, Size2D};
 use script_bindings::codegen::GenericBindings::VisualViewportBinding::VisualViewportMethods;
+use script_bindings::codegen::GenericBindings::WindowBinding::WindowMethods;
 use script_bindings::num::Finite;
 use script_bindings::root::{Dom, DomRoot};
 use script_bindings::script_runtime::CanGc;
@@ -72,7 +73,7 @@ impl VisualViewportMethods<crate::DomTypeHolder> for VisualViewport {
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsetleft>
     fn OffsetLeft(&self) -> Finite<f64> {
         // > 1. If the visual viewport’s associated document is not fully active, return 0.
-        if !self.window.has_fully_active_document() {
+        if !self.window.Document().is_fully_active() {
             return Finite::wrap(0.);
         }
 
@@ -84,7 +85,7 @@ impl VisualViewportMethods<crate::DomTypeHolder> for VisualViewport {
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsettop>
     fn OffsetTop(&self) -> Finite<f64> {
         // > 1. If the visual viewport’s associated document is not fully active, return 0.
-        if !self.window.has_fully_active_document() {
+        if !self.window.Document().is_fully_active() {
             return Finite::wrap(0.);
         }
 
@@ -96,7 +97,7 @@ impl VisualViewportMethods<crate::DomTypeHolder> for VisualViewport {
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-pageleft>
     fn PageLeft(&self) -> Finite<f64> {
         // > 1. If the visual viewport’s associated document is not fully active, return 0.
-        if !self.window.has_fully_active_document() {
+        if !self.window.Document().is_fully_active() {
             return Finite::wrap(0.);
         }
 
@@ -109,7 +110,7 @@ impl VisualViewportMethods<crate::DomTypeHolder> for VisualViewport {
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-pagetop>
     fn PageTop(&self) -> Finite<f64> {
         // > 1. If the visual viewport’s associated document is not fully active, return 0.
-        if !self.window.has_fully_active_document() {
+        if !self.window.Document().is_fully_active() {
             return Finite::wrap(0.);
         }
 
@@ -122,7 +123,7 @@ impl VisualViewportMethods<crate::DomTypeHolder> for VisualViewport {
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-width>
     fn Width(&self) -> Finite<f64> {
         // > 1. If the visual viewport’s associated document is not fully active, return 0.
-        if !self.window.has_fully_active_document() {
+        if !self.window.Document().is_fully_active() {
             return Finite::wrap(0.);
         }
 
@@ -135,7 +136,7 @@ impl VisualViewportMethods<crate::DomTypeHolder> for VisualViewport {
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-height>
     fn Height(&self) -> Finite<f64> {
         // > 1. If the visual viewport’s associated document is not fully active, return 0.
-        if !self.window.has_fully_active_document() {
+        if !self.window.Document().is_fully_active() {
             return Finite::wrap(0.);
         }
 
@@ -148,7 +149,7 @@ impl VisualViewportMethods<crate::DomTypeHolder> for VisualViewport {
     /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-scale>
     fn Scale(&self) -> Finite<f64> {
         // > 1. If the visual viewport’s associated document is not fully active, return 0.
-        if !self.window.has_fully_active_document() {
+        if !self.window.Document().is_fully_active() {
             return Finite::wrap(0.);
         }
 
@@ -160,7 +161,7 @@ impl VisualViewportMethods<crate::DomTypeHolder> for VisualViewport {
     }
 
     // <https://drafts.csswg.org/cssom-view/#dom-visualviewport-onresize>
-    event_handler!(change, GetOnresize, SetOnresize);
+    event_handler!(resize, GetOnresize, SetOnresize);
 
     // <https://drafts.csswg.org/cssom-view/#dom-visualviewport-onscroll>
     event_handler!(scroll, GetOnscroll, SetOnscroll);

--- a/components/script/dom/visualviewport.rs
+++ b/components/script/dom/visualviewport.rs
@@ -1,0 +1,129 @@
+use std::cell::Cell;
+
+use dom_struct::dom_struct;
+use euclid::Rect;
+use script_bindings::codegen::GenericBindings::VisualViewportBinding::VisualViewportMethods;
+use script_bindings::num::Finite;
+use script_bindings::root::DomRoot;
+use script_bindings::script_runtime::CanGc;
+use style_traits::CSSPixel;
+
+use crate::dom::bindings::reflector::reflect_dom_object;
+use crate::dom::eventtarget::EventTarget;
+use crate::dom::window::Window;
+
+/// <https://drafts.csswg.org/cssom-view/#the-visualviewport-interface>
+#[dom_struct]
+pub(crate) struct VisualViewport {
+    eventtarget: EventTarget,
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsetleft>
+    offset_left: Cell<f64>,
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsettop>
+    offset_top: Cell<f64>,
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-pageleft>
+    page_left: Cell<f64>,
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-pagetop>
+    page_top: Cell<f64>,
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-width>
+    width: Cell<f64>,
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-height>
+    height: Cell<f64>,
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-scale>
+    scale: Cell<f64>,
+}
+
+impl VisualViewport {
+    fn new_inherited(
+        offset_left: f64,
+        offset_top: f64,
+        page_left: f64,
+        page_top: f64,
+        width: f64,
+        height: f64,
+        scale: f64,
+    ) -> Self {
+        Self {
+            eventtarget: EventTarget::new_inherited(),
+            offset_left: Cell::new(offset_left),
+            offset_top: Cell::new(offset_top),
+            page_left: Cell::new(page_left),
+            page_top: Cell::new(page_top),
+            width: Cell::new(width),
+            height: Cell::new(height),
+            scale: Cell::new(scale),
+        }
+    }
+
+    /// The initial visual viewport based on a layout viewport relative to the initial containing block, where
+    /// the dimension would be the same as layout viewport leaving the offset and the scale to it's default value.
+    pub(crate) fn new_from_layout_viewport(
+        window: &Window,
+        viewport_rect: Rect<f32, CSSPixel>,
+        can_gc: CanGc,
+    ) -> DomRoot<Self> {
+        let new_visual_viewport = Self::new_inherited(
+            0.,
+            0.,
+            viewport_rect.min_x() as f64,
+            viewport_rect.min_y() as f64,
+            viewport_rect.width() as f64,
+            viewport_rect.height() as f64,
+            1.,
+        );
+
+        reflect_dom_object(Box::new(new_visual_viewport), window, can_gc)
+    }
+}
+
+impl VisualViewportMethods<crate::DomTypeHolder> for VisualViewport {
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsetleft>
+    fn OffsetLeft(&self) -> Finite<f64> {
+        Finite::wrap(self.offset_left.get())
+    }
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-offsettop>
+    fn OffsetTop(&self) -> Finite<f64> {
+        Finite::wrap(self.offset_top.get())
+    }
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-pageleft>
+    fn PageLeft(&self) -> Finite<f64> {
+        Finite::wrap(self.page_left.get())
+    }
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-pagetop>
+    fn PageTop(&self) -> Finite<f64> {
+        Finite::wrap(self.page_top.get())
+    }
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-width>
+    fn Width(&self) -> Finite<f64> {
+        Finite::wrap(self.width.get())
+    }
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-height>
+    fn Height(&self) -> Finite<f64> {
+        Finite::wrap(self.height.get())
+    }
+
+    /// <https://drafts.csswg.org/cssom-view/#dom-visualviewport-scale>
+    fn Scale(&self) -> Finite<f64> {
+        Finite::wrap(self.scale.get())
+    }
+
+    // <https://drafts.csswg.org/cssom-view/#dom-visualviewport-onresize>
+    event_handler!(change, GetOnresize, SetOnresize);
+
+    // <https://drafts.csswg.org/cssom-view/#dom-visualviewport-onscroll>
+    event_handler!(scroll, GetOnscroll, SetOnscroll);
+
+    // <https://drafts.csswg.org/cssom-view/#dom-visualviewport-onscrollend>
+    event_handler!(scrollend, GetOnscrollend, SetOnscrollend);
+}

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -42,7 +42,7 @@ use embedder_traits::{
     WebDriverJSResult, WebDriverLoadStatus,
 };
 use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect};
-use euclid::{Point2D, Scale, Size2D, Vector2D};
+use euclid::{Point2D, Rect, Scale, Size2D, Vector2D};
 use fonts::{CspViolationHandler, FontContext, WebFontDocumentContext};
 use ipc_channel::ipc::IpcSender;
 use js::glue::DumpJSStack;
@@ -175,6 +175,7 @@ use crate::dom::storage::Storage;
 use crate::dom::testrunner::TestRunner;
 use crate::dom::trustedtypepolicyfactory::TrustedTypePolicyFactory;
 use crate::dom::types::{ImageBitmap, UIEvent};
+use crate::dom::visualviewport::VisualViewport;
 use crate::dom::webgl::webglrenderingcontext::WebGLCommandSender;
 #[cfg(feature = "webgpu")]
 use crate::dom::webgpu::identityhub::IdentityHub;
@@ -455,6 +456,10 @@ pub(crate) struct Window {
 
     /// Whether or not this [`Window`] has a pending screenshot readiness request.
     has_pending_screenshot_readiness_request: Cell<bool>,
+
+    /// Visual viewport interface that is associated to this [`Window`].
+    /// <https://drafts.csswg.org/cssom-view/#visualviewport>
+    visual_viewport: MutNullableDom<VisualViewport>,
 }
 
 impl Window {
@@ -1563,8 +1568,28 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
     window_event_handlers!();
 
     /// <https://developer.mozilla.org/en-US/docs/Web/API/Window/screen>
-    fn Screen(&self) -> DomRoot<Screen> {
-        self.screen.or_init(|| Screen::new(self, CanGc::note()))
+    fn Screen(&self, can_gc: CanGc) -> DomRoot<Screen> {
+        self.screen.or_init(|| Screen::new(self, can_gc))
+    }
+
+    /// <https://drafts.csswg.org/cssom-view/#visualviewport>
+    fn GetVisualViewport(&self, can_gc: CanGc) -> Option<DomRoot<VisualViewport>> {
+        // Visual viewport is only relevant when the document is fully active.
+        if !self.document.get()?.is_fully_active() {
+            return None;
+        }
+
+        // TODO(#41341): we are only initializing the visual viewport here, but it is never updated.
+        Some(self.visual_viewport.or_init(|| {
+            VisualViewport::new_from_layout_viewport(
+                self,
+                Rect::new(
+                    self.scroll_offset().to_point().cast_unit(),
+                    self.viewport_details().size,
+                ),
+                can_gc,
+            )
+        }))
     }
 
     /// <https://html.spec.whatwg.org/multipage/#dom-windowbase64-btoa>
@@ -3539,6 +3564,7 @@ impl Window {
             endpoints_list: Default::default(),
             script_window_proxies: ScriptThread::window_proxies(),
             has_pending_screenshot_readiness_request: Default::default(),
+            visual_viewport: Default::default(),
         });
 
         WindowBinding::Wrap::<crate::DomTypeHolder>(GlobalScope::get_cx(), win)

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -458,7 +458,7 @@ pub(crate) struct Window {
     has_pending_screenshot_readiness_request: Cell<bool>,
 
     /// Visual viewport interface that is associated to this [`Window`].
-    /// <https://drafts.csswg.org/cssom-view/#visualviewport>
+    /// <https://drafts.csswg.org/cssom-view/#dom-window-visualviewport>
     visual_viewport: MutNullableDom<VisualViewport>,
 }
 

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -1577,7 +1577,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
         // > If the associated document is fully active, the visualViewport attribute must return the
         // > VisualViewport object associated with the Window object’s associated document. Otherwise,
         // > it must return null.
-        if !self.has_fully_active_document() {
+        if !self.Document().is_fully_active() {
             return None;
         }
 
@@ -2318,16 +2318,6 @@ impl Window {
 
     pub(crate) fn has_document(&self) -> bool {
         self.document.get().is_some()
-    }
-
-    pub(crate) fn has_fully_active_document(&self) -> bool {
-        if let Some(document) = self.document.get() &&
-            document.is_fully_active()
-        {
-            true
-        } else {
-            false
-        }
     }
 
     pub(crate) fn clear_js_runtime(&self) {

--- a/components/script/dom/window.rs
+++ b/components/script/dom/window.rs
@@ -42,7 +42,7 @@ use embedder_traits::{
     WebDriverJSResult, WebDriverLoadStatus,
 };
 use euclid::default::{Point2D as UntypedPoint2D, Rect as UntypedRect};
-use euclid::{Point2D, Rect, Scale, Size2D, Vector2D};
+use euclid::{Point2D, Scale, Size2D, Vector2D};
 use fonts::{CspViolationHandler, FontContext, WebFontDocumentContext};
 use ipc_channel::ipc::IpcSender;
 use js::glue::DumpJSStack;
@@ -1583,11 +1583,7 @@ impl WindowMethods<crate::DomTypeHolder> for Window {
 
         // TODO(#41341): we are only initializing the visual viewport here, but it is never updated.
         Some(self.visual_viewport.or_init(|| {
-            VisualViewport::new_from_layout_viewport(
-                self,
-                Rect::from_size(self.viewport_details().size),
-                can_gc,
-            )
+            VisualViewport::new_from_layout_viewport(self, self.viewport_details().size, can_gc)
         }))
     }
 

--- a/components/script_bindings/codegen/Bindings.conf
+++ b/components/script_bindings/codegen/Bindings.conf
@@ -777,7 +777,7 @@ DOMInterfaces = {
 },
 
 'Window': {
-    'canGc': ['CreateImageBitmap', 'CreateImageBitmap_', 'CookieStore', 'Fetch', 'FetchLater', 'Open', 'ReportError', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException'],
+    'canGc': ['CreateImageBitmap', 'CreateImageBitmap_', 'CookieStore', 'Fetch', 'FetchLater', 'Open', 'ReportError', 'Screen', 'SetInterval', 'SetTimeout', 'Stop', 'StructuredClone', 'TrustedTypes', 'WebdriverCallback', 'WebdriverException', 'GetVisualViewport'],
     'inRealms': ['Fetch', 'GetOpener', 'WebdriverCallback'],
     'additionalTraits': ['crate::interfaces::WindowHelpers'],
 },

--- a/components/script_bindings/webidls/VisualViewport.webidl
+++ b/components/script_bindings/webidls/VisualViewport.webidl
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// https://drafts.csswg.org/cssom-view/#the-visualviewport-interface
+
+[Exposed=Window]
+interface VisualViewport : EventTarget {
+  readonly attribute double offsetLeft;
+  readonly attribute double offsetTop;
+
+  readonly attribute double pageLeft;
+  readonly attribute double pageTop;
+
+  readonly attribute double width;
+  readonly attribute double height;
+
+  readonly attribute double scale;
+
+  attribute EventHandler onresize;
+  attribute EventHandler onscroll;
+  attribute EventHandler onscrollend;
+};

--- a/components/script_bindings/webidls/VisualViewport.webidl
+++ b/components/script_bindings/webidls/VisualViewport.webidl
@@ -4,7 +4,7 @@
 
 // https://drafts.csswg.org/cssom-view/#the-visualviewport-interface
 
-[Exposed=Window]
+[Pref="dom_visual_viewport_enabled", Exposed=Window]
 interface VisualViewport : EventTarget {
   readonly attribute double offsetLeft;
   readonly attribute double offsetTop;

--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -103,6 +103,7 @@ dictionary ScrollToOptions : ScrollOptions {
 partial interface Window {
   [Exposed=(Window), NewObject] MediaQueryList matchMedia(DOMString query);
   [SameObject, Replaceable] readonly attribute Screen screen;
+  [SameObject, Replaceable] readonly attribute VisualViewport? visualViewport;
 
   // browsing context
   undefined moveTo(long x, long y);

--- a/components/script_bindings/webidls/Window.webidl
+++ b/components/script_bindings/webidls/Window.webidl
@@ -103,7 +103,7 @@ dictionary ScrollToOptions : ScrollOptions {
 partial interface Window {
   [Exposed=(Window), NewObject] MediaQueryList matchMedia(DOMString query);
   [SameObject, Replaceable] readonly attribute Screen screen;
-  [SameObject, Replaceable] readonly attribute VisualViewport? visualViewport;
+  [Pref="dom_visual_viewport_enabled", SameObject, Replaceable] readonly attribute VisualViewport? visualViewport;
 
   // browsing context
   undefined moveTo(long x, long y);

--- a/resources/wpt-prefs.json
+++ b/resources/wpt-prefs.json
@@ -1,6 +1,7 @@
 {
   "dom_adoptedstylesheet_enabled": true,
   "dom_webxr_test": true,
+  "dom_visual_viewport_enabled": true,
   "gfx_text_antialiasing_enabled": false,
   "dom_testutils_enabled": true
 }

--- a/tests/wpt/include.ini
+++ b/tests/wpt/include.ini
@@ -342,5 +342,7 @@ skip: true
   skip: false
   [modules]
     skip: true
+[visual-viewport]
+  skip: false
 [xhr]
   skip: false

--- a/tests/wpt/meta/__dir__.ini
+++ b/tests/wpt/meta/__dir__.ini
@@ -4,4 +4,5 @@ prefs: [
   "dom_indexeddb_enabled:true",
   "dom_serviceworker_enabled:true",
   "dom_testutils_enabled:true",
+  "dom_visual_viewport_enabled:true",
 ]

--- a/tests/wpt/meta/css/cssom-view/idlharness.html.ini
+++ b/tests/wpt/meta/css/cssom-view/idlharness.html.ini
@@ -434,84 +434,6 @@
   [Text interface: document.createTextNode("x") must inherit property "getBoxQuads(optional BoxQuadOptions)" with the proper type]
     expected: FAIL
 
-  [VisualViewport interface: existence and properties of interface object]
-    expected: FAIL
-
-  [VisualViewport interface object length]
-    expected: FAIL
-
-  [VisualViewport interface object name]
-    expected: FAIL
-
-  [VisualViewport interface: existence and properties of interface prototype object]
-    expected: FAIL
-
-  [VisualViewport interface: existence and properties of interface prototype object's "constructor" property]
-    expected: FAIL
-
-  [VisualViewport interface: existence and properties of interface prototype object's @@unscopables property]
-    expected: FAIL
-
-  [VisualViewport interface: attribute offsetLeft]
-    expected: FAIL
-
-  [VisualViewport interface: attribute offsetTop]
-    expected: FAIL
-
-  [VisualViewport interface: attribute pageLeft]
-    expected: FAIL
-
-  [VisualViewport interface: attribute pageTop]
-    expected: FAIL
-
-  [VisualViewport interface: attribute width]
-    expected: FAIL
-
-  [VisualViewport interface: attribute height]
-    expected: FAIL
-
-  [VisualViewport interface: attribute scale]
-    expected: FAIL
-
-  [VisualViewport interface: attribute onresize]
-    expected: FAIL
-
-  [VisualViewport interface: attribute onscroll]
-    expected: FAIL
-
-  [VisualViewport must be primary interface of self.visualViewport]
-    expected: FAIL
-
-  [Stringification of self.visualViewport]
-    expected: FAIL
-
-  [VisualViewport interface: self.visualViewport must inherit property "offsetLeft" with the proper type]
-    expected: FAIL
-
-  [VisualViewport interface: self.visualViewport must inherit property "offsetTop" with the proper type]
-    expected: FAIL
-
-  [VisualViewport interface: self.visualViewport must inherit property "pageLeft" with the proper type]
-    expected: FAIL
-
-  [VisualViewport interface: self.visualViewport must inherit property "pageTop" with the proper type]
-    expected: FAIL
-
-  [VisualViewport interface: self.visualViewport must inherit property "width" with the proper type]
-    expected: FAIL
-
-  [VisualViewport interface: self.visualViewport must inherit property "height" with the proper type]
-    expected: FAIL
-
-  [VisualViewport interface: self.visualViewport must inherit property "scale" with the proper type]
-    expected: FAIL
-
-  [VisualViewport interface: self.visualViewport must inherit property "onresize" with the proper type]
-    expected: FAIL
-
-  [VisualViewport interface: self.visualViewport must inherit property "onscroll" with the proper type]
-    expected: FAIL
-
   [Element interface: document.createElement("div") must inherit property "checkVisibility(optional CheckVisibilityOptions)" with the proper type]
     expected: FAIL
 
@@ -524,12 +446,6 @@
   [Element interface: calling checkVisibility(optional CheckVisibilityOptions) on document.createElement("img") with too few arguments must throw TypeError]
     expected: FAIL
 
-  [Window interface: attribute visualViewport]
-    expected: FAIL
-
-  [Window interface: window must inherit property "visualViewport" with the proper type]
-    expected: FAIL
-
   [Element interface: operation checkVisibility(optional CheckVisibilityOptions)]
     expected: FAIL
 
@@ -537,12 +453,6 @@
     expected: FAIL
 
   [Element interface: calling checkVisibility(optional CheckVisibilityOptions) on document.createElementNS("x", "y") with too few arguments must throw TypeError]
-    expected: FAIL
-
-  [VisualViewport interface: attribute onscrollend]
-    expected: FAIL
-
-  [VisualViewport interface: self.visualViewport must inherit property "onscrollend" with the proper type]
     expected: FAIL
 
   [Document interface: operation caretPositionFromPoint(double, double, ShadowRoot...)]

--- a/tests/wpt/meta/css/cssom-view/scrollIntoView-fixed-outside-of-viewport.html.ini
+++ b/tests/wpt/meta/css/cssom-view/scrollIntoView-fixed-outside-of-viewport.html.ini
@@ -1,3 +1,0 @@
-[scrollIntoView-fixed-outside-of-viewport.html]
-  [Element.scrollIntoView doesn't scroll a position:fixed element outside of the layout viewport]
-    expected: FAIL

--- a/tests/wpt/meta/pointerevents/pointerevent_range_input.html.ini
+++ b/tests/wpt/meta/pointerevents/pointerevent_range_input.html.ini
@@ -1,32 +1,34 @@
 [pointerevent_range_input.html?mouse]
+  expected: TIMEOUT
   [Horizontal drag on a horizontal slider.]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Vertical drag on a horizontal slider.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Vertical drag on a horizontal slider with touch-action:none.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Vertical drag on a vertical slider.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Horizontal drag on a vertical slider.]
-    expected: FAIL
+    expected: NOTRUN
 
 
 [pointerevent_range_input.html?touch]
+  expected: TIMEOUT
   [Horizontal drag on a horizontal slider.]
-    expected: FAIL
+    expected: TIMEOUT
 
   [Vertical drag on a horizontal slider.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Vertical drag on a horizontal slider with touch-action:none.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Vertical drag on a vertical slider.]
-    expected: FAIL
+    expected: NOTRUN
 
   [Horizontal drag on a vertical slider.]
-    expected: FAIL
+    expected: NOTRUN

--- a/tests/wpt/meta/visual-viewport/viewport-apply-initial-scale-after-navigation.html.ini
+++ b/tests/wpt/meta/visual-viewport/viewport-apply-initial-scale-after-navigation.html.ini
@@ -1,0 +1,2 @@
+[viewport-apply-initial-scale-after-navigation.html]
+  expected: TIMEOUT

--- a/tests/wpt/meta/visual-viewport/viewport-resize-event-on-iframe-show.html.ini
+++ b/tests/wpt/meta/visual-viewport/viewport-resize-event-on-iframe-show.html.ini
@@ -1,0 +1,3 @@
+[viewport-resize-event-on-iframe-show.html]
+  [Resize event fired when an iframe is shown.]
+    expected: FAIL

--- a/tests/wpt/meta/visual-viewport/viewport-resize-event-on-iframe-size-change.html.ini
+++ b/tests/wpt/meta/visual-viewport/viewport-resize-event-on-iframe-size-change.html.ini
@@ -1,0 +1,3 @@
+[viewport-resize-event-on-iframe-size-change.html]
+  [Resize event fired when an iframe is resized.]
+    expected: FAIL


### PR DESCRIPTION
Add placeholder implementation of DOM `VisualViewport` according to the spec https://drafts.csswg.org/cssom-view/#visualviewport. This is the first step of implementing the interface and syncing it with the `PinchZoom` struct that we had in the `Embedder`. 

Since this interface's is not accurate and couldn't fulfill it's purpose, it would be gated behind a preference `dom_visual_viewport_enabled` and would be open after the interface had been integrated with `PinchZoom`, viewport resizing, and viewport scroll.

Testing: Existing WPT Test.
Part of: #41341
