### PR TITLE
script: Remove Drop implementation of FetchCanceller

### DIFF
--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -66,7 +66,7 @@ impl DroppableEventSource {
     }
 
     pub(crate) fn cancel(&self) {
-        self.canceller.borrow_mut().cancel();
+        self.canceller.borrow_mut().abort();
     }
 
     pub(crate) fn set_canceller(&self, data: FetchCanceller) {

--- a/components/script/dom/html/htmlmediaelement.rs
+++ b/components/script/dom/html/htmlmediaelement.rs
@@ -3666,7 +3666,7 @@ impl HTMLMediaElementFetchContext {
         }
         self.cancel_reason = Some(reason);
         self.data_source.borrow_mut().reset();
-        self.fetch_canceller.cancel();
+        self.fetch_canceller.abort();
     }
 
     fn cancel_reason(&self) -> &Option<CancelReason> {

--- a/components/script/dom/html/htmlvideoelement.rs
+++ b/components/script/dom/html/htmlvideoelement.rs
@@ -433,7 +433,7 @@ impl FetchResponseListener for PosterFrameFetchContext {
 
         if !status_is_ok {
             self.cancelled = true;
-            self.fetch_canceller.cancel();
+            self.fetch_canceller.abort();
         }
     }
 

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -1220,7 +1220,7 @@ impl XMLHttpRequest {
     }
 
     fn terminate_ongoing_fetch(&self) {
-        self.canceller.borrow_mut().cancel();
+        self.canceller.borrow_mut().abort();
         let GenerationId(prev_id) = self.generation_id.get();
         self.generation_id.set(GenerationId(prev_id + 1));
         self.response_status.set(Ok(()));

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -59,7 +59,7 @@ use crate::network_listener::{
 use crate::realms::{InRealm, enter_realm};
 use crate::script_runtime::CanGc;
 
-/// RAII fetch canceller object. By default initialized to having a
+/// Fetch canceller object. By default initialized to having a
 /// request associated with it, which can be aborted or terminated.
 /// Calling `ignore` will sever the relationship with the request,
 /// meaning it cannot be cancelled through this canceller from that point on.


### PR DESCRIPTION
Instead, we now explicitly call `.terminate()` and introduce relevant methods to FetchCanceller.

Follow-up from review in #41345