### PR TITLE
Script: Convert routed_promise to GenericCallback

### DIFF
--- a/components/script/clipboard_provider.rs
+++ b/components/script/clipboard_provider.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::generic_channel::GenericCallback;
 use base::id::WebViewId;
 use embedder_traits::{EmbedderMsg, ScriptToEmbedderChan};
-use ipc_channel::ipc::channel;
 use malloc_size_of_derive::MallocSizeOf;
 
 /// A trait which abstracts access to the embedder's clipboard in order to allow unit
@@ -24,9 +24,9 @@ pub(crate) struct EmbedderClipboardProvider {
 
 impl ClipboardProvider for EmbedderClipboardProvider {
     fn get_text(&mut self) -> Result<String, String> {
-        let (tx, rx) = channel().unwrap();
+        let (callback, rx) = GenericCallback::new_blocking().unwrap();
         self.embedder_sender
-            .send(EmbedderMsg::GetClipboardText(self.webview_id, tx))
+            .send(EmbedderMsg::GetClipboardText(self.webview_id, callback))
             .unwrap();
         rx.recv().unwrap()
     }

--- a/components/script/dom/clipboard.rs
+++ b/components/script/dom/clipboard.rs
@@ -28,16 +28,8 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::window::Window;
 use crate::realms::{InRealm, enter_realm};
-<<<<<<< HEAD
-use crate::routed_promise::{RoutedPromiseListener, route_promise};
-use crate::script_runtime::CanGc;
-||||||| parent of 0a403623201 (routed_promise to GenericCallback)
-use crate::routed_promise::{RoutedPromiseListener, route_promise};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
-=======
 use crate::routed_promise::{RoutedPromiseListener, callback_promise};
-use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
->>>>>>> 0a403623201 (routed_promise to GenericCallback)
+use crate::script_runtime::CanGc;
 
 /// The fulfillment handler for the reacting to representationDataPromise part of
 /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>.

--- a/components/script/dom/clipboard.rs
+++ b/components/script/dom/clipboard.rs
@@ -28,8 +28,16 @@ use crate::dom::promise::Promise;
 use crate::dom::promisenativehandler::{Callback, PromiseNativeHandler};
 use crate::dom::window::Window;
 use crate::realms::{InRealm, enter_realm};
+<<<<<<< HEAD
 use crate::routed_promise::{RoutedPromiseListener, route_promise};
 use crate::script_runtime::CanGc;
+||||||| parent of 0a403623201 (routed_promise to GenericCallback)
+use crate::routed_promise::{RoutedPromiseListener, route_promise};
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+=======
+use crate::routed_promise::{RoutedPromiseListener, callback_promise};
+use crate::script_runtime::{CanGc, JSContext as SafeJSContext};
+>>>>>>> 0a403623201 (routed_promise to GenericCallback)
 
 /// The fulfillment handler for the reacting to representationDataPromise part of
 /// <https://w3c.github.io/clipboard-apis/#dom-clipboard-readtext>.
@@ -111,8 +119,8 @@ impl ClipboardMethods<crate::DomTypeHolder> for Clipboard {
 
         // Step 3.3 Let data be a copy of the system clipboard data.
         let window = global.as_window();
-        let sender = route_promise(&p, self, global.task_manager().clipboard_task_source());
-        window.send_to_embedder(EmbedderMsg::GetClipboardText(window.webview_id(), sender));
+        let callback = callback_promise(&p, self, global.task_manager().clipboard_task_source());
+        window.send_to_embedder(EmbedderMsg::GetClipboardText(window.webview_id(), callback));
 
         // Step 3.4 Queue a global task on the clipboard task source,
         // given realm’s global object, to perform the below steps:

--- a/components/script/dom/servointernals.rs
+++ b/components/script/dom/servointernals.rs
@@ -20,7 +20,7 @@ use crate::dom::bindings::root::DomRoot;
 use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::realms::{AlreadyInRealm, InRealm};
-use crate::routed_promise::{RoutedPromiseListener, route_promise};
+use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::CanGc;
 use crate::script_thread::ScriptThread;
 
@@ -47,11 +47,11 @@ impl ServoInternalsMethods<crate::DomTypeHolder> for ServoInternals {
         let global = &self.global();
         let promise = Promise::new_in_current_realm(comp, can_gc);
         let task_source = global.task_manager().dom_manipulation_task_source();
-        let sender = route_promise(&promise, self, task_source);
+        let callback = callback_promise(&promise, self, task_source);
 
         let script_to_constellation_chan = global.script_to_constellation_chan();
         if script_to_constellation_chan
-            .send(ScriptToConstellationMessage::ReportMemory(sender))
+            .send(ScriptToConstellationMessage::ReportMemory(callback))
             .is_err()
         {
             promise.reject_error(Error::Operation(None), can_gc);

--- a/components/script/dom/webgpu/gpu.rs
+++ b/components/script/dom/webgpu/gpu.rs
@@ -22,7 +22,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::webgpu::gpuadapter::GPUAdapter;
 use crate::realms::InRealm;
-use crate::routed_promise::{RoutedPromiseListener, route_promise};
+use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -57,7 +57,7 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
         let global = &self.global();
         let promise = Promise::new_in_current_realm(comp, can_gc);
         let task_source = global.task_manager().dom_manipulation_task_source();
-        let sender = route_promise(&promise, self, task_source);
+        let callback = callback_promise(&promise, self, task_source);
 
         let power_preference = match options.powerPreference {
             Some(GPUPowerPreference::Low_power) => PowerPreference::LowPower,
@@ -69,7 +69,7 @@ impl GPUMethods<crate::DomTypeHolder> for GPU {
         let script_to_constellation_chan = global.script_to_constellation_chan();
         if script_to_constellation_chan
             .send(ScriptToConstellationMessage::RequestAdapter(
-                sender,
+                callback,
                 wgpu_core::instance::RequestAdapterOptions {
                     power_preference,
                     compatible_surface: None,

--- a/components/script/dom/webgpu/gpuadapter.rs
+++ b/components/script/dom/webgpu/gpuadapter.rs
@@ -27,7 +27,7 @@ use crate::dom::types::{GPUAdapterInfo, GPUSupportedLimits};
 use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::dom::webgpu::gpusupportedfeatures::gpu_to_wgt_feature;
 use crate::realms::InRealm;
-use crate::routed_promise::{RoutedPromiseListener, route_promise};
+use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -192,7 +192,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
     ) -> Rc<Promise> {
         // Step 2
         let promise = Promise::new_in_current_realm(comp, can_gc);
-        let sender = route_promise(
+        let callback = callback_promise(
             &promise,
             self,
             self.global().task_manager().dom_manipulation_task_source(),
@@ -235,7 +235,7 @@ impl GPUAdapterMethods<crate::DomTypeHolder> for GPUAdapter {
             .channel
             .0
             .send(WebGPURequest::RequestDevice {
-                sender,
+                sender: callback,
                 adapter_id: self.adapter,
                 descriptor: desc,
                 device_id,

--- a/components/script/dom/webgpu/gpubuffer.rs
+++ b/components/script/dom/webgpu/gpubuffer.rs
@@ -29,7 +29,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::webgpu::gpudevice::GPUDevice;
 use crate::realms::InRealm;
-use crate::routed_promise::{RoutedPromiseListener, route_promise};
+use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::{CanGc, JSContext};
 
 #[derive(JSTraceable, MallocSizeOf)]
@@ -271,13 +271,13 @@ impl GPUBufferMethods<crate::DomTypeHolder> for GPUBuffer {
             },
         };
 
-        let sender = route_promise(
+        let callback = callback_promise(
             &promise,
             self,
             self.global().task_manager().dom_manipulation_task_source(),
         );
         if let Err(e) = self.channel.0.send(WebGPURequest::BufferMapAsync {
-            sender,
+            callback,
             buffer_id: self.buffer.0,
             device_id: self.device.id().0,
             host_map,

--- a/components/script/dom/webgpu/gpucomputepipeline.rs
+++ b/components/script/dom/webgpu/gpucomputepipeline.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::generic_channel::GenericCallback;
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
 use webgpu_traits::{
     WebGPU, WebGPUBindGroupLayout, WebGPUComputePipeline, WebGPUComputePipelineResponse,
     WebGPURequest,
@@ -79,7 +79,7 @@ impl GPUComputePipeline {
     pub(crate) fn create(
         device: &GPUDevice,
         descriptor: &GPUComputePipelineDescriptor,
-        async_sender: Option<IpcSender<WebGPUComputePipelineResponse>>,
+        async_sender: Option<GenericCallback<WebGPUComputePipelineResponse>>,
     ) -> WebGPUComputePipeline {
         let compute_pipeline_id = device.global().wgpu_id_hub().create_compute_pipeline_id();
 

--- a/components/script/dom/webgpu/gpuqueue.rs
+++ b/components/script/dom/webgpu/gpuqueue.rs
@@ -23,7 +23,7 @@ use crate::dom::promise::Promise;
 use crate::dom::webgpu::gpubuffer::GPUBuffer;
 use crate::dom::webgpu::gpucommandbuffer::GPUCommandBuffer;
 use crate::dom::webgpu::gpudevice::GPUDevice;
-use crate::routed_promise::{RoutedPromiseListener, route_promise};
+use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -200,13 +200,13 @@ impl GPUQueueMethods<crate::DomTypeHolder> for GPUQueue {
         let global = self.global();
         let promise = Promise::new(&global, can_gc);
         let task_source = global.task_manager().dom_manipulation_task_source();
-        let sender = route_promise(&promise, self, task_source);
+        let callback = callback_promise(&promise, self, task_source);
 
         if let Err(e) = self
             .channel
             .0
             .send(WebGPURequest::QueueOnSubmittedWorkDone {
-                sender,
+                sender: callback,
                 queue_id: self.queue.0,
             })
         {

--- a/components/script/dom/webgpu/gpurenderpipeline.rs
+++ b/components/script/dom/webgpu/gpurenderpipeline.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use base::generic_channel::GenericCallback;
 use dom_struct::dom_struct;
-use ipc_channel::ipc::IpcSender;
 use webgpu_traits::{
     WebGPU, WebGPUBindGroupLayout, WebGPURenderPipeline, WebGPURenderPipelineResponse,
     WebGPURequest,
@@ -77,7 +77,7 @@ impl GPURenderPipeline {
         device: &GPUDevice,
         pipeline_layout: PipelineLayout,
         descriptor: RenderPipelineDescriptor<'static>,
-        async_sender: Option<IpcSender<WebGPURenderPipelineResponse>>,
+        async_sender: Option<GenericCallback<WebGPURenderPipelineResponse>>,
     ) -> Fallible<WebGPURenderPipeline> {
         let render_pipeline_id = device.global().wgpu_id_hub().create_render_pipeline_id();
 

--- a/components/script/dom/webgpu/gpushadermodule.rs
+++ b/components/script/dom/webgpu/gpushadermodule.rs
@@ -20,7 +20,7 @@ use crate::dom::globalscope::GlobalScope;
 use crate::dom::promise::Promise;
 use crate::dom::types::GPUDevice;
 use crate::realms::InRealm;
-use crate::routed_promise::{RoutedPromiseListener, route_promise};
+use crate::routed_promise::{RoutedPromiseListener, callback_promise};
 use crate::script_runtime::CanGc;
 
 #[dom_struct]
@@ -95,7 +95,7 @@ impl GPUShaderModule {
             promise.clone(),
             can_gc,
         );
-        let sender = route_promise(
+        let callback = callback_promise(
             &promise,
             &*shader_module,
             device
@@ -111,7 +111,7 @@ impl GPUShaderModule {
                 program_id,
                 program: descriptor.code.0.clone(),
                 label: None,
-                sender,
+                callback,
             })
             .expect("Failed to create WebGPU ShaderModule");
         shader_module

--- a/components/servo/clipboard_delegate.rs
+++ b/components/servo/clipboard_delegate.rs
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use ipc_channel::ipc::IpcSender;
+use base::generic_channel::GenericCallback;
 
 use crate::WebView;
 
 pub struct StringRequest {
-    pub(crate) result_sender: IpcSender<Result<String, String>>,
+    pub(crate) result_sender: GenericCallback<Result<String, String>>,
     response_sent: bool,
 }
 
@@ -23,8 +23,8 @@ impl StringRequest {
     }
 }
 
-impl From<IpcSender<Result<String, String>>> for StringRequest {
-    fn from(result_sender: IpcSender<Result<String, String>>) -> Self {
+impl From<GenericCallback<Result<String, String>>> for StringRequest {
+    fn from(result_sender: GenericCallback<Result<String, String>>) -> Self {
         Self {
             result_sender,
             response_sent: false,

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -843,7 +843,7 @@ impl Servo {
         log::set_max_level(filter);
     }
 
-    pub fn create_memory_report(&self, snd: IpcSender<MemoryReportResult>) {
+    pub fn create_memory_report(&self, snd: GenericCallback<MemoryReportResult>) {
         self.0
             .constellation_proxy
             .send(EmbedderToConstellationMessage::CreateMemoryReport(snd));

--- a/components/shared/base/generic_channel/callback.rs
+++ b/components/shared/base/generic_channel/callback.rs
@@ -155,7 +155,7 @@ where
         } else {
             let (sender, receiver) = crossbeam_channel::bounded(1);
             let callback = Arc::new(Mutex::new(move |msg| {
-                if let Err(_) = sender.send(msg) {
+                if sender.send(msg).is_err() {
                     log::error!("Error in callback");
                 }
             }));

--- a/components/shared/base/generic_channel/callback.rs
+++ b/components/shared/base/generic_channel/callback.rs
@@ -71,7 +71,7 @@ use serde::de::VariantAccess;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use servo_config::opts;
 
-use crate::generic_channel::{self, GenericReceiver, SendError, SendResult};
+use crate::generic_channel::{GenericReceiver, GenericReceiverVariants, SendError, SendResult};
 
 /// The callback type of our messages.
 ///
@@ -147,14 +147,22 @@ where
 
     /// Produces a GenericCallback and a channel. You can block on this channel for the result.
     pub fn new_blocking() -> Result<(Self, GenericReceiver<T>), ipc_channel::Error> {
-        let (sender, receiver) = generic_channel::channel().unwrap();
-        let callback = GenericCallback::new(move |message| {
-            if let Err(e) = sender.send(message.unwrap()) {
-                log::error!("Could not send for generic callback ({e})");
-            }
-        })
-        .unwrap();
-        Ok((callback, receiver))
+        if opts::get().multiprocess || opts::get().force_ipc {
+            let (sender, receiver) = ipc_channel::ipc::channel()?;
+            let generic_callback = GenericCallback(GenericCallbackVariants::CrossProcess(sender));
+            let receiver = GenericReceiver(GenericReceiverVariants::Ipc(receiver));
+            Ok((generic_callback, receiver))
+        } else {
+            let (sender, receiver) = crossbeam_channel::bounded(1);
+            let callback = Arc::new(Mutex::new(move |msg| {
+                if let Err(_) = sender.send(msg) {
+                    log::error!("Error in callback");
+                }
+            }));
+            let generic_callback = GenericCallback(GenericCallbackVariants::InProcess(callback));
+            let receiver = GenericReceiver(GenericReceiverVariants::Crossbeam(receiver));
+            Ok((generic_callback, receiver))
+        }
     }
 
     /// Send `value` to the callback.
@@ -352,5 +360,15 @@ mod single_process_callback_test {
             });
         });
         assert_eq!(number.load(Ordering::SeqCst), 42);
+    }
+
+    #[test]
+    fn generic_callback_blocking() {
+        let (callback, receiver) = GenericCallback::new_blocking().unwrap();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(1));
+            assert!(callback.send(42).is_ok());
+        });
+        assert_eq!(receiver.recv().unwrap(), 42);
     }
 }

--- a/components/shared/constellation/from_script_message.rs
+++ b/components/shared/constellation/from_script_message.rs
@@ -697,7 +697,7 @@ pub enum ScriptToConstellationMessage {
     #[cfg(feature = "webgpu")]
     /// Create a WebGPU Adapter instance
     RequestAdapter(
-        IpcSender<WebGPUAdapterResponse>,
+        GenericCallback<WebGPUAdapterResponse>,
         wgpu_core::instance::RequestAdapterOptions,
         wgpu_core::id::AdapterId,
     ),
@@ -709,7 +709,7 @@ pub enum ScriptToConstellationMessage {
     /// Notify the constellation that the size of some `<iframe>`s has changed.
     IFrameSizes(Vec<IFrameSizeMsg>),
     /// Request results from the memory reporter.
-    ReportMemory(IpcSender<MemoryReportResult>),
+    ReportMemory(GenericCallback<MemoryReportResult>),
     /// Return the result of the evaluated JavaScript with the given [`JavaScriptEvaluationId`].
     FinishJavaScriptEvaluation(
         JavaScriptEvaluationId,

--- a/components/shared/constellation/lib.rs
+++ b/components/shared/constellation/lib.rs
@@ -16,6 +16,7 @@ use std::fmt;
 use std::time::Duration;
 
 use base::cross_process_instant::CrossProcessInstant;
+use base::generic_channel::GenericCallback;
 use base::id::{MessagePortId, PipelineId, ScriptEventLoopId, WebViewId};
 use compositing_traits::largest_contentful_paint_candidate::LargestContentfulPaintType;
 use embedder_traits::user_contents::{UserContentManagerId, UserScript};
@@ -25,7 +26,6 @@ use embedder_traits::{
     ViewportDetails, WebDriverCommandMsg,
 };
 pub use from_script_message::*;
-use ipc_channel::ipc::IpcSender;
 use malloc_size_of_derive::MallocSizeOf;
 use profile_traits::mem::MemoryReportResult;
 use rustc_hash::FxHashMap;
@@ -100,7 +100,7 @@ pub enum EmbedderToConstellationMessage {
     /// error is encountered, a correpsonding message will be sent to the embedding layer.
     EvaluateJavaScript(WebViewId, JavaScriptEvaluationId, String),
     /// Create a memory report and return it via the ipc sender
-    CreateMemoryReport(IpcSender<MemoryReportResult>),
+    CreateMemoryReport(GenericCallback<MemoryReportResult>),
     /// Sends the generated image key to the image cache associated with this pipeline.
     SendImageKeysForPipeline(PipelineId, Vec<ImageKey>),
     /// A set of preferences were updated with the given new values.

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -453,7 +453,7 @@ pub enum EmbedderMsg {
     /// Inform embedder to clear the clipboard
     ClearClipboard(WebViewId),
     /// Gets system clipboard contents
-    GetClipboardText(WebViewId, IpcSender<Result<String, String>>),
+    GetClipboardText(WebViewId, GenericCallback<Result<String, String>>),
     /// Sets system clipboard contents
     SetClipboardText(WebViewId, String),
     /// Changes the cursor.

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -27,7 +27,6 @@ use base::id::{PipelineId, WebViewId};
 use crossbeam_channel::Sender;
 use euclid::{Box2D, Point2D, Scale, Size2D, Vector2D};
 use http::{HeaderMap, Method, StatusCode};
-use ipc_channel::ipc::IpcSender;
 use log::warn;
 use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;

--- a/components/shared/profile/mem.rs
+++ b/components/shared/profile/mem.rs
@@ -290,7 +290,7 @@ pub enum ProfilerMsg {
     Exit,
 
     /// Triggers sending back the memory profiling metrics,
-    Report(IpcSender<MemoryReportResult>),
+    Report(GenericCallback<MemoryReportResult>),
 }
 
 thread_local!(static SEEN_POINTERS: LazyCell<RefCell<HashSet<*const c_void>>> = const {

--- a/components/shared/webgpu/messages/recv.rs
+++ b/components/shared/webgpu/messages/recv.rs
@@ -8,6 +8,7 @@
 use arrayvec::ArrayVec;
 use base::Epoch;
 use base::generic_channel::GenericSharedMemory;
+use base::generic_channel::GenericCallback;
 use base::id::PipelineId;
 use ipc_channel::ipc::IpcSender;
 use pixels::SharedSnapshot;
@@ -68,7 +69,7 @@ pub enum WebGPURequest {
         image_key: ImageKey,
     },
     BufferMapAsync {
-        sender: IpcSender<Result<Mapping, BufferAccessError>>,
+        callback: GenericCallback<Result<Mapping, BufferAccessError>>,
         buffer_id: BufferId,
         device_id: DeviceId,
         host_map: HostMap,
@@ -132,7 +133,7 @@ pub enum WebGPURequest {
         descriptor: ComputePipelineDescriptor<'static>,
         implicit_ids: Option<(PipelineLayoutId, Vec<BindGroupLayoutId>)>,
         /// present only on ASYNC versions
-        async_sender: Option<IpcSender<WebGPUComputePipelineResponse>>,
+        async_sender: Option<GenericCallback<WebGPUComputePipelineResponse>>,
     },
     CreatePipelineLayout {
         device_id: DeviceId,
@@ -145,7 +146,7 @@ pub enum WebGPURequest {
         descriptor: RenderPipelineDescriptor<'static>,
         implicit_ids: Option<(PipelineLayoutId, Vec<BindGroupLayoutId>)>,
         /// present only on ASYNC versions
-        async_sender: Option<IpcSender<WebGPURenderPipelineResponse>>,
+        async_sender: Option<GenericCallback<WebGPURenderPipelineResponse>>,
     },
     CreateSampler {
         device_id: DeviceId,
@@ -157,7 +158,7 @@ pub enum WebGPURequest {
         program_id: ShaderModuleId,
         program: String,
         label: Option<String>,
-        sender: IpcSender<Option<ShaderCompilationInfo>>,
+        callback: GenericCallback<Option<ShaderCompilationInfo>>,
     },
     /// Creates context
     CreateContext {
@@ -226,12 +227,12 @@ pub enum WebGPURequest {
         device_id: DeviceId,
     },
     RequestAdapter {
-        sender: IpcSender<WebGPUAdapterResponse>,
+        sender: GenericCallback<WebGPUAdapterResponse>,
         options: RequestAdapterOptions,
         adapter_id: AdapterId,
     },
     RequestDevice {
-        sender: IpcSender<WebGPUDeviceResponse>,
+        sender: GenericCallback<WebGPUDeviceResponse>,
         adapter_id: WebGPUAdapter,
         descriptor: DeviceDescriptor<Option<String>>,
         device_id: DeviceId,
@@ -320,7 +321,7 @@ pub enum WebGPURequest {
         data: GenericSharedMemory,
     },
     QueueOnSubmittedWorkDone {
-        sender: IpcSender<()>,
+        sender: GenericCallback<()>,
         queue_id: QueueId,
     },
     PushErrorScope {
@@ -333,7 +334,7 @@ pub enum WebGPURequest {
     },
     PopErrorScope {
         device_id: DeviceId,
-        sender: IpcSender<WebGPUPoppedErrorScopeResponse>,
+        callback: GenericCallback<WebGPUPoppedErrorScopeResponse>,
     },
     ComputeGetBindGroupLayout {
         device_id: DeviceId,

--- a/components/shared/webgpu/messages/recv.rs
+++ b/components/shared/webgpu/messages/recv.rs
@@ -7,8 +7,7 @@
 
 use arrayvec::ArrayVec;
 use base::Epoch;
-use base::generic_channel::GenericSharedMemory;
-use base::generic_channel::GenericCallback;
+use base::generic_channel::{GenericCallback, GenericSharedMemory};
 use base::id::PipelineId;
 use ipc_channel::ipc::IpcSender;
 use pixels::SharedSnapshot;

--- a/components/webgpu/wgpu_thread.rs
+++ b/components/webgpu/wgpu_thread.rs
@@ -168,7 +168,7 @@ impl WGPU {
                         image_key,
                     } => self.set_image_key(context_id, image_key),
                     WebGPURequest::BufferMapAsync {
-                        sender,
+                        callback: sender,
                         buffer_id,
                         device_id,
                         host_map,
@@ -469,7 +469,7 @@ impl WGPU {
                         program_id,
                         program,
                         label,
-                        sender,
+                        callback: sender,
                     } => {
                         let global = &self.global;
                         let source =
@@ -1164,7 +1164,10 @@ impl WGPU {
                     WebGPURequest::DispatchError { device_id, error } => {
                         self.dispatch_error(device_id, error);
                     },
-                    WebGPURequest::PopErrorScope { device_id, sender } => {
+                    WebGPURequest::PopErrorScope {
+                        device_id,
+                        callback: sender,
+                    } => {
                         // <https://www.w3.org/TR/webgpu/#dom-gpudevice-poperrorscope>
                         let mut devices = self.devices.lock().unwrap();
                         let device_scope = devices


### PR DESCRIPTION
This changes routed_promise to use the GenericCallback functionality.
This mostly effected WebGPU but also Clipboard and Memory Reporting.

We also added a GenericCallback::new_blocking() functionality which produces a callback and a channel
which then can be blocked on. This was used a couple of times in the code.

Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>

Testing: This should not change functionality.
