### PR TITLE
script: Implement customElementRegistry support for document.importNode

### DIFF
--- a/components/script/dom/document.rs
+++ b/components/script/dom/document.rs
@@ -94,7 +94,7 @@ use crate::dom::bindings::codegen::Bindings::WindowBinding::{
 use crate::dom::bindings::codegen::Bindings::XPathEvaluatorBinding::XPathEvaluatorMethods;
 use crate::dom::bindings::codegen::Bindings::XPathNSResolverBinding::XPathNSResolver;
 use crate::dom::bindings::codegen::UnionTypes::{
-    NodeOrString, StringOrElementCreationOptions, TrustedHTMLOrString,
+    BooleanOrImportNodeOptions, NodeOrString, StringOrElementCreationOptions, TrustedHTMLOrString,
 };
 use crate::dom::bindings::domname::{
     self, is_valid_attribute_local_name, is_valid_element_local_name, namespace_from_domstring,
@@ -116,7 +116,9 @@ use crate::dom::compositionevent::CompositionEvent;
 use crate::dom::css::cssstylesheet::CSSStyleSheet;
 use crate::dom::css::fontfaceset::FontFaceSet;
 use crate::dom::css::stylesheetlist::{StyleSheetList, StyleSheetListOwner};
-use crate::dom::customelementregistry::{CustomElementDefinition, CustomElementReactionStack};
+use crate::dom::customelementregistry::{
+    CustomElementDefinition, CustomElementReactionStack, CustomElementRegistry,
+};
 use crate::dom::customevent::CustomEvent;
 use crate::dom::document_embedder_controls::DocumentEmbedderControls;
 use crate::dom::document_event_handler::DocumentEventHandler;
@@ -155,9 +157,7 @@ use crate::dom::largestcontentfulpaint::LargestContentfulPaint;
 use crate::dom::location::{Location, NavigationType};
 use crate::dom::messageevent::MessageEvent;
 use crate::dom::mouseevent::MouseEvent;
-use crate::dom::node::{
-    CloneChildrenFlag, Node, NodeDamage, NodeFlags, NodeTraits, ShadowIncluding,
-};
+use crate::dom::node::{Node, NodeDamage, NodeFlags, NodeTraits, ShadowIncluding};
 use crate::dom::nodeiterator::NodeIterator;
 use crate::dom::nodelist::NodeList;
 use crate::dom::pagetransitionevent::PageTransitionEvent;
@@ -2679,6 +2679,11 @@ impl Document {
         registry.lookup_definition(local_name, is)
     }
 
+    /// <https://dom.spec.whatwg.org/#document-custom-element-registry>
+    pub(crate) fn custom_element_registry(&self) -> DomRoot<CustomElementRegistry> {
+        self.window.CustomElements()
+    }
+
     pub(crate) fn increment_throw_on_dynamic_markup_insertion_counter(&self) {
         let counter = self.throw_on_dynamic_markup_insertion_counter.get();
         self.throw_on_dynamic_markup_insertion_counter
@@ -5118,20 +5123,41 @@ impl DocumentMethods<crate::DomTypeHolder> for Document {
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-importnode>
-    fn ImportNode(&self, node: &Node, deep: bool, can_gc: CanGc) -> Fallible<DomRoot<Node>> {
-        // Step 1.
+    fn ImportNode(
+        &self,
+        node: &Node,
+        options: BooleanOrImportNodeOptions,
+        can_gc: CanGc,
+    ) -> Fallible<DomRoot<Node>> {
+        // Step 1. If node is a document or shadow root, then throw a "NotSupportedError" DOMException.
         if node.is::<Document>() || node.is::<ShadowRoot>() {
             return Err(Error::NotSupported(None));
         }
-
-        // Step 2.
-        let clone_children = if deep {
-            CloneChildrenFlag::CloneChildren
-        } else {
-            CloneChildrenFlag::DoNotCloneChildren
+        // Step 2. Let subtree be false.
+        let (subtree, registry) = match options {
+            // Step 3. Let registry be null.
+            // Step 4. If options is a boolean, then set subtree to options.
+            BooleanOrImportNodeOptions::Boolean(boolean) => (boolean.into(), None),
+            // Step 5. Otherwise:
+            BooleanOrImportNodeOptions::ImportNodeOptions(options) => {
+                // Step 5.1. Set subtree to the negation of options["selfOnly"].
+                let subtree = (!options.selfOnly).into();
+                // Step 5.2. If options["customElementRegistry"] exists, then set registry to it.
+                let registry = options.customElementRegistry;
+                // Step 5.3. If registry’s is scoped is false and registry
+                // is not this’s custom element registry, then throw a "NotSupportedError" DOMException.
+                // TODO
+                (subtree, registry)
+            },
         };
+        // Step 6. If registry is null, then set registry to the
+        // result of looking up a custom element registry given this.
+        let registry = registry
+            .or_else(|| CustomElementRegistry::lookup_a_custom_element_registry(self.upcast()));
 
-        Ok(Node::clone(node, Some(self), clone_children, can_gc))
+        // Step 7. Return the result of cloning a node given node with
+        // document set to this, subtree set to subtree, and fallbackRegistry set to registry.
+        Ok(Node::clone(node, Some(self), subtree, registry, can_gc))
     }
 
     /// <https://dom.spec.whatwg.org/#dom-document-adoptnode>

--- a/components/script/dom/element.rs
+++ b/components/script/dom/element.rs
@@ -103,8 +103,8 @@ use crate::dom::characterdata::CharacterData;
 use crate::dom::create::create_element;
 use crate::dom::csp::{CspReporting, InlineCheckType, SourcePosition};
 use crate::dom::customelementregistry::{
-    CallbackReaction, CustomElementDefinition, CustomElementReaction, CustomElementState,
-    is_valid_custom_element_name,
+    CallbackReaction, CustomElementDefinition, CustomElementReaction, CustomElementRegistry,
+    CustomElementState, is_valid_custom_element_name,
 };
 use crate::dom::document::{Document, LayoutDocumentHelpers};
 use crate::dom::documentfragment::DocumentFragment;
@@ -1570,6 +1570,21 @@ impl Element {
 
     pub(crate) fn set_prefix(&self, prefix: Option<Prefix>) {
         *self.prefix.borrow_mut() = prefix;
+    }
+
+    pub(crate) fn set_custom_element_registry(
+        &self,
+        registry: Option<DomRoot<CustomElementRegistry>>,
+    ) {
+        self.ensure_rare_data().custom_element_registry = registry.as_deref().map(Dom::from_ref);
+    }
+
+    pub(crate) fn custom_element_registry(&self) -> Option<DomRoot<CustomElementRegistry>> {
+        self.rare_data()
+            .as_ref()?
+            .custom_element_registry
+            .as_deref()
+            .map(DomRoot::from_ref)
     }
 
     pub(crate) fn attrs(&self) -> Ref<'_, [Dom<Attr>]> {
@@ -3981,6 +3996,12 @@ impl ElementMethods<crate::DomTypeHolder> for Element {
 
         // Step 3. Return shadow.
         Some(shadow)
+    }
+
+    /// <https://dom.spec.whatwg.org/#dom-element-customelementregistry>
+    fn GetCustomElementRegistry(&self) -> Option<DomRoot<CustomElementRegistry>> {
+        // The customElementRegistry getter steps are to return this’s custom element registry.
+        self.custom_element_registry()
     }
 
     fn GetRole(&self) -> Option<DOMString> {

--- a/components/script/dom/html/htmltemplateelement.rs
+++ b/components/script/dom/html/htmltemplateelement.rs
@@ -147,6 +147,7 @@ impl VirtualMethods for HTMLTemplateElement {
                 &child,
                 Some(&copy_contents_doc),
                 CloneChildrenFlag::CloneChildren,
+                None,
                 CanGc::note(),
             );
             copy_contents.AppendChild(&copy_child, can_gc).unwrap();

--- a/components/script/dom/raredata.rs
+++ b/components/script/dom/raredata.rs
@@ -10,7 +10,7 @@ use stylo_atoms::Atom;
 
 use crate::dom::bindings::root::{Dom, MutNullableDom};
 use crate::dom::customelementregistry::{
-    CustomElementDefinition, CustomElementReaction, CustomElementState,
+    CustomElementDefinition, CustomElementReaction, CustomElementRegistry, CustomElementState,
 };
 use crate::dom::domtokenlist::DOMTokenList;
 use crate::dom::elementinternals::ElementInternals;
@@ -70,6 +70,8 @@ pub(crate) struct ElementRareData {
     pub(crate) custom_element_definition: Option<Rc<CustomElementDefinition>>,
     /// <https://dom.spec.whatwg.org/#concept-element-custom-element-state>
     pub(crate) custom_element_state: CustomElementState,
+    /// <https://dom.spec.whatwg.org/#dom-element-customelementregistry>
+    pub(crate) custom_element_registry: Option<Dom<CustomElementRegistry>>,
     /// The "name" content attribute; not used as frequently as id, but used
     /// in named getter loops so it's worth looking up quickly when present
     #[no_trace]

--- a/components/script/dom/svg/svgsvgelement.rs
+++ b/components/script/dom/svg/svgsvgelement.rs
@@ -128,6 +128,7 @@ impl SVGSVGElement {
             referenced_node,
             None,
             CloneChildrenFlag::CloneChildren,
+            None,
             can_gc,
         );
         let root_node = self.upcast::<Node>();

--- a/components/script_bindings/webidls/Document.webidl
+++ b/components/script_bindings/webidls/Document.webidl
@@ -50,7 +50,7 @@ interface Document : Node {
   ProcessingInstruction createProcessingInstruction(DOMString target, DOMString data);
 
   [CEReactions, NewObject, Throws]
-  Node importNode(Node node, optional boolean deep = false);
+  Node importNode(Node node, optional (boolean or ImportNodeOptions) options = false);
   [CEReactions, Throws]
   Node adoptNode(Node node);
 
@@ -82,6 +82,11 @@ enum DocumentVisibilityState { "visible", "hidden" };
 
 dictionary ElementCreationOptions {
   DOMString is;
+};
+
+dictionary ImportNodeOptions {
+  CustomElementRegistry customElementRegistry;
+  boolean selfOnly = false;
 };
 
 // https://html.spec.whatwg.org/multipage/#the-document-object

--- a/components/script_bindings/webidls/Element.webidl
+++ b/components/script_bindings/webidls/Element.webidl
@@ -86,6 +86,8 @@ interface Element : Node {
 
   [Throws] ShadowRoot attachShadow(ShadowRootInit init);
   readonly attribute ShadowRoot? shadowRoot;
+
+  readonly attribute CustomElementRegistry? customElementRegistry;
 };
 
 dictionary ShadowRootInit {

--- a/tests/wpt/meta/custom-elements/registries/Document-importNode-cross-document.window.js.ini
+++ b/tests/wpt/meta/custom-elements/registries/Document-importNode-cross-document.window.js.ini
@@ -1,10 +1,4 @@
 [Document-importNode-cross-document.window.html]
-  [Cloning with global registry]
-    expected: FAIL
-
-  [Cloning with explicit global registry]
-    expected: FAIL
-
   [Cloning with scoped registry]
     expected: FAIL
 

--- a/tests/wpt/meta/custom-elements/registries/Element-customElementRegistry-exceptions.html.ini
+++ b/tests/wpt/meta/custom-elements/registries/Element-customElementRegistry-exceptions.html.ini
@@ -4,3 +4,6 @@
 
   [customElementRegistry on a failed custom element created by setting innerHTML should return the associated scoped registry]
     expected: FAIL
+
+  [customElementRegistry on a failed custom element created by parser should return the specified custom regsitry]
+    expected: FAIL

--- a/tests/wpt/meta/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-in-xhtml.xhtml.ini
+++ b/tests/wpt/meta/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute-in-xhtml.xhtml.ini
@@ -1,12 +1,12 @@
 [scoped-custom-element-registry-customelementregistry-attribute-in-xhtml.xhtml]
-  [XHTML parser should create a custom element candidate with null registry if customelementregistry is set]
-    expected: FAIL
-
   [XHTML parser should create a defined custom element with null registry if customelementregistry is set]
     expected: FAIL
 
-  [XHTML fragment parser should create a custom element candidate with null registry if customelementregistry is set]
+  [XHTML fragment parser should create a defined custom element with null registry if customelementregistry is set]
     expected: FAIL
 
-  [XHTML fragment parser should create a defined custom element with null registry if customelementregistry is set]
+  [XHTML parser should create a custom element candidate with null registry if customelementregistry is set]
+    expected: FAIL
+
+  [XHTML fragment parser should create a custom element candidate with null registry if customelementregistry is set]
     expected: FAIL

--- a/tests/wpt/meta/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute.html.ini
+++ b/tests/wpt/meta/custom-elements/registries/scoped-custom-element-registry-customelementregistry-attribute.html.ini
@@ -1,17 +1,14 @@
 [scoped-custom-element-registry-customelementregistry-attribute.html]
-  [HTML parser should create a builtin element with null registry if customelementregistry is set]
-    expected: FAIL
-
   [Setting customelementregistry content attribute after a builtin element had finishsed parsing should not set null registry]
     expected: FAIL
 
-  [Cloning a builtin element with null regsitry should create an element with null registry]
+  [Cloning a custom element with null regsitry should create an element with null registry]
+    expected: FAIL
+
+  [Setting customelementregistry content attribute during constructor should not make it use null registry]
     expected: FAIL
 
   [HTML parser should create a custom element candidate with null registry if customelementregistry is set]
-    expected: FAIL
-
-  [Setting customelementregistry content attribute after a custom element candidate had finishsed parsing should not set null registry]
     expected: FAIL
 
   [Cloning a custom element candidate with null regsitry should create an element with null registry]
@@ -20,14 +17,5 @@
   [HTML parser should create a custom element with null registry if customelementregistry is set]
     expected: FAIL
 
-  [Setting customelementregistry content attribute after a custom element had finishsed parsing should not set null registry]
-    expected: FAIL
-
-  [Cloning a custom element with null regsitry should create an element with null registry]
-    expected: FAIL
-
   [Descendants of an element with customelementregistry should use null registry]
-    expected: FAIL
-
-  [Setting customelementregistry content attribute during constructor should not make it use null registry]
     expected: FAIL

--- a/tests/wpt/meta/custom-elements/registries/scoped-registry-append-does-not-upgrade.html.ini
+++ b/tests/wpt/meta/custom-elements/registries/scoped-registry-append-does-not-upgrade.html.ini
@@ -1,7 +1,4 @@
 [scoped-registry-append-does-not-upgrade.html]
-  [customElementRegistry of an upgrade candidate created in a document without a browsing context uses null regsitry by default]
-    expected: FAIL
-
   [Connecting a custom element candiate in a shadow root with a scoped custom element registry has null registry by default]
     expected: FAIL
 
@@ -24,4 +21,7 @@
     expected: FAIL
 
   [Inserting a node from another document with null registry results in the custom element registry to be set and upgraded.]
+    expected: FAIL
+
+  [customElementRegistry of an upgrade candidate created in a document without a browsing context uses null regsitry by default]
     expected: FAIL

--- a/tests/wpt/meta/custom-elements/upgrading/Document-importNode.html.ini
+++ b/tests/wpt/meta/custom-elements/upgrading/Document-importNode.html.ini
@@ -1,6 +1,0 @@
-[Document-importNode.html]
-  [autonomous: document.importNode() should import custom elements successfully]
-    expected: FAIL
-
-  [autonomous: document.importNode() should import "undefined" custom elements successfully]
-    expected: FAIL

--- a/tests/wpt/meta/dom/idlharness.window.js.ini
+++ b/tests/wpt/meta/dom/idlharness.window.js.ini
@@ -235,12 +235,3 @@
 
   [ShadowRoot interface: attribute customElementRegistry]
     expected: FAIL
-
-  [Element interface: attribute customElementRegistry]
-    expected: FAIL
-
-  [Element interface: element must inherit property "customElementRegistry" with the proper type]
-    expected: FAIL
-
-
-[idlharness.window.html?include=Node]


### PR DESCRIPTION
This method now allows you to pass in a custom registry. The registry isn't used yet for callers, since we don't support scoped registries. However, as we now pass in the registry to `Node::clone`, we set the registry when creating elements and cloning them.

As such, various tests start passing where we set the registry. Some tests started failing, but they rely on scoped registries which we don't support yet. These tests thus flipped: those that were erroneously failing are now passing and vice versa.

Part of #34319