### PR TITLE
script: Mark beacon requests as keepalive

### DIFF
--- a/components/script/dom/html/htmlformelement.rs
+++ b/components/script/dom/html/htmlformelement.rs
@@ -995,7 +995,7 @@ impl HTMLFormElement {
         let global = self.global();
 
         let request_body = bytes
-            .extract(&global, can_gc)
+            .extract(&global, false, can_gc)
             .expect("Couldn't extract body.")
             .into_net_request_body()
             .0;

--- a/components/script/dom/navigator.rs
+++ b/components/script/dom/navigator.rs
@@ -473,7 +473,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
         if let Some(data) = data {
             // Step 6.1. Set transmittedData and contentType to the result of extracting data's byte stream
             // with the keepalive flag set.
-            let extracted_body = data.extract(&global, can_gc)?;
+            let extracted_body = data.extract(&global, true, can_gc)?;
             // Step 6.2. If the amount of data that can be queued to be sent by keepalive enabled requests
             // is exceeded by the size of transmittedData (as defined in HTTP-network-or-cache fetch),
             // set the return value to false and terminate these steps.
@@ -512,7 +512,7 @@ impl NavigatorMethods<crate::DomTypeHolder> for Navigator {
             .method(http::Method::POST)
             .body(request_body)
             .origin(origin)
-            // TODO: Set keep-alive flag
+            .keep_alive(true)
             .credentials_mode(CredentialsMode::Include)
             .headers(headers);
         // Step 7.2. Fetch req.

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -452,7 +452,8 @@ impl Request {
         // Step 37. If init["body"] exists and is non-null, then:
         if let Some(Some(ref input_init_body)) = init.body {
             // Step 37.1. Let bodyWithType be the result of extracting init["body"], with keepalive set to request’s keepalive.
-            let mut body_with_type = input_init_body.extract(global, can_gc)?;
+            let mut body_with_type =
+                input_init_body.extract(global, r.request.borrow().keep_alive, can_gc)?;
 
             // Step 37.3. Let type be bodyWithType’s type.
             if let Some(contents) = body_with_type.content_type.take() {

--- a/components/script/dom/response.rs
+++ b/components/script/dom/response.rs
@@ -178,7 +178,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
         // 3. Let bodyWithType be null.
         // 4. If body is non-null, then set bodyWithType to the result of extracting body.
         let body_with_type = match body_init {
-            Some(body) => Some(body.extract(global, can_gc)?),
+            Some(body) => Some(body.extract(global, false, can_gc)?),
             None => None,
         };
 
@@ -254,7 +254,7 @@ impl ResponseMethods<crate::DomTypeHolder> for Response {
         // The spec's definition of JSON bytes is a UTF-8 encoding so using a DOMString here handles
         // the encoding part.
         let body_init = BodyInit::String(json_str);
-        let mut body = body_init.extract(global, can_gc)?;
+        let mut body = body_init.extract(global, false, can_gc)?;
 
         // 3. Let responseObject be the result of creating a Response object, given a new response,
         // "response", and the current realm.

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -562,7 +562,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
             },
             Some(DocumentOrXMLHttpRequestBodyInit::Blob(ref b)) => {
                 let extracted_body = b
-                    .extract(&self.global(), can_gc)
+                    .extract(&self.global(), false, can_gc)
                     .expect("Couldn't extract body.");
                 if !extracted_body.in_memory() && self.sync.get() {
                     warn!("Sync XHR with not in-memory Blob as body not supported");
@@ -573,16 +573,16 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
             },
             Some(DocumentOrXMLHttpRequestBodyInit::FormData(ref formdata)) => Some(
                 formdata
-                    .extract(&self.global(), can_gc)
+                    .extract(&self.global(), false, can_gc)
                     .expect("Couldn't extract body."),
             ),
             Some(DocumentOrXMLHttpRequestBodyInit::String(ref str)) => Some(
-                str.extract(&self.global(), can_gc)
+                str.extract(&self.global(), false, can_gc)
                     .expect("Couldn't extract body."),
             ),
             Some(DocumentOrXMLHttpRequestBodyInit::URLSearchParams(ref urlsp)) => Some(
                 urlsp
-                    .extract(&self.global(), can_gc)
+                    .extract(&self.global(), false, can_gc)
                     .expect("Couldn't extract body."),
             ),
             Some(DocumentOrXMLHttpRequestBodyInit::ArrayBuffer(ref typedarray)) => {

--- a/tests/wpt/meta/beacon/beacon-basic.https.window.js.ini
+++ b/tests/wpt/meta/beacon/beacon-basic.https.window.js.ini
@@ -7,6 +7,3 @@
 
   [Payload size restriction should be accumulated: type = blob]
     expected: FAIL
-
-  [sendBeacon() with a stream does not work due to the keepalive flag being set]
-    expected: FAIL


### PR DESCRIPTION
This is checked if the body is a stream, but the payload calculation needs to be in a follow-up PR.

Part of #38302