### PR TITLE
servoshell: Properly handle `WindowEvent::Focused`

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -194,7 +194,7 @@ impl ApplicationHandler<AppEvent> for App {
             if let Some(window) = state.window(window_id.into()) {
                 window.platform_window().handle_winit_window_event(
                     state.clone(),
-                    &window,
+                    window,
                     window_event,
                 );
             }

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -536,6 +536,9 @@ impl HeadedWindow {
 }
 
 impl PlatformWindow for HeadedWindow {
+    fn has_winit_window(&self) -> bool {
+        true
+    }
     fn screen_geometry(&self) -> ScreenGeometry {
         let hidpi_factor = self.hidpi_scale_factor();
         let toolbar_size = Size2D::new(0.0, (self.toolbar_height() * self.hidpi_scale_factor()).0);

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -594,14 +594,14 @@ impl PlatformWindow for HeadedWindow {
     fn handle_winit_window_event(
         &self,
         state: Rc<RunningAppState>,
-        window: &ServoShellWindow,
+        window: Rc<ServoShellWindow>,
         event: WindowEvent,
     ) {
         if event == WindowEvent::RedrawRequested {
             // WARNING: do not defer painting or presenting to some later tick of the event
             // loop or servoshell may become unresponsive! (servo#30312)
             let mut gui = self.gui.borrow_mut();
-            gui.update(&state, window, self);
+            gui.update(&state, &window, self);
             gui.paint(&self.winit_window);
         }
 
@@ -629,6 +629,7 @@ impl PlatformWindow for HeadedWindow {
         // Handle the event
         let mut consumed = false;
         match event {
+            WindowEvent::Focused(true) => state.handle_focused(window.clone()),
             WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
                 // Intercept any ScaleFactorChanged events away from EguiGlow::on_window_event, so
                 // we can use our own logic for calculating the scale factor and set egui’s
@@ -682,7 +683,7 @@ impl PlatformWindow for HeadedWindow {
                     .on_window_event(&self.winit_window, event);
 
                 if let WindowEvent::Resized(_) = event {
-                    self.rebuild_user_interface(&state, window);
+                    self.rebuild_user_interface(&state, &window);
                 }
 
                 if response.repaint && *event != WindowEvent::RedrawRequested {
@@ -710,7 +711,7 @@ impl PlatformWindow for HeadedWindow {
             if let Some(webview) = window.active_webview() {
                 match event {
                     WindowEvent::KeyboardInput { event, .. } => {
-                        self.handle_keyboard_input(state.clone(), window, event)
+                        self.handle_keyboard_input(state.clone(), &window, event)
                     },
                     WindowEvent::ModifiersChanged(modifiers) => {
                         self.modifiers_state.set(modifiers.state())

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -237,6 +237,11 @@ impl RunningAppState {
         initial_url: Url,
     ) -> Rc<ServoShellWindow> {
         let window = Rc::new(ServoShellWindow::new(platform_window));
+
+        // On Android and OHOS, newly created windows are automatically focused.
+        // On Desktop, it is up to the `winit::event::WindowEvent::Focused`.
+        #[cfg(any(target_env = "ohos", target_os = "android"))]
+        self.focus_window(window.clone());
         window.create_and_activate_toplevel_webview(self.clone(), initial_url);
         self.windows
             .borrow_mut()

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -237,7 +237,6 @@ impl RunningAppState {
         initial_url: Url,
     ) -> Rc<ServoShellWindow> {
         let window = Rc::new(ServoShellWindow::new(platform_window));
-        self.focus_window(window.clone());
         window.create_and_activate_toplevel_webview(self.clone(), initial_url);
         self.windows
             .borrow_mut()
@@ -553,6 +552,10 @@ impl RunningAppState {
         if let Some(gamepad_support) = self.gamepad_support.borrow_mut().as_mut() {
             gamepad_support.handle_gamepad_events(active_webview);
         }
+    }
+
+    pub(crate) fn handle_focused(&self, window: Rc<ServoShellWindow>) {
+        *self.focused_window.borrow_mut() = Some(window.clone());
     }
 
     /// Interrupt any ongoing WebDriver-based script evaluation.

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -236,12 +236,14 @@ impl RunningAppState {
         platform_window: Rc<dyn PlatformWindow>,
         initial_url: Url,
     ) -> Rc<ServoShellWindow> {
+        let has_winit_window = platform_window.has_winit_window();
         let window = Rc::new(ServoShellWindow::new(platform_window));
 
-        // On Android and OHOS, newly created windows are automatically focused.
-        // On Desktop, it is up to the `winit::event::WindowEvent::Focused`.
-        #[cfg(any(target_env = "ohos", target_os = "android"))]
-        self.focus_window(window.clone());
+        // For [`HeadedWindow`], it is up to the `winit::event::WindowEvent::Focused`.
+        // Otherwise, newly created windows are automatically focused.
+        if !has_winit_window {
+            self.focus_window(window.clone());
+        }
         window.create_and_activate_toplevel_webview(self.clone(), initial_url);
         self.windows
             .borrow_mut()

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -237,6 +237,7 @@ impl RunningAppState {
         initial_url: Url,
     ) -> Rc<ServoShellWindow> {
         let window = Rc::new(ServoShellWindow::new(platform_window));
+        self.focus_window(window.clone());
         window.create_and_activate_toplevel_webview(self.clone(), initial_url);
         self.windows
             .borrow_mut()

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -374,7 +374,7 @@ pub(crate) trait PlatformWindow {
     fn handle_winit_window_event(
         &self,
         _: Rc<RunningAppState>,
-        _: &ServoShellWindow,
+        _: Rc<ServoShellWindow>,
         _: winit::event::WindowEvent,
     ) {
     }

--- a/ports/servoshell/window.rs
+++ b/ports/servoshell/window.rs
@@ -437,4 +437,7 @@ pub(crate) trait PlatformWindow {
     fn notify_media_session_event(&self, _: MediaSessionEvent) {}
     fn notify_crashed(&self, _: WebView, _reason: String, _backtrace: Option<String>) {}
     fn show_console_message(&self, _level: ConsoleLogLevel, _message: &str) {}
+    fn has_winit_window(&self) -> bool {
+        false
+    }
 }


### PR DESCRIPTION
There are two bugs listed below. Basically, we never ever set https://github.com/servo/servo/blob/1b0bd11e111508fa3ee7e77ccdf6cf4149d137bb/ports/servoshell/running_app_state.rs#L253-L255 except by WebDriver command, so it's always been `None`. 

This PR lets `WindowEvent::Focused` determine `focused_window` for `HeadedWindow`.
For those without `winit::Window`, such as Android/OHOS/`HeadlessWindow`, the newly created window is automatically focused.

Fixes: #41398
Fixes: #41399
