### PR TITLE
script: Use the improved servo-media `can_play_type` method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8054,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
+source = "git+https://github.com/tharkum/servo-media?branch=gstreamer-containers-codecs-registration#0bfe2f00ed1dcd459d537653916648613c665c6e"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -8067,7 +8067,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
+source = "git+https://github.com/tharkum/servo-media?branch=gstreamer-containers-codecs-registration#0bfe2f00ed1dcd459d537653916648613c665c6e"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -8088,7 +8088,7 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
+source = "git+https://github.com/tharkum/servo-media?branch=gstreamer-containers-codecs-registration#0bfe2f00ed1dcd459d537653916648613c665c6e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8098,7 +8098,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
+source = "git+https://github.com/tharkum/servo-media?branch=gstreamer-containers-codecs-registration#0bfe2f00ed1dcd459d537653916648613c665c6e"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -8112,7 +8112,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
+source = "git+https://github.com/tharkum/servo-media?branch=gstreamer-containers-codecs-registration#0bfe2f00ed1dcd459d537653916648613c665c6e"
 dependencies = [
  "byte-slice-cast",
  "glib",
@@ -8145,7 +8145,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
+source = "git+https://github.com/tharkum/servo-media?branch=gstreamer-containers-codecs-registration#0bfe2f00ed1dcd459d537653916648613c665c6e"
 dependencies = [
  "gstreamer",
  "gstreamer-video",
@@ -8155,7 +8155,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-android"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
+source = "git+https://github.com/tharkum/servo-media?branch=gstreamer-containers-codecs-registration#0bfe2f00ed1dcd459d537653916648613c665c6e"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8169,7 +8169,7 @@ dependencies = [
 [[package]]
 name = "servo-media-gstreamer-render-unix"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
+source = "git+https://github.com/tharkum/servo-media?branch=gstreamer-containers-codecs-registration#0bfe2f00ed1dcd459d537653916648613c665c6e"
 dependencies = [
  "glib",
  "gstreamer",
@@ -8184,7 +8184,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
+source = "git+https://github.com/tharkum/servo-media?branch=gstreamer-containers-codecs-registration#0bfe2f00ed1dcd459d537653916648613c665c6e"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -8196,7 +8196,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
+source = "git+https://github.com/tharkum/servo-media?branch=gstreamer-containers-codecs-registration#0bfe2f00ed1dcd459d537653916648613c665c6e"
 dependencies = [
  "uuid",
 ]
@@ -8204,12 +8204,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
+source = "git+https://github.com/tharkum/servo-media?branch=gstreamer-containers-codecs-registration#0bfe2f00ed1dcd459d537653916648613c665c6e"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#e55a9c69cd3f7fa52a2a33f2219eb081fddaebbc"
+source = "git+https://github.com/tharkum/servo-media?branch=gstreamer-containers-codecs-registration#0bfe2f00ed1dcd459d537653916648613c665c6e"
 dependencies = [
  "log",
  "servo-media-streams",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,3 +300,8 @@ codegen-units = 1
 #
 # [patch."https://github.com/servo/rust-content-security-policy"]
 # content-security-policy = { path = "../rust-content-security-policy" }
+
+[patch."https://github.com/servo/media"]
+servo-media = { git = "https://github.com/tharkum/servo-media", branch = "gstreamer-containers-codecs-registration" }
+servo-media-dummy = { git = "https://github.com/tharkum/servo-media", branch = "gstreamer-containers-codecs-registration" }
+servo-media-gstreamer = { git = "https://github.com/tharkum/servo-media", branch = "gstreamer-containers-codecs-registration" }

--- a/tests/wpt/meta/content-security-policy/media-src/media-src-7_2_2.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/media-src/media-src-7_2_2.sub.html.ini
@@ -1,4 +1,0 @@
-[media-src-7_2_2.sub.html]
-  expected: TIMEOUT
-  [Test that securitypolicyviolation events are fired]
-    expected: TIMEOUT

--- a/tests/wpt/meta/content-security-policy/media-src/media-src-blocked.sub.html.ini
+++ b/tests/wpt/meta/content-security-policy/media-src/media-src-blocked.sub.html.ini
@@ -1,4 +1,0 @@
-[media-src-blocked.sub.html]
-  expected: TIMEOUT
-  [Disallowed audio source element]
-    expected: TIMEOUT

--- a/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-colorSpaceConversion.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/imagebitmap/createImageBitmap-colorSpaceConversion.html.ini
@@ -1,0 +1,3 @@
+[createImageBitmap-colorSpaceConversion.html]
+  [createImageBitmap from a Video, and drawImage on the created ImageBitmap with colorSpaceConversion: none]
+    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html.ini
@@ -58,39 +58,3 @@
 
   [Rec2020-222000000, Context display-p3, ImageData display-p3, cropSource=true]
     expected: FAIL
-
-  [sRGB-FF0100, Context srgb, ImageData srgb, cropSource=false]
-    expected: FAIL
-
-  [sRGB-FF0100, Context srgb, ImageData srgb, cropSource=true]
-    expected: FAIL
-
-  [sRGB-FF0100, Context display-p3, ImageData srgb, cropSource=false]
-    expected: FAIL
-
-  [sRGB-FF0100, Context display-p3, ImageData srgb, cropSource=true]
-    expected: FAIL
-
-  [sRGB-BB0000, Context srgb, ImageData srgb, cropSource=false]
-    expected: FAIL
-
-  [sRGB-BB0000, Context srgb, ImageData srgb, cropSource=true]
-    expected: FAIL
-
-  [sRGB-BB0000, Context display-p3, ImageData srgb, cropSource=false]
-    expected: FAIL
-
-  [sRGB-BB0000, Context display-p3, ImageData srgb, cropSource=true]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context srgb, ImageData srgb, cropSource=false]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context srgb, ImageData srgb, cropSource=true]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context display-p3, ImageData srgb, cropSource=false]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context display-p3, ImageData srgb, cropSource=true]
-    expected: FAIL

--- a/tests/wpt/meta/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html.ini
+++ b/tests/wpt/meta/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html.ini
@@ -58,39 +58,3 @@
 
   [Rec2020-222000000, Context display-p3, ImageData display-p3, scaleImage=true]
     expected: FAIL
-
-  [sRGB-FF0100, Context srgb, ImageData srgb, scaleImage=false]
-    expected: FAIL
-
-  [sRGB-FF0100, Context srgb, ImageData srgb, scaleImage=true]
-    expected: FAIL
-
-  [sRGB-FF0100, Context display-p3, ImageData srgb, scaleImage=false]
-    expected: FAIL
-
-  [sRGB-FF0100, Context display-p3, ImageData srgb, scaleImage=true]
-    expected: FAIL
-
-  [sRGB-BB0000, Context srgb, ImageData srgb, scaleImage=false]
-    expected: FAIL
-
-  [sRGB-BB0000, Context srgb, ImageData srgb, scaleImage=true]
-    expected: FAIL
-
-  [sRGB-BB0000, Context display-p3, ImageData srgb, scaleImage=false]
-    expected: FAIL
-
-  [sRGB-BB0000, Context display-p3, ImageData srgb, scaleImage=true]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context srgb, ImageData srgb, scaleImage=false]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context srgb, ImageData srgb, scaleImage=true]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context display-p3, ImageData srgb, scaleImage=false]
-    expected: FAIL
-
-  [Rec2020-3FF000000, Context display-p3, ImageData srgb, scaleImage=true]
-    expected: FAIL

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/mime-types/canPlayType.html.ini
@@ -1,26 +1,8 @@
 [canPlayType.html]
-  [video/mp4; codecs="mp4v.20.8" (optional)]
-    expected: PRECONDITION_FAILED
-
   [video/3gpp; codecs="samr" (optional)]
     expected: PRECONDITION_FAILED
 
-  [video/mp4; codecs="mp4v.20.240" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [audio/webm (optional)]
-    expected: PRECONDITION_FAILED
-
-  [audio/mp4; codecs="mp4a.40.2" (optional)]
-    expected: PRECONDITION_FAILED
-
   [video/ogg; codecs="theora" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4; codecs="avc1.64001E" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4 (optional)]
     expected: PRECONDITION_FAILED
 
   [video/ogg; codecs="vorbis" (optional)]
@@ -29,37 +11,13 @@
   [audio/ogg; codecs="opus" (optional)]
     expected: PRECONDITION_FAILED
 
-  [video/webm (optional)]
-    expected: FAIL
-
-  [video/webm with and without codecs]
-    expected: FAIL
-
-  [video/mp4; codecs="avc1.4D401E" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [audio/wav (optional)]
-    expected: FAIL
-
-  [video/mp4; codecs="avc1.42E01E" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4; codecs="avc1.58A01E" (optional)]
-    expected: PRECONDITION_FAILED
-
   [video/ogg (optional)]
     expected: PRECONDITION_FAILED
 
-  [audio/mp4 (optional)]
-    expected: PRECONDITION_FAILED
-
   [video/3gpp (optional)]
-    expected: FAIL
+    expected: PRECONDITION_FAILED
 
   [audio/ogg (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4; codecs="mp4a.40.2" (optional)]
     expected: PRECONDITION_FAILED
 
   [audio/ogg; codecs="vorbis" (optional)]
@@ -71,26 +29,14 @@
   [video/3gpp; codecs="mp4v.20.8" (optional)]
     expected: PRECONDITION_FAILED
 
-  [audio/wav with and without codecs]
-    expected: FAIL
-
-  [audio/webm; codecs="opus" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [audio/webm; codecs="vorbis" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/webm; codecs="opus" (optional)]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4 codecs subset]
-    expected: PRECONDITION_FAILED
-
-  [video/mp4 codecs order]
-    expected: PRECONDITION_FAILED
-
   [video/ogg codecs subset]
     expected: PRECONDITION_FAILED
 
   [video/ogg codecs order]
+    expected: PRECONDITION_FAILED
+
+  [video/3gpp codecs subset]
+    expected: PRECONDITION_FAILED
+
+  [video/3gpp codecs order]
     expected: PRECONDITION_FAILED

--- a/tests/wpt/meta/html/semantics/embedded-content/media-elements/playing-the-media-resource/fragmented-mp4-end.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/media-elements/playing-the-media-resource/fragmented-mp4-end.html.ini
@@ -1,3 +1,0 @@
-[fragmented-mp4-end.html]
-  [fragmented-mp4-end]
-    expected: PRECONDITION_FAILED

--- a/tests/wpt/meta/html/semantics/embedded-content/the-video-element/resize-during-playback.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-video-element/resize-during-playback.html.ini
@@ -1,3 +1,0 @@
-[resize-during-playback.html]
-  [mp4 video]
-    expected: PRECONDITION_FAILED

--- a/tests/wpt/meta/html/semantics/embedded-content/the-video-element/video_timeupdate_on_seek.html.ini
+++ b/tests/wpt/meta/html/semantics/embedded-content/the-video-element/video_timeupdate_on_seek.html.ini
@@ -2,3 +2,6 @@
   expected: TIMEOUT
   [timeupdate is emitted after a seek before the data is received: webm.]
     expected: TIMEOUT
+
+  [timeupdate is emitted after a seek before the data is received: mp4.]
+    expected: TIMEOUT

--- a/tests/wpt/meta/resource-timing/initiator-type/video.html.ini
+++ b/tests/wpt/meta/resource-timing/initiator-type/video.html.ini
@@ -1,6 +1,3 @@
 [video.html]
   [The initiator type for <track src> must be 'track']
     expected: FAIL
-
-  [The initiator type for <source src> with type="video/mp4" must be 'video']
-    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/misc/texture-corner-case-videos.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/misc/texture-corner-case-videos.html.ini
@@ -1,0 +1,18 @@
+[texture-corner-case-videos.html]
+  [WebGL test #6]
+    expected: FAIL
+
+  [WebGL test #7]
+    expected: FAIL
+
+  [WebGL test #8]
+    expected: FAIL
+
+  [WebGL test #9]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #11]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/misc/texture-video-transparent.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/misc/texture-video-transparent.html.ini
@@ -1,0 +1,720 @@
+[texture-video-transparent.html]
+  [WebGL test #0]
+    expected: FAIL
+
+  [WebGL test #1]
+    expected: FAIL
+
+  [WebGL test #2]
+    expected: FAIL
+
+  [WebGL test #3]
+    expected: FAIL
+
+  [WebGL test #4]
+    expected: FAIL
+
+  [WebGL test #5]
+    expected: FAIL
+
+  [WebGL test #6]
+    expected: FAIL
+
+  [WebGL test #7]
+    expected: FAIL
+
+  [WebGL test #8]
+    expected: FAIL
+
+  [WebGL test #9]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #11]
+    expected: FAIL
+
+  [WebGL test #12]
+    expected: FAIL
+
+  [WebGL test #13]
+    expected: FAIL
+
+  [WebGL test #14]
+    expected: FAIL
+
+  [WebGL test #15]
+    expected: FAIL
+
+  [WebGL test #16]
+    expected: FAIL
+
+  [WebGL test #17]
+    expected: FAIL
+
+  [WebGL test #18]
+    expected: FAIL
+
+  [WebGL test #19]
+    expected: FAIL
+
+  [WebGL test #20]
+    expected: FAIL
+
+  [WebGL test #21]
+    expected: FAIL
+
+  [WebGL test #22]
+    expected: FAIL
+
+  [WebGL test #23]
+    expected: FAIL
+
+  [WebGL test #24]
+    expected: FAIL
+
+  [WebGL test #25]
+    expected: FAIL
+
+  [WebGL test #26]
+    expected: FAIL
+
+  [WebGL test #27]
+    expected: FAIL
+
+  [WebGL test #28]
+    expected: FAIL
+
+  [WebGL test #29]
+    expected: FAIL
+
+  [WebGL test #30]
+    expected: FAIL
+
+  [WebGL test #31]
+    expected: FAIL
+
+  [WebGL test #32]
+    expected: FAIL
+
+  [WebGL test #33]
+    expected: FAIL
+
+  [WebGL test #34]
+    expected: FAIL
+
+  [WebGL test #35]
+    expected: FAIL
+
+  [WebGL test #36]
+    expected: FAIL
+
+  [WebGL test #37]
+    expected: FAIL
+
+  [WebGL test #38]
+    expected: FAIL
+
+  [WebGL test #39]
+    expected: FAIL
+
+  [WebGL test #40]
+    expected: FAIL
+
+  [WebGL test #41]
+    expected: FAIL
+
+  [WebGL test #42]
+    expected: FAIL
+
+  [WebGL test #43]
+    expected: FAIL
+
+  [WebGL test #44]
+    expected: FAIL
+
+  [WebGL test #45]
+    expected: FAIL
+
+  [WebGL test #46]
+    expected: FAIL
+
+  [WebGL test #47]
+    expected: FAIL
+
+  [WebGL test #48]
+    expected: FAIL
+
+  [WebGL test #49]
+    expected: FAIL
+
+  [WebGL test #50]
+    expected: FAIL
+
+  [WebGL test #51]
+    expected: FAIL
+
+  [WebGL test #52]
+    expected: FAIL
+
+  [WebGL test #53]
+    expected: FAIL
+
+  [WebGL test #54]
+    expected: FAIL
+
+  [WebGL test #55]
+    expected: FAIL
+
+  [WebGL test #56]
+    expected: FAIL
+
+  [WebGL test #57]
+    expected: FAIL
+
+  [WebGL test #58]
+    expected: FAIL
+
+  [WebGL test #59]
+    expected: FAIL
+
+  [WebGL test #60]
+    expected: FAIL
+
+  [WebGL test #61]
+    expected: FAIL
+
+  [WebGL test #62]
+    expected: FAIL
+
+  [WebGL test #63]
+    expected: FAIL
+
+  [WebGL test #64]
+    expected: FAIL
+
+  [WebGL test #65]
+    expected: FAIL
+
+  [WebGL test #66]
+    expected: FAIL
+
+  [WebGL test #67]
+    expected: FAIL
+
+  [WebGL test #68]
+    expected: FAIL
+
+  [WebGL test #69]
+    expected: FAIL
+
+  [WebGL test #70]
+    expected: FAIL
+
+  [WebGL test #71]
+    expected: FAIL
+
+  [WebGL test #72]
+    expected: FAIL
+
+  [WebGL test #73]
+    expected: FAIL
+
+  [WebGL test #74]
+    expected: FAIL
+
+  [WebGL test #75]
+    expected: FAIL
+
+  [WebGL test #76]
+    expected: FAIL
+
+  [WebGL test #77]
+    expected: FAIL
+
+  [WebGL test #78]
+    expected: FAIL
+
+  [WebGL test #79]
+    expected: FAIL
+
+  [WebGL test #80]
+    expected: FAIL
+
+  [WebGL test #81]
+    expected: FAIL
+
+  [WebGL test #82]
+    expected: FAIL
+
+  [WebGL test #83]
+    expected: FAIL
+
+  [WebGL test #84]
+    expected: FAIL
+
+  [WebGL test #85]
+    expected: FAIL
+
+  [WebGL test #86]
+    expected: FAIL
+
+  [WebGL test #87]
+    expected: FAIL
+
+  [WebGL test #88]
+    expected: FAIL
+
+  [WebGL test #89]
+    expected: FAIL
+
+  [WebGL test #90]
+    expected: FAIL
+
+  [WebGL test #91]
+    expected: FAIL
+
+  [WebGL test #92]
+    expected: FAIL
+
+  [WebGL test #93]
+    expected: FAIL
+
+  [WebGL test #94]
+    expected: FAIL
+
+  [WebGL test #95]
+    expected: FAIL
+
+  [WebGL test #96]
+    expected: FAIL
+
+  [WebGL test #97]
+    expected: FAIL
+
+  [WebGL test #98]
+    expected: FAIL
+
+  [WebGL test #99]
+    expected: FAIL
+
+  [WebGL test #100]
+    expected: FAIL
+
+  [WebGL test #101]
+    expected: FAIL
+
+  [WebGL test #102]
+    expected: FAIL
+
+  [WebGL test #103]
+    expected: FAIL
+
+  [WebGL test #104]
+    expected: FAIL
+
+  [WebGL test #105]
+    expected: FAIL
+
+  [WebGL test #106]
+    expected: FAIL
+
+  [WebGL test #107]
+    expected: FAIL
+
+  [WebGL test #108]
+    expected: FAIL
+
+  [WebGL test #109]
+    expected: FAIL
+
+  [WebGL test #110]
+    expected: FAIL
+
+  [WebGL test #111]
+    expected: FAIL
+
+  [WebGL test #112]
+    expected: FAIL
+
+  [WebGL test #113]
+    expected: FAIL
+
+  [WebGL test #114]
+    expected: FAIL
+
+  [WebGL test #115]
+    expected: FAIL
+
+  [WebGL test #116]
+    expected: FAIL
+
+  [WebGL test #117]
+    expected: FAIL
+
+  [WebGL test #118]
+    expected: FAIL
+
+  [WebGL test #119]
+    expected: FAIL
+
+  [WebGL test #120]
+    expected: FAIL
+
+  [WebGL test #121]
+    expected: FAIL
+
+  [WebGL test #122]
+    expected: FAIL
+
+  [WebGL test #123]
+    expected: FAIL
+
+  [WebGL test #124]
+    expected: FAIL
+
+  [WebGL test #125]
+    expected: FAIL
+
+  [WebGL test #126]
+    expected: FAIL
+
+  [WebGL test #127]
+    expected: FAIL
+
+  [WebGL test #128]
+    expected: FAIL
+
+  [WebGL test #129]
+    expected: FAIL
+
+  [WebGL test #130]
+    expected: FAIL
+
+  [WebGL test #131]
+    expected: FAIL
+
+  [WebGL test #132]
+    expected: FAIL
+
+  [WebGL test #133]
+    expected: FAIL
+
+  [WebGL test #134]
+    expected: FAIL
+
+  [WebGL test #135]
+    expected: FAIL
+
+  [WebGL test #136]
+    expected: FAIL
+
+  [WebGL test #137]
+    expected: FAIL
+
+  [WebGL test #138]
+    expected: FAIL
+
+  [WebGL test #139]
+    expected: FAIL
+
+  [WebGL test #140]
+    expected: FAIL
+
+  [WebGL test #141]
+    expected: FAIL
+
+  [WebGL test #142]
+    expected: FAIL
+
+  [WebGL test #143]
+    expected: FAIL
+
+  [WebGL test #144]
+    expected: FAIL
+
+  [WebGL test #145]
+    expected: FAIL
+
+  [WebGL test #146]
+    expected: FAIL
+
+  [WebGL test #147]
+    expected: FAIL
+
+  [WebGL test #148]
+    expected: FAIL
+
+  [WebGL test #149]
+    expected: FAIL
+
+  [WebGL test #150]
+    expected: FAIL
+
+  [WebGL test #151]
+    expected: FAIL
+
+  [WebGL test #152]
+    expected: FAIL
+
+  [WebGL test #153]
+    expected: FAIL
+
+  [WebGL test #154]
+    expected: FAIL
+
+  [WebGL test #155]
+    expected: FAIL
+
+  [WebGL test #156]
+    expected: FAIL
+
+  [WebGL test #157]
+    expected: FAIL
+
+  [WebGL test #158]
+    expected: FAIL
+
+  [WebGL test #159]
+    expected: FAIL
+
+  [WebGL test #160]
+    expected: FAIL
+
+  [WebGL test #161]
+    expected: FAIL
+
+  [WebGL test #162]
+    expected: FAIL
+
+  [WebGL test #163]
+    expected: FAIL
+
+  [WebGL test #164]
+    expected: FAIL
+
+  [WebGL test #165]
+    expected: FAIL
+
+  [WebGL test #166]
+    expected: FAIL
+
+  [WebGL test #167]
+    expected: FAIL
+
+  [WebGL test #168]
+    expected: FAIL
+
+  [WebGL test #169]
+    expected: FAIL
+
+  [WebGL test #170]
+    expected: FAIL
+
+  [WebGL test #171]
+    expected: FAIL
+
+  [WebGL test #172]
+    expected: FAIL
+
+  [WebGL test #173]
+    expected: FAIL
+
+  [WebGL test #174]
+    expected: FAIL
+
+  [WebGL test #175]
+    expected: FAIL
+
+  [WebGL test #176]
+    expected: FAIL
+
+  [WebGL test #177]
+    expected: FAIL
+
+  [WebGL test #178]
+    expected: FAIL
+
+  [WebGL test #179]
+    expected: FAIL
+
+  [WebGL test #180]
+    expected: FAIL
+
+  [WebGL test #181]
+    expected: FAIL
+
+  [WebGL test #182]
+    expected: FAIL
+
+  [WebGL test #183]
+    expected: FAIL
+
+  [WebGL test #184]
+    expected: FAIL
+
+  [WebGL test #185]
+    expected: FAIL
+
+  [WebGL test #186]
+    expected: FAIL
+
+  [WebGL test #187]
+    expected: FAIL
+
+  [WebGL test #188]
+    expected: FAIL
+
+  [WebGL test #189]
+    expected: FAIL
+
+  [WebGL test #190]
+    expected: FAIL
+
+  [WebGL test #191]
+    expected: FAIL
+
+  [WebGL test #192]
+    expected: FAIL
+
+  [WebGL test #193]
+    expected: FAIL
+
+  [WebGL test #194]
+    expected: FAIL
+
+  [WebGL test #195]
+    expected: FAIL
+
+  [WebGL test #196]
+    expected: FAIL
+
+  [WebGL test #197]
+    expected: FAIL
+
+  [WebGL test #198]
+    expected: FAIL
+
+  [WebGL test #199]
+    expected: FAIL
+
+  [WebGL test #200]
+    expected: FAIL
+
+  [WebGL test #201]
+    expected: FAIL
+
+  [WebGL test #202]
+    expected: FAIL
+
+  [WebGL test #203]
+    expected: FAIL
+
+  [WebGL test #204]
+    expected: FAIL
+
+  [WebGL test #205]
+    expected: FAIL
+
+  [WebGL test #206]
+    expected: FAIL
+
+  [WebGL test #207]
+    expected: FAIL
+
+  [WebGL test #208]
+    expected: FAIL
+
+  [WebGL test #209]
+    expected: FAIL
+
+  [WebGL test #210]
+    expected: FAIL
+
+  [WebGL test #211]
+    expected: FAIL
+
+  [WebGL test #212]
+    expected: FAIL
+
+  [WebGL test #213]
+    expected: FAIL
+
+  [WebGL test #214]
+    expected: FAIL
+
+  [WebGL test #215]
+    expected: FAIL
+
+  [WebGL test #216]
+    expected: FAIL
+
+  [WebGL test #217]
+    expected: FAIL
+
+  [WebGL test #218]
+    expected: FAIL
+
+  [WebGL test #219]
+    expected: FAIL
+
+  [WebGL test #220]
+    expected: FAIL
+
+  [WebGL test #221]
+    expected: FAIL
+
+  [WebGL test #222]
+    expected: FAIL
+
+  [WebGL test #223]
+    expected: FAIL
+
+  [WebGL test #224]
+    expected: FAIL
+
+  [WebGL test #225]
+    expected: FAIL
+
+  [WebGL test #226]
+    expected: FAIL
+
+  [WebGL test #227]
+    expected: FAIL
+
+  [WebGL test #228]
+    expected: FAIL
+
+  [WebGL test #229]
+    expected: FAIL
+
+  [WebGL test #230]
+    expected: FAIL
+
+  [WebGL test #231]
+    expected: FAIL
+
+  [WebGL test #232]
+    expected: FAIL
+
+  [WebGL test #233]
+    expected: FAIL
+
+  [WebGL test #234]
+    expected: FAIL
+
+  [WebGL test #235]
+    expected: FAIL
+
+  [WebGL test #236]
+    expected: FAIL
+
+  [WebGL test #237]
+    expected: FAIL
+
+  [WebGL test #238]
+    expected: FAIL
+
+  [WebGL test #239]
+    expected: FAIL

--- a/tests/wpt/webgl/meta/conformance/textures/misc/video-rotation.html.ini
+++ b/tests/wpt/webgl/meta/conformance/textures/misc/video-rotation.html.ini
@@ -1,3 +1,120 @@
 [video-rotation.html]
-  [WebGL test #0]
+  [WebGL test #8]
+    expected: FAIL
+
+  [WebGL test #10]
+    expected: FAIL
+
+  [WebGL test #11]
+    expected: FAIL
+
+  [WebGL test #12]
+    expected: FAIL
+
+  [WebGL test #14]
+    expected: FAIL
+
+  [WebGL test #15]
+    expected: FAIL
+
+  [WebGL test #16]
+    expected: FAIL
+
+  [WebGL test #17]
+    expected: FAIL
+
+  [WebGL test #18]
+    expected: FAIL
+
+  [WebGL test #19]
+    expected: FAIL
+
+  [WebGL test #20]
+    expected: FAIL
+
+  [WebGL test #21]
+    expected: FAIL
+
+  [WebGL test #22]
+    expected: FAIL
+
+  [WebGL test #23]
+    expected: FAIL
+
+  [WebGL test #24]
+    expected: FAIL
+
+  [WebGL test #25]
+    expected: FAIL
+
+  [WebGL test #27]
+    expected: FAIL
+
+  [WebGL test #28]
+    expected: FAIL
+
+  [WebGL test #29]
+    expected: FAIL
+
+  [WebGL test #31]
+    expected: FAIL
+
+  [WebGL test #40]
+    expected: FAIL
+
+  [WebGL test #42]
+    expected: FAIL
+
+  [WebGL test #43]
+    expected: FAIL
+
+  [WebGL test #44]
+    expected: FAIL
+
+  [WebGL test #46]
+    expected: FAIL
+
+  [WebGL test #47]
+    expected: FAIL
+
+  [WebGL test #48]
+    expected: FAIL
+
+  [WebGL test #49]
+    expected: FAIL
+
+  [WebGL test #50]
+    expected: FAIL
+
+  [WebGL test #51]
+    expected: FAIL
+
+  [WebGL test #52]
+    expected: FAIL
+
+  [WebGL test #53]
+    expected: FAIL
+
+  [WebGL test #54]
+    expected: FAIL
+
+  [WebGL test #55]
+    expected: FAIL
+
+  [WebGL test #56]
+    expected: FAIL
+
+  [WebGL test #57]
+    expected: FAIL
+
+  [WebGL test #59]
+    expected: FAIL
+
+  [WebGL test #60]
+    expected: FAIL
+
+  [WebGL test #61]
+    expected: FAIL
+
+  [WebGL test #63]
     expected: FAIL


### PR DESCRIPTION
The media codecs/containers registration and parsing was improved inside `servo-media` crate, so `source` type selection and the media element `canPlayType` method are more efficient.
    
Testing: Improvements in the following tests
- content-security-policy/media-src/media-src-7_2_2.sub.html
- content-security-policy/media-src/media-src-blocked.sub.html
- html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage*
- html/semantics/embedded-content/media-elements/mime-types/canPlayType.html
- html/semantics/embedded-content/media-elements/playing-the-media-resource/fragmented-mp4-end.html
- html/semantics/embedded-content/the-video-element/resize-during-playback.html
- resource-timing/initiator-type/video.html
    
Partial regressions in the following tests:
- html/canvas/element/manual/imagebitmap/createImageBitmap-colorSpaceConversion.html
  The `webm` video with `vp9` codec (compare to `mp4` video with `h264` codec) has more pixel color differencies (14) than expected tolerance (10)
- html/semantics/embedded-content/the-video-element/video_timeupdate_on_seek.html
- webgl/conformance/textures/misc/texture-corner-case-videos.html
  The `avc1` codec is supported but subtests are failing with uncommon pixel shape (Sample Aspect Ratio - 136:135)
- webgl/meta/conformance/textures/misc/texture-video-transparent.html
   The `hvc1` codec is supported but without alpha, so subtests are failing with transparency blending (unexpected black color)
- webgl/conformance/textures/misc/video-rotation.html
   The `avc1` and `vp09` codecs are supported but subtests are failing with video `90, 180, 270` rotations
