### PR TITLE
wpt: Fix typo when update wpt results from link

### DIFF
--- a/python/wpt/update.py
+++ b/python/wpt/update.py
@@ -119,13 +119,13 @@ def run_update(**kwargs: Any) -> bool:
     """Run the update process returning True if the process is successful."""
     run_logs: list[str] = kwargs.get("run_log", "")
     if any([GITHUB_ACTION_RUN_URL_REGEX.search(run_log) for run_log in run_logs]):
-        return download_run_resultsa_and_then_run_update(kwargs)
+        return download_run_results_and_then_run_update(kwargs)
 
     logger = setup_logging(kwargs, {"mach": sys.stdout})
     return WPTUpdate(logger, **kwargs).run() != exit_unclean
 
 
-def download_run_resultsa_and_then_run_update(kwargs: dict[str, Any]) -> bool:
+def download_run_results_and_then_run_update(kwargs: dict[str, Any]) -> bool:
     """If any of the arguments passed to `./mach update-wpt` are URLs, attempt to
     interpret them as GitHub Action Run URLs and download any test results, passing
     the downloaded results as the input to the WPT metadata update."""


### PR DESCRIPTION
This just fixes a typo:
`download_run_resultsa_and_then_run_update` -> `download_run_results_and_then_run_update`