### PR TITLE
servoshell: Rename desktop `Window` structs to `HeadedWindow` and `HeadlessWindow`

### DIFF
--- a/ports/servoshell/desktop/app.rs
+++ b/ports/servoshell/desktop/app.rs
@@ -20,8 +20,9 @@ use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoopProxy};
 use winit::window::WindowId;
 
 use super::event_loop::AppEvent;
-use super::{headed_window, headless_window};
 use crate::desktop::event_loop::ServoShellEventLoop;
+use crate::desktop::headed_window::HeadedWindow;
+use crate::desktop::headless_window::HeadlessWindow;
 use crate::desktop::protocols;
 use crate::desktop::tracing::trace_winit_event;
 use crate::parser::get_default_url;
@@ -138,10 +139,10 @@ impl App {
         );
 
         let Some(active_event_loop) = active_event_loop else {
-            return headless_window::Window::new(&self.servoshell_preferences);
+            return HeadlessWindow::new(&self.servoshell_preferences);
         };
 
-        headed_window::Window::new(
+        HeadedWindow::new(
             &self.servoshell_preferences,
             active_event_loop,
             self.event_loop_proxy

--- a/ports/servoshell/desktop/gui.rs
+++ b/ports/servoshell/desktop/gui.rs
@@ -253,7 +253,7 @@ impl Gui {
         &mut self,
         state: &RunningAppState,
         window: &ServoShellWindow,
-        headed_window: &headed_window::Window,
+        headed_window: &headed_window::HeadedWindow,
     ) {
         self.rendering_context
             .make_current()

--- a/ports/servoshell/desktop/headed_window.rs
+++ b/ports/servoshell/desktop/headed_window.rs
@@ -60,7 +60,7 @@ use crate::window::{
 
 pub(crate) const INITIAL_WINDOW_TITLE: &str = "Servo";
 
-pub struct Window {
+pub struct HeadedWindow {
     /// The egui interface that is responsible for showing the user interface elements of
     /// this headed `Window`.
     gui: RefCell<Gui>,
@@ -103,7 +103,7 @@ pub struct Window {
     last_mouse_position: Cell<Option<Point2D<f32, DeviceIndependentPixel>>>,
 }
 
-impl Window {
+impl HeadedWindow {
     pub(crate) fn new(
         servoshell_preferences: &ServoShellPreferences,
         event_loop: &ActiveEventLoop,
@@ -143,7 +143,7 @@ impl Window {
         let window_handle = winit_window
             .window_handle()
             .expect("winit window did not have a window handle");
-        Window::force_srgb_color_space(window_handle.as_raw());
+        HeadedWindow::force_srgb_color_space(window_handle.as_raw());
 
         let monitor = winit_window
             .current_monitor()
@@ -192,7 +192,7 @@ impl Window {
         ));
 
         debug!("Created window {:?}", winit_window.id());
-        Rc::new(Window {
+        Rc::new(HeadedWindow {
             gui,
             winit_window,
             webview_relative_mouse_point: Cell::new(Point2D::zero()),
@@ -535,7 +535,7 @@ impl Window {
     }
 }
 
-impl PlatformWindow for Window {
+impl PlatformWindow for HeadedWindow {
     fn screen_geometry(&self) -> ScreenGeometry {
         let hidpi_factor = self.hidpi_scale_factor();
         let toolbar_size = Size2D::new(0.0, (self.toolbar_height() * self.hidpi_scale_factor()).0);

--- a/ports/servoshell/desktop/headless_window.rs
+++ b/ports/servoshell/desktop/headless_window.rs
@@ -23,7 +23,7 @@ use winit::dpi::PhysicalSize;
 use crate::prefs::ServoShellPreferences;
 use crate::window::{MIN_WINDOW_INNER_SIZE, PlatformWindow, ServoShellWindow, ServoShellWindowId};
 
-pub struct Window {
+pub struct HeadlessWindow {
     id: ServoShellWindowId,
     fullscreen: Cell<bool>,
     device_pixel_ratio_override: Option<Scale<f32, DeviceIndependentPixel, DevicePixel>>,
@@ -34,7 +34,7 @@ pub struct Window {
     rendering_context: Rc<SoftwareRenderingContext>,
 }
 
-impl Window {
+impl HeadlessWindow {
     pub fn new(servoshell_preferences: &ServoShellPreferences) -> Rc<Self> {
         let size = servoshell_preferences.initial_window_size;
 
@@ -55,7 +55,7 @@ impl Window {
             });
 
         static CURRENT_WINDOW_ID: AtomicU64 = AtomicU64::new(0);
-        let window = Window {
+        let window = HeadlessWindow {
             id: CURRENT_WINDOW_ID
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                 .into(),
@@ -71,7 +71,7 @@ impl Window {
     }
 }
 
-impl Drop for Window {
+impl Drop for HeadlessWindow {
     fn drop(&mut self) {
         if let Err(error) = self.rendering_context.make_current() {
             error!("Failed to make the rendering context current: {error:?}");
@@ -79,7 +79,7 @@ impl Drop for Window {
     }
 }
 
-impl PlatformWindow for Window {
+impl PlatformWindow for HeadlessWindow {
     fn id(&self) -> ServoShellWindowId {
         self.id
     }


### PR DESCRIPTION
It's pretty confusing that these two struct implementations of
`PlatformWindow` are named the same thing. This PR renames them to more
accurately reflect what they are.

Testing: This PR just does a simple rename so existing tests should suffice.
