### PR TITLE
libservo: Stop exporting `ipc-channel` for gamepad responders and use callbacks

### DIFF
--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -283,7 +283,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
 
         let callback = GenericCallback::new(move |message| match message {
             Ok(msg) => listener.handle_stopped(msg),
-            Err(err) => warn!("Error receiving a GamepadMsg: {:?}", err),
+            Err(error) => warn!("Error receiving a GamepadMsg: {error:?}"),
         })
         .expect("Could not create callback");
 

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -361,7 +361,7 @@ impl GamepadHapticActuator {
             }),
         );
 
-        let callback = GenericCallback::new(|_msg| ()).expect("Could not create callback");
+        let callback = GenericCallback::new(|_| ()).expect("Could not create callback");
 
         let document = self.global().as_window().Document();
         let event = EmbedderMsg::StopGamepadHapticEffect(

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -223,7 +223,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
 
         let callback = GenericCallback::new(move |message| match message {
             Ok(msg) => listener.handle_completed(msg),
-            Err(err) => warn!("Error receiving a GamepadMsg: {:?}", err),
+            Err(error) => warn!("Error receiving a GamepadMsg: {error:?}"),
         })
         .expect("Could not create generic callback");
 

--- a/components/script/dom/gamepad/gamepadhapticactuator.rs
+++ b/components/script/dom/gamepad/gamepadhapticactuator.rs
@@ -282,7 +282,7 @@ impl GamepadHapticActuatorMethods<crate::DomTypeHolder> for GamepadHapticActuato
         };
 
         let callback = GenericCallback::new(move |message| match message {
-            Ok(msg) => listener.handle_stopped(msg),
+            Ok(success) => listener.handle_stopped(success),
             Err(error) => warn!("Error receiving a GamepadMsg: {error:?}"),
         })
         .expect("Could not create callback");

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -26,7 +26,7 @@ mod webview_delegate;
 
 // These are Servo's public exports. Everything (apart from a couple exceptions below)
 // should be exported at the root. See <https://github.com/servo/servo/issues/18475>.
-pub use base::generic_channel::GenericSender;
+pub use base::generic_channel::{GenericCallback, GenericSender};
 pub use base::id::WebViewId;
 pub use compositing::WebRenderDebugOption;
 pub use compositing_traits::rendering_context::{
@@ -35,7 +35,6 @@ pub use compositing_traits::rendering_context::{
 pub use embedder_traits::user_contents::UserScript;
 pub use embedder_traits::*;
 pub use image::RgbaImage;
-pub use ipc_channel::ipc::IpcSender;
 pub use keyboard_types::{
     Code, CompositionEvent, CompositionState, Key, KeyState, Location, Modifiers, NamedKey,
 };

--- a/components/servo/lib.rs
+++ b/components/servo/lib.rs
@@ -26,7 +26,7 @@ mod webview_delegate;
 
 // These are Servo's public exports. Everything (apart from a couple exceptions below)
 // should be exported at the root. See <https://github.com/servo/servo/issues/18475>.
-pub use base::generic_channel::{GenericCallback, GenericSender};
+pub use base::generic_channel::GenericSender;
 pub use base::id::WebViewId;
 pub use compositing::WebRenderDebugOption;
 pub use compositing_traits::rendering_context::{

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -541,25 +541,23 @@ impl ServoInner {
                 webview_id,
                 gamepad_index,
                 gamepad_haptic_effect_type,
-                ipc_sender,
+                callback,
             ) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
                     webview.delegate().play_gamepad_haptic_effect(
                         webview,
                         gamepad_index,
                         gamepad_haptic_effect_type,
-                        ipc_sender,
+                        callback,
                     );
                 }
             },
             #[cfg(feature = "gamepad")]
-            EmbedderMsg::StopGamepadHapticEffect(webview_id, gamepad_index, ipc_sender) => {
+            EmbedderMsg::StopGamepadHapticEffect(webview_id, gamepad_index, callback) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview.delegate().stop_gamepad_haptic_effect(
-                        webview,
-                        gamepad_index,
-                        ipc_sender,
-                    );
+                    webview
+                        .delegate()
+                        .stop_gamepad_haptic_effect(webview, gamepad_index, callback);
                 }
             },
             EmbedderMsg::ShowNotification(webview_id, notification) => {

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -550,7 +550,7 @@ impl ServoInner {
                         gamepad_haptic_effect_type,
                         Box::new(move |success| {
                             callback
-                                .send(msg)
+                                .send(success)
                                 .expect("Could not send message via callback")
                         }),
                     );
@@ -564,7 +564,7 @@ impl ServoInner {
                         gamepad_index,
                         Box::new(move |success| {
                             callback
-                                .send(msg)
+                                .send(success)
                                 .expect("Could not send message via callback")
                         }),
                     );

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -548,16 +548,26 @@ impl ServoInner {
                         webview,
                         gamepad_index,
                         gamepad_haptic_effect_type,
-                        callback,
+                        Box::new(move |msg| {
+                            callback
+                                .send(msg)
+                                .expect("Could not send message via callback")
+                        }),
                     );
                 }
             },
             #[cfg(feature = "gamepad")]
             EmbedderMsg::StopGamepadHapticEffect(webview_id, gamepad_index, callback) => {
                 if let Some(webview) = self.get_webview_handle(webview_id) {
-                    webview
-                        .delegate()
-                        .stop_gamepad_haptic_effect(webview, gamepad_index, callback);
+                    webview.delegate().stop_gamepad_haptic_effect(
+                        webview,
+                        gamepad_index,
+                        Box::new(move |msg| {
+                            callback
+                                .send(msg)
+                                .expect("Could not send message via callback")
+                        }),
+                    );
                 }
             },
             EmbedderMsg::ShowNotification(webview_id, notification) => {

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -548,7 +548,7 @@ impl ServoInner {
                         webview,
                         gamepad_index,
                         gamepad_haptic_effect_type,
-                        Box::new(move |msg| {
+                        Box::new(move |success| {
                             callback
                                 .send(msg)
                                 .expect("Could not send message via callback")

--- a/components/servo/servo.rs
+++ b/components/servo/servo.rs
@@ -562,7 +562,7 @@ impl ServoInner {
                     webview.delegate().stop_gamepad_haptic_effect(
                         webview,
                         gamepad_index,
-                        Box::new(move |msg| {
+                        Box::new(move |success| {
                             callback
                                 .send(msg)
                                 .expect("Could not send message via callback")

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -950,14 +950,14 @@ pub trait WebViewDelegate {
         _webview: WebView,
         _: usize,
         _: GamepadHapticEffectType,
-        _: Box<dyn Fn(bool)>,
+        _: Box<dyn FnOnce(bool)>,
     ) {
     }
     /// Request to stop a haptic effect on a connected gamepad. The embedder is expected to
     /// call the provided callback when the effect is complete with `true` for success
     /// and `false` for failure.
     #[cfg(feature = "gamepad")]
-    fn stop_gamepad_haptic_effect(&self, _webview: WebView, _: usize, _: Box<dyn Fn(bool)>) {}
+    fn stop_gamepad_haptic_effect(&self, _webview: WebView, _: usize, _: Box<dyn FnOnce(bool)>) {}
 
     /// Triggered when this [`WebView`] will load a web (HTTP/HTTPS) resource. The load may be
     /// intercepted and alternate contents can be loaded by the client by calling

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use base::generic_channel::{GenericCallback, GenericSender};
+use base::generic_channel::GenericSender;
 use base::id::PipelineId;
 use compositing_traits::rendering_context::RenderingContext;
 use constellation_traits::EmbedderToConstellationMessage;
@@ -948,12 +948,12 @@ pub trait WebViewDelegate {
         _webview: WebView,
         _: usize,
         _: GamepadHapticEffectType,
-        _: GenericCallback<bool>,
+        _: Box<dyn Fn(bool)>,
     ) {
     }
     /// Request to stop a haptic effect on a connected gamepad.
     #[cfg(feature = "gamepad")]
-    fn stop_gamepad_haptic_effect(&self, _webview: WebView, _: usize, _: GenericCallback<bool>) {}
+    fn stop_gamepad_haptic_effect(&self, _webview: WebView, _: usize, _: Box<dyn Fn(bool)>) {}
 
     /// Triggered when this [`WebView`] will load a web (HTTP/HTTPS) resource. The load may be
     /// intercepted and alternate contents can be loaded by the client by calling

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use base::generic_channel::GenericSender;
+use base::generic_channel::{GenericCallback, GenericSender};
 use base::id::PipelineId;
 use compositing_traits::rendering_context::RenderingContext;
 use constellation_traits::EmbedderToConstellationMessage;
@@ -20,7 +20,6 @@ use embedder_traits::{
     SimpleDialogRequest, TraversalId, WebResourceRequest, WebResourceResponse,
     WebResourceResponseMsg,
 };
-use ipc_channel::ipc::IpcSender;
 use url::Url;
 use webrender_api::units::{DeviceIntPoint, DeviceIntRect, DeviceIntSize};
 
@@ -949,12 +948,12 @@ pub trait WebViewDelegate {
         _webview: WebView,
         _: usize,
         _: GamepadHapticEffectType,
-        _: IpcSender<bool>,
+        _: GenericCallback<bool>,
     ) {
     }
     /// Request to stop a haptic effect on a connected gamepad.
     #[cfg(feature = "gamepad")]
-    fn stop_gamepad_haptic_effect(&self, _webview: WebView, _: usize, _: IpcSender<bool>) {}
+    fn stop_gamepad_haptic_effect(&self, _webview: WebView, _: usize, _: GenericCallback<bool>) {}
 
     /// Triggered when this [`WebView`] will load a web (HTTP/HTTPS) resource. The load may be
     /// intercepted and alternate contents can be loaded by the client by calling

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -951,7 +951,9 @@ pub trait WebViewDelegate {
         _: Box<dyn Fn(bool)>,
     ) {
     }
-    /// Request to stop a haptic effect on a connected gamepad.
+    /// Request to stop a haptic effect on a connected gamepad. The embedder is expected to
+    /// call the provided callback when the effect is complete with `true` for success
+    /// and `false` for failure.
     #[cfg(feature = "gamepad")]
     fn stop_gamepad_haptic_effect(&self, _webview: WebView, _: usize, _: Box<dyn Fn(bool)>) {}
 

--- a/components/servo/webview_delegate.rs
+++ b/components/servo/webview_delegate.rs
@@ -941,7 +941,9 @@ pub trait WebViewDelegate {
     /// After this point, any further responses to that request will be ignored.
     fn hide_embedder_control(&self, _webview: WebView, _control_id: EmbedderControlId) {}
 
-    /// Request to play a haptic effect on a connected gamepad.
+    /// Request to play a haptic effect on a connected gamepad. The embedder is expected to
+    /// call the provided callback when the effect is complete with `true` for success
+    /// and `false` for failure.
     #[cfg(feature = "gamepad")]
     fn play_gamepad_haptic_effect(
         &self,

--- a/components/shared/embedder/lib.rs
+++ b/components/shared/embedder/lib.rs
@@ -500,10 +500,15 @@ pub enum EmbedderMsg {
     RequestDevtoolsConnection(GenericSender<AllowOrDeny>),
     /// Request to play a haptic effect on a connected gamepad.
     #[cfg(feature = "gamepad")]
-    PlayGamepadHapticEffect(WebViewId, usize, GamepadHapticEffectType, IpcSender<bool>),
+    PlayGamepadHapticEffect(
+        WebViewId,
+        usize,
+        GamepadHapticEffectType,
+        GenericCallback<bool>,
+    ),
     /// Request to stop a haptic effect on a connected gamepad.
     #[cfg(feature = "gamepad")]
-    StopGamepadHapticEffect(WebViewId, usize, IpcSender<bool>),
+    StopGamepadHapticEffect(WebViewId, usize, GenericCallback<bool>),
     /// Informs the embedder that the constellation has completed shutdown.
     /// Required because the constellation can have pending calls to make
     /// (e.g. SetFrameTree) at the time that we send it an ExitMsg.

--- a/ports/servoshell/Cargo.toml
+++ b/ports/servoshell/Cargo.toml
@@ -64,7 +64,6 @@ dpi = { workspace = true }
 euclid = { workspace = true }
 hitrace = { workspace = true, optional = true }
 image = { workspace = true }
-ipc-channel = { workspace = true }
 keyboard-types = { workspace = true }
 libc = { workspace = true }
 libservo = { path = "../../components/servo", features = ["background_hang_monitor", "bluetooth", "testbinding", "vello_cpu"], default-features = false }

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -158,7 +158,7 @@ impl GamepadSupport {
         &mut self,
         index: usize,
         effect_type: GamepadHapticEffectType,
-        effect_complete_sender: Box<dyn Fn(bool)>,
+        callback: Box<dyn Fn(bool)>,
     ) {
         let GamepadHapticEffectType::DualRumble(params) = effect_type;
         if let Some(connected_gamepad) = self
@@ -191,13 +191,8 @@ impl GamepadSupport {
                 .add_gamepad(&connected_gamepad.1)
                 .finish(&mut self.handle)
                 .expect("Failed to create haptic effect, ensure connected gamepad supports force feedback.");
-            self.haptic_effects.insert(
-                index,
-                HapticEffect {
-                    effect,
-                    callback,
-                },
-            );
+            self.haptic_effects
+                .insert(index, HapticEffect { effect, callback });
             self.haptic_effects[&index]
                 .effect
                 .play()

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -9,12 +9,12 @@ use gilrs::{EventType, Gilrs};
 use log::{debug, warn};
 use servo::{
     GamepadEvent, GamepadHapticEffectType, GamepadIndex, GamepadInputBounds,
-    GamepadSupportedHapticEffects, GamepadUpdateType, InputEvent, IpcSender, WebView,
+    GamepadSupportedHapticEffects, GamepadUpdateType, GenericCallback, InputEvent, WebView,
 };
 
 pub struct HapticEffect {
     pub effect: Effect,
-    pub sender: IpcSender<bool>,
+    pub callback: GenericCallback<bool>,
 }
 
 pub(crate) struct GamepadSupport {
@@ -118,7 +118,7 @@ impl GamepadSupport {
                         return;
                     };
                     effect
-                        .sender
+                        .callback
                         .send(true)
                         .expect("Failed to send haptic effect completion.");
                     self.haptic_effects.remove(&event.id.into());
@@ -161,7 +161,7 @@ impl GamepadSupport {
         &mut self,
         index: usize,
         effect_type: GamepadHapticEffectType,
-        effect_complete_sender: IpcSender<bool>,
+        effect_complete_sender: GenericCallback<bool>,
     ) {
         let GamepadHapticEffectType::DualRumble(params) = effect_type;
         if let Some(connected_gamepad) = self
@@ -198,7 +198,7 @@ impl GamepadSupport {
                 index,
                 HapticEffect {
                     effect,
-                    sender: effect_complete_sender,
+                    callback: effect_complete_sender,
                 },
             );
             self.haptic_effects[&index]

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -195,7 +195,7 @@ impl GamepadSupport {
                 index,
                 HapticEffect {
                     effect,
-                    callback: effect_complete_sender,
+                    callback,
                 },
             );
             self.haptic_effects[&index]

--- a/ports/servoshell/desktop/gamepad.rs
+++ b/ports/servoshell/desktop/gamepad.rs
@@ -9,12 +9,12 @@ use gilrs::{EventType, Gilrs};
 use log::{debug, warn};
 use servo::{
     GamepadEvent, GamepadHapticEffectType, GamepadIndex, GamepadInputBounds,
-    GamepadSupportedHapticEffects, GamepadUpdateType, GenericCallback, InputEvent, WebView,
+    GamepadSupportedHapticEffects, GamepadUpdateType, InputEvent, WebView,
 };
 
 pub struct HapticEffect {
     pub effect: Effect,
-    pub callback: GenericCallback<bool>,
+    pub callback: Box<dyn Fn(bool)>,
 }
 
 pub(crate) struct GamepadSupport {
@@ -117,10 +117,7 @@ impl GamepadSupport {
                         warn!("Failed to find haptic effect for id {}", event.id);
                         return;
                     };
-                    effect
-                        .callback
-                        .send(true)
-                        .expect("Failed to send haptic effect completion.");
+                    (effect.callback)(true);
                     self.haptic_effects.remove(&event.id.into());
                 },
                 _ => {},
@@ -161,7 +158,7 @@ impl GamepadSupport {
         &mut self,
         index: usize,
         effect_type: GamepadHapticEffectType,
-        effect_complete_sender: GenericCallback<bool>,
+        effect_complete_sender: Box<dyn Fn(bool)>,
     ) {
         let GamepadHapticEffectType::DualRumble(params) = effect_type;
         if let Some(connected_gamepad) = self

--- a/ports/servoshell/egl/gamepad.rs
+++ b/ports/servoshell/egl/gamepad.rs
@@ -22,7 +22,7 @@ impl GamepadSupport {
         &mut self,
         _index: usize,
         _effect_type: GamepadHapticEffectType,
-        _effect_complete_sender: Box<dyn Fn(bool)>,
+        _effect_complete_callback: Box<dyn Fn(bool)>,
     ) {
         unreachable!("Dummy gamepad support should never be called.");
     }

--- a/ports/servoshell/egl/gamepad.rs
+++ b/ports/servoshell/egl/gamepad.rs
@@ -22,7 +22,7 @@ impl GamepadSupport {
         &mut self,
         _index: usize,
         _effect_type: GamepadHapticEffectType,
-        _effect_complete_callback: Box<dyn Fn(bool)>,
+        _effect_complete_callback: Box<dyn FnOnce(bool)>,
     ) {
         unreachable!("Dummy gamepad support should never be called.");
     }

--- a/ports/servoshell/egl/gamepad.rs
+++ b/ports/servoshell/egl/gamepad.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use servo::{GamepadHapticEffectType, IpcSender, WebView};
+use servo::{GamepadHapticEffectType, GenericCallback, WebView};
 
 /// A dummy version of [`crate::desktop::GamepadSupport`] used to avoid conditional compilation in
 /// servoshell and as a skeleton to implement gamepad support for platforms that do not
@@ -22,7 +22,7 @@ impl GamepadSupport {
         &mut self,
         _index: usize,
         _effect_type: GamepadHapticEffectType,
-        _effect_complete_sender: IpcSender<bool>,
+        _effect_complete_sender: GenericCallback<bool>,
     ) {
         unreachable!("Dummy gamepad support should never be called.");
     }

--- a/ports/servoshell/egl/gamepad.rs
+++ b/ports/servoshell/egl/gamepad.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use servo::{GamepadHapticEffectType, GenericCallback, WebView};
+use servo::{GamepadHapticEffectType, WebView};
 
 /// A dummy version of [`crate::desktop::GamepadSupport`] used to avoid conditional compilation in
 /// servoshell and as a skeleton to implement gamepad support for platforms that do not
@@ -22,7 +22,7 @@ impl GamepadSupport {
         &mut self,
         _index: usize,
         _effect_type: GamepadHapticEffectType,
-        _effect_complete_sender: GenericCallback<bool>,
+        _effect_complete_sender: Box<dyn Fn(bool)>,
     ) {
         unreachable!("Dummy gamepad support should never be called.");
     }

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -24,6 +24,15 @@ use servo::{
     WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView, WebViewDelegate,
     WebViewId, pref,
 };
+use servo::{
+    AllowOrDenyRequest, AuthenticationRequest, CSSPixel, ConsoleLogLevel, CreateNewWebViewRequest,
+    DeviceIntPoint, DeviceIntSize, EmbedderControl, EmbedderControlId, EventLoopWaker,
+    GamepadHapticEffectType, GenericCallback, GenericSender, InputEvent, InputEventId,
+    InputEventResult, JSValue, LoadStatus, MediaSessionEvent, PermissionRequest, PrefValue,
+    ScreenshotCaptureError, Servo, ServoDelegate, ServoError, TraversalId, WebDriverCommandMsg,
+    WebDriverJSResult, WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView,
+    WebViewDelegate, WebViewId, pref,
+};
 use url::Url;
 
 #[cfg(feature = "gamepad")]
@@ -740,7 +749,7 @@ impl WebViewDelegate for RunningAppState {
         _webview: WebView,
         index: usize,
         effect_type: GamepadHapticEffectType,
-        effect_complete_sender: IpcSender<bool>,
+        effect_complete_sender: GenericCallback<bool>,
     ) {
         match self.gamepad_support.borrow_mut().as_mut() {
             Some(gamepad_support) => {
@@ -757,7 +766,7 @@ impl WebViewDelegate for RunningAppState {
         &self,
         _webview: WebView,
         index: usize,
-        haptic_stop_sender: IpcSender<bool>,
+        haptic_stop_sender: GenericCallback<bool>,
     ) {
         let stopped = match self.gamepad_support.borrow_mut().as_mut() {
             Some(gamepad_support) => gamepad_support.stop_haptic_effect(index),

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -18,18 +18,9 @@ use servo::GamepadHapticEffectType;
 use servo::{
     AllowOrDenyRequest, AuthenticationRequest, CSSPixel, ConsoleLogLevel, CreateNewWebViewRequest,
     DeviceIntPoint, DeviceIntSize, EmbedderControl, EmbedderControlId, EventLoopWaker,
-    GenericSender, InputEvent, InputEventId, InputEventResult, IpcSender, JSValue, LoadStatus,
+    GenericSender, InputEvent, InputEventId, InputEventResult, JSValue, LoadStatus,
     MediaSessionEvent, PermissionRequest, PrefValue, ScreenshotCaptureError, Servo, ServoDelegate,
     ServoError, TraversalId, UserContentManager, WebDriverCommandMsg, WebDriverJSResult,
-    WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView, WebViewDelegate,
-    WebViewId, pref,
-};
-use servo::{
-    AllowOrDenyRequest, AuthenticationRequest, CSSPixel, ConsoleLogLevel, CreateNewWebViewRequest,
-    DeviceIntPoint, DeviceIntSize, EmbedderControl, EmbedderControlId, EventLoopWaker,
-    GamepadHapticEffectType, GenericSender, InputEvent, InputEventId, InputEventResult, JSValue,
-    LoadStatus, MediaSessionEvent, PermissionRequest, PrefValue, ScreenshotCaptureError, Servo,
-    ServoDelegate, ServoError, TraversalId, WebDriverCommandMsg, WebDriverJSResult,
     WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView, WebViewDelegate,
     WebViewId, pref,
 };

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -740,7 +740,7 @@ impl WebViewDelegate for RunningAppState {
         _webview: WebView,
         index: usize,
         effect_type: GamepadHapticEffectType,
-        effect_complete_callback: Box<dyn Fn(bool)>,
+        effect_complete_callback: Box<dyn FnOnce(bool)>,
     ) {
         match self.gamepad_support.borrow_mut().as_mut() {
             Some(gamepad_support) => {
@@ -757,7 +757,7 @@ impl WebViewDelegate for RunningAppState {
         &self,
         _webview: WebView,
         index: usize,
-        haptic_stop_callback: Box<dyn Fn(bool)>,
+        haptic_stop_callback: Box<dyn FnOnce(bool)>,
     ) {
         let stopped = match self.gamepad_support.borrow_mut().as_mut() {
             Some(gamepad_support) => gamepad_support.stop_haptic_effect(index),

--- a/ports/servoshell/running_app_state.rs
+++ b/ports/servoshell/running_app_state.rs
@@ -27,11 +27,11 @@ use servo::{
 use servo::{
     AllowOrDenyRequest, AuthenticationRequest, CSSPixel, ConsoleLogLevel, CreateNewWebViewRequest,
     DeviceIntPoint, DeviceIntSize, EmbedderControl, EmbedderControlId, EventLoopWaker,
-    GamepadHapticEffectType, GenericCallback, GenericSender, InputEvent, InputEventId,
-    InputEventResult, JSValue, LoadStatus, MediaSessionEvent, PermissionRequest, PrefValue,
-    ScreenshotCaptureError, Servo, ServoDelegate, ServoError, TraversalId, WebDriverCommandMsg,
-    WebDriverJSResult, WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView,
-    WebViewDelegate, WebViewId, pref,
+    GamepadHapticEffectType, GenericSender, InputEvent, InputEventId, InputEventResult, JSValue,
+    LoadStatus, MediaSessionEvent, PermissionRequest, PrefValue, ScreenshotCaptureError, Servo,
+    ServoDelegate, ServoError, TraversalId, WebDriverCommandMsg, WebDriverJSResult,
+    WebDriverLoadStatus, WebDriverScriptCommand, WebDriverSenders, WebView, WebViewDelegate,
+    WebViewId, pref,
 };
 use url::Url;
 
@@ -749,14 +749,14 @@ impl WebViewDelegate for RunningAppState {
         _webview: WebView,
         index: usize,
         effect_type: GamepadHapticEffectType,
-        effect_complete_sender: GenericCallback<bool>,
+        effect_complete_callback: Box<dyn Fn(bool)>,
     ) {
         match self.gamepad_support.borrow_mut().as_mut() {
             Some(gamepad_support) => {
-                gamepad_support.play_haptic_effect(index, effect_type, effect_complete_sender);
+                gamepad_support.play_haptic_effect(index, effect_type, effect_complete_callback);
             },
             None => {
-                let _ = effect_complete_sender.send(false);
+                effect_complete_callback(false);
             },
         }
     }
@@ -766,13 +766,13 @@ impl WebViewDelegate for RunningAppState {
         &self,
         _webview: WebView,
         index: usize,
-        haptic_stop_sender: GenericCallback<bool>,
+        haptic_stop_callback: Box<dyn Fn(bool)>,
     ) {
         let stopped = match self.gamepad_support.borrow_mut().as_mut() {
             Some(gamepad_support) => gamepad_support.stop_haptic_effect(index),
             None => false,
         };
-        let _ = haptic_stop_sender.send(stopped);
+        haptic_stop_callback(stopped);
     }
 
     fn show_embedder_control(&self, webview: WebView, embedder_control: EmbedderControl) {


### PR DESCRIPTION
With this we stop exporting ipc-channel in libservo and switch to GenericChannel/GenericCallback.

Testing: Generic Channels are tested all over the place.
