### PR TITLE
libservo: Add initial `NetworkManager::cache_entries` API

### DIFF
--- a/components/net/http_cache.rs
+++ b/components/net/http_cache.rs
@@ -22,7 +22,7 @@ use malloc_size_of_derive::MallocSizeOf;
 use net_traits::http_status::HttpStatus;
 use net_traits::request::Request;
 use net_traits::response::{HttpsState, Response, ResponseBody};
-use net_traits::{FetchMetadata, Metadata, ResourceFetchTiming};
+use net_traits::{CacheEntryDescriptor, FetchMetadata, Metadata, ResourceFetchTiming};
 use parking_lot::Mutex as ParkingLotMutex;
 use quick_cache::sync::{Cache, DefaultLifecycle, PlaceholderGuard};
 use quick_cache::{DefaultHashBuilder, UnitWeighter};
@@ -805,6 +805,14 @@ impl HttpCache {
                 let _ = done_sender.send(to_send.clone());
             }
         }
+    }
+
+    /// Returns descriptors for cache entries currently stored in this cache.
+    pub fn cache_entry_descriptors(&self) -> Vec<CacheEntryDescriptor> {
+        self.entries
+            .iter()
+            .map(|(key, _)| CacheEntryDescriptor::new(key.url.to_string()))
+            .collect()
     }
 
     /// Clear the contents of this cache.

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -526,7 +526,7 @@ impl ResourceChannelManager {
                     history_states.remove(&history_state);
                 }
             },
-            CoreResourceMsg::ListCacheEntries(sender) => {
+            CoreResourceMsg::GetCacheEntries(sender) => {
                 let _ = sender.send(http_state.http_cache.cache_entry_descriptors());
             },
             CoreResourceMsg::ClearCache(sender) => {

--- a/components/net/resource_thread.rs
+++ b/components/net/resource_thread.rs
@@ -526,6 +526,9 @@ impl ResourceChannelManager {
                     history_states.remove(&history_state);
                 }
             },
+            CoreResourceMsg::ListCacheEntries(sender) => {
+                let _ = sender.send(http_state.http_cache.cache_entry_descriptors());
+            },
             CoreResourceMsg::ClearCache(sender) => {
                 http_state.http_cache.clear();
                 if let Some(sender) = sender {

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -61,6 +61,7 @@ pub use webrender_api::units::{
     DeviceIntPoint, DeviceIntRect, DeviceIntSize, DevicePixel, DevicePoint, DeviceVector2D,
 };
 
+pub use crate::network_manager::{CacheEntry, NetworkManager};
 pub use crate::servo::{Servo, ServoBuilder, run_content_process};
 pub use crate::servo_delegate::{ServoDelegate, ServoError};
 pub use crate::site_data_manager::{SiteData, SiteDataManager, StorageType};

--- a/components/servo/network_manager.rs
+++ b/components/servo/network_manager.rs
@@ -2,7 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use std::collections::HashSet;
+
 use net_traits::ResourceThreads;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CacheEntry {
+    key: String,
+}
+
+impl CacheEntry {
+    pub fn new(key: String) -> CacheEntry {
+        CacheEntry { key }
+    }
+
+    pub fn key(&self) -> String {
+        self.key.clone()
+    }
+}
 
 /// Provides APIs for managing network-related state.
 ///
@@ -23,6 +40,32 @@ impl NetworkManager {
             public_resource_threads,
             private_resource_threads,
         }
+    }
+
+    /// Returns cache entries currently stored in the HTTP cache.
+    ///
+    /// The returned list contains one [`CacheEntry`] per unique cache key
+    /// (URL) for which the networking layer currently maintains cached
+    /// responses.
+    ///
+    /// Both public and private browsing contexts are included in the result.
+    ///
+    /// Note: The networking layer currently only implements an in-memory HTTP
+    /// cache. Support for an on-disk cache is under development.
+    pub fn cache_entries(&self) -> Vec<CacheEntry> {
+        let mut entries: HashSet<String> = HashSet::default();
+
+        let public_entries = self.public_resource_threads.cache_entries();
+        for public_entry in public_entries {
+            entries.insert(public_entry.key);
+        }
+
+        let private_entries = self.private_resource_threads.cache_entries();
+        for private_entry in private_entries {
+            entries.insert(private_entry.key);
+        }
+
+        entries.into_iter().map(CacheEntry::new).collect()
     }
 
     /// Clears the network (HTTP) cache.

--- a/components/servo/network_manager.rs
+++ b/components/servo/network_manager.rs
@@ -59,7 +59,7 @@ impl NetworkManager {
         let unique_keys: HashSet<String> = public_entries
             .into_iter()
             .chain(private_entries)
-            .map(|e| e.key)
+            .map(|entry| entry.key)
             .collect();
 
         unique_keys.into_iter().map(CacheEntry::new).collect()

--- a/components/servo/network_manager.rs
+++ b/components/servo/network_manager.rs
@@ -12,12 +12,12 @@ pub struct CacheEntry {
 }
 
 impl CacheEntry {
-    pub fn new(key: String) -> CacheEntry {
-        CacheEntry { key }
+    pub fn new(key: String) -> Self {
+        Self { key }
     }
 
-    pub fn key(&self) -> String {
-        self.key.clone()
+    pub fn key(&self) -> &str {
+        &self.key
     }
 }
 
@@ -53,19 +53,16 @@ impl NetworkManager {
     /// Note: The networking layer currently only implements an in-memory HTTP
     /// cache. Support for an on-disk cache is under development.
     pub fn cache_entries(&self) -> Vec<CacheEntry> {
-        let mut entries: HashSet<String> = HashSet::default();
-
         let public_entries = self.public_resource_threads.cache_entries();
-        for public_entry in public_entries {
-            entries.insert(public_entry.key);
-        }
-
         let private_entries = self.private_resource_threads.cache_entries();
-        for private_entry in private_entries {
-            entries.insert(private_entry.key);
-        }
 
-        entries.into_iter().map(CacheEntry::new).collect()
+        let unique_keys: HashSet<String> = public_entries
+            .into_iter()
+            .chain(private_entries)
+            .map(|e| e.key)
+            .collect();
+
+        unique_keys.into_iter().map(CacheEntry::new).collect()
     }
 
     /// Clears the network (HTTP) cache.

--- a/components/servo/tests/network_manager.rs
+++ b/components/servo/tests/network_manager.rs
@@ -8,11 +8,56 @@ use std::rc::Rc;
 
 use http_body_util::combinators::BoxBody;
 use hyper::body::{Bytes, Incoming};
+use hyper::header::{self, HeaderValue};
 use hyper::{Request as HyperRequest, Response as HyperResponse};
 use net::test_util::{make_body, make_server};
-use servo::WebViewBuilder;
+use servo::{CacheEntry, WebViewBuilder};
 
 use crate::common::{ServoTest, WebViewDelegateImpl};
+
+#[test]
+fn test_cache_entries() {
+    let servo_test = ServoTest::new();
+    let servo = servo_test.servo();
+    let delegate = Rc::new(WebViewDelegateImpl::default());
+    let webview = WebViewBuilder::new(servo, servo_test.rendering_context.clone())
+        .delegate(delegate.clone())
+        .build();
+    let delegate_clone = delegate.clone();
+    servo_test.spin(move || !delegate_clone.url_changed.get());
+
+    let network_manager = servo.network_manager();
+
+    let cache_entries = network_manager.cache_entries();
+    assert_eq!(cache_entries.len(), 0);
+
+    static MESSAGE: &'static [u8] = b"<!DOCTYPE html>\nHello";
+    let handler =
+        move |_: HyperRequest<Incoming>,
+              response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+            response.headers_mut().insert(
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("max-age=3600"),
+            );
+            *response.body_mut() = make_body(MESSAGE.to_vec());
+        };
+
+    let (server, url) = make_server(handler);
+    let port = url.port().unwrap();
+
+    delegate.reset();
+    webview.load(url.clone().into_url());
+    let delegate_clone = delegate.clone();
+    servo_test.spin(move || !delegate_clone.url_changed.get());
+
+    let _ = server.close();
+
+    let cache_entries = network_manager.cache_entries();
+    assert_eq!(
+        &cache_entries,
+        &[CacheEntry::new(format!("http://localhost:{}/", port)),]
+    );
+}
 
 #[test]
 fn test_clear_cache() {
@@ -23,6 +68,10 @@ fn test_clear_cache() {
     let handler =
         move |_: HyperRequest<Incoming>,
               response: &mut HyperResponse<BoxBody<Bytes, hyper::Error>>| {
+            response.headers_mut().insert(
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("max-age=3600"),
+            );
             *response.body_mut() = make_body(MESSAGE.to_vec());
         };
     let (server, url) = make_server(handler);
@@ -38,8 +87,13 @@ fn test_clear_cache() {
 
     let _ = server.close();
 
-    servo_test.servo().network_manager().clear_cache();
+    let network_manager = servo_test.servo().network_manager();
 
-    // TODO: Check that the cache was actually cleared once there's a way to
-    //       check it.
+    let cache_entries = network_manager.cache_entries();
+    assert_eq!(cache_entries.len(), 1);
+
+    network_manager.clear_cache();
+
+    let cache_entries = network_manager.cache_entries();
+    assert_eq!(cache_entries.len(), 0);
 }

--- a/components/servo/tests/network_manager.rs
+++ b/components/servo/tests/network_manager.rs
@@ -55,7 +55,7 @@ fn test_cache_entries() {
     let cache_entries = network_manager.cache_entries();
     assert_eq!(
         &cache_entries,
-        &[CacheEntry::new(format!("http://localhost:{}/", port)),]
+        &[CacheEntry::new(format!("http://localhost:{port}/")),]
     );
 }
 

--- a/components/shared/net/lib.rs
+++ b/components/shared/net/lib.rs
@@ -508,7 +508,7 @@ impl ResourceThreads {
         let (sender, receiver) = generic_channel::channel().unwrap();
         let _ = self
             .core_thread
-            .send(CoreResourceMsg::ListCacheEntries(sender));
+            .send(CoreResourceMsg::GetCacheEntries(sender));
         receiver.recv().unwrap()
     }
 
@@ -633,7 +633,7 @@ pub enum CoreResourceMsg {
     /// Removes history states for the given ids
     RemoveHistoryStates(Vec<HistoryStateId>),
     /// Gets a list of origin descriptors derived from entries in the cache
-    ListCacheEntries(GenericSender<Vec<CacheEntryDescriptor>>),
+    GetCacheEntries(GenericSender<Vec<CacheEntryDescriptor>>),
     /// Clear the network cache.
     ClearCache(Option<GenericSender<()>>),
     /// Send the service worker network mediator for an origin to CoreResourceThread
@@ -663,7 +663,7 @@ pub struct CacheEntryDescriptor {
 
 impl CacheEntryDescriptor {
     pub fn new(key: String) -> Self {
-        CacheEntryDescriptor { key }
+        Self { key }
     }
 }
 


### PR DESCRIPTION
Add initial support in `NetworkManager` for listing entries currently stored
in the HTTP cache. Each returned entry is identified by its cache key (URL).
    
The necessary support has been added to the net crate to expose cache entry
information.

Testing: A new integration test has been added.
